### PR TITLE
composebox_typeahead: Don't show typeahead when matches linkifiers.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -17,6 +17,7 @@ import type {EmojiDict} from "./emoji.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as linkifiers from "./linkifiers.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import * as muted_users from "./muted_users.ts";
@@ -932,6 +933,24 @@ const ALLOWED_MARKDOWN_FEATURES = {
     timestamp: true,
 };
 
+function query_matches_linkifier_pattern(text: string): boolean {
+    for (const pattern of linkifiers.get_linkifier_map().keys()) {
+        const matches = pattern.test(text);
+        pattern.lastIndex = 0;
+        if (matches) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// When the typed text matches a linkifier pattern, require at least
+// 3 characters before showing typeahead suggestions to avoid
+// distracting typeahead when typing linkifier patterns.
+function should_suppress_typeahead_for_linkifier(token: string, query: string): boolean {
+    return token.length < 3 && query_matches_linkifier_pattern(query);
+}
+
 export function get_candidates(
     query: string,
     input_element: TypeaheadInputElement,
@@ -1013,6 +1032,11 @@ export function get_candidates(
         }
         completing = "emoji";
         token = current_token.slice(1);
+
+        if (should_suppress_typeahead_for_linkifier(token, query)) {
+            return [];
+        }
+
         const candidate_list: EmojiSuggestion[] = emoji_collection.map((emoji_dict) => ({
             ...emoji_dict,
             type: "emoji",
@@ -1037,6 +1061,11 @@ export function get_candidates(
             completing = null;
             return [];
         }
+
+        if (should_suppress_typeahead_for_linkifier(filtered_current_token, query)) {
+            return [];
+        }
+
         token = filtered_current_token;
 
         const opts = get_stream_topic_data(input_element);
@@ -1201,6 +1230,10 @@ export function get_candidates(
 
         // Don't autocomplete if there is a space following a '#'
         if (current_token.startsWith(" ")) {
+            return [];
+        }
+
+        if (should_suppress_typeahead_for_linkifier(current_token, query)) {
             return [];
         }
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -56,6 +56,7 @@ const stream_topic_history = zrequire("stream_topic_history");
 const compose_state = zrequire("compose_state");
 const emoji = zrequire("emoji");
 const emoji_picker = zrequire("emoji_picker");
+const linkifiers = zrequire("linkifiers");
 const typeahead_helper = zrequire("typeahead_helper");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
@@ -1861,7 +1862,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
         type: "input",
     };
 
-    function get_values(input, rest) {
+    function get_values(input, rest = "") {
         // Stub out split_at_cursor that uses $(':focus')
         override_rewire(ct, "split_at_cursor", () => [input, rest]);
         const values = ct.get_candidates(input, input_element);
@@ -2338,6 +2339,66 @@ test("begins_typeahead", ({override, override_rewire}) => {
         assert_typeahead_starts_with("```p", symbol, p_langs);
         assert_typeahead_starts_with("~~~p", symbol, p_langs);
     }
+
+    // Set up a linkifier that matches #channel markdown.
+    linkifiers.update_linkifier_rules([
+        {
+            pattern: "#(?P<id>[A-Za-z*]+)",
+            url_template: "https://github.com/zulip/issues/{id}",
+            id: 1,
+        },
+    ]);
+
+    // Channel typeahead suppressed when matching linkifier with short token.
+    assert.deepEqual(get_values("#Sw"), []);
+    assert.deepEqual(get_values("#De"), []);
+    assert.deepEqual(get_values("#**Sw"), []);
+
+    // typeahead returns results when there are multiple(>3) token matches.
+    assert.deepEqual(get_values("#Swe"), [sweden_stream]);
+
+    // Set up a linkifier that matches @mention markdown.
+    linkifiers.update_linkifier_rules([
+        {
+            pattern: "@(?P<id>[a-zA-Z0-9_]+)",
+            url_template: "https://github.com/zulip/issues/{id}",
+            id: 2,
+        },
+    ]);
+
+    // Mention typeahead suppressed when matching linkifier with short token.
+    assert.deepEqual(get_values("@le"), []);
+    assert.deepEqual(get_values("@ki"), []);
+    assert.deepEqual(get_values("@_le"), []);
+    assert.deepEqual(get_values("@_ki"), []);
+
+    // typeahead returns results when there are multiple(>3) token matches.
+    assert.deepEqual(get_values("@lear"), [
+        {is_silent: false, ...cordelia_item},
+        {is_silent: false, ...lear_item},
+    ]);
+    assert.deepEqual(get_values("@_lear"), [
+        {is_silent: true, ...cordelia_item},
+        {is_silent: true, ...lear_item},
+    ]);
+
+    // Set up a linkifier that matches :emoji markdown.
+    linkifiers.update_linkifier_rules([
+        {
+            pattern: ":(?P<id>[a-z]+)",
+            url_template: "https://github.com/zulip/issues/{id}",
+            id: 3,
+        },
+    ]);
+
+    // Emoji typeahead suppressed when matching linkifier with short token.
+    assert.deepEqual(get_values(":ta"), []);
+    assert.deepEqual(get_values(":st"), []);
+
+    // typeahead returns results when there are multiple(>3) token matches.
+    assert.deepEqual(get_values(":tad"), emoji_objects([emoji_tada.name, emoji_stadium.name]));
+
+    linkifiers.update_linkifier_rules([]);
 });
 
 test("tokenizing", () => {


### PR DESCRIPTION
We refrain from showing typeahead if it matches any linkifier patterns and only show it when 3 characters are present. Since there is no fuzzy matching in the compose box typeahead, typing three characters means the suggestion must match all three characters or there will be no match.
The regex test for the query is likely to involve a small number of characters.

<!-- Describe your pull request here.-->

Fixes: [#design > channel mentions typeahead vs. linkifiers @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20mentions.20typeahead.20vs.2E.20linkifiers/near/2406279)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
|Before|After|
|-|-|
|<img width="480" height="270" alt="Screenshot from 2026-04-11 02-35-42" src="https://github.com/user-attachments/assets/a708407f-0567-41fc-9589-8d4c98d8255f" />|<img width="480" height="270" alt="Screenshot from 2026-04-11 02-44-20" src="https://github.com/user-attachments/assets/758cd0e0-9a6d-4941-b09b-2658feaaef53" />|
||<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/3533697b-ec2f-43c1-ac5d-476a6d5f3875" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
