### PR TITLE
email: include full subject in body when longer than 60 chars  Fixes #10539

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -459,9 +459,15 @@ def process_stream_message(to: str, message: EmailMessage) -> None:
         options["include_quotes"] = is_forwarded(subject_header)
 
     subject = strip_from_subject(subject_header)
+
     # We don't want to reject email messages with disallowed characters in the Subject,
     # so we just remove them to make it a valid Zulip topic name.
     subject = "".join([char for char in subject if is_character_printable(char)])
+
+    # ✅ Added logic for GSoC issue
+    if len(subject) > 60:
+        options["subject_in_body"] = True
+
     if channel.topics_policy == StreamTopicsPolicyEnum.empty_topic_only.value:
         options["subject_in_body"] = True
         topic = ""
@@ -471,13 +477,14 @@ def process_stream_message(to: str, message: EmailMessage) -> None:
         topic = subject
 
     body = construct_zulip_body(message, subject, realm, sender=sender, **options)
+
     send_zulip(sender, channel, topic, body)
+
     logger.info(
         "Successfully processed email to %s (%s)",
         channel.name,
         realm.string_id,
     )
-
 
 def process_missed_message(to: str, message: EmailMessage) -> None:
     auto_submitted = message.get("Auto-Submitted", "")


### PR DESCRIPTION
Fixes #10539

## Summary
This PR includes the full email subject in the message body when the subject exceeds 60 characters.

## Changes
- Added logic in process_stream_message to detect long subjects
- Set subject_in_body flag in options
- Leveraged existing construct_zulip_body support

## Testing
- Manual testing of email processing
- Verified behavior for long and short subjects
- Ensured no changes for short subjects

## Notes
No changes to existing behavior for normal-length subjects.