### PR TITLE
docker: Fix failing CI.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -144,7 +144,7 @@ jobs:
             os: jammy
             extra-args: ""
 
-          - docker_image: zulip/ci:noble
+          - docker_image: amanagr2/ci:noble
             name: Ubuntu 24.04 production install
             os: noble
             extra-args: ""

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -43,7 +43,7 @@ jobs:
             include_documentation_tests: true
             include_frontend_tests: false
           # Ubuntu 24.04 ships with Python 3.12.2.
-          - docker_image: zulip/ci:noble
+          - docker_image: amanagr2/ci:noble
             name: Ubuntu 24.04 (Python 3.12, backend)
             os: noble
             include_documentation_tests: false


### PR DESCRIPTION
discussion: [#automated testing > rabbitmq-server fails to start](https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/rabbitmq-server.20fails.20to.20start/with/2419361)

Added this layer on top of zulip/ci:noble

/bin/sh -c sudo apt-get update && sudo apt-get -y install  --no-install-recommends software-properties-common && sudo add-apt-repository -y ppa:lvoytek/rabbitmq-server-fixes

https://hub.docker.com/repository/docker/amanagr2/ci/tags/noble/sha256:4d4c3d6204b0510ca4ff654048b20681d16a8561fc5e1d3085e5f970b1e16bf6