### PR TITLE
webhooks/codeship: Add status emoji to build notifications.

### DIFF
--- a/zerver/webhooks/codeship/tests.py
+++ b/zerver/webhooks/codeship/tests.py
@@ -8,21 +8,21 @@ class CodeshipHookTests(WebhookTestCase):
         """
         Tests if codeship testing status is mapped correctly
         """
-        expected_message = "[Build](https://www.codeship.com/projects/10213/builds/973711) triggered by beanieboi on master branch started."
+        expected_message = ":arrows_counterclockwise: [Build](https://www.codeship.com/projects/10213/builds/973711) triggered by beanieboi on master branch started."
         self.check_webhook("testing_build", self.TOPIC_NAME, expected_message)
 
     def test_codeship_build_in_error_status_message(self) -> None:
         """
         Tests if codeship error status is mapped correctly
         """
-        expected_message = "[Build](https://www.codeship.com/projects/10213/builds/973711) triggered by beanieboi on master branch failed."
+        expected_message = ":cross_mark: [Build](https://www.codeship.com/projects/10213/builds/973711) triggered by beanieboi on master branch failed."
         self.check_webhook("error_build", self.TOPIC_NAME, expected_message)
 
     def test_codeship_build_in_success_status_message(self) -> None:
         """
         Tests if codeship success status is mapped correctly
         """
-        expected_message = "[Build](https://www.codeship.com/projects/10213/builds/973711) triggered by beanieboi on master branch succeeded."
+        expected_message = ":check: [Build](https://www.codeship.com/projects/10213/builds/973711) triggered by beanieboi on master branch succeeded."
         self.check_webhook("success_build", self.TOPIC_NAME, expected_message)
 
     def test_codeship_build_in_other_status_status_message(self) -> None:

--- a/zerver/webhooks/codeship/view.py
+++ b/zerver/webhooks/codeship/view.py
@@ -20,6 +20,12 @@ CODESHIP_STATUS_MAPPER = {
     "success": "succeeded",
 }
 
+CODESHIP_STATUS_EMOJI_MAP: dict[str, str] = {
+    "success": ":check:",
+    "error": ":cross_mark:",
+    "testing": ":arrows_counterclockwise:",
+}
+
 
 @webhook_view("Codeship")
 @typed_endpoint
@@ -44,12 +50,17 @@ def get_topic_for_http_request(payload: WildValue) -> str:
 
 
 def get_body_for_http_request(payload: WildValue) -> str:
-    return CODESHIP_MESSAGE_TEMPLATE.format(
+    build_status = payload["status"].tame(check_string)
+    message = CODESHIP_MESSAGE_TEMPLATE.format(
         build_url=payload["build_url"].tame(check_string),
         committer=payload["committer"].tame(check_string),
         branch=payload["branch"].tame(check_string),
         status=get_status_message(payload),
     )
+    emoji = CODESHIP_STATUS_EMOJI_MAP.get(build_status, "")
+    if emoji:
+        return f"{emoji} {message}"
+    return message
 
 
 def get_status_message(payload: WildValue) -> str:


### PR DESCRIPTION
Fixes part of #37250.

When users receive Codeship build notifications in Zulip, the outcome
(success, failure, or in-progress) is only communicated through text.
Adding a status emoji at the start of the message makes the result
immediately visible at a glance, consistent with the CircleCI webhook
integration already merged.

## my change

- `:check:` for successful builds
- `:cross_mark:` for failed builds  
- `:arrows_counterclockwise:` for in-progress (testing) builds
- No emoji for unknown statuses (graceful fallback)

## Test plan

- [x] `./tools/test-backend zerver.webhooks.codeship`
- [x] `./tools/lint zerver/webhooks/codeship/view.py`
