### PR TITLE
notifications: Fix stale favicon notification dots on tab restore.

### DIFF
--- a/web/src/favicon.ts
+++ b/web/src/favicon.ts
@@ -66,3 +66,16 @@ export function update_favicon(new_message_count: number, pm_count: number): voi
         blueslip.error("Failed to update favicon", undefined, error);
     }
 }
+
+// Prevents the browser from caching a stale notification dot when the
+// tab is closed or suspended, which led to incorrect dots showing up
+// on tab restore/wake. See issue #30163.
+if (typeof window !== "undefined" && window.addEventListener) {
+    window.addEventListener("pagehide", () => {
+        try {
+            $("#favicon").attr("href", static_favicon_image);
+        } catch {
+            // Ignore errors
+        }
+    });
+}

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -77,16 +77,23 @@ export function redraw_title(): void {
         " - " +
         "Zulip";
 
+    if (document.title === new_title) {
+        return;
+    }
+
     document.title = new_title;
 }
+
+let initialized = false;
 
 export function update_unread_counts(counts: FullUnreadCountsData): void {
     const new_unread_count = unread.calculate_notifiable_count(counts);
     const new_pm_count = counts.direct_message_count;
-    if (new_unread_count === unread_count && new_pm_count === pm_count) {
+    if (new_unread_count === unread_count && new_pm_count === pm_count && initialized) {
         return;
     }
 
+    initialized = true;
     unread_count = new_unread_count;
     pm_count = new_pm_count;
 
@@ -98,6 +105,16 @@ export function update_unread_counts(counts: FullUnreadCountsData): void {
 
     // TODO: Add a `electron_bridge.updateDirectMessageCount(new_pm_count);` call?
     redraw_title();
+}
+
+if (typeof window !== "undefined" && window.addEventListener) {
+    window.addEventListener("pageshow", (event) => {
+        // If the page is restored from the bfcache, we need to restore
+        // the favicon since it may have been cleared by the pagehide handler.
+        if (event.persisted && initialized) {
+            favicon.update_favicon(unread_count, pm_count);
+        }
+    });
 }
 
 export function update_narrow_title(filter?: Filter): void {


### PR DESCRIPTION
Fixes: #30163.

**Why this is needed:**
Browsers (especially Chromium based) eagerly cache the last active favicon snapshot in a persistent SQLite database alongside the URL fragment. If a user suspends their laptop, closes a tab, or the browser aggressively discards the tab to save memory while a notification dot is active, that red dot is permanently stored as the initial icon for that URL state.

Next time the user opens their laptop or focuses the sleeping tab, the browser UI thread aggressively renders its cached dotted favicon while the Zulip SPA is booting up. Once update_favicon runs and calculates 0 unreads, the dot vanishes, causing an annoying "phantom notification" flash.

**What was done to fix it:**
* We hooked into the Page Lifecycle API pagehide event in web/src/favicon.ts. When the page is unloading or being frozen, we aggressively reset the favicon to the default static_favicon_image. This successfully tricks the browser into caching the clean favicon instead of the notification one inside its history database.
* To support browsers using the back-forward cache (bfcache), we hook into pageshow inside web/src/narrow_title.ts. If event.persisted is true, we immediately re-apply the true unread status from our local client state to correctly redraw the dot if there are actually unread messages.

**Test Plan:**
- [x] Tested manually: Set an unread message to trigger the dotted favicon -> duplicated the tab & closed it/suspended the tab -> restored the tab. Verified the favicon initialized cleanly without an unread dot before the UI finished loading.
- [x] `./tools/test-js-with-node` passes locally and all linter warnings (`./tools/lint`) are clean.
- [x] `./tools/run-mypy` passes locally.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
