### PR TITLE
message-list-view: Remove hack for undefined StreamSubscription.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -383,73 +383,44 @@ export function populate_group_from_message(
         assert(message.type === "stream");
         // stream messages have string display_recipient
         assert(typeof display_recipient === "string");
-        const color = stream_data.get_color(message.stream_id);
-        const recipient_bar_color = stream_color.get_recipient_bar_color(color);
-        const stream_privacy_icon_color = stream_color.get_stream_privacy_icon_color(color);
-        const invite_only = stream_data.is_invite_only_by_stream_id(message.stream_id);
-        const is_web_public = stream_data.is_web_public(message.stream_id);
+        const stream_id = message.stream_id;
         const topic = message.topic;
-        const topic_display_name = util.get_final_topic_display_name(topic);
-        const is_empty_string_topic = topic === "";
-        const match_topic_html = util.get_match_topic(message);
-        const stream_url = hash_util.channel_url_by_user_setting(message.stream_id);
-        const is_archived = stream_data.is_stream_archived_by_id(message.stream_id);
-        const topic_url = internal_url.by_stream_topic_url(
-            message.stream_id,
-            message.topic,
-            sub_store.maybe_get_stream_name,
-            message.id,
-        );
-
-        const sub = sub_store.get(message.stream_id);
-        let stream_id;
-        if (sub === undefined) {
-            // Hack to handle unusual cases like the tutorial where
-            // the streams used don't actually exist in the subs
-            // module.  Ideally, we'd clean this up by making the
-            // tutorial populate stream_settings_ui.ts "properly".
-            stream_id = -1;
-        } else {
-            stream_id = sub.stream_id;
-        }
-
-        const is_subscribed = stream_data.is_subscribed(stream_id);
-        const topic_is_resolved = resolved_topic.is_resolved(topic);
-        const user_can_resolve_topic = stream_data.can_resolve_topics(sub);
-        const visibility_policy = user_topics.get_topic_visibility_policy(stream_id, topic);
-        // The following field is not specific to this group, but this is the
-        // easiest way we've figured out for passing the data to the template rendering.
-        const all_visibility_policies = user_topics.all_visibility_policies;
-
-        const topic_links = message.topic_links;
-
+        const sub = sub_store.get(stream_id);
+        assert(sub !== undefined);
         return {
             message_group_id,
             message_containers: [],
             is_stream,
             ...get_topic_edit_properties(message),
-            user_can_resolve_topic,
+            user_can_resolve_topic: stream_data.can_resolve_topics(sub),
             ...subscription_markers,
             date_html,
             display_recipient,
             date_unchanged,
-            topic_links,
+            topic_links: message.topic_links,
             topic,
-            topic_display_name,
-            is_empty_string_topic,
-            recipient_bar_color,
-            stream_privacy_icon_color,
-            invite_only,
-            is_web_public,
-            match_topic_html,
-            stream_url,
-            is_archived,
-            topic_url,
+            topic_display_name: util.get_final_topic_display_name(topic),
+            is_empty_string_topic: topic === "",
+            recipient_bar_color: stream_color.get_recipient_bar_color(sub.color),
+            stream_privacy_icon_color: stream_color.get_stream_privacy_icon_color(sub.color),
+            invite_only: sub.invite_only,
+            is_web_public: sub.is_web_public,
+            match_topic_html: util.get_match_topic(message),
+            stream_url: hash_util.channel_url_by_user_setting(stream_id),
+            is_archived: sub.is_archived,
+            topic_url: internal_url.by_stream_topic_url(
+                stream_id,
+                topic,
+                sub_store.maybe_get_stream_name,
+                message.id,
+            ),
             stream_id,
-            is_subscribed,
-            topic_is_resolved,
-            visibility_policy,
-            all_visibility_policies,
+            is_subscribed: sub.subscribed,
+            topic_is_resolved: resolved_topic.is_resolved(topic),
+            visibility_policy: user_topics.get_topic_visibility_policy(stream_id, topic),
+            // The following field is not specific to this group, but this is the
+            // easiest way we've figured out for passing the data to the template rendering.
+            all_visibility_policies: user_topics.all_visibility_policies,
             always_display_date,
         };
     }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -811,19 +811,13 @@ export function can_subscribe_others(sub: StreamSubscription): boolean {
     );
 }
 
-export function can_resolve_topics(sub: StreamSubscription | undefined): boolean {
-    if (sub?.is_archived) {
+export function can_resolve_topics(sub: StreamSubscription): boolean {
+    if (sub.is_archived) {
         return false;
     }
 
     if (settings_data.user_can_resolve_topic()) {
         return true;
-    }
-
-    if (sub === undefined) {
-        // If we're in a context without a channel, only the global
-        // permission is relevant.
-        return false;
     }
 
     return settings_data.user_has_permission_for_group_setting(

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -1651,9 +1651,7 @@ test("can_resolve_topics", ({override}) => {
     };
     stream_data.add_sub_for_tests(archived_sub);
 
-    assert.equal(stream_data.can_resolve_topics(undefined), false);
     initialize_and_override_current_user(admin_user_id, override);
-    assert.equal(stream_data.can_resolve_topics(undefined), true);
     assert.equal(stream_data.can_resolve_topics(sub), true);
     initialize_and_override_current_user(moderator_user_id, override);
     assert.equal(stream_data.can_resolve_topics(sub), false);


### PR DESCRIPTION
In `message_list_view.populate_group_from_message`, the tutorial referred to in the comment for the case when a channel message's `stream_id` returns `undefined` (instead of a `StreamSubscription` object) was removed in commit be7f6db854.

Since we now can assert that a `StreamSubscription` object is returned for the message in question, we can populate the `MessageGroup` fields via the fields in that object.

**Notes**:
- Removes calls to various functions that check for the same object (e.g., we use `sub.color` instead of calling `stream_data.get_color` and `sub.subscribed` instead of calling `stream_data.is_subscribed(stream_id)`.
- Removes the undefined case from `stream_data.can_resolve_topics` as a follow-up from #38593.
- Calls the various functions for the returned `MesageGroup` fields directly, instead of setting them as constants.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
