### PR TITLE
[ai] data_import: Bound import attachment downloads.

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -93,6 +93,7 @@ class UploadFileRequest:
     params: dict[str, Any] | None
     headers: dict[str, Any] | None
     kwargs: dict[str, Any]
+    expected_size: int
 
 
 GroupDMKey = TypeVar("GroupDMKey", bound=Hashable)
@@ -739,17 +740,54 @@ def download_and_export_upload_file(
     output_dir: str, upload_file_request: UploadFileRequest
 ) -> None:
     file_output_path = os.path.join(output_dir, "uploads", upload_file_request.output_file_path)
+    temporary_file_output_path = f"{file_output_path}.part"
 
-    response = request_file_stream(
-        upload_file_request.request_url,
-        upload_file_request.params,
-        upload_file_request.headers,
-        **upload_file_request.kwargs,
-    )
+    if upload_file_request.expected_size < 0:
+        raise Exception("Failed downloading file: expected size must be non-negative.")
 
     os.makedirs(os.path.dirname(file_output_path), exist_ok=True)
-    with open(file_output_path, "wb") as upload_file:
-        shutil.copyfileobj(response.raw, upload_file)
+    try:
+        with (
+            request_file_stream(
+                upload_file_request.request_url,
+                upload_file_request.params,
+                upload_file_request.headers,
+                **upload_file_request.kwargs,
+            ) as response,
+            open(temporary_file_output_path, "wb") as upload_file,
+        ):
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    content_length_value = int(content_length)
+                except ValueError:
+                    raise Exception("Failed downloading file: invalid Content-Length header.")
+
+                if content_length_value > upload_file_request.expected_size:
+                    raise Exception(
+                        "Failed downloading file: Content-Length exceeds expected size."
+                    )
+
+            bytes_downloaded = 0
+            while True:
+                chunk = response.raw.read(64 * 1024)
+                if not chunk:
+                    break
+
+                bytes_downloaded += len(chunk)
+                if bytes_downloaded > upload_file_request.expected_size:
+                    raise Exception("Failed downloading file: downloaded size exceeds expected size.")
+
+                upload_file.write(chunk)
+
+            if bytes_downloaded != upload_file_request.expected_size:
+                raise Exception("Failed downloading file: downloaded size does not match expected size.")
+
+        os.replace(temporary_file_output_path, file_output_path)
+    except Exception:
+        if os.path.exists(temporary_file_output_path):
+            os.remove(temporary_file_output_path)
+        raise
 
 
 def build_realm_emoji(realm_id: int, name: str, id: int, file_name: str) -> ZerverFieldsT:

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1318,6 +1318,7 @@ def process_message_files(
                     params=None,
                     headers=None,
                     kwargs={},
+                    expected_size=fileinfo["size"],
                 ),
             )
 

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -3272,6 +3272,7 @@ To Do
                     params=None,
                     headers=None,
                     kwargs={},
+                    expected_size=1,
                 ),
             )
         self.assertIn(
@@ -3279,6 +3280,151 @@ To Do
             logs.output,
         )
         self.assertEqual("Failed downloading file.", str(e.exception))
+
+    def test_download_and_export_upload_file_rejects_download_larger_than_expected_size(self) -> None:
+        request_url = "https://files.slack.com/files-pri/ABC/oversized.bin"
+        expected_size = 4
+
+        mocked_response = mock.MagicMock()
+        mocked_response.__enter__.return_value = mocked_response
+        mocked_response.__exit__.return_value = False
+        mocked_response.headers = {}
+        mocked_response.raw = BytesIO(b"12345")
+
+        output_dir = tempfile.mkdtemp()
+        output_file_path = "0/ab/cd/oversized.bin"
+        try:
+            with mock.patch(
+                "zerver.data_import.import_util.request_file_stream", return_value=mocked_response
+            ):
+                with self.assertRaisesRegex(
+                    Exception,
+                    "Failed downloading file: downloaded size exceeds expected size.",
+                ):
+                    download_and_export_upload_file(
+                        output_dir,
+                        UploadFileRequest(
+                            output_file_path=output_file_path,
+                            request_url=request_url,
+                            params=None,
+                            headers=None,
+                            kwargs={},
+                            expected_size=expected_size,
+                        ),
+                    )
+
+            self.assertFalse(
+                os.path.exists(os.path.join(output_dir, "uploads", output_file_path))
+            )
+        finally:
+            remove_folder(output_dir)
+
+    @responses.activate
+    def test_download_and_export_upload_file_rejects_large_content_length(self) -> None:
+        request_url = "https://files.slack.com/files-pri/ABC/too-large-header.bin"
+        expected_size = 4
+        responses.add(
+            responses.GET,
+            request_url,
+            body=b"1234",
+            status=200,
+            headers={"Content-Length": "5"},
+        )
+
+        output_dir = tempfile.mkdtemp()
+        output_file_path = "0/ab/cd/too-large-header.bin"
+        try:
+            with self.assertRaisesRegex(
+                Exception,
+                "Failed downloading file: Content-Length exceeds expected size.",
+            ):
+                download_and_export_upload_file(
+                    output_dir,
+                    UploadFileRequest(
+                        output_file_path=output_file_path,
+                        request_url=request_url,
+                        params=None,
+                        headers=None,
+                        kwargs={},
+                        expected_size=expected_size,
+                    ),
+                )
+
+            self.assertFalse(
+                os.path.exists(os.path.join(output_dir, "uploads", output_file_path))
+            )
+        finally:
+            remove_folder(output_dir)
+
+    @responses.activate
+    def test_download_and_export_upload_file_rejects_size_mismatch(self) -> None:
+        request_url = "https://files.slack.com/files-pri/ABC/truncated.bin"
+        expected_size = 6
+        responses.add(
+            responses.GET,
+            request_url,
+            body=b"12345",
+            status=200,
+            headers={"Content-Length": "5"},
+        )
+
+        output_dir = tempfile.mkdtemp()
+        output_file_path = "0/ab/cd/truncated.bin"
+        try:
+            with self.assertRaisesRegex(
+                Exception,
+                "Failed downloading file: downloaded size does not match expected size.",
+            ):
+                download_and_export_upload_file(
+                    output_dir,
+                    UploadFileRequest(
+                        output_file_path=output_file_path,
+                        request_url=request_url,
+                        params=None,
+                        headers=None,
+                        kwargs={},
+                        expected_size=expected_size,
+                    ),
+                )
+
+            self.assertFalse(
+                os.path.exists(os.path.join(output_dir, "uploads", output_file_path))
+            )
+        finally:
+            remove_folder(output_dir)
+
+    @responses.activate
+    def test_download_and_export_upload_file_succeeds_for_matching_size(self) -> None:
+        request_url = "https://files.slack.com/files-pri/ABC/ok.bin"
+        file_body = b"12345"
+        responses.add(
+            responses.GET,
+            request_url,
+            body=file_body,
+            status=200,
+            headers={"Content-Length": str(len(file_body))},
+        )
+
+        output_dir = tempfile.mkdtemp()
+        output_file_path = "0/ab/cd/ok.bin"
+        file_path = os.path.join(output_dir, "uploads", output_file_path)
+        try:
+            download_and_export_upload_file(
+                output_dir,
+                UploadFileRequest(
+                    output_file_path=output_file_path,
+                    request_url=request_url,
+                    params=None,
+                    headers=None,
+                    kwargs={},
+                    expected_size=len(file_body),
+                ),
+            )
+
+            with open(file_path, "rb") as f:
+                self.assertEqual(f.read(), file_body)
+        finally:
+            remove_folder(output_dir)
 
     @responses.activate
     def test_slack_get_emojis(self) -> None:


### PR DESCRIPTION
Fixes: unbounded attachment download during import can exhaust disk.

`download_and_export_upload_file` previously streamed remote bytes directly to disk with no cap tied to expected attachment size. A malicious or broken source could stream excess data and consume server storage during import.

This PR hardens the Slack attachment download path by enforcing strict expected-size checks:

- add `expected_size` to `UploadFileRequest` and pass Slack `fileinfo["size"]` into each download request,
- reject negative expected sizes,
- reject `Content-Length` values larger than expected,
- reject streamed downloads that exceed expected size,
- reject size mismatches when total downloaded bytes do not match expected,
- write to a temporary `.part` file and only atomically move into place after full validation,
- remove partial files when download validation fails.

It also adds focused regression coverage for:

- oversized streamed download,
- oversized `Content-Length`,
- final size mismatch,
- successful download when sizes match.

**How changes were tested:**

- [x] `python3 -m py_compile zerver/data_import/import_util.py zerver/data_import/slack.py zerver/tests/test_slack_importer.py`
- [ ] `./tools/lint zerver/data_import/import_util.py zerver/data_import/slack.py zerver/tests/test_slack_importer.py` (blocked in this container: Zulip dev environment `.venv` not provisioned)
- [ ] `./tools/test-backend zerver.tests.test_slack_importer` (blocked in this container: Zulip dev environment `.venv` not provisioned)

**Screenshots and screen captures:**

N/A (no UI changes).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
