### PR TITLE
Locale-based 12/24 hour time inference for new users (#12555)

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -524,6 +524,8 @@ def do_create_user(
     email_address_visibility: int | None = None,
     add_initial_stream_subscriptions: bool = True,
     external_auth_id_dict: dict[str, str] | None = None,
+    twenty_four_hour_time: bool | None = None,
+    time_format_locale: str | None = None,
 ) -> UserProfile:
     if settings.BILLING_ENABLED:
         from corporate.lib.stripe import RealmBillingSession
@@ -546,6 +548,8 @@ def do_create_user(
         source_profile=source_profile,
         enable_marketing_emails=enable_marketing_emails,
         email_address_visibility=email_address_visibility,
+        twenty_four_hour_time=twenty_four_hour_time,
+        time_format_locale=time_format_locale,
     )
 
     if user_profile.avatar_source == UserProfile.AVATAR_FROM_JDENTICON:

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from email.headerregistry import Address
 
+import icu
 from django.contrib.auth.models import UserManager
 from django.utils.timezone import now as timezone_now
 
@@ -19,6 +20,30 @@ from zerver.models import (
     UserProfile,
 )
 from zerver.models.realms import get_fake_email_domain
+
+
+def infer_twenty_four_hour_time(time_format_locale: str) -> bool:
+    """
+    Best-effort guess of whether the locale's default time format is 24-hour.
+
+    This is used for initializing new user accounts. We use ICU because it has
+    reliable locale data for time formats.
+    """
+
+    # ICU expects locale identifiers like en_GB, while HTTP headers commonly use en-GB.
+    locale_str = time_format_locale.replace("-", "_")
+    try:
+        date_format = icu.DateFormat.createTimeInstance(icu.DateFormat.kShort, icu.Locale(locale_str))
+        if not isinstance(date_format, icu.SimpleDateFormat):
+            return False
+        pattern = date_format.toPattern()
+    except Exception:
+        return False
+
+    # 24-hour: H (0-23) or k (1-24). 12-hour: h (1-12) or K (0-11).
+    if "H" in pattern or "k" in pattern:
+        return True
+    return False
 
 
 def copy_default_settings(
@@ -174,6 +199,8 @@ def create_user(
     force_date_joined: datetime | None = None,
     enable_marketing_emails: bool | None = None,
     email_address_visibility: int | None = None,
+    twenty_four_hour_time: bool | None = None,
+    time_format_locale: str | None = None,
 ) -> UserProfile:
     realm_user_default = RealmUserDefault.objects.get(realm=realm)
     if bot_type is None:
@@ -233,6 +260,16 @@ def create_user(
     else:
         # This will be executed only for bots.
         user_profile.save()
+
+    if bot_type is None and source_profile is None:
+        inferred_twenty_four_hour_time = twenty_four_hour_time
+        if inferred_twenty_four_hour_time is None:
+            inferred_twenty_four_hour_time = infer_twenty_four_hour_time(
+                time_format_locale or default_language
+            )
+        if user_profile.twenty_four_hour_time != inferred_twenty_four_hour_time:
+            user_profile.twenty_four_hour_time = inferred_twenty_four_hour_time
+            user_profile.save(update_fields=["twenty_four_hour_time"])
 
     if bot_type is None and enable_marketing_emails is not None:
         user_profile.enable_marketing_emails = enable_marketing_emails

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -33,7 +33,9 @@ def infer_twenty_four_hour_time(time_format_locale: str) -> bool:
     # ICU expects locale identifiers like en_GB, while HTTP headers commonly use en-GB.
     locale_str = time_format_locale.replace("-", "_")
     try:
-        date_format = icu.DateFormat.createTimeInstance(icu.DateFormat.kShort, icu.Locale(locale_str))
+        date_format = icu.DateFormat.createTimeInstance(
+            icu.DateFormat.kShort, icu.Locale(locale_str)
+        )
         if not isinstance(date_format, icu.SimpleDateFormat):
             return False
         pattern = date_format.toPattern()

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -89,6 +89,24 @@ def get_browser_language_code(request: HttpRequest) -> str | None:
     return None
 
 
+def get_browser_locale(request: HttpRequest) -> str | None:
+    """
+    Return the browser's preferred locale (e.g. "en-GB"), if available.
+
+    This differs from get_browser_language_code by not restricting to Zulip's
+    translated languages; it is intended for heuristics like time format.
+    """
+    accept_lang_header = request.headers.get("Accept-Language")
+    if accept_lang_header is None:
+        return None
+
+    for accept_lang, priority in parse_accept_lang_header(accept_lang_header):
+        if accept_lang == "*":
+            continue
+        return accept_lang
+    return None
+
+
 def get_default_language_for_new_user(realm: Realm, *, request: HttpRequest | None) -> str:
     if request is None:
         # Users created via the API or LDAP will not have a

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1611,11 +1611,7 @@ class UserSignUpTest(ZulipTestCase):
 
         outbox.pop()
 
-    def test_default_twenty_four_hour_time(self) -> None:
-        """
-        Check if the default twenty_four_hour_time setting of new user
-        is the default twenty_four_hour_time of the realm.
-        """
+    def test_twenty_four_hour_time_is_inferred_from_locale(self) -> None:
         email = self.nonreg_email("newguy")
         password = "newpassword"
         realm = get_realm("zulip")
@@ -1637,14 +1633,40 @@ class UserSignUpTest(ZulipTestCase):
         result = self.client_get(confirmation_url)
         self.assertEqual(result.status_code, 200)
 
-        result = self.submit_reg_form_for_user(email, password)
+        # Locale en-US defaults to 12-hour time. This should override the realm default.
+        result = self.submit_reg_form_for_user(email, password, HTTP_ACCEPT_LANGUAGE="en-US")
         self.assertEqual(result.status_code, 302)
 
         user_profile = self.nonreg_user("newguy")
+        self.assertFalse(user_profile.twenty_four_hour_time)
+
+    def test_twenty_four_hour_time_is_inferred_as_24_hour_for_en_gb(self) -> None:
+        email = "newguy2@zulip.com"
+        password = "newpassword"
+        realm = get_realm("zulip")
         realm_user_default = RealmUserDefault.objects.get(realm=realm)
-        self.assertEqual(
-            user_profile.twenty_four_hour_time, realm_user_default.twenty_four_hour_time
+        do_set_realm_user_default_setting(
+            realm_user_default, "twenty_four_hour_time", False, acting_user=None
         )
+
+        result = self.client_post("/accounts/home/", {"email": email})
+        self.assertEqual(result.status_code, 302)
+        self.assertTrue(
+            result["Location"].endswith(f"/accounts/send_confirm/?email={quote(email)}")
+        )
+        result = self.client_get(result["Location"])
+        self.assert_in_response("check your email", result)
+
+        confirmation_url = self.get_confirmation_url_from_outbox(email)
+        result = self.client_get(confirmation_url)
+        self.assertEqual(result.status_code, 200)
+
+        # Locale en-GB defaults to 24-hour time. This should override the realm default.
+        result = self.submit_reg_form_for_user(email, password, HTTP_ACCEPT_LANGUAGE="en-GB,en;q=0.9")
+        self.assertEqual(result.status_code, 302)
+
+        user_profile = UserProfile.objects.get(realm=realm, delivery_email=email)
+        self.assertTrue(user_profile.twenty_four_hour_time)
 
     def test_email_address_visibility_for_new_user(self) -> None:
         email = self.nonreg_email("newguy")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1662,7 +1662,9 @@ class UserSignUpTest(ZulipTestCase):
         self.assertEqual(result.status_code, 200)
 
         # Locale en-GB defaults to 24-hour time. This should override the realm default.
-        result = self.submit_reg_form_for_user(email, password, HTTP_ACCEPT_LANGUAGE="en-GB,en;q=0.9")
+        result = self.submit_reg_form_for_user(
+            email, password, HTTP_ACCEPT_LANGUAGE="en-GB,en;q=0.9"
+        )
         self.assertEqual(result.status_code, 302)
 
         user_profile = UserProfile.objects.get(realm=realm, delivery_email=email)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -77,6 +77,7 @@ from zerver.lib.email_validation import email_allowed_for_realm, validate_email_
 from zerver.lib.exceptions import JsonableError, RateLimitedError
 from zerver.lib.i18n import (
     get_browser_language_code,
+    get_browser_locale,
     get_default_language_for_anonymous_user,
     get_default_language_for_new_user,
     get_language_name,
@@ -848,6 +849,7 @@ def registration_helper(
                     enable_marketing_emails=enable_marketing_emails,
                     email_address_visibility=email_address_visibility,
                     external_auth_id_dict=external_auth_id_dict,
+                    time_format_locale=get_browser_locale(request),
                 )
 
                 # Mark the preregistration object as used if the user was
@@ -1538,6 +1540,7 @@ def create_demo_helper(
         acting_user=None,
         default_language=user_default_language,
         default_stream_groups=[],
+        time_format_locale=get_browser_locale(request),
         # We don't require an email address when creating a demo organization;
         # the user will be able to add an email address later.
         email="",


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Automatically sets the 12-hour or 24-hour time format for new users based on their locale instead of just using the realm default.
US users (en-US) get 12-hour format.
GB users (en-GB) get 24-hour format.
This affects new human accounts in existing realms and works both via web registration and invitation acceptance.

Fixes: settings: Automatically set 24-hour time at account creation. #12555

**How changes were tested:**

Added and ran backend tests in `zerver/tests/test_signup.py.`
Verified manually in the Django shell:
```
from zerver.actions.create_user import do_create_user
from zerver.models import Realm

realm = Realm.objects.get(string_id="zulip")

user_us = do_create_user(
    realm=realm,
    email="test_us@example.com",
    password="testpassword",
    full_name="Test US",
    role=400,
    twenty_four_hour_time=None,
    time_format_locale="en-US",
)
print(user_us.twenty_four_hour_time)  # False

user_gb = do_create_user(
    realm=realm,
    email="test_gb@example.com",
    password="testpassword",
    full_name="Test GB",
    role=400,
    twenty_four_hour_time=None,
    time_format_locale="en-GB",
)
print(user_gb.twenty_four_hour_time)  # True
```
Verified web registration flow also applies the same 12h/24h logic.

### What changes are made and why
In this PR, I updated five files to make new human accounts automatically set their 12-hour or 24-hour time format based on the user’s locale instead of using the realm default. I added a function to infer the 24-hour time setting from the locale in `create_user.py`, modified `do_create_user` in `actions/create_user.py` to pass the locale info, added a helper to parse browser locale in `lib/i18n.py`, wired the locale into the web registration flow in `views/registration.py`, and updated `test_signup.py` to verify that locale-based time inference works for different locales like en-US (12-hour) and en-GB (24-hour).


<details>
<summary>Self-review checklist</summary> 

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
