### PR TITLE
custom_profile_fields: Add 'Checkboxes' field type

### DIFF
--- a/api_docs/unmerged.d/ZF-37c254.md
+++ b/api_docs/unmerged.d/ZF-37c254.md
@@ -1,0 +1,9 @@
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
+  [`POST /realm/profile_fields`](/api/create-custom-profile-field), and
+  [`GET /realm/profile_fields`](/api/get-custom-profile-fields): Added
+  support for the new `Checkboxes` custom profile field type.
+
+* [`PATCH /users/me/profile_data`](/api/update-profile-data) and
+  [`PATCH /users/{user_id}`](/api/update-user): Added support for passing
+  an array of choice IDs as the field value when updating user's value
+  for a Checkboxes type custom profile field.

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -35,6 +35,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
         [all_field_types.PARAGRAPH.id, "text"],
         [all_field_types.SHORT_TEXT.id, "text"],
         [all_field_types.DROPDOWN.id, "select"],
+        [all_field_types.CHECKBOXES.id, "checkboxes"],
         [all_field_types.USER.id, "user"],
         [all_field_types.DATE.id, "date"],
         [all_field_types.EXTERNAL_ACCOUNT.id, "text"],
@@ -49,17 +50,28 @@ export function append_custom_profile_fields(element_id: string, user_id: number
         };
         const editable_by_user = current_user.is_admin || field.editable_by_user;
         const is_dropdown_field = field.type === all_field_types.DROPDOWN.id;
+        const is_checkboxes_field = field.type === all_field_types.CHECKBOXES.id;
         const field_choices = [];
 
-        if (is_dropdown_field) {
+        if (is_dropdown_field || is_checkboxes_field) {
             const field_choice_dict = settings_components.custom_profile_field_choices_schema.parse(
                 JSON.parse(field.field_data),
             );
+            const current_val = field_value.value;
+            const selected_values = new Set<string>();
+            if (is_checkboxes_field && current_val) {
+                const parsed_values = z.array(z.string()).parse(JSON.parse(current_val));
+                for (const item of parsed_values) {
+                    selected_values.add(item);
+                }
+            }
             for (const [value, {order, text}] of Object.entries(field_choice_dict)) {
                 field_choices[Number(order)] = {
                     value,
                     text,
-                    selected: value === field_value.value,
+                    selected: is_checkboxes_field
+                        ? selected_values.has(value)
+                        : value === current_val,
                 };
             }
         }
@@ -74,6 +86,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
             is_url_field: field.type === all_field_types.URL.id,
             is_pronouns_field: field.type === all_field_types.PRONOUNS.id,
             is_dropdown_field,
+            is_checkboxes_field,
             field_choices,
             for_manage_user_modal: element_id === "#edit-user-form .custom-profile-field-form",
             is_empty_required_field: field.required && !field_value.value,
@@ -85,7 +98,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
 
 export type CustomProfileFieldData = {
     id: number;
-    value?: number[] | string;
+    value?: number[] | string[] | string;
 };
 
 function update_custom_profile_field(

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -847,6 +847,33 @@ export function set_up(): void {
         },
     );
 
+    $("#profile-settings").on(
+        "change",
+        ".custom_user_field_value_multiple",
+        function (this: HTMLElement, _e: JQuery.Event) {
+            const $input_elem = $(this);
+            const field_id = Number.parseInt($input_elem.attr("name")!, 10);
+            const $container = $input_elem.closest(".custom_user_field_value_multiple_container");
+            const values: string[] = [];
+
+            $container.find<HTMLInputElement>("input:checked").each(function () {
+                values.push(this.value);
+            });
+
+            if (values.length === 0) {
+                custom_profile_fields_ui.update_user_custom_profile_fields(
+                    [{id: field_id}],
+                    channel.del,
+                );
+            } else {
+                custom_profile_fields_ui.update_user_custom_profile_fields(
+                    [{id: field_id, value: values}],
+                    channel.patch,
+                );
+            }
+        },
+    );
+
     $("#account-settings .deactivate_realm_button").on(
         "click",
         settings_org.deactivate_organization,

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -849,6 +849,33 @@ export function set_up(): void {
         },
     );
 
+    $("#profile-settings").on(
+        "change",
+        ".custom_user_field_value_multiple",
+        function (this: HTMLElement, _e: JQuery.Event) {
+            const $input_elem = $(this);
+            const field_id = Number.parseInt($input_elem.attr("name")!, 10);
+            const $container = $input_elem.closest(".custom_user_field_value_multiple_container");
+            const values: string[] = [];
+
+            $container.find<HTMLInputElement>("input:checked").each(function () {
+                values.push(this.value);
+            });
+
+            if (values.length === 0) {
+                custom_profile_fields_ui.update_user_custom_profile_fields(
+                    [{id: field_id}],
+                    channel.del,
+                );
+            } else {
+                custom_profile_fields_ui.update_user_custom_profile_fields(
+                    [{id: field_id, value: values}],
+                    channel.patch,
+                );
+            }
+        },
+    );
+
     $("#account-settings .deactivate_realm_button").on(
         "click",
         settings_org.deactivate_organization,

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -485,7 +485,7 @@ export function read_field_data_from_form(
     const field_types = realm.custom_profile_field_types;
 
     // Only the following field types support associated field data.
-    if (field_type_id === field_types.DROPDOWN.id) {
+    if (field_type_id === field_types.DROPDOWN.id || field_type_id === field_types.CHECKBOXES.id) {
         return read_custom_profile_field_choices_from_form($profile_field_form, old_field_data);
     } else if (field_type_id === field_types.EXTERNAL_ACCOUNT.id) {
         const parsed_old_field_data = old_field_data

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -484,7 +484,7 @@ export function read_field_data_from_form(
     const field_types = realm.custom_profile_field_types;
 
     // Only the following field types support associated field data.
-    if (field_type_id === field_types.DROPDOWN.id) {
+    if (field_type_id === field_types.DROPDOWN.id || field_type_id === field_types.CHECKBOXES.id) {
         return read_custom_profile_field_choices_from_form($profile_field_form, old_field_data);
     }
     if (field_type_id === field_types.EXTERNAL_ACCOUNT.id) {

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import SortableJS from "sortablejs";
 import type * as tippy from "tippy.js";
+import * as z from "zod/mini";
 
 import render_confirm_delete_profile_field from "../templates/confirm_dialog/confirm_delete_profile_field.hbs";
 import render_confirm_delete_profile_field_option from "../templates/confirm_dialog/confirm_delete_profile_field_option.hbs";
@@ -303,6 +304,7 @@ function update_form_for_field_type_selection(): void {
             $("#profile_field_hint").val(default_hint);
             break;
         }
+        case field_types.CHECKBOXES.id:
         case field_types.DROPDOWN.id: {
             $("#profile_field_choices_row").show();
         }
@@ -456,16 +458,28 @@ function show_modal_for_deleting_options(
     let users_count_with_deleted_option_selected = 0;
     for (const user_id of active_user_ids) {
         const field_value = people.get_custom_profile_data(user_id, field.id);
-        if (field_value !== undefined && deleted_values[field_value.value]) {
-            users_count_with_deleted_option_selected += 1;
+        if (field_value !== undefined) {
+            if (field.type === realm.custom_profile_field_types.CHECKBOXES.id) {
+                const selected_values = z.array(z.string()).parse(JSON.parse(field_value.value));
+                if (selected_values.some((val: string) => deleted_values[val] !== undefined)) {
+                    users_count_with_deleted_option_selected += 1;
+                }
+            } else if (deleted_values[field_value.value] !== undefined) {
+                users_count_with_deleted_option_selected += 1;
+            }
         }
     }
     const deleted_options_count = Object.keys(deleted_values).length;
+    const deleted_options_string = Object.values(deleted_values).join(", ");
+    const is_checkboxes_field = field.type === realm.custom_profile_field_types.CHECKBOXES.id;
+
     const modal_content_html = render_confirm_delete_profile_field_option({
         count: users_count_with_deleted_option_selected,
         field_name: field.name,
         deleted_options_count,
         deleted_values,
+        deleted_options_string,
+        is_checkboxes_field,
     });
 
     confirm_dialog.launch({
@@ -612,7 +626,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
         field_data = JSON.parse(field.field_data);
     }
     let choices: FieldChoice[] = [];
-    if (field.type === field_types.DROPDOWN.id) {
+    if (field.type === field_types.DROPDOWN.id || field.type === field_types.CHECKBOXES.id) {
         const custom_profile_field_choices =
             settings_components.custom_profile_field_choices_schema.parse(field_data);
         choices = parse_field_choices_from_field_data(custom_profile_field_choices);
@@ -629,6 +643,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
             editable_by_user: field.editable_by_user,
             use_for_user_matching: field.use_for_user_matching,
             is_dropdown_field: field.type === field_types.DROPDOWN.id,
+            is_checkboxes_field: field.type === field_types.CHECKBOXES.id,
             is_external_account_field: field.type === field_types.EXTERNAL_ACCOUNT.id,
             valid_to_display_in_summary: is_valid_to_display_in_summary(field.type),
             valid_to_use_for_user_matching: is_valid_to_use_for_user_matching(field.type),
@@ -650,7 +665,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
                 .addClass("display_in_profile_summary_tooltip disabled_label");
         }
 
-        if (field.type === field_types.DROPDOWN.id) {
+        if (field.type === field_types.DROPDOWN.id || field.type === field_types.CHECKBOXES.id) {
             set_up_custom_profile_field_choices_edit_form($profile_field_form, field);
         }
 
@@ -730,7 +745,10 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
             dialog_widget.submit_api_request(channel.patch, url, data, opts);
         }
 
-        if (field.type === field_types.DROPDOWN.id && data["field_data"] !== undefined) {
+        if (
+            (field.type === field_types.DROPDOWN.id || field.type === field_types.CHECKBOXES.id) &&
+            data["field_data"] !== undefined
+        ) {
             const new_values = new Set(
                 Object.keys(
                     settings_components.custom_profile_field_choices_schema.parse(

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -2,6 +2,7 @@ import {$} from "jquery";
 import assert from "minimalistic-assert";
 import SortableJS from "sortablejs";
 import type * as tippy from "tippy.js";
+import * as z from "zod/mini";
 
 import render_confirm_delete_profile_field from "../templates/confirm_dialog/confirm_delete_profile_field.hbs";
 import render_confirm_delete_profile_field_option from "../templates/confirm_dialog/confirm_delete_profile_field_option.hbs";
@@ -305,6 +306,7 @@ function update_form_for_field_type_selection(): void {
             $("#profile_field_hint").val(default_hint);
             break;
         }
+        case field_types.CHECKBOXES.id:
         case field_types.DROPDOWN.id: {
             $("#profile_field_choices_row").show();
         }
@@ -457,8 +459,15 @@ function show_modal_for_deleting_options(
     let users_count_with_deleted_option_selected = 0;
     for (const user_id of active_user_ids) {
         const field_value = people.get_custom_profile_data(user_id, field.id);
-        if (field_value !== undefined && deleted_values.has(field_value.value)) {
-            users_count_with_deleted_option_selected += 1;
+        if (field_value !== undefined) {
+            if (field.type === realm.custom_profile_field_types.CHECKBOXES.id) {
+                const selected_values = z.array(z.string()).parse(JSON.parse(field_value.value));
+                if (selected_values.some((val) => deleted_values.has(val))) {
+                    users_count_with_deleted_option_selected += 1;
+                }
+            } else if (deleted_values.has(field_value.value)) {
+                users_count_with_deleted_option_selected += 1;
+            }
         }
     }
     const deleted_options_count = deleted_values.size;
@@ -467,6 +476,7 @@ function show_modal_for_deleting_options(
         field_name: field.name,
         deleted_options_count,
         deleted_option_texts: deleted_values.values().toArray(),
+        is_checkboxes_field: field.type === realm.custom_profile_field_types.CHECKBOXES.id,
     });
 
     confirm_dialog.launch({
@@ -615,7 +625,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
         field_data = JSON.parse(field.field_data);
     }
     let choices: FieldChoice[] = [];
-    if (field.type === field_types.DROPDOWN.id) {
+    if (field.type === field_types.DROPDOWN.id || field.type === field_types.CHECKBOXES.id) {
         const custom_profile_field_choices =
             settings_components.custom_profile_field_choices_schema.parse(field_data);
         choices = parse_field_choices_from_field_data(custom_profile_field_choices);
@@ -632,6 +642,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
             editable_by_user: field.editable_by_user,
             use_for_user_matching: field.use_for_user_matching,
             is_dropdown_field: field.type === field_types.DROPDOWN.id,
+            is_checkboxes_field: field.type === field_types.CHECKBOXES.id,
             is_external_account_field: field.type === field_types.EXTERNAL_ACCOUNT.id,
             valid_to_display_in_summary: is_valid_to_display_in_summary(field.type),
             valid_to_use_for_user_matching: is_valid_to_use_for_user_matching(field.type),
@@ -653,7 +664,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
                 .addClass("display_in_profile_summary_tooltip disabled_label");
         }
 
-        if (field.type === field_types.DROPDOWN.id) {
+        if (field.type === field_types.DROPDOWN.id || field.type === field_types.CHECKBOXES.id) {
             set_up_custom_profile_field_choices_edit_form($profile_field_form, field);
         }
 
@@ -733,7 +744,10 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
             dialog_widget.submit_api_request(channel.patch, url, data, opts);
         }
 
-        if (field.type === field_types.DROPDOWN.id && data["field_data"] !== undefined) {
+        if (
+            (field.type === field_types.DROPDOWN.id || field.type === field_types.CHECKBOXES.id) &&
+            data["field_data"] !== undefined
+        ) {
             const new_values = new Set(
                 Object.keys(
                     settings_components.custom_profile_field_choices_schema.parse(

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -405,6 +405,7 @@ const custom_profile_field_types_schema = z.object({
     PARAGRAPH: z.object({id: z.number(), name: z.string()}),
     DATE: z.object({id: z.number(), name: z.string()}),
     DROPDOWN: z.object({id: z.number(), name: z.string()}),
+    CHECKBOXES: z.object({id: z.number(), name: z.string()}),
     URL: z.object({id: z.number(), name: z.string()}),
     EXTERNAL_ACCOUNT: z.object({id: z.number(), name: z.string()}),
     USER: z.object({id: z.number(), name: z.string()}),

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -393,6 +393,7 @@ const custom_profile_field_types_schema = z.object({
     PARAGRAPH: z.object({id: z.number(), name: z.string()}),
     DATE: z.object({id: z.number(), name: z.string()}),
     DROPDOWN: z.object({id: z.number(), name: z.string()}),
+    CHECKBOXES: z.object({id: z.number(), name: z.string()}),
     URL: z.object({id: z.number(), name: z.string()}),
     EXTERNAL_ACCOUNT: z.object({id: z.number(), name: z.string()}),
     USER: z.object({id: z.number(), name: z.string()}),

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -79,6 +79,7 @@ export type CustomProfileFieldData = {
     is_user_field: boolean;
     is_link: boolean;
     is_external_account: boolean;
+    is_checkboxes_field: boolean;
     type: number;
     display_in_profile_summary: boolean | undefined;
     required: boolean;
@@ -477,6 +478,7 @@ export function get_custom_profile_field_data(
         is_user_field: false,
         is_link: field_type === field_types.URL.id,
         is_external_account: field_type === field_types.EXTERNAL_ACCOUNT.id,
+        is_checkboxes_field: field_type === field_types.CHECKBOXES.id,
         is_long_text: field_type === field_types.PARAGRAPH.id,
         type: field_type,
         display_in_profile_summary: field.display_in_profile_summary,
@@ -499,6 +501,20 @@ export function get_custom_profile_field_data(
                 JSON.parse(field.field_data),
             );
             profile_field.value = field_choice_dict[field_value.value]!.text;
+            break;
+        }
+        case field_types.CHECKBOXES.id: {
+            const field_data = settings_components.custom_profile_field_choices_schema.parse(
+                JSON.parse(field.field_data),
+            );
+            const selected_ids = z.array(z.string()).parse(JSON.parse(field_value.value));
+
+            const readable_values: string[] = [];
+            for (const id of selected_ids) {
+                readable_values.push(field_data[id]!.text);
+            }
+
+            profile_field.value = readable_values.join(", ");
             break;
         }
         case field_types.SHORT_TEXT.id:
@@ -1132,7 +1148,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
 
 function get_human_profile_data(fields_user_pills: Map<number, user_pill.UserPillWidget>): {
     id: number;
-    value: string | number[];
+    value: string | number[] | string[];
 }[] {
     /*
         This formats custom profile field data to send to the server.
@@ -1142,12 +1158,25 @@ function get_human_profile_data(fields_user_pills: Map<number, user_pill.UserPil
         TODO: Ideally, this logic would be cleaned up or deduplicated with
         the settings_account.ts logic.
     */
-    const new_profile_data = [];
+    const new_profile_data: {id: number; value: string | number[] | string[]}[] = [];
     $("#edit-user-form .custom_user_field_value").each(function () {
+        const value = $(this).val();
+        assert(typeof value === "string");
         new_profile_data.push({
             id: Number.parseInt($(this).closest(".custom_user_field").attr("data-field-id")!, 10),
-            value: $(this).val(),
+            value,
         });
+    });
+    $("#edit-user-form .custom_user_field_value_multiple_container").each(function () {
+        const field_id = Number.parseInt(
+            $(this).closest(".custom_user_field").attr("data-field-id")!,
+            10,
+        );
+        const values = $(this)
+            .find<HTMLInputElement>("input:checked")
+            .map((_i, elem) => elem.value)
+            .get();
+        new_profile_data.push({id: field_id, value: values});
     });
     // Append user type field values also
     for (const [field_id, field_pills] of fields_user_pills) {
@@ -1167,8 +1196,17 @@ function get_current_values(
     $edit_form: JQuery,
 ): Record<string, unknown> & {user_id?: string | undefined} {
     const raw_current_values = dialog_widget.get_current_values(
-        $edit_form.find("input:not(.datepicker), select, textarea, button, .pill-container"),
+        $edit_form.find(
+            "input:not(.datepicker, .custom_user_field_value_multiple), select, textarea, button, .pill-container",
+        ),
     );
+    $edit_form.find(".custom_user_field_value_multiple_container").each(function () {
+        const name = $(this).find("input").attr("name")!;
+        raw_current_values[name] = $(this)
+            .find<HTMLInputElement>("input:checked")
+            .map((_i, elem) => elem.value)
+            .get();
+    });
     const schema = z.intersection(
         z.object({
             user_id: z.optional(z.string()),

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -80,6 +80,7 @@ export type CustomProfileFieldData = {
     is_user_field: boolean;
     is_link: boolean;
     is_external_account: boolean;
+    is_checkboxes_field: boolean;
     type: number;
     display_in_profile_summary: boolean | undefined;
     required: boolean;
@@ -478,6 +479,7 @@ export function get_custom_profile_field_data(
         is_user_field: false,
         is_link: field_type === field_types.URL.id,
         is_external_account: field_type === field_types.EXTERNAL_ACCOUNT.id,
+        is_checkboxes_field: field_type === field_types.CHECKBOXES.id,
         is_long_text: field_type === field_types.PARAGRAPH.id,
         type: field_type,
         display_in_profile_summary: field.display_in_profile_summary,
@@ -500,6 +502,15 @@ export function get_custom_profile_field_data(
                 JSON.parse(field.field_data),
             );
             profile_field.value = field_choice_dict[field_value.value]!.text;
+            break;
+        }
+        case field_types.CHECKBOXES.id: {
+            const field_data = settings_components.custom_profile_field_choices_schema.parse(
+                JSON.parse(field.field_data),
+            );
+            const selected_ids = z.array(z.string()).parse(JSON.parse(field_value.value));
+
+            profile_field.value = selected_ids.map((id) => field_data[id]!.text).join(", ");
             break;
         }
         case field_types.SHORT_TEXT.id:
@@ -1137,7 +1148,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
 
 function get_human_profile_data(fields_user_pills: Map<number, user_pill.UserPillWidget>): {
     id: number;
-    value: string | number[];
+    value: string | number[] | string[];
 }[] {
     /*
         This formats custom profile field data to send to the server.
@@ -1147,12 +1158,25 @@ function get_human_profile_data(fields_user_pills: Map<number, user_pill.UserPil
         TODO: Ideally, this logic would be cleaned up or deduplicated with
         the settings_account.ts logic.
     */
-    const new_profile_data = [];
+    const new_profile_data: {id: number; value: string | number[] | string[]}[] = [];
     $("#edit-user-form .custom_user_field_value").each(function () {
+        const value = $(this).val();
+        assert(typeof value === "string");
         new_profile_data.push({
             id: Number.parseInt($(this).closest(".custom_user_field").attr("data-field-id")!, 10),
-            value: $(this).val(),
+            value,
         });
+    });
+    $("#edit-user-form .custom_user_field_value_multiple_container").each(function () {
+        const field_id = Number.parseInt(
+            $(this).closest(".custom_user_field").attr("data-field-id")!,
+            10,
+        );
+        const values = $(this)
+            .find<HTMLInputElement>("input:checked")
+            .map((_i, elem) => elem.value)
+            .get();
+        new_profile_data.push({id: field_id, value: values});
     });
     // Append user type field values also
     for (const [field_id, field_pills] of fields_user_pills) {
@@ -1172,8 +1196,17 @@ function get_current_values(
     $edit_form: JQuery,
 ): Record<string, unknown> & {user_id?: string | undefined} {
     const raw_current_values = dialog_widget.get_current_values(
-        $edit_form.find("input:not(.datepicker), select, textarea, button, .pill-container"),
+        $edit_form.find(
+            "input:not(.datepicker, .custom_user_field_value_multiple), select, textarea, button, .pill-container",
+        ),
     );
+    $edit_form.find(".custom_user_field_value_multiple_container").each(function () {
+        const name = $(this).find("input").attr("name")!;
+        raw_current_values[name] = $(this)
+            .find<HTMLInputElement>("input:checked")
+            .map((_i, elem) => elem.value)
+            .get();
+    });
     const schema = z.intersection(
         z.object({
             user_id: z.optional(z.string()),

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -1232,6 +1232,7 @@
 ul.modal-options-list {
     list-style: none;
     margin: 0;
+    overflow-wrap: anywhere;
 }
 
 .modal-option-content {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -181,6 +181,10 @@
         margin: 0;
     }
 
+    .custom-profile-field-value.popover-checkboxes-value {
+        display: block;
+    }
+
     .custom-profile-field-link {
         color: var(--color-text-item);
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2444,6 +2444,16 @@ label.preferences-radio-choice-label {
             border-color: hsl(206deg 80% 62% / 80%);
         }
     }
+
+    &.settings-profile-user-field:has(
+            .custom_user_field_value_multiple_container
+        ) {
+        border: none;
+    }
+
+    .profile-field-checkbox .rendered-checkbox {
+        outline: 1px solid hsl(3deg 57% 33%);
+    }
 }
 
 #generate-integration-url-modal {
@@ -2542,4 +2552,15 @@ label.preferences-radio-choice-label {
 .profile-field-choices .choice-row input.modal_text_input:disabled {
     opacity: var(--opacity-disabled-profile-field-choice-input);
     color: var(--color-text-default);
+}
+
+.settings-profile-user-field:has(.custom_user_field_value_multiple_container) {
+    max-width: var(--modal-input-width);
+}
+
+/* Custom Profile Fields - Checkboxes */
+.custom_user_field_value_multiple_container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 15px;
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2425,6 +2425,16 @@ input.settings_text_input:disabled {
             border-color: hsl(206deg 80% 62% / 80%);
         }
     }
+
+    &.settings-profile-user-field:has(
+            .custom_user_field_value_multiple_container
+        ) {
+        border: none;
+    }
+
+    .profile-field-checkbox .rendered-checkbox {
+        outline: 1px solid hsl(3deg 57% 33%);
+    }
 }
 
 #generate-integration-url-modal {
@@ -2523,4 +2533,29 @@ input.settings_text_input:disabled {
 .profile-field-choices .choice-row input.modal_text_input:disabled {
     opacity: var(--opacity-disabled-profile-field-choice-input);
     color: var(--color-text-default);
+}
+
+.settings-profile-user-field:has(.custom_user_field_value_multiple_container) {
+    max-width: var(--modal-input-width);
+}
+
+/* Custom Profile Fields - Checkboxes */
+.custom_user_field_value_multiple_container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px 15px;
+
+    .profile-field-checkbox {
+        display: flex;
+        align-items: flex-start;
+        max-width: 100%;
+
+        .rendered-checkbox {
+            flex-shrink: 0;
+        }
+
+        .profile-field-checkbox-text {
+            overflow-wrap: anywhere;
+        }
+    }
 }

--- a/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
@@ -1,26 +1,56 @@
-<p>
-    {{#if (eq count 1)}}
-        {{#tr}}
-            This will clear the <z-field-name></z-field-name> profile field for 1 user.
-            {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
-        {{/tr}}
-    {{else}}
-        {{#tr}}
-            This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
-            {{#*inline "z-count"}}{{count}}{{/inline}}
-            {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
-        {{/tr}}
-    {{/if}}
-</p>
-<div>
-    {{#if (eq deleted_options_count 1)}}
-        {{t "Deleted option:" }}
-    {{else}}
-        {{t "Deleted options:" }}
-    {{/if}}
-</div>
-<ul class="modal-options-list">
-    {{#each (object_values deleted_values)}}
-        <li>{{this}}</li>
-    {{/each}}
-</ul>
+{{#if is_checkboxes_field}}
+    <p>
+        {{#if (eq deleted_options_count 1)}}
+            {{#tr}}
+                The following option will be deleted: <z-options></z-options>.
+                {{#*inline "z-options"}}<strong>{{deleted_options_string}}</strong>{{/inline}}
+            {{/tr}}
+        {{else}}
+            {{#tr}}
+                The following options will be deleted: <z-options></z-options>.
+                {{#*inline "z-options"}}<strong>{{deleted_options_string}}</strong>{{/inline}}
+            {{/tr}}
+        {{/if}}
+    </p>
+    <p>
+        {{#if (eq count 1)}}
+            {{#tr}}
+                This will modify the <z-field-name></z-field-name> profile field for 1 user.
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{else}}
+            {{#tr}}
+                This will modify the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
+                {{#*inline "z-count"}}{{count}}{{/inline}}
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{/if}}
+    </p>
+{{else}}
+    <p>
+        {{#if (eq count 1)}}
+            {{#tr}}
+                This will clear the <z-field-name></z-field-name> profile field for 1 user.
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{else}}
+            {{#tr}}
+                This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
+                {{#*inline "z-count"}}{{count}}{{/inline}}
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{/if}}
+    </p>
+    <div>
+        {{#if (eq deleted_options_count 1)}}
+            {{t "Deleted option:" }}
+        {{else}}
+            {{t "Deleted options:" }}
+        {{/if}}
+    </div>
+    <ul class="modal-options-list">
+        {{#each (object_values deleted_values)}}
+            <li>{{this}}</li>
+        {{/each}}
+    </ul>
+{{/if}}

--- a/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
@@ -1,15 +1,30 @@
 <p>
-    {{#if (eq count 1)}}
-        {{#tr}}
-            This will clear the <z-field-name></z-field-name> profile field for 1 user.
-            {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
-        {{/tr}}
+    {{#if is_checkboxes_field}}
+        {{#if (eq count 1)}}
+            {{#tr}}
+                This will modify the <z-field-name></z-field-name> profile field for 1 user.
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{else}}
+            {{#tr}}
+                This will modify the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
+                {{#*inline "z-count"}}{{count}}{{/inline}}
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{/if}}
     {{else}}
-        {{#tr}}
-            This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
-            {{#*inline "z-count"}}{{count}}{{/inline}}
-            {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
-        {{/tr}}
+        {{#if (eq count 1)}}
+            {{#tr}}
+                This will clear the <z-field-name></z-field-name> profile field for 1 user.
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{else}}
+            {{#tr}}
+                This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
+                {{#*inline "z-count"}}{{count}}{{/inline}}
+                {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+            {{/tr}}
+        {{/if}}
     {{/if}}
 </p>
 <div>

--- a/web/templates/popovers/user_card/user_card_popover_custom_fields.hbs
+++ b/web/templates/popovers/user_card/user_card_popover_custom_fields.hbs
@@ -22,6 +22,10 @@
             <div class="custom-profile-field-value rendered_markdown" data-tippy-content="{{this.name}}">
                 {{rendered_markdown this.rendered_value}}
             </div>
+        {{else if this.is_checkboxes_field}}
+            <div class="custom-profile-field-value popover-checkboxes-value" data-tippy-content="{{this.name}}">
+                <span class="custom-profile-field-text">{{this.value}}</span>
+            </div>
         {{else}}
             <div class="custom-profile-field-value" data-tippy-content="{{this.name}}">
                 <span class="custom-profile-field-text">{{this.value}}</span>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -8,6 +8,16 @@
     <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}} {{#unless editable_by_user}}not-editable-by-user-input-wrapper{{/unless}}{{#if (and is_date_field editable_by_user)}}editable-date-field{{/if}}">
         {{#if is_long_text_field}}
         <textarea id="id_custom_profile_field_input_{{ field.id }}" maxlength="500" class="custom_user_field_value {{#if for_manage_user_modal}}modal-textarea{{else}}settings-textarea{{/if}}" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>{{ field_value.value }}</textarea>
+        {{else if is_checkboxes_field}}
+        <div class="custom_user_field_value_multiple_container">
+            {{#each field_choices}}
+                <label class="checkbox profile-field-checkbox">
+                    <input type="checkbox" class="custom_user_field_value_multiple" name="{{ ../field.id }}" value="{{ this.value }}" {{#if this.selected}}checked{{/if}} {{#unless ../editable_by_user}}disabled{{/unless}}/>
+                    <span class="rendered-checkbox"></span>
+                    {{ this.text }}
+                </label>
+            {{/each}}
+        </div>
         {{else if is_dropdown_field}}
         <select id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>
             <option value=""></option>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -8,6 +8,16 @@
     <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}} {{#unless editable_by_user}}not-editable-by-user-input-wrapper{{/unless}}{{#if (and is_date_field editable_by_user)}}editable-date-field{{/if}}">
         {{#if is_long_text_field}}
         <textarea id="id_custom_profile_field_input_{{ field.id }}" maxlength="500" class="custom_user_field_value {{#if for_manage_user_modal}}modal-textarea{{else}}settings-textarea{{/if}}" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>{{ field_value.value }}</textarea>
+        {{else if is_checkboxes_field}}
+        <div class="custom_user_field_value_multiple_container">
+            {{#each field_choices}}
+                <label class="checkbox profile-field-checkbox">
+                    <input type="checkbox" class="custom_user_field_value_multiple" name="{{ ../field.id }}" value="{{ this.value }}" {{#if this.selected}}checked{{/if}} {{#unless ../editable_by_user}}disabled{{/unless}}/>
+                    <span class="rendered-checkbox"></span>
+                    <span class="profile-field-checkbox-text">{{ this.text }}</span>
+                </label>
+            {{/each}}
+        </div>
         {{else if is_dropdown_field}}
         <select id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>
             <option value=""></option>

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -8,7 +8,7 @@
         <label for="id-custom-profile-field-hint" class="modal-field-label">{{t "Hint" }}</label>
         <input type="text" name="hint" id="id-custom-profile-field-hint" class="modal_text_input prop-element" value="{{ hint }}" maxlength="80" data-setting-widget-type="string" />
     </div>
-    {{#if is_dropdown_field }}
+    {{#if (or is_dropdown_field is_checkboxes_field)}}
     <div class="input-group prop-element profile-field-choices-wrapper" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
         <label for="profile_field_choices_edit" class="modal-field-label">{{t "Field choices" }}</label>
         <div class="profile-field-choices" name="profile_field_choices_edit">

--- a/web/templates/settings/profile_field_choice.hbs
+++ b/web/templates/settings/profile_field_choice.hbs
@@ -3,7 +3,7 @@
         <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
         <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     </span>
-    <input type='text' class="modal_text_input" placeholder='{{t "New option" }}' value="{{ text }}" {{#if is_existing_choice}}disabled{{/if}} />
+    <input type='text' class="modal_text_input" maxlength="50" placeholder='{{t "New option" }}' value="{{ text }}" {{#if is_existing_choice}}disabled{{/if}} />
     {{#if is_existing_choice}}
         {{> ../components/icon_button intent="neutral" custom_classes="edit-choice tippy-zulip-tooltip" icon="edit" data-tippy-content=(t "Making changes to this choice will modify the profiles of the users who've selected it.") aria-label=(t "Edit choice") }}
     {{/if}}

--- a/web/tests/settings_profile_fields.test.cjs
+++ b/web/tests/settings_profile_fields.test.cjs
@@ -14,12 +14,14 @@ const DROPDOWN_ID = 3;
 const EXTERNAL_ACCOUNT_ID = 7;
 const PARAGRAPH_ID = 2;
 const USER_FIELD_ID = 6;
+const CHECKBOXES_ID = 9;
 
 const SHORT_TEXT_NAME = "Short text";
 const DROPDOWN_NAME = "Dropdown";
 const EXTERNAL_ACCOUNT_NAME = "External account";
 const PARAGRAPH_NAME = "Paragraph";
 const USER_FIELD_NAME = "Person";
+const CHECKBOXES_NAME = "Checkboxes";
 
 const custom_profile_field_types = {
     SHORT_TEXT: {
@@ -41,6 +43,10 @@ const custom_profile_field_types = {
     USER: {
         id: USER_FIELD_ID,
         name: USER_FIELD_NAME,
+    },
+    CHECKBOXES: {
+        id: CHECKBOXES_ID,
+        name: CHECKBOXES_NAME,
     },
 };
 

--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -76,6 +76,7 @@ def try_add_realm_custom_profile_field(
     if custom_profile_field.field_type in (
         CustomProfileField.DROPDOWN,
         CustomProfileField.EXTERNAL_ACCOUNT,
+        CustomProfileField.CHECKBOXES,
     ):
         custom_profile_field.field_data = orjson.dumps(field_data or {}).decode()
 
@@ -108,6 +109,43 @@ def remove_custom_profile_field_value_if_required(
     removed_values = old_values - new_values
 
     if not removed_values:
+        return
+
+    if field.field_type == CustomProfileField.CHECKBOXES:
+        field_values = CustomProfileFieldValue.objects.filter(field=field).select_related(
+            "user_profile"
+        )
+
+        values_to_update = []
+        ids_to_delete = []
+        updated_user_values: list[tuple[UserProfile, str | None]] = []
+        for field_value in field_values:
+            val_list = orjson.loads(field_value.value)
+            new_val_list = [value for value in val_list if value not in removed_values]
+            if len(new_val_list) == len(val_list):
+                continue
+
+            if new_val_list:
+                field_value.value = orjson.dumps(new_val_list).decode()
+                values_to_update.append(field_value)
+                updated_user_values.append((field_value.user_profile, field_value.value))
+            else:
+                ids_to_delete.append(field_value.id)
+                updated_user_values.append((field_value.user_profile, None))
+
+        CustomProfileFieldValue.objects.filter(id__in=ids_to_delete).delete()
+        CustomProfileFieldValue.objects.bulk_update(values_to_update, ["value"])
+
+        for user_profile, value in updated_user_values:
+            notify_user_update_custom_profile_data(
+                user_profile,
+                {
+                    "id": field.id,
+                    "value": value,
+                    "rendered_value": None,
+                    "type": field.field_type,
+                },
+            )
         return
 
     values_to_delete = CustomProfileFieldValue.objects.filter(
@@ -158,10 +196,14 @@ def try_update_realm_custom_profile_field(
     if field.field_type in (
         CustomProfileField.DROPDOWN,
         CustomProfileField.EXTERNAL_ACCOUNT,
+        CustomProfileField.CHECKBOXES,
     ):
         # If field_data is None, field_data is unchanged and there is no need for
         # comparing field_data values.
-        if field_data is not None and field.field_type == CustomProfileField.DROPDOWN:
+        if field_data is not None and field.field_type in (
+            CustomProfileField.DROPDOWN,
+            CustomProfileField.CHECKBOXES,
+        ):
             remove_custom_profile_field_value_if_required(field, field_data)
 
         # If field.field_data is the default empty string, we will set field_data
@@ -269,6 +311,11 @@ def get_custom_profile_field_display_value(field_value: CustomProfileFieldValue)
         field_data_dict = orjson.loads(field_value.field.field_data)
         value_key = field_value.value
         return field_data_dict[value_key]["text"]
+
+    if type == CustomProfileField.CHECKBOXES:
+        field_data_dict = orjson.loads(field_value.field.field_data)
+        value_keys = orjson.loads(field_value.value)
+        return ", ".join(field_data_dict[str(key)]["text"] for key in value_keys)
 
     if type == CustomProfileField.USER:
         user_ids = orjson.loads(field_value.value)

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -16,9 +16,11 @@ ResultT = TypeVar("ResultT")
 Validator: TypeAlias = Callable[[str, object], ResultT]
 ExtendedValidator: TypeAlias = Callable[[str, str, object], str]
 RealmUserValidator: TypeAlias = Callable[[int, object, bool], list[int]]
+CheckboxesValidator = Callable[[str, str, object], list[str]]
+CheckboxesFieldElement = tuple[int, StrPromise, CheckboxesValidator, Callable[[Any], Any], str]
 
 
-ProfileDataElementValue: TypeAlias = str | list[int]
+ProfileDataElementValue: TypeAlias = str | list[int] | list[str]
 
 
 class ProfileDataElementBase(TypedDict, total=False):

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -533,6 +533,10 @@ def validate_user_custom_profile_field(
         # Put an assertion so that mypy doesn't complain.
         assert field_data is not None
         return choice_field_validator(var_name, field_data, value)
+    elif field_type == CustomProfileField.CHECKBOXES:
+        checkboxes_validator = CustomProfileField.CHECKBOXES_FIELD_VALIDATORS[field_type]
+        checkboxes_validator(var_name, field.field_data, value)
+        return value
     elif field_type == CustomProfileField.USER:
         user_field_validator = CustomProfileField.USER_FIELD_VALIDATORS[field_type]
         return user_field_validator(realm_id, value, False)

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -531,6 +531,10 @@ def validate_user_custom_profile_field(
         # Put an assertion so that mypy doesn't complain.
         assert field_data is not None
         return choice_field_validator(var_name, field_data, value)
+    elif field_type == CustomProfileField.CHECKBOXES:
+        checkboxes_validator = CustomProfileField.CHECKBOXES_FIELD_VALIDATORS[field_type]
+        checkboxes_validator(var_name, field.field_data, value)
+        return value
     elif field_type == CustomProfileField.USER:
         user_field_validator = CustomProfileField.USER_FIELD_VALIDATORS[field_type]
         return user_field_validator(realm_id, value, False)

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -385,10 +385,14 @@ def check_external_account_url_pattern(var_name: str, val: object) -> str:
 
 def validate_custom_profile_field_choices(
     field_data: ProfileFieldData,
+    existing_field_data: ProfileFieldData | None = None,
 ) -> dict[str, dict[str, str]]:
     """
     This function is used to validate the data sent to the server while
     creating/editing choices of the choice field in Organization settings.
+
+    The text length limit applies only to new or changed options, so existing
+    fields with longer options stay editable.
     """
     validator = check_dict_only(
         [
@@ -396,6 +400,10 @@ def validate_custom_profile_field_choices(
             ("order", check_required_string),
         ]
     )
+
+    # For choice fields, every field_data value is a choice dict, so this cast
+    # lets the per-choice lookups below be typed without a runtime check.
+    existing_choices = cast(dict[str, dict[str, str]], existing_field_data or {})
 
     # To create an array of texts of each option
     distinct_field_names: set[str] = set()
@@ -406,6 +414,11 @@ def validate_custom_profile_field_choices(
 
         valid_value = validator("field_data", value)
         assert value is valid_value  # To justify the unchecked cast below
+
+        # Enforce the length cap only on new or changed option text.
+        existing_choice = existing_choices.get(key)
+        if existing_choice is None or existing_choice["text"] != valid_value["text"]:
+            check_short_string('field_data["text"]', valid_value["text"])
 
         distinct_field_names.add(valid_value["text"])
 

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -602,6 +602,27 @@ def check_string_or_int(var_name: str, val: object) -> str | int:
     raise ValidationError(_("{var_name} is not a string or integer").format(var_name=var_name))
 
 
+def validate_checkboxes_field(var_name: str, field_data: str, value: object) -> list[str]:
+    items = check_list(check_string)(var_name, value)
+
+    if not items:
+        raise ValidationError(_("{var_name} cannot be empty.").format(var_name=var_name))
+
+    if len(set(items)) != len(items):
+        raise ValidationError(
+            _("{var_name} cannot have duplicate choices.").format(var_name=var_name)
+        )
+
+    field_data_dict = orjson.loads(field_data)
+
+    for item in items:
+        if item not in field_data_dict:
+            msg = _("'{value}' is not a valid choice for '{field_name}'.")
+            raise ValidationError(msg.format(value=item, field_name=var_name))
+
+    return items
+
+
 @dataclass(eq=False)
 class WildValue:  # noqa: PLW1641
     var_name: str

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -385,10 +385,14 @@ def check_external_account_url_pattern(var_name: str, val: object) -> str:
 
 def validate_custom_profile_field_choices(
     field_data: ProfileFieldData,
+    existing_choices: dict[str, dict[str, str]] | None = None,
 ) -> dict[str, dict[str, str]]:
     """
     This function is used to validate the data sent to the server while
     creating/editing choices of the choice field in Organization settings.
+
+    The text length limit applies only to new or changed options, so existing
+    fields with longer options stay editable.
     """
     validator = check_dict_only(
         [
@@ -396,6 +400,9 @@ def validate_custom_profile_field_choices(
             ("order", check_required_string),
         ]
     )
+
+    if existing_choices is None:
+        existing_choices = {}
 
     # To create an array of texts of each option
     distinct_field_names: set[str] = set()
@@ -406,6 +413,10 @@ def validate_custom_profile_field_choices(
 
         valid_value = validator("field_data", value)
         assert value is valid_value  # To justify the unchecked cast below
+
+        existing_choice = existing_choices.get(key)
+        if existing_choice is None or existing_choice["text"] != valid_value["text"]:
+            check_short_string('field_data["text"]', valid_value["text"])
 
         distinct_field_names.add(valid_value["text"])
 

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -600,6 +600,27 @@ def check_string_or_int(var_name: str, val: object) -> str | int:
     raise ValidationError(_("{var_name} is not a string or integer").format(var_name=var_name))
 
 
+def validate_checkboxes_field(var_name: str, field_data: str, value: object) -> list[str]:
+    items = check_list(check_string)(var_name, value)
+
+    if not items:
+        raise ValidationError(_("{var_name} cannot be empty.").format(var_name=var_name))
+
+    if len(set(items)) != len(items):
+        raise ValidationError(
+            _("{var_name} cannot have duplicate choices.").format(var_name=var_name)
+        )
+
+    field_data_dict = orjson.loads(field_data)
+
+    for item in items:
+        if item not in field_data_dict:
+            msg = _("'{value}' is not a valid choice for '{field_name}'.")
+            raise ValidationError(msg.format(value=item, field_name=var_name))
+
+    return items
+
+
 @dataclass(eq=False)
 class WildValue:  # noqa: PLW1641
     var_name: str

--- a/zerver/migrations/0001_squashed_0569.py
+++ b/zerver/migrations/0001_squashed_0569.py
@@ -1548,6 +1548,7 @@ class Migration(migrations.Migration):
                     "field_type",
                     models.PositiveSmallIntegerField(
                         choices=[
+                            (9, "Checkboxes"),
                             (4, "Date"),
                             (3, "Dropdown"),
                             (7, "External account"),

--- a/zerver/migrations/0417_alter_customprofilefield_field_type.py
+++ b/zerver/migrations/0417_alter_customprofilefield_field_type.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
             name="field_type",
             field=models.PositiveSmallIntegerField(
                 choices=[
+                    (9, "Checkboxes"),
                     (4, "Date"),
                     (3, "Dropdown"),
                     (7, "External account"),

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -11,6 +11,8 @@ from django_stubs_ext import StrPromise
 from typing_extensions import override
 
 from zerver.lib.types import (
+    CheckboxesFieldElement,
+    CheckboxesValidator,
     ExtendedFieldElement,
     ExtendedValidator,
     FieldElement,
@@ -27,6 +29,7 @@ from zerver.lib.validator import (
     check_long_string,
     check_short_string,
     check_url,
+    validate_checkboxes_field,
     validate_dropdown_field,
 )
 from zerver.models.realms import Realm
@@ -97,6 +100,7 @@ class CustomProfileField(models.Model):
     USER = 6
     EXTERNAL_ACCOUNT = 7
     PRONOUNS = 8
+    CHECKBOXES = 9
 
     # These are the fields whose validators require more than var_name
     # and value argument. i.e. DROPDOWN require field_data, USER require
@@ -104,12 +108,26 @@ class CustomProfileField(models.Model):
     DROPDOWN_FIELD_TYPE_DATA: list[ExtendedFieldElement] = [
         (DROPDOWN, gettext_lazy("Dropdown"), validate_dropdown_field, str, "DROPDOWN"),
     ]
+
+    CHECKBOXES_FIELD_TYPE_DATA: list[CheckboxesFieldElement] = [
+        (
+            CHECKBOXES,
+            gettext_lazy("Checkboxes"),
+            validate_checkboxes_field,
+            orjson.loads,
+            "CHECKBOXES",
+        ),
+    ]
+
     USER_FIELD_TYPE_DATA: list[UserFieldElement] = [
         (USER, gettext_lazy("Users"), check_valid_user_ids, orjson.loads, "USER"),
     ]
 
     DROPDOWN_FIELD_VALIDATORS: dict[int, ExtendedValidator] = {
         item[0]: item[2] for item in DROPDOWN_FIELD_TYPE_DATA
+    }
+    CHECKBOXES_FIELD_VALIDATORS: dict[int, CheckboxesValidator] = {
+        item[0]: item[2] for item in CHECKBOXES_FIELD_TYPE_DATA
     }
     USER_FIELD_VALIDATORS: dict[int, RealmUserValidator] = {
         item[0]: item[2] for item in USER_FIELD_TYPE_DATA
@@ -132,7 +150,13 @@ class CustomProfileField(models.Model):
     ]
 
     ALL_FIELD_TYPES = sorted(
-        [*FIELD_TYPE_DATA, *DROPDOWN_FIELD_TYPE_DATA, *USER_FIELD_TYPE_DATA], key=lambda x: x[1]
+        [
+            *FIELD_TYPE_DATA,
+            *DROPDOWN_FIELD_TYPE_DATA,
+            *CHECKBOXES_FIELD_TYPE_DATA,
+            *USER_FIELD_TYPE_DATA,
+        ],
+        key=lambda x: x[1],
     )
 
     FIELD_VALIDATORS: dict[int, Validator[ProfileDataElementValue]] = {

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12596,7 +12596,11 @@ paths:
                     field data for the user.
                   type: array
                   example:
-                    [{"id": 4, "value": "0"}, {"id": 5, "value": "1909-04-05"}]
+                    [
+                      {"id": 4, "value": "0"},
+                      {"id": 5, "value": ["0", "1"]},
+                      {"id": 6, "value": "1909-04-05"},
+                    ]
                   items:
                     $ref: "#/components/schemas/ProfileDataUpdate"
               required:
@@ -15153,6 +15157,16 @@ paths:
                               "required": false,
                               "editable_by_user": true,
                             },
+                            {
+                              "id": 10,
+                              "name": "Programming languages",
+                              "type": 9,
+                              "hint": "Select your favorite programming languages.",
+                              "field_data": '{"0":{"text":"Python","order":"1"},"1":{"text":"Rust","order":"2"},"2":{"text":"C++","order":"3"}}',
+                              "order": 10,
+                              "required": false,
+                              "editable_by_user": true,
+                            },
                           ],
                       }
     patch:
@@ -15182,7 +15196,7 @@ paths:
                   type: array
                   items:
                     type: integer
-                  example: [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+                  example: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
               required:
                 - order
             encoding:
@@ -15232,18 +15246,22 @@ paths:
                     - **6**: Users
                     - **7**: External account
                     - **8**: Pronouns
+                    - **9**: Checkboxes
 
-                    **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+                    **Changes**: Field type `9` added in Zulip 13.0 (feature level ZF-37c254).
+
+                    Field type `8` added in Zulip 6.0 (feature level 151).
                   type: integer
                   example: 3
                 field_data:
                   description: |
-                    Field types 3 (Dropdown) and 7 (External account) support storing
-                    additional configuration for the field type in the `field_data` attribute.
+                    Field types 3 (Dropdown), 7 (External account), and 9 (Checkboxes)
+                    support storing additional configuration for the field type in the
+                    `field_data` attribute.
 
-                    For field type 3 (Dropdown), this attribute is a JSON dictionary
-                    defining the choices and the order they will be displayed in the
-                    dropdown UI for individual users to select an option.
+                    For field types 3 (Dropdown) and 9 (Checkboxes), this attribute is
+                    a JSON dictionary defining the choices and the order they will be
+                    displayed in the UI for individual users to make their selection.
 
                     The interface for field type 7 is not yet stabilized.
                   type: object
@@ -18486,8 +18504,11 @@ paths:
                             - `EXTERNAL_ACCOUNT` for external accounts.
                             - `USER` for selecting a user for the field.
                             - `PRONOUNS` for a short text field with convenient typeahead for one's preferred pronouns.
+                            - `CHECKBOXES` for a field allowing users to select multiple options from a predefined list.
 
-                            **Changes**: `PRONOUNS` type added in Zulip 6.0 (feature level 151).
+                            **Changes**: `CHECKBOXES` type added in Zulip 13.0 (feature level ZF-37c254).
+
+                            `PRONOUNS` type added in Zulip 6.0 (feature level 151).
                           additionalProperties: false
                           properties:
                             id:
@@ -27874,8 +27895,11 @@ components:
             - **6**: Users
             - **7**: External account
             - **8**: Pronouns
+            - **9**: Checkboxes
 
-            **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+            **Changes**: Field type `9` added in Zulip 13.0 (feature level ZF-37c254).
+
+            Field type `8` added in Zulip 6.0 (feature level 151).
         order:
           type: integer
           description: |
@@ -27893,12 +27917,13 @@ components:
         field_data:
           type: string
           description: |
-            Field types 3 (Dropdown) and 7 (External account) support storing
-            additional configuration for the field type in the `field_data` attribute.
+            Field types 3 (Dropdown), 7 (External account), and 9 (Checkboxes)
+            support storing additional configuration for the field type in the
+            `field_data` attribute.
 
-            For field type 3 (Dropdown), this attribute is a JSON dictionary
-            defining the choices and the order they will be displayed in the
-            dropdown UI for individual users to select an option.
+            For field types 3 (Dropdown) and 9 (Checkboxes), this attribute is
+            a JSON dictionary defining the choices and the order they will be
+            displayed in the UI for individual users to make their selection.
 
             The interface for field type 7 is not yet stabilized.
         display_in_profile_summary:
@@ -30057,6 +30082,17 @@ components:
               description: |
                 An array of integer user IDs, which is for the **Users** type of
                 [custom profile field](/help/custom-profile-fields#profile-field-types).
+
+            - type: array
+              minItems: 1
+              uniqueItems: true
+              items:
+                type: string
+              description: |
+                An array of string values, which is for the **Checkboxes** type of
+                [custom profile field](/help/custom-profile-fields#profile-field-types).
+
+                **Changes**: New in Zulip 13.0 (feature level ZF-37c254).
       required:
         - id
         - value
@@ -31229,7 +31265,11 @@ components:
                 items:
                   $ref: "#/components/schemas/ProfileDataUpdate"
                 example:
-                  [{"id": 4, "value": "0"}, {"id": 5, "value": "1909-04-05"}]
+                  [
+                    {"id": 4, "value": "0"},
+                    {"id": 5, "value": ["0", "1"]},
+                    {"id": 6, "value": "1909-04-05"},
+                  ]
               new_email:
                 description: |
                   New email address for the user. Requires the user making the request

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12656,7 +12656,11 @@ paths:
                     field data for the user.
                   type: array
                   example:
-                    [{"id": 4, "value": "0"}, {"id": 5, "value": "1909-04-05"}]
+                    [
+                      {"id": 4, "value": "0"},
+                      {"id": 5, "value": ["0", "1"]},
+                      {"id": 6, "value": "1909-04-05"},
+                    ]
                   items:
                     $ref: "#/components/schemas/ProfileDataUpdate"
               required:
@@ -15332,6 +15336,16 @@ paths:
                               "required": false,
                               "editable_by_user": true,
                             },
+                            {
+                              "id": 10,
+                              "name": "Programming languages",
+                              "type": 9,
+                              "hint": "Select your favorite programming languages.",
+                              "field_data": '{"0":{"text":"Python","order":"1"},"1":{"text":"Rust","order":"2"},"2":{"text":"C++","order":"3"}}',
+                              "order": 10,
+                              "required": false,
+                              "editable_by_user": true,
+                            },
                           ],
                       }
     patch:
@@ -15361,7 +15375,7 @@ paths:
                   type: array
                   items:
                     type: integer
-                  example: [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+                  example: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
               required:
                 - order
             encoding:
@@ -15411,18 +15425,22 @@ paths:
                     - **6**: Users
                     - **7**: External account
                     - **8**: Pronouns
+                    - **9**: Checkboxes
 
-                    **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+                    **Changes**: Field type `9` added in Zulip 13.0 (feature level ZF-37c254).
+
+                    Field type `8` added in Zulip 6.0 (feature level 151).
                   type: integer
                   example: 3
                 field_data:
                   description: |
-                    Field types 3 (Dropdown) and 7 (External account) support storing
-                    additional configuration for the field type in the `field_data` attribute.
+                    Field types 3 (Dropdown), 7 (External account), and 9 (Checkboxes)
+                    support storing additional configuration for the field type in the
+                    `field_data` attribute.
 
-                    For field type 3 (Dropdown), this attribute is a JSON dictionary
-                    defining the choices and the order they will be displayed in the
-                    dropdown UI for individual users to select an option.
+                    For field types 3 (Dropdown) and 9 (Checkboxes), this attribute is
+                    a JSON dictionary defining the choices and the order they will be
+                    displayed in the UI for individual users to make their selection.
 
                     The interface for field type 7 is not yet stabilized.
                   type: object
@@ -18745,8 +18763,11 @@ paths:
                             - `EXTERNAL_ACCOUNT` for external accounts.
                             - `USER` for selecting a user for the field.
                             - `PRONOUNS` for a short text field with convenient typeahead for one's preferred pronouns.
+                            - `CHECKBOXES` for a field allowing users to select multiple options from a predefined list.
 
-                            **Changes**: `PRONOUNS` type added in Zulip 6.0 (feature level 151).
+                            **Changes**: `CHECKBOXES` type added in Zulip 13.0 (feature level ZF-37c254).
+
+                            `PRONOUNS` type added in Zulip 6.0 (feature level 151).
                           additionalProperties: false
                           properties:
                             id:
@@ -28149,8 +28170,11 @@ components:
             - **6**: Users
             - **7**: External account
             - **8**: Pronouns
+            - **9**: Checkboxes
 
-            **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
+            **Changes**: Field type `9` added in Zulip 13.0 (feature level ZF-37c254).
+
+            Field type `8` added in Zulip 6.0 (feature level 151).
         order:
           type: integer
           description: |
@@ -28168,12 +28192,13 @@ components:
         field_data:
           type: string
           description: |
-            Field types 3 (Dropdown) and 7 (External account) support storing
-            additional configuration for the field type in the `field_data` attribute.
+            Field types 3 (Dropdown), 7 (External account), and 9 (Checkboxes)
+            support storing additional configuration for the field type in the
+            `field_data` attribute.
 
-            For field type 3 (Dropdown), this attribute is a JSON dictionary
-            defining the choices and the order they will be displayed in the
-            dropdown UI for individual users to select an option.
+            For field types 3 (Dropdown) and 9 (Checkboxes), this attribute is
+            a JSON dictionary defining the choices and the order they will be
+            displayed in the UI for individual users to make their selection.
 
             The interface for field type 7 is not yet stabilized.
         display_in_profile_summary:
@@ -30338,6 +30363,17 @@ components:
               description: |
                 An array of integer user IDs, which is for the **Users** type of
                 [custom profile field](/help/custom-profile-fields#profile-field-types).
+
+            - type: array
+              minItems: 1
+              uniqueItems: true
+              items:
+                type: string
+              description: |
+                An array of string values, which is for the **Checkboxes** type of
+                [custom profile field](/help/custom-profile-fields#profile-field-types).
+
+                **Changes**: New in Zulip 13.0 (feature level ZF-37c254).
       required:
         - id
         - value
@@ -31527,7 +31563,11 @@ components:
                 items:
                   $ref: "#/components/schemas/ProfileDataUpdate"
                 example:
-                  [{"id": 4, "value": "0"}, {"id": 5, "value": "1909-04-05"}]
+                  [
+                    {"id": 4, "value": "0"},
+                    {"id": 5, "value": ["0", "1"]},
+                    {"id": 6, "value": "1909-04-05"},
+                  ]
               new_email:
                 description: |
                   New email address for the user. Requires the user making the request

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -172,6 +172,15 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         data["field_data"] = orjson.dumps(
             {
+                "0": {"text": "x" * 51, "order": "1"},
+                "1": {"text": "Java", "order": "2"},
+            }
+        ).decode()
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_error(result, 'field_data["text"] is too long (limit: 50 characters)')
+
+        data["field_data"] = orjson.dumps(
+            {
                 "0": {"text": "Python", "order": "1"},
                 "1": {"text": "Java", "order": "2"},
             }
@@ -1052,6 +1061,75 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertTrue(
             CustomProfileFieldValue.objects.filter(field_id=field.id, value="1").exists()
         )
+
+    def test_update_field_with_long_existing_choice(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+
+        long_text = "x" * 60
+        # Create directly, bypassing the view's length check, to seed a field
+        # with an option longer than the limit.
+        field = try_add_realm_custom_profile_field(
+            realm,
+            "Legacy dropdown",
+            CustomProfileField.DROPDOWN,
+            field_data={
+                "0": {"text": long_text, "order": "1"},
+                "1": {"text": "Short", "order": "2"},
+            },
+        )
+
+        # Renaming without resending choices succeeds.
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}", {"name": "Renamed dropdown"}
+        )
+        self.assert_json_success(result)
+
+        # Reordering an unchanged long option succeeds.
+        reordered = {
+            "0": {"text": long_text, "order": "2"},
+            "1": {"text": "Short", "order": "1"},
+        }
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            {"field_data": orjson.dumps(reordered).decode()},
+        )
+        self.assert_json_success(result)
+
+        # Adding a new under-limit option alongside the long one succeeds.
+        with_new_short = {
+            "0": {"text": long_text, "order": "1"},
+            "1": {"text": "Short", "order": "2"},
+            "2": {"text": "Also short", "order": "3"},
+        }
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            {"field_data": orjson.dumps(with_new_short).decode()},
+        )
+        self.assert_json_success(result)
+
+        # A new over-limit option is rejected.
+        with_new_long = {
+            "0": {"text": long_text, "order": "1"},
+            "1": {"text": "Short", "order": "2"},
+            "2": {"text": "y" * 51, "order": "3"},
+        }
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            {"field_data": orjson.dumps(with_new_long).decode()},
+        )
+        self.assert_json_error(result, 'field_data["text"] is too long (limit: 50 characters)')
+
+        # Editing the long option to a new over-limit value is rejected.
+        changed_long = {
+            "0": {"text": "z" * 51, "order": "1"},
+            "1": {"text": "Short", "order": "2"},
+        }
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            {"field_data": orjson.dumps(changed_long).decode()},
+        )
+        self.assert_json_error(result, 'field_data["text"] is too long (limit: 50 characters)')
 
     def test_default_external_account_type_field(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -188,6 +188,30 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_success(result)
 
+    def test_create_checkboxes_field(self) -> None:
+        self.login("iago")
+        data: dict[str, str | int] = {}
+        data["name"] = "Favorite tools"
+        data["field_type"] = CustomProfileField.CHECKBOXES
+
+        data["field_data"] = orjson.dumps(
+            {
+                "0": {"text": "x" * 51, "order": "1"},
+                "1": {"text": "Git", "order": "2"},
+            }
+        ).decode()
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_error(result, 'field_data["text"] is too long (limit: 50 characters)')
+
+        data["field_data"] = orjson.dumps(
+            {
+                "0": {"text": "Docker", "order": "1"},
+                "1": {"text": "Git", "order": "2"},
+            }
+        ).decode()
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_success(result)
+
     def test_create_default_external_account_field(self) -> None:
         self.login("iago")
         realm = get_realm("zulip")
@@ -898,14 +922,25 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             field_name, [invalid_user_id], f"Invalid user IDs: {invalid_user_id}"
         )
 
+    def test_update_invalid_checkboxes_field(self) -> None:
+        field_name = "Programming languages"
+        self.assert_error_update_invalid_value(field_name, [], f"{field_name} cannot be empty.")
+        self.assert_error_update_invalid_value(
+            field_name, ["0", "0"], f"{field_name} cannot have duplicate choices."
+        )
+        self.assert_error_update_invalid_value(
+            field_name, ["99"], f"'99' is not a valid choice for '{field_name}'."
+        )
+
     def test_update_profile_data_successfully(self) -> None:
         self.login("iago")
         realm = get_realm("zulip")
-        fields: list[tuple[str, str | list[int]]] = [
+        fields: list[tuple[str, str | list[int] | list[str]]] = [
             ("Phone number", "*short* text data"),
             ("Biography", "~~short~~ **long** text data"),
             ("Favorite food", "long short text data"),
             ("Favorite editor", "0"),
+            ("Programming languages", ["0", "1"]),
             ("Birthday", "1909-03-05"),
             ("Favorite website", "https://zulip.com"),
             ("Mentor", [self.example_user("cordelia").id]),
@@ -979,6 +1014,22 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             {
                 "id": field.id,
                 "value": "1",
+            }
+        ]
+
+        result = self.client_patch(
+            "/json/users/me/profile_data", {"data": orjson.dumps(data).decode()}
+        )
+        self.assert_json_success(result)
+
+    def test_update_checkboxes_field_successfully(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+        field = CustomProfileField.objects.get(name="Programming languages", realm=realm)
+        data = [
+            {
+                "id": field.id,
+                "value": ["0", "2"],
             }
         ]
 
@@ -1130,6 +1181,45 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             {"field_data": orjson.dumps(changed_long).decode()},
         )
         self.assert_json_error(result, 'field_data["text"] is too long (limit: 50 characters)')
+
+    def test_remove_checkboxes_field_options(self) -> None:
+        user = self.example_user("iago")
+        self.login_user(user)
+        realm = user.realm
+
+        field = CustomProfileField.objects.get(name="Programming languages", realm=realm)
+
+        hamlet = self.example_user("hamlet")
+        self.set_user_custom_profile_data(hamlet, [{"id": field.id, "value": ["0", "1"]}])
+
+        cordelia = self.example_user("cordelia")
+        self.set_user_custom_profile_data(cordelia, [{"id": field.id, "value": ["1"]}])
+
+        aaron = self.example_user("aaron")
+        self.set_user_custom_profile_data(aaron, [{"id": field.id, "value": ["0"]}])
+
+        new_field_data = {
+            "0": {"text": "Python", "order": "1"},
+            "2": {"text": "C++", "order": "3"},
+        }
+
+        payload = {
+            "name": "Programming languages",
+            "field_data": orjson.dumps(new_field_data).decode(),
+        }
+
+        result = self.client_patch(f"/json/realm/profile_fields/{field.id}", payload)
+        self.assert_json_success(result)
+
+        self.assertFalse(
+            CustomProfileFieldValue.objects.filter(user_profile=cordelia, field=field).exists()
+        )
+
+        hamlet_value = CustomProfileFieldValue.objects.get(user_profile=hamlet, field=field)
+        self.assertEqual(orjson.loads(hamlet_value.value), ["0"])
+
+        aaron_value = CustomProfileFieldValue.objects.get(user_profile=aaron, field=field)
+        self.assertEqual(orjson.loads(aaron_value.value), ["0"])
 
     def test_default_external_account_type_field(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1790,6 +1790,59 @@ class NormalActionsTest(BaseAction):
         self.assertEqual(custom_field_payload["id"], field.id)
         self.assertEqual(custom_field_payload["value"], None)
 
+        # Test that deleting a checkboxes choice correctly updates profile data
+        # for users who had that choice selected.
+        checkbox_field = CustomProfileField.objects.get(
+            name="Programming languages", realm=hamlet.realm
+        )
+
+        cordelia = self.example_user("cordelia")
+
+        # Hamlet selects both Rust ("1") and C++ ("2").
+        custom_checkbox_value_hamlet: ProfileDataElementUpdateDict = {
+            "id": checkbox_field.id,
+            "value": orjson.dumps(["1", "2"]).decode(),
+        }
+        self.set_user_custom_profile_data(hamlet, [custom_checkbox_value_hamlet])
+
+        # Cordelia selects only C++ ("2").
+        custom_checkbox_value_cordelia: ProfileDataElementUpdateDict = {
+            "id": checkbox_field.id,
+            "value": orjson.dumps(["2"]).decode(),
+        }
+        self.set_user_custom_profile_data(cordelia, [custom_checkbox_value_cordelia])
+
+        # Remove option "2" (C++) by updating the field to only contain Python and Rust
+        new_checkbox_choices: dict[str, Any] = {
+            "0": {"text": "Python", "order": "1"},
+            "1": {"text": "Rust", "order": "2"},
+        }
+
+        with self.verify_action(num_events=3) as events:
+            try_update_realm_custom_profile_field(
+                realm=realm,
+                field=checkbox_field,
+                name=checkbox_field.name,
+                field_data=new_checkbox_choices,
+            )
+
+        check_realm_user_update("events[0]", events[0], "custom_profile_field")
+        check_realm_user_update("events[1]", events[1], "custom_profile_field")
+        check_custom_profile_fields("events[2]", events[2])
+
+        user_events = {
+            events[0]["person"]["user_id"]: events[0],
+            events[1]["person"]["user_id"]: events[1],
+        }
+
+        cordelia_payload = user_events[cordelia.id]["person"]["custom_profile_field"]
+        self.assertEqual(cordelia_payload["id"], checkbox_field.id)
+        self.assertEqual(cordelia_payload["value"], None)
+
+        hamlet_payload = user_events[hamlet.id]["person"]["custom_profile_field"]
+        self.assertEqual(hamlet_payload["id"], checkbox_field.id)
+        self.assertEqual(hamlet_payload["value"], orjson.dumps(["1"]).decode())
+
     def test_pronouns_type_support_in_custom_profile_fields_events(self) -> None:
         realm = self.user_profile.realm
         field = CustomProfileField.objects.get(realm=realm, name="Pronouns")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -863,6 +863,7 @@ class PermissionTest(ZulipTestCase):
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "0",
+            "Programming languages": ["0", "1"],
             "Birthday": "1909-03-05",
             "Favorite website": "https://zulip.com",
             "Mentor": [cordelia.id],
@@ -901,6 +902,7 @@ class PermissionTest(ZulipTestCase):
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "Vim",  # SELECT field: "0" -> "Vim"
+            "Programming languages": "Python, Rust",
             "Birthday": "1909-03-05",
             "Favorite website": "https://zulip.com",
             "Mentor": silent_mention_syntax_for_user(cordelia),
@@ -951,6 +953,11 @@ class PermissionTest(ZulipTestCase):
             ("Birthday", "1909-34-55", "Birthday is not a date"),
             ("Favorite website", "not url", "Favorite website is not a URL"),
             ("Mentor", "not list of user ids", "User IDs is not a list"),
+            (
+                "Programming languages",
+                ["99"],
+                "'99' is not a valid choice for 'Programming languages'.",
+            ),
         ]
 
         for field_name, field_value, error_msg in invalid_fields:
@@ -1002,6 +1009,8 @@ class PermissionTest(ZulipTestCase):
             value: str | None | list[Any] = ""
             if field.field_type == CustomProfileField.USER:
                 value = []
+            elif field.field_type == CustomProfileField.CHECKBOXES:
+                value = []
             empty_profile_data.append(
                 {
                     "id": field.id,
@@ -1024,6 +1033,7 @@ class PermissionTest(ZulipTestCase):
             "Biography": "A test user",
             "Favorite food": None,
             "Favorite editor": None,
+            "Programming languages": ["0"],
             "Birthday": None,
             "Favorite website": "https://zulip.github.io",
             "Mentor": [hamlet.id],

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -864,6 +864,7 @@ class PermissionTest(ZulipTestCase):
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "0",
+            "Programming languages": ["0", "1"],
             "Birthday": "1909-03-05",
             "Favorite website": "https://zulip.com",
             "Mentor": [cordelia.id],
@@ -902,6 +903,7 @@ class PermissionTest(ZulipTestCase):
             "Biography": "long text data",
             "Favorite food": "short text data",
             "Favorite editor": "Vim",  # SELECT field: "0" -> "Vim"
+            "Programming languages": "Python, Rust",
             "Birthday": "1909-03-05",
             "Favorite website": "https://zulip.com",
             "Mentor": silent_mention_syntax_for_user(cordelia),
@@ -952,6 +954,11 @@ class PermissionTest(ZulipTestCase):
             ("Birthday", "1909-34-55", "Birthday is not a date"),
             ("Favorite website", "not url", "Favorite website is not a URL"),
             ("Mentor", "not list of user ids", "User IDs is not a list"),
+            (
+                "Programming languages",
+                ["99"],
+                "'99' is not a valid choice for 'Programming languages'.",
+            ),
         ]
 
         for field_name, field_value, error_msg in invalid_fields:
@@ -1003,6 +1010,8 @@ class PermissionTest(ZulipTestCase):
             value: str | list[Any] | None = ""
             if field.field_type == CustomProfileField.USER:
                 value = []
+            elif field.field_type == CustomProfileField.CHECKBOXES:
+                value = []
             empty_profile_data.append(
                 {
                     "id": field.id,
@@ -1025,6 +1034,7 @@ class PermissionTest(ZulipTestCase):
             "Biography": "A test user",
             "Favorite food": None,
             "Favorite editor": None,
+            "Programming languages": ["0"],
             "Birthday": None,
             "Favorite website": "https://zulip.github.io",
             "Mentor": [hamlet.id],

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -56,7 +56,7 @@ def validate_custom_field_data(
     existing_field_data: ProfileFieldData | None = None,
 ) -> None:
     try:
-        if field_type == CustomProfileField.DROPDOWN:
+        if field_type in (CustomProfileField.DROPDOWN, CustomProfileField.CHECKBOXES):
             # Choice type field must have at least have one choice
             if len(field_data) < 1:
                 raise JsonableError(_("Field must have at least one choice."))

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -50,13 +50,17 @@ def validate_field_name_and_hint(name: str, hint: str) -> None:
         raise JsonableError(error.message)
 
 
-def validate_custom_field_data(field_type: int, field_data: ProfileFieldData) -> None:
+def validate_custom_field_data(
+    field_type: int,
+    field_data: ProfileFieldData,
+    existing_field_data: ProfileFieldData | None = None,
+) -> None:
     try:
         if field_type == CustomProfileField.DROPDOWN:
             # Choice type field must have at least have one choice
             if len(field_data) < 1:
                 raise JsonableError(_("Field must have at least one choice."))
-            validate_custom_profile_field_choices(field_data)
+            validate_custom_profile_field_choices(field_data, existing_field_data)
         elif field_type == CustomProfileField.EXTERNAL_ACCOUNT:
             validate_external_account_field_data(field_data)
     except ValidationError as error:
@@ -98,9 +102,10 @@ def validate_custom_profile_field(
     field_data: ProfileFieldData,
     display_in_profile_summary: bool,
     use_for_user_matching: bool,
+    existing_field_data: ProfileFieldData | None = None,
 ) -> None:
     # Validate field data
-    validate_custom_field_data(field_type, field_data)
+    validate_custom_field_data(field_type, field_data, existing_field_data)
 
     if not is_default_external_field(field_type, field_data):
         # If field is default external field then we will fetch all data
@@ -129,13 +134,17 @@ def validate_custom_profile_field_update(
         name = field.name
     if hint is None:
         hint = field.hint
+    # Stored choices; the length limit applies only to new or changed options.
+    existing_field_data: ProfileFieldData = {}
+    if field.field_data != "":
+        existing_field_data = orjson.loads(field.field_data)
     if field_data is None:
         if field.field_data == "":
             # We're passing this just for validation, sinec the function won't
             # accept a string. This won't change the actual value.
             field_data = {}
         else:
-            field_data = orjson.loads(field.field_data)
+            field_data = existing_field_data
     if display_in_profile_summary is None:
         display_in_profile_summary = field.display_in_profile_summary
     if use_for_user_matching is None:
@@ -143,7 +152,13 @@ def validate_custom_profile_field_update(
 
     assert field_data is not None
     validate_custom_profile_field(
-        name, hint, field.field_type, field_data, display_in_profile_summary, use_for_user_matching
+        name,
+        hint,
+        field.field_type,
+        field_data,
+        display_in_profile_summary,
+        use_for_user_matching,
+        existing_field_data,
     )
 
 

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -50,13 +50,20 @@ def validate_field_name_and_hint(name: str, hint: str) -> None:
         raise JsonableError(error.message)
 
 
-def validate_custom_field_data(field_type: int, field_data: ProfileFieldData) -> None:
+def validate_custom_field_data(
+    field_type: int,
+    field_data: ProfileFieldData,
+    existing_field: CustomProfileField | None = None,
+) -> None:
     try:
         if field_type == CustomProfileField.DROPDOWN:
             # Choice type field must have at least have one choice
             if len(field_data) < 1:
                 raise JsonableError(_("Field must have at least one choice."))
-            validate_custom_profile_field_choices(field_data)
+            existing_choices: dict[str, dict[str, str]] | None = None
+            if existing_field is not None:
+                existing_choices = orjson.loads(existing_field.field_data)
+            validate_custom_profile_field_choices(field_data, existing_choices)
         elif field_type == CustomProfileField.EXTERNAL_ACCOUNT:
             validate_external_account_field_data(field_data)
     except ValidationError as error:
@@ -98,9 +105,10 @@ def validate_custom_profile_field(
     field_data: ProfileFieldData,
     display_in_profile_summary: bool,
     use_for_user_matching: bool,
+    existing_field: CustomProfileField | None = None,
 ) -> None:
     # Validate field data
-    validate_custom_field_data(field_type, field_data)
+    validate_custom_field_data(field_type, field_data, existing_field)
 
     if not is_default_external_field(field_type, field_data):
         # If field is default external field then we will fetch all data
@@ -143,7 +151,13 @@ def validate_custom_profile_field_update(
 
     assert field_data is not None
     validate_custom_profile_field(
-        name, hint, field.field_type, field_data, display_in_profile_summary, use_for_user_matching
+        name,
+        hint,
+        field.field_type,
+        field_data,
+        display_in_profile_summary,
+        use_for_user_matching,
+        existing_field=field,
     )
 
 

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -56,7 +56,7 @@ def validate_custom_field_data(
     existing_field: CustomProfileField | None = None,
 ) -> None:
     try:
-        if field_type == CustomProfileField.DROPDOWN:
+        if field_type in (CustomProfileField.DROPDOWN, CustomProfileField.CHECKBOXES):
             # Choice type field must have at least have one choice
             if len(field_data) < 1:
                 raise JsonableError(_("Field must have at least one choice."))

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -226,7 +226,7 @@ def reactivate_user_backend(
 
 class ProfileDataElement(BaseModel):
     id: int
-    value: str | list[int] | None
+    value: str | list[int] | list[str] | None
 
 
 @typed_endpoint

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -854,6 +854,17 @@ class Command(ZulipBaseCommand):
             favorite_editor = try_add_realm_custom_profile_field(
                 zulip_realm, "Favorite editor", CustomProfileField.DROPDOWN, field_data=field_data
             )
+            prog_field_data: ProfileFieldData = {
+                "0": {"text": "Python", "order": "1"},
+                "1": {"text": "Rust", "order": "2"},
+                "2": {"text": "C++", "order": "3"},
+            }
+            prog_languages = try_add_realm_custom_profile_field(
+                zulip_realm,
+                "Programming languages",
+                CustomProfileField.CHECKBOXES,
+                field_data=prog_field_data,
+            )
             birthday = try_add_realm_custom_profile_field(
                 zulip_realm, "Birthday", CustomProfileField.DATE
             )
@@ -883,6 +894,7 @@ class Command(ZulipBaseCommand):
                     {"id": biography.id, "value": "Betrayer of Othello."},
                     {"id": favorite_food.id, "value": "Apples"},
                     {"id": favorite_editor.id, "value": "1"},
+                    {"id": prog_languages.id, "value": '["0", "1"]'},
                     {"id": birthday.id, "value": "2000-01-01"},
                     {"id": favorite_website.id, "value": "https://zulip.readthedocs.io/en/latest/"},
                     {"id": mentor.id, "value": [hamlet.id]},
@@ -902,6 +914,7 @@ class Command(ZulipBaseCommand):
                     },
                     {"id": favorite_food.id, "value": "Dark chocolate"},
                     {"id": favorite_editor.id, "value": "0"},
+                    {"id": prog_languages.id, "value": '["0", "1"]'},
                     {"id": birthday.id, "value": "1900-01-01"},
                     {"id": favorite_website.id, "value": "https://blog.zulig.org"},
                     {"id": mentor.id, "value": [iago.id]},


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #17495<!-- Issue link, or clear description.-->
This PR attempts to resolve conflicts and fix all the reviews in [#37018](https://github.com/zulip/zulip/pull/37018) .

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Screenshots and screen captures:</summary>
<img width="811" height="846" alt="image" src="https://github.com/user-attachments/assets/79acd95a-21e7-4e8e-a665-147481714957" />
<img width="821" height="964" alt="image" src="https://github.com/user-attachments/assets/6648008b-89d3-4c96-a2f0-8d67a4dd5e83" />
<img width="1203" height="899" alt="image" src="https://github.com/user-attachments/assets/8fa83bf9-70d1-4eb5-9c66-34401831e1d6" />
<img width="1569" height="934" alt="image" src="https://github.com/user-attachments/assets/726b3810-0831-4f06-9b0f-f1f15bf910a0" />
<img width="809" height="749" alt="image" src="https://github.com/user-attachments/assets/57dd8f4d-d21a-431c-ab44-1a459d992abf" />
<img width="1837" height="982" alt="image" src="https://github.com/user-attachments/assets/4aa8907d-717c-41c5-a47b-bedd82a339ec" />
<img width="1166" height="390" alt="image" src="https://github.com/user-attachments/assets/94fd3738-1366-41de-90da-01e4ed53a524" />
<img width="806" height="262" alt="image" src="https://github.com/user-attachments/assets/376f9486-7b36-417a-9530-b913ba865c8d" />
<img width="425" height="541" alt="image" src="https://github.com/user-attachments/assets/74b51ac5-b594-4a36-9904-fd0cd7446909" />


</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
