### PR TITLE
openapi: Fix Anchor schema to allow integer and string values

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -26509,7 +26509,9 @@ components:
         The event's type, relevant both for client-side dispatch and server-side
         filtering by event type in [POST /register](/api/register-queue).
     Anchor:
-      type: string
+    oneOf:
+    - type: integer
+    - type: string
     Attachment:
       type: object
       description: |


### PR DESCRIPTION
Fixes a mismatch in the OpenAPI specification for the `anchor` parameter
in the GET /messages endpoint.

The backend and frontend support both integer message IDs and string
values such as "newest", "oldest", "first_unread", and "date".
However, the OpenAPI schema defined `Anchor` as only a string.

Updated the `Anchor` schema to allow both integer and string values
using `oneOf`, aligning the documentation with the actual behavior.