### PR TITLE
frontend: Show tooltip for truncated user names in DM sidebar

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -135,6 +135,10 @@ export function update_private_messages(): void {
     const conversations = pm_list_data.get_conversations(search_term);
     const pm_list_info = pm_list_data.get_list_info(zoomed, search_term);
     const conversations_to_be_shown = pm_list_info.conversations_to_be_shown;
+    const filtered_conversations_to_be_shown =
+        pm_list_info.conversations_to_be_shown.filter(
+            (conv) => conv.max_message_id !== undefined && conv.max_message_id !== null,
+        );
 
     const all_conversations_shown = conversations_to_be_shown.length === conversations.length;
     const is_header_visible =
@@ -172,7 +176,7 @@ export function update_private_messages(): void {
     } else {
         const new_dom = _build_direct_messages_list({
             all_conversations_shown,
-            conversations_to_be_shown,
+            conversations_to_be_shown: filtered_conversations_to_be_shown,
             search_term,
         });
         set_dom_to(new_dom, zoomed);

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -135,10 +135,6 @@ export function update_private_messages(): void {
     const conversations = pm_list_data.get_conversations(search_term);
     const pm_list_info = pm_list_data.get_list_info(zoomed, search_term);
     const conversations_to_be_shown = pm_list_info.conversations_to_be_shown;
-    const filtered_conversations_to_be_shown =
-        pm_list_info.conversations_to_be_shown.filter(
-            (conv) => conv.max_message_id !== undefined && conv.max_message_id !== null,
-        );
 
     const all_conversations_shown = conversations_to_be_shown.length === conversations.length;
     const is_header_visible =
@@ -176,7 +172,7 @@ export function update_private_messages(): void {
     } else {
         const new_dom = _build_direct_messages_list({
             all_conversations_shown,
-            conversations_to_be_shown: filtered_conversations_to_be_shown,
+            conversations_to_be_shown,
             search_term,
         });
         set_dom_to(new_dom, zoomed);

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -8,7 +8,7 @@
         {{/if}}
 
         <span class="conversation-partners">
-            <span class="conversation-partners-list">{{recipients}}
+            <span class="conversation-partners-list" title="{{recipients}}">{{recipients}}
                 {{#if is_current_user}}<span class="my_user_status">{{t '(you)'}}</span>{{/if}}
                 {{> status_emoji status_emoji_info}}
                 {{#if is_bot}}


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

This PR adds a tooltip to user names in the Direct Messages sidebar to improve usability when names are truncated.

Implementation:
- Added `title` attribute to user name element in DM sidebar rendering

Before:
Truncated names did not show full user names on hover.

After:
Hovering over truncated names shows full user name in a tooltip.

Testing:
- Verified with long user names
- Tooltip displays correctly on hover