### PR TITLE
Fix/emoji empty file validation

### DIFF
--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -378,6 +378,14 @@ class RealmEmojiTest(ZulipTestCase):
             result = self.client_post("/json/realm/emoji/my_emoji", {"file": fp})
         self.assert_json_error(result, "Invalid image format")
 
+    def test_emoji_upload_empty_file_error(self) -> None:
+        self.login("iago")
+        from io import BytesIO
+        empty_file = BytesIO(b"")
+        empty_file.name = "empty.png"
+        result = self.client_post("/json/realm/emoji/my_emoji", {"file": empty_file})
+        self.assert_json_error(result, "Uploaded file is empty.")
+
     def test_upload_already_existed_emoji(self) -> None:
         self.login("iago")
         with get_test_image_file("img.png") as fp1:

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from unittest import mock
 
 from zerver.actions.create_realm import do_create_realm
@@ -380,7 +381,6 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_emoji_upload_empty_file_error(self) -> None:
         self.login("iago")
-        from io import BytesIO
         empty_file = BytesIO(b"")
         empty_file.name = "empty.png"
         result = self.client_post("/json/realm/emoji/my_emoji", {"file": empty_file})

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -45,6 +45,8 @@ def upload_emoji(
     [emoji_file] = request.FILES.values()
     assert isinstance(emoji_file, UploadedFile)
     assert emoji_file.size is not None
+    if emoji_file.size == 0:
+        raise JsonableError(_("Uploaded file is empty."))
     if emoji_file.size > settings.MAX_EMOJI_FILE_SIZE_MIB * 1024 * 1024:
         raise JsonableError(
             _("Uploaded file is larger than the allowed limit of {max_size} MiB").format(


### PR DESCRIPTION
Problem

The emoji upload endpoint was missing validation for empty/zero-byte files, unlike avatar and icon uploads which properly validate and reject empty files with a clear error message.
Files changed

    zerver/views/realm_emoji.py: Added empty file validation check
    zerver/tests/test_realm_emoji.py: Added test case for empty file validation

Fix details

    Added if emoji_file.size == 0: check in upload_emoji() function
    Returns clear error message: "Uploaded file is empty."
    Follows existing validation pattern used in avatar and icon uploads
    Added comprehensive test case test_emoji_upload_empty_file_error()

Testing

    Added test that creates a zero-byte file and verifies proper error response
    Test follows existing Zulip test patterns using BytesIO and self.assert_json_error()
    Code compiles successfully without syntax errors

Impact

    Prevents confusing errors when users accidentally upload empty files
    Provides consistent validation behavior across all upload endpoints
    Low-risk change with clear error handling

This is a minimal, focused fix that improves user experience by providing clear feedback for empty file uploads, matching the behavior of other upload endpoints in Zulip