### PR TITLE
Fix smtp timeout

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -336,7 +336,7 @@ def send_immediate_email(
         )
         connection.close()
         raise EmailNotDeliveredError
-    except smtplib.SMTPException as e:
+    except (smtplib.SMTPException, OSError) as e:
         logger.exception("Error sending %s email to %s: %s", template, mail.to, e, stack_info=True)
         connection.close()
         raise EmailNotDeliveredError

--- a/zerver/management/commands/send_test_email.py
+++ b/zerver/management/commands/send_test_email.py
@@ -61,6 +61,16 @@ class Command(sendtestemail.Command):
                 print("Full SMTP log follows:")
                 print(f.getvalue())
                 raise CommandError("Email sending failed!")
+            except OSError as e:
+                print(f"Failed to send mails: {e}")
+                print()
+                print("Full SMTP log follows:")
+                print(f.getvalue())
+                print()
+                print(
+                    "This usually means that your host or firewall is blocking outgoing SMTP traffic."
+                )
+                raise CommandError("Email sending failed!")
         print()
         print("Successfully sent 2 emails to {}!".format(", ".join(kwargs["email"])))
 


### PR DESCRIPTION
This PR addresses **Issue #1357**, where installing Zulip on a host that blocks outgoing SMTP traffic by default (such as Scaleway blocking port 25 or 465) would cause the server to hang or crash abruptly with a confusing Python traceback when trying to send emails.
Specifically, it handles `OSError` (which encompasses `TimeoutError` and `ConnectionRefusedError` from Python's socket module):
- In [zerver/lib/send_email.py](cci:7://file:///c:/Users/Kartik%20chouksey/zulip/zerver/lib/send_email.py:0:0-0:0), we now catch `OSError` and properly raise an [EmailNotDeliveredError](cci:2://file:///c:/Users/Kartik%20chouksey/zulip/zerver/lib/send_email.py:246:0-247:8). This allows the registration flow to fail gracefully, catching the error and displaying an appropriate UI error state instead of timing out or hanging the backend worker continuously.
- In [zerver/management/commands/send_test_email.py](cci:7://file:///c:/Users/Kartik%20chouksey/zulip/zerver/management/commands/send_test_email.py:0:0-0:0), we now catch `OSError` during test email execution. Instead of spitting out an unhandled Python traceback, it gracefully prints a clean and obvious symptom string: `"This usually means that your host or firewall is blocking outgoing SMTP traffic."`
### Relevant Issues
Fixes #1357
### Testing
- Validated `manage.py send_test_email` behavior when hitting a firewall (reproduces the graceful exit and prints the new instruction).
- Verified [EmailNotDeliveredError](cci:2://file:///c:/Users/Kartik%20chouksey/zulip/zerver/lib/send_email.py:246:0-247:8) mappings to ensure Zulip registration flows appropriately catch and handle these backend errors. All downstream tests pass correctly.