### PR TITLE
left_sidebar: Only show purple hover effect on non-touchscreens.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2408,6 +2408,9 @@ body:not(.spectator-view)
     #left-sidebar:not(.direct-messages-hidden-by-filters).zoom-in-topics
     #left-sidebar-modal {
     .left-sidebar-modal-close-area {
+        /* Avoid annoying flash of gray in the close area
+           on iOS/iPadOS */
+        -webkit-tap-highlight-color: transparent;
         padding-top: calc(
             var(--left-sidebar-modal-close-area-padding-top) +
                 var(--line-height-sidebar-row-prominent)


### PR DESCRIPTION
Context:
https://chat.zulip.org/#narrow/channel/101-design/topic/modal.20styling.20for.20zoomed.20in.20sidebar.20.2334471/near/2403119
