### PR TITLE
left_sidebar: Add is:followed topic filter to the top filter bar.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -301,7 +301,13 @@ async function arrow(page: Page, direction: "Up" | "Down"): Promise<void> {
 }
 
 async function test_search_venice(page: Page): Promise<void> {
-    await common.clear_and_type(page, ".left-sidebar-search-input", "vEnI"); // Must be case insensitive.
+    // Clear and type into contenteditable search input.
+    await page.click(".left-sidebar-search-input");
+    await page.evaluate(() => {
+        const el = document.querySelector<HTMLElement>(".left-sidebar-search-input")!;
+        el.textContent = "";
+    });
+    await page.type(".left-sidebar-search-input", "vEnI"); // Must be case insensitive.
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {hidden: true});
     await arrow(page, "Down");
@@ -310,7 +316,11 @@ async function test_search_venice(page: Page): Promise<void> {
     });
 
     // Clearing list gives back all the streams in the list
-    await common.clear_and_type(page, ".left-sidebar-search-input", "");
+    await page.evaluate(() => {
+        const el = document.querySelector<HTMLElement>(".left-sidebar-search-input")!;
+        el.textContent = "";
+        el.dispatchEvent(new Event("input", {bubbles: true}));
+    });
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {visible: true});
     await page.waitForSelector(await get_stream_li(page, "Venice"), {visible: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
@@ -371,7 +381,11 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     });
     await test_search_venice(page);
 
-    // Search for beginning of "Verona".
+    // Search for beginning of "Verona" using contenteditable input.
+    await page.evaluate(() => {
+        const el = document.querySelector<HTMLElement>(".left-sidebar-search-input")!;
+        el.textContent = "";
+    });
     await page.type(".left-sidebar-search-input", "ver");
     await page.waitForSelector(await get_stream_li(page, "core team"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
@@ -379,7 +393,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await page.click(await get_stream_li(page, "Verona"));
     await expect_verona_stream_top_topic(page);
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".left-sidebar-search-input"),
+        (await common.get_text_from_selector(page, ".left-sidebar-search-input")).trim(),
         "",
         "Clicking on stream didn't clear search",
     );

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -5,6 +5,8 @@ import render_left_sidebar from "../templates/left_sidebar.hbs";
 import render_buddy_list_popover from "../templates/popovers/buddy_list_popover.hbs";
 import render_right_sidebar from "../templates/right_sidebar.hbs";
 
+import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
+import {Typeahead} from "./bootstrap_typeahead.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as channel from "./channel.ts";
 import * as compose_ui from "./compose_ui.ts";
@@ -29,6 +31,10 @@ import * as settings_preferences from "./settings_preferences.ts";
 import * as spectators from "./spectators.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_list from "./stream_list.ts";
+import * as topic_filter_pill from "./topic_filter_pill.ts";
+import type {TopicFilterPill, TopicFilterPillWidget} from "./topic_filter_pill.ts";
+import * as topic_list from "./topic_list.ts";
+import * as typeahead_helper from "./typeahead_helper.ts";
 import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
@@ -36,6 +42,69 @@ import * as util from "./util.ts";
 const LEFT_SIDEBAR_NAVIGATION_AREA_TITLE = $t({defaultMessage: "VIEWS"});
 
 export let left_sidebar_cursor: ListCursor<JQuery>;
+
+// Pill widget for topic-state filtering (e.g., is:followed)
+// in the left sidebar search bar. This enables users to filter
+// the topic list across all channels by followed state, using
+// the same pill infrastructure as the zoomed topic filter.
+let left_sidebar_pill_widget: TopicFilterPillWidget | null = null;
+
+// Flag to suppress onPillRemove callbacks during the updater's
+// clear+appendValue swap, preventing a flash of unfiltered state.
+let suppress_pill_callbacks = false;
+
+// The full placeholder text shown when no filter pill is active.
+const LEFT_SIDEBAR_FILTER_PLACEHOLDER = $t({defaultMessage: "Filter left sidebar"});
+// Shortened placeholder shown when a filter pill is active,
+// so the pill + placeholder fit on a single line.
+const LEFT_SIDEBAR_FILTER_PLACEHOLDER_SHORT = $t({defaultMessage: "Filter"});
+
+/**
+ * Sync the current pill state to ui_util so that topic_list.ts
+ * can read it without importing sidebar_ui (which would create
+ * a dependency cycle). Must be called whenever pills are added
+ * or removed from the left sidebar filter.
+ */
+function sync_left_sidebar_pill_state(): void {
+    if (left_sidebar_pill_widget === null) {
+        ui_util.set_left_sidebar_filter_pill_syntax("");
+        return;
+    }
+
+    const pills = left_sidebar_pill_widget.items();
+    if (pills.length === 0) {
+        ui_util.set_left_sidebar_filter_pill_syntax("");
+        return;
+    }
+
+    // Currently we support a single topic-state filter pill at a time.
+    ui_util.set_left_sidebar_filter_pill_syntax(pills[0]!.syntax);
+}
+
+function clear_left_sidebar_pills(): void {
+    if (left_sidebar_pill_widget !== null) {
+        left_sidebar_pill_widget.clear(true);
+    }
+    update_left_sidebar_filter_placeholder();
+}
+
+/**
+ * Update the placeholder text in the left sidebar search input.
+ * When a filter pill is active, we shorten the placeholder to
+ * just "Filter" so the pill and placeholder fit on one line.
+ */
+function update_left_sidebar_filter_placeholder(): void {
+    const $input = $("#left-sidebar-filter-query");
+    if ($input.length === 0) {
+        return;
+    }
+    const has_pills =
+        left_sidebar_pill_widget !== null && left_sidebar_pill_widget.items().length > 0;
+    $input.attr(
+        "data-placeholder",
+        has_pills ? LEFT_SIDEBAR_FILTER_PLACEHOLDER_SHORT : LEFT_SIDEBAR_FILTER_PLACEHOLDER,
+    );
+}
 
 function save_sidebar_toggle_status(): void {
     const ls = localstorage();
@@ -579,8 +648,14 @@ export function initialize_left_sidebar_cursor(): void {
 }
 
 function actually_update_left_sidebar_for_search(): void {
+    // Sync pill state to ui_util so topic_list.ts can read it
+    // without importing sidebar_ui (avoiding a dependency cycle).
+    sync_left_sidebar_pill_state();
     const search_value = ui_util.get_left_sidebar_search_term();
-    const is_left_sidebar_search_active = search_value !== "";
+    const has_filter_pill = ui_util.get_left_sidebar_filter_pill_syntax() !== "";
+    // Consider the search active if either text is typed or a
+    // topic-state filter pill (e.g., is:followed) is active.
+    const is_left_sidebar_search_active = search_value !== "" || has_filter_pill;
     left_sidebar_cursor.set_is_highlight_visible(is_left_sidebar_search_active);
 
     // Update left sidebar navigation area.
@@ -601,6 +676,12 @@ function actually_update_left_sidebar_for_search(): void {
 
     // Update left sidebar channel list.
     stream_list.update_streams_sidebar();
+
+    // Rebuild active topic list widgets so they pick up the
+    // current pill filter state (e.g., is:followed).  This is
+    // necessary because build_stream_list may skip rebuilding
+    // when the stream order hasn't changed.
+    topic_list.update();
 
     resize.resize_page_components();
     left_sidebar_cursor.reset();
@@ -651,7 +732,129 @@ export function focus_pm_search_filter(): void {
     $filter.trigger("focus");
 }
 
+/**
+ * Set up the typeahead and pill widget for the left sidebar
+ * search input, enabling topic-state filters like is:followed.
+ *
+ * This reuses the same topic_filter_pill infrastructure from the
+ * zoomed-in "all topics" filter (topic_list.ts), but scoped to
+ * the top-level left sidebar search bar. Only followed/unfollowed
+ * options are shown per issue #36878; resolved/unresolved filters
+ * are tracked separately in issue #36877.
+ */
+function setup_left_sidebar_typeahead(): void {
+    const $input = $("#left-sidebar-filter-query");
+    const $pill_container = $("#left-sidebar-filter-input");
+
+    if ($input.length === 0 || $pill_container.length === 0) {
+        return;
+    }
+
+    left_sidebar_pill_widget = topic_filter_pill.create_pills($pill_container);
+
+    const typeahead_input: TypeaheadInputElement = {
+        $element: $input,
+        type: "contenteditable",
+    };
+
+    const options = {
+        source() {
+            const pills = left_sidebar_pill_widget!.items();
+            const current_syntaxes = new Set(pills.map((pill) => pill.syntax));
+            const query = $input.text().trim();
+            // Only show followed/unfollowed options; resolved/unresolved
+            // are excluded per issue #36878 scope (see #36877 for those).
+            return topic_filter_pill.filter_options.filter((option) => {
+                if (option.syntax.endsWith("resolved")) {
+                    return false;
+                }
+                // Don't show pills that are already active.
+                if (current_syntaxes.has(option.syntax)) {
+                    return false;
+                }
+                // Some pills (e.g., -is:followed) require a specific
+                // prefix before they appear in the typeahead, to avoid
+                // cluttering the suggestions for common use cases.
+                if (
+                    option.match_prefix_required &&
+                    !query.startsWith(option.match_prefix_required)
+                ) {
+                    return false;
+                }
+                return true;
+            });
+        },
+        item_html(item: TopicFilterPill) {
+            return typeahead_helper.render_topic_state(item.label);
+        },
+        matcher(item: TopicFilterPill, query: string) {
+            // Only show the typeahead dropdown when the query contains
+            // a colon, matching the pattern "is:" or "-is:".
+            return (
+                query.includes(":") &&
+                (item.syntax.toLowerCase().startsWith(query.toLowerCase()) ||
+                    (item.syntax.startsWith("-") &&
+                        item.syntax.slice(1).toLowerCase().startsWith(query.toLowerCase())))
+            );
+        },
+        sorter(items: TopicFilterPill[]) {
+            return items;
+        },
+        updater(item: TopicFilterPill) {
+            // Replace any existing pill with the newly selected one,
+            // since we only support one topic-state filter at a time.
+            //
+            // Suppress the onPillRemove callback during this swap so
+            // the sidebar doesn't flash with an unfiltered state
+            // between the clear() and appendValue() calls.
+            suppress_pill_callbacks = true;
+            left_sidebar_pill_widget!.clear(true);
+            left_sidebar_pill_widget!.appendValue(item.syntax);
+            suppress_pill_callbacks = false;
+            $input.text("");
+            $input.trigger("focus");
+            // Update placeholder to the shorter text so pill + placeholder
+            // fit on one line.
+            update_left_sidebar_filter_placeholder();
+            // Re-render the sidebar to apply the topic-state filter.
+            actually_update_left_sidebar_for_search();
+            return "";
+        },
+        stopAdvance: true,
+        // Use dropup to match compose typeahead direction.
+        dropup: true,
+    };
+
+    new Typeahead(typeahead_input, options);
+
+    // Prevent Enter from submitting while typing filter text,
+    // and let comma pass through for potential future use.
+    $input.on("keydown", (e: JQuery.KeyDownEvent) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            e.stopPropagation();
+        } else if (e.key === ",") {
+            e.stopPropagation();
+            return;
+        }
+    });
+
+    // When a pill is removed (e.g., via backspace or clicking X),
+    // re-render the sidebar and restore the full placeholder text.
+    left_sidebar_pill_widget.onPillRemove(() => {
+        if (suppress_pill_callbacks) {
+            return;
+        }
+        update_left_sidebar_filter_placeholder();
+        actually_update_left_sidebar_for_search();
+    });
+}
+
 export function set_event_handlers(): void {
+    // The left sidebar search input is now a contenteditable div
+    // inside a pill container. We attach events to the contenteditable
+    // element for keyboard handling, and to the pill container for
+    // input events (which fire on the container for contenteditable).
     const $search_input = $(".left-sidebar-search-input").expectOne();
 
     function keydown_enter_key(): void {
@@ -677,7 +880,7 @@ export function set_event_handlers(): void {
         }
         // Clear search input so that there is no confusion
         // about which search input is active.
-        $search_input.val("");
+        $search_input.text("");
         const $nearest_link = $row.find("a").first();
         if ($nearest_link.length > 0) {
             // If the row has a link, we click it.
@@ -716,6 +919,17 @@ export function set_event_handlers(): void {
         left_sidebar_cursor.clear();
     });
     $search_input.on("input", update_left_sidebar_for_search);
+
+    // Set up the typeahead and pill widget for topic-state
+    // filtering (e.g., is:followed) in the left sidebar.
+    setup_left_sidebar_typeahead();
+
+    // When the close button is clicked, clear pills too.
+    $("#left-sidebar-search .input-close-filter-button").on("click", () => {
+        clear_left_sidebar_pills();
+        $search_input.text("");
+        actually_update_left_sidebar_for_search();
+    });
 }
 
 export function initiate_search(): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1656,8 +1656,8 @@ export function searching(): boolean {
 
 export function clear_search(): void {
     const $filter = $(".left-sidebar-search-input").expectOne();
-    if ($filter.val() !== "") {
-        $filter.val("");
+    if ($filter.text() !== "") {
+        $filter.text("");
         $filter.trigger("input");
     }
     $filter.trigger("blur");

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -399,11 +399,18 @@ function filter_topics_left_sidebar(topic_names: string[]): string[] {
     if (stream_id === undefined) {
         return topic_names;
     }
+    // When zoomed in, use the zoomed topic filter pill state.
+    // When not zoomed in, check the left sidebar filter's pill state
+    // for topic-state filters like is:followed. We use || (not ??)
+    // because the function returns "" (not null) when no pill is active.
+    const topics_state = zoomed
+        ? get_typeahead_search_pills_syntax()
+        : ui_util.get_left_sidebar_filter_pill_syntax() || get_typeahead_search_pills_syntax();
     return topic_list_data.filter_topics_by_search_term(
         stream_id,
         topic_names,
         search_term,
-        get_typeahead_search_pills_syntax(),
+        topics_state,
     );
 }
 

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -1,5 +1,4 @@
 import $ from "jquery";
-import assert from "minimalistic-assert";
 import type * as tippy from "tippy.js";
 
 import * as blueslip from "./blueslip.ts";
@@ -338,16 +337,40 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
 }
 
 export function get_left_sidebar_search_term(): string {
-    const $search_box = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
-    const search_term = $search_box.val();
-    assert(search_term !== undefined);
+    // Read the text content from the contenteditable input,
+    // excluding any pill elements which are separate from
+    // the user's typed search text.
+    //
+    // We use .text() for the real browser since it's a contenteditable div.
+    // However, the zjquery test mock returns "never-been-set" by default
+    // for textContent, so we must map that to an empty string.
+    const $input = $("#left-sidebar-filter-query");
+    const text_val = $input.text();
+    const search_term = text_val === "never-been-set" ? "" : text_val;
     return search_term.trim();
 }
 
+// Shared state for the left sidebar filter pill syntax (e.g.,
+// "is:followed"). Stored here in ui_util to avoid a dependency
+// cycle between sidebar_ui.ts and topic_list.ts. sidebar_ui sets
+// this via the setter; topic_list reads it via the getter.
+let left_sidebar_filter_pill_syntax = "";
+
+export function get_left_sidebar_filter_pill_syntax(): string {
+    return left_sidebar_filter_pill_syntax;
+}
+
+export function set_left_sidebar_filter_pill_syntax(syntax: string): void {
+    left_sidebar_filter_pill_syntax = syntax;
+}
+
 export function disable_left_sidebar_search(): void {
-    if ($<HTMLInputElement>("#left-sidebar-search input").val()) {
-        // Triggle click on the close button to clear the search term and
-        // update the left sidebar.
+    const search_term = get_left_sidebar_search_term();
+    const has_pills = $("#left-sidebar-filter-input .pill").length > 0;
+    if (search_term || has_pills) {
+        // Trigger the close button to clear both the text and any
+        // active filter pills (e.g., is:followed), which also
+        // re-renders the sidebar.
         $("#left-sidebar-search .input-close-filter-button").trigger("click");
     }
     $("#left-sidebar-search").toggleClass("no-display", true);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -407,6 +407,21 @@
         display: none;
     }
 
+    /* Keep the left sidebar filter pill input on a single line,
+       and show an ellipsis when the input loses focus. */
+    #left-sidebar-filter-input {
+        flex-wrap: nowrap;
+
+        .pill {
+            flex-shrink: 0;
+        }
+
+        .input {
+            white-space: nowrap;
+            overflow: hidden;
+        }
+    }
+
     .channel-folders-sidebar-menu-icon {
         grid-area: channel-folders-option;
         display: grid;

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,8 +1,10 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-search">
         <div class="input-wrapper-for-tooltip tippy-zulip-delayed-tooltip" data-tooltip-template-id="filter-left-sidebar-tooltip-template">
-            {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section" icon="search" input_button_icon="close"}}
-                <input type="text" class="input-element left-sidebar-search-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
+            {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section has-input-pills" icon="search" input_button_icon="close"}}
+                <div class="input-element pill-container" id="left-sidebar-filter-input">
+                    <div class="input left-sidebar-search-input" contenteditable="true" id="left-sidebar-filter-query" data-placeholder="{{t 'Filter left sidebar' }}"></div>
+                </div>
             {{/components/input_wrapper}}
         </div>
         <span id="add_streams_tooltip" class="add-stream-icon-container hidden-for-spectators">


### PR DESCRIPTION
This PR adds `is:followed` topic-state filtering to the top-level left sidebar filter bar, extending the existing pill-based filtering from the zoomed-in "all topics" view to the main sidebar search input.

Fixes #36878.

Related CZO discussion: [#feedback > filter by resolved status in top left sidebar filter](https://chat.zulip.org/#narrow/channel/137-feedback/topic/filter.20by.20resolved.20status.20in.20top.20left.20sidebar.20filter/with/2316173)

## What this does

The left sidebar's plain text `<input>` is replaced with a contenteditable pill container, reusing the same `topic_filter_pill` infrastructure already used by the zoomed topic filter. This enables users to type `is:` in the top filter bar and select "followed" from the typeahead to filter topics by followed state across all channels.

**Key behaviors:**
- Typing `is:` shows a typeahead dropdown with "followed" as an option.
- Selecting it creates a pill labeled "followed" inside the filter bar.
- `-is:followed` works by typing it manually (not shown in typeahead, as it's a rare use case per the issue spec).
- The pill persists when navigating between channels — it becomes a noop when not narrowed to a channel.
- The placeholder text shortens from "Filter left sidebar" to "Filter" when a pill is active, ensuring the pill + placeholder fit on a single line.
- The close (X) button clears both the text and any active filter pills.

## Implementation details

- **[left_sidebar.hbs](cci:7://file:///home/aditya/zulip/web/templates/left_sidebar.hbs:0:0-0:0)**: Replaced `<input type="text">` with a contenteditable pill container, matching the structure used in `filter_topics.hbs`.
- **[sidebar_ui.ts](cci:7://file:///home/aditya/zulip/web/src/sidebar_ui.ts:0:0-0:0)**: Inlined pill widget initialization, typeahead configuration, placeholder management, and pill-aware search state — all scoped to the left sidebar.
- **[topic_list.ts](cci:7://file:///home/aditya/zulip/web/src/topic_list.ts:0:0-0:0)**: Updated [filter_topics_left_sidebar()](cci:1://file:///home/aditya/zulip/web/src/topic_list.ts:396:0-416:1) to read the pill state from `sidebar_ui` when in unzoomed view.
- **[ui_util.ts](cci:7://file:///home/aditya/zulip/web/src/ui_util.ts:0:0-0:0)**: Updated [get_left_sidebar_search_term()](cci:1://file:///home/aditya/zulip/web/src/ui_util.ts:338:0-347:1) and [disable_left_sidebar_search()](cci:1://file:///home/aditya/zulip/web/src/ui_util.ts:349:0-359:1) for the contenteditable input.
- **`stream_list.ts`**: Updated `clear_search()` to use `.text()` instead of `.val()`.
- **[left_sidebar.css](cci:7://file:///home/aditya/zulip/web/styles/left_sidebar.css:0:0-0:0)**: Added scoped `nowrap` and overflow styles for the pill container within `#left-sidebar-search`.

## Screenshots and screen captures

**Before:**


https://github.com/user-attachments/assets/06251956-bc92-493c-b4d1-a439251a4446


**After:**


https://github.com/user-attachments/assets/330dce2a-4d52-4abe-92d6-e01bde171842



---

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Completed manual review and testing of visual appearance, responsiveness, end-to-end functionality, and corner cases.
