### PR TITLE
webhooks/appveyor: Add status emoji to build notifications.

### DIFF
--- a/zerver/webhooks/appveyor/tests.py
+++ b/zerver/webhooks/appveyor/tests.py
@@ -8,7 +8,7 @@ class AppveyorHookTests(WebhookTestCase):
         """
         expected_topic_name = "Hubot-DSC-Resource"
         expected_message = """
-[Build Hubot-DSC-Resource 2.0.59 completed](https://ci.appveyor.com/project/joebloggs/hubot-dsc-resource/build/2.0.59):
+:check: [Build Hubot-DSC-Resource 2.0.59 completed](https://ci.appveyor.com/project/joebloggs/hubot-dsc-resource/build/2.0.59):
 * **Commit**: [c06e208b47: Increment version number.](https://github.com/joebloggs/Hubot-DSC-Resource/commit/c06e208b47) by Joe Bloggs
 * **Started**: <time:2018-09-09T19:04:00+00:00>
 * **Finished**: <time:2018-09-09T19:06:00+00:00>
@@ -22,7 +22,7 @@ class AppveyorHookTests(WebhookTestCase):
         """
         expected_topic_name = "Hubot-DSC-Resource"
         expected_message = """
-[Build Hubot-DSC-Resource 2.0.59 failed](https://ci.appveyor.com/project/joebloggs/hubot-dsc-resource/build/2.0.59):
+:cross_mark: [Build Hubot-DSC-Resource 2.0.59 failed](https://ci.appveyor.com/project/joebloggs/hubot-dsc-resource/build/2.0.59):
 * **Commit**: [c06e208b47: Increment version number.](https://github.com/joebloggs/Hubot-DSC-Resource/commit/c06e208b47) by Joe Bloggs
 * **Started**: <time:2018-09-09T19:04:00+00:00>
 * **Finished**: <time:2018-09-09T19:06:00+00:00>

--- a/zerver/webhooks/appveyor/view.py
+++ b/zerver/webhooks/appveyor/view.py
@@ -12,6 +12,15 @@ from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
 APPVEYOR_TOPIC_TEMPLATE = "{project_name}"
+
+APPVEYOR_STATUS_EMOJI_MAP: dict[str, str] = {
+    "success": ":check:",
+    "completed": ":check:",
+    "failed": ":cross_mark:",
+    "cancelled": ":no_entry:",
+    "error": ":cross_mark:",
+}
+
 APPVEYOR_MESSAGE_TEMPLATE = """
 [Build {project_name} {build_version} {status}]({build_url}):
 * **Commit**: [{commit_id}: {commit_message}]({commit_url}) by {committer_name}
@@ -65,5 +74,8 @@ def get_body(payload: WildValue) -> str:
         to_snake(field): get_global_time(value) if field in ["started", "finished"] else value
         for field, value in ((field, event_data[field].tame(check_string)) for field in fields)
     }
-
-    return APPVEYOR_MESSAGE_TEMPLATE.format(**data)
+    message = APPVEYOR_MESSAGE_TEMPLATE.format(**data)
+    emoji = APPVEYOR_STATUS_EMOJI_MAP.get(data["status"], "")
+    if emoji:
+        message = f"{emoji} {message}"
+    return message


### PR DESCRIPTION
Fixes part of #37250.

When users receive Appveyor build notifications in Zulip, the outcome
is only communicated through text. Adding a status emoji at the start
of the message makes the result immediately visible at a glance,
consistent with the CircleCI webhook integration already merged.

## Changes

- `:check:` for successful/completed builds
- `:cross_mark:` for failed builds
- `:no_entry:` for cancelled builds
- No emoji for unknown statuses (graceful fallback)

## about test

- [x] `./tools/test-backend zerver.webhooks.appveyor`
- [x] `./tools/lint zerver/webhooks/appveyor/view.py`

