### PR TITLE
docs (api): Clarify 'to' parameter in send_message endpoint.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8769,6 +8769,7 @@ paths:
                     For channel messages, either the name or integer ID of the channel. For
                     direct messages, either a list containing integer user IDs or a list
                     containing string Zulip API email addresses.
+                    Including your own user ID or email in this list is allowed, but it will be ignored by the server.
 
                     **Changes**: Support for using user/channel IDs was added in Zulip 2.0.0.
                   oneOf:


### PR DESCRIPTION
This PR addresses issue #19619 by clarifying the behavior of the `to` parameter in the `send_message` endpoint. 

I noticed a previous attempt (#38547) was closed because the changes were mistakenly made directly in the markdown template. To do this correctly, I have updated the `description` field for the `to` parameter inside `zerver/openapi/zulip.yaml`. 

It now explicitly states that for private messages, including the sender's own user ID or email in the list is allowed, but it will be ignored by the server.

**How changes were tested:**
* Ran `./tools/check-openapi` to ensure the YAML syntax and indentation are perfectly valid.
* Spun up the local help center dev server (`./tools/run-dev --only-help-center`) to visually verify that the OpenAPI schema renders the markdown correctly on the API docs page.

**Screenshots and screen captures:**

<img width="1909" height="999" alt="Screenshot from 2026-03-28 17-22-36" src="https://github.com/user-attachments/assets/43ac9513-f8cb-4f81-85c3-921a41604d8c" />
<img width="1908" height="1026" alt="Screenshot from 2026-03-28 17-23-01" src="https://github.com/user-attachments/assets/29a628aa-5b88-4595-8ec8-2f4ef928265b" />


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>