### PR TITLE
help: Explain moderation use case for alert words.

### DIFF
--- a/starlight_help/src/content/docs/dm-mention-alert-notifications.mdx
+++ b/starlight_help/src/content/docs/dm-mention-alert-notifications.mdx
@@ -61,9 +61,11 @@ mentions](/help/restrict-wildcard-mentions) in large channels.
 
 ## Alert words
 
-Zulip lets you to specify **alert words or phrases** that send you a desktop
-notification whenever the alert word is included in a message. Alert words are
-case-insensitive.
+Zulip lets you to specify case-insensitive **alert words or phrases** that send you a desktop
+notification whenever the alert word is included in a message. For example, you
+can set up an alert for the name of a product you're responsible for. Alerts for
+problematic words or phrases can help moderators respond quickly when there's an
+issue.
 
 <ZulipTip>
   Alert words in messages you receive while the alert is enabled will be highlighted.

--- a/starlight_help/src/content/docs/moderating-open-organizations.mdx
+++ b/starlight_help/src/content/docs/moderating-open-organizations.mdx
@@ -64,15 +64,20 @@ problematic behavior.
 * Configure who can [authorize and start](/help/restrict-direct-messages) direct
   message conversations.
 
+## Monitoring
+
+* [Enable moderation requests](/help/enable-moderation-requests) to make it easy
+  to [report](/help/report-a-message) problematic messages to community
+  moderators.
+* Configure [alert words](/help/dm-mention-alert-notifications#alert-words) to
+  get notified when a problematic word or phrase is included in a message.
+
 ## Response
 
 The following features are an important part of an organization's
 playbook when responding to abuse or spam that is not prevented by the
 organization's policy choices.
 
-* [Enable moderation requests](/help/enable-moderation-requests) to make it easy
-  to [report](/help/report-a-message) problematic messages to community
-  moderators.
 * Individual users can [mute abusive users](/help/mute-a-user) to stop
   harassment that moderators have not yet addressed, or [collapse
   individual messages](/help/collapse-a-message) that they don't want


### PR DESCRIPTION
This use case came up in a conversation with a potential customer.

# https://zulip.com/help/dm-mention-alert-notifications#alert-words
<img width="1590" height="570" alt="Screenshot 2026-03-27 at 16 40 13@2x" src="https://github.com/user-attachments/assets/b044ebc6-3b7d-4960-850c-2ca39a956b6d" />

# https://zulip.com/help/moderating-open-organizations#response
<img width="1648" height="690" alt="Screenshot 2026-03-27 at 16 40 43@2x" src="https://github.com/user-attachments/assets/0d3de285-1683-4617-bffb-3680a4c7f4f9" />
