### PR TITLE
user_profile: Include active tab in URL for back-button support

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -194,6 +194,33 @@ export function group_edit_url(group: UserGroup, right_side_tab: string): string
     return hash;
 }
 
+const valid_user_profile_tab_values = new Set(["profile", "channels", "groups", "manage"]);
+
+export function user_profile_url(user_id: number, tab = "profile"): string {
+    if (!valid_user_profile_tab_values.has(tab)) {
+        blueslip.warn("invalid user profile tab: " + tab);
+        return `#user/${user_id}/profile`;
+    }
+
+    return `#user/${user_id}/${tab}`;
+}
+
+export function validate_user_profile_hash(hash: string): string {
+    const hash_components = hash.slice(1).split(/\//);
+    const user_id = hash_components[1];
+
+    if (user_id === undefined || !/^\d+$/.test(user_id)) {
+        return hash;
+    }
+
+    let tab = hash_components[2];
+    if (tab === undefined || !valid_user_profile_tab_values.has(tab)) {
+        tab = "profile";
+    }
+
+    return user_profile_url(Number.parseInt(user_id, 10), tab);
+}
+
 export function search_public_streams_notice_url(terms: NarrowCanonicalTerm[]): string {
     const public_operator: NarrowCanonicalTerm = {operator: "channels", operand: "public"};
     return search_terms_to_hash([public_operator, ...terms]);

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -82,6 +82,52 @@ function get_settings_tab(section: string): string | undefined {
     return undefined;
 }
 
+function show_user_profile_from_hash(section: string): void {
+    const user_id = Number.parseInt(section, 10);
+    const tab = hash_parser.get_current_nth_hash_section(2);
+    const default_tab_key = user_profile.get_tab_key_for_hash_tab(tab);
+
+    if (!people.is_known_user_id(user_id)) {
+        user_profile.show_user_profile_access_error_modal();
+        return;
+    }
+
+    const current_user_id = user_profile.get_user_id_if_user_profile_modal_open();
+    if (current_user_id === user_id) {
+        user_profile.change_state(default_tab_key);
+    } else {
+        user_profile.show_user_profile(user_id, default_tab_key);
+    }
+}
+
+function should_preserve_user_profile_modal_on_hashchange(
+    current_hash: string,
+    old_hash: string | undefined,
+): boolean {
+    if (old_hash === undefined) {
+        return false;
+    }
+
+    if (
+        hash_parser.get_hash_category(current_hash) !== "user" ||
+        hash_parser.get_hash_category(old_hash) !== "user"
+    ) {
+        return false;
+    }
+
+    const current_user_id = hash_parser.get_hash_section(current_hash);
+    const old_user_id = hash_parser.get_hash_section(old_hash);
+
+    if (!/^\d+$/.test(current_user_id) || current_user_id !== old_user_id) {
+        return false;
+    }
+
+    return (
+        user_profile.get_user_id_if_user_profile_modal_open() ===
+        Number.parseInt(current_user_id, 10)
+    );
+}
+
 export function set_hash_to_home_view(triggered_by_escape_key = false): void {
     if (browser_history.is_current_hash_home_view()) {
         return;
@@ -319,6 +365,14 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
         }
     }
 
+    if (base === "user") {
+        const valid_hash = hash_util.validate_user_profile_hash(window.location.hash);
+        if (valid_hash !== window.location.hash) {
+            window.history.replaceState(null, "", browser_history.get_full_url(valid_hash));
+            section = hash_parser.get_current_hash_section();
+        }
+    }
+
     // Start by handling the specific case of going from
     // something like "#channels/all" to "#channels/subscribed".
     //
@@ -346,6 +400,11 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
         if (base === "groups") {
             const right_side_tab = hash_parser.get_current_nth_hash_section(3);
             user_group_edit.change_state(section, undefined, right_side_tab);
+        }
+
+        if (base === "user") {
+            show_user_profile_from_hash(section);
+            return;
         }
 
         if (base === "settings") {
@@ -513,12 +572,7 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
     }
 
     if (base === "user") {
-        const user_id = Number.parseInt(hash_parser.get_current_hash_section(), 10);
-        if (!people.is_known_user_id(user_id)) {
-            user_profile.show_user_profile_access_error_modal();
-        } else {
-            user_profile.show_user_profile(user_id);
-        }
+        show_user_profile_from_hash(hash_parser.get_current_hash_section());
         return;
     }
 }
@@ -530,6 +584,7 @@ function hashchanged(
 ): boolean | undefined {
     const current_hash = window.location.hash;
     const old_hash = e && ("oldURL" in e ? new URL(e.oldURL).hash : browser_history.old_hash());
+    const old_hash_for_modal_logic = old_hash ?? browser_history.old_hash();
     const is_hash_web_public_compatible = browser_history.update_web_public_hash(current_hash);
 
     const was_internal_change = browser_history.save_old_hash();
@@ -553,7 +608,14 @@ function hashchanged(
 
     if (hash_parser.is_overlay_hash(current_hash)) {
         browser_history.state.changing_hash = true;
-        modals.close_active_if_any();
+        if (
+            !should_preserve_user_profile_modal_on_hashchange(
+                current_hash,
+                old_hash_for_modal_logic,
+            )
+        ) {
+            modals.close_active_if_any();
+        }
         do_hashchange_overlay(old_hash);
         browser_history.state.changing_hash = false;
         return undefined;

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -32,7 +32,7 @@ import * as custom_profile_fields_ui from "./custom_profile_fields_ui.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import type {DropdownWidget, DropdownWidgetOptions} from "./dropdown_widget.ts";
-import {get_current_hash_category} from "./hash_parser.ts";
+import {get_current_hash_category, get_current_hash_section} from "./hash_parser.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {InputPillContainer} from "./input_pill.ts";
@@ -96,6 +96,63 @@ let original_values: (Record<string, unknown> & {user_id?: string | undefined}) 
 const INCOMING_WEBHOOK_BOT_TYPE = 2;
 const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 const EMBEDDED_BOT_TYPE = "4";
+
+type UserProfileTabKey =
+    | "profile-tab"
+    | "user-profile-streams-tab"
+    | "user-profile-groups-tab"
+    | "manage-profile-tab";
+
+const user_profile_tab_key_by_hash_tab = new Map<string, UserProfileTabKey>([
+    ["profile", "profile-tab"],
+    ["channels", "user-profile-streams-tab"],
+    ["groups", "user-profile-groups-tab"],
+    ["manage", "manage-profile-tab"],
+]);
+
+const user_profile_hash_tab_by_tab_key = new Map<UserProfileTabKey, string>([
+    ["profile-tab", "profile"],
+    ["user-profile-streams-tab", "channels"],
+    ["user-profile-groups-tab", "groups"],
+    ["manage-profile-tab", "manage"],
+]);
+
+export function get_tab_key_for_hash_tab(tab: string): UserProfileTabKey {
+    return user_profile_tab_key_by_hash_tab.get(tab) ?? "profile-tab";
+}
+
+function get_hash_tab_for_tab_key(tab_key: UserProfileTabKey): string {
+    return user_profile_hash_tab_by_tab_key.get(tab_key) ?? "profile";
+}
+
+function is_user_profile_tab_key(key: string): key is UserProfileTabKey {
+    switch (key) {
+        case "profile-tab":
+        case "user-profile-streams-tab":
+        case "user-profile-groups-tab":
+        case "manage-profile-tab":
+            return true;
+        default:
+            return false;
+    }
+}
+
+function should_update_hash_for_user_profile_tab(user_id: number): boolean {
+    return (
+        get_current_hash_category() === "user" && get_current_hash_section() === user_id.toString()
+    );
+}
+
+function maybe_update_hash_for_user_profile_tab(user_id: number, tab_key: UserProfileTabKey): void {
+    if (!should_update_hash_for_user_profile_tab(user_id)) {
+        return;
+    }
+
+    const new_hash = hash_util.user_profile_url(user_id, get_hash_tab_for_tab_key(tab_key));
+    if (window.location.hash !== new_hash) {
+        browser_history.go_to_location(new_hash);
+    }
+}
 
 export function show_button_spinner($button: JQuery): void {
     const $spinner = $button.find(".modal__spinner");
@@ -577,8 +634,22 @@ function on_user_profile_hide(): void {
     }
 }
 
-function show_manage_user_tab(target: string): void {
+export function change_state(target: UserProfileTabKey): void {
+    if (!(modals.any_active() && modals.active_modal() === "#user-profile-modal")) {
+        return;
+    }
+
+    const $tab = $(`#user-profile-modal .ind-tab[data-tab-key="${CSS.escape(target)}"]`);
+    if ($tab.length === 0) {
+        toggler.goto("profile-tab");
+        return;
+    }
+
     toggler.goto(target);
+}
+
+function show_manage_user_tab(target: UserProfileTabKey): void {
+    change_state(target);
 }
 
 function initialize_user_type_fields(user: User): void {
@@ -692,7 +763,10 @@ function add_user_to_groups(group_ids: number[], user_id: number, $alert_box: JQ
     add_user_to_next_group();
 }
 
-export function show_user_profile(user_id: number, default_tab_key = "profile-tab"): void {
+export function show_user_profile(
+    user_id: number,
+    default_tab_key: UserProfileTabKey = "profile-tab",
+): void {
     const user = people.get_by_user_id(user_id);
     // Reset these widgets so that they are created again for the opened modal.
     user_streams_list_widget = undefined;
@@ -754,23 +828,35 @@ export function show_user_profile(user_id: number, default_tab_key = "profile-ta
     $(".tabcontent").hide();
     $("#user-profile-modal .dialog_submit_button").prop("disabled", true);
 
-    let default_tab = 0;
+    const tab_values: ({label: string; key: UserProfileTabKey} & {label_html?: never})[] = [
+        {label: $t({defaultMessage: "Profile"}), key: "profile-tab"},
+        {label: $t({defaultMessage: "Channels"}), key: "user-profile-streams-tab"},
+        {label: $t({defaultMessage: "User groups"}), key: "user-profile-groups-tab"},
+    ];
 
-    if (default_tab_key === "user-profile-streams-tab") {
-        default_tab = 1;
-    } else if (default_tab_key === "manage-profile-tab") {
-        default_tab = 3;
+    if (can_manage_profile) {
+        const manage_profile_label = user.is_bot
+            ? $t({defaultMessage: "Manage bot"})
+            : people.is_my_user_id(user.user_id)
+              ? $t({defaultMessage: "Edit profile"})
+              : $t({defaultMessage: "Manage user"});
+        tab_values.push({
+            label: manage_profile_label,
+            key: "manage-profile-tab",
+        });
     }
+
+    if (!tab_values.some((tab) => tab.key === default_tab_key)) {
+        default_tab_key = "profile-tab";
+    }
+
+    const default_tab = tab_values.findIndex((tab) => tab.key === default_tab_key);
 
     let has_initialized_user_type_fields = false;
     const opts = {
         selected: default_tab,
         child_wants_focus: true,
-        values: [
-            {label: $t({defaultMessage: "Profile"}), key: "profile-tab"},
-            {label: $t({defaultMessage: "Channels"}), key: "user-profile-streams-tab"},
-            {label: $t({defaultMessage: "User groups"}), key: "user-profile-groups-tab"},
-        ],
+        values: tab_values,
         callback(_name: string | undefined, key: string) {
             $(".tabcontent").hide();
             $(`#${CSS.escape(key)}`).show();
@@ -803,21 +889,12 @@ export function show_user_profile(user_id: number, default_tab_key = "profile-ta
                 $(".modal__container .ind-tab").attr("tabindex", "-1");
                 $(".modal__container .ind-tab.selected").attr("tabindex", "0");
             }, 0);
+
+            if (is_user_profile_tab_key(key)) {
+                maybe_update_hash_for_user_profile_tab(user.user_id, key);
+            }
         },
     };
-
-    if (can_manage_profile) {
-        const manage_profile_label = user.is_bot
-            ? $t({defaultMessage: "Manage bot"})
-            : people.is_my_user_id(user.user_id)
-              ? $t({defaultMessage: "Edit profile"})
-              : $t({defaultMessage: "Manage user"});
-        const manage_profile_tab = {
-            label: manage_profile_label,
-            key: "manage-profile-tab",
-        };
-        opts.values.push(manage_profile_tab);
-    }
 
     toggler = components.toggle(opts);
     const $elem = toggler.get();

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -216,6 +216,21 @@ run_test("test_channels_settings_edit_url", () => {
     );
 });
 
+run_test("test_user_profile_url", () => {
+    assert.equal(hash_util.user_profile_url(42), "#user/42/profile");
+    assert.equal(hash_util.user_profile_url(42, "channels"), "#user/42/channels");
+});
+
+run_test("test_validate_user_profile_hash", () => {
+    assert.equal(hash_util.validate_user_profile_hash("#user/42"), "#user/42/profile");
+    assert.equal(hash_util.validate_user_profile_hash("#user/42/channels"), "#user/42/channels");
+    assert.equal(hash_util.validate_user_profile_hash("#user/42/streams"), "#user/42/profile");
+    assert.equal(
+        hash_util.validate_user_profile_hash("#user/42/profile/extra"),
+        "#user/42/profile",
+    );
+});
+
 run_test("test_by_conversation_and_time_url", () => {
     let message = {
         type: "stream",

--- a/web/tests/hashchange.test.cjs
+++ b/web/tests/hashchange.test.cjs
@@ -18,6 +18,9 @@ const admin = mock_esm("../src/admin");
 const drafts_overlay_ui = mock_esm("../src/drafts_overlay_ui");
 const info_overlay = mock_esm("../src/info_overlay");
 const message_viewport = mock_esm("../src/message_viewport");
+const modals = mock_esm("../src/modals", {
+    close_active_if_any() {},
+});
 const overlays = mock_esm("../src/overlays");
 const popovers = mock_esm("../src/popovers");
 const recent_view_ui = mock_esm("../src/recent_view_ui");
@@ -31,6 +34,26 @@ const spectators = mock_esm("../src/spectators", {
 const stream_settings_ui = mock_esm("../src/stream_settings_ui");
 const ui_util = mock_esm("../src/ui_util");
 const ui_report = mock_esm("../src/ui_report");
+const user_profile = mock_esm("../src/user_profile", {
+    change_state() {},
+    get_tab_key_for_hash_tab(tab) {
+        if (tab === "channels") {
+            return "user-profile-streams-tab";
+        }
+        if (tab === "groups") {
+            return "user-profile-groups-tab";
+        }
+        if (tab === "manage") {
+            return "manage-profile-tab";
+        }
+        return "profile-tab";
+    },
+    get_user_id_if_user_profile_modal_open() {
+        return undefined;
+    },
+    show_user_profile() {},
+    show_user_profile_access_error_modal() {},
+});
 set_global("favicon", {});
 
 const browser_history = zrequire("browser_history");
@@ -162,6 +185,9 @@ function test_helper({override, override_rewire, change_tab}) {
     stub(ui_util, "blur_active_element");
     stub(ui_report, "error");
     stub(spectators, "login_to_access");
+    stub_with_args(user_profile, "change_state");
+    stub_with_args(user_profile, "show_user_profile");
+    stub(user_profile, "show_user_profile_access_error_modal");
 
     if (change_tab) {
         override_rewire(message_view, "show", (terms) => {
@@ -400,6 +426,83 @@ run_test("hash_interactions", ({override, override_rewire}) => {
     browser_history.exit_overlay();
 
     helper.assert_events([[ui_util, "blur_active_element"]]);
+});
+
+run_test("user_profile_tab_hash_navigation", ({override}) => {
+    $window_stub = $.create("window-stub");
+    override(user_settings, "web_home_view", "recent");
+    browser_history.clear_for_testing();
+
+    const user_one = {
+        user_id: 201,
+        email: "user-one@example.com",
+        full_name: "User One",
+    };
+    const user_two = {
+        user_id: 202,
+        email: "user-two@example.com",
+        full_name: "User Two",
+    };
+    people.add_active_user(user_one, "server_events");
+    people.add_active_user(user_two, "server_events");
+
+    let open_user_id;
+    override(user_profile, "get_user_id_if_user_profile_modal_open", () => open_user_id);
+    const show_user_profile_calls = [];
+    override(user_profile, "show_user_profile", (...args) => {
+        show_user_profile_calls.push(args);
+    });
+    const change_state_calls = [];
+    override(user_profile, "change_state", (tab_key) => {
+        change_state_calls.push(tab_key);
+    });
+    let close_active_modal_calls = 0;
+    override(modals, "close_active_if_any", () => {
+        close_active_modal_calls += 1;
+    });
+    override(popovers, "hide_all", noop);
+    override(overlays, "close_for_hash_change", noop);
+    override(recent_view_ui, "show", noop);
+
+    let replaced_hash;
+    override(history, "replaceState", (_state, _title, url) => {
+        replaced_hash = new URL(url).hash;
+        window.location.hash = replaced_hash;
+    });
+
+    window.location.hash = "#user/201";
+    hashchange.initialize();
+    assert.equal(replaced_hash, "#user/201/profile");
+    assert.equal(show_user_profile_calls.length, 1);
+    assert.equal(show_user_profile_calls[0][0], 201);
+    assert.equal(show_user_profile_calls[0][1], "profile-tab");
+    const close_active_calls_before_tab_switch = close_active_modal_calls;
+
+    open_user_id = 201;
+    assert.equal(user_profile.get_user_id_if_user_profile_modal_open(), 201);
+    window.location.hash = "#user/201/channels";
+    $window_stub.trigger("hashchange");
+    assert.equal(change_state_calls.at(-1), "user-profile-streams-tab");
+    assert.equal(close_active_modal_calls, close_active_calls_before_tab_switch);
+
+    window.location.hash = "#user/201/groups";
+    $window_stub.trigger("hashchange");
+    assert.equal(change_state_calls.at(-1), "user-profile-groups-tab");
+    assert.equal(close_active_modal_calls, close_active_calls_before_tab_switch);
+
+    replaced_hash = undefined;
+    window.location.hash = "#user/201/not-a-tab";
+    $window_stub.trigger("hashchange");
+    assert.equal(replaced_hash, "#user/201/profile");
+    assert.equal(change_state_calls.at(-1), "profile-tab");
+    assert.equal(close_active_modal_calls, close_active_calls_before_tab_switch);
+
+    window.location.hash = "#user/202/manage";
+    $window_stub.trigger("hashchange");
+    assert.equal(show_user_profile_calls.length, 2);
+    assert.equal(show_user_profile_calls[1][0], 202);
+    assert.equal(show_user_profile_calls[1][1], "manage-profile-tab");
+    assert.equal(close_active_modal_calls, close_active_calls_before_tab_switch + 1);
 });
 
 run_test("update_hash_to_match_filter", ({override, override_rewire}) => {


### PR DESCRIPTION
Implemented a minimal routing-based fix so user-profile tabs are URL-addressable and browser Back/Forward navigates tabs correctly.

#### Fixes: #38156.

*Note: This PR continues the unfinished work from #38251 to address issue #38156.*

**Differences from previous PR (#38251):**
I decided to start fresh because the previous PR relied heavily on DOM traversal and had unresolved bugs pointed out in the review (specifically, the URL hash not resetting when closing the modal, and brittle back-button behavior). This PR takes a cleaner, minimal routing-based approach to solve those edge cases without over-engineering.

**The Fix:**
- Added support for sub-tabs in `hash_util.ts` validation and URL generation.
- Updated `user_profile.ts` to trigger hash updates on tab change (while preserving the exception for opening from the Settings UI).
- Implemented a targeted guard in `hashchange.ts` to prevent `modals.close_active_if_any()` from firing during same-user tab navigation.

**How changes were tested:**
- Ran automated tests: `./tools/test-js-with-node web/tests/hashchange.test.cjs web/tests/hash_util.test.cjs` (All passed).
- Manually tested navigating between tabs to ensure the URL hash updates properly (`#user/{id}/{tab}`).
- Manually verified that pressing the browser's Back/Forward buttons smoothly switches tabs without closing the modal.
- Manually verified the edge case: Opening a user profile from the Settings UI does *not* trigger the hash update, preserving existing behavior.
- Manually verified that closing the modal completely clears the `#user/...` hash.

**Screenshots and screen captures:**

| Before | After |
| :--- | :--- |
| <img width="1917" alt="Before Profile" src="https://github.com/user-attachments/assets/95025d00-a7b1-46a5-9198-6d29fefe4343" /> | <img width="1913" alt="After Channels" src="https://github.com/user-attachments/assets/73c4edb9-f559-4195-ab85-e95008382ac9" /> |
| <img width="1918" alt="Before Groups" src="https://github.com/user-attachments/assets/6ff6677e-714f-471c-b3f6-2371422b8233" /> | <img width="1917" alt="After Groups" src="https://github.com/user-attachments/assets/cfc0edfe-3955-4182-a484-75002b388a10" /> |

**Videos (Before vs After):**
<table>
  <tr>
    <th>Before (Modal closes on back button)</th>
    <th>After (Back button navigates tabs)</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/606f719a-612c-46ea-8f4c-635547ea96a1" controls="controls" muted="muted" style="max-width:100%;"></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/958ce7b0-dba1-4025-9657-582b2bee8cf5" controls="controls" muted="muted" style="max-width:100%;"></video>
    </td>
  </tr>
</table>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>