### PR TITLE
channel_settings: Treat "new" as a right-side tab.

### DIFF
--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -326,6 +326,10 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
     // the new overlay.
     if (coming_from_overlay && base === old_base) {
         if (base === "channels") {
+            if (hash_parser.get_current_nth_hash_section(1) === "new") {
+                stream_settings_ui.launch("subscribed", undefined, "new");
+                return;
+            }
             if (hash_parser.get_current_nth_hash_section(1) === "folders") {
                 const folder_id = hash_parser.get_current_nth_hash_section(2);
                 stream_settings_ui.change_state(

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1134,6 +1134,13 @@ export function change_state(
         return;
     }
 
+    if (right_side_tab === "new") {
+        toggler.goto("subscribed");
+        do_open_create_stream(folder_id);
+        show_right_section();
+        return;
+    }
+
     if (section === "all") {
         if (folder_id !== undefined) {
             stream_settings_components.set_folder_filter_dropdown_value(folder_id);


### PR DESCRIPTION
Previously, navigating to #channels/new caused the 'Subscribed' sidebar highlight to be lost. This happened because the hash parsing logic didn't explicitly link the 'new' state to the 'subscribed' section.

This commit refactors web/src/hashchange.ts to map '#channels/new' as a right-side tab of the 'subscribed' section. It also ensures the UI toggler in stream_settings_ui.ts remains on the correct tab, maintaining a consistent sidebar state.

Fixes #27730.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
