### PR TITLE
reactions: Avoid layout shift when adding/removing reactions

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -34,15 +34,9 @@
             color: var(--color-message-reaction-text-reacted);
             background-color: var(--color-message-reaction-background-reacted);
             border-color: var(--color-message-reaction-border-reacted);
-            /* Make this border thicker by half a pixel,
-               to make own reactions more prominent. */
-            border-width: 1.5px;
-            /* Reduce the padding top and bottom by half
-               a pixel accordingly, to maintain the same
-               pill height. */
-            padding: 1px 4px 1px 3px;
+            box-shadow: inset 0 0 0 0.7px
+                var(--color-message-reaction-border-reacted);
             font-weight: var(--font-weight-message-reaction);
-            box-shadow: none;
         }
 
         &.disabled {


### PR DESCRIPTION
Removing `border-width` and 'padding' on reacted pills that cause a layout shift in the `message_reactions` container, which shifts messages below it when adding or removing a reaction.

Fix this by replacing the `border-width` change with an `inset box-shadow`, which maintains the visual border thickness on reacted pills without affecting layout.

Fixes: [#issues > later messages move up/down when adding reactji](https://chat.zulip.org/#narrow/channel/9-issues/topic/later.20messages.20move.20up.2Fdown.20when.20adding.20reactji/with/2408773)

Fixes: #38923

<hr>


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**



| Before | After |
|--------|-------|
|<img width="758" height="238" alt="Screenshot 2026-04-13 234232" src="https://github.com/user-attachments/assets/070e6d03-439e-4819-a5b4-33d5800924fc" />|<img width="766" height="244" alt="Screenshot 2026-04-13 234401" src="https://github.com/user-attachments/assets/f28becef-26ee-49e1-910c-8681d9aedc87" />|


| Before | After |
|--------|-------|
|<img width="961" height="243" alt="Screenshot 2026-04-13 235127" src="https://github.com/user-attachments/assets/50c9b34b-f9cd-40ea-8efe-97e0fa282d2f" />|<img width="977" height="238" alt="Screenshot 2026-04-14 000108" src="https://github.com/user-attachments/assets/c12950a9-c8b8-4260-bdd3-4698b120ed64" />|

| Before | After |
|--------|-------|
|<img width="3600" height="1800" alt="Screen Shot 2026-04-13 at 23 55 47" src="https://github.com/user-attachments/assets/e0a5d3ea-b8e0-4b88-8802-ef56305a046e" />|<img width="3600" height="1800" alt="Screen Shot 2026-04-13 at 23 56 54" src="https://github.com/user-attachments/assets/fd32d150-4ec5-4a30-9280-a82430cdade7" />|

| Before | After |
|--------|-------|
|<img width="3600" height="1800" alt="Screen Shot 2026-04-13 at 23 58 31" src="https://github.com/user-attachments/assets/275ac302-bf42-42b4-81a2-2e8fb4583f12" />|<img width="3600" height="1800" alt="Screen Shot 2026-04-13 at 23 57 39" src="https://github.com/user-attachments/assets/059dd5fb-1282-47df-9ef3-13f673f8402b" />|

**Layout shift fixed**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/926ffbda-6c3c-412f-ba13-dae634c959b1" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/2628ed20-f7c4-4e2a-ac91-8695f0553d9a" width="400" controls></video> |

**Layout shift fixed(Mobile view)**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/5ae9e48f-bf8d-4c86-8e21-ed97668b2fe3" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/abc8efa0-e90c-48ae-a18b-50517a22ec49" width="400" controls></video> |

**Covered a wide screen**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/e4aa31f9-9e69-49df-9370-afe46a841863" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/3099596d-7718-4ce0-9892-ffb72f161aa8" width="400" controls></video> |

**GIF**
![ezgif com-animated-gif-maker](https://github.com/user-attachments/assets/6426df28-c6a5-4844-b232-94b42218f664)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
