### PR TITLE
api docs: Document the /bot_storage endpoint.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 494**
+
+* [`PUT /bot_storage`](/api/update-bot-storage),
+  [`GET /bot_storage`](/api/get-bot-storage),
+  [`DELETE /bot_storage`](/api/remove-bot-storage): These
+  endpoints now require the caller to be a bot user account.
+  Previously, any authenticated user account could call these
+  endpoints.
+
 **Feature level 493**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -166,6 +166,12 @@
 * [Get events from an event queue](/api/get-events)
 * [Delete an event queue](/api/delete-queue)
 
+## Interactive bots
+
+* [Get a bot's stored data](/api/get-bot-storage)
+* [Update a bot's stored data](/api/update-bot-storage)
+* [Remove a bot's stored data](/api/remove-bot-storage)
+
 ## Specialty endpoints
 
 * [Fetch an API key (production)](/api/fetch-api-key)

--- a/tools/test-api
+++ b/tools/test-api
@@ -110,7 +110,15 @@ with test_server_running(
         site=site,
     )
 
-    test_the_api(client, nonadmin_client, owner_client)
+    # Prepare the bot client using the pre-existing default bot in the dev realm.
+    bot_user = get_user("default-bot@zulip.com", get_realm("zulip"))
+    bot_client = Client(
+        email="default-bot@zulip.com",
+        api_key=bot_user.api_key,
+        site=site,
+    )
+
+    test_the_api(client, nonadmin_client, owner_client, bot_client)
     test_generated_curl_examples_for_success(client)
     test_js_bindings(client)
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 493
+API_FEATURE_LEVEL = 494
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -30,6 +30,7 @@ from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.exceptions import (
     AccessDeniedError,
     AnomalousWebhookPayloadError,
+    BotRequiredError,
     InvalidAPIKeyError,
     InvalidAPIKeyFormatError,
     InvalidJSONError,
@@ -161,6 +162,24 @@ def require_realm_admin(
     ) -> HttpResponse:
         if not user_profile.is_realm_admin:
             raise OrganizationAdministratorRequiredError
+        return func(request, user_profile, *args, **kwargs)
+
+    return wrapper
+
+
+def require_bot_user(
+    func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse],
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
+    @wraps(func)
+    def wrapper(
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
+    ) -> HttpResponse:
+        if not user_profile.is_bot:
+            raise BotRequiredError
         return func(request, user_profile, *args, **kwargs)
 
     return wrapper

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -67,6 +67,7 @@ class ErrorCode(Enum):
     FAILED_TO_CONNECT_BOUNCER = auto()
     INTERNAL_SERVER_ERROR_ON_BOUNCER = auto()
     ADMIN_ACTION_REQUIRED = auto()
+    PERMISSION_DENIED = auto()
 
 
 class JsonableError(Exception):
@@ -334,6 +335,18 @@ class OrganizationOwnerRequiredError(JsonableError):
     @override
     def msg_format() -> str:
         return _("Must be an organization owner")
+
+
+class BotRequiredError(JsonableError):
+    code: ErrorCode = ErrorCode.PERMISSION_DENIED
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Must be a bot user")
 
 
 class AuthenticationFailedError(JsonableError):

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1172,6 +1172,22 @@ Output:
             **extra,
         )
 
+    def api_put(
+        self, user: UserProfile, url: str, info: Mapping[str, Any] = {}, **extra: str
+    ) -> "TestHttpResponse":
+        assert not url.startswith("/json/"), "Invalid URL for API authentication"
+        extra["HTTP_AUTHORIZATION"] = self.encode_user(user)
+        return self.client_put(
+            url,
+            info,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            headers=None,
+            query_params=None,
+            **extra,
+        )
+
     def api_patch(
         self, user: UserProfile, url: str, info: Mapping[str, Any] = {}, **extra: str
     ) -> "TestHttpResponse":

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -19,6 +19,7 @@ from zerver.actions.reactions import do_add_reaction
 from zerver.actions.realm_domains import do_add_realm_domain
 from zerver.actions.realm_linkifiers import do_add_linkifier
 from zerver.actions.realm_playgrounds import check_add_realm_playground
+from zerver.lib.bot_storage import set_bot_storage
 from zerver.lib.events import do_events_register
 from zerver.lib.initial_password import initial_password
 from zerver.lib.test_classes import ZulipTestCase
@@ -499,3 +500,26 @@ def delete_realm_domain_owner_auth() -> dict[str, object]:
 
     do_add_realm_domain(owner.realm, "delete-domain-example.com", False, acting_user=None)
     return {"domain": "delete-domain-example.com"}
+
+
+@openapi_param_value_generator(["/bot_storage:put"])
+def update_bot_storage_bot_auth() -> dict[str, object]:
+    bot = helpers.example_user("default_bot")
+    AUTHENTICATION_LINE[0] = f"{bot.email}:{bot.api_key}"
+    return {}
+
+
+@openapi_param_value_generator(["/bot_storage:get"])
+def get_bot_storage_bot_auth() -> dict[str, object]:
+    bot = helpers.example_user("default_bot")
+    set_bot_storage(bot, [("foo", "bar")])
+    AUTHENTICATION_LINE[0] = f"{bot.email}:{bot.api_key}"
+    return {}
+
+
+@openapi_param_value_generator(["/bot_storage:delete"])
+def remove_bot_storage_bot_auth() -> dict[str, object]:
+    bot = helpers.example_user("default_bot")
+    set_bot_storage(bot, [("foo", "bar")])
+    AUTHENTICATION_LINE[0] = f"{bot.email}:{bot.api_key}"
+    return {}

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -837,6 +837,39 @@ def regenerate_bot_api_key(client: Client) -> None:
     validate_against_openapi_schema(result, "/bots/{bot_id}/api_key/regenerate", "post", "200")
 
 
+@openapi_test_function("/bot_storage:put")
+def update_bot_storage(client: Client) -> None:
+    # {code_example|start}
+    # Store value of "bar" for the key "foo" for a bot user.
+    result = client.update_storage({"storage": {"foo": "bar"}})
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/bot_storage", "put", "200")
+
+
+@openapi_test_function("/bot_storage:get")
+def get_bot_storage(client: Client) -> None:
+    # {code_example|start}
+    # Retrieve all data stored for a bot user.
+    result = client.get_storage()
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/bot_storage", "get", "200")
+
+
+@openapi_test_function("/bot_storage:delete")
+def remove_bot_storage(client: Client) -> None:
+    # {code_example|start}
+    # Remove all data stored for a bot user.
+    result = client.call_endpoint(
+        url="/bot_storage",
+        method="DELETE",
+    )
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/bot_storage", "delete", "200")
+
+
 @openapi_test_function("/get_stream_id:get")
 def get_stream_id(client: Client) -> int:
     name = "python-test"
@@ -2265,8 +2298,19 @@ def test_api_key_endpoints(client: Client) -> None:
     regenerate_api_key(client)
 
 
-def test_the_api(client: Client, nonadmin_client: Client, owner_client: Client) -> None:
+def test_bot_storage(bot_client: Client) -> None:
+    update_bot_storage(bot_client)
+    get_bot_storage(bot_client)
+    remove_bot_storage(bot_client)
+
+
+def test_the_api(
+    client: Client, nonadmin_client: Client, owner_client: Client, bot_client: Client
+) -> None:
     get_user_agent(client)
+    # test_bot_storage authenticates as default-bot, whose API key is
+    # regenerated in test_api_key_endpoints.
+    test_bot_storage(bot_client)
     # Run `test_api_key_endpoints` before `test_users` so Device records created by
     # `register_push_device` & `register_device` are not bulk-deleted by
     # `regenerate_api_key`, since they are needed for curl tests.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7128,8 +7128,16 @@ paths:
       summary: Get a bot's stored data
       tags: ["bots"]
       description: |
+        !!! warn ""
+
+            **Note:** This endpoint is only available to [bot user](/help/bots-overview)
+            accounts.
+
         Retrieve [data stored](/help/interactive-bots-api#bot_handlerstorage)
         for a bot user.
+
+        **Changes**: Prior to Zulip 12.0 (feature level 494), users who
+        were not bots could access this endpoint.
       x-curl-examples-parameters:
         oneOf:
           - type: exclude
@@ -7201,16 +7209,34 @@ paths:
                         description: |
                           A typical failed JSON response when a requested key does not exist
                           in the bot's storage:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "PERMISSION_DENIED",
+                            "msg": "Must be a bot user",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response when the user is not a bot:
     put:
       operationId: update-bot-storage
       summary: Update a bot's stored data
       tags: ["bots"]
       description: |
+        !!! warn ""
+
+            **Note:** This endpoint is only available to [bot user](/help/bots-overview)
+            accounts.
+
         Add or update [data stored](/help/interactive-bots-api#bot_handlerstorage)
         for a bot user.
 
         Each bot has a limited storage set by the server, which normally is a
         default of 10,000,000 characters.
+
+        **Changes**: Prior to Zulip 12.0 (feature level 494), users who
+        were not bots could access this endpoint.
       requestBody:
         required: true
         content:
@@ -7254,13 +7280,31 @@ paths:
                         description: |
                           A typical failed JSON response when the request would exceed the
                           server's storage size limit:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "PERMISSION_DENIED",
+                            "msg": "Must be a bot user",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response when the user is not a bot:
     delete:
       operationId: remove-bot-storage
       summary: Remove a bot's stored data
       tags: ["bots"]
       description: |
+        !!! warn ""
+
+            **Note:** This endpoint is only available to [bot user](/help/bots-overview)
+            accounts.
+
         Delete [data stored](/help/interactive-bots-api#bot_handlerstorage)
         for a bot user.
+
+        **Changes**: Prior to Zulip 12.0 (feature level 494), users who
+        were not bots could access this endpoint.
       requestBody:
         required: false
         content:
@@ -7301,6 +7345,16 @@ paths:
                         description: |
                           A typical failed JSON response when a key to be deleted does not exist
                           in the bot's storage:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "PERMISSION_DENIED",
+                            "msg": "Must be a bot user",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response when the user is not a bot:
   /drafts:
     get:
       operationId: get-drafts

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7122,6 +7122,185 @@ paths:
                       }
                     description: |
                       A typical failed JSON response for when the user is not logged in:
+  /bot_storage:
+    get:
+      operationId: get-bot-storage
+      summary: Get a bot's stored data
+      tags: ["bots"]
+      description: |
+        Retrieve [data stored](/help/interactive-bots-api#bot_handlerstorage)
+        for a bot user.
+      x-curl-examples-parameters:
+        oneOf:
+          - type: exclude
+            parameters:
+              enum:
+                - keys
+      parameters:
+        - name: keys
+          in: query
+          description: |
+            A JSON-encoded list of keys for data in the bot's storage.
+
+            If not provided, then all data that's stored for the bot is
+            returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example: ["foo"]
+          required: false
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      storage:
+                        type: object
+                        description: |
+                          A dictionary with string key-value pairs of
+                          data stored for the bot user.
+
+                          If the `keys` parameter was passed, then only
+                          the key-value pairs matching the list of keys
+                          will be returned.
+                        additionalProperties:
+                          description: |
+                            `{key}`: The stored string value for this key.
+                          type: string
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "storage": {"foo": "bar"},
+                      }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Key does not exist.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response when a requested key does not exist
+                          in the bot's storage:
+    put:
+      operationId: update-bot-storage
+      summary: Update a bot's stored data
+      tags: ["bots"]
+      description: |
+        Add or update [data stored](/help/interactive-bots-api#bot_handlerstorage)
+        for a bot user.
+
+        Each bot has a limited storage set by the server, which normally is a
+        default of 10,000,000 characters.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                storage:
+                  description: |
+                    A JSON-encoded dictionary mapping string keys to string values
+                    that will be added to the bot's storage.
+
+                    If the bot's storage already has a specific key, then the value
+                    stored for that key will be updated for the new value.
+                  type: object
+                  additionalProperties:
+                    type: string
+                  example: {"foo": "bar"}
+              required:
+                - storage
+            encoding:
+              storage:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Request exceeds storage limit by 42 characters. The limit is 10000000 characters.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response when the request would exceed the
+                          server's storage size limit:
+    delete:
+      operationId: remove-bot-storage
+      summary: Remove a bot's stored data
+      tags: ["bots"]
+      description: |
+        Delete [data stored](/help/interactive-bots-api#bot_handlerstorage)
+        for a bot user.
+      requestBody:
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                keys:
+                  description: |
+                    A JSON-encoded list of keys to delete from the bot's storage.
+
+                    If not provided, then all data that's stored for the bot is
+                    deleted.
+                  type: array
+                  items:
+                    type: string
+                  example: ["foo"]
+            encoding:
+              keys:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Key does not exist.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response when a key to be deleted does not exist
+                          in the bot's storage:
   /drafts:
     get:
       operationId: get-drafts

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -225,7 +225,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         #### These personal settings endpoints have modest value to document:
         "/users/me/avatar",
         #### Should be documented as part of interactive bots documentation
-        "/bot_storage",
         "/submessage",
         "/zcommand",
         #### These "organization settings" endpoint have modest value to document:
@@ -930,6 +929,7 @@ class OpenAPIAttributesTest(ZulipTestCase):
             "invites",
             "reminders",
             "navigation_views",
+            "bots",
         ]
         paths = OpenAPISpec(OPENAPI_SPEC_PATH).openapi()["paths"]
         for path, path_item in paths.items():

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -258,27 +258,36 @@ class TestServiceBotStateHandler(ZulipTestCase):
         self.assertTrue(storage.contains("another key"))
         self.assertRaises(StateError, lambda: storage.remove("some key"))
 
-    def test_internal_endpoint(self) -> None:
-        self.login_user(self.user_profile)
+    def test_bot_storage_restrictions(self) -> None:
+        bot_storage_url = "/api/v1/bot_storage"
+        result = self.api_put(self.user_profile, bot_storage_url, {"storage": "{}"})
+        self.assert_json_error(result, "Must be a bot user")
+        result = self.api_get(self.user_profile, bot_storage_url)
+        self.assert_json_error(result, "Must be a bot user")
+        result = self.api_delete(self.user_profile, bot_storage_url)
+        self.assert_json_error(result, "Must be a bot user")
+
+    def test_bot_storage_endpoint(self) -> None:
+        bot_storage_url = "/api/v1/bot_storage"
 
         # Store some data.
         initial_dict = {"key 1": "value 1", "key 2": "value 2", "key 3": "value 3"}
         params = {
             "storage": orjson.dumps(initial_dict).decode(),
         }
-        result = self.client_put("/json/bot_storage", params)
+        result = self.api_put(self.bot_profile, bot_storage_url, params)
         self.assert_json_success(result)
 
         # Assert the stored data for some keys.
         params = {
             "keys": orjson.dumps(["key 1", "key 3"]).decode(),
         }
-        result = self.client_get("/json/bot_storage", params)
+        result = self.api_get(self.bot_profile, bot_storage_url, params)
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["storage"], {"key 3": "value 3", "key 1": "value 1"})
 
         # Assert the stored data for all keys.
-        result = self.client_get("/json/bot_storage")
+        result = self.api_get(self.bot_profile, bot_storage_url)
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["storage"], initial_dict)
 
@@ -287,13 +296,13 @@ class TestServiceBotStateHandler(ZulipTestCase):
         params = {
             "storage": orjson.dumps(dict_update).decode(),
         }
-        result = self.client_put("/json/bot_storage", params)
+        result = self.api_put(self.bot_profile, bot_storage_url, params)
         self.assert_json_success(result)
 
         # Assert the data was updated.
         updated_dict = initial_dict.copy()
         updated_dict.update(dict_update)
-        result = self.client_get("/json/bot_storage")
+        result = self.api_get(self.bot_profile, bot_storage_url)
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["storage"], updated_dict)
 
@@ -301,19 +310,19 @@ class TestServiceBotStateHandler(ZulipTestCase):
         invalid_params = {
             "keys": ["This is a list, but should be a serialized string."],
         }
-        result = self.client_get("/json/bot_storage", invalid_params)
+        result = self.api_get(self.bot_profile, bot_storage_url, invalid_params)
         self.assert_json_error(result, "keys is not valid JSON")
 
         params = {
             "keys": orjson.dumps(["key 1", "nonexistent key"]).decode(),
         }
-        result = self.client_get("/json/bot_storage", params)
+        result = self.api_get(self.bot_profile, bot_storage_url, params)
         self.assert_json_error(result, "Key does not exist.")
 
         params = {
             "storage": orjson.dumps({"foo": [1, 2, 3]}).decode(),
         }
-        result = self.client_put("/json/bot_storage", params)
+        result = self.api_put(self.bot_profile, bot_storage_url, params)
         self.assert_json_error(result, 'storage["foo"] is not a string')
 
         # Remove some entries.
@@ -321,13 +330,13 @@ class TestServiceBotStateHandler(ZulipTestCase):
         params = {
             "keys": orjson.dumps(keys_to_remove).decode(),
         }
-        result = self.client_delete("/json/bot_storage", params)
+        result = self.api_delete(self.bot_profile, bot_storage_url, params)
         self.assert_json_success(result)
 
         # Assert the entries were removed.
         for key in keys_to_remove:
             updated_dict.pop(key)
-        result = self.client_get("/json/bot_storage")
+        result = self.api_get(self.bot_profile, bot_storage_url)
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["storage"], updated_dict)
 
@@ -335,20 +344,20 @@ class TestServiceBotStateHandler(ZulipTestCase):
         params = {
             "keys": orjson.dumps(["key 3", "nonexistent key"]).decode(),
         }
-        result = self.client_delete("/json/bot_storage", params)
+        result = self.api_delete(self.bot_profile, bot_storage_url, params)
         self.assert_json_error(result, "Key does not exist.")
 
         # Assert an error has been thrown and no entries were removed.
-        result = self.client_get("/json/bot_storage")
+        result = self.api_get(self.bot_profile, bot_storage_url)
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["storage"], updated_dict)
 
         # Remove the entire storage.
-        result = self.client_delete("/json/bot_storage")
+        result = self.api_delete(self.bot_profile, bot_storage_url)
         self.assert_json_success(result)
 
         # Assert the entire storage has been removed.
-        result = self.client_get("/json/bot_storage")
+        result = self.api_get(self.bot_profile, bot_storage_url)
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["storage"], {})
 

--- a/zerver/views/storage.py
+++ b/zerver/views/storage.py
@@ -1,6 +1,7 @@
 from django.http import HttpRequest, HttpResponse
 from pydantic import Json
 
+from zerver.decorator import require_bot_user
 from zerver.lib.bot_storage import (
     StateError,
     get_bot_storage,
@@ -14,6 +15,7 @@ from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.models import UserProfile
 
 
+@require_bot_user
 @typed_endpoint
 def update_storage(
     request: HttpRequest,
@@ -28,6 +30,7 @@ def update_storage(
     return json_success(request)
 
 
+@require_bot_user
 @typed_endpoint
 def get_storage(
     request: HttpRequest,
@@ -44,6 +47,7 @@ def get_storage(
     return json_success(request, data={"storage": storage})
 
 
+@require_bot_user
 @typed_endpoint
 def remove_storage(
     request: HttpRequest,


### PR DESCRIPTION
This PR documents the `/bot_storage` endpoint, which was listed in `pending_endpoints` in `test_openapi.py`. The endpoint gives interactive bots a persistent, isolated key-value store between messages. It was already implemented in the backend but had no API documentation and no access control restriction.

**Commit 1** documents all three operations:

- **GET** `/bot_storage` - retrieve stored values; optionally pass a `keys` list, or omit to fetch everything
-  **PUT** `/bot_storage` - upsert one or more key-value pairs (via a JSON-encoded `storage` dict)
- **DELETE** `/bot_storage` - delete stored keys; same optional `keys` parameter, or omit to clear all storage

**Commit 2** adds a backend restriction: all three views now reject non-bot accounts with a 400 Bad Request ("Must be a bot user"). Non-bot accounts have no use for bot storage, and this makes the constraint explicit rather than relying on callers to self-enforce it. It also adds `api_put` to `ZulipTestCase` in `test_classes.py`, consistent with the existing `api_get`, `api_post`, `api_patch`, and `api_delete` helpers.

Fixes: Removes `/bot_storage` out of `pending_endpoints` in the `test_openapi.py`

**Note to maintainers:**

1. **GET `keys` parameter structure.** The `keys` query parameter uses the `content: application/json` schema form (rather than a top-level `schema:`) because it's a JSON-encoded array - consistent with other endpoints in the spec (e.g. `/messages` GET). An `example:` value is required on the schema to avoid a `ValueError` in the curl example generator; without it, the docs page returns a 500.

2. **`"bots"` added to `VALID_TAGS`.** The three operations are tagged `["bots"]`, which wasn't in the allowlist in `test_openapi.py::test_attributes`.

3.  **Bot authentication in curl/API generators.** The curl param generators and `test-api` runner authenticate as `default-bot@zulip.com` (via `helpers.example_user("default_bot")`), consistent with how other bot-only endpoints are tested.

<details>
<summary><strong>Screenshots</strong></summary>

<br>

**The sidebar:** (Moved "Interactive bots" before "Speciality endpoints")
<img width="285" height="357" alt="image" src="https://github.com/user-attachments/assets/755d4229-b89f-4f4e-a34e-943399dc3a6d" />

**GET** `/bot_storage` rendered page:
<img width="549" height="1207" alt="image" src="https://github.com/user-attachments/assets/1aaa60b9-a196-42a1-b037-42bdc888ad2a" />


**PUT** `/bot_storage` rendered page:
<img width="586" height="1180" alt="image" src="https://github.com/user-attachments/assets/ee3a99a4-eda0-4d9b-b960-19111ce74892" />

**DELETE** `/bot_storage` rendered page:
<img width="587" height="1210" alt="image" src="https://github.com/user-attachments/assets/f0a327bf-702a-4e98-b55a-4566d736db28" />

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>