### PR TITLE
Revert "docker: Fix failing CI."

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -144,7 +144,7 @@ jobs:
             os: jammy
             extra-args: ""
 
-          - docker_image: amanagr2/ci:noble
+          - docker_image: zulip/ci:noble
             name: Ubuntu 24.04 production install
             os: noble
             extra-args: ""

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -43,7 +43,7 @@ jobs:
             include_documentation_tests: true
             include_frontend_tests: false
           # Ubuntu 24.04 ships with Python 3.12.2.
-          - docker_image: amanagr2/ci:noble
+          - docker_image: zulip/ci:noble
             name: Ubuntu 24.04 (Python 3.12, backend)
             os: noble
             include_documentation_tests: false


### PR DESCRIPTION
This reverts commit 220d3320e1329e79ae8444758940f826efe6b8e0 (#38693).

The issue was fixed upstream.