### PR TITLE
stream-settings: Fix missing calls to resize subscribers list.

### DIFF
--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -144,6 +144,7 @@ export function create({
     onPillCreateAction,
     onPillRemoveAction,
     add_button_pill_update_callback,
+    onTextInputCallback,
 }: {
     $pill_container: JQuery;
     get_potential_subscribers: () => User[];
@@ -152,6 +153,7 @@ export function create({
     onPillCreateAction?: (pill_user_ids: number[]) => void;
     onPillRemoveAction?: (pill_user_ids: number[]) => void;
     add_button_pill_update_callback?: () => void;
+    onTextInputCallback?: () => void;
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
@@ -181,6 +183,12 @@ export function create({
                 const user_ids = await get_pill_user_ids(pill_widget);
                 onPillRemoveAction(user_ids);
             })();
+        });
+    }
+
+    if (onTextInputCallback) {
+        pill_widget.onTextInputHook(() => {
+            onTextInputCallback();
         });
     }
 

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -75,6 +75,7 @@ function build_pill_widget({
         // a user and when not to depending upon their group, channel
         // and individual pills.
         onPillRemoveAction: on_pill_remove,
+        onTextInputCallback: resize.resize_stream_creation_subscribers_list,
     });
 }
 

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -171,6 +171,7 @@ export function enable_subscriber_management({
 
     $pill_container.find(".input").on("input", () => {
         $parent_container.find(".stream_subscription_request_result").empty();
+        resize.resize_stream_subscribers_list();
     });
 
     const user_can_remove_subscribers = stream_data.can_unsubscribe_others(sub);


### PR DESCRIPTION
We were missing calls to resize subscribers list when there was just an input in the subscriber box without adding new pills.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
