### PR TITLE
provision: Use uv sync --no-managed-python

### DIFF
--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -31,6 +31,6 @@ else:
 os.chdir(ZULIP_PATH)
 run(["scripts/lib/install-uv"])
 run(
-    ["uv", "sync", "--frozen", "--only-group=prod"],
+    ["uv", "sync", "--frozen", "--no-managed-python", "--only-group=prod"],
     env={k: v for k, v in os.environ.items() if k not in {"PYTHONDEVMODE", "PYTHONWARNINGS"}},
 )

--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -76,7 +76,7 @@ mv zulip-git-version "$OUTPUT_DIR/$prefix/"
 
 cd "$OUTPUT_DIR/$prefix"
 
-env -u PYTHONDEVMODE -u PYTHONWARNINGS uv sync --frozen
+env -u PYTHONDEVMODE -u PYTHONWARNINGS uv sync --frozen --no-managed-python
 
 # create var/log directory in the new temporary checkout
 mkdir -p "var/log"

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -428,7 +428,7 @@ def main(options: argparse.Namespace) -> NoReturn:
     # Install Python environment
     run_as_root([*proxy_env, "scripts/lib/install-uv"], sudo_args=["--preserve-env=PATH"])
     run(
-        [*proxy_env, "uv", "sync", "--frozen"],
+        [*proxy_env, "uv", "sync", "--frozen", "--no-managed-python"],
         env={k: v for k, v in os.environ.items() if k not in {"PYTHONDEVMODE", "PYTHONWARNINGS"}},
     )
     # Clean old symlinks used before uv migration


### PR DESCRIPTION
This is the default, but if we ever want to switch to uv’s managed Python later (#37835), it will be necessary to have this earlier to stop uv from keeping it after checking out an earlier branch.