### PR TITLE
Enhance render_confirmation_key_error with context

### DIFF
--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -48,15 +48,26 @@ class ConfirmationKeyError(Exception):
         super().__init__()
         self.error_type = error_type
 
-
 def render_confirmation_key_error(
-    request: HttpRequest, exception: ConfirmationKeyError
+    request: HttpRequest, 
+    exception: ConfirmationKeyError, 
+    key: str | None = None  # Add the key as an optional argument
 ) -> HttpResponse:
+    context = {"key": key}
+    
     if exception.error_type == ConfirmationKeyError.WRONG_LENGTH:
-        return TemplateResponse(request, "confirmation/link_malformed.html", status=404)
+        return TemplateResponse(request, "confirmation/link_malformed.html", context, status=404)
+    
     if exception.error_type == ConfirmationKeyError.EXPIRED:
-        return TemplateResponse(request, "confirmation/link_expired.html", status=404)
-    return TemplateResponse(request, "confirmation/link_does_not_exist.html", status=404)
+        # Check if we can find the expired object to provide a better UX
+        conf = Confirmation.objects.filter(confirmation_key=key).first()
+        if conf:
+            context["confirmation_type"] = conf.type
+            context["can_resend"] = True
+            # For privacy, don't pass the full object, just the necessary flags
+        return TemplateResponse(request, "confirmation/link_expired.html", context, status=404)
+        
+    return TemplateResponse(request, "confirmation/link_does_not_exist.html", context, status=404)
 
 
 def generate_key() -> str:


### PR DESCRIPTION
Add optional key argument to render_confirmation_key_error and improve error handling.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
