### PR TITLE
message_events: Rerender current view on stale-state topic move

### DIFF
--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -857,6 +857,28 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 }
             }
 
+                        if (
+                !changed_narrow &&
+                !refreshed_current_narrow &&
+                !local_cache_missing_messages &&
+                current_filter &&
+                message_lists.current !== undefined
+            ) {
+                const mismatched = event_messages.filter(
+                    (msg) =>
+                        message_lists.current!.get(msg.id) !== undefined &&
+                        !current_filter.predicate()(msg),
+                );
+                if (mismatched.length > 0) {
+                    refreshed_current_narrow = true;
+                    message_view.show(current_filter.terms(), {
+                        then_select_id: current_selected_id,
+                        trigger: "stream/topic change",
+                        force_rerender: true,
+                    });
+                }
+            }
+
             // Ensure messages that are no longer part of this
             // narrow are deleted and messages that are now part
             // of this narrow are added to the message_list.
@@ -887,6 +909,29 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                     list.remove_and_rerender(event_msg_ids);
                     // For filters that cannot be processed locally, ask server.
                     message_events_util.maybe_add_narrowed_messages(event_messages, list);
+                }
+            }
+            // NEW: If the current narrow was not changed/refreshed but still contains
+            // messages that were moved (e.g. because the frontend had stale topic state),
+            // force a rerender so topic labels and list membership reflect the new state.
+            if (
+                !changed_narrow &&
+                !refreshed_current_narrow &&
+                message_lists.current !== undefined
+            ) {
+                const current_list = message_lists.current;
+                const stale_msg_ids = event_messages
+                    .map((msg) => msg.id)
+                    .filter((id) => current_list.get(id) !== undefined);
+                if (stale_msg_ids.length > 0) {
+                    if (current_list.data.filter.can_apply_locally()) {
+                        current_list.data.remove(stale_msg_ids);
+                        current_list.data.add_messages(event_messages);
+                        current_list.rerender();
+                    } else {
+                        current_list.remove_and_rerender(stale_msg_ids);
+                        message_events_util.maybe_add_narrowed_messages(event_messages, current_list);
+                    }
                 }
             }
         }

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -857,7 +857,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 }
             }
 
-                        if (
+            if (
                 !changed_narrow &&
                 !refreshed_current_narrow &&
                 !local_cache_missing_messages &&
@@ -930,7 +930,10 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                         current_list.rerender();
                     } else {
                         current_list.remove_and_rerender(stale_msg_ids);
-                        message_events_util.maybe_add_narrowed_messages(event_messages, current_list);
+                        message_events_util.maybe_add_narrowed_messages(
+                            event_messages,
+                            current_list,
+                        );
                     }
                 }
             }


### PR DESCRIPTION
When a message is moved from a topic that the frontend believes it is in, but the backend has already moved it elsewhere, the frontend was not rerendering the current message list to reflect the updated state. This caused the topic label to stay stale until a full page refresh. 
Fixed this by:

Checking if the current narrow contains moved messages that no longer match its filter after a topic move, and force-rerendering if so.
Ensuring moved messages visible in the current list are removed and re-added even when no narrow change is triggered.

Fixes: https://github.com/zulip/zulip/issues/23205 When two users interact with the same message concurrently — one moving it to a new topic while the other's frontend still shows it in the old topic — attempting a second move from the stale topic causes the frontend to not update the topic label or message list. The UI only corrects itself after a full page refresh. Additionally, any action taken on the stale view (such as resolving the topic) fires against the wrong topic name.
How changes were tested:
Reproduced the bug manually using two browser tabs (simulating two users):

In Tab A, navigated to #issues > mute/unmute stream is slow
In Tab B, moved a message from that topic to #issues > email-delivery-spam (with follow-on messages)
Without refreshing Tab A, attempted to move the same message to #issues > too many emails being sent
Before the fix: Tab A showed no update — the topic label stayed stale and messages remained visible under the wrong topic until a page refresh
After the fix: Tab A immediately rerenders, messages are correctly removed from the stale topic view, and the sidebar reflects the actual current state without requiring a refresh

Also ran the frontend test suite: ./tools/test-js-with-node web/tests/message_events.test.cjs
Screenshots and screen captures:
Tab A immediately reflecting the correct state after the fix, showing the Notification Bot confirmation of the move from #issues > email-delivery-spam without requiring a page refresh.
<img width="1036" height="1151" alt="image" src="https://github.com/user-attachments/assets/e6bf8f22-16ad-4b8e-8034-8ad85ad51b5c" />


Self review checklist :-
 Explains differences from previous plans (e.g., issue description).
 Highlights technical choices and bugs encountered.
 Calls out remaining decisions and concerns.
 Automated tests verify logic where appropriate.
Individual commits are ready for review 

Completed manual review and testing of the following:
 Visual appearance of the changes.
 Strings and tooltips.
 End-to-end functionality of buttons, interactions and flows.
 Corner cases, error conditions, and easily imagined bugs.