### PR TITLE
inbox: Fix focus outline overflow.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -152,7 +152,10 @@
                 }
 
                 .zulip-icon-chevron-down {
-                    padding: 0.3125em 0.25em; /* 5px 4px at 16px em */
+                    /* We are using very specific vertical padding here
+                     * to avoid the inbox row grid overflow. */
+                    padding: 0.125em 0.25em; /* 2px 4px at 16px em */
+                    vertical-align: top;
                     transform: rotate(180deg);
                 }
             }


### PR DESCRIPTION
At 12px + >100% zoom in Firefox, you focus outline of unread count of last collapsed channel is cut due to chevron icon taking more space than that is available cause the whole grid to take more than allotted space.

Reduced vertical padding of chevron icon  so that the grid now fits in the allotted space.

| before | after |
| --- | --- |
| <img width="831" height="461" alt="Screenshot 2026-03-28 092531" src="https://github.com/user-attachments/assets/91d2c084-1f09-415c-bb24-2b8d0346d1a7" /> | <img width="841" height="492" alt="Screenshot 2026-03-28 092728" src="https://github.com/user-attachments/assets/bbf6aea0-a5bd-4934-8fb7-d47012d4ad1c" /> |


discussion: [#issues > keyboard selection box cut off in inbox channel row](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20selection.20box.20cut.20off.20in.20inbox.20channel.20row/with/2391148)