### PR TITLE
Fix YouTube embed title issue caused by privacy redirect

### DIFF
--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -2,8 +2,7 @@ import re
 from collections.abc import Callable
 from re import Match
 from typing import Any
-from urllib.parse import urljoin
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlsplit
 
 import magic
 import requests
@@ -96,21 +95,22 @@ def get_link_embed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> 
     # as-is; if so, we use it.  Otherwise, we use it as a _base_ for
     # the other, less sophisticated techniques which we apply as
     # successive fallbacks.
-    
 
     data = get_oembed_data(url, maxwidth=maxwidth, maxheight=maxheight)
-    parsed = urlparse(url)
+    parsed = urlsplit(url)
     is_youtube = parsed.netloc in ("youtube.com", "www.youtube.com", "youtu.be")
 
     if data is not None and isinstance(data, UrlOEmbedData):
-    # YouTube sometimes returns consent/privacy page titles via oEmbed
-        if is_youtube and data.title and (
-            "privacy" in data.title.lower() or "consent" in data.title.lower()
+        # YouTube sometimes returns consent/privacy page titles via oEmbed
+        if (
+            is_youtube
+            and data.title
+            and ("privacy" in data.title.lower() or "consent" in data.title.lower())
         ):
             data = None  # fallback to OpenGraph/Generic parsing
         else:
             return data
-    
+
     response = PreviewSession().get(mark_sanitized(url), stream=True)
     if not response.ok:
         return None

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -100,7 +100,7 @@ def get_link_embed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> 
 
     data = get_oembed_data(url, maxwidth=maxwidth, maxheight=maxheight)
     parsed = urlparse(url)
-    is_youtube = "youtube.com" in parsed.netloc or "youtu.be" in parsed.netloc
+    is_youtube = parsed.netloc in ("youtube.com", "www.youtube.com", "youtu.be")
 
     if data is not None and isinstance(data, UrlOEmbedData):
     # YouTube sometimes returns consent/privacy page titles via oEmbed

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from re import Match
 from typing import Any
 from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 import magic
 import requests
@@ -95,10 +96,21 @@ def get_link_embed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> 
     # as-is; if so, we use it.  Otherwise, we use it as a _base_ for
     # the other, less sophisticated techniques which we apply as
     # successive fallbacks.
-    data = get_oembed_data(url, maxwidth=maxwidth, maxheight=maxheight)
-    if data is not None and isinstance(data, UrlOEmbedData):
-        return data
+    
 
+    data = get_oembed_data(url, maxwidth=maxwidth, maxheight=maxheight)
+    parsed = urlparse(url)
+    is_youtube = "youtube.com" in parsed.netloc or "youtu.be" in parsed.netloc
+
+    if data is not None and isinstance(data, UrlOEmbedData):
+    # YouTube sometimes returns consent/privacy page titles via oEmbed
+        if is_youtube and data.title and (
+            "privacy" in data.title.lower() or "consent" in data.title.lower()
+        ):
+            data = None  # fallback to OpenGraph/Generic parsing
+        else:
+            return data
+    
     response = PreviewSession().get(mark_sanitized(url), stream=True)
     if not response.ok:
         return None


### PR DESCRIPTION
Fixes #19361

Zulip was incorrectly using the title from YouTube's privacy/consent redirect page 
instead of the actual video title.

This patch detects such cases in oEmbed data and falls back to OpenGraph/Generic parsing.

- Detect YouTube URLs
- Ignore "privacy"/"consent" titles
- Use fallback parsing

All tests pass successfully.