### PR TITLE
left_sidebar: Fix jump when clicking a topic.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -515,14 +515,7 @@ export function left_sidebar_scroll_zoomed_in_topic_into_view(): void {
             direct_message_divider_height +
             channel_folder_header_height;
 
-        const $channel_section = $selected_topic.closest(".stream-expanded");
-        const channel_section_height = $channel_section.outerHeight(true) ?? 0;
-        const available_topic_height = ($scroll_container.height() ?? 0) - sticky_header_height;
-
-        let $scroll_target = $selected_topic;
-        if (channel_section_height <= available_topic_height) {
-            $scroll_target = $channel_section;
-        }
+        const $scroll_target = $selected_topic;
         scroll_util.scroll_element_into_container(
             $scroll_target,
             $scroll_container,


### PR DESCRIPTION
Stops the sidebar from auto-scrolling to the channel header when a topic is clicked.

<!-- Describe your pull request here.-->

Fixes: [#user questions > Clicking topic auto-scrolls sidebar when channel not in view](https://chat.zulip.org/#narrow/channel/138-user-questions/topic/Clicking.20topic.20auto-scrolls.20sidebar.20when.20channel.20not.20in.20view/with/2424747)<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


**Screenshots and screen captures:**

https://github.com/user-attachments/assets/b40d3081-d81a-42e7-98eb-fd5d59b261cf

https://github.com/user-attachments/assets/8bc38e9d-bfb4-4401-8ce8-b085017f04e4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
