### PR TITLE
api-docs: Document /realm/profile_fields/{field_id}

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -147,6 +147,8 @@
 * [Get all custom profile fields](/api/get-custom-profile-fields)
 * [Reorder custom profile fields](/api/reorder-custom-profile-fields)
 * [Create a custom profile field](/api/create-custom-profile-field)
+* [Update a custom profile field](/api/update-custom-profile-field)
+* [Delete a custom profile field](/api/delete-custom-profile-field)
 * [Update realm-level defaults of user settings](/api/update-realm-user-settings-defaults)
 * [Get all data exports](/api/get-realm-exports)
 * [Create a data export](/api/export-realm)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14602,6 +14602,143 @@ paths:
                         description: |
                           The ID for the custom profile field.
                     example: {"result": "success", "msg": "", "id": 9}
+  /realm/profile_fields/{field_id}:
+    patch:
+      operationId: update-custom-profile-field
+      summary: Update a custom profile field
+      tags: ["server_and_organizations"]
+      description: |
+        Update a custom profile field in the user's organization.
+
+        `PATCH {{ api_url }}/v1/realm/profile_fields/{field_id}`
+
+        This endpoint can be used by organization administrators to update
+        the configuration of an existing custom profile field.
+      x-requires-administrator: true
+      parameters:
+        - in: path
+          name: field_id
+          schema:
+            type: integer
+          required: true
+          description: |
+            The ID of the custom profile field to update.
+          example: 5
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: |
+                    The name of the custom profile field.
+                  example: "Birthday"
+                hint:
+                  type: string
+                  description: |
+                    The help text to be displayed for the custom profile field.
+                  example: "Your birthday."
+                field_data:
+                  type: object
+                  description: |
+                    Additional configuration data for supported field types.
+                  example: {}
+                display_in_profile_summary:
+                  type: boolean
+                  description: |
+                    Whether clients should display this profile field in a
+                    summary section of a user's profile.
+                  example: true
+                required:
+                  type: boolean
+                  description: |
+                    Whether this custom profile field is required.
+                  example: true
+                editable_by_user:
+                  type: boolean
+                  description: |
+                    Whether regular users can edit this profile field on their
+                    own account.
+                  example: true
+                use_for_user_matching:
+                  type: boolean
+                  description: |
+                    Whether this custom profile field should be used to match
+                    users in typeahead suggestions.
+                  example: false
+            encoding:
+              field_data:
+                contentType: application/json
+              display_in_profile_summary:
+                contentType: application/json
+              required:
+                contentType: application/json
+              editable_by_user:
+                contentType: application/json
+              use_for_user_matching:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                duplicate_field_name:
+                  value:
+                    result: "error"
+                    msg: "A field with that label already exists."
+                    code: "BAD_REQUEST"
+    delete:
+      operationId: delete-custom-profile-field
+      summary: Delete a custom profile field
+      tags: ["server_and_organizations"]
+      description: |
+        Delete a custom profile field in the user's organization.
+
+        `DELETE {{ api_url }}/v1/realm/profile_fields/{field_id}`
+
+        This endpoint can be used by organization administrators to remove
+        an existing custom profile field.
+      x-requires-administrator: true
+      parameters:
+        - in: path
+          name: field_id
+          schema:
+            type: integer
+          required: true
+          description: |
+            The ID of the custom profile field to delete.
+          example: 1
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodedError"
+              examples:
+                field_not_found:
+                  value:
+                    result: "error"
+                    msg: "Field id 9 not found."
+                    code: "BAD_REQUEST"
   /realm/user_settings_defaults:
     patch:
       operationId: update-realm-user-settings-defaults

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14715,7 +14715,7 @@ paths:
           required: true
           description: |
             The ID of the custom profile field to delete.
-          example: 1
+          example: 5
       responses:
         "200":
           description: Success.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14610,8 +14610,6 @@ paths:
       description: |
         Update a custom profile field in the user's organization.
 
-        `PATCH {{ api_url }}/v1/realm/profile_fields/{field_id}`
-
         This endpoint can be used by organization administrators to update
         the configuration of an existing custom profile field.
       x-requires-administrator: true
@@ -14705,8 +14703,6 @@ paths:
       tags: ["server_and_organizations"]
       description: |
         Delete a custom profile field in the user's organization.
-
-        `DELETE {{ api_url }}/v1/realm/profile_fields/{field_id}`
 
         This endpoint can be used by organization administrators to remove
         an existing custom profile field.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -237,7 +237,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots",
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
-        "/realm/profile_fields/{field_id}",
         "/realm/icon",
         "/realm/logo",
         "/realm/deactivate",


### PR DESCRIPTION
Document PATCH and DELETE /realm/profile_fields/{field_id}.

This PR adds OpenAPI documentation for:
- PATCH /realm/profile_fields/{field_id} to update a custom profile field
- DELETE /realm/profile_fields/{field_id} to delete a custom profile field

Files changed:
- zerver/openapi/zulip.yaml
- api_docs/include/rest-endpoints.md
- zerver/tests/test_openapi.py

What was added:
- endpoint documentation for PATCH and DELETE
- sidebar links for the new API docs pages
- removal of this endpoint from undocumented endpoints in test_openapi.py

Testing:
- ./tools/test-backend zerver/tests/test_openapi.py

Update: I generated the rendered API documentation locally and reviewed the new PATCH and DELETE pages. I found that the endpoint path was appearing twice near the top of both pages, removed the extra raw endpoint line from the descriptions, and verified the corrected rendered output locally. Final screenshots are attached below.
<img width="1658" height="1218" alt="Screenshot 2026-04-06 194028" src="https://github.com/user-attachments/assets/5afaa9a9-f1d8-47c4-ac70-a4126d7e0f14" />
<img width="1532" height="1197" alt="Screenshot 2026-04-06 194012" src="https://github.com/user-attachments/assets/6ed66919-ec3a-4b1f-ae8d-9a2696e56bec" />
