### PR TITLE
alert_words: Use bulk query for case-insensitive word deletion

### DIFF
--- a/zerver/lib/alert_words.py
+++ b/zerver/lib/alert_words.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 
 import ahocorasick
 from django.db import transaction
+from django.db.models.functions import Lower
 
 from zerver.lib.cache import (
     cache_with_key,
@@ -74,9 +75,10 @@ def add_user_alert_words(user_profile: UserProfile, new_words: Iterable[str]) ->
 
 @transaction.atomic(savepoint=False)
 def remove_user_alert_words(user_profile: UserProfile, delete_words: Iterable[str]) -> list[str]:
-    # TODO: Ideally, this would be a bulk query, but Django doesn't have a `__iexact`.
-    # We can clean this up if/when PostgreSQL has more native support for case-insensitive fields.
-    # If we turn this into a bulk operation, we will need to call flush_realm_alert_words() here.
-    for delete_word in delete_words:
-        AlertWord.objects.filter(user_profile=user_profile, word__iexact=delete_word).delete()
+    delete_words_lower = [word.lower() for word in delete_words]
+    AlertWord.objects.annotate(word_lower=Lower("word")).filter(
+        user_profile=user_profile,
+        word_lower__in=delete_words_lower,
+    ).delete()
+    flush_realm_alert_words(user_profile.realm_id)
     return user_alert_words(user_profile)

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -78,15 +78,25 @@ class AlertWordTests(ZulipTestCase):
         for multi-word and non-ascii words.
         """
         user = self.get_user()
-
         expected_remaining_alerts = set(self.interesting_alert_word_list)
         do_add_alert_words(user, self.interesting_alert_word_list)
-
         for alert_word in self.interesting_alert_word_list:
             do_remove_alert_words(user, [alert_word])
             expected_remaining_alerts.remove(alert_word)
             actual_remaining_alerts = user_alert_words(user)
             self.assertEqual(set(actual_remaining_alerts), expected_remaining_alerts)
+
+    def test_remove_words_bulk_case_insensitive(self) -> None:
+        """
+        Removing multiple alert words in one call works correctly,
+        including case-insensitive matching.
+        """
+        user = self.get_user()
+        do_add_alert_words(user, ["hello", "world", "python"])
+        # Delete using different casing — should still match
+        do_remove_alert_words(user, ["HELLO", "World"])
+        remaining = user_alert_words(user)
+        self.assertEqual(set(remaining), {"python"})
 
     def test_realm_words(self) -> None:
         """


### PR DESCRIPTION
## Problem

`remove_user_alert_words` deleted alert words one at a time in a loop,
issuing one DELETE query per word. The existing TODO comment noted this
should be a bulk operation but that Django lacked `__iexact` support
for bulk deletes.

## Fix

Use `Lower()` annotation to enable a single bulk DELETE query with
case-insensitive matching, replacing the per-word loop.

Before (N queries):
```python
for delete_word in delete_words:
    AlertWord.objects.filter(user_profile=user_profile, word__iexact=delete_word).delete()
```

After (1 query):
```python
delete_words_lower = [word.lower() for word in delete_words]
AlertWord.objects.annotate(word_lower=Lower("word")).filter(
    user_profile=user_profile,
    word_lower__in=delete_words_lower,
).delete()
flush_realm_alert_words(user_profile.realm_id)
```

Also adds `flush_realm_alert_words()` call noted in the original TODO,
and adds a test for bulk case-insensitive deletion.