### PR TITLE
Reactions: Live-update names in user reaction pills.

### DIFF
--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -741,3 +741,33 @@ export function rewire_update_vote_text_on_message(
 ): void {
     update_vote_text_on_message = value;
 }
+
+export function update_reaction_names(user_id: number): void {
+    // When a user's full name changes, we need to update all reaction pills
+    // that display this user's name. This function finds all messages with
+    // reactions and updates their vote text if they display user names instead
+    // of just counts.
+    const message_lists_to_check = message_lists.all_rendered_message_lists();
+    for (const msg_list of message_lists_to_check) {
+        const messages = msg_list.data.all_messages_after_mute_filtering();
+        for (const message of messages) {
+            if (message.clean_reactions.size === 0) {
+                continue;
+            }
+
+            let message_has_user = false;
+            for (const clean_reaction of message.clean_reactions.values()) {
+                if (clean_reaction.user_ids.includes(user_id)) {
+                    message_has_user = true;
+                    break;
+                }
+            }
+
+            if (message_has_user) {
+                // Update all reactions in this message since the display mode
+                // and vote text might change based on total reactions
+                update_vote_text_on_message(message);
+            }
+        }
+    }
+}

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -16,6 +16,7 @@ import * as message_live_update from "./message_live_update.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
+import * as reactions from "./reactions.ts";
 import * as settings from "./settings.ts";
 import * as settings_account from "./settings_account.ts";
 import * as settings_bots from "./settings_bots.ts";
@@ -106,6 +107,7 @@ export const update_person = function update(event: UserUpdate): void {
         message_live_update.update_user_full_name(event.user_id, event.full_name);
         pm_list.update_private_messages();
         user_profile.update_profile_modal_ui(user, event);
+        reactions.update_reaction_names(event.user_id);
         if (people.is_my_user_id(event.user_id)) {
             current_user.full_name = event.full_name;
             settings_account.update_full_name(event.full_name);

--- a/web/tests/reactions.test.cjs
+++ b/web/tests/reactions.test.cjs
@@ -1489,3 +1489,35 @@ test("process_reaction_click bad local id", ({override}) => {
     blueslip.expect("error", "Data integrity problem for reaction");
     reactions.process_reaction_click("some-msg-id", "bad-local-id");
 });
+
+test("update_reaction_names", ({override, override_rewire}) => {
+    const message_with_bob_reaction = sample_message_with_clean_reactions();
+    const message_without_reactions = {
+        id: 2001,
+        clean_reactions: new Map(),
+    };
+    const message_without_bob_reaction = {
+        id: 3001,
+        clean_reactions: message_with_bob_reaction.clean_reactions,
+    };
+
+    override(message_lists, "all_rendered_message_lists", () => [
+        {
+            data: {
+                all_messages_after_mute_filtering: () => [
+                    message_with_bob_reaction,
+                    message_without_reactions,
+                    message_without_bob_reaction,
+                ],
+            },
+        },
+    ]);
+
+    const stub = make_stub();
+    override_rewire(reactions, "update_vote_text_on_message", stub.f);
+
+    people.set_full_name(bob, "Robert Bob");
+    reactions.update_reaction_names(6);
+
+    assert.ok(stub.num_calls > 0);
+});


### PR DESCRIPTION
Previously, when a user changed their username, the change was applied only to the reaction tooltip. The username in the reaction pill remained unchanged and required a reload for the change to take effect.

This PR fixes this shortcoming. Now, the username is also live-updated in reaction pills, along with the tooltip.

Fixes: #38595

**Before** 
(Requires reload)

https://github.com/user-attachments/assets/09b4b6c9-cb40-487a-8d23-c346878f53ff


**After**
(No reload required, live updates)

https://github.com/user-attachments/assets/e7470701-f764-4fd2-bc73-128f3beb895c


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
