### PR TITLE
tooltips: Fix image preview tooltip dislocation on scroll.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -33,6 +33,7 @@ type Config = {
 
 // We need to store all message list instances together to destroy them in case of re-rendering.
 const message_list_tippy_instances = new Set<tippy.Instance>();
+const media_image_tooltip_cleanup_callbacks = new WeakMap<tippy.Instance, () => void>();
 
 // This keeps track of all the instances created and destroyed.
 const store_message_list_instances_plugin = {
@@ -379,8 +380,22 @@ export function initialize(): void {
                 $(instance.reference).parent().attr("aria-label") ??
                 $(instance.reference).parent().attr("href");
             instance.setContent(parse_html(render_message_media_preview_tooltip({title})));
+
+            const hide_on_scroll = (): void => {
+                popover_menus.hide_current_popover_if_visible(instance);
+            };
+            media_image_tooltip_cleanup_callbacks.get(instance)?.();
+            document.addEventListener("scroll", hide_on_scroll, {
+                capture: true,
+                passive: true,
+            });
+            media_image_tooltip_cleanup_callbacks.set(instance, () => {
+                document.removeEventListener("scroll", hide_on_scroll, true);
+            });
         },
         onHidden(instance) {
+            media_image_tooltip_cleanup_callbacks.get(instance)?.();
+            media_image_tooltip_cleanup_callbacks.delete(instance);
             instance.destroy();
         },
     });


### PR DESCRIPTION
This PR fixes #38640

https://github.com/user-attachments/assets/4eae1df5-0291-4c69-a7c1-2232fb4aa62e

 This PR addresses a bug where tooltips for media previews in the message list would remain "floating" in a fixed position even after the user scrolled the reference image out of view.

Key Changes:

Implemented targeted scroll-hide logic within message_list_tooltips.ts specifically for media image tooltips.

Utilized a WeakMap to manage listener cleanup, ensuring that scroll listeners are strictly tied to the tooltip lifecycle and removed upon destruction to prevent memory leaks.

Focused the fix on the tooltip lifecycle to avoid global side effects or performance overhead from broad scroll listeners.

Fixes: #(Floating tooltips on media preview scroll)

How changes were tested:

Manual Reproduction: Confirmed the bug by hovering over a large uploaded image and scrolling; the tooltip previously stayed stuck on the screen.

Fix Verification: Confirmed that with these changes, the tooltip now dismisses immediately upon scrolling.

Regression Testing: Verified that standard hover functionality for other message list elements remains unaffected.

Screenshots and screen captures:
[Insert screenshots/GIFs here]

<details>
<summary>Self-review checklist</summary>

[x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.

[x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

[x] Highlights technical choices and bugs encountered.

[x] Automated tests verify logic where appropriate.

[x] Each commit is a coherent idea.

[x] Commit message(s) explain reasoning and motivation for changes.

[x] Visual appearance of the changes.

[x] Strings and tooltips.

[x] End-to-end functionality of buttons, interactions and flows.

[x] Corner cases, error conditions, and easily imagined bugs.

</details>



