### PR TITLE
soft_reactivate: Reactivate if topic mention has < 12 members.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -639,7 +639,7 @@ def do_send_missedmessage_events_reply_in_zulip(
 
     # Soft reactivate the long_term_idle user personally mentioned
     soft_reactivate_if_personal_notification(
-        user_profile, unique_triggers, mentioned_user_group_members_count
+        user_profile, unique_triggers, mentioned_user_group_members_count, missed_messages
     )
 
     with override_language(user_profile.default_language):

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1805,9 +1805,13 @@ def handle_push_notification(user_profile_id: int, missed_message: dict[str, Any
         mentioned_user_group_name = mentioned_user_group.name
         mentioned_user_group_members_count = mentioned_user_group.members_count
 
-    # Soft reactivate if pushing to a long_term_idle user that is personally mentioned
+    # Soft reactivate if pushing to a long_term_idle user that is personally mentioned.
+    # Pass the already-fetched message so the topic-size check needn't re-fetch it.
     soft_reactivate_if_personal_notification(
-        user_profile, {trigger}, mentioned_user_group_members_count
+        user_profile,
+        {trigger},
+        mentioned_user_group_members_count,
+        [{**missed_message, "message": message}],
     )
 
     if message.is_channel_message:

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -13,6 +13,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.lib.logging_util import log_to_file
 from zerver.lib.queue import queue_event_on_commit
+from zerver.lib.topic import participants_for_topic_count_capped
 from zerver.lib.user_message import bulk_insert_all_ums
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
@@ -402,22 +403,57 @@ def queue_soft_reactivation(user_profile_id: int) -> None:
     queue_event_on_commit("deferred_work", event)
 
 
+def has_small_topic_wildcard_mention(
+    missed_messages: list[dict[str, Any]], user_profile: UserProfile
+) -> bool:
+    """Whether any topic wildcard (@topic) mention in this batch targets a
+    topic small enough to soft-reactivate the recipient for: at most
+    'settings.MAX_TOPIC_SIZE_FOR_MENTION_REACTIVATION' participants
+    (senders plus reactors, matching who @topic notifies). Callers pass
+    the already-fetched message under the "message" key.
+    """
+    topic_wildcard_triggers = {
+        NotificationTriggers.TOPIC_WILDCARD_MENTION,
+        NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
+    }
+
+    unique_topics: set[tuple[int, str]] = set()
+    for missed_message in missed_messages:
+        if missed_message["trigger"] not in topic_wildcard_triggers:
+            continue
+        message = missed_message["message"]
+        if message.is_channel_message:
+            unique_topics.add((message.recipient_id, message.topic_name()))
+
+    cap = settings.MAX_TOPIC_SIZE_FOR_MENTION_REACTIVATION
+    for recipient_id, topic_name in unique_topics:
+        count = participants_for_topic_count_capped(
+            user_profile.realm_id, recipient_id, topic_name, cap=cap
+        )
+        if count <= cap:
+            return True
+    return False
+
+
 def soft_reactivate_if_personal_notification(
     user_profile: UserProfile,
     unique_triggers: set[str],
     mentioned_user_group_members_count: int | None,
+    missed_messages: list[dict[str, Any]],
 ) -> None:
     """When we're about to send an email/push notification to a
     long_term_idle user, it's very likely that the user will try to
     return to Zulip. As a result, it makes sense to optimistically
     soft-reactivate that user, to give them a good return experience.
 
-    It's important that we do nothing for stream wildcard or large
+    It's important that we do nothing for stream wildcard, large
     group mentions (size > 'settings.MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION'),
-    because soft-reactivating an entire realm or a large group would be
+    or large topic mentions (size > 'settings.MAX_TOPIC_SIZE_FOR_MENTION_REACTIVATION')
+    because soft-reactivating an entire realm or a large group/topic would be
     very expensive. The caller is responsible for passing a
     mentioned_user_group_members_count that is None for messages that
-    contain both a personal mention and a group mention.
+    contain both a personal mention and a group mention. missed_messages
+    must include the already-fetched message under the "message" key.
     """
     if not user_profile.long_term_idle:
         return
@@ -432,18 +468,11 @@ def soft_reactivate_if_personal_notification(
         elif mentioned_user_group_members_count <= settings.MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION:
             small_group_mention = True
 
-    topic_wildcard_mention = any(
-        trigger in unique_triggers
-        for trigger in [
-            NotificationTriggers.TOPIC_WILDCARD_MENTION,
-            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
-        ]
-    )
-    if (
-        not direct_message
-        and not personal_mention
-        and not small_group_mention
-        and not topic_wildcard_mention
+    if not (
+        direct_message
+        or personal_mention
+        or small_group_mention
+        or has_small_topic_wildcard_mention(missed_messages, user_profile)
     ):
         return
 

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -354,10 +354,12 @@ def get_topic_resolution_and_bare_name(stored_name: str) -> tuple[bool, str]:
     return (False, stored_name)
 
 
-def participants_for_topic(realm_id: int, recipient_id: int, topic_name: str) -> set[int]:
+def topic_participant_ids(
+    realm_id: int, recipient_id: int, topic_name: str
+) -> QuerySet[UserProfile, int]:
     """
-    Users who either sent or reacted to the messages in the topic.
-    The function is expensive for large numbers of messages in the topic.
+    Query for the IDs of users who either sent or reacted to messages in
+    the topic. Lazy, so callers can cap it with a slice.
     """
     messages = Message.objects.filter(
         # Uses index: zerver_message_realm_recipient_upper_subject
@@ -366,17 +368,30 @@ def participants_for_topic(realm_id: int, recipient_id: int, topic_name: str) ->
         subject__iexact=topic_name,
         is_channel_message=True,
     )
-    participants = set(
-        UserProfile.objects.filter(
-            Q(id__in=Subquery(messages.values("sender_id")))
-            | Q(
-                id__in=Subquery(
-                    Reaction.objects.filter(message__in=messages).values("user_profile_id")
-                )
-            )
-        ).values_list("id", flat=True)
-    )
-    return participants
+    return UserProfile.objects.filter(
+        Q(id__in=Subquery(messages.values("sender_id")))
+        | Q(
+            id__in=Subquery(Reaction.objects.filter(message__in=messages).values("user_profile_id"))
+        )
+    ).values_list("id", flat=True)
+
+
+def participants_for_topic(realm_id: int, recipient_id: int, topic_name: str) -> set[int]:
+    """
+    Users who either sent or reacted to the messages in the topic.
+    The function is expensive for large numbers of messages in the topic.
+    """
+    return set(topic_participant_ids(realm_id, recipient_id, topic_name))
+
+
+def participants_for_topic_count_capped(
+    realm_id: int, recipient_id: int, topic_name: str, cap: int
+) -> int:
+    """
+    Returns min(actual_distinct_participant_count, cap + 1), using a
+    LIMIT cap + 1 so Postgres stops scanning once the cap is exceeded.
+    """
+    return topic_participant_ids(realm_id, recipient_id, topic_name)[: cap + 1].count()
 
 
 def maybe_rename_general_chat_to_empty_topic(topic_name: str) -> str:

--- a/zerver/tests/test_handle_push_notification.py
+++ b/zerver/tests/test_handle_push_notification.py
@@ -13,6 +13,7 @@ from analytics.models import RealmCount
 from corporate.lib.stripe import BillingUserCounts
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_edit import check_update_message
+from zerver.actions.reactions import do_add_reaction
 from zerver.actions.user_groups import add_subgroups_to_user_group, check_add_user_group
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
@@ -22,9 +23,10 @@ from zerver.lib.push_notifications import (
     handle_remove_push_notification,
 )
 from zerver.lib.remote_server import PushNotificationBouncerRetryLaterError
+from zerver.lib.soft_deactivation import has_small_topic_wildcard_mention
 from zerver.lib.test_classes import PushNotificationTestCase
 from zerver.lib.test_helpers import activate_push_notification_service
-from zerver.models import PushDeviceToken, Recipient, UserMessage, UserTopic
+from zerver.models import Message, PushDeviceToken, Recipient, UserMessage, UserTopic
 from zerver.models.realms import get_realm
 from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.scheduled_jobs import NotificationTriggers
@@ -965,7 +967,27 @@ class HandlePushNotificationTest(PushNotificationTestCase):
             mock_send_android.assert_called_with(user_identity, android_devices, {"gcm": True}, {})
             mock_push_notifications.assert_called_once()
 
-    @override_settings(MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION=2)
+    def test_topic_wildcard_helper_false_for_non_stream_message(self) -> None:
+        othello = self.example_user("othello")
+        user = self.example_user("hamlet")
+        message_id = self.send_personal_message(othello, user, "DM body")
+        message = Message.objects.get(id=message_id)
+
+        self.assertFalse(
+            has_small_topic_wildcard_mention(
+                [
+                    {
+                        "message": message,
+                        "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                    }
+                ],
+                user,
+            )
+        )
+
+    @override_settings(
+        MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION=2, MAX_TOPIC_SIZE_FOR_MENTION_REACTIVATION=2
+    )
     @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
     def test_user_push_soft_reactivate_soft_deactivated_user(
         self, mock_push_notifications: mock.MagicMock
@@ -991,6 +1013,13 @@ class HandlePushNotificationTest(PushNotificationTestCase):
             zulip_realm, "subgroup", [othello, cordelia], acting_user=othello
         )
         add_subgroups_to_user_group(large_user_group, [subgroup], acting_user=None)
+
+        for user in [othello, cordelia, self.user_profile]:
+            self.subscribe(user, "Denmark")
+            self.send_stream_message(user, "Denmark", "seeding", topic_name="large_topic")
+
+        self.send_stream_message(othello, "Denmark", "seeding", topic_name="small_topic")
+        self.send_stream_message(self.user_profile, "Denmark", "seeding", topic_name="small_topic")
 
         # Personal mention in a stream message should soft reactivate the user
         def mention_in_stream() -> None:
@@ -1117,6 +1146,76 @@ class HandlePushNotificationTest(PushNotificationTestCase):
 
         self.soft_deactivate_main_user()
         self.expect_to_stay_long_term_idle(self.user_profile, send_large_group_mention)
+
+        def send_small_topic_mention() -> None:
+            mention = "@**topic**"
+            stream_mentioned_message_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="small_topic"
+            )
+            handle_push_notification(
+                self.user_profile.id,
+                {
+                    "message_id": stream_mentioned_message_id,
+                    "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                },
+            )
+
+        self.soft_deactivate_main_user()
+        self.expect_soft_reactivation(self.user_profile, send_small_topic_mention)
+
+        def send_large_topic_mention() -> None:
+            mention = "@**topic**"
+            stream_mentioned_message_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="large_topic"
+            )
+            handle_push_notification(
+                self.user_profile.id,
+                {
+                    "message_id": stream_mentioned_message_id,
+                    "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                },
+            )
+
+        self.soft_deactivate_main_user()
+        self.expect_to_stay_long_term_idle(self.user_profile, send_large_topic_mention)
+
+        def send_reaction_heavy_topic_mention() -> None:
+            initial_msg_id = self.send_stream_message(
+                othello, "Denmark", "msg", topic_name="reaction_topic"
+            )
+            initial_msg = Message.objects.get(id=initial_msg_id)
+
+            do_add_reaction(cordelia, initial_msg, "smile", "1f642", "unicode_emoji")
+            do_add_reaction(self.user_profile, initial_msg, "tada", "1f389", "unicode_emoji")
+
+            mention = "@**topic**"
+            stream_mentioned_message_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="reaction_topic"
+            )
+            handle_push_notification(
+                self.user_profile.id,
+                {
+                    "message_id": stream_mentioned_message_id,
+                    "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                },
+            )
+
+        self.soft_deactivate_main_user()
+        self.expect_to_stay_long_term_idle(self.user_profile, send_reaction_heavy_topic_mention)
+
+        personal_message_id = self.send_personal_message(othello, self.user_profile, "This is a DM")
+
+        def fire_push_with_synthetic_trigger() -> None:
+            handle_push_notification(
+                self.user_profile.id,
+                {
+                    "message_id": personal_message_id,
+                    "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                },
+            )
+
+        self.soft_deactivate_main_user()
+        self.expect_to_stay_long_term_idle(self.user_profile, fire_push_with_synthetic_trigger)
 
     @mock.patch("zerver.lib.push_notifications.logger.info")
     @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -16,6 +16,7 @@ from django_stubs_ext import StrPromise
 
 from zerver.actions.create_user import do_create_user
 from zerver.actions.message_send import internal_send_private_message
+from zerver.actions.reactions import do_add_reaction
 from zerver.actions.user_groups import add_subgroups_to_user_group, check_add_user_group
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
@@ -1824,7 +1825,9 @@ class TestMessageNotificationEmails(ZulipTestCase):
         email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(msg_id, verify_body_include, email_subject, verify_html_body=True)
 
-    @override_settings(MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION=2)
+    @override_settings(
+        MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION=2, MAX_TOPIC_SIZE_FOR_MENTION_REACTIVATION=2
+    )
     def test_long_term_idle_user_missed_message(self) -> None:
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")
@@ -1982,6 +1985,99 @@ class TestMessageNotificationEmails(ZulipTestCase):
 
         reset_hamlet_as_soft_deactivated_user()
         self.expect_to_stay_long_term_idle(hamlet, send_large_group_mention)
+
+        self.subscribe(cordelia, "Denmark")
+        self.send_stream_message(othello, "Denmark", "msg", topic_name="large_topic")
+        self.send_stream_message(cordelia, "Denmark", "msg", topic_name="large_topic")
+        self.send_stream_message(hamlet, "Denmark", "msg", topic_name="large_topic")
+
+        self.send_stream_message(othello, "Denmark", "msg", topic_name="small_topic")
+        self.send_stream_message(hamlet, "Denmark", "msg", topic_name="small_topic")
+
+        def send_small_topic_mention() -> None:
+            mention = "@**topic**"
+            stream_mentioned_message_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="small_topic"
+            )
+            self.handle_missedmessage_emails(
+                hamlet.id,
+                {
+                    stream_mentioned_message_id: MissedMessageData(
+                        trigger=NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                    ),
+                },
+            )
+
+        reset_hamlet_as_soft_deactivated_user()
+        self.expect_soft_reactivation(hamlet, send_small_topic_mention)
+
+        def send_large_topic_mention() -> None:
+            mention = "@**topic**"
+            stream_mentioned_message_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="large_topic"
+            )
+            self.handle_missedmessage_emails(
+                hamlet.id,
+                {
+                    stream_mentioned_message_id: MissedMessageData(
+                        trigger=NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                    ),
+                },
+            )
+
+        reset_hamlet_as_soft_deactivated_user()
+        self.expect_to_stay_long_term_idle(hamlet, send_large_topic_mention)
+
+        def send_mixed_batch_topic_mentions() -> None:
+            mention = "@**topic**"
+            large_topic_msg_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="large_topic"
+            )
+            small_topic_msg_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="small_topic"
+            )
+
+            self.handle_missedmessage_emails(
+                hamlet.id,
+                {
+                    large_topic_msg_id: MissedMessageData(
+                        trigger=NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                    ),
+                    small_topic_msg_id: MissedMessageData(
+                        trigger=NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                    ),
+                },
+            )
+
+        reset_hamlet_as_soft_deactivated_user()
+        self.expect_soft_reactivation(hamlet, send_mixed_batch_topic_mentions)
+
+        # Reactors count toward the cap too, so senders within the cap
+        # plus reactors can still exceed it.
+        def send_reaction_heavy_topic_mention() -> None:
+            initial_msg_id = self.send_stream_message(
+                othello, "Denmark", "msg", topic_name="reaction_topic"
+            )
+            initial_msg = Message.objects.get(id=initial_msg_id)
+
+            do_add_reaction(cordelia, initial_msg, "smile", "1f642", "unicode_emoji")
+            do_add_reaction(hamlet, initial_msg, "tada", "1f389", "unicode_emoji")
+
+            mention = "@**topic**"
+            stream_mentioned_message_id = self.send_stream_message(
+                othello, "Denmark", mention, topic_name="reaction_topic"
+            )
+            self.handle_missedmessage_emails(
+                hamlet.id,
+                {
+                    stream_mentioned_message_id: MissedMessageData(
+                        trigger=NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                    ),
+                },
+            )
+
+        reset_hamlet_as_soft_deactivated_user()
+        self.expect_to_stay_long_term_idle(hamlet, send_reaction_heavy_topic_mention)
 
     def test_followed_topic_missed_message(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -722,6 +722,10 @@ MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS = 100
 # be soft-reactivated in the case of user group mention.
 MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION = 11
 
+# The maximum number of topic participants up to which members should
+# be soft-reactivated in the case of a topic wildcard mention.
+MAX_TOPIC_SIZE_FOR_MENTION_REACTIVATION = 11
+
 # The maximum number of newly subscribed users for which the server
 # will consider sending DMs to each new subscriber.
 MAX_BULK_NEW_SUBSCRIPTION_MESSAGES = 100


### PR DESCRIPTION
Previously, an email or push notification triggered by a topic
wildcard (@topic) mention always soft-reactivated a long-term-idle
recipient, on the assumption that @topic mentions reach a small set
of users. Topics can be large, though, so this could enqueue a
soft-reactivation for every participant of a huge topic, flooding the
deferred_work queue.

We now soft-reactivate for a topic wildcard mention only when the
topic has at most MAX_TOPIC_SIZE_FOR_MENTION_REACTIVATION participants,
counting senders plus reactors to match the set of users an @topic
mention notifies. participants_for_topic_count_capped computes this
with a LIMIT cap + 1 query that stops scanning once the cap is
exceeded, and we run it only for long-term-idle recipients, since the
count is used solely to gate reactivation. The push path reuses the
message it already fetched, avoiding a duplicate query.

Fixes #27586.

<!-- Describe your pull request here.-->




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
