### PR TITLE
oidc: Add OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS setting.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4917,6 +4917,34 @@ class GenericOpenIdConnectTest(SocialAuthBase):
             m.output, [self.logger_output("/login/oidc/: Missing idp param.", type="info")]
         )
 
+    def test_social_auth_oidc_require_limit_to_subdomains(self) -> None:
+        idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS)
+        idps_dict["testoidc2"] = copy.deepcopy(idps_dict["testoidc"])
+        idps_dict["testoidc2"]["oidc_url"] = "https://example.com/idp2/api/openid"
+        idps_dict["testoidc2"]["display_name"] = "Second Test IdP"
+        idps_dict["testoidc2"]["limit_to_subdomains"] = ["zulip"]
+
+        with self.settings(
+            SOCIAL_AUTH_OIDC_ENABLED_IDPS=idps_dict, OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS=True
+        ):
+            with self.assertLogs(self.logger_string, level="ERROR") as m:
+                # Initialization of the backend should validate the configured IdPs
+                # with respect to the OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS setting and remove
+                # the non-compliant ones.
+                GenericOpenIdConnectBackend()
+            self.assertEqual(list(settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS.keys()), ["testoidc2"])
+        self.assertEqual(
+            m.output,
+            [
+                self.logger_output(
+                    "OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS is enabled and the following "
+                    "IdPs don't have limit_to_subdomains specified and will be ignored: "
+                    "['testoidc']",
+                    "error",
+                )
+            ],
+        )
+
     def test_social_auth_oidc_idp_limited_to_subdomains_attempt_wrong_realm(self) -> None:
         idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS)
         idps_dict["testoidc"]["limit_to_subdomains"] = ["zulip"]

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -3789,6 +3789,21 @@ class GenericOpenIdConnectBackend(SocialAuthMixin, OpenIdConnectAuth):
     full_name_validated = getattr(settings, "SOCIAL_AUTH_OIDC_FULL_NAME_VALIDATED", False)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if settings.OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS:
+            idps_without_limit_to_subdomains = [
+                idp_name
+                for idp_name, idp_dict in settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS.items()
+                if "limit_to_subdomains" not in idp_dict
+            ]
+            if idps_without_limit_to_subdomains:
+                self.logger.error(
+                    "OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS is enabled and the following IdPs don't have"
+                    " limit_to_subdomains specified and will be ignored: %r",
+                    idps_without_limit_to_subdomains,
+                )
+                for idp_name in idps_without_limit_to_subdomains:
+                    del settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS[idp_name]
+
         self.server_settings_dict: dict[str, OIDCIdPConfigDict] = (
             settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS
         )

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -99,6 +99,7 @@ SOCIAL_AUTH_SAML_SECURITY_CONFIG: dict[str, Any] = {}
 # Set this to True to enforce that any configured IdP needs to specify
 # the limit_to_subdomains setting to be considered valid:
 SAML_REQUIRE_LIMIT_TO_SUBDOMAINS = False
+OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS = False
 
 # Historical name for SOCIAL_AUTH_GITHUB_KEY; still allowed in production.
 GOOGLE_OAUTH2_CLIENT_ID: str | None = None


### PR DESCRIPTION
Works the exact same way as SAML_REQUIRE_LIMIT_TO_SUBDOMAINS.

Fixes #36580.

From the issue description:
> Probably needs a #backend conversation to decide on what a good name might be and confirm we want to do it.

Do we want a #backend discussion? I didn't open it for now, because it feels like given the existence of `SAML_REQUIRE_LIMIT_TO_SUBDOMAINS`, it's really hard to come up with a different name for this one than `OIDC_REQUIRE_LIMIT_TO_SUBDOMAINS`. Any variation will be some kind of inconsistency with naming conventions of some other related setting.