### PR TITLE
[ai] subscribers: Use CSS flex layout for subscriber list height.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -1,6 +1,5 @@
 import autosize from "autosize";
 import $ from "jquery";
-import assert from "minimalistic-assert";
 
 import * as blueslip from "./blueslip.ts";
 import * as compose_state from "./compose_state.ts";
@@ -156,78 +155,6 @@ export function resize_bottom_whitespace(): void {
     if (compose_state.composing()) {
         reset_compose_message_max_height(bottom_whitespace_height);
     }
-}
-
-export function resize_stream_subscribers_list(): void {
-    // Calculates the height of the subscribers list in stream settings.
-    // This avoids the stream settings from overflowing the container and
-    // having a scroll bar.
-
-    if ($("#channels_overlay_container").find(".two-pane-settings-overlay.show").length === 0) {
-        // Don't run if stream settings overlay is not open.
-        return;
-    }
-
-    if (
-        $("#stream_settings .stream_section[data-stream-section='subscribers']").length === 0 ||
-        $("#stream_settings .stream_section[data-stream-section='subscribers']").css("display") ===
-            "none"
-    ) {
-        // Don't run if subscribers section is not opened.
-        return;
-    }
-
-    const $subscriptions_info = $("#subscription_overlay .two-pane-settings-container .right");
-
-    const $tab_container = $("#stream_settings .stream_settings_header");
-    const $add_subscribers_heading = $(
-        ".subscriber_list_settings_container .add-subscribers-heading",
-    );
-    const $add_subscribers_widget = $(
-        ".subscriber_list_settings_container .subscriber_list_settings",
-    );
-    const $notification_message_container = $(
-        ".subscriber_list_settings_container .send_notification_to_new_subscribers_container",
-    );
-    const $subscribers_list_header = $("#stream_settings .subscribers-list-header");
-    const $small_window_alert_notification_container = $(
-        ".subscription_settings .small-window-alert-notification-container",
-    );
-
-    const elements_above_subscribers_list = [
-        $tab_container,
-        $add_subscribers_heading,
-        $add_subscribers_widget,
-        $notification_message_container,
-        $subscribers_list_header,
-        $small_window_alert_notification_container,
-    ];
-
-    let total_height_of_elements_above_subscribers_list = 0;
-    for (const $elem of elements_above_subscribers_list) {
-        const outer_height = $elem.outerHeight(true);
-        assert(outer_height !== undefined);
-        total_height_of_elements_above_subscribers_list += outer_height;
-    }
-
-    const right_subheader_height = height_of($(".right .two-pane-settings-subheader"));
-    // Margin of 18px is present at both top and bottom, so 2*18px will be
-    // subtracted to calculate maximum allowed height for subscribers list.
-    const subscription_settings_inner_box_margin = 18;
-    const subscriptions_info_height = $subscriptions_info.height();
-    assert(subscriptions_info_height !== undefined);
-
-    // Since .subscribers_list_container has box-sizing set to content-box,
-    // the max-height should not include border width.
-    const susbcribers_list_container_bottom_border_width = 1;
-
-    const subscribers_list_height =
-        subscriptions_info_height -
-        total_height_of_elements_above_subscribers_list -
-        right_subheader_height -
-        2 * subscription_settings_inner_box_margin -
-        susbcribers_list_container_bottom_border_width;
-    $(":root").css("--stream-subscriber-list-max-height", `${subscribers_list_height}px`);
 }
 
 export function resize_stream_creation_subscribers_list(): void {
@@ -428,6 +355,5 @@ export function resize_page_components(): void {
     resize_settings_overlay($("#channels_overlay_container"));
     resize_settings_creation_overlay($("#groups_overlay_container"));
     resize_settings_creation_overlay($("#channels_overlay_container"));
-    resize_stream_subscribers_list();
     resize_stream_creation_subscribers_list();
 }

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -30,7 +30,6 @@ import type {User} from "./people.ts";
 import * as people from "./people.ts";
 import * as popovers from "./popovers.ts";
 import {postprocess_content} from "./postprocess_content.ts";
-import {resize_stream_subscribers_list} from "./resize.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as settings_components from "./settings_components.ts";
 import * as settings_config from "./settings_config.ts";
@@ -548,7 +547,6 @@ export function archive_stream(stream_id: number, $alert_element: JQuery): void 
         error(xhr) {
             ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $alert_element);
             dialog_widget.hide_dialog_spinner();
-            resize_stream_subscribers_list();
         },
     });
 }
@@ -950,7 +948,6 @@ export function initialize(): void {
                         $(".stream_change_property_info"),
                     );
                     dialog_widget.hide_dialog_spinner();
-                    resize_stream_subscribers_list();
                 },
             });
         }

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -20,7 +20,6 @@ import * as loading from "./loading.ts";
 import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
-import * as resize from "./resize.ts";
 import * as scroll_util from "./scroll_util.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
@@ -80,7 +79,6 @@ function show_stream_subscription_request_error_result(error_message: string): v
     scroll_util
         .get_content_element($stream_subscription_req_result_elem)
         .html(rendered_error_banner);
-    resize.resize_stream_subscribers_list();
 }
 
 function show_stream_subscription_request_success_result({
@@ -116,7 +114,6 @@ function show_stream_subscription_request_success_result({
     scroll_util
         .get_content_element($stream_subscription_req_result_elem)
         .html(rendered_success_banner);
-    resize.resize_stream_subscribers_list();
 }
 
 function update_notification_choice_checkbox(added_user_count: number): void {
@@ -157,7 +154,6 @@ export function enable_subscriber_management({
 
     const pill_update_callback = function (): void {
         void stream_edit_update_notification_choice();
-        resize.resize_stream_subscribers_list();
     };
     pill_widget = add_subscribers_pill.create({
         $pill_container,
@@ -171,7 +167,6 @@ export function enable_subscriber_management({
 
     $pill_container.find(".input").on("input", () => {
         $parent_container.find(".stream_subscription_request_result").empty();
-        resize.resize_stream_subscribers_list();
     });
 
     const user_can_remove_subscribers = stream_data.can_unsubscribe_others(sub);
@@ -209,7 +204,6 @@ async function render_subscriber_list_widget(
     });
     loading.destroy_indicator($(".subscriber-list-settings-loading"));
     $(".subscriber_list_settings_container").toggleClass("no-display", false);
-    resize.resize_stream_subscribers_list();
 }
 
 function make_list_widget({

--- a/web/src/stream_edit_toggler.ts
+++ b/web/src/stream_edit_toggler.ts
@@ -4,7 +4,6 @@ import * as browser_history from "./browser_history.ts";
 import * as components from "./components.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
-import * as resize from "./resize.ts";
 import * as sub_store from "./sub_store.ts";
 
 export let toggler: components.Toggle;
@@ -34,11 +33,7 @@ export function setup_toggler(): void {
                 const hash = hash_util.channels_settings_edit_url(sub, select_tab);
                 browser_history.update(hash);
             }
-            if (key === "subscribers") {
-                requestAnimationFrame(() => {
-                    resize.resize_stream_subscribers_list();
-                });
-            }
+            $("#stream_settings").toggleClass("subscribers-tab-active", key === "subscribers");
         },
     });
 }

--- a/web/src/stream_settings_components.ts
+++ b/web/src/stream_settings_components.ts
@@ -229,7 +229,6 @@ export function ajaxSubscribe(
                     $t_html({defaultMessage: "Already subscribed"}),
                     $(".stream_change_property_info"),
                 );
-                resize.resize_stream_subscribers_list();
             }
             // The rest of the work is done via the subscribe event we will get
 
@@ -252,7 +251,6 @@ export function ajaxSubscribe(
                 xhr,
                 $(".stream_change_property_info"),
             );
-            resize.resize_stream_subscribers_list();
         },
     });
 }
@@ -295,7 +293,6 @@ function ajaxUnsubscribe(
                 xhr,
                 $(".stream_change_property_info"),
             );
-            resize.resize_stream_subscribers_list();
         },
     });
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1304,6 +1304,70 @@ h4.user_group_setting_subsection_title {
         }
     }
 
+    #stream_settings.subscribers-tab-active {
+        /* When the subscribers tab is active, disable simplebar on
+           #stream_settings so the panel itself is not scrollable —
+           only the subscriber list table scrolls via its own simplebar.
+           Simplebar reads the host element's computed overflow-y and
+           disables its scrollbar when it sees 'hidden'. */
+        overflow-y: hidden;
+
+        /* Propagate the container height through simplebar's wrapper
+           DOM to the actual content. :has() targets only the outer
+           simplebar-content (the one containing .subscription_settings),
+           not the nested one inside .subscriber_list_container. */
+        .simplebar-content:has(> .subscription_settings) {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+
+            .subscription_settings,
+            .inner-box {
+                flex: 1;
+                overflow: hidden;
+                display: flex;
+                flex-direction: column;
+            }
+
+            .stream_section[data-stream-section="subscribers"] {
+                flex: 1;
+                overflow: hidden;
+
+                .edit_subscribers_for_stream,
+                .subscriber_list_settings_container {
+                    height: 100%;
+                }
+
+                .subscriber_list_settings_container .subscriber-list-box {
+                    /* flex: 1 takes remaining space after the auto-sized siblings. */
+                    flex: 1;
+                    overflow: hidden;
+                    /* Hide borders here since they would extend to the
+                       full flex item height; they are redeclared on
+                       .subscriber_list_container instead. */
+                    border-left: none;
+                    border-right: none;
+
+                    .subscriber_list_container {
+                        box-sizing: border-box;
+                        max-height: 100%;
+                        /* overflow: clip prevents the native scrollbar that would otherwise
+                           appear because the simplebar placeholder can overflow the
+                           container. Unlike overflow: hidden, clip does not disable
+                           simplebar (simplebar only disables on overflow: hidden). */
+                        overflow: clip;
+                        border-left: 1px solid
+                            var(--color-border-table-subscriber-list);
+                        border-right: 1px solid
+                            var(--color-border-table-subscriber-list);
+                        border-top-left-radius: 4px;
+                        border-top-right-radius: 4px;
+                    }
+                }
+            }
+        }
+    }
+
     #personal-stream-settings {
         .stream_change_property_status {
             margin: 9px auto 3px 3px;


### PR DESCRIPTION
Replace the JS-based `resize_stream_subscribers_list` function with a pure CSS solution. The old approach required calling the resize function from many places whenever any element above the subscriber table changed height, which was fragile and buggy.

When the subscribers tab is active, a `subscribers-tab-active` class is toggled on `#stream_settings`. This sets `overflow-y: hidden` to disable simplebar on the outer panel, then uses a flex layout chain to distribute the available height so only the subscriber list table scrolls via its own simplebar.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-04-03 21-41-44.webm](https://github.com/user-attachments/assets/4180cb35-69ae-458d-b649-6b6901b349f5)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
