### PR TITLE
help: Document running a custom bot.

### DIFF
--- a/starlight_help/src/content/docs/running-bots.mdx
+++ b/starlight_help/src/content/docs/running-bots.mdx
@@ -2,17 +2,16 @@
 title: Running interactive bots
 ---
 
+import {TabItem, Tabs} from "@astrojs/starlight/components";
+
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import ZulipNote from "../../components/ZulipNote.astro";
 
 Zulip's API has a powerful framework for interactive bots that react to messages
-in Zulip. You can [write your own interactive bot](/help/writing-bots), or run an
+in Zulip. You can [write and run a custom bot](/help/writing-bots), or run an
 existing [Zulip bot](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 
 ## Running a bot
-
-This guide will show you how to run an existing
-[Zulip bot](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots).
 
 <ZulipNote>
   Please be considerate when testing experimental bots on public servers such as chat.zulip.org.
@@ -27,36 +26,82 @@ You'll need:
   [production](https://zulip.readthedocs.io/en/latest/production/install.html) server).
 * A computer where you're running the bot from.
 
-<FlattenedSteps>
-  1. [Create a bot](/help/add-a-bot-or-integration), making sure to select
-     **Generic bot** as the **Bot type**.
+<Tabs>
+  <TabItem label="Existing bot">
+    <FlattenedSteps>
+      1. [Create a bot](/help/add-a-bot-or-integration), making sure to select
+         **Generic bot** as the **Bot type**.
 
-  1. [Download the bot's `zuliprc` file](/api/api-keys#download-a-zuliprc-file).
+      1. [Download the bot's `zuliprc` file](/api/api-keys#download-a-zuliprc-file).
 
-  1. Use the following command to install the
-     [`zulip_bots` Python package](https://pypi.org/project/zulip-bots/):
+      1. Use the following command to install the
+         [`zulip_bots` Python package](https://pypi.org/project/zulip-bots/):
 
-     ```
-        pip3 install zulip_bots
-     ```
+         ```
+         pip3 install zulip_bots
+         ```
 
-  1. Use the following command to start the bot process *(replacing
-     `~/path/to/zuliprc` with the path to the `zuliprc` file you downloaded above)*:
+      1. Use the following command to start the bot process *(replacing `<bot-name>`
+         with the bot's name from the
+         [Zulip bots directory](https://github.com/zulip/python-zulip-api/tree/main/zulip_bots/zulip_bots/bots)
+         and `~/path/to/zuliprc` with the path to the `zuliprc` file you downloaded above)*:
 
-     ```
-     zulip-run-bot <bot-name> --config-file ~/path/to/zuliprc
-     ```
+         ```
+         zulip-run-bot <bot-name> --config-file ~/path/to/zuliprc
+         ```
 
-  1. Check the output of the command above to make sure your bot is running.
-     It should include the following line:
+      1. Check the output of the command above to make sure your bot is running.
+         It should include the following line:
 
-     ```
-     INFO:root:starting message handling...
-     ```
+         ```
+         INFO:root:starting message handling...
+         ```
 
-  1. Test your setup by [starting a new direct message](/help/starting-a-new-direct-message)
-     with the bot or [mentioning](/help/mention-a-user-or-group) the bot on a channel.
-</FlattenedSteps>
+      1. Test your setup by [starting a new direct message](/help/starting-a-new-direct-message)
+         with the bot or [mentioning](/help/mention-a-user-or-group) the bot on a channel.
+    </FlattenedSteps>
+  </TabItem>
+
+  <TabItem label="Custom bot">
+    <FlattenedSteps>
+      1. [Write the code for your custom bot](/help/writing-bots), and note the path
+         to the `<my-bot>.py` file you created.
+
+      1. [Create a bot](/help/add-a-bot-or-integration), making sure to select
+         **Generic bot** as the **Bot type**.
+
+      1. [Download the bot's `zuliprc` file](/api/api-keys#download-a-zuliprc-file).
+
+      1. Use the following command to install the
+         [`zulip_bots` Python package](https://pypi.org/project/zulip-bots/):
+
+         ```
+         pip3 install zulip_bots
+         ```
+
+      1. Use the following command to start the bot process *(replacing
+         `~/path/to/my_bot.py` with the path to your bot file and
+         `~/path/to/zuliprc` with the path to the `zuliprc` file you downloaded above)*:
+
+         ```
+         zulip-run-bot ~/path/to/my_bot.py --config-file ~/path/to/zuliprc
+         ```
+
+         If your bot requires a third-party configuration file, you can specify
+         it with the `--bot-config-file` option.
+
+      1. Check the output of the command above to make sure your bot is running.
+         It should include the following line:
+
+         ```
+         INFO:root:starting message handling...
+         ```
+
+      1. Test your setup by [starting a new direct message](/help/starting-a-new-direct-message)
+         with the bot or [mentioning](/help/mention-a-user-or-group) the bot on a channel.
+    </FlattenedSteps>
+  </TabItem>
+</Tabs>
 
 <ZulipNote>
   To use the latest development version of the `zulip_bots` package, follow


### PR DESCRIPTION
The [running-bots](/help/running-bots) help page previously only showed how to run an existing bot from Zulip's bot directory. Users who had written their own bot following the [writing-bots](/help/writing-bots) guide had no documentation for how to actually run it.

This adds a **Custom bot** tab to the "Running a bot" section showing that `zulip-run-bot` also accepts a path to a `.py` file directly, alongside the existing **Existing bot** tab. The intro text is also updated to mention both options.

Fixes: #36603 

**How changes were tested:**

- [x] Verified the page rendered manually
- [x] Confirmed both tabs display correctly with correct step numbering
- [x] All internal links (`/help/writing-bots`, `/help/add-a-bot-or-integration`, `/api/configuring-python-bindings`) resolve correctly
- [x] Ran `./tools/lint starlight_help/src/content/docs/running-bots.mdx`

**Screenshots**:
Before:
<img width="778" height="1158" alt="Screenshot 2026-03-31 222018" src="https://github.com/user-attachments/assets/2a5287d2-fbbc-456c-a664-6fdecf11145f" />

After:
The existing bot:
<img width="774" height="1223" alt="Screenshot 2026-03-31 222035" src="https://github.com/user-attachments/assets/81a34c1b-611f-45f5-bb53-8fb69dade5eb" />

The custom bot:
<img width="682" height="1187" alt="image" src="https://github.com/user-attachments/assets/d09eb177-1cc3-4dd1-bef4-095fd8fa21e8" />

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>