### PR TITLE
help: Document new scroll-to-date feature.

### DIFF
--- a/starlight_help/astro.config.mjs
+++ b/starlight_help/astro.config.mjs
@@ -385,6 +385,7 @@ export default defineConfig({
                         "view-messages-sent-by-a-user",
                         "link-to-a-message-or-conversation",
                         "search-for-messages",
+                        "scroll-to-date",
                         "printing-messages",
                         {
                             label: "View message content as Markdown",

--- a/starlight_help/src/content/docs/scroll-to-date.mdx
+++ b/starlight_help/src/content/docs/scroll-to-date.mdx
@@ -1,0 +1,26 @@
+---
+title: Scroll to date
+---
+
+import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
+
+import FlattenedSteps from "../../components/FlattenedSteps.astro";
+import KeyboardTip from "../../components/KeyboardTip.astro";
+import ZulipTip from "../../components/ZulipTip.astro";
+
+You can instantly scroll to any date in your message feed, whether you're
+viewing [a conversation](/help/reading-conversations), [a channel
+feed](/help/channel-feed), [search results](/help/search-for-messages), or
+anything else. Suggested dates help you quickly find key moments.
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    1. Click on a date on the right side of a message recipient bar or a date
+       divider in the message feed.
+    1. Select one of the suggested dates to scroll to, or choose a custom date.
+  </TabItem>
+</Tabs>
+
+## Related articles
+
+* [Searching for messages](/help/search-for-messages)


### PR DESCRIPTION
Follow-up to #38404.

<details><summary>Screenshot</summary>
<p>

<img width="2038" height="1536" alt="Screenshot 2026-03-25 at 13 33 23@2x" src="https://github.com/user-attachments/assets/bd5156e2-d7c4-4e59-a69b-3730073cc6d1" />


</p>
</details> 