### PR TITLE
lightbox: Hide prev/next arrows when no more images to navigate

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -283,6 +283,7 @@ export function render_lightbox_media_list(): void {
             $lightbox_media_list.append($node);
         }
     }
+    update_arrow_visibility();
 }
 
 function display_image(payload: Media): void {
@@ -635,6 +636,20 @@ export function next(): void {
     $(".image-list .image.selected").next().trigger("click");
 }
 
+function update_arrow_visibility(): void {
+    const $selected = $(".image-list .image.selected");
+    const has_prev = $selected.prev(".image").length > 0;
+    const has_next = $selected.next(".image").length > 0;
+    $("#lightbox_overlay .center .arrow[data-direction='prev']").toggleClass(
+        "invisible",
+        !has_prev,
+    );
+    $("#lightbox_overlay .center .arrow[data-direction='next']").toggleClass(
+        "invisible",
+        !has_next,
+    );
+}
+
 function remove_video_players(): void {
     // Remove video players from the DOM. Used when closing lightbox
     // so that videos doesn't keep playing in the background.
@@ -768,6 +783,7 @@ export function initialize(): void {
 
         $(".image-list .image.selected").removeClass("selected");
         $(this).addClass("selected");
+        update_arrow_visibility();
 
         const parentOffset = this.parentElement!.clientWidth + this.parentElement!.scrollLeft;
         // this is the left and right of the image compared to its parent.


### PR DESCRIPTION
Previously, the lightbox image viewer always showed both the forward and backward navigation arrows, even when there was only one image/video to view.

Now, the prev arrow is hidden when the first image/video is selected, the next arrow is hidden when the last image/video is selected, and both arrows are hidden when there is only one image/video. This uses the existing '`invisible`' CSS class (`visibility: hidden`) to avoid layout shifts when toggling arrow visibility.


Fixes: [#issues > Image viewer has arrows that do nothing](https://chat.zulip.org/#narrow/channel/9-issues/topic/Image.20viewer.20has.20arrows.20that.20do.20nothing/with/2421353)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/a7766b12-5c5a-4813-9414-74a3beee8ef6" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/cc8bec7b-4aba-4e7d-a1c0-30f985d468a7" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
