### PR TITLE
tornado: Only copy as shallowly as necessary.

### DIFF
--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -474,11 +474,19 @@ def prune_internal_data(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Prunes the internal_data data structures, which are not intended to
     be exposed to API clients.
     """
-    events = copy.deepcopy(events)
-    for event in events:
-        if event["type"] == "message" and "internal_data" in event:
+    # This performs the most shallow copy possible, since events may
+    # have significant data.
+    if not any(event["type"] == "message" for event in events):
+        return events
+    new_events = []
+    for orig_event in events:
+        if orig_event["type"] == "message" and "internal_data" in orig_event:
+            event = dict(orig_event)
             del event["internal_data"]
-    return events
+            new_events.append(event)
+        else:
+            new_events.append(orig_event)
+    return new_events
 
 
 # Queue-ids which still need to be sent a web_reload_client event.


### PR DESCRIPTION
Performing a deepcopy can be resource-intensive.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
