### PR TITLE
tornado: Support both realm_url and legacy realm_uri in events.

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -34,6 +34,7 @@ from zerver.tornado.event_queue import (
     maybe_enqueue_notifications,
     missedmessage_hook,
     persistent_queue_filename,
+    process_notification,
     receiver_is_off_zulip,
 )
 from zerver.tornado.views import cleanup_event_queue, get_events
@@ -90,6 +91,38 @@ class MaybeEnqueueNotificationsTest(ZulipTestCase):
 
             email_notice = mock_queue_json_publish.call_args_list[1][0][1]
             self.assertEqual(email_notice["mentioned_user_group_id"], 33)
+
+
+class ProcessNotificationCompatibilityTest(ZulipTestCase):
+    def test_realm_uri_aliases_to_realm_url(self) -> None:
+        notice = {
+            "event": {"type": "test_event", "realm_uri": "http://zulip.testserver"},
+            "users": [self.example_user("hamlet").id],
+        }
+
+        with mock.patch("zerver.tornado.event_queue.process_event") as mock_process_event:
+            process_notification(notice)
+
+        processed_event = mock_process_event.call_args[0][0]
+        self.assertEqual(processed_event["realm_uri"], "http://zulip.testserver")
+        self.assertEqual(processed_event["realm_url"], "http://zulip.testserver")
+
+    def test_realm_url_not_overridden_by_realm_uri(self) -> None:
+        notice = {
+            "event": {
+                "type": "test_event",
+                "realm_uri": "http://old.zulip.testserver",
+                "realm_url": "http://new.zulip.testserver",
+            },
+            "users": [self.example_user("hamlet").id],
+        }
+
+        with mock.patch("zerver.tornado.event_queue.process_event") as mock_process_event:
+            process_notification(notice)
+
+        processed_event = mock_process_event.call_args[0][0]
+        self.assertEqual(processed_event["realm_uri"], "http://old.zulip.testserver")
+        self.assertEqual(processed_event["realm_url"], "http://new.zulip.testserver")
 
 
 class StreamWatchersTest(ZulipTestCase):

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1760,6 +1760,13 @@ def process_mark_message_unread_event(event: Mapping[str, Any], users: Iterable[
 
 def process_notification(notice: Mapping[str, Any]) -> None:
     event: Mapping[str, Any] = notice["event"]
+    # TODO/compatibility: realm_uri is a deprecated alias for realm_url in
+    # notices from older Django processes during rolling deploys.
+    # Remove this once old Django processes can no longer publish realm_uri.
+    if "realm_url" not in event and "realm_uri" in event:
+        event = dict(event)
+        event["realm_url"] = event["realm_uri"]
+
     users: list[int] | list[Mapping[str, Any]] = notice["users"]
     start_time = time.perf_counter()
 


### PR DESCRIPTION
Hey everyone! This PR addresses the zero-downtime deployment concern raised by @timabbott regarding the transition from `realm_uri` to `realm_url` (Fixes #23380).

During a rolling deploy, older Django processes might still send the legacy `realm_uri` in event payloads. If the updated Tornado process strictly expects `realm_url`, it could cause crashes. 

To prevent this, I've added a simple backward-compatibility shim in `zerver/tornado/event_queue.py` (`process_notification`). It checks for `realm_url`, and safely falls back to `realm_uri` if it's missing. 

I've also included the standard `TODO/compatibility` comment as per Zulip's conventions, and added tests in `test_event_queue.py` to make sure the fallback behavior works exactly as expected.