### PR TITLE
openapi: Document the /realm/subdomain/{subdomain} endpoint

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14458,6 +14458,51 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+          
+  /realm/subdomain/{subdomain}:
+    get:
+      operationId: check_subdomain_available
+      summary: Check subdomain availability
+      description: |
+        Check whether a subdomain is available for use by a new organization.
+      tags:
+        - server_and_organizations
+      parameters:
+        - name: subdomain
+          in: path
+          description: The subdomain to check for availability.
+          schema:
+            type: string
+          example: neworganization
+          required: true
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result:
+                        $ref: "#/components/schemas/NonEmptyString"
+                      msg:
+                        $ref: "#/components/schemas/NonEmptyString"
+                      data:
+                        type: object
+                        additionalProperties: false
+                        required:
+                          - msg
+                        properties:
+                          msg:
+                            type: string
+                            description: |
+                              Either `available` if the subdomain is available,
+                              or a string describing why it is unavailable.
+                            example: available
+                    required:
+                      - data
   /realm/profile_fields:
     get:
       operationId: get-custom-profile-fields

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -239,7 +239,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/realm/icon",
         "/realm/logo",
         "/realm/deactivate",
-        "/realm/subdomain/{subdomain}",
         # API for Zoom video calls.  Unclear if this can support other apps.
         "/calls/zoom/create",
         #### The following are fake endpoints that live in our zulip.yaml
@@ -490,13 +489,13 @@ so maybe we shouldn't include it in pending_endpoints.
             # function as defined in our urls.py:
             #
             # * method is the HTTP method, e.g. GET, POST, or PATCH
-            #
+        
             # * p.pattern.regex.pattern is the URL pattern; might require
             #   some processing to match with OpenAPI rules
             #
             # * accepted_arguments is the full set of arguments
             #   this method accepts.
-            #
+    
             # * The documented parameters for the endpoint as recorded in our
             #   OpenAPI data in zerver/openapi/zulip.yaml.
             #


### PR DESCRIPTION
This PR documents the `/realm/subdomain/{subdomain}` endpoint
in our OpenAPI specification (`zerver/openapi/zulip.yaml`) and
removes it from `pending_endpoints` in `test_openapi.py`.

The `check_subdomain_available` endpoint allows clients to verify
whether a given subdomain is available before creating a new
Zulip organization. It returns a JSON response with a `msg` field
indicating either `available` or the reason it is unavailable.

Fixes: #38349

**How changes were tested:**
- Verified the endpoint exists in `zproject/urls.py`:
  `path("realm/subdomain/<subdomain>", check_subdomain_available)`
- Verified the view function in `zerver/views/realm.py` (line 651)
- Removed `/realm/subdomain/{subdomain}` from `pending_endpoints`
  in `test_openapi.py`

**Note:** I used AI assistance to understand the codebase structure
and OpenAPI YAML format while implementing this change.
<img width="1326" height="487" alt="gsoc" src="https://github.com/user-attachments/assets/b34bdeb5-247d-470c-bf28-f7c165d63fc7" />
<img width="1011" height="685" alt="gsoc1" src="https://github.com/user-attachments/assets/acd1a83e-551a-4fa4-b5f0-07417824f8f8" />
<img width="1181" height="716" alt="gsoc2" src="https://github.com/user-attachments/assets/0b50d226-18cd-4062-8b61-4f858d261115" />
<img width="604" height="211" alt="gsoc3" src="https://github.com/user-attachments/assets/74754b15-7727-4a21-a90d-648083cf857a" />
