### PR TITLE
saved_snippets: Don't curve bottom border + hide bottom border on last item.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1996,6 +1996,11 @@ textarea.new_message_textarea {
             white-space: nowrap;
         }
     }
+
+    /* Don't show bottom border separator on the last item. */
+    .dropdown-list .list-item:last-child .dropdown-list-item-common-styles {
+        border-bottom: none;
+    }
 }
 
 #add-new-saved-snippet-modal,


### PR DESCRIPTION
Bottom border on the last option looked too close to the top border of the create new snippet option so I removed it in the last commit. Feel free to drop that commit if that change does not look good. Here is a screenshot of the state without that commit

<img width="333" height="223" alt="Screenshot 2026-04-02 at 1 13 43 PM" src="https://github.com/user-attachments/assets/4b2df2d1-2ecc-46ac-b3d6-56c4c14a1963" />


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="333" height="223" alt="Screenshot 2026-04-02 at 1 12 09 PM" src="https://github.com/user-attachments/assets/f6946032-0a0a-42e2-831c-4c27c1778d81" />
After:
<img width="333" height="223" alt="Screenshot 2026-04-02 at 1 11 52 PM" src="https://github.com/user-attachments/assets/7cb476d8-12b4-44ee-b08e-6de4f9602880" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
