### PR TITLE
message_list_tooltips: Flip tooltip when reference is clipped.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -63,6 +63,28 @@ function message_list_tooltip(target: string, props: Partial<tippy.Props> = {}):
                 return false;
             }
 
+            // Flip tooltip when the reference is partially clipped
+            // by a scroll container (compose preview) or the sticky
+            // recipient header (message feed).
+            if (instance.props.placement === "top") {
+                const ref_rect = instance.reference.getBoundingClientRect();
+                let clipping_top: number | undefined;
+
+                const preview_area = instance.reference.closest(".preview_message_area");
+                if (preview_area) {
+                    clipping_top = preview_area.getBoundingClientRect().top;
+                } else {
+                    const sticky_header = document.querySelector(".sticky_header");
+                    if (sticky_header) {
+                        clipping_top = sticky_header.getBoundingClientRect().bottom;
+                    }
+                }
+
+                if (clipping_top !== undefined && ref_rect.top < clipping_top) {
+                    instance.setProps({placement: "bottom"});
+                }
+            }
+
             if (onShow !== undefined && onShow(instance) === false) {
                 // Only return false if `onShow` returns false. We don't want to hide
                 // tooltip if `onShow` returns `undefined`.


### PR DESCRIPTION
Fixes #38640

When a tooltip reference element is partially hidden — by the scroll container in compose/message-edit preview, or by the sticky recipient header in the message feed — flip the tooltip from "top" to "bottom" so it appears on the visible side.


Tested that the fix works for compose, message edit and message list elements.

| before | after |
| --- | --- |
 | <img width="499" height="442" alt="Screenshot From 2026-04-02 00-14-35" src="https://github.com/user-attachments/assets/08d3e3db-3930-486b-b601-f3a010109dfd" /> |  <img width="812" height="545" alt="Screenshot From 2026-04-02 00-13-35" src="https://github.com/user-attachments/assets/900d93b7-0f63-4200-a8d2-6098c61afdbc" /> |
| <img width="718" height="651" alt="Screenshot From 2026-04-02 00-14-17" src="https://github.com/user-attachments/assets/b5e9e7d7-d258-4778-aaff-5b4dbc5e96fc" /> | <img width="1120" height="1080" alt="Screenshot From 2026-04-02 00-13-25" src="https://github.com/user-attachments/assets/6ac338ab-97e4-44ff-9020-002014fd97a1" /> |
| <img width="1108" height="1015" alt="image" src="https://github.com/user-attachments/assets/67e4e4b6-43fb-4846-8f72-82e43a52ca57" /> | <img width="1120" height="1080" alt="Screenshot From 2026-04-02 00-13-02" src="https://github.com/user-attachments/assets/56e4aee8-38a4-4a53-98c8-d2cd85614825" /> |
 
----

Used Claude to generated the code after identifying the fix.