### PR TITLE
drafts: Handle invalid recipients in DM drafts.

### DIFF
--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -93,6 +93,7 @@ export const draft_model = (function () {
     const KEY = "drafts";
     const ls = localstorage();
     let fixed_buggy_drafts = false;
+    let fixed_private_draft_recipient_ids = false;
 
     function get(): Record<string, LocalStorageDraft> {
         let drafts = ls.get(KEY);
@@ -105,7 +106,34 @@ export const draft_model = (function () {
             drafts = ls.get(KEY);
         }
 
+        if (!fixed_private_draft_recipient_ids) {
+            fix_private_draft_recipient_ids();
+            drafts = ls.get(KEY);
+        }
+
         return drafts_schema.parse(drafts);
+    }
+
+    function fix_private_draft_recipient_ids(): void {
+        // This is needed to make sure that invalid users are removed from
+        // recipient list of DM drafts. We do not expect this to happen in
+        // production unless a UserProfile is manually deleted from
+        // the database, but this happens in development environment
+        // when the database is re-populated.
+        const drafts = drafts_schema.parse(ls.get(KEY));
+        for (const [draft_id, draft] of Object.entries(drafts)) {
+            if (draft.type !== "private") {
+                continue;
+            }
+            const valid_recipient_ids = draft.private_message_recipient_ids.filter((user_id) =>
+                people.is_valid_user_id(user_id),
+            );
+            if (valid_recipient_ids.length !== draft.private_message_recipient_ids.length) {
+                drafts[draft_id] = {...draft, private_message_recipient_ids: valid_recipient_ids};
+            }
+        }
+        ls.set(KEY, drafts);
+        fixed_private_draft_recipient_ids = true;
     }
 
     function fix_buggy_drafts(): void {

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -51,9 +51,12 @@ const zoe = make_user({
 });
 set_current_user(aaron);
 people.add_active_user(aaron);
+people.add_valid_user_id(aaron.user_id);
 people.initialize_current_user(aaron.user_id);
 people.add_active_user(iago);
+people.add_valid_user_id(iago.user_id);
 people.add_active_user(zoe);
+people.add_valid_user_id(zoe.user_id);
 
 const stream_A = make_stream({
     subscribed: false,
@@ -176,7 +179,7 @@ function test(label, f) {
 // when we get to delete drafts.fix_drafts_with_undefined_topics.
 //
 // This test must run before others, so that
-// fixed_buggy_drafts is false.
+// fixed_buggy_drafts and fixed_private_draft_recipient_ids are false.
 test("fix buggy drafts", () => {
     const buggy_draft = {
         stream_id: stream_B.stream_id,
@@ -192,10 +195,31 @@ test("fix buggy drafts", () => {
         content: "Test direct message",
         updatedAt: Date.now(),
     };
+    // 999 is an invalid user ID not present in the people store.
+    const draft_with_invalid_recipient = {
+        private_message_recipient_ids: [iago.user_id, 999],
+        reply_to: "iago@zulip.com, invalid-user@zulip.com",
+        type: "private",
+        content: "Test direct message 2",
+        updatedAt: Date.now(),
+        is_sending_saving: false,
+        drafts_version: 1,
+    };
+    const draft_with_only_invalid_recipients = {
+        private_message_recipient_ids: [999],
+        reply_to: "invalid-user@zulip.com",
+        type: "private",
+        content: "Test direct message 3",
+        updatedAt: Date.now(),
+        is_sending_saving: false,
+        drafts_version: 1,
+    };
     const ls = localstorage();
     ls.set("drafts", {
         id1: buggy_draft,
         id2: draft_with_pm_emails,
+        id3: draft_with_invalid_recipient,
+        id4: draft_with_only_invalid_recipients,
     });
     const draft_model = drafts.draft_model;
 
@@ -214,6 +238,13 @@ test("fix buggy drafts", () => {
     const fixed_draft = draft_model.getDraft("id2");
     assert.equal(fixed_draft.private_message_recipient, undefined);
     assert.deepEqual(fixed_draft.private_message_recipient_ids, [iago.user_id, zoe.user_id]);
+
+    // fix_private_draft_recipient_ids removes invalid user IDs.
+    const fixed_invalid_recipient_draft = draft_model.getDraft("id3");
+    assert.deepEqual(fixed_invalid_recipient_draft.private_message_recipient_ids, [iago.user_id]);
+
+    const fixed_only_invalid_recipients_draft = draft_model.getDraft("id4");
+    assert.deepEqual(fixed_only_invalid_recipients_draft.private_message_recipient_ids, []);
 });
 
 test("draft_model add", () => {


### PR DESCRIPTION
In development environment, there can be cases when some recipients for a draft DM become invalid due to rebuilding of database and the user IDs used for them become invalid. This commit fixes that by removing such users from the recipient list.

We do not expect this to happen in production unless a UserProfile is manually deleted from DB. For cases like deleting a user using "delete_user" management command or an inaccessible user for guest, the client still have their user IDs and thus those user IDs are valid.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/channel/9-issues/topic/.5BBlueslip.5D.20Unknown.20user_id.20in.20maybe_get_user_by_id/with/2423124


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
