### PR TITLE
event_queue: Don't mutate `idle_queue_timeout` parameter type.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -135,10 +135,12 @@ class ClientDescriptor:
         # Default for idle_queue_timeout is DEFAULT_EVENT_QUEUE_TIMEOUT_SECS;
         # but users can set it as high as MAX_QUEUE_TIMEOUT_SECS.
         if idle_queue_timeout is None:
-            idle_queue_timeout = DEFAULT_EVENT_QUEUE_TIMEOUT_SECS
+            queue_timeout_secs = DEFAULT_EVENT_QUEUE_TIMEOUT_SECS
         elif idle_queue_timeout == "mobile":
-            idle_queue_timeout = MOBILE_EVENT_QUEUE_TIMEOUT_SECS
-        self.queue_timeout = min(idle_queue_timeout, MAX_QUEUE_TIMEOUT_SECS)
+            queue_timeout_secs = MOBILE_EVENT_QUEUE_TIMEOUT_SECS
+        else:
+            queue_timeout_secs = idle_queue_timeout
+        self.queue_timeout = min(queue_timeout_secs, MAX_QUEUE_TIMEOUT_SECS)
 
     def to_dict(self) -> dict[str, Any]:
         # If you add a new key to this dict, make sure you add appropriate


### PR DESCRIPTION
PR to address: https://github.com/zulip/zulip/pull/38537#discussion_r2998114366

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
