### PR TITLE
support OIDC in SOCIAL_AUTH_SYNC_ATTRS_DICT syncing

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -3799,6 +3799,12 @@ class GenericOpenIdConnectBackend(SocialAuthMixin, OpenIdConnectAuth):
 
         super().__init__(*args, **kwargs)
 
+    @override
+    def get_user_details(self, response: dict[str, Any]) -> dict[str, Any]:
+        result = super().get_user_details(response)
+        result["extra_attrs"] = {"groups": response.get("groups", [])}
+        return result
+
     @classmethod
     @override
     def display_icon(cls) -> str | None:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -2139,7 +2139,7 @@ def social_auth_sync_user_attributes(
     # Unlike LDAP or SCIM, this hook can only do syncing during the authentication
     # flow, as that's when the data is provided and we don't have a way to query
     # for it otherwise.
-    if backend.name != "saml":
+    if backend.name not in ["saml", "oidc"]:
         assert not extra_attrs
         return None
 


### PR DESCRIPTION
Fixes: #38731

**How changes were tested:**
- Reviewed the OIDC and social auth sync flow in `zproject/backends.py`.
- Verified that OIDC now populates `details["extra_attrs"]` with `groups`.
- Verified that `social_auth_sync_user_attributes` now allows the `oidc` backend to use the existing sync path.

**Screenshots and screen captures:**
- Not applicable (backend/auth change).
