### PR TITLE
webhooks/circleci: Add status emoji to job and workflow notifications.

### DIFF
--- a/zerver/webhooks/circleci/tests.py
+++ b/zerver/webhooks/circleci/tests.py
@@ -10,7 +10,7 @@ class CircleCiHookTests(WebhookTestCase):
     def test_bitbucket_job_completed(self) -> None:
         expected_topic_name = "circleci-webhook-testing"
         expected_message = """
-Job `build-and-test` within Pipeline #4 has succeeded.
+:check: Job `build-and-test` within Pipeline #4 has succeeded.
 
 Triggered on [`8ab595d2de9: app.py edited online with Bitbucket`](https://bitbucket.org/hariprashant1/circleci-webhook-testing/commits/8ab595d2de95767993472837df2cb7884519a92b) on branch `master` by Hari Prashant Bhimaraju.
 """.strip()
@@ -19,7 +19,7 @@ Triggered on [`8ab595d2de9: app.py edited online with Bitbucket`](https://bitbuc
     def test_bitbucket_manual_workflow_completed(self) -> None:
         expected_topic_name = "circleci-webhook-testing"
         expected_message = """
-Workflow [`sample`](https://app.circleci.com/pipelines/bitbucket/hariprashant1/circleci-webhook-testing/2/workflows/baa45986-84db-47a0-bc6c-89e9fe751bc9) within Pipeline #2 has succeeded.
+:check: Workflow [`sample`](https://app.circleci.com/pipelines/bitbucket/hariprashant1/circleci-webhook-testing/2/workflows/baa45986-84db-47a0-bc6c-89e9fe751bc9) within Pipeline #2 has succeeded.
 
 Triggered on `master`'s HEAD on [cab5eacb4cc](https://bitbucket.org/hariprashant1/circleci-webhook-testing/commits/cab5eacb4ccee2710529894425341fa20a48fe6a).
 """.strip()
@@ -30,7 +30,7 @@ Triggered on `master`'s HEAD on [cab5eacb4cc](https://bitbucket.org/hariprashant
     def test_bitbucket_workflow_completed(self) -> None:
         expected_topic_name = "circleci-webhook-testing"
         expected_message = """
-Workflow [`sample`](https://app.circleci.com/pipelines/bitbucket/hariprashant1/circleci-webhook-testing/4/workflows/fd29ef0c-3e39-4c8f-b1d5-d8be1bab8165) within Pipeline #4 has succeeded.
+:check: Workflow [`sample`](https://app.circleci.com/pipelines/bitbucket/hariprashant1/circleci-webhook-testing/4/workflows/fd29ef0c-3e39-4c8f-b1d5-d8be1bab8165) within Pipeline #4 has succeeded.
 
 Triggered on [`8ab595d2de9: app.py edited online with Bitbucket`](https://bitbucket.org/hariprashant1/circleci-webhook-testing/commits/8ab595d2de95767993472837df2cb7884519a92b) on branch `master` by Hari Prashant Bhimaraju.
 """.strip()
@@ -39,7 +39,7 @@ Triggered on [`8ab595d2de9: app.py edited online with Bitbucket`](https://bitbuc
     def test_github_job_completed(self) -> None:
         expected_topic_name = "main branch - build notifications"
         expected_message = """
-Job `build-and-test` within Pipeline #4 has succeeded.
+:check: Job `build-and-test` within Pipeline #4 has succeeded.
 
 Triggered on [`a5e30a90822: Fix remove-op on reaction event.`](https://github.com/zulip-testing/circleci-webhook-test/commit/a5e30a908224e46626a796d058289475f6d387b5) on branch `main` by Hari Prashant Bhimaraju.
 """.strip()
@@ -48,7 +48,7 @@ Triggered on [`a5e30a90822: Fix remove-op on reaction event.`](https://github.co
     def test_github_tag_workflow_completed(self) -> None:
         expected_topic_name = "circleci-webhook-test"
         expected_message = """
-Workflow [`sample`](https://app.circleci.com/pipelines/github/prah23/circleci-webhook-test/20/workflows/045c6271-78e2-4802-8a62-f4fa6d25d0c9) within Pipeline #20 has succeeded.
+:check: Workflow [`sample`](https://app.circleci.com/pipelines/github/prah23/circleci-webhook-test/20/workflows/045c6271-78e2-4802-8a62-f4fa6d25d0c9) within Pipeline #20 has succeeded.
 
 Triggered on the latest tag on [0e6e66c14e6](https://github.com/prah23/circleci-webhook-test/commit/0e6e66c14e61fbcd95db716b0f30d67dbcce7814).
 """.strip()
@@ -57,7 +57,7 @@ Triggered on the latest tag on [0e6e66c14e6](https://github.com/prah23/circleci-
     def test_github_workflow_completed(self) -> None:
         expected_topic_name = "circleci-webhook-test"
         expected_message = """
-Workflow [`sample`](https://app.circleci.com/pipelines/github/zulip-testing/circleci-webhook-test/4/workflows/7381218b-d04c-4aa3-b8b8-8c00a9319d1f) within Pipeline #4 has succeeded.
+:check: Workflow [`sample`](https://app.circleci.com/pipelines/github/zulip-testing/circleci-webhook-test/4/workflows/7381218b-d04c-4aa3-b8b8-8c00a9319d1f) within Pipeline #4 has succeeded.
 
 Triggered on [`a5e30a90822: .circleci: Update Webhook URL.`](https://github.com/zulip-testing/circleci-webhook-test/commit/a5e30a908224e46626a796d058289475f6d387b5) on branch `main` by Hari Prashant Bhimaraju.
 """.strip()
@@ -66,7 +66,7 @@ Triggered on [`a5e30a90822: .circleci: Update Webhook URL.`](https://github.com/
     def test_gitlab_job_completed(self) -> None:
         expected_topic_name = "circleci-webhook-test"
         expected_message = """
-Job `build-and-test` within Pipeline #3 has succeeded.
+:check: Job `build-and-test` within Pipeline #3 has succeeded.
 
 Triggered on [`c31f86994c5: app: Enhance message within hello().`](https://gitlab.com/zulip-testing/circleci-webhook-test/-/commit/c31f86994c54672f97b5bd5e544315b7bd40e4c1) on branch `main` by Hari Prashant Bhimaraju.
 """.strip()
@@ -75,7 +75,7 @@ Triggered on [`c31f86994c5: app: Enhance message within hello().`](https://gitla
     def test_gitlab_workflow_completed(self) -> None:
         expected_topic_name = "circleci-webhook-test"
         expected_message = """
-Workflow [`sample`](https://app.circleci.com/pipelines/circleci/89xcrx7UvWQfzcUPAEmu5Q/63AY3yf3XeUQojmQcGZTtB/3/workflows/b23ceb64-127a-4075-a27c-d204a7a0a3b3) within Pipeline #3 has succeeded.
+:check: Workflow [`sample`](https://app.circleci.com/pipelines/circleci/89xcrx7UvWQfzcUPAEmu5Q/63AY3yf3XeUQojmQcGZTtB/3/workflows/b23ceb64-127a-4075-a27c-d204a7a0a3b3) within Pipeline #3 has succeeded.
 
 Triggered on [`c31f86994c5: app: Enhance message within hello().`](https://gitlab.com/zulip-testing/circleci-webhook-test/-/commit/c31f86994c54672f97b5bd5e544315b7bd40e4c1) on branch `main` by Hari Prashant Bhimaraju.
 """.strip()

--- a/zerver/webhooks/circleci/view.py
+++ b/zerver/webhooks/circleci/view.py
@@ -25,6 +25,14 @@ outcome_to_formatted_status_map = {
     "error": "had an error",
 }
 
+OUTCOME_EMOJI_MAP: dict[str, str] = {
+    "success": ":check:",
+    "failed": ":cross_mark:",
+    "canceled": ":no_entry:",
+    "unauthorized": ":warning:",
+    "error": ":cross_mark:",
+}
+
 GITHUB_COMMIT_LINK = "{target_repository_url}/commit/{commit_sha}"
 
 BITBUCKET_COMMIT_LINK = "{target_repository_url}/commits/{commit_sha}"
@@ -175,7 +183,7 @@ def get_body(payload: WildValue) -> str:
         job_name = payload["job"]["name"].tame(check_string)
         status = payload["job"]["status"].tame(check_string)
         formatted_status = outcome_to_formatted_status_map.get(status)
-        return JOB_BODY_TEMPLATE.format(
+        body = JOB_BODY_TEMPLATE.format(
             job_name=job_name,
             pipeline_number=pipeline_number,
             formatted_status=formatted_status,
@@ -187,10 +195,15 @@ def get_body(payload: WildValue) -> str:
         workflow_url = payload["workflow"]["url"].tame(check_url)
         status = payload["workflow"]["status"].tame(check_string)
         formatted_status = outcome_to_formatted_status_map.get(status)
-        return WORKFLOW_BODY_TEMPLATE.format(
+        body = WORKFLOW_BODY_TEMPLATE.format(
             workflow_name=workflow_name,
             workflow_url=workflow_url,
             pipeline_number=pipeline_number,
             formatted_status=formatted_status,
             commit_details=commit_details,
         )
+
+    emoji = OUTCOME_EMOJI_MAP.get(status, "")
+    if emoji:
+        body = f"{emoji} {body.lstrip()}"
+    return body


### PR DESCRIPTION
Fixes part of #37250

Add status-based emoji prefixes to CircleCI webhook notifications for completed jobs and completed workflows. it is to make notification outcomes easier to recognize at a glance.

## Test plan

- [x] `./tools/test-backend zerver.webhooks.circleci.tests.CircleCiHookTests` . All 9 tests pass
- [x] `./tools/run-mypy zerver/webhooks/circleci/view.py` . No issues