### PR TITLE
reminder: Generate accurate `with` topic link.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -63,6 +63,7 @@ from zerver.lib.thumbnail import (
 )
 from zerver.lib.timeout import unsafe_timeout
 from zerver.lib.timezone import common_timezones
+from zerver.lib.topic_link_util import TOPIC_LINK_SYNTAX_FOR_DISPLAY
 from zerver.lib.types import LinkifierDict
 from zerver.lib.url_encoding import encode_channel, encode_hash_component
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
@@ -1879,7 +1880,9 @@ class StreamTopicPattern(StreamTopicMessageProcessor):
             el.text = markdown.util.AtomicString(f"#{stream_name} > ")
             el.append(topic_el)
         else:
-            text = f"#{stream_name} > {topic_name}"
+            text = TOPIC_LINK_SYNTAX_FOR_DISPLAY.format(
+                channel_name=stream_name, topic_name=topic_name
+            )
             el.text = markdown.util.AtomicString(text)
 
         return el, m.start(), m.end()

--- a/zerver/lib/reminders.py
+++ b/zerver/lib/reminders.py
@@ -9,9 +9,12 @@ from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.message import get_user_mentions_for_display, truncate_content
 from zerver.lib.message_cache import MessageDict
-from zerver.lib.topic_link_util import get_stream_topic_link_syntax
+from zerver.lib.topic_link_util import (
+    TOPIC_LINK_SYNTAX_FOR_DISPLAY,
+    escape_invalid_stream_topic_characters,
+)
 from zerver.lib.types import UserDisplayRecipient
-from zerver.lib.url_encoding import message_link_url
+from zerver.lib.url_encoding import message_link_url, stream_message_url
 from zerver.models import Message, Stream, UserProfile
 from zerver.models.scheduled_jobs import ScheduledMessage
 from zerver.tornado.django_api import send_event_on_commit
@@ -54,10 +57,21 @@ def get_reminder_formatted_content(
             id=message.recipient.type_id,
             realm=current_user.realm,
         )
-        topic_pretty_link = get_stream_topic_link_syntax(
-            stream_id=stream.id,
-            stream_name=stream.name,
-            topic_name=message.topic_name(),
+        url = stream_message_url(
+            realm=None,
+            message={
+                "id": message.id,
+                "stream_id": stream.id,
+                "display_recipient": stream.name,
+                "topic": message.topic_name(),
+            },
+            conversation_link=True,
+            include_base_url=False,
+        )
+        escape = escape_invalid_stream_topic_characters
+        topic_pretty_link = TOPIC_LINK_SYNTAX_FOR_DISPLAY.format(
+            channel_name=escape(stream.name),
+            topic_name=escape(message.topic_name()),
         )
         if note:
             content = _(
@@ -72,7 +86,7 @@ def get_reminder_formatted_content(
         context = dict(
             user_silent_mention=user_silent_mention,
             conversation_url=conversation_url,
-            topic_pretty_link=topic_pretty_link,
+            topic_pretty_link=f"[{topic_pretty_link}]({url})",
         )
     else:
         if note:

--- a/zerver/lib/topic_link_util.py
+++ b/zerver/lib/topic_link_util.py
@@ -14,6 +14,8 @@ def will_produce_broken_stream_topic_link(word: str) -> bool:
     return bool(invalid_stream_topic_regex.search(word))
 
 
+TOPIC_LINK_SYNTAX_FOR_DISPLAY = "#{channel_name} > {topic_name}"
+
 escape_mapping = {
     "`": "&#96;",
     ">": "&gt;",

--- a/zerver/tests/test_reminders.py
+++ b/zerver/tests/test_reminders.py
@@ -73,7 +73,7 @@ class RemindersTest(ZulipTestCase):
     def get_channel_message_reminder_content(self, msg_content: str, msg_id: int) -> str:
         return (
             f"You requested a reminder for the following message.\n\n"
-            f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/channel/3-Verona/topic/test/near/{msg_id}) in #**Verona>test**:\n```quote\n{msg_content}\n```"
+            f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/channel/3-Verona/topic/test/near/{msg_id}) in [#Verona > test](#narrow/channel/3-Verona/topic/test/with/{msg_id}):\n```quote\n{msg_content}\n```"
         )
 
     def test_schedule_reminder(self) -> None:
@@ -485,7 +485,7 @@ class RemindersTest(ZulipTestCase):
         self.assertEqual(
             scheduled_message.content,
             f"You requested a reminder for the following message. Note:\n > {note}\n\n"
-            f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/channel/3-Verona/topic/test/near/{message_id}) in #**Verona>test**:\n```quote\n{content}\n```",
+            f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/channel/3-Verona/topic/test/near/{message_id}) in [#Verona > test](#narrow/channel/3-Verona/topic/test/with/{message_id}):\n```quote\n{content}\n```",
         )
 
         message_id = self.send_dm_from_hamlet_to_othello(content)
@@ -531,7 +531,9 @@ class RemindersTest(ZulipTestCase):
             scheduled_message.content,
             "You requested a reminder for the following message. Note:\n > {123}\n\n"
             f"@_**King Hamlet|10** [said](http://zulip.testserver/#narrow/channel/3-Verona/topic/.7B789.7D/near/{message_id})"
-            " in #**Verona>{789}**:\n" + f"```quote\n{content}\n```",
+            " in [#Verona > {789}](#narrow/channel/3-Verona/topic/.7B789.7D/with/"
+            f"{message_id}):\n"
+            f"```quote\n{content}\n```",
         )
 
     def test_schedule_reminder_ones_own_message(self) -> None:


### PR DESCRIPTION
Previously the reminder module generates inaccurate `with` topic link for channel message reminders, the generated link would point towards the latest message in the topic instead of the message to be reminded.

This uses a channel topic link syntax-like text as the link syntax since currently can't format a valid channel topic link syntax with a link because the text would get formatted by both `StreamTopicPattern` and `LinkInlineProcessor`, which results in the custom link being replaced with the one `StreamTopicPattern` generates.

<!-- Describe your pull request here.-->

Fixes: #38089
CZO: [#issues > 🎯 reminder for channel message generates wrong topic link](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20reminder.20for.20channel.20message.20generates.20wrong.20topic.20link/with/2386657)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
