### PR TITLE
saved snippets: Add arrow and style the saved snippet

### DIFF
--- a/web/src/saved_snippets_ui.ts
+++ b/web/src/saved_snippets_ui.ts
@@ -236,7 +236,9 @@ export function setup_saved_snippets_dropdown_widget(widget_selector: string): v
             const x_offset = -(popper_rect.width / 2 - ref_rect.width / 2);
             instance.setProps({offset: [x_offset, 5]});
         },
-        tippy_props: {},
+        tippy_props: {
+            arrow: true,
+        },
     });
     saved_snippets_widget.setup();
 }

--- a/web/src/saved_snippets_ui.ts
+++ b/web/src/saved_snippets_ui.ts
@@ -230,12 +230,13 @@ export function setup_saved_snippets_dropdown_widget(widget_selector: string): v
         on_exit_with_escape_callback: () => get_dropdown_target_textarea()?.trigger("focus"),
         focus_target_on_hidden: false,
         prefer_top_start_placement: true,
-        tippy_props: {
-            // Using -100 as x offset makes saved snippet icon be in the center
-            // of the dropdown widget and 5 as y offset is what we use in compose
-            // recipient dropdown widget.
-            offset: [-100, 5],
+        on_mount_callback(instance: tippy.Instance) {
+            const ref_rect = instance.reference.getBoundingClientRect();
+            const popper_rect = instance.popper.getBoundingClientRect();
+            const x_offset = -(popper_rect.width / 2 - ref_rect.width / 2);
+            instance.setProps({offset: [x_offset, 5]});
         },
+        tippy_props: {},
     });
     saved_snippets_widget.setup();
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1262,25 +1262,26 @@ div.overlay .flex.overlay-content > .overlay-container,
     display: flex;
     position: relative;
     padding: 7px 14px;
-    background-color: var(--color-background-zulip-button);
+    background-color: var(--color-background-neutral-subtle-action-button);
     justify-content: flex-start;
     color: var(--color-dropdown-item);
-    border: none;
-    border-top: 1px solid var(--color-border-zulip-button);
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border: 1px solid var(--color-border-zulip-button);
+    border-radius: 4px;
     font-family: inherit;
     font-size: inherit;
 
     &:hover {
         color: var(--color-dropdown-item);
-        background-color: var(--background-color-active-dropdown-item);
+        background-color: var(
+            --color-background-neutral-subtle-action-button-hover
+        );
+        border-color: var(--color-border-zulip-button-interactive);
     }
 
     &:focus,
     &.current_selection {
         background-color: var(
-            --background-color-current-selection-dropdown-item
+            --color-background-neutral-subtle-action-button-hover
         );
         outline: none;
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1967,6 +1967,10 @@ textarea.new_message_textarea {
 
 .saved_snippets-dropdown-list-container {
     width: 17.8571em; /* 250px at 14px/em */
+    .sticky-bottom-option-button {
+        width: calc(100% - 6px);
+        margin: 3px;
+    }
 
     .dropdown-list .dropdown-list-item-common-styles {
         padding: 0.3571em 0.7143em; /* 5px 10px at 14px/em */

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -73,6 +73,10 @@
         color: hsl(0deg 0% 75%);
         padding: 0;
     }
+
+    > .tippy-arrow {
+        color: var(--color-background-dropdown-widget);
+    }
 }
 
 .tippy-box[data-theme="popover-menu"] {


### PR DESCRIPTION
Add the tooltip arrow for the "Add saved snippet" and adjust its offset for better alignment with their icon.

Additionally, it focuses on the styling for the "Create new saved snippet" button within the saved snippets dropdown. The global `.sticky-bottom-option-button` class is used across multiple dropdown components, so changes are limited to `.saved_snippets-dropdown-list-container` to avoid side effects.

Fixes: [#design > Saved snippets dropdown arrow(Tooltip pointer) styling](https://chat.zulip.org/#narrow/channel/101-design/topic/Saved.20snippets.20dropdown.20arrow.28Tooltip.20pointer.29.20styling/with/2415073)

Fixes: #38925


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
<hr>
-->

### **Screenshots and screen captures:**

**Different font sizes**

| 14px | 12px |
|--------|-------|
|<img width="190" height="242" alt="chrome_CLGtMF3aON" src="https://github.com/user-attachments/assets/2fac7dea-7ba7-4b3e-9889-9ccd5f2f228a" />|<img width="163" height="213" alt="chrome_9rorUXwdM6" src="https://github.com/user-attachments/assets/2308604b-da09-4f0c-a30f-78b2df00134f" />|

| 18px | 20px |
|--------|-------|
|<img width="244" height="261" alt="chrome_ooy3DYzq9u" src="https://github.com/user-attachments/assets/0ab70926-b9fe-4bcf-93e9-e1dffb3b9394" />|<img width="271" height="267" alt="chrome_4zKIRxqvk0" src="https://github.com/user-attachments/assets/c35f903a-6e35-42a0-9ac8-619a6b2a6b22" />|

### **Dark theme**

- **with filter**

| Before | After |
|--------|-------|
|<img width="216" height="248" alt="chrome_ivJo7ac9yG" src="https://github.com/user-attachments/assets/fd29c0ae-0827-4854-897a-50279961b2b1" />|<img width="216" height="253" alt="chrome_VFIUTaRrej" src="https://github.com/user-attachments/assets/7ea206a1-484d-4e93-b281-2ae5d38790e1" />|

- **without filter**

| Before | After |
|--------|-------|
|<img width="217" height="193" alt="chrome_cneKrOYdYe" src="https://github.com/user-attachments/assets/598022e4-c80a-4115-a59a-ce1914dc6641" />|<img width="217" height="198" alt="chrome_58BK46q7vM" src="https://github.com/user-attachments/assets/8019a58c-3466-4d75-bc1a-862e308952d0" />|

- **No added snippet in the list**

| Before | After |
|--------|-------|
|<img width="217" height="82" alt="chrome_GxAW6ja8HA" src="https://github.com/user-attachments/assets/0eefe66a-2964-450f-80f6-bf0be1e1aaa1" />|<img width="217" height="87" alt="chrome_27EEJ5iRTL" src="https://github.com/user-attachments/assets/6358aea7-0427-4fb8-b2da-e33f5c17f160" />|

###**Light theme**

- **with filter**

| Before | After |
|--------|-------|
|<img width="217" height="249" alt="chrome_grrDwdUf7d" src="https://github.com/user-attachments/assets/0cb7dd02-f7a0-4e02-93a7-074fb000c43c" />|<img width="217" height="254" alt="chrome_NrvJTeIRzd" src="https://github.com/user-attachments/assets/c3d60c3f-0ba8-4ab3-9d53-62be6a75a086" />|

- **without filter**

| Before | After |
|--------|-------|
|<img width="217" height="193" alt="chrome_4kWKn8wIgl" src="https://github.com/user-attachments/assets/0ec2b30a-1387-4613-b57d-d3f3c896fffc" />|<img width="217" height="198" alt="chrome_IDm8QYITaO" src="https://github.com/user-attachments/assets/d054f638-eec0-4c2f-8a49-1cf36d02181c" />|

- **No added snippet in the list**

| Before | After |
|--------|-------|
|<img width="218" height="82" alt="chrome_Z57dI32OVf" src="https://github.com/user-attachments/assets/1f9e2622-ded7-4a84-a139-ea5c57fee421" />|<img width="217" height="87" alt="chrome_Ktrq8EakNq" src="https://github.com/user-attachments/assets/c96b1a4a-964d-4aa3-884d-a605c4066323" />|

### - **Hover effect video**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/2999fe15-1f8e-4743-8675-2668482d8b87" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/063126a5-f21b-493d-9418-611a4164d4ff" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
