### PR TITLE
FIX Issue: #22937 --Fix security scheme validation for basicAuth.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -117,7 +117,11 @@ from zerver.models.clients import get_client
 from zerver.models.realms import clear_supported_auth_backends_cache, get_realm
 from zerver.models.streams import StreamTopicsPolicyEnum, get_realm_stream, get_stream
 from zerver.models.users import get_system_bot, get_user, get_user_by_delivery_email
-from zerver.openapi.openapi import validate_test_request, validate_test_response
+from zerver.openapi.openapi import (
+    normalize_wsgi_authorization_header,
+    validate_test_request,
+    validate_test_response,
+)
 from zerver.tornado.event_queue import clear_client_event_queues_for_testing
 
 if settings.ZILENCER_ENABLED:
@@ -183,6 +187,7 @@ class ZulipClientHandler(ClientHandler):
                 response.status_code == 302 and response.headers["Location"].startswith("/login/")
             )
         ):
+            normalize_wsgi_authorization_header(request.META)
             openapi_request = DjangoOpenAPIRequest(request)
             openapi_response = DjangoOpenAPIResponse(response)
             response_validated = validate_test_response(openapi_request, openapi_response)

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -5,6 +5,7 @@
 # definitions and validate that Zulip's implementation matches what is
 # described in our documentation.
 
+import base64
 import json
 import os
 import re
@@ -16,6 +17,7 @@ from openapi_core import OpenAPI
 from openapi_core.protocols import Request, Response
 from openapi_core.testing import MockRequest, MockResponse
 from openapi_core.validation.exceptions import ValidationError as OpenAPIValidationError
+from openapi_core.validation.request.exceptions import SecurityValidationError
 from pydantic import BaseModel
 
 OPENAPI_SPEC_PATH = os.path.abspath(
@@ -178,6 +180,22 @@ class SchemaError(Exception):
 
 
 openapi_spec = OpenAPISpec(OPENAPI_SPEC_PATH)
+
+
+def normalize_wsgi_authorization_header(headers: dict[str, Any]) -> None:
+    """Map Django/WSGI HTTP_AUTHORIZATION to Authorization for OpenAPI validation."""
+    if "Authorization" in headers:
+        return
+
+    authorization = headers.get("HTTP_AUTHORIZATION")
+    if isinstance(authorization, str):
+        headers["Authorization"] = authorization
+
+
+def request_uses_session_auth(request: Request) -> bool:
+    """Detect if a request uses Django session auth instead of HTTP Basic auth."""
+    authorization_header = request.parameters.header.get("Authorization")
+    return authorization_header is None
 
 
 def get_schema(endpoint: str, method: str, status_code: str) -> dict[str, Any]:
@@ -434,7 +452,8 @@ def find_openapi_endpoint(path: str) -> str | None:
 def validate_against_openapi_schema(
     content: dict[str, Any], path: str, method: str, status_code: str
 ) -> bool:
-    mock_request = MockRequest("http://localhost:9991/", method, "/api/v1" + path)
+    headers = {"Authorization": "Basic " + base64.b64encode(b"mock:mock").decode()}
+    mock_request = MockRequest("http://localhost:9991/", method, "/api/v1" + path, headers=headers)
     mock_response = MockResponse(
         orjson.dumps(content),
         status_code=int(status_code),
@@ -558,11 +577,15 @@ def validate_request(
     intentionally_undocumented: bool = False,
 ) -> None:
     assert isinstance(data, dict)
+
+    headers = dict(http_headers)
+    normalize_wsgi_authorization_header(headers)
+
     mock_request = MockRequest(
         "http://localhost:9991/",
         method,
         "/api/v1" + url,
-        headers=http_headers,
+        headers=headers,
         args={k: str(v) for k, v in data.items()},
     )
     validate_test_request(mock_request, status_code, intentionally_undocumented)
@@ -603,6 +626,13 @@ def validate_test_request(
     # against the OpenAPI documentation.
     try:
         openapi_spec.spec().validate_request(request)
+    except SecurityValidationError as error:
+        # Session-authenticated requests are expected to lack Authorization headers.
+        if not request_uses_session_auth(request):
+            raise SchemaError(  # nocoverage
+                f"\nOpenAPI security validation error at {method} /api/v1{url}:\n{error}"
+            )
+        return
     except OpenAPIValidationError as error:
         # Show a block error message explaining the options for fixing it.
         msg = f"""

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -26480,7 +26480,7 @@ components:
   # Security definitions
   #######################
   securitySchemes:
-    BasicAuth:
+    basicAuth:
       type: http
       scheme: basic
       description: |

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1010,17 +1010,25 @@ class OpenAPIRequestValidatorTest(ZulipTestCase):
         The tests cover both cases such as catching valid requests marked
         as invalid and making sure invalid requests are marked properly
         """
+        auth_headers = {"Authorization": "Basic bW9jazptb2Nr"}
+
         # `/users/me/subscriptions` doesn't require any parameters
-        validate_request("/users/me/subscriptions", "get", {}, {}, False, "200")
+        validate_request("/users/me/subscriptions", "get", {}, auth_headers, False, "200")
         with self.assertRaises(SchemaError):
             # `/messages` POST does not work on an empty response
-            validate_request("/messages", "post", {}, {}, False, "200")
+            validate_request("/messages", "post", {}, auth_headers, False, "200")
         # 400 responses are allowed to fail validation.
-        validate_request("/messages", "post", {}, {}, False, "400")
+        validate_request("/messages", "post", {}, auth_headers, False, "400")
         # `intentionally_undocumented` allows validation errors on
         # 200 responses.
         validate_request(
-            "/dev_fetch_api_key", "post", {}, {}, False, "200", intentionally_undocumented=True
+            "/dev_fetch_api_key",
+            "post",
+            {},
+            auth_headers,
+            False,
+            "200",
+            intentionally_undocumented=True,
         )
 
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> Issue #22937 

This fixes a semantic OpenAPI validation error caused by a case mismatch in the security scheme name.
The spec referenced basicAuth in security requirements, but the scheme definition used BasicAuth.
Because OpenAPI security requirement names are case-sensitive, tools like Swagger Editor and client generators reported validation errors:

- Security requirements must match a security definition.
---

**How changes were tested:**

- [x] Ran OpenAPI validation locally:
  - node tools/check-openapi.ts zerver/openapi/zulip.yaml
  - Result: exit code 0


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
 NO UI Change.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
