### PR TITLE
highlight/alert-word: Fix link color contrast in dark mode

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1132,7 +1132,7 @@
     --color-background-popover: light-dark(hsl(0deg 0% 100%), hsl(0deg 0% 17%));
     --color-background-alert-word: light-dark(
         hsl(18deg 100% 84%),
-        hsl(22deg 70% 35%)
+        hsl(18deg 100% 75%)
     );
     --color-buddy-list-highlighted-user: var(
         --color-background-hover-narrow-filter
@@ -1845,6 +1845,7 @@
         transparent,
         var(--color-markdown-pre-border)
     );
+    --color-text-alert-word: light-dark(currentcolor, hsl(0deg 0% 0%));
     --color-markdown-link: light-dark(
         hsl(200deg 100% 40%),
         var(--color-text-generic-link)
@@ -1855,6 +1856,14 @@
         var(--color-text-generic-link-interactive)
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
+    --color-markdown-link-alert-word: light-dark(
+        hsl(200deg 100% 40%),
+        hsl(210deg 100% 25%)
+    );
+    --color-markdown-link-alert-word-hover: light-dark(
+        hsl(200deg 100% 25%),
+        hsl(210deg 100% 18%)
+    );
     --color-background-image-thumbnail: light-dark(
         hsl(0deg 0% 0% / 3%),
         hsl(0deg 0% 100% / 3%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1845,6 +1845,11 @@
         transparent,
         var(--color-markdown-pre-border)
     );
+    --color-background-search-highlight: light-dark(
+        hsl(51deg 100% 79%),
+        hsl(51deg 100% 72%)
+    );
+    --color-text-search-highlight: light-dark(currentcolor, hsl(0deg 0% 0%));
     --color-text-alert-word: light-dark(currentcolor, hsl(0deg 0% 0%));
     --color-markdown-link: light-dark(
         hsl(200deg 100% 40%),
@@ -1856,6 +1861,14 @@
         var(--color-text-generic-link-interactive)
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
+    --color-markdown-link-highlight: light-dark(
+        hsl(200deg 100% 40%),
+        hsl(210deg 100% 25%)
+    );
+    --color-markdown-link-highlight-hover: light-dark(
+        hsl(200deg 100% 25%),
+        hsl(210deg 100% 18%)
+    );
     --color-markdown-link-alert-word: light-dark(
         hsl(200deg 100% 40%),
         hsl(210deg 100% 25%)

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -230,11 +230,6 @@
         background-color: hsl(0deg 0% 0% / 20%);
     }
 
-    /* Search highlight used in both topics and rendered_markdown */
-    .highlight {
-        background-color: hsl(51deg 100% 23%);
-    }
-
     .searching-for-more-topics img {
         filter: invert(100%);
     }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -349,6 +349,7 @@
 
     .alert-word {
         background-color: var(--color-background-alert-word);
+        color: var(--color-text-alert-word);
     }
 
     /* Timestamps */
@@ -872,6 +873,26 @@
             & code {
                 color: var(--color-markdown-code-link-hover);
             }
+        }
+
+        /* Link styles that are also related to alert words */
+        &:has(.alert-word) {
+            &:hover,
+            &:focus {
+                text-decoration-color: var(
+                    --color-markdown-link-alert-word-hover
+                );
+            }
+        }
+
+        & .alert-word {
+            color: var(--color-markdown-link-alert-word);
+            font-weight: 500;
+        }
+
+        &:hover .alert-word,
+        &:focus .alert-word {
+            color: var(--color-markdown-link-alert-word-hover);
         }
     }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -1104,7 +1104,28 @@
 
 /* Search highlight used in both topics and rendered_markdown */
 .highlight {
-    background-color: hsl(51deg 100% 79%);
+    background-color: var(--color-background-search-highlight);
+    color: var(--color-text-search-highlight);
+}
+
+/* Link styles that are also related to search highlights */
+a:not(.icon-button) {
+    &:has(.highlight) {
+        &:hover,
+        &:focus {
+            text-decoration-color: var(--color-markdown-link-highlight-hover);
+        }
+    }
+
+    & .highlight {
+        color: var(--color-markdown-link-highlight);
+        font-weight: 500;
+    }
+
+    &:hover .highlight,
+    &:focus .highlight {
+        color: var(--color-markdown-link-highlight-hover);
+    }
 }
 
 /* For elements where we want to show as much markdown content we can


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- Add theme-aware CSS variables to fix low contrast inside search highlights and alert words in dark mode.
- According to [Web Content Accessibility Guideline](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html), minimum contrast ratio should not be below 4.5. Contrast ratio is updated to be above the minimum.
- Color is updated according to this [issue comment](https://github.com/zulip/zulip/issues/12614#issuecomment-1556028086)
> Regular text becomes black, links color become `#004080` and `font-weight:500`,
> alert bg is `#FFA680`, search bg is `#FFEA70`

Fixes: https://github.com/zulip/zulip/issues/12614

**How changes were tested:**
- Manually tested in both light and dark mode in dev server and viewing messages containing alert & search words


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
|before - alert word|after - alert word| 
| --- | --- |
|<img width="284" height="79" alt="alertword_before(2)" src="https://github.com/user-attachments/assets/0742218d-5077-47d6-90d1-dbd0cd9f7695" />|<img width="284" height="79" alt="alertword_after(2)" src="https://github.com/user-attachments/assets/d7f4fae2-f02a-4c50-b9c5-e9e5e37185d8" />|

|before - search word|after - search word| 
| --- | --- |
|<img width="293" height="168" alt="searchword_before" src="https://github.com/user-attachments/assets/db452383-0bd8-45d2-8e94-66af338b904a" />|<img width="293" height="168" alt="searchword_after" src="https://github.com/user-attachments/assets/d578f676-f981-4cff-8cee-0eed975041c2" />|

|before - alert word in light mode|after - alert word in light mode|
| --- | --- |
|<img width="285" height="75" alt="lightmode_before" src="https://github.com/user-attachments/assets/1bd9a07b-c101-4e5e-b152-5fe90b100afc" />|<img width="285" height="75" alt="lightmode_after" src="https://github.com/user-attachments/assets/6d9a9f4c-18aa-403a-adef-51f69b6c32ce" />|

|before - search word in light mode|after - search word in light mode|
| --- | --- |
|<img width="285" height="168" alt="lightmode_before(2)" src="https://github.com/user-attachments/assets/99c2f8ef-4376-415a-aa61-4a7207ea5bd4" />|<img width="285" height="168" alt="lightmode_after(2)" src="https://github.com/user-attachments/assets/0af5b782-4ffe-4f00-a954-729ca3610c5b" />|

|not hovered- link alert word|hovered - link alert word|
| --- | --- | 
|<img width="65" height="28" alt="not_hovered" src="https://github.com/user-attachments/assets/a36d4974-6c53-455d-a092-115a8152da3d" />|<img width="65" height="28" alt="hovered" src="https://github.com/user-attachments/assets/549bd402-a171-4c8c-baae-c4ff0e593b49" />|

|before - contrast ratio for alert word(4.74)|after - contrast ratio for alert word(10.99)|
| --- | --- |
|<img width="431" height="356" alt="스크린샷 2026-03-27 135952" src="https://github.com/user-attachments/assets/ea0f6a8e-c837-48cd-9cde-c500c3bc1ed4" />|<img width="424" height="351" alt="스크린샷 2026-03-27 141502" src="https://github.com/user-attachments/assets/80ff5820-f644-4dcc-867f-7b87c9284835" />|

|before - contrast ratio for link alert word(1.64)|after - contrast ratio for link alert word(5.39)|
| --- | --- |
|<img width="398" height="347" alt="스크린샷 2026-03-27 141742" src="https://github.com/user-attachments/assets/c652d9e3-0b43-41d8-a475-0342778f4934" />|<img width="407" height="353" alt="스크린샷 2026-03-27 141602" src="https://github.com/user-attachments/assets/7c923475-5002-4565-b723-07335a09f01c" />|


|before - contrast ratio for search word(4.36)|after - contrast ratio for search word(17.2)|
| --- | --- |
|<img width="407" height="348" alt="스크린샷 2026-03-27 140031" src="https://github.com/user-attachments/assets/db9b4955-b4bc-40e0-b497-b913063e6573" />|<img width="404" height="352" alt="스크린샷 2026-03-27 140110" src="https://github.com/user-attachments/assets/bd037fd0-c804-4ce3-98b1-91e5d97e9efd" />|


<details>



<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
