### PR TITLE
Trap focus inside for overlays during keyboard navigation. 

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -19,6 +19,7 @@ import {message_render_response_schema} from "./message_store.ts";
 import * as message_view from "./message_view.ts";
 import * as messages_overlay_ui from "./messages_overlay_ui.ts";
 import * as mouse_drag from "./mouse_drag.ts";
+import * as overlay_util from "./overlay_util.ts";
 import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
 import {postprocess_content} from "./postprocess_content.ts";
@@ -534,8 +535,37 @@ export function initialize(): void {
         });
     });
 
-    $("body").on("focus", "#drafts_table .overlay-message-info-box", function (this: HTMLElement) {
-        messages_overlay_ui.activate_element(this, keyboard_handling_context);
+    $("body").on("focus", "#draft_overlay", (e) => {
+        if (!(e.target instanceof HTMLElement)) {
+            return;
+        }
+        const draft_row = e.target.closest(".overlay-message-info-box");
+        if (draft_row instanceof HTMLElement) {
+            // A draft gained focus; mark it as the selected draft.
+            messages_overlay_ui.activate_element(draft_row, keyboard_handling_context);
+        } else if (e.target.matches(overlay_util.OVERLAY_FOCUSABLE_SELECTOR)) {
+            // Another focusable element (e.g. a header button) gained focus;
+            // draft info-boxes are already handled by the branch above, so
+            // the `.overlay-message-info-box` part of the selector never
+            // matches here.
+            // Only clear the draft selection when the control was reached via
+            // keyboard (Tab), where both it and the draft would show a focus
+            // ring; a pointer click shows no ring on the control, so keep the
+            // selection.
+            if (e.target.matches(":focus-visible")) {
+                $("#drafts_table .overlay-message-info-box").removeClass("active");
+            }
+        } else {
+            // Focus landed on a non-interactive area. Return focus to the
+            // selected draft or the first one if none is selected, so that
+            // keyboard navigation continues from a draft.
+            const draft_to_focus =
+                $("#drafts_table .overlay-message-info-box.active")[0] ??
+                $("#drafts_table .overlay-message-info-box")[0];
+            if (draft_to_focus !== undefined) {
+                messages_overlay_ui.activate_element(draft_to_focus, keyboard_handling_context);
+            }
+        }
     });
     $("body").on(
         "click",

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -169,6 +169,22 @@ function initialize_focus(event_name: string, context: Context): void {
         return;
     }
 
+    const $items_list = $(`.${CSS.escape(context.items_list_selector)}`);
+
+    // Focus can leave the list while its selection persists -- e.g. the
+    // user clicks elsewhere in the overlay, which clears focus but leaves
+    // the active item visually highlighted. Resume navigation from that
+    // active item rather than restarting at the first or last one.
+    const $active_box = $(`.${CSS.escape(context.box_item_selector)}.active`);
+    if ($active_box.length > 0) {
+        activate_element(util.the($active_box), context);
+        scroll_util.scroll_element_into_container(
+            $active_box.parent(`.${CSS.escape(context.row_item_selector)}`),
+            $items_list,
+        );
+        return;
+    }
+
     const modal_items_ids = context.get_items_ids();
     const id = modal_items_ids.at(event_name === "up_arrow" ? -1 : 0);
     if (id === undefined) {
@@ -180,7 +196,6 @@ function initialize_focus(event_name: string, context: Context): void {
     const focus_element = util.the($element).children[0];
     assert(focus_element instanceof HTMLElement);
     activate_element(focus_element, context);
-    const $items_list = $(`.${CSS.escape(context.items_list_selector)}`);
     scroll_util.scroll_element_into_container($element, $items_list);
     return;
 }

--- a/web/src/overlay_util.ts
+++ b/web/src/overlay_util.ts
@@ -15,14 +15,45 @@ export function enable_scrolling(): void {
 }
 
 export const OVERLAY_FOCUSABLE_SELECTOR =
-    "input, button, select, .input, .sidebar-item, .ind-tab.first, a[href], a[tabindex='0']";
+    "input, button, select, .input, .sidebar-item, .ind-tab.first, a[href], a[tabindex='0'], .overlay-message-info-box";
 
 export function get_visible_focusable_elements_in_overlay_container(
     $container: JQuery,
 ): HTMLElement[] {
     const visible_focusable_elements = [...$(OVERLAY_FOCUSABLE_SELECTOR, $container)].filter(
         (element) =>
-            element.getClientRects().length > 0 && $(element).css("visibility") !== "hidden",
+            element.getClientRects().length > 0 &&
+            $(element).css("visibility") !== "hidden" &&
+            !$(element).is(":disabled"),
     );
     return visible_focusable_elements;
+}
+
+export function wrap_overlay_tab_focus(
+    shift_key: boolean,
+    focusable_elements: HTMLElement[],
+): boolean {
+    if (focusable_elements.length === 0) {
+        // Nothing focusable inside the overlay; keep Tab trapped within it.
+        return true;
+    }
+
+    const active_element =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focus_is_in_overlay =
+        active_element !== null && focusable_elements.includes(active_element);
+    const first_element = focusable_elements[0]!;
+    const last_element = focusable_elements.at(-1)!;
+
+    if (shift_key) {
+        if (active_element === first_element || !focus_is_in_overlay) {
+            last_element.focus();
+            return true;
+        }
+    } else if (active_element === last_element || !focus_is_in_overlay) {
+        first_element.focus();
+        return true;
+    }
+
+    return false;
 }

--- a/web/src/overlay_util.ts
+++ b/web/src/overlay_util.ts
@@ -14,14 +14,13 @@ export function enable_scrolling(): void {
     $(":root").css({"overflow-y": "scroll", "--disabled-scrollbar-width": "0px"});
 }
 
+export const OVERLAY_FOCUSABLE_SELECTOR =
+    "input, button, select, .input, .sidebar-item, .ind-tab.first, a[href], a[tabindex='0']";
+
 export function get_visible_focusable_elements_in_overlay_container(
     $container: JQuery,
 ): HTMLElement[] {
-    const visible_focusable_elements = [
-        ...$container.find(
-            "input, button, select, .input, .sidebar-item, .ind-tab.first, a[href], a[tabindex='0']",
-        ),
-    ].filter(
+    const visible_focusable_elements = [...$(OVERLAY_FOCUSABLE_SELECTOR, $container)].filter(
         (element) =>
             element.getClientRects().length > 0 && $(element).css("visibility") !== "hidden",
     );

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -124,6 +124,7 @@ export function open_overlay(opts: OverlayOptions): void {
     opts.$overlay.attr("aria-hidden", "false");
     $(".app").attr("aria-hidden", "true");
     $("#navbar-fixed-container").attr("aria-hidden", "true");
+    opts.$overlay.trigger("focus");
 }
 
 export function close_overlay(name: string): void {
@@ -321,6 +322,20 @@ export function trap_focus_for_settings_overlay(): void {
                 e.preventDefault();
                 visible_focusable_elements[0]!.focus();
             }
+        }
+    });
+
+    const overlay_focus_trap_selector = "#draft_overlay";
+    $("body").on("keydown", overlay_focus_trap_selector, function (this: HTMLElement, e) {
+        if (e.key !== "Tab") {
+            return;
+        }
+
+        const visible_focusable_elements =
+            overlay_util.get_visible_focusable_elements_in_overlay_container($(this));
+
+        if (overlay_util.wrap_overlay_tab_focus(e.shiftKey, visible_focusable_elements)) {
+            e.preventDefault();
         }
     });
 }

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -326,7 +326,7 @@ export function trap_focus_for_settings_overlay(): void {
     });
 
     const overlay_focus_trap_selector =
-        "#draft_overlay, #reminders-overlay, #scheduled_messages_overlay, #message-history-overlay";
+        "#draft_overlay, #reminders-overlay, #scheduled_messages_overlay, #message-history-overlay, #about-zulip";
     $("body").on("keydown", overlay_focus_trap_selector, function (this: HTMLElement, e) {
         if (e.key !== "Tab") {
             return;

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -325,7 +325,8 @@ export function trap_focus_for_settings_overlay(): void {
         }
     });
 
-    const overlay_focus_trap_selector = "#draft_overlay, #reminders-overlay";
+    const overlay_focus_trap_selector =
+        "#draft_overlay, #reminders-overlay, #scheduled_messages_overlay";
     $("body").on("keydown", overlay_focus_trap_selector, function (this: HTMLElement, e) {
         if (e.key !== "Tab") {
             return;

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -325,7 +325,7 @@ export function trap_focus_for_settings_overlay(): void {
         }
     });
 
-    const overlay_focus_trap_selector = "#draft_overlay";
+    const overlay_focus_trap_selector = "#draft_overlay, #reminders-overlay";
     $("body").on("keydown", overlay_focus_trap_selector, function (this: HTMLElement, e) {
         if (e.key !== "Tab") {
             return;

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -326,7 +326,7 @@ export function trap_focus_for_settings_overlay(): void {
     });
 
     const overlay_focus_trap_selector =
-        "#draft_overlay, #reminders-overlay, #scheduled_messages_overlay";
+        "#draft_overlay, #reminders-overlay, #scheduled_messages_overlay, #message-history-overlay";
     $("body").on("keydown", overlay_focus_trap_selector, function (this: HTMLElement, e) {
         if (e.key !== "Tab") {
             return;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -247,6 +247,10 @@ div.overlay {
     .overlay-container {
         background-color: var(--color-background-modal);
     }
+
+    &:focus {
+        outline: none;
+    }
 }
 
 .input-append {

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -1,4 +1,4 @@
-<div id="draft_overlay" class="overlay" data-overlay="drafts">
+<div id="draft_overlay" class="overlay" data-overlay="drafts" tabindex="-1">
     <div class="flex overlay-content">
         <div class="drafts-container overlay-messages-container overlay-container">
             <div class="overlay-messages-header">

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -1,4 +1,4 @@
-<div id="message-history-overlay" class="overlay" data-overlay="message_edit_history">
+<div id="message-history-overlay" class="overlay" data-overlay="message_edit_history" tabindex="-1">
     <div class="flex overlay-content">
         <div class="message-edit-history-container overlay-messages-container overlay-container">
             <div class="overlay-messages-header">

--- a/web/templates/reminders_overlay.hbs
+++ b/web/templates/reminders_overlay.hbs
@@ -1,4 +1,4 @@
-<div id="reminders-overlay" class="overlay" data-overlay="reminders">
+<div id="reminders-overlay" class="overlay" data-overlay="reminders" tabindex="-1">
     <div class="flex overlay-content">
         <div class="overlay-messages-container overlay-container reminders-container">
             <div class="overlay-messages-header">

--- a/web/templates/scheduled_messages_overlay.hbs
+++ b/web/templates/scheduled_messages_overlay.hbs
@@ -1,4 +1,4 @@
-<div id="scheduled_messages_overlay" class="overlay" data-overlay="scheduled">
+<div id="scheduled_messages_overlay" class="overlay" data-overlay="scheduled" tabindex="-1">
     <div class="flex overlay-content">
         <div class="overlay-messages-container overlay-container scheduled-messages-container">
             <div class="overlay-messages-header">


### PR DESCRIPTION
<!-- Describe your pull request here.-->
While navigating through keyboard using Tab or shift+Tab make sure the focus is inside the overlay.
Fixes: [#issues > Tabbing  is not working in Drafts overlay](https://chat.zulip.org/#narrow/channel/9-issues/topic/Tabbing.20.20is.20not.20working.20in.20Drafts.20overlay/with/2416149)
Fixes: https://github.com/zulip/zulip/issues/26941
Changes:
- Trap focus inside for drafts overlay during keyboard navigation.  
- Clear active state when focus leaves draft items.

**How changes were tested:**
Manually verified the behaviour.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
`Focus is not escaping for draft overlay and when we move out of the drafts list active state is removed`


https://github.com/user-attachments/assets/8bc41ff4-4632-4cf4-b7fb-1da0293246db













<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>


