### PR TITLE
decorated_channel_name: Squash whitespaces in Handlebars template.

### DIFF
--- a/web/templates/decorated_channel_name.hbs
+++ b/web/templates/decorated_channel_name.hbs
@@ -1,7 +1,9 @@
 <span class="decorated-channel-name-wrapper{{#if inline_with_text}} inline-decorated-channel-name{{/if}}">
+    {{~!-- squash whitespace --~}}
     <span class="channel-privacy-type-icon{{#if show_colored_icon}} stream-privacy-original-color-{{stream.stream_id}}{{/if}}"{{#if show_colored_icon}} style="color: {{stream.color}}"{{/if}}>
         {{~> stream_privacy stream ~}}
     </span>
     {{~!-- squash whitespace --~}}
     <span class="decorated-channel-name">{{stream.name}}</span>
+    {{~!-- squash whitespace --~}}
 </span>

--- a/web/tests/stream_pill.test.cjs
+++ b/web/tests/stream_pill.test.cjs
@@ -154,9 +154,7 @@ run_test("generate_pill_html", () => {
         "<div class='pill 'data-stream-id=\"101\" tabindex=0>\n" +
             '    <span class="pill-label">\n' +
             '        <span class="pill-value">\n' +
-            '                <span class="decorated-channel-name-wrapper">\n' +
-            '    <span class="channel-privacy-type-icon"><i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i></span><span class="decorated-channel-name">Denmark</span>\n' +
-            "</span>\n" +
+            '                <span class="decorated-channel-name-wrapper"><span class="channel-privacy-type-icon"><i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i></span><span class="decorated-channel-name">Denmark</span></span>\n' +
             "        </span></span>\n" +
             '    <div class="exit">\n' +
             '        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n' +


### PR DESCRIPTION
This PR squashes the whitespaces in the decorated_channel_name.hbs template to prevent properties such as `white-space: pre` — used for rendering the multiple space characters in channel/topic names, from rendering extra whitespaces between the span elements.

Fixes: Follow-up for #37920, and required for #37847.

**How changes were tested:**
- Tested on top of #37847, to see how the whitespaces are rendered in messages.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After squashing whitespaces |
|--------|--------|
| <img width="928" height="405" alt="Screenshot 2026-03-27 at 5 59 03 PM" src="https://github.com/user-attachments/assets/37f0f13b-f3ca-44b2-988e-f22d36398558" /> | <img width="928" height="405" alt="Screenshot 2026-03-27 at 5 59 22 PM" src="https://github.com/user-attachments/assets/fa8c8a14-eb82-4dbe-a27d-4ce8b4114581" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
