### PR TITLE
tornado: Remove incorrect Django URL pattern parsing

### DIFF
--- a/zerver/tornado/application.py
+++ b/zerver/tornado/application.py
@@ -1,26 +1,10 @@
-from collections.abc import Iterator, Sequence
-
 import tornado.web
 from django.conf import settings
 from django.core.handlers.base import BaseHandler
-from django.urls import URLPattern, URLResolver
 from tornado import autoreload
 
 from zerver.lib.queue import TornadoQueueClient
 from zerver.tornado.handlers import AsyncDjangoHandler
-from zproject.tornado_urls import urlpatterns as tornado_urlpatterns
-
-
-def extract_all_url_patterns(
-    url_patterns: Sequence[object], base_pattern: str = "/"
-) -> Iterator[str]:
-    for pattern in url_patterns:
-        if isinstance(pattern, URLPattern):
-            yield base_pattern + str(pattern.pattern)
-        elif isinstance(pattern, URLResolver):
-            yield from extract_all_url_patterns(
-                pattern.url_patterns, base_pattern + str(pattern.pattern)
-            )
 
 
 def setup_tornado_rabbitmq(queue_client: TornadoQueueClient) -> None:  # nocoverage
@@ -33,10 +17,7 @@ def create_tornado_application(*, autoreload: bool = False) -> tornado.web.Appli
     django_handler.load_middleware()
 
     return tornado.web.Application(
-        [
-            (url, AsyncDjangoHandler, dict(django_handler=django_handler))
-            for url in extract_all_url_patterns(tornado_urlpatterns)
-        ],
+        [(tornado.routing.AnyMatches(), AsyncDjangoHandler, dict(django_handler=django_handler))],
         debug=settings.DEBUG,
         autoreload=autoreload,
         # Disable Tornado's own request logging, since we have our own


### PR DESCRIPTION
`pattern.pattern` is of type `RegexPattern | RoutePattern | LocalePrefixPattern` and can’t be assumed to be regex formatted like Tornado expects. For example, `str(zproject.urls.urlpatterns[7].pattern) == 'accounts/login/social/<backend>'`. This would have confused us if we ever wanted to add more Tornado patterns.

Given `ROOT_URLCONF = "zproject.tornado_urls"`, it’s no longer necessary to match specific URLs here at all. The only side effect is that Tornado now inherits the Django 404 page.

- Cc @alexmv (https://github.com/zulip/zulip/pull/38453#pullrequestreview-4008309425).