### PR TITLE
[ai] recent_view: Scroll to top when changing filters.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1300,8 +1300,10 @@ function update_recent_view_folder_filter_button(): void {
 }
 
 function hard_redraw_with_scroll_to_top(): void {
+    row_focus = 0;
     assert(topics_widget !== undefined);
     topics_widget.hard_redraw();
+    window.scrollTo(0, 0);
 }
 
 function folder_filter_click_handler(
@@ -2280,7 +2282,9 @@ export function initialize({
         const filter = this.getAttribute("data-filter");
         assert(filter !== null);
         set_filter(filter);
+        row_focus = 0;
         update_filters_view();
+        window.scrollTo(0, 0);
         revive_current_focus();
     });
 


### PR DESCRIPTION
discussion: [#issues > 🎯 Scroll not resetting on filter change in Recent](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Scroll.20not.20resetting.20on.20filter.20change.20in.20Recent/with/2412044)

When a user scrolls down in the Recent Conversations view and then
switches filters (e.g., toggling "Unread"/"Participated" or selecting
a different dropdown/folder filter), the scroll position was not
resetting to the top. This was confusing because the filtered content
changed but the view stayed at the same scroll offset.

**Fix:** Add `row_focus = 0` and `window.scrollTo(0, 0)` to
`hard_redraw_with_scroll_to_top()` (used by the dropdown and folder
filter handlers) and to the toggle button click handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Pointed Claude to the issue thread to open this PR.

Tested manually that changes work as expected.