### PR TITLE
group-popover: Show "Group settings" option for system groups.

### DIFF
--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -73,7 +73,7 @@
                 <span class="popover-group-menu-placeholder"><i>{{t 'This group has no members.'}}</i></span>
             {{/unless}}
         </li>
-        {{#unless (or is_guest is_system_group)}}
+        {{#unless is_guest}}
             <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
             <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
                 <a href="{{group_edit_url}}" role="menuitem" class="navigate-link-on-enter popover-menu-link" tabindex="0">


### PR DESCRIPTION
Previously, "Group settings" was not shown in popover for system groups because we did not show system groups in groups settings UI. But now we have added "Roles" tab in group settings UI for system groups so "Group settings" option can be shown in the popover.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->[#design > show system groups in group settings UI? @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/show.20system.20groups.20in.20group.20settings.20UI.3F/near/2419982)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-03-27 23-14-10.webm](https://github.com/user-attachments/assets/f10d912a-393a-4a51-a7ac-df392f3fdd40)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
