### PR TITLE
push_notifications: Filter non-human clients from active receivers

### DIFF
--- a/zerver/lib/client_type.py
+++ b/zerver/lib/client_type.py
@@ -1,0 +1,91 @@
+from typing import Final, Literal
+
+from zerver.lib.user_agent import parse_user_agent
+
+ClientType = Literal[
+    "desktop",
+    "mobile",
+    "web",
+    "terminal",
+    "archiver",
+    "content_mirror",
+    "bot",
+    "other",
+]
+
+HUMAN_CLIENT_TYPES: Final[frozenset[ClientType]] = frozenset(
+    {
+        "desktop",
+        "mobile",
+        "web",
+        "terminal",
+    }
+)
+
+_BROWSER_USER_AGENTS: Final[frozenset[str]] = frozenset(
+    {
+        "mozilla",
+        "chrome",
+        "firefox",
+        "safari",
+        "edge",
+        "edg",
+        "opera",
+        "mobile safari",
+        "mobilesafari",
+    }
+)
+
+
+def classify_client_name(client_name: str) -> ClientType | None:
+    normalized_client_name = client_name.lower()
+
+    if normalized_client_name == "website" or normalized_client_name in _BROWSER_USER_AGENTS:
+        return "web"
+
+    if normalized_client_name in {"zulipmobile", "zulipandroid", "zulipios", "android", "ios"}:
+        return "mobile"
+
+    if normalized_client_name in {"zulipelectron", "zulipdesktop", "zulipflutter"}:
+        return "desktop"
+
+    if normalized_client_name in {"zulipterminal", "terminal"}:
+        return "terminal"
+
+    if "mirror" in normalized_client_name:
+        return "content_mirror"
+
+    if "archive" in normalized_client_name:
+        return "archiver"
+
+    if "bot" in normalized_client_name or "webhook" in normalized_client_name:
+        return "bot"
+
+    if "script" in normalized_client_name or "api" in normalized_client_name:
+        return "other"
+
+    return None
+
+
+def infer_client_type(
+    *,
+    client_type: ClientType | None,
+    client_name: str,
+    user_agent: str | None,
+) -> ClientType:
+    if client_type is not None:
+        return client_type
+
+    if user_agent is not None:
+        parsed_user_agent = parse_user_agent(user_agent)
+        user_agent_name = parsed_user_agent.get("name")
+        if user_agent_name is not None:
+            inferred_type_from_user_agent = classify_client_name(user_agent_name)
+            if inferred_type_from_user_agent is not None:
+                return inferred_type_from_user_agent
+
+    inferred_type_from_client_name = classify_client_name(client_name)
+    if inferred_type_from_client_name is not None:
+        return inferred_type_from_client_name
+
+    return "other"

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -28,6 +28,7 @@ from zerver.lib.channel_folders import (
     get_channel_folders_for_spectators,
     get_channel_folders_in_realm,
 )
+from zerver.lib.client_type import ClientType
 from zerver.lib.compatibility import is_outdated_server
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.devices import get_devices
@@ -2117,6 +2118,7 @@ def do_events_register(
     fetch_event_types: Collection[str] | None = None,
     spectator_requested_language: str | None = None,
     pronouns_field_type_supported: bool = True,
+    client_type: ClientType = "other",
 ) -> dict[str, Any]:
     # Technically we don't need to check this here because
     # build_narrow_predicate will check it, but it's nicer from an error
@@ -2208,6 +2210,7 @@ def do_events_register(
         empty_topic_name=empty_topic_name,
         simplified_presence_events=simplified_presence_events,
         individual_emoji_changes=individual_emoji_changes,
+        client_type=client_type,
     )
 
     if result is None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18139,8 +18139,29 @@ paths:
                     [help-linkifiers]: /help/add-a-custom-linkifier
                     [rfc6570]: https://www.rfc-editor.org/rfc/rfc6570.html
                     [events-linkifiers]: /api/get-events#realm_linkifiers
+
                   type: object
                   example: {"notification_settings_null": true}
+
+                client_type:
+                  description: |
+                    A string indicating the type of the client.
+                    Used by the server to determine if the client is a human-facing app
+                    for the purpose of routing push notifications.
+
+                    **Changes**: New in Zulip 12.0 (feature level 482).
+                  type: string
+                  enum:
+                    - "desktop"
+                    - "mobile"
+                    - "web"
+                    - "terminal"
+                    - "archiver"
+                    - "content_mirror"
+                    - "bot"
+                    - "other"
+                  example: "mobile"
+
                 fetch_event_types:
                   description: |
                     Same as the `event_types` parameter except that the values in

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1595,12 +1595,13 @@ class OfflineEventQueueTest(ZulipTestCase):
         self,
         user: UserProfile,
         queue_timeout: int | str | None,
+        client_type_name: str = "ZulipFlutter",
     ) -> ClientDescriptor:
         queue_data: dict[str, Any] = dict(
             all_public_streams=False,
             apply_markdown=True,
             client_gravatar=True,
-            client_type_name="ZulipFlutter",
+            client_type_name=client_type_name,
             event_types=["message"],
             last_connection_time=time.time(),
             queue_timeout=queue_timeout,
@@ -1687,6 +1688,26 @@ class OfflineEventQueueTest(ZulipTestCase):
             mark_clients_offline({client2.event_queue.id}, {hamlet.id})
             mock_enqueue.assert_called_once()
 
+    def test_last_client_for_user_ignores_non_human_queues(self) -> None:
+        hamlet = self.example_user("hamlet")
+        human_client = self.allocate_queue(
+            hamlet,
+            queue_timeout=self.LONG_LIVED_EVENT_QUEUE_TIMEOUT_SECS,
+            client_type_name="website",
+        )
+        self.allocate_queue(
+            hamlet,
+            queue_timeout=self.LONG_LIVED_EVENT_QUEUE_TIMEOUT_SECS,
+            client_type_name="home grown API program",
+        )
+
+        iago = self.example_user("iago")
+        self.send_personal_message(iago, hamlet)
+
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            mark_clients_offline({human_client.event_queue.id}, {hamlet.id})
+            mock_enqueue.assert_called_once()
+
     def test_receiver_is_off_zulip_with_offline_queue(self) -> None:
         hamlet = self.example_user("hamlet")
         client = self.allocate_queue(hamlet, queue_timeout=self.LONG_LIVED_EVENT_QUEUE_TIMEOUT_SECS)
@@ -1697,6 +1718,25 @@ class OfflineEventQueueTest(ZulipTestCase):
         # After marking offline, user should be "off Zulip".
         client.offline = True
         self.assertTrue(receiver_is_off_zulip(hamlet.id))
+
+    def test_receiver_is_off_zulip_ignores_non_human_queue(self) -> None:
+        hamlet = self.example_user("hamlet")
+
+        # Non-human event queues receiving messages should not suppress push notifications.
+        self.allocate_queue(
+            hamlet,
+            queue_timeout=self.LONG_LIVED_EVENT_QUEUE_TIMEOUT_SECS,
+            client_type_name="home grown API program",
+        )
+        self.assertTrue(receiver_is_off_zulip(hamlet.id))
+
+        # Adding a human queue should mark the user as on Zulip.
+        self.allocate_queue(
+            hamlet,
+            queue_timeout=self.LONG_LIVED_EVENT_QUEUE_TIMEOUT_SECS,
+            client_type_name="website",
+        )
+        self.assertFalse(receiver_is_off_zulip(hamlet.id))
 
     @time_machine.travel(NOW, tick=False)
     def test_gc_event_queues(self) -> None:

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -55,6 +55,19 @@ class EventsEndpointTest(ZulipTestCase):
         result = self.client_post("/json/register", skip_user_agent=True)
         self.assert_json_success(result)
 
+    def test_events_register_user_agent_inference_coverage(self) -> None:
+        # Test various User-Agents to hit all inference branches (terminal, bot, archiver, other)
+        agents_to_test = [
+            "ZulipTerminal/0.8.2",
+            "Zulip Python Bot",
+            "SomeArchiver/1.0",
+            "RandomUnknownBrowser/9.9",
+            "SomeContentMirrorApp",
+        ]
+        for agent in agents_to_test:
+            result = self.client_post("/json/register", HTTP_USER_AGENT=agent)
+            self.assert_json_success(result)
+
     def test_narrows(self) -> None:
         user = self.example_user("hamlet")
         with mock.patch("zerver.lib.events.request_event_queue", return_value=None) as m:
@@ -221,6 +234,28 @@ class EventsEndpointTest(ZulipTestCase):
             user, "/api/v1/register", {"idle_queue_timeout": orjson.dumps("invalid").decode()}
         )
         self.assert_json_error_contains(result, "idle_queue_timeout")
+
+    def test_client_type_parameter_is_forwarded(self) -> None:
+        user = self.example_user("hamlet")
+
+        with mock.patch("zerver.lib.events.request_event_queue", return_value=None) as m:
+            result = self.api_post(user, "/api/v1/register", {"client_type": "desktop"})
+
+        self.assert_json_error(result, "Could not allocate event queue")
+        self.assertEqual(m.call_args.kwargs["client_type"], "desktop")
+
+    def test_client_type_is_inferred_from_user_agent(self) -> None:
+        user = self.example_user("hamlet")
+
+        with mock.patch("zerver.lib.events.request_event_queue", return_value=None) as m:
+            result = self.api_post(
+                user,
+                "/api/v1/register",
+                HTTP_USER_AGENT="ZulipTerminal/0.1",
+            )
+
+        self.assert_json_error(result, "Could not allocate event queue")
+        self.assertEqual(m.call_args.kwargs["client_type"], "terminal")
 
     def test_events_register_spectators(self) -> None:
         # Verify that POST /register works for spectators, but not for

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -14,6 +14,7 @@ from requests.models import PreparedRequest, Response
 from typing_extensions import override
 from urllib3.util import Retry
 
+from zerver.lib.client_type import ClientType
 from zerver.lib.partial import partial
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.models import Client, Realm, UserProfile
@@ -102,6 +103,7 @@ def request_event_queue(
     empty_topic_name: bool = False,
     simplified_presence_events: bool = False,
     individual_emoji_changes: bool = False,
+    client_type: ClientType = "other",
 ) -> EventQueueData | None:
     if not settings.USING_TORNADO:
         return None
@@ -121,6 +123,7 @@ def request_event_queue(
         "client": "internal",
         "user_profile_id": user_profile.id,
         "user_client": user_client.name,
+        "client_type": orjson.dumps(client_type),
         "narrow": orjson.dumps(narrow),
         "secret": settings.SHARED_SECRET,
         "bulk_message_deletion": orjson.dumps(bulk_message_deletion),

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -22,6 +22,7 @@ from tornado import autoreload
 from typing_extensions import override
 
 from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
+from zerver.lib.client_type import HUMAN_CLIENT_TYPES, ClientType, infer_client_type
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message_cache import MessageDict
 from zerver.lib.narrow_helpers import narrow_dataclasses_from_tuples
@@ -80,6 +81,7 @@ class ClientDescriptor:
         event_queue: "EventQueue",
         event_types: Sequence[str] | None,
         client_type_name: str,
+        client_type: ClientType,
         apply_markdown: bool,
         client_gravatar: bool,
         slim_presence: bool,
@@ -117,6 +119,7 @@ class ClientDescriptor:
         self.slim_presence = slim_presence
         self.all_public_streams = all_public_streams
         self.client_type_name = client_type_name
+        self.client_type = client_type
         self._timeout_handle: Any = None  # TODO: should be return type of ioloop.call_later
         self.narrow = narrow
         self.narrow_predicate = build_narrow_predicate(modern_narrow)
@@ -159,6 +162,7 @@ class ClientDescriptor:
             all_public_streams=self.all_public_streams,
             narrow=self.narrow,
             client_type_name=self.client_type_name,
+            client_type=self.client_type,
             bulk_message_deletion=self.bulk_message_deletion,
             stream_typing_notifications=self.stream_typing_notifications,
             pronouns_field_type_supported=self.pronouns_field_type_supported,
@@ -178,7 +182,7 @@ class ClientDescriptor:
 
     @classmethod
     def from_dict(cls, d: MutableMapping[str, Any]) -> "ClientDescriptor":
-        if "client_type" in d:
+        if "client_type_name" not in d and "client_type" in d:
             # Temporary migration for the rename of client_type to client_type_name
             d["client_type_name"] = d["client_type"]
         if "client_gravatar" not in d:
@@ -194,6 +198,11 @@ class ClientDescriptor:
             event_queue=EventQueue.from_dict(d["event_queue"]),
             event_types=d["event_types"],
             client_type_name=d["client_type_name"],
+            client_type=infer_client_type(
+                client_type=d.get("client_type"),
+                client_name=d["client_type_name"],
+                user_agent=None,
+            ),
             apply_markdown=d["apply_markdown"],
             client_gravatar=d["client_gravatar"],
             slim_presence=d["slim_presence"],
@@ -592,13 +601,25 @@ def do_gc_event_queues(
     # but email notifications are not — duplicate
     # ScheduledMessageNotificationEmail rows will be created.
     # The same issue exists in mark_clients_offline below.
+    users_with_active_human_message_queues: set[int] = set()
+    for user_id in affected_users:
+        for c in get_client_descriptors_for_user(user_id):
+            if (
+                c.accepts_messages()
+                and c.client_type in HUMAN_CLIENT_TYPES
+                and not c.offline
+                and c.event_queue.id not in to_remove
+            ):
+                users_with_active_human_message_queues.add(user_id)
+                break
+
     for id in to_remove:
         web_reload_clients.pop(id, None)
         for cb in gc_hooks:
             cb(
                 clients[id].user_profile_id,
                 clients[id],
-                clients[id].user_profile_id not in user_clients,
+                clients[id].user_profile_id not in users_with_active_human_message_queues,
             )
         del clients[id]
 
@@ -617,7 +638,12 @@ def mark_clients_offline(
     users_with_active_queues: set[int] = set()
     for user_id in affected_users:
         for c in get_client_descriptors_for_user(user_id):
-            if c.accepts_messages() and not c.offline and c.event_queue.id not in to_mark_offline:
+            if (
+                c.accepts_messages()
+                and c.client_type in HUMAN_CLIENT_TYPES
+                and not c.offline
+                and c.event_queue.id not in to_mark_offline
+            ):
                 users_with_active_queues.add(user_id)
                 break
 
@@ -1028,7 +1054,11 @@ def receiver_is_off_zulip(user_profile_id: int) -> bool:
     not_offline_message_event_queues = [
         client
         for client in all_client_descriptors
-        if client.accepts_messages() and not client.offline
+        if (
+            client.accepts_messages()
+            and client.client_type in HUMAN_CLIENT_TYPES
+            and not client.offline
+        )
     ]
     off_zulip = len(not_offline_message_event_queues) == 0
     return off_zulip

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Json, PositiveInt, StringConstraints, model_vali
 from typing_extensions import ParamSpec
 
 from zerver.decorator import internal_api_view, process_client
+from zerver.lib.client_type import ClientType, infer_client_type
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.queue import get_queue_client
 from zerver.lib.request import RequestNotes
@@ -173,6 +174,10 @@ def get_events_backend(
         Json[list[str]] | None,
         ApiParamConfig(documentation_status=DocumentationStatus.INTENTIONALLY_UNDOCUMENTED),
     ] = None,
+    client_type: Annotated[
+        Json[ClientType] | None,
+        ApiParamConfig(documentation_status=DocumentationStatus.INTENTIONALLY_UNDOCUMENTED),
+    ] = None,
     dont_block: Json[bool] = False,
     narrow: Annotated[
         Json[list[list[str]]] | None,
@@ -239,6 +244,11 @@ def get_events_backend(
     else:
         valid_user_client_name = user_client.name
 
+    resolved_client_type = infer_client_type(
+        client_type=client_type,
+        client_name=valid_user_client_name,
+        user_agent=request.headers.get("User-Agent"),
+    )
     new_queue_data = None
     if queue_id is None:
         new_queue_data = dict(
@@ -246,6 +256,7 @@ def get_events_backend(
             realm_id=user_profile.realm_id,
             event_types=event_types,
             client_type_name=valid_user_client_name,
+            client_type=resolved_client_type,
             apply_markdown=apply_markdown,
             client_gravatar=client_gravatar,
             slim_presence=slim_presence,

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 from pydantic import Json, PositiveInt
 
 from zerver.context_processors import get_valid_realm_from_request
+from zerver.lib.client_type import ClientType, infer_client_type
 from zerver.lib.compatibility import is_pronouns_field_type_supported
 from zerver.lib.events import DEFAULT_CLIENT_CAPABILITIES, ClientCapabilities, do_events_register
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
@@ -48,6 +49,7 @@ def events_register_backend(
     event_types: Json[list[str]] | None = None,
     fetch_event_types: Json[list[str]] | None = None,
     include_subscribers: Literal["true", "false", "partial"] = "false",
+    client_type: ClientType | None = None,
     narrow: Json[NarrowT] | None = None,
     presence_history_limit_days: Json[int] | None = None,
     idle_queue_timeout: Json[PositiveInt | Literal["mobile"]] | None = None,
@@ -103,6 +105,12 @@ def events_register_backend(
     client = RequestNotes.get_notes(request).client
     assert client is not None
 
+    resolved_client_type = infer_client_type(
+        client_type=client_type,
+        client_name=client.name,
+        user_agent=request.headers.get("User-Agent"),
+    )
+
     pronouns_field_type_supported = is_pronouns_field_type_supported(
         request.headers.get("User-Agent")
     )
@@ -130,5 +138,6 @@ def events_register_backend(
         fetch_event_types=fetch_event_types,
         spectator_requested_language=spectator_requested_language,
         pronouns_field_type_supported=pronouns_field_type_supported,
+        client_type=resolved_client_type,
     )
     return json_success(request, data=ret)


### PR DESCRIPTION
Hi @timabbott,

I've spent some time investigating this today and implemented the core logic to filter out non-human clients from the `receiver_is_off_zulip` check. 

Fixes #16772.

**Summary of changes:**
1. Introduced the `ClientType` literal along with a `User-Agent` fallback parsing logic for legacy clients.
2. Updated the Tornado event queue state and deserialization to properly persist `client_type`.
3. Modified the active queue counting logic so it now strictly considers `HUMAN_CLIENT_TYPES`.

**Status:**
All CI pipeline failures have been resolved and the backend test coverage is fully green. This PR is now ready for review! Let me know what you think.

**Self-review checklist**

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

**Communicate decisions, questions, and potential concerns.**

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

**Individual commits are ready for review (see commit discipline).**

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

**Completed manual review and testing of the following:**

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
