### PR TITLE
email: Attach file when message content > 10KB.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -195,13 +195,24 @@ def construct_zulip_body(
     if postamble != "":
         postamble = "\n" + postamble
 
-    # Truncate the content ourselves, to ensure that the attachments
-    # all make it into the body-as-posted
-    body = truncate_content(
-        body,
-        settings.MAX_MESSAGE_LENGTH - len(preamble) - len(postamble),
-        "\n[message truncated]",
-    )
+    limit = settings.MAX_MESSAGE_LENGTH - len(preamble) - len(postamble)
+
+    if len(body) > limit:
+        # Upload as text file to prevent truncation (see #17669)
+        content_bytes = body.encode("utf-8")
+        uri, _path_id = upload_message_attachment(
+            "MessageText.txt",
+            "text/plain",
+            content_bytes,
+            sender,
+            target_realm=realm,
+        )
+        body = _("Message content too long. See attached: {link}").format(
+            link=f"[MessageText.txt]({uri})"
+        )
+    else:
+        body = truncate_content(body, limit, "\n[message truncated]")
+
     return preamble + body + postamble
 
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -960,9 +960,17 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.assertEqual(attachment.realm, stream.realm)
         self.assertEqual(attachment.is_realm_public, True)
 
-        assert message.content.endswith(
-            f"aaaaaa\n[message truncated]\n[image.png](/user_uploads/{attachment.path_id})"
+        self.assertIn("Message content too long. See attached", message.content)
+
+        image_attachment = Attachment.objects.get(file_name="image.png", realm=stream.realm)
+        text_attachment = Attachment.objects.get(file_name="MessageText.txt", realm=stream.realm)
+
+        self.assertIn(
+            f"[MessageText.txt](/user_uploads/{text_attachment.path_id})", message.content
         )
+        self.assertIn(f"[image.png](/user_uploads/{image_attachment.path_id})", message.content)
+
+        self.assertEqual(Attachment.objects.filter(messages__id=message.id).count(), 2)
 
     def test_message_with_attachment_utf8_filename(self) -> None:
         user_profile = self.example_user("hamlet")


### PR DESCRIPTION
Previously emails of size > 10kb were truncated ,
Instead of truncating long emails, the change in this PR uploads the full body as 'MessageText.txt' attachment and includes a link in the message content.

Fixes #17669.

How resulting message will look : 
<img width="635" height="92" alt="image" src="https://github.com/user-attachments/assets/072e5c55-9d06-4b77-8812-c2919fcb52f9" />


**How changes were tested:**
- Verified changes by  adding a new test case in `zerver/tests/test_email_mirror.py` that simulates a long email body exceeding `MAX_MESSAGE_LENGTH`.
- Ran all existing email mirror tests and confirmed they pass
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
