### PR TITLE
Show link previews in message preview  #19465

### DIFF
--- a/api_docs/unmerged.d/ZF-4c56a7.md
+++ b/api_docs/unmerged.d/ZF-4c56a7.md
@@ -1,0 +1,9 @@
+* [`POST /messages/render`](/api/render-message): Added the
+  `fetch_link_previews` parameter, which requests that the server include
+  link previews for the draft's links: previews it already has are
+  included in the rendered content, and the rest are fetched
+  asynchronously and delivered via the new `compose_link_preview` event.
+* [`GET /events`](/api/get-events): The new `compose_link_preview` event
+  is sent to a user when the server finishes fetching link previews for
+  a message draft they are previewing, so the compose preview can be
+  live-updated with the rendered embeds.

--- a/api_docs/unmerged.d/ZF-4c56a7.md
+++ b/api_docs/unmerged.d/ZF-4c56a7.md
@@ -1,0 +1,9 @@
+* [`POST /messages/render`](/api/render-message): Added the
+  `populate_url_embed_data` parameter, which requests that the server
+  populate URL embed data for the content's links: data it already has is
+  included in the rendered content, and the rest is fetched asynchronously
+  and delivered via the new `url_embed_data` event.
+* [`GET /events`](/api/get-events): The new `url_embed_data` event is sent
+  to a user when the server finishes fetching the URL embed data for
+  content they asked it to render, so that a client displaying the rendered
+  content can live-update it.

--- a/starlight_help/src/content/docs/preview-your-message-before-sending.mdx
+++ b/starlight_help/src/content/docs/preview-your-message-before-sending.mdx
@@ -29,8 +29,14 @@ import PreviewIcon from "~icons/zulip-icon/preview";
   </TabItem>
 </Tabs>
 
+Links in your message will show website previews, unless they are
+[disabled](/help/image-video-and-website-previews#configure-whether-website-previews-are-shown)
+in your organization. A website preview may take a moment to appear, since Zulip
+has to load the linked page to generate it.
+
 ## Related articles
 
 * [Message formatting](/help/format-your-message-using-markdown)
+* [Image, video and website previews](/help/image-video-and-website-previews)
 * [Resize the compose box](/help/resize-the-compose-box)
 * [Mastering the compose box](/help/mastering-the-compose-box)

--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -92,6 +92,8 @@ export function render_preview_area(): void {
         $("#compose .markdown_preview_spinner"),
         $("#compose .preview_content"),
         content,
+        true,
+        true,
     );
     const edit_height = $compose_textarea.height();
     $preview_message_area.css({"min-height": edit_height + "px"});

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1713,6 +1713,45 @@ export function exit_preview_mode($container: JQuery): void {
     $container.find(".markdown_preview").show();
 }
 
+function apply_preview_render(
+    $preview_container: JQuery,
+    $preview_spinner: JQuery,
+    $preview_content_box: JQuery,
+    content: string,
+    rendered_content: string,
+    raw_content?: string,
+): void {
+    // raw_content is checked for status messages ("/me ..."); it's
+    // undefined when we have no authoritative raw content (e.g. errors).
+    let rendered_preview_html;
+    if (raw_content !== undefined && markdown.is_status_message(raw_content)) {
+        // Handle previews of /me messages
+        rendered_preview_html =
+            "<p><strong>" +
+            _.escape(current_user.full_name) +
+            "</strong>" +
+            rendered_content.slice("<p>/me".length);
+    } else {
+        rendered_preview_html = rendered_content;
+    }
+
+    $preview_content_box.html(postprocess_content(rendered_preview_html));
+    rendered_markdown.update_elements($preview_content_box);
+
+    // Check for thumbnail loading placeholders and start polling
+    clear_thumbnail_polling();
+    pending_thumbnail_paths = extract_thumbnail_paths($preview_content_box);
+
+    if (pending_thumbnail_paths.size > 0) {
+        void poll_thumbnail_status(
+            $preview_container,
+            $preview_spinner,
+            $preview_content_box,
+            content,
+        );
+    }
+}
+
 export function render_and_show_preview(
     $preview_container: JQuery,
     $preview_spinner: JQuery,
@@ -1727,40 +1766,14 @@ export function render_and_show_preview(
     const preview_render_count = compose_state.get_preview_render_count() + 1;
     compose_state.set_preview_render_count(preview_render_count);
 
-    function show_preview(rendered_content: string, raw_content?: string): void {
-        // content is passed to check for status messages ("/me ...")
-        // and will be undefined in case of errors
-        let rendered_preview_html;
-        if (raw_content !== undefined && markdown.is_status_message(raw_content)) {
-            // Handle previews of /me messages
-            rendered_preview_html =
-                "<p><strong>" +
-                _.escape(current_user.full_name) +
-                "</strong>" +
-                rendered_content.slice("<p>/me".length);
-        } else {
-            rendered_preview_html = rendered_content;
-        }
-
-        $preview_content_box.html(postprocess_content(rendered_preview_html));
-        rendered_markdown.update_elements($preview_content_box);
-
-        // Check for thumbnail loading placeholders and start polling
-        clear_thumbnail_polling();
-        pending_thumbnail_paths = extract_thumbnail_paths($preview_content_box);
-
-        if (pending_thumbnail_paths.size > 0) {
-            void poll_thumbnail_status(
-                $preview_container,
-                $preview_spinner,
-                $preview_content_box,
-                content,
-            );
-        }
-    }
-
     if (content.length === 0) {
-        show_preview($t_html({defaultMessage: "Nothing to preview"}));
+        apply_preview_render(
+            $preview_container,
+            $preview_spinner,
+            $preview_content_box,
+            content,
+            $t_html({defaultMessage: "Nothing to preview"}),
+        );
     } else {
         if (markdown.contains_backend_only_syntax(content) && show_spinner) {
             const $spinner = $preview_spinner.expectOne();
@@ -1775,7 +1788,13 @@ export function render_and_show_preview(
             // echoed frontend rendering before receiving the
             // authoritative backend rendering from the server).
             const rendered_content = markdown.render(content).content;
-            show_preview(rendered_content);
+            apply_preview_render(
+                $preview_container,
+                $preview_spinner,
+                $preview_content_box,
+                content,
+                rendered_content,
+            );
         }
         void channel.post({
             url: "/json/messages/render",
@@ -1795,13 +1814,26 @@ export function render_and_show_preview(
                 if (markdown.contains_backend_only_syntax(content)) {
                     loading.destroy_indicator($preview_spinner);
                 }
-                show_preview(data.rendered, content);
+                apply_preview_render(
+                    $preview_container,
+                    $preview_spinner,
+                    $preview_content_box,
+                    content,
+                    data.rendered,
+                    content,
+                );
             },
             error() {
                 if (markdown.contains_backend_only_syntax(content)) {
                     loading.destroy_indicator($preview_spinner);
                 }
-                show_preview($t_html({defaultMessage: "Failed to generate preview"}));
+                apply_preview_render(
+                    $preview_container,
+                    $preview_spinner,
+                    $preview_content_box,
+                    content,
+                    $t_html({defaultMessage: "Failed to generate preview"}),
+                );
             },
         });
     }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1763,8 +1763,13 @@ export function rewire_apply_preview_render(value: typeof apply_preview_render):
 }
 
 // Separate from compose_state's render count, which the message-edit preview
-// shares and so must not be superseded from here.
-let embed_update_count = 0;
+// shares and so must not be superseded from here. Kept per preview, since the
+// compose box and each message-edit row render independently.
+const embed_update_counts = new WeakMap<HTMLElement, number>();
+
+function get_embed_update_count($preview_container: JQuery): number {
+    return embed_update_counts.get(util.the($preview_container)) ?? 0;
+}
 
 export function render_and_show_preview(
     $preview_container: JQuery,
@@ -1772,7 +1777,7 @@ export function render_and_show_preview(
     $preview_content_box: JQuery,
     content: string,
     show_spinner = true,
-    // Only the compose preview consumes the resulting event.
+    // The drafts overlay has no open preview to live-update.
     populate_url_embed_data = false,
 ): void {
     if (prevent_next_spinner) {
@@ -1781,7 +1786,7 @@ export function render_and_show_preview(
 
     const preview_render_count = compose_state.get_preview_render_count() + 1;
     compose_state.set_preview_render_count(preview_render_count);
-    const link_preview_update_count_at_request = embed_update_count;
+    const embed_update_count_at_request = get_embed_update_count($preview_container);
 
     if (content.length === 0) {
         apply_preview_render(
@@ -1837,7 +1842,7 @@ export function render_and_show_preview(
                 }
                 if (
                     populate_url_embed_data &&
-                    link_preview_update_count_at_request !== embed_update_count
+                    embed_update_count_at_request !== get_embed_update_count($preview_container)
                 ) {
                     // This response predates embeds an update already
                     // applied, so applying it would drop their cards.
@@ -1871,24 +1876,35 @@ export function render_and_show_preview(
     }
 }
 
-// Live-update the open compose preview with the embed_links worker's re-render.
-export function update_compose_preview_embeds(content: string, rendered_content: string): void {
-    const $preview_container = $("#compose");
+// Live-update one open preview with the embed_links worker's re-render. The
+// caller has already checked that the preview still shows this content.
+export function apply_embeds_to_preview(
+    $preview_container: JQuery,
+    content: string,
+    rendered_content: string,
+): void {
     if (!$preview_container.hasClass("preview_mode")) {
         return;
     }
-    if (content !== compose_state.message_content()) {
-        return;
-    }
     // Supersede any in-flight render whose response predates the embeds.
-    embed_update_count += 1;
+    embed_update_counts.set(
+        util.the($preview_container),
+        get_embed_update_count($preview_container) + 1,
+    );
     apply_preview_render(
         $preview_container,
-        $("#compose .markdown_preview_spinner"),
-        $("#compose .preview_content"),
+        $preview_container.find(".markdown_preview_spinner"),
+        $preview_container.find(".preview_content"),
         content,
         rendered_content,
         content,
         true,
     );
+}
+
+export function update_compose_preview_embeds(content: string, rendered_content: string): void {
+    if (content !== compose_state.message_content()) {
+        return;
+    }
+    apply_embeds_to_preview($("#compose"), content, rendered_content);
 }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1611,6 +1611,8 @@ async function poll_thumbnail_status(
     $preview_spinner: JQuery,
     $preview_content_box: JQuery,
     content: string,
+    // Threaded through so a thumbnail re-render doesn't drop a shown card.
+    fetch_link_previews = false,
     attempt = 1,
 ): Promise<void> {
     if (attempt > MAX_THUMBNAIL_RETRIES) {
@@ -1650,6 +1652,7 @@ async function poll_thumbnail_status(
                 $preview_content_box,
                 content,
                 false,
+                fetch_link_previews,
             );
             return;
         }
@@ -1662,6 +1665,7 @@ async function poll_thumbnail_status(
                     $preview_spinner,
                     $preview_content_box,
                     content,
+                    fetch_link_previews,
                     attempt + 1,
                 );
             }, retry_delay_secs * 1000);
@@ -1713,14 +1717,15 @@ export function exit_preview_mode($container: JQuery): void {
     $container.find(".markdown_preview").show();
 }
 
-function apply_preview_render(
+export let apply_preview_render = (
     $preview_container: JQuery,
     $preview_spinner: JQuery,
     $preview_content_box: JQuery,
     content: string,
     rendered_content: string,
     raw_content?: string,
-): void {
+    fetch_link_previews = false,
+): void => {
     // raw_content is checked for status messages ("/me ..."); it's
     // undefined when we have no authoritative raw content (e.g. errors).
     let rendered_preview_html;
@@ -1748,8 +1753,13 @@ function apply_preview_render(
             $preview_spinner,
             $preview_content_box,
             content,
+            fetch_link_previews,
         );
     }
+};
+
+export function rewire_apply_preview_render(value: typeof apply_preview_render): void {
+    apply_preview_render = value;
 }
 
 export function render_and_show_preview(
@@ -1758,6 +1768,8 @@ export function render_and_show_preview(
     $preview_content_box: JQuery,
     content: string,
     show_spinner = true,
+    // Only the compose preview consumes the resulting event.
+    fetch_link_previews = false,
 ): void {
     if (prevent_next_spinner) {
         show_spinner = false;
@@ -1773,6 +1785,8 @@ export function render_and_show_preview(
             $preview_content_box,
             content,
             $t_html({defaultMessage: "Nothing to preview"}),
+            undefined,
+            fetch_link_previews,
         );
     } else {
         if (markdown.contains_backend_only_syntax(content) && show_spinner) {
@@ -1794,11 +1808,13 @@ export function render_and_show_preview(
                 $preview_content_box,
                 content,
                 rendered_content,
+                undefined,
+                fetch_link_previews,
             );
         }
         void channel.post({
             url: "/json/messages/render",
-            data: {content},
+            data: {content, fetch_link_previews},
             success(response_data) {
                 if (
                     preview_render_count !== compose_state.get_preview_render_count() ||
@@ -1821,6 +1837,7 @@ export function render_and_show_preview(
                     content,
                     data.rendered,
                     content,
+                    fetch_link_previews,
                 );
             },
             error() {
@@ -1833,8 +1850,32 @@ export function render_and_show_preview(
                     $preview_content_box,
                     content,
                     $t_html({defaultMessage: "Failed to generate preview"}),
+                    undefined,
+                    fetch_link_previews,
                 );
             },
         });
     }
+}
+
+// Live-update the open compose preview with the embed_links worker's re-render.
+export function update_compose_link_preview(content: string, rendered_content: string): void {
+    const $preview_container = $("#compose");
+    if (!$preview_container.hasClass("preview_mode")) {
+        return;
+    }
+    if (content !== compose_state.message_content()) {
+        return;
+    }
+    // Supersede any in-flight render whose response predates the embeds.
+    compose_state.set_preview_render_count(compose_state.get_preview_render_count() + 1);
+    apply_preview_render(
+        $preview_container,
+        $("#compose .markdown_preview_spinner"),
+        $("#compose .preview_content"),
+        content,
+        rendered_content,
+        content,
+        true,
+    );
 }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1611,6 +1611,8 @@ async function poll_thumbnail_status(
     $preview_spinner: JQuery,
     $preview_content_box: JQuery,
     content: string,
+    // Threaded through so a thumbnail re-render doesn't drop a shown card.
+    populate_url_embed_data = false,
     attempt = 1,
 ): Promise<void> {
     if (attempt > MAX_THUMBNAIL_RETRIES) {
@@ -1650,6 +1652,7 @@ async function poll_thumbnail_status(
                 $preview_content_box,
                 content,
                 false,
+                populate_url_embed_data,
             );
             return;
         }
@@ -1662,6 +1665,7 @@ async function poll_thumbnail_status(
                     $preview_spinner,
                     $preview_content_box,
                     content,
+                    populate_url_embed_data,
                     attempt + 1,
                 );
             }, retry_delay_secs * 1000);
@@ -1713,14 +1717,15 @@ export function exit_preview_mode($container: JQuery): void {
     $container.find(".markdown_preview").show();
 }
 
-function apply_preview_render(
+export let apply_preview_render = (
     $preview_container: JQuery,
     $preview_spinner: JQuery,
     $preview_content_box: JQuery,
     content: string,
     rendered_content: string,
     raw_content?: string,
-): void {
+    populate_url_embed_data = false,
+): void => {
     // raw_content is checked for status messages ("/me ..."); it's
     // undefined when we have no authoritative raw content (e.g. errors).
     let rendered_preview_html;
@@ -1748,9 +1753,18 @@ function apply_preview_render(
             $preview_spinner,
             $preview_content_box,
             content,
+            populate_url_embed_data,
         );
     }
+};
+
+export function rewire_apply_preview_render(value: typeof apply_preview_render): void {
+    apply_preview_render = value;
 }
+
+// Separate from compose_state's render count, which the message-edit preview
+// shares and so must not be superseded from here.
+let embed_update_count = 0;
 
 export function render_and_show_preview(
     $preview_container: JQuery,
@@ -1758,6 +1772,8 @@ export function render_and_show_preview(
     $preview_content_box: JQuery,
     content: string,
     show_spinner = true,
+    // Only the compose preview consumes the resulting event.
+    populate_url_embed_data = false,
 ): void {
     if (prevent_next_spinner) {
         show_spinner = false;
@@ -1765,6 +1781,7 @@ export function render_and_show_preview(
 
     const preview_render_count = compose_state.get_preview_render_count() + 1;
     compose_state.set_preview_render_count(preview_render_count);
+    const link_preview_update_count_at_request = embed_update_count;
 
     if (content.length === 0) {
         apply_preview_render(
@@ -1773,6 +1790,8 @@ export function render_and_show_preview(
             $preview_content_box,
             content,
             $t_html({defaultMessage: "Nothing to preview"}),
+            undefined,
+            populate_url_embed_data,
         );
     } else {
         if (markdown.contains_backend_only_syntax(content) && show_spinner) {
@@ -1794,11 +1813,13 @@ export function render_and_show_preview(
                 $preview_content_box,
                 content,
                 rendered_content,
+                undefined,
+                populate_url_embed_data,
             );
         }
         void channel.post({
             url: "/json/messages/render",
-            data: {content},
+            data: {content, populate_url_embed_data},
             success(response_data) {
                 if (
                     preview_render_count !== compose_state.get_preview_render_count() ||
@@ -1814,6 +1835,14 @@ export function render_and_show_preview(
                 if (markdown.contains_backend_only_syntax(content)) {
                     loading.destroy_indicator($preview_spinner);
                 }
+                if (
+                    populate_url_embed_data &&
+                    link_preview_update_count_at_request !== embed_update_count
+                ) {
+                    // This response predates embeds an update already
+                    // applied, so applying it would drop their cards.
+                    return;
+                }
                 apply_preview_render(
                     $preview_container,
                     $preview_spinner,
@@ -1821,6 +1850,7 @@ export function render_and_show_preview(
                     content,
                     data.rendered,
                     content,
+                    populate_url_embed_data,
                 );
             },
             error() {
@@ -1833,8 +1863,32 @@ export function render_and_show_preview(
                     $preview_content_box,
                     content,
                     $t_html({defaultMessage: "Failed to generate preview"}),
+                    undefined,
+                    populate_url_embed_data,
                 );
             },
         });
     }
+}
+
+// Live-update the open compose preview with the embed_links worker's re-render.
+export function update_compose_preview_embeds(content: string, rendered_content: string): void {
+    const $preview_container = $("#compose");
+    if (!$preview_container.hasClass("preview_mode")) {
+        return;
+    }
+    if (content !== compose_state.message_content()) {
+        return;
+    }
+    // Supersede any in-flight render whose response predates the embeds.
+    embed_update_count += 1;
+    apply_preview_render(
+        $preview_container,
+        $("#compose .markdown_preview_spinner"),
+        $("#compose .preview_content"),
+        content,
+        rendered_content,
+        content,
+        true,
+    );
 }

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1860,10 +1860,24 @@ export function render_preview_area($row: JQuery): void {
         $row.find(".markdown_preview_spinner"),
         $row.find(".preview_content"),
         content,
+        true,
+        true,
     );
     const edit_height = $msg_edit_content.height();
     $preview_message_area.css({"min-height": edit_height + "px"});
     $preview_message_area.show();
+}
+
+export function update_preview_embeds(content: string, rendered_content: string): void {
+    for (const $message_edit_content of currently_editing_messages.values()) {
+        if ($message_edit_content.val() === content) {
+            compose_ui.apply_embeds_to_preview(
+                $message_edit_content.closest(".message_row"),
+                content,
+                rendered_content,
+            );
+        }
+    }
 }
 
 export function clear_preview_area($element: JQuery): void {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -16,6 +16,7 @@ import * as compose_closed_ui from "./compose_closed_ui.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
+import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
 import {electron_bridge} from "./electron_bridge.ts";
 import * as emoji from "./emoji.ts";
@@ -161,6 +162,9 @@ export function dispatch_normal_event(event) {
             }
             break;
 
+        case "compose_link_preview":
+            compose_ui.update_compose_link_preview(event.content, event.rendered_content);
+            break;
         case "custom_profile_fields":
             realm.custom_profile_fields = event.fields;
             settings_profile_fields.populate_profile_fields(realm.custom_profile_fields);

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -16,6 +16,7 @@ import * as compose_closed_ui from "./compose_closed_ui.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
+import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
 import * as condense from "./condense.ts";
 import {electron_bridge} from "./electron_bridge.ts";
@@ -1201,6 +1202,10 @@ export function dispatch_normal_event(event) {
             }
             break;
         }
+
+        case "url_embed_data":
+            compose_ui.update_compose_preview_embeds(event.content, event.rendered_content);
+            break;
 
         case "user_group":
             switch (event.op) {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -1205,6 +1205,7 @@ export function dispatch_normal_event(event) {
 
         case "url_embed_data":
             compose_ui.update_compose_preview_embeds(event.content, event.rendered_content);
+            message_edit.update_preview_embeds(event.content, event.rendered_content);
             break;
 
         case "user_group":

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -768,6 +768,7 @@ test_ui("on_events", ({override, override_rewire}) => {
             assert.equal(payload.url, "/json/messages/render");
             assert.ok(payload.data);
             assert.deepEqual(payload.data.content, current_message);
+            assert.equal(payload.data.fetch_link_previews, true);
 
             function test(func, param) {
                 let destroy_indicator_called = false;

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -768,6 +768,7 @@ test_ui("on_events", ({override, override_rewire}) => {
             assert.equal(payload.url, "/json/messages/render");
             assert.ok(payload.data);
             assert.deepEqual(payload.data.content, current_message);
+            assert.equal(payload.data.populate_url_embed_data, true);
 
             function test(func, param) {
                 let destroy_indicator_called = false;

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -25,6 +25,7 @@ mock_esm("../src/message_lists", {
 });
 
 const compose_ui = zrequire("compose_ui");
+const compose_state = zrequire("compose_state");
 const linkifiers = zrequire("linkifiers");
 const stream_data = zrequire("stream_data");
 stream_data.set_channel_has_locally_available_topic(() => false);
@@ -1591,4 +1592,41 @@ run_test("maybe_set_compose_textarea_typeahead ignores edit box typeaheads", () 
     };
     compose_ui.maybe_set_compose_textarea_typeahead(edit_typeahead);
     assert.equal(compose_ui.compose_textarea_typeahead, compose_typeahead);
+});
+
+run_test("update_compose_link_preview", ({override_rewire}) => {
+    let apply_args;
+    override_rewire(compose_ui, "apply_preview_render", (...args) => {
+        apply_args = args;
+    });
+
+    const $compose = $("#compose");
+    const content = "http://example.com/";
+    const rendered_content = '<p><a href="http://example.com/">example</a></p>';
+    $("textarea#compose-textarea").val(content);
+
+    // Not in preview mode: the update is ignored.
+    $compose.removeClass("preview_mode");
+    apply_args = undefined;
+    compose_ui.update_compose_link_preview(content, rendered_content);
+    assert.equal(apply_args, undefined);
+
+    // In preview mode but the draft changed since the fetch: ignored.
+    $compose.addClass("preview_mode");
+    $("textarea#compose-textarea").val("http://example.com/ edited");
+    apply_args = undefined;
+    compose_ui.update_compose_link_preview(content, rendered_content);
+    assert.equal(apply_args, undefined);
+
+    // In preview mode and the draft still matches: apply the render.
+    $("textarea#compose-textarea").val(content);
+    apply_args = undefined;
+    const render_count_before = compose_state.get_preview_render_count();
+    compose_ui.update_compose_link_preview(content, rendered_content);
+    assert.ok(apply_args !== undefined);
+    assert.equal(apply_args[3], content);
+    assert.equal(apply_args[4], rendered_content);
+    assert.equal(apply_args[5], content);
+    assert.equal(apply_args[6], true);
+    assert.equal(compose_state.get_preview_render_count(), render_count_before + 1);
 });

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -24,7 +24,12 @@ mock_esm("../src/message_lists", {
     current: {},
 });
 
+const rendered_markdown = mock_esm("../src/rendered_markdown");
+const channel = mock_esm("../src/channel");
+const loading = mock_esm("../src/loading");
+
 const compose_ui = zrequire("compose_ui");
+const compose_state = zrequire("compose_state");
 const linkifiers = zrequire("linkifiers");
 const stream_data = zrequire("stream_data");
 stream_data.set_channel_has_locally_available_topic(() => false);
@@ -1591,4 +1596,89 @@ run_test("maybe_set_compose_textarea_typeahead ignores edit box typeaheads", () 
     };
     compose_ui.maybe_set_compose_textarea_typeahead(edit_typeahead);
     assert.equal(compose_ui.compose_textarea_typeahead, compose_typeahead);
+});
+
+run_test("update_compose_preview_embeds", ({override}) => {
+    override(rendered_markdown, "update_elements", noop);
+
+    const $compose = $("#compose");
+    const $preview_content = $("#compose .preview_content");
+    $preview_content.set_find_results(
+        ".image-loading-placeholder",
+        $.create("no-images", {elements: []}),
+    );
+
+    const content = "http://example.com/";
+    const rendered_content = "<p>draft with an embed</p>";
+    const already_shown = "<p>draft without an embed</p>";
+    $("textarea#compose-textarea").val(content);
+
+    // Not in preview mode: the update is ignored.
+    $compose.removeClass("preview_mode");
+    $preview_content.html(already_shown);
+    compose_ui.update_compose_preview_embeds(content, rendered_content);
+    assert.equal($preview_content.html(), already_shown);
+
+    // In preview mode but the draft changed since the fetch: ignored.
+    $compose.addClass("preview_mode");
+    $("textarea#compose-textarea").val("http://example.com/ edited");
+    compose_ui.update_compose_preview_embeds(content, rendered_content);
+    assert.equal($preview_content.html(), already_shown);
+
+    // In preview mode and the draft still matches: the embeds are applied.
+    $("textarea#compose-textarea").val(content);
+    compose_ui.update_compose_preview_embeds(content, rendered_content);
+    assert.equal($preview_content.html(), rendered_content);
+
+    // The message-edit preview shares this count, so disturbing it here
+    // would cancel an unrelated edit-box render.
+    const render_count_before = compose_state.get_preview_render_count();
+    compose_ui.update_compose_preview_embeds(content, rendered_content);
+    assert.equal(compose_state.get_preview_render_count(), render_count_before);
+});
+
+run_test("url_embed_data outlives an older render response", ({override}) => {
+    override(rendered_markdown, "update_elements", noop);
+
+    const $compose = $("#compose");
+    const $preview_content = $("#compose .preview_content");
+    $preview_content.set_find_results(
+        ".image-loading-placeholder",
+        $.create("no-images", {elements: []}),
+    );
+    $compose.addClass("preview_mode");
+
+    // The topic wildcard mention is backend-only syntax, so a spinner is
+    // shown and only the render response tears it down.
+    const content = "@**topic** http://example.com/";
+    $("textarea#compose-textarea").val(content);
+    const with_embed = "<p>draft with an embed</p>";
+    const without_embed = "<p>draft without an embed</p>";
+
+    let render_success;
+    override(loading, "make_indicator", noop);
+    override(channel, "post", (payload) => {
+        render_success = payload.success;
+    });
+    compose_ui.render_and_show_preview(
+        $compose,
+        $("#compose .markdown_preview_spinner"),
+        $preview_content,
+        content,
+        true,
+        true,
+    );
+
+    compose_ui.update_compose_preview_embeds(content, with_embed);
+    assert.equal($preview_content.html(), with_embed);
+
+    let destroy_indicator_called = false;
+    override(loading, "destroy_indicator", () => {
+        destroy_indicator_called = true;
+    });
+    render_success({msg: "", result: "success", rendered: without_embed});
+
+    assert.equal($preview_content.html(), with_embed);
+    // Discarding the response must not also leave its spinner behind.
+    assert.ok(destroy_indicator_called);
 });

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -1607,6 +1607,8 @@ run_test("update_compose_preview_embeds", ({override}) => {
         ".image-loading-placeholder",
         $.create("no-images", {elements: []}),
     );
+    $compose.set_find_results(".markdown_preview_spinner", $("#compose .markdown_preview_spinner"));
+    $compose.set_find_results(".preview_content", $preview_content);
 
     const content = "http://example.com/";
     const rendered_content = "<p>draft with an embed</p>";
@@ -1637,6 +1639,32 @@ run_test("update_compose_preview_embeds", ({override}) => {
     assert.equal(compose_state.get_preview_render_count(), render_count_before);
 });
 
+run_test("apply_embeds_to_preview updates any preview that is open", ({override}) => {
+    override(rendered_markdown, "update_elements", noop);
+
+    const content = "http://example.com/";
+    const rendered_content = "<p>message with an embed</p>";
+    const already_shown = "<p>message without an embed</p>";
+
+    const $preview_content = $.create("edit-row .preview_content");
+    $preview_content.set_find_results(
+        ".image-loading-placeholder",
+        $.create("edit-row no-images", {elements: []}),
+    );
+    const $edit_row = $.create("edit-row");
+    $edit_row.set_find_results(".markdown_preview_spinner", $.create("edit-row spinner"));
+    $edit_row.set_find_results(".preview_content", $preview_content);
+
+    // The edit box is not previewing: nothing to update.
+    $preview_content.html(already_shown);
+    compose_ui.apply_embeds_to_preview($edit_row, content, rendered_content);
+    assert.equal($preview_content.html(), already_shown);
+
+    $edit_row.addClass("preview_mode");
+    compose_ui.apply_embeds_to_preview($edit_row, content, rendered_content);
+    assert.equal($preview_content.html(), rendered_content);
+});
+
 run_test("url_embed_data outlives an older render response", ({override}) => {
     override(rendered_markdown, "update_elements", noop);
 
@@ -1646,6 +1674,8 @@ run_test("url_embed_data outlives an older render response", ({override}) => {
         ".image-loading-placeholder",
         $.create("no-images", {elements: []}),
     );
+    $compose.set_find_results(".markdown_preview_spinner", $("#compose .markdown_preview_spinner"));
+    $compose.set_find_results(".preview_content", $preview_content);
     $compose.addClass("preview_mode");
 
     // The topic wildcard mention is backend-only syntax, so a spinner is

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -45,6 +45,10 @@ mock_esm("../src/compose_validate", {
     warn_if_guest_in_dm_recipient: noop,
 });
 const condense = mock_esm("../src/condense");
+const message_edit = mock_esm("../src/message_edit", {
+    update_inline_topic_edit_ui() {},
+    update_preview_embeds() {},
+});
 const message_events = mock_esm("../src/message_events", {
     update_views_filtered_on_message_property: noop,
     update_current_view_for_topic_visibility: noop,
@@ -1085,9 +1089,13 @@ run_test("submessage", ({override}) => {
 run_test("url_embed_data", ({override}) => {
     const event = event_fixtures.url_embed_data;
     const stub = make_stub();
+    const message_edit_stub = make_stub();
     override(compose_ui, "update_compose_preview_embeds", stub.f);
+    override(message_edit, "update_preview_embeds", message_edit_stub.f);
     dispatch(event);
     assert.equal(stub.num_calls, 1);
+    // The message-edit preview consumes the same event.
+    assert.equal(message_edit_stub.num_calls, 1);
     const args = stub.get_args("content", "rendered_content");
     assert_same(args.content, event.content);
     assert_same(args.rendered_content, event.rendered_content);

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -26,6 +26,7 @@ const attachments_ui = mock_esm("../src/attachments_ui");
 const audible_notifications = mock_esm("../src/audible_notifications");
 const bot_data = mock_esm("../src/bot_data");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
+const compose_ui = mock_esm("../src/compose_ui");
 const {electron_bridge} = mock_esm("../src/electron_bridge", {
     electron_bridge: {},
 });
@@ -1079,6 +1080,17 @@ run_test("submessage", ({override}) => {
 });
 
 // For subscriptions, see dispatch_subs.test.cjs
+
+run_test("compose_link_preview", ({override}) => {
+    const event = event_fixtures.compose_link_preview;
+    const stub = make_stub();
+    override(compose_ui, "update_compose_link_preview", stub.f);
+    dispatch(event);
+    assert.equal(stub.num_calls, 1);
+    const args = stub.get_args("content", "rendered_content");
+    assert_same(args.content, event.content);
+    assert_same(args.rendered_content, event.rendered_content);
+});
 
 run_test("typing", ({override}) => {
     // Simulate that we are not typing.

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -26,6 +26,7 @@ const attachments_ui = mock_esm("../src/attachments_ui");
 const audible_notifications = mock_esm("../src/audible_notifications");
 const bot_data = mock_esm("../src/bot_data");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
+const compose_ui = mock_esm("../src/compose_ui");
 const {electron_bridge} = mock_esm("../src/electron_bridge", {
     electron_bridge: {},
 });
@@ -1080,6 +1081,17 @@ run_test("submessage", ({override}) => {
 });
 
 // For subscriptions, see dispatch_subs.test.cjs
+
+run_test("url_embed_data", ({override}) => {
+    const event = event_fixtures.url_embed_data;
+    const stub = make_stub();
+    override(compose_ui, "update_compose_preview_embeds", stub.f);
+    dispatch(event);
+    assert.equal(stub.num_calls, 1);
+    const args = stub.get_args("content", "rendered_content");
+    assert_same(args.content, event.content);
+    assert_same(args.rendered_content, event.rendered_content);
+});
 
 run_test("typing", ({override}) => {
     // Simulate that we are not typing.

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -206,6 +206,12 @@ exports.fixtures = {
         },
     },
 
+    compose_link_preview: {
+        type: "compose_link_preview",
+        content: "http://example.com/",
+        rendered_content: '<p><a href="http://example.com/">http://example.com/</a></p>',
+    },
+
     custom_profile_fields: {
         type: "custom_profile_fields",
         fields: [

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -1002,6 +1002,12 @@ exports.fixtures = {
         all: false,
     },
 
+    url_embed_data: {
+        type: "url_embed_data",
+        content: "http://example.com/",
+        rendered_content: '<p><a href="http://example.com/">http://example.com/</a></p>',
+    },
+
     user_group__add: {
         type: "user_group",
         op: "add",

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -5,12 +5,14 @@ const assert = require("node:assert/strict");
 const {make_realm} = require("./lib/example_realm.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
 
 const message_edit = zrequire("message_edit");
 const {set_current_user, set_realm} = zrequire("state_data");
 
 const is_content_editable = message_edit.is_content_editable;
 
+const compose_ui = mock_esm("../src/compose_ui");
 const stream_data = mock_esm("../src/stream_data");
 
 const realm = make_realm();
@@ -303,4 +305,30 @@ run_test("stream_and_topic_exist_in_edit_history", () => {
         ),
         false,
     );
+});
+
+run_test("update_preview_embeds", ({override}) => {
+    const content = "http://example.com/";
+    const rendered_content = "<p>message with an embed</p>";
+    const $row = $.create("message row being edited");
+    const $message_edit_content = $.create("textarea.message_edit_content");
+    $message_edit_content.set_closest_results(".message_row", $row);
+    message_edit.currently_editing_messages.set(17, $message_edit_content);
+
+    const applied_to = [];
+    override(compose_ui, "apply_embeds_to_preview", ($preview_container) => {
+        applied_to.push($preview_container.selector);
+    });
+
+    // The message has been edited since the fetch: the update is dropped.
+    $message_edit_content.val("http://example.com/ edited");
+    message_edit.update_preview_embeds(content, rendered_content);
+    assert.equal(applied_to.length, 0);
+
+    // The edit box still holds the content that was rendered.
+    $message_edit_content.val(content);
+    message_edit.update_preview_embeds(content, rendered_content);
+    assert.deepEqual(applied_to, ["message row being edited"]);
+
+    message_edit.currently_editing_messages.clear();
 });

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -25,7 +25,14 @@ from zerver.actions.user_topics import (
 )
 from zerver.lib.addressee import Addressee
 from zerver.lib.alert_words import get_alert_word_automaton
-from zerver.lib.cache import cache_with_key, user_profile_delivery_email_cache_key
+from zerver.lib.cache import (
+    cache_get,
+    cache_set,
+    cache_with_key,
+    compose_preview_pending_cache_key,
+    preview_url_cache_key,
+    user_profile_delivery_email_cache_key,
+)
 from zerver.lib.create_user import create_user
 from zerver.lib.exceptions import (
     DirectMessageInitiationError,
@@ -124,7 +131,7 @@ from zerver.models.streams import (
     get_stream_by_id_in_realm,
 )
 from zerver.models.users import get_system_bot, get_user_by_delivery_email, is_cross_realm_bot_email
-from zerver.tornado.django_api import send_event_on_commit
+from zerver.tornado.django_api import send_event_on_commit, send_event_rollback_unsafe
 
 
 def compute_irc_user_fullname(email: str) -> str:
@@ -191,6 +198,89 @@ def render_incoming_message(
     except MarkdownRenderingError:
         raise JsonableError(_("Unable to render message"))
     return rendering_result
+
+
+def render_message_for_compose_preview(
+    sender: UserProfile,
+    content: str,
+    *,
+    url_embed_data: dict[str, UrlEmbedData | None] | None = None,
+) -> MessageRenderingResult:
+    message = Message()
+    message.sender = sender
+    message.realm = sender.realm
+    message.content = content
+    try:
+        return render_message_markdown(
+            message=message,
+            content=content,
+            realm=sender.realm,
+            url_embed_data=url_embed_data,
+        )
+    except MarkdownRenderingError:
+        raise JsonableError(_("Unable to render message"))
+
+
+# Short enough that a fetch which never populated the cache is retried by a
+# later preview.
+COMPOSE_PREVIEW_FETCH_PENDING_TIMEOUT_SECONDS = 60
+
+
+def get_compose_preview_embeds_and_enqueue_fetch(
+    sender: UserProfile,
+    content: str,
+    links_for_preview: set[str],
+) -> dict[str, UrlEmbedData | None]:
+    """Return the cached embeds to bake into the render, and enqueue an
+    embed_links job for the rest.
+
+    The job lists *every* previewable link, since the client swaps in the
+    worker's re-render, which would otherwise drop the cached links' cards.
+
+    The pending marker is keyed on the draft the job will deliver, not the
+    link, because a job for a draft the user has since edited renders content
+    the client discards.
+    """
+    url_embed_data: dict[str, UrlEmbedData | None] = {}
+    has_uncached_link = False
+    for url in links_for_preview:
+        cache_entry = cache_get(preview_url_cache_key(url))
+        if cache_entry is None:
+            has_uncached_link = True
+        else:
+            # cache_with_key stores values in a singleton tuple.
+            url_embed_data[url] = cache_entry[0]
+
+    # A draft too long to send isn't worth fetching previews for, and this
+    # bounds the content we copy into the queue and the event.
+    if has_uncached_link and len(content) <= settings.MAX_MESSAGE_LENGTH:
+        pending_cache_key = compose_preview_pending_cache_key(sender.id, content)
+        if cache_get(pending_cache_key) is None:
+            cache_set(
+                pending_cache_key,
+                True,
+                timeout=COMPOSE_PREVIEW_FETCH_PENDING_TIMEOUT_SECONDS,
+            )
+            queue_event_on_commit(
+                "embed_links",
+                {
+                    "compose_preview": True,
+                    "user_id": sender.id,
+                    "content": content,
+                    "urls": list(links_for_preview),
+                },
+            )
+
+    return url_embed_data
+
+
+def do_send_compose_link_preview(sender: UserProfile, content: str, rendered_content: str) -> None:
+    event = {
+        "type": "compose_link_preview",
+        "content": content,
+        "rendered_content": rendered_content,
+    }
+    send_event_rollback_unsafe(sender.realm, event, [sender.id])
 
 
 @dataclass

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -25,7 +25,15 @@ from zerver.actions.user_topics import (
 )
 from zerver.lib.addressee import Addressee
 from zerver.lib.alert_words import get_alert_word_automaton
-from zerver.lib.cache import cache_with_key, user_profile_delivery_email_cache_key
+from zerver.lib.cache import (
+    cache_get,
+    cache_set,
+    cache_with_key,
+    preview_url_cache_key,
+    preview_url_fetch_failed_cache_key,
+    url_embed_data_pending_cache_key,
+    user_profile_delivery_email_cache_key,
+)
 from zerver.lib.create_user import create_user
 from zerver.lib.exceptions import (
     DirectMessageInitiationError,
@@ -203,6 +211,87 @@ def render_incoming_message(
     except MarkdownRenderingError:
         raise JsonableError(_("Unable to render message"))
     return rendering_result
+
+
+def render_unsaved_message(
+    sender: UserProfile,
+    content: str,
+    *,
+    url_embed_data: dict[str, UrlEmbedData | None] | None = None,
+) -> MessageRenderingResult:
+    message = Message()
+    message.sender = sender
+    message.realm = sender.realm
+    message.content = content
+    return render_message_markdown(
+        message=message,
+        content=content,
+        realm=sender.realm,
+        url_embed_data=url_embed_data,
+    )
+
+
+URL_EMBED_DATA_PENDING_TIMEOUT_SECONDS = 60
+
+PREVIEW_URL_FETCH_FAILED_TIMEOUT_SECONDS = 60
+
+
+def get_cached_embeds_and_enqueue_fetch(
+    sender: UserProfile,
+    content: str,
+    links_for_preview: set[str],
+) -> dict[str, UrlEmbedData | None]:
+    """Return the cached embeds to bake into the render, and enqueue an
+    embed_links job for the rest.
+
+    The job lists the cached links alongside the ones to fetch, since the
+    client swaps in the worker's re-render, which would otherwise drop the
+    cached links' cards. A link whose fetch we have given up on is left out,
+    so that a sibling link's job does not refetch it.
+
+    The pending marker is keyed on the draft the job will deliver, not the
+    link, because a job for a draft the user has since edited renders content
+    the client discards. It is best-effort: a lost race costs a redundant job.
+    """
+    url_embed_data: dict[str, UrlEmbedData | None] = {}
+    urls_to_fetch = []
+    for url in links_for_preview:
+        cache_entry = cache_get(preview_url_cache_key(url))
+        if cache_entry is not None:
+            # cache_with_key stores values in a singleton tuple.
+            url_embed_data[url] = cache_entry[0]
+        elif cache_get(preview_url_fetch_failed_cache_key(url)) is None:
+            urls_to_fetch.append(url)
+
+    if urls_to_fetch:
+        pending_cache_key = url_embed_data_pending_cache_key(sender.id, content)
+        if cache_get(pending_cache_key) is None:
+            cache_set(
+                pending_cache_key,
+                True,
+                timeout=URL_EMBED_DATA_PENDING_TIMEOUT_SECONDS,
+            )
+            queue_event_on_commit(
+                "embed_links",
+                {
+                    "populate_url_embed_data": True,
+                    "user_id": sender.id,
+                    "content": content,
+                    "urls": [*url_embed_data, *urls_to_fetch],
+                    "uncached_urls": urls_to_fetch,
+                },
+            )
+
+    return url_embed_data
+
+
+def do_send_url_embed_data_event(sender: UserProfile, content: str, rendered_content: str) -> None:
+    event = {
+        "type": "url_embed_data",
+        "content": content,
+        "rendered_content": rendered_content,
+    }
+    send_event_on_commit(sender.realm, event, [sender.id])
 
 
 @dataclass

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -476,6 +476,14 @@ def preview_url_cache_key(url: str) -> str:
     return f"preview_url:{hashlib.sha1(url.encode()).hexdigest()}"
 
 
+def url_embed_data_pending_cache_key(user_profile_id: int, content: str) -> str:
+    return f"url_embed_data_pending:{user_profile_id}:{hashlib.sha1(content.encode()).hexdigest()}"
+
+
+def preview_url_fetch_failed_cache_key(url: str) -> str:
+    return f"preview_url_fetch_failed:{hashlib.sha1(url.encode()).hexdigest()}"
+
+
 def display_recipient_cache_key(recipient_id: int) -> str:
     return f"display_recipient_dict:{recipient_id}"
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -476,6 +476,10 @@ def preview_url_cache_key(url: str) -> str:
     return f"preview_url:{hashlib.sha1(url.encode()).hexdigest()}"
 
 
+def compose_preview_pending_cache_key(user_profile_id: int, content: str) -> str:
+    return f"compose_preview_pending:{user_profile_id}:{hashlib.sha1(content.encode()).hexdigest()}"
+
+
 def display_recipient_cache_key(recipient_id: int) -> str:
     return f"display_recipient_dict:{recipient_id}"
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -26,6 +26,7 @@ from zerver.lib.event_types import (
     ChannelFolderAddEvent,
     ChannelFolderReorderEvent,
     ChannelFolderUpdateEvent,
+    ComposeLinkPreviewEvent,
     CustomProfileFieldsEvent,
     DefaultStreamGroupsEvent,
     DefaultStreamsEvent,
@@ -181,6 +182,7 @@ check_attachment_remove = make_checker(AttachmentRemoveEvent)
 check_attachment_update = make_checker(AttachmentUpdateEvent)
 check_channel_folder_add = make_checker(ChannelFolderAddEvent)
 check_channel_folder_reorder = make_checker(ChannelFolderReorderEvent)
+check_compose_link_preview = make_checker(ComposeLinkPreviewEvent)
 check_custom_profile_fields = make_checker(CustomProfileFieldsEvent)
 check_default_stream_groups = make_checker(DefaultStreamGroupsEvent)
 check_default_streams = make_checker(DefaultStreamsEvent)

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -116,6 +116,7 @@ from zerver.lib.event_types import (
     UpdateMessageEvent,
     UpdateMessageFlagsAddEvent,
     UpdateMessageFlagsRemoveEvent,
+    UrlEmbedDataEvent,
     UserGroupAddEvent,
     UserGroupAddMembersEvent,
     UserGroupAddSubgroupsEvent,
@@ -235,6 +236,7 @@ check_typing_edit_message_start = make_checker(TypingEditMessageStartEvent)
 check_typing_edit_message_stop = make_checker(TypingEditMessageStopEvent)
 check_update_message_flags_add = make_checker(UpdateMessageFlagsAddEvent)
 check_update_message_flags_remove = make_checker(UpdateMessageFlagsRemoveEvent)
+check_url_embed_data = make_checker(UrlEmbedDataEvent)
 check_user_group_add = make_checker(UserGroupAddEvent)
 check_user_group_add_members = make_checker(UserGroupAddMembersEvent)
 check_user_group_add_subgroups = make_checker(UserGroupAddSubgroupsEvent)

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -98,6 +98,12 @@ class ChannelFolderUpdateEvent(BaseEvent):
     data: ChannelFolderDataForUpdate
 
 
+class ComposeLinkPreviewEvent(BaseEvent):
+    type: Literal["compose_link_preview"]
+    content: str
+    rendered_content: str
+
+
 class DetailedCustomProfileCore(BaseModel):
     id: int
     type: int

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1177,6 +1177,12 @@ class Group(BaseModel):
     deactivated: bool
 
 
+class UrlEmbedDataEvent(BaseEvent):
+    type: Literal["url_embed_data"]
+    content: str
+    rendered_content: str
+
+
 class UserGroupAddEvent(BaseEvent):
     type: Literal["user_group"]
     op: Literal["add"]

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1827,6 +1827,9 @@ def apply_event(
     elif event["type"] == "typing_edit_message":
         # Typing message edit notification events are transient and thus ignored
         pass
+    elif event["type"] == "compose_link_preview":
+        # Compose link-preview updates are transient and thus ignored
+        pass
     elif event["type"] == "attachment":
         # Attachment events are just for updating the "uploads" UI;
         # they are not sent directly.

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1827,6 +1827,9 @@ def apply_event(
     elif event["type"] == "typing_edit_message":
         # Typing message edit notification events are transient and thus ignored
         pass
+    elif event["type"] == "url_embed_data":
+        # URL embed data updates are transient and thus ignored
+        pass
     elif event["type"] == "attachment":
         # Attachment events are just for updating the "uploads" UI;
         # they are not sent directly.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3525,6 +3525,48 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
+                                Event sent to a user when the server finishes fetching the
+                                [link previews](/help/image-video-and-website-previews) for a
+                                message draft that the user is previewing in the compose box.
+
+                                Because fetching link previews can be slow, the compose preview
+                                is first shown without them; this event then delivers the draft
+                                re-rendered with the fetched previews so the client can
+                                live-update the open preview. The event is sent only to the
+                                user composing the draft.
+
+                                Clients should apply `rendered_content` only if `content` still
+                                matches the current draft, since the user may have edited the
+                                draft while the previews were being fetched.
+
+                                **Changes**: New in Zulip 13.0 (feature level ZF-4c56a7).
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - compose_link_preview
+                                content:
+                                  type: string
+                                  description: |
+                                    The raw Markdown content of the draft that was re-rendered.
+                                rendered_content:
+                                  type: string
+                                  description: |
+                                    The draft re-rendered as HTML with the fetched link
+                                    previews included.
+                              example:
+                                {
+                                  "type": "compose_link_preview",
+                                  "content": "http://example.com/",
+                                  "rendered_content": '<p><a href="http://example.com/">http://example.com/</a></p>',
+                                  "id": 0,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
                                 Event sent to a user when [message flags][message-flags] are added
                                 to messages.
 
@@ -9948,6 +9990,21 @@ paths:
               properties:
                 content:
                   $ref: "#/components/schemas/RequiredContent"
+                fetch_link_previews:
+                  type: boolean
+                  default: false
+                  example: true
+                  description: |
+                    Whether the server should include
+                    [link previews](/help/image-video-and-website-previews)
+                    for the draft's links: already fetched previews are
+                    included in `rendered`, and the rest are fetched
+                    asynchronously and delivered to the requesting user via a
+                    `compose_link_preview` event once ready. Used by the
+                    compose box's message preview to live-update with
+                    link-preview cards.
+
+                    **Changes**: New in Zulip 13.0 (feature level ZF-4c56a7).
               required:
                 - content
       responses:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3525,6 +3525,49 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
+                                Event sent to a user when the server finishes fetching the
+                                [URL embed data](/help/image-video-and-website-previews) for
+                                content they asked it to render with
+                                `populate_url_embed_data`.
+
+                                Because fetching that data can be slow, the render response
+                                omits what the server did not already have; this event then
+                                delivers the content re-rendered with the fetched data, so the
+                                client can live-update what it is displaying. The event is sent
+                                only to the user who requested the render.
+
+                                Clients should apply `rendered_content` only if `content` still
+                                matches what they are displaying, since the user may have
+                                edited it while the data was being fetched.
+
+                                **Changes**: New in Zulip 13.0 (feature level ZF-4c56a7).
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - url_embed_data
+                                content:
+                                  type: string
+                                  description: |
+                                    The raw Markdown content that was re-rendered.
+                                rendered_content:
+                                  type: string
+                                  description: |
+                                    That content re-rendered as HTML, with the fetched URL
+                                    embed data included.
+                              example:
+                                {
+                                  "type": "url_embed_data",
+                                  "content": "http://example.com/",
+                                  "rendered_content": '<p><a href="http://example.com/">http://example.com/</a></p>',
+                                  "id": 0,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
                                 Event sent to a user when [message flags][message-flags] are added
                                 to messages.
 
@@ -9984,6 +10027,20 @@ paths:
               properties:
                 content:
                   $ref: "#/components/schemas/RequiredContent"
+                populate_url_embed_data:
+                  type: boolean
+                  default: false
+                  example: true
+                  description: |
+                    Whether the server should populate
+                    [URL embed data](/help/image-video-and-website-previews)
+                    for the links in `content`: data the server already has is
+                    included in `rendered`, and the rest is fetched
+                    asynchronously and delivered to the requesting user via a
+                    `url_embed_data` event once ready, so that a client
+                    displaying the rendered content can live-update it.
+
+                    **Changes**: New in Zulip 13.0 (feature level ZF-4c56a7).
               required:
                 - content
       responses:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -66,6 +66,7 @@ from zerver.actions.message_edit import (
     do_update_message,
 )
 from zerver.actions.message_flags import do_update_message_flags
+from zerver.actions.message_send import do_send_compose_link_preview
 from zerver.actions.muted_users import do_mute_user, do_unmute_user
 from zerver.actions.navigation_views import (
     do_add_navigation_view,
@@ -173,6 +174,7 @@ from zerver.lib.event_schema import (
     check_channel_folder_add,
     check_channel_folder_reorder,
     check_channel_folder_update,
+    check_compose_link_preview,
     check_custom_profile_fields,
     check_default_stream_groups,
     check_default_streams,
@@ -1631,6 +1633,13 @@ class NormalActionsTest(BaseAction):
             )
 
         check_invites_changed("events[6]", events[5])
+
+    def test_compose_link_preview_events(self) -> None:
+        with self.verify_action(state_change_expected=False) as events:
+            do_send_compose_link_preview(
+                self.user_profile, "http://example.com/", "<p>rendered</p>"
+            )
+        check_compose_link_preview("events[0]", events[0])
 
     def test_typing_events(self) -> None:
         with self.verify_action(state_change_expected=False) as events:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -66,6 +66,7 @@ from zerver.actions.message_edit import (
     do_update_message,
 )
 from zerver.actions.message_flags import do_update_message_flags
+from zerver.actions.message_send import do_send_url_embed_data_event
 from zerver.actions.muted_users import do_mute_user, do_unmute_user
 from zerver.actions.navigation_views import (
     do_add_navigation_view,
@@ -243,6 +244,7 @@ from zerver.lib.event_schema import (
     check_update_message,
     check_update_message_flags_add,
     check_update_message_flags_remove,
+    check_url_embed_data,
     check_user_group_add,
     check_user_group_add_members,
     check_user_group_add_subgroups,
@@ -1631,6 +1633,13 @@ class NormalActionsTest(BaseAction):
             )
 
         check_invites_changed("events[6]", events[5])
+
+    def test_url_embed_data_events(self) -> None:
+        with self.verify_action(state_change_expected=False) as events:
+            do_send_url_embed_data_event(
+                self.user_profile, "http://example.com/", "<p>rendered</p>"
+            )
+        check_url_embed_data("events[0]", events[0])
 
     def test_typing_events(self) -> None:
         with self.verify_action(state_change_expected=False) as events:

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -12,7 +12,18 @@ from requests.exceptions import ConnectionError
 from typing_extensions import override
 
 from zerver.actions.message_delete import do_delete_messages
-from zerver.lib.cache import cache_delete, cache_get, preview_url_cache_key
+from zerver.actions.message_send import (
+    PREVIEW_URL_FETCH_FAILED_TIMEOUT_SECONDS,
+    render_unsaved_message,
+)
+from zerver.lib.cache import (
+    cache_delete,
+    cache_get,
+    cache_set,
+    preview_url_cache_key,
+    preview_url_fetch_failed_cache_key,
+    url_embed_data_pending_cache_key,
+)
 from zerver.lib.camo import get_camo_url
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.lib.test_classes import ZulipTestCase
@@ -373,6 +384,373 @@ class PreviewTestCase(ZulipTestCase):
         msg = Message.objects.select_related("sender").get(id=msg_id)
         assert msg.rendered_content is not None
         self.assertIn(embedded_link, msg.rendered_content)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_link_embed(self) -> None:
+        # The preview enqueues the fetch; the worker then pushes the embed back.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(url_embed_data_pending_cache_key(user.id, url))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        self.assert_json_success(result)
+        self.assertNotIn("message_embed", result.json()["rendered"])
+
+        patched.assert_called_once()
+        self.assertEqual(patched.call_args[0][0], "embed_links")
+        event = patched.call_args[0][1]
+        self.assertEqual(
+            event,
+            {
+                "populate_url_embed_data": True,
+                "user_id": user.id,
+                "content": url,
+                "urls": [url],
+                "uncached_urls": [url],
+            },
+        )
+
+        self.create_mock_response(url)
+        with (
+            self.settings(TEST_SUITE=False),
+            self.assertLogs(level="INFO") as info_logs,
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            FetchLinksEmbedData().consume(event)
+        self.assertIn(
+            "INFO:root:Time spent on get_link_embed_data for http://test.org/: ",
+            info_logs.output[0],
+        )
+
+        self.assertEqual(events[0]["users"], [user.id])
+        preview_event = events[0]["event"]
+        self.assertEqual(preview_event["type"], "url_embed_data")
+        self.assertEqual(preview_event["content"], url)
+        self.assertIn(
+            f'<a href="{url}" title="The Rock">The Rock</a>',
+            preview_event["rendered_content"],
+        )
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_render_without_populate_url_embed_data_does_not_enqueue(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(url_embed_data_pending_cache_key(user.id, url))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post("/json/messages/render", {"content": url})
+        self.assert_json_success(result)
+        patched.assert_not_called()
+        self.assertIsNone(cache_get(url_embed_data_pending_cache_key(user.id, url)))
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_uses_cached_embed(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        self.create_mock_response(url)
+        get_link_embed_data(url)
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        self.assert_json_success(result)
+        self.assertIn(
+            f'<a href="{url}" title="The Rock">The Rock</a>',
+            result.json()["rendered"],
+        )
+        patched.assert_not_called()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_dedupes_job_for_same_draft(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(url_embed_data_pending_cache_key(user.id, url))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        patched.assert_called_once()
+        self.assertIsNotNone(cache_get(url_embed_data_pending_cache_key(user.id, url)))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        self.assert_json_success(result)
+        patched.assert_not_called()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_enqueues_job_for_edited_draft(self) -> None:
+        # The in-flight job renders the pre-edit draft, which the client
+        # discards, so the edited draft needs a job of its own.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        edited_content = f"{url} hello"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(url_embed_data_pending_cache_key(user.id, url))
+        cache_delete(url_embed_data_pending_cache_key(user.id, edited_content))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        patched.assert_called_once()
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render",
+                {"content": edited_content, "populate_url_embed_data": "true"},
+            )
+        patched.assert_called_once()
+        self.assertEqual(patched.call_args[0][1]["content"], edited_content)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_enqueues_job_for_each_sender(self) -> None:
+        # A job only updates the preview of the user it was enqueued for.
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(url_embed_data_pending_cache_key(hamlet.id, url))
+        cache_delete(url_embed_data_pending_cache_key(othello.id, url))
+
+        self.login_user(hamlet)
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        patched.assert_called_once()
+
+        self.login_user(othello)
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        patched.assert_called_once()
+        self.assertEqual(patched.call_args[0][1]["user_id"], othello.id)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_skips_second_render_for_uncacheable_link(self) -> None:
+        # A link cached as "no preview" renders identically, so skip the second render.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_set(preview_url_cache_key(url), None)
+
+        with (
+            mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched,
+            mock.patch(
+                "zerver.views.message_send.render_unsaved_message",
+                wraps=render_unsaved_message,
+            ) as render_spy,
+        ):
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "populate_url_embed_data": "true"}
+            )
+        self.assert_json_success(result)
+        patched.assert_not_called()
+        render_spy.assert_called_once()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_mixed_cached_and_uncached_links(self) -> None:
+        # The worker's re-render must keep the cached link's card too.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        cached_url = "http://test.org/"
+        uncached_url = "http://example.com/"
+        for url in (cached_url, uncached_url):
+            cache_delete(preview_url_cache_key(url))
+
+        self.create_mock_response(cached_url)
+        get_link_embed_data(cached_url)
+
+        content = f"{cached_url} {uncached_url}"
+        cache_delete(url_embed_data_pending_cache_key(user.id, content))
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": content, "populate_url_embed_data": "true"}
+            )
+        self.assert_json_success(result)
+        self.assertIn(
+            f'<a href="{cached_url}" title="The Rock">The Rock</a>',
+            result.json()["rendered"],
+        )
+        self.assertNotIn(
+            f'<a href="{uncached_url}" title="The Rock">The Rock</a>',
+            result.json()["rendered"],
+        )
+
+        patched.assert_called_once()
+        event = patched.call_args[0][1]
+        self.assertEqual(event["populate_url_embed_data"], True)
+        self.assertEqual(event["content"], content)
+        self.assertEqual(set(event["urls"]), {cached_url, uncached_url})
+        self.assertEqual(event["uncached_urls"], [uncached_url])
+
+        self.create_mock_response(uncached_url)
+        with (
+            self.settings(TEST_SUITE=False),
+            self.assertLogs(level="INFO"),
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            FetchLinksEmbedData().consume(event)
+
+        preview_event = events[0]["event"]
+        self.assertEqual(preview_event["type"], "url_embed_data")
+        self.assertIn(
+            f'<a href="{cached_url}" title="The Rock">The Rock</a>',
+            preview_event["rendered_content"],
+        )
+        self.assertIn(
+            f'<a href="{uncached_url}" title="The Rock">The Rock</a>',
+            preview_event["rendered_content"],
+        )
+
+    def test_compose_preview_sends_no_event_when_nothing_previewable(self) -> None:
+        # The re-render would reproduce the HTML the preview already shows.
+        user = self.example_user("hamlet")
+        url = "http://no-preview.example/"
+        event = {
+            "populate_url_embed_data": True,
+            "user_id": user.id,
+            "content": url,
+            "urls": [url],
+            "uncached_urls": [url],
+        }
+        with (
+            mock.patch.object(
+                FetchLinksEmbedData, "fetch_url_embed_data", return_value={url: None}
+            ),
+            self.capture_send_event_calls(expected_num_events=0),
+        ):
+            FetchLinksEmbedData().consume(event)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_sends_no_event_when_only_cached_links_have_embeds(self) -> None:
+        user = self.example_user("hamlet")
+        cached_url = "http://test.org/"
+        uncached_url = "http://only-uncached.example/"
+        content = f"{cached_url} {uncached_url}"
+        event = {
+            "populate_url_embed_data": True,
+            "user_id": user.id,
+            "content": content,
+            "urls": [cached_url, uncached_url],
+            "uncached_urls": [uncached_url],
+        }
+        with (
+            mock.patch.object(
+                FetchLinksEmbedData,
+                "fetch_url_embed_data",
+                return_value={cached_url: UrlEmbedData(title="The Rock"), uncached_url: None},
+            ),
+            self.capture_send_event_calls(expected_num_events=0),
+        ):
+            FetchLinksEmbedData().consume(event)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_skips_link_whose_fetch_cached_nothing(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://stalls.example/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(preview_url_fetch_failed_cache_key(url))
+
+        event = {
+            "populate_url_embed_data": True,
+            "user_id": user.id,
+            "content": url,
+            "urls": [url],
+            "uncached_urls": [url],
+        }
+        with (
+            mock.patch.object(
+                FetchLinksEmbedData, "fetch_url_embed_data", return_value={url: None}
+            ),
+            self.capture_send_event_calls(expected_num_events=0),
+        ):
+            FetchLinksEmbedData().consume(event)
+        self.assertIsNotNone(cache_get(preview_url_fetch_failed_cache_key(url)))
+
+        content = f"{url} edited"
+        cache_delete(url_embed_data_pending_cache_key(user.id, content))
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": content, "populate_url_embed_data": "true"}
+            )
+        self.assert_json_success(result)
+        patched.assert_not_called()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_omits_failed_link_from_sibling_job(self) -> None:
+        # A link we have given up fetching must not ride along in a job for
+        # its siblings, whose fetch would retry it.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        failed_url = "http://stalls.example/"
+        fresh_url = "http://example.com/"
+        for url in (failed_url, fresh_url):
+            cache_delete(preview_url_cache_key(url))
+            cache_delete(preview_url_fetch_failed_cache_key(url))
+        cache_set(
+            preview_url_fetch_failed_cache_key(failed_url),
+            True,
+            timeout=PREVIEW_URL_FETCH_FAILED_TIMEOUT_SECONDS,
+        )
+
+        content = f"{failed_url} {fresh_url}"
+        cache_delete(url_embed_data_pending_cache_key(user.id, content))
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": content, "populate_url_embed_data": "true"}
+            )
+        self.assert_json_success(result)
+
+        patched.assert_called_once()
+        event = patched.call_args[0][1]
+        self.assertEqual(event["urls"], [fresh_url])
+        self.assertEqual(event["uncached_urls"], [fresh_url])
+
+    def test_compose_preview_skips_deleted_sender(self) -> None:
+        # A deleted sender is dropped without a wasted fetch (looked up first).
+        event = {
+            "populate_url_embed_data": True,
+            "user_id": 1234567890,
+            "content": "http://test.org/",
+            "urls": ["http://test.org/"],
+            "uncached_urls": ["http://test.org/"],
+        }
+        with (
+            mock.patch.object(FetchLinksEmbedData, "fetch_url_embed_data") as mock_fetch,
+            self.capture_send_event_calls(expected_num_events=0),
+        ):
+            FetchLinksEmbedData().consume(event)
+        mock_fetch.assert_not_called()
 
     @responses.activate
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -5,6 +5,7 @@ from unittest import mock
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import responses
+from django.conf import settings
 from django.test import override_settings
 from django.utils.html import escape
 from pyoembed.providers import get_provider
@@ -12,7 +13,14 @@ from requests.exceptions import ConnectionError
 from typing_extensions import override
 
 from zerver.actions.message_delete import do_delete_messages
-from zerver.lib.cache import cache_delete, cache_get, preview_url_cache_key
+from zerver.actions.message_send import render_message_for_compose_preview
+from zerver.lib.cache import (
+    cache_delete,
+    cache_get,
+    cache_set,
+    compose_preview_pending_cache_key,
+    preview_url_cache_key,
+)
 from zerver.lib.camo import get_camo_url
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.lib.test_classes import ZulipTestCase
@@ -373,6 +381,298 @@ class PreviewTestCase(ZulipTestCase):
         msg = Message.objects.select_related("sender").get(id=msg_id)
         assert msg.rendered_content is not None
         self.assertIn(embedded_link, msg.rendered_content)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_link_embed(self) -> None:
+        # The preview enqueues the fetch; the worker then pushes the embed back.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(compose_preview_pending_cache_key(user.id, url))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        self.assert_json_success(result)
+        self.assertNotIn("message_embed", result.json()["rendered"])
+
+        patched.assert_called_once()
+        self.assertEqual(patched.call_args[0][0], "embed_links")
+        event = patched.call_args[0][1]
+        self.assertEqual(
+            event,
+            {
+                "compose_preview": True,
+                "user_id": user.id,
+                "content": url,
+                "urls": [url],
+            },
+        )
+
+        self.create_mock_response(url)
+        with (
+            self.settings(TEST_SUITE=False),
+            self.assertLogs(level="INFO") as info_logs,
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            FetchLinksEmbedData().consume(event)
+        self.assertIn(
+            "INFO:root:Time spent on get_link_embed_data for http://test.org/: ",
+            info_logs.output[0],
+        )
+
+        self.assertEqual(events[0]["users"], [user.id])
+        preview_event = events[0]["event"]
+        self.assertEqual(preview_event["type"], "compose_link_preview")
+        self.assertEqual(preview_event["content"], url)
+        self.assertIn(
+            f'<a href="{url}" title="The Rock">The Rock</a>',
+            preview_event["rendered_content"],
+        )
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_render_without_fetch_link_previews_flag_does_not_enqueue(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(compose_preview_pending_cache_key(user.id, url))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post("/json/messages/render", {"content": url})
+        self.assert_json_success(result)
+        patched.assert_not_called()
+        self.assertIsNone(cache_get(compose_preview_pending_cache_key(user.id, url)))
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_uses_cached_embed(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        self.create_mock_response(url)
+        get_link_embed_data(url)
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        self.assert_json_success(result)
+        self.assertIn(
+            f'<a href="{url}" title="The Rock">The Rock</a>',
+            result.json()["rendered"],
+        )
+        patched.assert_not_called()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_dedupes_job_for_same_draft(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(compose_preview_pending_cache_key(user.id, url))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        patched.assert_called_once()
+        self.assertIsNotNone(cache_get(compose_preview_pending_cache_key(user.id, url)))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        self.assert_json_success(result)
+        patched.assert_not_called()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_enqueues_job_for_edited_draft(self) -> None:
+        # The in-flight job renders the pre-edit draft, which the client
+        # discards, so the edited draft needs a job of its own.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        edited_content = f"{url} hello"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(compose_preview_pending_cache_key(user.id, url))
+        cache_delete(compose_preview_pending_cache_key(user.id, edited_content))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        patched.assert_called_once()
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render",
+                {"content": edited_content, "fetch_link_previews": "true"},
+            )
+        patched.assert_called_once()
+        self.assertEqual(patched.call_args[0][1]["content"], edited_content)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_skips_draft_too_long_to_send(self) -> None:
+        # A draft that couldn't be sent as-is isn't worth fetching previews for.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        content = f"{url} " + "x" * settings.MAX_MESSAGE_LENGTH
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(compose_preview_pending_cache_key(user.id, content))
+
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": content, "fetch_link_previews": "true"}
+            )
+        self.assert_json_success(result)
+        patched.assert_not_called()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_enqueues_job_for_each_sender(self) -> None:
+        # A job only updates the preview of the user it was enqueued for.
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        url = "http://test.org/"
+        cache_delete(preview_url_cache_key(url))
+        cache_delete(compose_preview_pending_cache_key(hamlet.id, url))
+        cache_delete(compose_preview_pending_cache_key(othello.id, url))
+
+        self.login_user(hamlet)
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        patched.assert_called_once()
+
+        self.login_user(othello)
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        patched.assert_called_once()
+        self.assertEqual(patched.call_args[0][1]["user_id"], othello.id)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_skips_second_render_for_uncacheable_link(self) -> None:
+        # A link cached as "no preview" renders identically, so skip the second render.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/"
+        cache_set(preview_url_cache_key(url), None)
+
+        with (
+            mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched,
+            mock.patch(
+                "zerver.views.message_send.render_message_for_compose_preview",
+                wraps=render_message_for_compose_preview,
+            ) as render_spy,
+        ):
+            result = self.client_post(
+                "/json/messages/render", {"content": url, "fetch_link_previews": "true"}
+            )
+        self.assert_json_success(result)
+        patched.assert_not_called()
+        render_spy.assert_called_once()
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_compose_preview_mixed_cached_and_uncached_links(self) -> None:
+        # The worker's re-render must keep the cached link's card too.
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        cached_url = "http://test.org/"
+        uncached_url = "http://example.com/"
+        for url in (cached_url, uncached_url):
+            cache_delete(preview_url_cache_key(url))
+
+        self.create_mock_response(cached_url)
+        get_link_embed_data(cached_url)
+
+        content = f"{cached_url} {uncached_url}"
+        cache_delete(compose_preview_pending_cache_key(user.id, content))
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            result = self.client_post(
+                "/json/messages/render", {"content": content, "fetch_link_previews": "true"}
+            )
+        self.assert_json_success(result)
+        self.assertIn(
+            f'<a href="{cached_url}" title="The Rock">The Rock</a>',
+            result.json()["rendered"],
+        )
+        self.assertNotIn(
+            f'<a href="{uncached_url}" title="The Rock">The Rock</a>',
+            result.json()["rendered"],
+        )
+
+        patched.assert_called_once()
+        event = patched.call_args[0][1]
+        self.assertEqual(event["compose_preview"], True)
+        self.assertEqual(event["content"], content)
+        self.assertEqual(set(event["urls"]), {cached_url, uncached_url})
+
+        self.create_mock_response(uncached_url)
+        with (
+            self.settings(TEST_SUITE=False),
+            self.assertLogs(level="INFO"),
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            FetchLinksEmbedData().consume(event)
+
+        preview_event = events[0]["event"]
+        self.assertEqual(preview_event["type"], "compose_link_preview")
+        self.assertIn(
+            f'<a href="{cached_url}" title="The Rock">The Rock</a>',
+            preview_event["rendered_content"],
+        )
+        self.assertIn(
+            f'<a href="{uncached_url}" title="The Rock">The Rock</a>',
+            preview_event["rendered_content"],
+        )
+
+    def test_compose_preview_sends_no_event_when_nothing_previewable(self) -> None:
+        # The re-render would reproduce the HTML the preview already shows.
+        user = self.example_user("hamlet")
+        url = "http://test.org/"
+        event = {
+            "compose_preview": True,
+            "user_id": user.id,
+            "content": url,
+            "urls": [url],
+        }
+        with (
+            mock.patch.object(
+                FetchLinksEmbedData, "fetch_url_embed_data", return_value={url: None}
+            ),
+            self.capture_send_event_calls(expected_num_events=0),
+        ):
+            FetchLinksEmbedData().consume(event)
+
+    def test_compose_preview_skips_deleted_sender(self) -> None:
+        # A deleted sender is dropped without a wasted fetch (looked up first).
+        event = {
+            "compose_preview": True,
+            "user_id": 1234567890,
+            "content": "http://test.org/",
+            "urls": ["http://test.org/"],
+        }
+        with (
+            mock.patch.object(FetchLinksEmbedData, "fetch_url_embed_data") as mock_fetch,
+            self.capture_send_event_calls(expected_num_events=0),
+        ):
+            FetchLinksEmbedData().consume(event)
+        mock_fetch.assert_not_called()
 
     @responses.activate
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3877,6 +3877,15 @@ class MarkdownErrorTests(ZulipTestCase):
         ):
             self.send_stream_message(self.example_user("othello"), "Denmark", message)
 
+    def test_render_message_errors(self) -> None:
+        with self.simulated_markdown_failure():
+            result = self.api_post(
+                self.example_user("othello"),
+                "/api/v1/messages/render",
+                dict(content="whatever"),
+            )
+        self.assert_json_error(result, "Unable to render message")
+
     @override_settings(MAX_MESSAGE_LENGTH=10)
     def test_ultra_long_rendering(self) -> None:
         """A rendered message with an ultra-long length (> 100 * MAX_MESSAGE_LENGTH)

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -16,9 +16,10 @@ from zerver.actions.message_send import (
     create_mirror_user_if_needed,
     extract_private_recipients,
     extract_stream_indicator,
+    get_compose_preview_embeds_and_enqueue_fetch,
+    render_message_for_compose_preview,
 )
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.markdown import render_message_markdown
 from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import (
@@ -28,7 +29,7 @@ from zerver.lib.typed_endpoint import (
     typed_endpoint,
 )
 from zerver.lib.zcommand import process_zcommands
-from zerver.models import Client, Message, RealmDomain, UserProfile
+from zerver.models import Client, RealmDomain, UserProfile
 from zerver.models.users import get_user_including_cross_realm
 
 
@@ -257,14 +258,21 @@ def render_message_backend(
     user_profile: UserProfile,
     *,
     content: str,
+    fetch_link_previews: Json[bool] = False,
 ) -> HttpResponse:
-    message = Message()
-    message.sender = user_profile
-    message.realm = user_profile.realm
-    message.content = content
-    client = RequestNotes.get_notes(request).client
-    assert client is not None
-    message.sending_client = client
+    rendering_result = render_message_for_compose_preview(user_profile, content)
 
-    rendering_result = render_message_markdown(message, content, realm=user_profile.realm)
+    # The message-edit preview and drafts overlay don't consume the
+    # compose_link_preview event, so they leave this off.
+    if fetch_link_previews and rendering_result.links_for_preview:
+        url_embed_data = get_compose_preview_embeds_and_enqueue_fetch(
+            user_profile, content, rendering_result.links_for_preview
+        )
+        # A link cached as "no preview available" (None) renders identically,
+        # so only a real cached embed is worth a second render.
+        if any(embed_data is not None for embed_data in url_embed_data.values()):
+            rendering_result = render_message_for_compose_preview(
+                user_profile, content, url_embed_data=url_embed_data
+            )
+
     return json_success(request, data={"rendered": rendering_result.rendered_content})

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -17,9 +17,10 @@ from zerver.actions.message_send import (
     create_mirror_user_if_needed,
     extract_private_recipients,
     extract_stream_indicator,
+    get_cached_embeds_and_enqueue_fetch,
+    render_unsaved_message,
 )
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.markdown import render_message_markdown
 from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import (
@@ -29,7 +30,7 @@ from zerver.lib.typed_endpoint import (
     typed_endpoint,
 )
 from zerver.lib.zcommand import process_zcommands
-from zerver.models import Client, Message, RealmDomain, UserProfile
+from zerver.models import Client, RealmDomain, UserProfile
 from zerver.models.users import get_user_including_cross_realm
 
 
@@ -267,14 +268,21 @@ def render_message_backend(
     user_profile: UserProfile,
     *,
     content: Annotated[str, StringConstraints(max_length=settings.MAX_MESSAGE_LENGTH)],
+    populate_url_embed_data: Json[bool] = False,
 ) -> HttpResponse:
-    message = Message()
-    message.sender = user_profile
-    message.realm = user_profile.realm
-    message.content = content
-    client = RequestNotes.get_notes(request).client
-    assert client is not None
-    message.sending_client = client
+    rendering_result = render_unsaved_message(user_profile, content)
 
-    rendering_result = render_message_markdown(message, content, realm=user_profile.realm)
+    # The message-edit preview and drafts overlay don't consume the
+    # url_embed_data event, so they leave this off.
+    if populate_url_embed_data and rendering_result.links_for_preview:
+        url_embed_data = get_cached_embeds_and_enqueue_fetch(
+            user_profile, content, rendering_result.links_for_preview
+        )
+        # A link cached as "no preview available" (None) renders identically,
+        # so only a real cached embed is worth a second render.
+        if any(embed_data is not None for embed_data in url_embed_data.values()):
+            rendering_result = render_unsaved_message(
+                user_profile, content, url_embed_data=url_embed_data
+            )
+
     return json_success(request, data={"rendered": rendering_result.rendered_content})

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -272,8 +272,8 @@ def render_message_backend(
 ) -> HttpResponse:
     rendering_result = render_unsaved_message(user_profile, content)
 
-    # The message-edit preview and drafts overlay don't consume the
-    # url_embed_data event, so they leave this off.
+    # The drafts overlay has no open preview to live-update, so it
+    # leaves this off.
     if populate_url_embed_data and rendering_result.links_for_preview:
         url_embed_data = get_cached_embeds_and_enqueue_fetch(
             user_profile, content, rendering_result.links_for_preview

--- a/zerver/worker/embed_links.py
+++ b/zerver/worker/embed_links.py
@@ -9,11 +9,16 @@ from django.db import transaction
 from typing_extensions import override
 
 from zerver.actions.message_edit import do_update_embedded_data
-from zerver.actions.message_send import render_incoming_message
+from zerver.actions.message_send import (
+    do_send_compose_link_preview,
+    render_incoming_message,
+    render_message_for_compose_preview,
+)
 from zerver.lib.mention import MentionBackend, MentionData
 from zerver.lib.url_preview import preview as url_preview
 from zerver.lib.url_preview.types import UrlEmbedData
-from zerver.models import Message, Realm
+from zerver.models import Message, Realm, UserProfile
+from zerver.models.users import get_user_profile_by_id
 from zerver.worker.base import InterruptConsumeError, QueueProcessingWorker, assign_queue
 
 logger = logging.getLogger(__name__)
@@ -27,13 +32,11 @@ class FetchLinksEmbedData(QueueProcessingWorker):
 
     @override
     def consume(self, event: Mapping[str, Any]) -> None:
-        url_embed_data: dict[str, UrlEmbedData | None] = {}
-        for url in event["urls"]:
-            start_time = time.time()
-            url_embed_data[url] = url_preview.get_link_embed_data(url)
-            logging.info(
-                "Time spent on get_link_embed_data for %s: %s", url, time.time() - start_time
-            )
+        if event.get("compose_preview"):
+            self.handle_compose_link_preview(event)
+            return
+
+        url_embed_data = self.fetch_url_embed_data(event["urls"])
 
         # Ideally, we should use `durable=True` here. However, in the
         # `test_message_update_race_condition` test, this function is not called
@@ -72,6 +75,31 @@ class FetchLinksEmbedData(QueueProcessingWorker):
             )
             do_update_embedded_data(message.sender, message, rendering_result, mention_data)
 
+    def fetch_url_embed_data(self, urls: list[str]) -> dict[str, UrlEmbedData | None]:
+        url_embed_data: dict[str, UrlEmbedData | None] = {}
+        for url in urls:
+            start_time = time.time()
+            url_embed_data[url] = url_preview.get_link_embed_data(url)
+            logging.info(
+                "Time spent on get_link_embed_data for %s: %s", url, time.time() - start_time
+            )
+        return url_embed_data
+
+    def handle_compose_link_preview(self, event: Mapping[str, Any]) -> None:
+        try:
+            sender = get_user_profile_by_id(event["user_id"])
+        except UserProfile.DoesNotExist:
+            # The composing user may have been deleted.
+            return
+        url_embed_data = self.fetch_url_embed_data(event["urls"])
+        if all(embed_data is None for embed_data in url_embed_data.values()):
+            # The re-render would reproduce the HTML the preview already shows.
+            return
+        rendering_result = render_message_for_compose_preview(
+            sender, event["content"], url_embed_data=url_embed_data
+        )
+        do_send_compose_link_preview(sender, event["content"], rendering_result.rendered_content)
+
     @override
     def timer_expired(
         self, limit: int, events: list[dict[str, Any]], signal: int, frame: FrameType | None
@@ -79,11 +107,13 @@ class FetchLinksEmbedData(QueueProcessingWorker):
         assert len(events) == 1
         event = events[0]
 
+        # Compose-preview jobs have no message_id; a KeyError here would mask
+        # the timeout we are trying to report.
         logging.warning(
             "Timed out in %s after %s seconds while fetching URLs for message %s: %s",
             self.queue_name,
             limit,
-            event["message_id"],
+            event.get("message_id"),
             event["urls"],
         )
         raise InterruptConsumeError

--- a/zerver/worker/embed_links.py
+++ b/zerver/worker/embed_links.py
@@ -9,11 +9,23 @@ from django.db import transaction
 from typing_extensions import override
 
 from zerver.actions.message_edit import do_update_embedded_data
-from zerver.actions.message_send import render_incoming_message
+from zerver.actions.message_send import (
+    PREVIEW_URL_FETCH_FAILED_TIMEOUT_SECONDS,
+    do_send_url_embed_data_event,
+    render_incoming_message,
+    render_unsaved_message,
+)
+from zerver.lib.cache import (
+    cache_get,
+    cache_set,
+    preview_url_cache_key,
+    preview_url_fetch_failed_cache_key,
+)
 from zerver.lib.mention import MentionBackend, MentionData
 from zerver.lib.url_preview import preview as url_preview
 from zerver.lib.url_preview.types import UrlEmbedData
-from zerver.models import Message, Realm
+from zerver.models import Message, Realm, UserProfile
+from zerver.models.users import get_user_profile_by_id
 from zerver.worker.base import InterruptConsumeError, QueueProcessingWorker, assign_queue
 
 logger = logging.getLogger(__name__)
@@ -27,13 +39,11 @@ class FetchLinksEmbedData(QueueProcessingWorker):
 
     @override
     def consume(self, event: Mapping[str, Any]) -> None:
-        url_embed_data: dict[str, UrlEmbedData | None] = {}
-        for url in event["urls"]:
-            start_time = time.time()
-            url_embed_data[url] = url_preview.get_link_embed_data(url)
-            logging.info(
-                "Time spent on get_link_embed_data for %s: %s", url, time.time() - start_time
-            )
+        if event.get("populate_url_embed_data"):
+            self.handle_url_embed_data_request(event)
+            return
+
+        url_embed_data = self.fetch_url_embed_data(event["urls"])
 
         # Ideally, we should use `durable=True` here. However, in the
         # `test_message_update_race_condition` test, this function is not called
@@ -72,6 +82,45 @@ class FetchLinksEmbedData(QueueProcessingWorker):
             )
             do_update_embedded_data(message.sender, message, rendering_result, mention_data)
 
+    def fetch_url_embed_data(self, urls: list[str]) -> dict[str, UrlEmbedData | None]:
+        url_embed_data: dict[str, UrlEmbedData | None] = {}
+        for url in urls:
+            start_time = time.time()
+            url_embed_data[url] = url_preview.get_link_embed_data(url)
+            logging.info(
+                "Time spent on get_link_embed_data for %s: %s", url, time.time() - start_time
+            )
+        return url_embed_data
+
+    def handle_url_embed_data_request(self, event: Mapping[str, Any]) -> None:
+        try:
+            sender = get_user_profile_by_id(event["user_id"])
+        except UserProfile.DoesNotExist:
+            # The composing user may have been deleted.
+            return
+        url_embed_data = self.fetch_url_embed_data(event["urls"])
+
+        # The view baked the already cached embeds into the render the client
+        # is showing, so only the links it lacked can change the preview.
+        uncached_urls = event["uncached_urls"]
+        for url in uncached_urls:
+            # Only a fetch that ran to completion caches a result, so bound
+            # the retries of one that raised.
+            if cache_get(preview_url_cache_key(url)) is None:
+                cache_set(
+                    preview_url_fetch_failed_cache_key(url),
+                    True,
+                    timeout=PREVIEW_URL_FETCH_FAILED_TIMEOUT_SECONDS,
+                )
+
+        if all(url_embed_data.get(url) is None for url in uncached_urls):
+            # The re-render would reproduce the HTML the preview already shows.
+            return
+        rendering_result = render_unsaved_message(
+            sender, event["content"], url_embed_data=url_embed_data
+        )
+        do_send_url_embed_data_event(sender, event["content"], rendering_result.rendered_content)
+
     @override
     def timer_expired(
         self, limit: int, events: list[dict[str, Any]], signal: int, frame: FrameType | None
@@ -79,11 +128,13 @@ class FetchLinksEmbedData(QueueProcessingWorker):
         assert len(events) == 1
         event = events[0]
 
+        # Render-request jobs have no message_id; a KeyError here would mask
+        # the timeout we are trying to report.
         logging.warning(
             "Timed out in %s after %s seconds while fetching URLs for message %s: %s",
             self.queue_name,
             limit,
-            event["message_id"],
+            event.get("message_id"),
             event["urls"],
         )
         raise InterruptConsumeError


### PR DESCRIPTION
Fixes: #19465

---

Currently, clicking the compose preview (eye) icon shows the message rendered, but previews of linked websites and videos (such as YouTube) don't appear - even though they show up once the message is sent - because the render endpoint doesn't fetch their embed data, and it can't simply fetch it inline, since downloading the external page can take seconds and would make the preview hang.

This PR makes those previews appear in the compose preview. It reuses the **existing `embed_links` queue worker** - the same mechanism that renders link previews after a message is sent - rather than introducing a separate code path:

- `/json/messages/render` renders the draft, bakes in any embeds already in the cache, and enqueues an `embed_links` job for the uncached links.
- The worker fetches those embeds, re-renders an unsaved message stub, and pushes the result to **only the composing user** via a new transient `compose_link_preview` event.
- The client swaps the rendered HTML into the open preview, but only while preview mode is open and only when the event's content still matches the current draft - so a late update for a draft the user has since edited is discarded.

Because the same `links_for_preview` selection drives both this and the send path, the compose preview stays consistent with the eventual message. Realm settings are respected automatically: when `inline_url_embed_preview` is off, `links_for_preview` is empty and nothing is enqueued.

Cards for standard websites appear after a short delay (the worker makes two sequential HTTP requests to scrape metadata) - the same delay users already see on sent messages; YouTube and direct image links resolve faster. Once a URL is cached, it's baked into the first render and appears instantly.

---

## Screenshots and screen captures:

### *1. Standard link preview in compose box*
<img width="933" height="252" alt="Screenshot 2026-03-24 151825" src="https://github.com/user-attachments/assets/065fada5-8f08-4178-8355-af413b39d644" />

---

### *2. Video link preview in compose box*
<img width="931" height="300" alt="Screenshot 2026-03-24 152213" src="https://github.com/user-attachments/assets/e5236f5e-fc30-4f17-8c15-34cb687229dd" />

---

### *3. Image preview in compose box*
<img width="926" height="303" alt="Screenshot 2026-03-24 152331" src="https://github.com/user-attachments/assets/5a30e0d2-8819-4d6e-8af1-581b7e067770" />

---

### *4. Multiple link previews in compose box*
<img width="922" height="450" alt="image" src="https://github.com/user-attachments/assets/da0b01d5-144d-42d9-9139-5bc1aeff963e" />

---

### *5. Video: YouTube preview in compose box*

https://github.com/user-attachments/assets/eeaded8e-e9da-4bb2-bc40-e3d54868b3bd

---

### *6. Video: link preview in compose box*

https://github.com/user-attachments/assets/dce8a0ae-9a0d-4ef7-bbc4-5c15ce836791

---

### Relationship to other PRs

There is an earlier draft PR (#31703) exploring link previews in compose preview. This PR is an independent implementation of the feature.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
