### PR TITLE
webhooks/semaphore: Add status emoji to pipeline notifications.

### DIFF
--- a/zerver/webhooks/semaphore/tests.py
+++ b/zerver/webhooks/semaphore/tests.py
@@ -14,7 +14,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore_build(self) -> None:
         expected_topic_name = "knighthood/master"  # repo/branch
         expected_message = """
-[Build 314](https://semaphoreci.com/donquixote/knighthood/branches/master/builds/314) passed:
+:check: [Build 314](https://semaphoreci.com/donquixote/knighthood/branches/master/builds/314) passed:
 * **Commit**: [a490b8d508e: Create user account for Rocinante](https://github.com/donquixote/knighthood/commit/a490b8d508ebbdab1d77a5c2aefa35ceb2d62daf)
 * **Author**: don@lamancha.com
 """.strip()
@@ -28,7 +28,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore_deploy(self) -> None:
         expected_topic_name = "knighthood/master"
         expected_message = """
-[Deploy 17](https://semaphoreci.com/donquixote/knighthood/servers/lamancha-271/deploys/17) of [build 314](https://semaphoreci.com/donquixote/knighthood/branches/master/builds/314) passed:
+:check: [Deploy 17](https://semaphoreci.com/donquixote/knighthood/servers/lamancha-271/deploys/17) of [build 314](https://semaphoreci.com/donquixote/knighthood/branches/master/builds/314) passed:
 * **Commit**: [a490b8d508e: Create user account for Rocinante](https://github.com/donquixote/knighthood/commit/a490b8d508ebbdab1d77a5c2aefa35ceb2d62daf)
 * **Author**: don@lamancha.com
 * **Server**: lamancha-271
@@ -45,7 +45,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore2_push(self) -> None:
         expected_topic_name = "notifications/rw/webhook_impl"  # repo/branch
         expected_message = """
-[Notifications](https://semaphore.semaphoreci.com/workflows/acabe58e-4bcc-4d39-be06-e98d71917703) pipeline **stopped**:
+:no_entry: [Notifications](https://semaphore.semaphoreci.com/workflows/acabe58e-4bcc-4d39-be06-e98d71917703) pipeline **stopped**:
 * **Commit**: [(2d9f5fcec1c)](https://github.com/renderedtext/notifications/commit/2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563) Implement webhooks for SemaphoreCI
 * **Branch**: rw/webhook_impl
 * **Author**: [radwo](https://github.com/radwo)
@@ -57,7 +57,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore2_push_non_gh_repo(self) -> None:
         expected_topic_name = "notifications/rw/webhook_impl"  # repo/branch
         expected_message = """
-[Notifications](https://semaphore.semaphoreci.com/workflows/acabe58e-4bcc-4d39-be06-e98d71917703) pipeline **stopped**:
+:no_entry: [Notifications](https://semaphore.semaphoreci.com/workflows/acabe58e-4bcc-4d39-be06-e98d71917703) pipeline **stopped**:
 * **Commit**: (2d9f5fcec1c) Implement webhooks for SemaphoreCI
 * **Branch**: rw/webhook_impl
 * **Author**: radwo
@@ -70,7 +70,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore_pull_request(self) -> None:
         expected_topic_name = "notifications/test-notifications"
         expected_message = """
-[Notifications](https://semaphore.semaphoreci.com/workflows/84383f37-d025-4811-b719-61c6acc92a1e) pipeline **failed**:
+:cross_mark: [Notifications](https://semaphore.semaphoreci.com/workflows/84383f37-d025-4811-b719-61c6acc92a1e) pipeline **failed**:
 * **Pull request**: [Testing PR notifications](https://github.com/renderedtext/notifications/pull/3)
 * **Branch**: test-notifications
 * **Author**: [radwo](https://github.com/radwo)
@@ -82,7 +82,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore_pull_request_non_gh_repo(self) -> None:
         expected_topic_name = "notifications/test-notifications"
         expected_message = """
-[Notifications](https://semaphore.semaphoreci.com/workflows/84383f37-d025-4811-b719-61c6acc92a1e) pipeline **failed**:
+:cross_mark: [Notifications](https://semaphore.semaphoreci.com/workflows/84383f37-d025-4811-b719-61c6acc92a1e) pipeline **failed**:
 * **Pull request**: Testing PR notifications (#3)
 * **Branch**: test-notifications
 * **Author**: radwo
@@ -98,7 +98,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore_tag(self) -> None:
         expected_topic_name = "notifications"
         expected_message = """
-[Notifications](https://semaphore.semaphoreci.com/workflows/a8704319-2422-4828-9b11-6b2afa3554e6) pipeline **stopped**:
+:no_entry: [Notifications](https://semaphore.semaphoreci.com/workflows/a8704319-2422-4828-9b11-6b2afa3554e6) pipeline **stopped**:
 * **Tag**: [v1.0.1](https://github.com/renderedtext/notifications/tree/v1.0.1)
 * **Author**: [radwo](https://github.com/radwo)
 """.strip()
@@ -109,7 +109,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore_tag_non_gh_repo(self) -> None:
         expected_topic_name = "notifications"
         expected_message = """
-[Notifications](https://semaphore.semaphoreci.com/workflows/a8704319-2422-4828-9b11-6b2afa3554e6) pipeline **stopped**:
+:no_entry: [Notifications](https://semaphore.semaphoreci.com/workflows/a8704319-2422-4828-9b11-6b2afa3554e6) pipeline **stopped**:
 * **Tag**: v1.0.1
 * **Author**: radwo
 """.strip()
@@ -120,7 +120,7 @@ class SemaphoreHookTests(WebhookTestCase):
 
     def test_semaphore_unknown(self) -> None:
         expected_topic_name = "knighthood/master"
-        expected_message = "unknown: passed"
+        expected_message = ":check: unknown: passed"
         self.check_webhook(
             "unknown",
             expected_topic_name,
@@ -131,7 +131,7 @@ class SemaphoreHookTests(WebhookTestCase):
     def test_semaphore_unknown_event(self) -> None:
         expected_topic_name = "notifications"
         expected_message = """
-[Notifications](https://semaphore.semaphoreci.com/workflows/a8704319-2422-4828-9b11-6b2afa3554e6) pipeline **stopped** for unknown event
+:no_entry: [Notifications](https://semaphore.semaphoreci.com/workflows/a8704319-2422-4828-9b11-6b2afa3554e6) pipeline **stopped** for unknown event
 """.strip()
         with patch(
             "zerver.webhooks.semaphore.tests.SemaphoreHookTests.get_body", self.get_unknown_event

--- a/zerver/webhooks/semaphore/view.py
+++ b/zerver/webhooks/semaphore/view.py
@@ -11,6 +11,13 @@ from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.lib.webhooks.git import get_short_sha
 from zerver.models import UserProfile
 
+SEMAPHORE_STATUS_EMOJI_MAP: dict[str, str] = {
+    "passed": ":check:",
+    "failed": ":cross_mark:",
+    "stopped": ":no_entry:",
+    "canceled": ":no_entry:",
+}
+
 # Semaphore Classic templates
 
 BUILD_TEMPLATE = """
@@ -157,6 +164,9 @@ def semaphore_classic(payload: WildValue) -> tuple[str, str, str, str]:
     else:  # should never get here
         content = f"{event}: {result}"
 
+    emoji = SEMAPHORE_STATUS_EMOJI_MAP.get(result, "")
+    if emoji:
+        content = f"{emoji} {content}"
     return content, project_name, branch_name, event
 
 
@@ -219,6 +229,11 @@ def semaphore_2(payload: WildValue) -> tuple[str, str, str | None, str]:
         branch_name = ""
         context.update(event_name=event)
         content = DEFAULT_TEMPLATE.format(**context)
+
+    pipeline_result = context["pipeline_result"]
+    emoji = SEMAPHORE_STATUS_EMOJI_MAP.get(pipeline_result, "")
+    if emoji:
+        content = f"{emoji} {content}"
     return content, project_name, branch_name, event
 
 


### PR DESCRIPTION
Fixes part of #37250.

When users receive Semaphore notifications in Zulip, the outcome is
only communicated through text. Adding a status emoji at the start of
the message makes the result immediately visible at a glance,
consistent with the CircleCI webhook integration already merged.

Applies to both Semaphore Classic (build/deploy events) and
Semaphore 2.0 (branch/pull_request/tag events).

## Changes

- `:check:` for passed pipelines/builds
- `:cross_mark:` for failed pipelines/builds
- `:no_entry:` for stopped/cancelled pipelines
- No emoji for unknown statuses (graceful fallback)

##  test

- [x] `./tools/test-backend zerver.webhooks.semaphore`
- [x] `./tools/lint zerver/webhooks/semaphore/view.py`

