### PR TITLE
webhooks/github: Add status emojis to notification messages

### DIFF
--- a/zerver/webhooks/github/fixtures/status__missing_commit.json
+++ b/zerver/webhooks/github/fixtures/status__missing_commit.json
@@ -1,0 +1,73 @@
+{
+  "id": 214015194,
+  "sha": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "name": "baxterthehacker/public-repo",
+  "target_url": null,
+  "context": "default",
+  "description": null,
+  "state": "success",
+  "commit": null,
+  "branches": [
+    {
+      "name": "master",
+      "commit": {
+        "sha": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+        "url": "https://api.github.com/repos/baxterthehacker/public-repo/commits/9049f1265b7d61be4a8904a9a27120d2064dab3b"
+      }
+    }
+  ],
+  "created_at": "2015-05-05T23:40:39Z",
+  "updated_at": "2015-05-05T23:40:39Z",
+  "repository": {
+    "id": 35129377,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "login": "baxterthehacker",
+      "id": 6752317,
+      "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/baxterthehacker",
+      "html_url": "https://github.com/baxterthehacker",
+      "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+      "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+      "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+      "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+      "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+      "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://api.github.com/repos/baxterthehacker/public-repo",
+    "created_at": "2015-05-05T23:40:12Z",
+    "updated_at": "2015-05-05T23:40:30Z",
+    "pushed_at": "2015-05-05T23:40:39Z",
+    "default_branch": "master"
+  },
+  "sender": {
+    "login": "baxterthehacker",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker",
+    "html_url": "https://github.com/baxterthehacker",
+    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -380,12 +380,12 @@ class GitHubWebhookTest(WebhookTestCase):
 
     def test_page_build_msg(self) -> None:
         expected_message = (
-            "GitHub Pages build, triggered by baxterthehacker, has finished building."
+            ":check: GitHub Pages build, triggered by baxterthehacker, has finished building."
         )
         self.check_webhook("page_build", TOPIC_REPO, expected_message)
 
     def test_page_build_errored_msg(self) -> None:
-        expected_message = "GitHub Pages build, triggered by baxterthehacker, has failed: \n``` quote\nSomething went wrong.\n```."
+        expected_message = ":cross_mark: GitHub Pages build, triggered by baxterthehacker, has failed: \n``` quote\nSomething went wrong.\n```."
         self.check_webhook("page_build__errored", TOPIC_REPO, expected_message)
 
     def test_status_msg(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -389,12 +389,16 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("page_build__errored", TOPIC_REPO, expected_message)
 
     def test_status_msg(self) -> None:
-        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success."
+        expected_message = ":check: [9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success."
         self.check_webhook("status", TOPIC_REPO, expected_message)
 
     def test_status_with_target_url_msg(self) -> None:
-        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status)."
+        expected_message = ":check: [9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status)."
         self.check_webhook("status__with_target_url", TOPIC_REPO, expected_message)
+
+    def test_status_missing_commit(self) -> None:
+        expected_message = ":check: 9049f1265b7 changed its status to success."
+        self.check_webhook("status__missing_commit", TOPIC_REPO, expected_message)
 
     def test_pull_request_review_msg(self) -> None:
         expected_message = "baxterthehacker submitted [PR review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n``` quote\nLooks great!\n```"

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -145,7 +145,7 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("deployment", TOPIC_DEPLOYMENT, expected_message)
 
     def test_deployment_status_msg(self) -> None:
-        expected_message = "Deployment changed status to success."
+        expected_message = ":check: Deployment changed status to success."
         self.check_webhook("deployment_status", TOPIC_DEPLOYMENT, expected_message)
 
     def test_fork_msg(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -562,9 +562,8 @@ class GitHubWebhookTest(WebhookTestCase):
 
     def test_check_run(self) -> None:
         expected_topic_name = "hello-world / checks"
-        expected_message = """
-Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92930d](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))
-""".strip()
+        expected_message = """:check: Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92930d](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))""".strip()
+
         self.check_webhook("check_run__completed", expected_topic_name, expected_message)
 
     def test_team_edited_description(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -401,18 +401,18 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("status__missing_commit", TOPIC_REPO, expected_message)
 
     def test_pull_request_review_msg(self) -> None:
-        expected_message = "baxterthehacker submitted [PR review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n``` quote\nLooks great!\n```"
+        expected_message = ":check: baxterthehacker submitted [PR review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n``` quote\nLooks great!\n```"
         self.check_webhook("pull_request_review", TOPIC_PR, expected_message)
 
     def test_pull_request_review_msg_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic_name = "notifications"
-        expected_message = "baxterthehacker submitted [PR review for #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n``` quote\nLooks great!\n```"
+        expected_message = ":check: baxterthehacker submitted [PR review for #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n``` quote\nLooks great!\n```"
         self.check_webhook("pull_request_review", expected_topic_name, expected_message)
 
     def test_pull_request_review_msg_with_empty_body(self) -> None:
         expected_topic_name = "groonga / PR #1581 grn_db_value_lock: unlock GRN_TYPE obj..."
-        expected_message = "kou submitted [PR review](https://github.com/groonga/groonga/pull/1581#pullrequestreview-1483047907)."
+        expected_message = ":speech_balloon: kou submitted [PR review](https://github.com/groonga/groonga/pull/1581#pullrequestreview-1483047907)."
         self.check_webhook("pull_request_review__empty_body", expected_topic_name, expected_message)
 
     def test_pull_request_review_comment_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -52,6 +52,17 @@ CHECK_RUN_CONCLUSION_EMOJI: dict[str, str] = {
     "neutral": ":grey_question:",
     "stale": ":zzz:",
 }
+
+DEPLOYMENT_STATUS_EMOJI: dict[str, str] = {
+    "success": ":check:",
+    "failure": ":cross_mark:",
+    "error": ":cross_mark:",
+    "pending": ":working_on_it:",
+    "in_progress": ":working_on_it:",
+    "queued": ":time_ticking:",
+    "waiting": ":time_ticking:",
+}
+
 TOPIC_FOR_DISCUSSION = "{repo} discussion #{number}: {title}"
 DISCUSSION_TEMPLATES = {
     "created": "{sender} created [discussion #{discussion_number}]({url}) in {category}:\n\n{body_fence} quote\n### {title}\n{body}\n{body_fence}",
@@ -269,9 +280,10 @@ def get_deployment_body(helper: Helper) -> str:
 
 def get_change_deployment_status_body(helper: Helper) -> str:
     payload = helper.payload
-    return "Deployment changed status to {}.".format(
-        payload["deployment_status"]["state"].tame(check_string),
-    )
+    state = payload["deployment_status"]["state"].tame(check_string)
+    emoji = DEPLOYMENT_STATUS_EMOJI.get(state, "")
+    prefix = f"{emoji} " if emoji else ""
+    return f"{prefix}Deployment changed status to {state}."
 
 
 def get_create_or_delete_body(action: str, helper: Helper) -> str:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -70,6 +70,12 @@ COMMIT_STATUS_EMOJI: dict[str, str] = {
     "pending": ":working_on_it:",
 }
 
+PAGE_BUILD_STATUS_EMOJI: dict[str, str] = {
+    "built": ":check:",
+    "errored": ":cross_mark:",
+    "building": ":working_on_it:",
+}
+
 TOPIC_FOR_DISCUSSION = "{repo} discussion #{number}: {title}"
 DISCUSSION_TEMPLATES = {
     "created": "{sender} created [discussion #{discussion_number}]({url}) in {category}:\n\n{body_fence} quote\n### {title}\n{body}\n{body_fence}",
@@ -611,7 +617,10 @@ def get_page_build_body(helper: Helper) -> str:
             ),
         )
 
-    return "GitHub Pages build, triggered by {}, {}.".format(
+    emoji = PAGE_BUILD_STATUS_EMOJI.get(status, "")
+    prefix = f"{emoji} " if emoji else ""
+    return "{}GitHub Pages build, triggered by {}, {}.".format(
+        prefix,
         payload["build"]["pusher"]["login"].tame(check_string),
         action,
     )

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -42,6 +42,16 @@ from zerver.models import UserProfile
 
 fixture_to_headers = default_fixture_to_headers("HTTP_X_GITHUB_EVENT")
 
+CHECK_RUN_CONCLUSION_EMOJI: dict[str, str] = {
+    "success": ":check:",
+    "failure": ":cross_mark:",
+    "cancelled": ":no_entry:",
+    "skipped": ":fast_forward:",
+    "timed_out": ":alarm_clock:",
+    "action_required": ":warning:",
+    "neutral": ":grey_question:",
+    "stale": ":zzz:",
+}
 TOPIC_FOR_DISCUSSION = "{repo} discussion #{number}: {title}"
 DISCUSSION_TEMPLATES = {
     "created": "{sender} created [discussion #{discussion_number}]({url}) in {category}:\n\n{body_fence} quote\n### {title}\n{body}\n{body_fence}",
@@ -798,7 +808,7 @@ def get_pull_request_review_requested_body(helper: Helper) -> str:
 def get_check_run_body(helper: Helper) -> str:
     payload = helper.payload
     template = """
-Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}))
+{emoji} Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}))
 """.strip()
 
     kwargs = {
@@ -811,6 +821,9 @@ Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}
             payload["check_run"]["head_sha"].tame(check_string),
         ),
         "conclusion": payload["check_run"]["conclusion"].tame(check_string),
+        "emoji": CHECK_RUN_CONCLUSION_EMOJI.get(
+            payload["check_run"]["conclusion"].tame(check_string), ""
+        ),
     }
 
     return template.format(**kwargs)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -76,6 +76,13 @@ PAGE_BUILD_STATUS_EMOJI: dict[str, str] = {
     "building": ":working_on_it:",
 }
 
+PULL_REQUEST_REVIEW_STATE_EMOJI: dict[str, str] = {
+    "approved": ":check:",
+    "changes_requested": ":cross_mark:",
+    "commented": ":speech_balloon:",
+    "dismissed": ":no_entry:",
+}
+
 TOPIC_FOR_DISCUSSION = "{repo} discussion #{number}: {title}"
 DISCUSSION_TEMPLATES = {
     "created": "{sender} created [discussion #{discussion_number}]({url}) in {category}:\n\n{body_fence} quote\n### {title}\n{body}\n{body_fence}",
@@ -697,11 +704,14 @@ def get_pull_request_ready_for_review_body(helper: Helper) -> str:
 def get_pull_request_review_body(helper: Helper) -> str:
     payload = helper.payload
     include_title = helper.include_title
+    review_state = payload["review"]["state"].tame(check_string)
+    emoji = PULL_REQUEST_REVIEW_STATE_EMOJI.get(review_state, "")
+    prefix = f"{emoji} " if emoji else ""
     title = "for #{} {}".format(
         payload["pull_request"]["number"].tame(check_int),
         payload["pull_request"]["title"].tame(check_string),
     )
-    return get_pull_request_event_message(
+    body = get_pull_request_event_message(
         user_name=get_sender_name(helper),
         action="submitted",
         url=payload["review"]["html_url"].tame(check_string),
@@ -709,6 +719,7 @@ def get_pull_request_review_body(helper: Helper) -> str:
         title=title if include_title else None,
         message=payload["review"]["body"].tame(check_none_or(check_string)),
     )
+    return f"{prefix}{body}"
 
 
 def get_pull_request_review_request_removed_body(helper: Helper) -> str:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -63,6 +63,13 @@ DEPLOYMENT_STATUS_EMOJI: dict[str, str] = {
     "waiting": ":time_ticking:",
 }
 
+COMMIT_STATUS_EMOJI: dict[str, str] = {
+    "success": ":check:",
+    "failure": ":cross_mark:",
+    "error": ":cross_mark:",
+    "pending": ":working_on_it:",
+}
+
 TOPIC_FOR_DISCUSSION = "{repo} discussion #{number}: {title}"
 DISCUSSION_TEMPLATES = {
     "created": "{sender} created [discussion #{discussion_number}]({url}) in {category}:\n\n{body_fence} quote\n### {title}\n{body}\n{body_fence}",
@@ -612,18 +619,24 @@ def get_page_build_body(helper: Helper) -> str:
 
 def get_status_body(helper: Helper) -> str:
     payload = helper.payload
+    state = payload["state"].tame(check_string)
+    emoji = COMMIT_STATUS_EMOJI.get(state, "")
+    prefix = f"{emoji} " if emoji else ""
     if payload["target_url"]:
         status = "[{}]({})".format(
-            payload["state"].tame(check_string),
+            state,
             payload["target_url"].tame(check_string),
         )
     else:
-        status = payload["state"].tame(check_string)
-    return "[{}]({}) changed its status to {}.".format(
-        get_short_sha(payload["sha"].tame(check_string)),
-        payload["commit"]["html_url"].tame(check_string),
-        status,
-    )
+        status = state
+    if payload.get("commit"):
+        sha_link = "[{}]({})".format(
+            get_short_sha(payload["sha"].tame(check_string)),
+            payload["commit"]["html_url"].tame(check_string),
+        )
+    else:
+        sha_link = get_short_sha(payload["sha"].tame(check_string))
+    return f"{prefix}{sha_link} changed its status to {status}."
 
 
 def get_locked_or_unlocked_pull_request_body(helper: Helper) -> str:


### PR DESCRIPTION
Added emoji markers to GitHub webhook notifications so people can quickly see the result of an event.

These event types now show an emoji based on the final result.

check_run: uses the check result
deployment_status: uses the deployment result
status: uses the commit status result, and also fixes a crash when commit data is missing
page_build: uses the page build result
pull_request_review: uses the review result

Fixes #37250