### PR TITLE
portico: Correct logo lists.

### DIFF
--- a/web/src/portico/hello.ts
+++ b/web/src/portico/hello.ts
@@ -11,8 +11,10 @@ function get_random_item_from_array<T>(array: T[]): T {
     return array[Math.floor(Math.random() * array.length)]!;
 }
 
+// This list should be squared with the logos listed
+// in templates/portico/hello.html
 const current_client_logo_class_names = new Set([
-    "client-logos-div client-logos__logo_akamai",
+    "client-logos-div client-logos__logo_pilot",
     "client-logos-div client-logos__logo_linux_foundation",
     "client-logos-div client-logos__logo_tum",
     "client-logos-div client-logos__logo_wikimedia",
@@ -20,10 +22,8 @@ const current_client_logo_class_names = new Set([
     "client-logos-div client-logos__logo_dr_on_demand",
 ]);
 const future_client_logo_class_names = new Set([
-    "client-logos-div client-logos__logo_pilot",
     "client-logos-div client-logos__logo_recurse",
     "client-logos-div client-logos__logo_maria",
-
     "client-logos-div client-logos__logo_layershift",
     "client-logos-div client-logos__logo_julia",
     "client-logos-div client-logos__logo_ucsd",


### PR DESCRIPTION
This removes a stale reference to the Akamai logo, and brings the `current_client_logo_class_names` set in line with those listed in `hello.html`. Previously, the Pilot logo could be displayed twice.

<!-- Describe your pull request here.-->

Fixes: [#issues > landing page: Pilot logo showing up twice](https://chat.zulip.org/#narrow/channel/9-issues/topic/landing.20page.3A.20Pilot.20logo.20showing.20up.20twice/with/2417431)