### PR TITLE
right_sidebar: Use ::before pseudo-element for user status circle

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -167,6 +167,15 @@
         line-height: 1;
         /* ...which is approximately 8px at 15px/1em in Vlad's design. */
         font-size: 0.5333em;
+        position: relative;
+    }
+
+    .user-circle::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        background-color: currentColor;
     }
 
     .user_sidebar_entry.with_avatar {
@@ -203,10 +212,18 @@
                a 1px border, especially at smaller font sizes. */
             border: 1.5px solid var(--color-background);
             border-radius: 50%;
+        }
 
-            &.user-circle-offline {
-                display: none;
-            }
+        .user-circle::before {
+            background-color: currentColor;
+        }
+
+        .user-circle.user-circle-offline::before {
+            display: none;
+        }
+
+        .user-circle.user-circle-offline {
+            display: none;
         }
     }
 


### PR DESCRIPTION
Refactored the user status circle in the buddy list to use the ::before pseudo-element instead of direct styling.

This improves CSS structure and aligns with modern best practices.

This change does not affect visual output and only refactors the implementation.

Tested locally and verified that the status circle renders correctly without UI regressions.

Fixes #37031