### PR TITLE
[ai] left-sidebar: Add keyboard navigation for vdot menus and buddy list section headers. 

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -46,6 +46,7 @@ EXEMPT_FILES = make_set(
     [
         "web/src/about_zulip.ts",
         "web/src/abstract_gif_network.ts",
+        "web/src/activity_ui.ts",
         "web/src/add_group_members_pill.ts",
         "web/src/add_stream_options_popover.ts",
         "web/src/add_subscribers_pill.ts",
@@ -254,6 +255,7 @@ EXEMPT_FILES = make_set(
         "web/src/settings_user_topics.ts",
         "web/src/settings_users.ts",
         "web/src/setup.ts",
+        "web/src/sidebar_tooltip_helpers.ts",
         "web/src/sidebar_ui.ts",
         "web/src/spectators.ts",
         "web/src/spoilers.ts",

--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -268,6 +268,142 @@ function keydown_enter_key(): void {
     popovers.hide_all();
 }
 
+function focus_user_row($row: JQuery): void {
+    util.the($row.find("a.user-presence-link")).focus({preventScroll: true});
+}
+
+// Helpers that find the nearest visible user row relative to a section header
+// or link. "Visible" means not inside a collapsed section.
+
+function first_user_in_or_after($section: JQuery): JQuery {
+    if (!$section.hasClass("collapsed")) {
+        const $entry = $section.find("li.user_sidebar_entry").first();
+        if ($entry.length > 0) {
+            return $entry;
+        }
+    }
+    return first_user_after($section);
+}
+function first_user_after($section: JQuery): JQuery {
+    return $section.nextAll(":not(.collapsed)").find("li.user_sidebar_entry").first();
+}
+function last_user_before($section: JQuery): JQuery {
+    return $section.prevAll(":not(.collapsed)").find("li.user_sidebar_entry").last();
+}
+function last_user_in_or_before($section: JQuery): JQuery {
+    if (!$section.hasClass("collapsed")) {
+        const $entry = $section.find("li.user_sidebar_entry").last();
+        if ($entry.length > 0) {
+            return $entry;
+        }
+    }
+    return last_user_before($section);
+}
+function last_user_in_buddy_list(): JQuery {
+    return $(
+        "#buddy_list_wrapper .buddy-list-section-container:not(.collapsed) li.user_sidebar_entry",
+    ).last();
+}
+
+// Given the currently-focused element and arrow-key direction, return the user
+// row we should land on. Returns undefined to do nothing (e.g., ArrowDown from
+// the last element in the buddy list).
+function resolve_arrow_target($active: JQuery, direction: "up" | "down"): JQuery | undefined {
+    const $active_user_row = $active.closest("li.user_sidebar_entry");
+    if ($active_user_row.length > 0) {
+        // Focus is inside a user row (e.g., the user's name link or the vdot
+        // menu icon). Return that row; the caller syncs the cursor to it and
+        // then steps prev/next, because the cursor already knows which rows
+        // are visible — DOM traversal would have to replicate that logic.
+        return $active_user_row;
+    }
+
+    const $section = $active.closest(".buddy-list-section-container");
+    if ($active.closest(".buddy-list-subsection-header").length > 0) {
+        // Focus is on a section header (the toggle triangle or the heading).
+        // ArrowDown lands on the first user in this section if it's expanded,
+        // or the first user in the next expanded section. ArrowUp lands on
+        // the last user in the previous expanded section.
+        return direction === "down" ? first_user_in_or_after($section) : last_user_before($section);
+    }
+    if ($active.closest(".view-all-subscribers-link").length > 0) {
+        // Focus is on the "View all subscribers" link, which sits below the
+        // users in the "users matching view" section. ArrowDown crosses into
+        // the next section's first user; ArrowUp goes back to the last user
+        // of the current section.
+        return direction === "down" ? first_user_after($section) : last_user_in_or_before($section);
+    }
+    if (
+        $active.closest(".view-all-users-link").length > 0 ||
+        $active.closest(".invite-user-shortcut").length > 0
+    ) {
+        // Focus is on one of the two links at the very bottom of the buddy
+        // list ("View all users" or "Invite to organization"). ArrowDown has
+        // nowhere to go; ArrowUp lands on the last visible user row.
+        return direction === "down" ? undefined : last_user_in_buddy_list();
+    }
+    // We've installed this handler on #buddy_list_wrapper, so every focusable
+    // descendant should be covered by a branch above. Log and bail if not.
+    blueslip.error("Unexpected focused element in buddy list", {
+        element: $active[0]?.nodeName,
+        class: $active[0]?.className,
+    });
+    return undefined;
+}
+
+// Handle arrow key navigation when a buddy list element has Tab focus,
+// so that Tab and arrow key navigation stay in sync. Three steps:
+//   (a) resolve which user row we should land on,
+//   (b) sync the cursor to it,
+//   (c) move DOM focus to it.
+function handle_buddy_list_arrow_navigation(e: JQuery.KeyDownEvent): void {
+    // This handler is registered inside set_cursor_and_filter, which creates
+    // user_cursor, so it's always defined by the time we get here.
+    assert(user_cursor !== undefined);
+
+    if (e.key === "Tab") {
+        // Tab is handled by the browser, but we clear the cursor highlight
+        // so it doesn't remain painted on the arrow-navigated row after
+        // focus moves elsewhere.
+        user_cursor.clear();
+        return;
+    }
+    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
+        return;
+    }
+    if (e.altKey || e.ctrlKey || e.shiftKey || !(document.activeElement instanceof HTMLElement)) {
+        return;
+    }
+
+    const direction = e.key === "ArrowDown" ? "down" : "up";
+    const $active = $(document.activeElement);
+    const $landing_row = resolve_arrow_target($active, direction);
+    if ($landing_row === undefined || $landing_row.length === 0) {
+        return;
+    }
+
+    user_cursor.set_is_highlight_visible(true);
+    user_cursor.go_to(buddy_list.get_user_id_from_li({$li: $landing_row}));
+
+    // If focus was inside a user row, we landed on *that* user; step the
+    // cursor one further in the arrow direction.
+    let $focus_row = $landing_row;
+    if ($active.closest("li.user_sidebar_entry").length > 0) {
+        if (direction === "down") {
+            user_cursor.next();
+        } else {
+            user_cursor.prev();
+        }
+        const new_user_id = user_cursor.get_key();
+        assert(new_user_id !== undefined);
+        $focus_row = buddy_list.find_li({key: new_user_id, force_render: true})!;
+    }
+
+    focus_user_row($focus_row);
+    e.preventDefault();
+    e.stopPropagation();
+}
+
 export let set_cursor_and_filter = (): void => {
     user_cursor = new ListCursor({
         list: buddy_list,
@@ -306,8 +442,21 @@ export let set_cursor_and_filter = (): void => {
                 user_cursor!.next();
                 return true;
             },
+            Tab() {
+                // If the user navigated to a row with arrow keys, Tab should focus that
+                // row instead of the next element in DOM order.
+                assert(user_cursor !== undefined);
+                const cursor_key = user_cursor.get_key();
+                if (cursor_key !== undefined && user_cursor.is_highlight_visible) {
+                    focus_user_row(buddy_list.find_li({key: cursor_key, force_render: true})!);
+                }
+                user_cursor.clear();
+                return false;
+            },
         },
     });
+
+    $("#buddy_list_wrapper").on("keydown", handle_buddy_list_arrow_navigation);
 };
 
 export function rewire_set_cursor_and_filter(value: typeof set_cursor_and_filter): void {

--- a/web/src/add_stream_options_popover.ts
+++ b/web/src/add_stream_options_popover.ts
@@ -9,54 +9,61 @@ import * as settings_data from "./settings_data.ts";
 import {parse_html} from "./ui_util.ts";
 
 export function initialize(): void {
-    popover_menus.register_popover_menu("#add_streams_button", {
-        theme: "popover-menu",
-        onShow(instance) {
-            const can_create_streams =
-                settings_data.user_can_create_private_streams() ||
-                settings_data.user_can_create_public_streams() ||
-                settings_data.user_can_create_web_public_streams();
+    popover_menus.register_popover_menu(
+        "#add_streams_button",
+        {
+            theme: "popover-menu",
+            onMount(instance) {
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                const can_create_streams =
+                    settings_data.user_can_create_private_streams() ||
+                    settings_data.user_can_create_public_streams() ||
+                    settings_data.user_can_create_web_public_streams();
 
-            if (!can_create_streams) {
-                // If the user can't create streams, we directly
-                // navigate them to the Stream settings subscribe UI.
-                window.location.assign("#channels/all");
-                // Returning false from an onShow handler cancels the show.
-                return false;
-            }
+                if (!can_create_streams) {
+                    // If the user can't create streams, we directly
+                    // navigate them to the Stream settings subscribe UI.
+                    window.location.assign("#channels/all");
+                    // Returning false from an onShow handler cancels the show.
+                    return false;
+                }
 
-            // Assuming that the instance can be shown, track and
-            // prep the instance for showing
-            popover_menus.popover_instances.stream_settings = instance;
-            instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
-            popover_menus.on_show_prep(instance);
+                // Assuming that the instance can be shown, track and
+                // prep the instance for showing
+                popover_menus.popover_instances.stream_settings = instance;
+                instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
+                popover_menus.on_show_prep(instance);
 
-            //  When showing the popover menu, we want the
-            // "Add channels" and the "Filter channels" tooltip
-            //  to appear below the "Add channels" icon.
-            const streams_inline_icon: tippy.ReferenceElement | undefined =
-                $("#streams_inline_icon").get(0);
-            assert(streams_inline_icon !== undefined);
-            streams_inline_icon._tippy?.setProps({
-                placement: "bottom",
-            });
+                //  When showing the popover menu, we want the
+                // "Add channels" and the "Filter channels" tooltip
+                //  to appear below the "Add channels" icon.
+                const streams_inline_icon: tippy.ReferenceElement | undefined =
+                    $("#streams_inline_icon").get(0);
+                assert(streams_inline_icon !== undefined);
+                streams_inline_icon._tippy?.setProps({
+                    placement: "bottom",
+                });
 
-            return undefined;
+                return undefined;
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.stream_settings = null;
+
+                //  After the popover menu is closed, we want the
+                //  "Add channels" and the "Filter channels" tooltip
+                //  to appear at it's original position that is
+                //  above the "Add channels" icon.
+                const streams_inline_icon: tippy.ReferenceElement | undefined =
+                    $("#streams_inline_icon").get(0);
+                assert(streams_inline_icon !== undefined);
+                streams_inline_icon._tippy?.setProps({
+                    placement: "top",
+                });
+            },
         },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.stream_settings = null;
-
-            //  After the popover menu is closed, we want the
-            //  "Add channels" and the "Filter channels" tooltip
-            //  to appear at it's original position that is
-            //  above the "Add channels" icon.
-            const streams_inline_icon: tippy.ReferenceElement | undefined =
-                $("#streams_inline_icon").get(0);
-            assert(streams_inline_icon !== undefined);
-            streams_inline_icon._tippy?.setProps({
-                placement: "top",
-            });
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 }

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -24,10 +24,11 @@ import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as settings_config from "./settings_config.ts";
+import {disconnect_toggle_class, observe_toggle_class} from "./sidebar_tooltip_helpers.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
-import {INTERACTIVE_HOVER_DELAY} from "./tippyjs.ts";
+import {EXTRA_LONG_HOVER_DELAY, INTERACTIVE_HOVER_DELAY} from "./tippyjs.ts";
 import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
@@ -301,6 +302,26 @@ export class BuddyList extends BuddyListConf {
                 });
             },
         );
+
+        tippy.delegate("body", {
+            target: ".section-toggle-tooltip-target",
+            onShow(instance) {
+                const $toggle = $(instance.reference);
+                observe_toggle_class(instance, () => {
+                    if ($toggle.hasClass("rotate-icon-down")) {
+                        instance.setContent($t({defaultMessage: "Collapse section"}));
+                    } else {
+                        instance.setContent($t({defaultMessage: "Expand section"}));
+                    }
+                });
+            },
+            delay: EXTRA_LONG_HOVER_DELAY,
+            appendTo: () => document.body,
+            onHidden(instance) {
+                disconnect_toggle_class(instance);
+                instance.destroy();
+            },
+        });
     }
 
     async non_participant_users_matching_view_count(): Promise<number | null> {

--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -7,6 +7,7 @@ import render_left_sidebar_menu_popover from "../templates/popovers/left_sidebar
 
 import * as channel from "./channel.ts";
 import * as channel_folders_ui from "./channel_folders_ui.ts";
+import * as keydown_util from "./keydown_util.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -111,63 +112,67 @@ function collapse_all_sections(instance: tippy.Instance): void {
 }
 
 export function initialize(): void {
-    popover_menus.register_popover_menu("#left-sidebar-search .channel-folders-sidebar-menu-icon", {
-        ...popover_menus.left_sidebar_tippy_options,
-        theme: "popover-menu",
-        onMount(instance) {
-            const $popper = $(instance.popper);
-            assert(instance.reference instanceof HTMLElement);
-            $popper.one("click", "#left_sidebar_channel_folders", () => {
-                do_change_show_channel_folders_left_sidebar(instance);
-            });
-            $popper.one("click", "#left_sidebar_expand_all", () => {
-                expand_all_sections(instance);
-            });
-            $popper.one("click", "#left_sidebar_collapse_all", () => {
-                collapse_all_sections(instance);
-            });
+    popover_menus.register_popover_menu(
+        "#left-sidebar-search .channel-folders-sidebar-menu-icon",
+        {
+            ...popover_menus.left_sidebar_tippy_options,
+            theme: "popover-menu",
+            onMount(instance) {
+                const $popper = $(instance.popper);
+                assert(instance.reference instanceof HTMLElement);
+                $popper.one("click", "#left_sidebar_channel_folders", () => {
+                    do_change_show_channel_folders_left_sidebar(instance);
+                });
+                $popper.one("click", "#left_sidebar_expand_all", () => {
+                    expand_all_sections(instance);
+                });
+                $popper.one("click", "#left_sidebar_collapse_all", () => {
+                    collapse_all_sections(instance);
+                });
+                $popper.one("click", ".web_stream_unreads_count_display_policy_selector", (e) => {
+                    const value = Number($(e.currentTarget).attr("value"));
+                    do_change_web_stream_unreads_count_display_policy(instance, value);
+                });
 
-            $popper.one("click", ".web_stream_unreads_count_display_policy_selector", (e) => {
-                const value = Number($(e.currentTarget).attr("value"));
-                do_change_web_stream_unreads_count_display_policy(instance, value);
-            });
+                $popper.one("click", ".web_channel_default_view_selector", (e) => {
+                    const value = Number($(e.currentTarget).attr("value"));
+                    do_change_web_channel_default_view(instance, value);
+                });
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                const show_channel_folders = user_settings.web_left_sidebar_show_channel_folders;
+                const show_collapse_expand_all_options = true;
+                // Assuming that the instance can be shown, track and
+                // prep the instance for showing
+                popover_menus.popover_instances.show_folders_sidebar = instance;
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_left_sidebar_menu_popover({
+                            show_channel_folders,
+                            channel_folders_id: "left_sidebar_channel_folders",
+                            show_collapse_expand_all_options,
+                            web_stream_unreads_count_display_policy_values:
+                                settings_config.web_stream_unreads_count_display_policy_values,
+                            web_stream_unreads_count_display_policy:
+                                user_settings.web_stream_unreads_count_display_policy,
+                            web_channel_default_view_values:
+                                settings_config.web_channel_default_view_values,
+                            web_channel_default_view: user_settings.web_channel_default_view,
+                        }),
+                    ),
+                );
+                popover_menus.on_show_prep(instance);
 
-            $popper.one("click", ".web_channel_default_view_selector", (e) => {
-                const value = Number($(e.currentTarget).attr("value"));
-                do_change_web_channel_default_view(instance, value);
-            });
+                return undefined;
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.show_folders_sidebar = null;
+            },
         },
-        onShow(instance) {
-            const show_channel_folders = user_settings.web_left_sidebar_show_channel_folders;
-            const show_collapse_expand_all_options = true;
-            // Assuming that the instance can be shown, track and
-            // prep the instance for showing
-            popover_menus.popover_instances.show_folders_sidebar = instance;
-            instance.setContent(
-                ui_util.parse_html(
-                    render_left_sidebar_menu_popover({
-                        show_channel_folders,
-                        channel_folders_id: "left_sidebar_channel_folders",
-                        show_collapse_expand_all_options,
-                        web_stream_unreads_count_display_policy_values:
-                            settings_config.web_stream_unreads_count_display_policy_values,
-                        web_stream_unreads_count_display_policy:
-                            user_settings.web_stream_unreads_count_display_policy,
-                        web_channel_default_view_values:
-                            settings_config.web_channel_default_view_values,
-                        web_channel_default_view: user_settings.web_channel_default_view,
-                    }),
-                ),
-            );
-            popover_menus.on_show_prep(instance);
-
-            return undefined;
-        },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.show_folders_sidebar = null;
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
     popover_menus.register_popover_menu("#inbox-view .channel-folders-inbox-menu-icon", {
         ...popover_menus.left_sidebar_tippy_options,
@@ -204,54 +209,72 @@ export function initialize(): void {
         },
     });
 
+    function on_folder_sidebar_menu_icon_press(
+        element: HTMLElement,
+        e: JQuery.ClickEvent | JQuery.KeyDownEvent,
+    ): void {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const folder_id = Number.parseInt(
+            $(element).closest(".stream-list-section-container").attr("data-section-id")!,
+            10,
+        );
+        popover_menus.toggle_popover_menu(element, {
+            ...popover_menus.left_sidebar_tippy_options,
+            theme: "popover-menu",
+            onMount(instance) {
+                popover_menus.popover_instances.folder_actions = instance;
+                const $popper = $(instance.popper);
+                assert(instance.reference instanceof HTMLElement);
+                ui_util.show_left_sidebar_menu_icon(instance.reference);
+                $popper.one("click", "#folder_popover_view_channels", () => {
+                    let section = "all";
+                    if (current_user.is_guest) {
+                        section = "subscribed";
+                    }
+                    stream_settings_ui.launch(section, undefined, undefined, folder_id);
+                });
+                $popper.one("click", "#folder_popover_manage_folder", () => {
+                    channel_folders_ui.handle_editing_channel_folder(folder_id);
+                });
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_left_sidebar_folder_popover({
+                            can_manage_folder: settings_data.can_user_manage_folder(),
+                        }),
+                    ),
+                );
+                popover_menus.on_show_prep(instance);
+
+                return undefined;
+            },
+            onHidden(instance) {
+                ui_util.hide_left_sidebar_menu_icon();
+                instance.destroy();
+                popover_menus.popover_instances.folder_actions = null;
+            },
+        });
+    }
+
     $("#streams_list").on(
         "click",
         ".stream-list-section-container .folder-section-sidebar-menu-icon",
         function (this: HTMLElement, e) {
-            e.preventDefault();
-            e.stopPropagation();
+            on_folder_sidebar_menu_icon_press(this, e);
+        },
+    );
 
-            const folder_id = Number.parseInt(
-                $(this).closest(".stream-list-section-container").attr("data-section-id")!,
-                10,
-            );
-            popover_menus.toggle_popover_menu(this, {
-                ...popover_menus.left_sidebar_tippy_options,
-                theme: "popover-menu",
-                onMount(instance) {
-                    popover_menus.popover_instances.folder_actions = instance;
-                    const $popper = $(instance.popper);
-                    assert(instance.reference instanceof HTMLElement);
-                    ui_util.show_left_sidebar_menu_icon(instance.reference);
-                    $popper.one("click", "#folder_popover_view_channels", () => {
-                        let section = "all";
-                        if (current_user.is_guest) {
-                            section = "subscribed";
-                        }
-                        stream_settings_ui.launch(section, undefined, undefined, folder_id);
-                    });
-                    $popper.one("click", "#folder_popover_manage_folder", () => {
-                        channel_folders_ui.handle_editing_channel_folder(folder_id);
-                    });
-                },
-                onShow(instance) {
-                    instance.setContent(
-                        ui_util.parse_html(
-                            render_left_sidebar_folder_popover({
-                                can_manage_folder: settings_data.can_user_manage_folder(),
-                            }),
-                        ),
-                    );
-                    popover_menus.on_show_prep(instance);
-
-                    return undefined;
-                },
-                onHidden(instance) {
-                    ui_util.hide_left_sidebar_menu_icon();
-                    instance.destroy();
-                    popover_menus.popover_instances.folder_actions = null;
-                },
-            });
+    $("#streams_list").on(
+        "keydown",
+        ".stream-list-section-container .folder-section-sidebar-menu-icon",
+        function (this: HTMLElement, e) {
+            if (keydown_util.is_enter_event(e)) {
+                on_folder_sidebar_menu_icon_press(this, e);
+            }
         },
     );
 }

--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -18,6 +18,7 @@ import * as stream_list from "./stream_list.ts";
 import * as stream_settings_ui from "./stream_settings_ui.ts";
 import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
+import * as util from "./util.ts";
 
 function do_change_show_channel_folders_left_sidebar(instance: tippy.Instance): void {
     const show_channel_folders = user_settings.web_left_sidebar_show_channel_folders;
@@ -171,7 +172,11 @@ export function initialize(): void {
                 popover_menus.popover_instances.show_folders_sidebar = null;
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).siblings(".stream-list-section-toggle")),
+        },
     );
 
     popover_menus.register_popover_menu("#inbox-view .channel-folders-inbox-menu-icon", {
@@ -220,44 +225,51 @@ export function initialize(): void {
             $(element).closest(".stream-list-section-container").attr("data-section-id")!,
             10,
         );
-        popover_menus.toggle_popover_menu(element, {
-            ...popover_menus.left_sidebar_tippy_options,
-            theme: "popover-menu",
-            onMount(instance) {
-                popover_menus.popover_instances.folder_actions = instance;
-                const $popper = $(instance.popper);
-                assert(instance.reference instanceof HTMLElement);
-                ui_util.show_left_sidebar_menu_icon(instance.reference);
-                $popper.one("click", "#folder_popover_view_channels", () => {
-                    let section = "all";
-                    if (current_user.is_guest) {
-                        section = "subscribed";
-                    }
-                    stream_settings_ui.launch(section, undefined, undefined, folder_id);
-                });
-                $popper.one("click", "#folder_popover_manage_folder", () => {
-                    channel_folders_ui.handle_editing_channel_folder(folder_id);
-                });
-                popover_menus.focus_popover(instance);
-            },
-            onShow(instance) {
-                instance.setContent(
-                    ui_util.parse_html(
-                        render_left_sidebar_folder_popover({
-                            can_manage_folder: settings_data.can_user_manage_folder(),
-                        }),
-                    ),
-                );
-                popover_menus.on_show_prep(instance);
+        popover_menus.toggle_popover_menu(
+            element,
+            {
+                ...popover_menus.left_sidebar_tippy_options,
+                theme: "popover-menu",
+                onMount(instance) {
+                    popover_menus.popover_instances.folder_actions = instance;
+                    const $popper = $(instance.popper);
+                    assert(instance.reference instanceof HTMLElement);
+                    ui_util.show_left_sidebar_menu_icon(instance.reference);
+                    $popper.one("click", "#folder_popover_view_channels", () => {
+                        let section = "all";
+                        if (current_user.is_guest) {
+                            section = "subscribed";
+                        }
+                        stream_settings_ui.launch(section, undefined, undefined, folder_id);
+                    });
+                    $popper.one("click", "#folder_popover_manage_folder", () => {
+                        channel_folders_ui.handle_editing_channel_folder(folder_id);
+                    });
+                    popover_menus.focus_popover(instance);
+                },
+                onShow(instance) {
+                    instance.setContent(
+                        ui_util.parse_html(
+                            render_left_sidebar_folder_popover({
+                                can_manage_folder: settings_data.can_user_manage_folder(),
+                            }),
+                        ),
+                    );
+                    popover_menus.on_show_prep(instance);
 
-                return undefined;
+                    return undefined;
+                },
+                onHidden(instance) {
+                    ui_util.hide_left_sidebar_menu_icon();
+                    instance.destroy();
+                    popover_menus.popover_instances.folder_actions = null;
+                },
             },
-            onHidden(instance) {
-                ui_util.hide_left_sidebar_menu_icon();
-                instance.destroy();
-                popover_menus.popover_instances.folder_actions = null;
+            {
+                get_focus_return_element: (reference) =>
+                    util.the($(reference).siblings(".stream-list-section-toggle")),
             },
-        });
+        );
     }
 
     $("#streams_list").on(

--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -219,6 +219,7 @@ export function initialize(): void {
                 ...popover_menus.left_sidebar_tippy_options,
                 theme: "popover-menu",
                 onMount(instance) {
+                    popover_menus.popover_instances.folder_actions = instance;
                     const $popper = $(instance.popper);
                     assert(instance.reference instanceof HTMLElement);
                     ui_util.show_left_sidebar_menu_icon(instance.reference);
@@ -248,6 +249,7 @@ export function initialize(): void {
                 onHidden(instance) {
                     ui_util.hide_left_sidebar_menu_icon();
                     instance.destroy();
+                    popover_menus.popover_instances.folder_actions = null;
                 },
             });
         },

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -21,6 +21,7 @@ import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
 import * as unread_ops from "./unread_ops.ts";
 import {user_settings} from "./user_settings.ts";
+import * as util from "./util.ts";
 
 function common_click_handlers(): void {
     $("body").on("click", ".set-home-view", (e) => {
@@ -118,7 +119,11 @@ export function initialize(): void {
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).siblings(".left-sidebar-navigation-label-container")),
+        },
     );
 
     // Drafts popover
@@ -155,7 +160,11 @@ export function initialize(): void {
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).siblings(".left-sidebar-navigation-label-container")),
+        },
     );
 
     // Inbox popover
@@ -207,7 +216,11 @@ export function initialize(): void {
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).siblings(".left-sidebar-navigation-label-container")),
+        },
     );
 
     // Combined feed popover
@@ -259,7 +272,11 @@ export function initialize(): void {
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).siblings(".left-sidebar-navigation-label-container")),
+        },
     );
 
     // Recent view popover
@@ -310,7 +327,11 @@ export function initialize(): void {
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).siblings(".left-sidebar-navigation-label-container")),
+        },
     );
 
     popover_menus.register_popover_menu(
@@ -361,7 +382,11 @@ export function initialize(): void {
                 popover_menus.popover_instances.top_left_sidebar = null;
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).siblings(".left-sidebar-navigation-label-container")),
+        },
     );
 
     common_click_handlers();

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -72,266 +72,297 @@ function register_toggle_unread_message_count(
 
 export function initialize(): void {
     // Starred messages popover
-    popover_menus.register_popover_menu(".starred-messages-sidebar-menu-icon", {
-        ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
-            const $popper = $(instance.popper);
-            popover_menus.popover_instances.starred_messages = instance;
-            assert(instance.reference instanceof HTMLElement);
-            ui_util.show_left_sidebar_menu_icon(instance.reference);
+    popover_menus.register_popover_menu(
+        ".starred-messages-sidebar-menu-icon",
+        {
+            ...popover_menus.left_sidebar_tippy_options,
+            onMount(instance) {
+                const $popper = $(instance.popper);
+                popover_menus.popover_instances.starred_messages = instance;
+                assert(instance.reference instanceof HTMLElement);
+                ui_util.show_left_sidebar_menu_icon(instance.reference);
 
-            $popper.one("click", "#unstar_all_messages", () => {
-                starred_messages_ui.confirm_unstar_all_messages();
-                popover_menus.hide_current_popover_if_visible(instance);
-            });
-            $popper.one("click", "#toggle_display_starred_msg_count", () => {
-                const starred_msg_counts = user_settings.starred_message_counts;
-                const data = {
-                    starred_message_counts: JSON.stringify(!starred_msg_counts),
-                };
-                void channel.patch({
-                    url: "/json/settings",
-                    data,
+                $popper.one("click", "#unstar_all_messages", () => {
+                    starred_messages_ui.confirm_unstar_all_messages();
+                    popover_menus.hide_current_popover_if_visible(instance);
                 });
-                popover_menus.hide_current_popover_if_visible(instance);
-            });
-        },
-        onShow(instance) {
-            popovers.hide_all();
-            const show_unstar_all_button = starred_messages.get_count() > 0;
+                $popper.one("click", "#toggle_display_starred_msg_count", () => {
+                    const starred_msg_counts = user_settings.starred_message_counts;
+                    const data = {
+                        starred_message_counts: JSON.stringify(!starred_msg_counts),
+                    };
+                    void channel.patch({
+                        url: "/json/settings",
+                        data,
+                    });
+                    popover_menus.hide_current_popover_if_visible(instance);
+                });
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                popovers.hide_all();
+                const show_unstar_all_button = starred_messages.get_count() > 0;
 
-            instance.setContent(
-                ui_util.parse_html(
-                    render_left_sidebar_starred_messages_popover({
-                        show_unstar_all_button,
-                        starred_message_counts: user_settings.starred_message_counts,
-                    }),
-                ),
-            );
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_left_sidebar_starred_messages_popover({
+                            show_unstar_all_button,
+                            starred_message_counts: user_settings.starred_message_counts,
+                        }),
+                    ),
+                );
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.starred_messages = null;
+                ui_util.hide_left_sidebar_menu_icon();
+            },
         },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.starred_messages = null;
-            ui_util.hide_left_sidebar_menu_icon();
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
     // Drafts popover
-    popover_menus.register_popover_menu(".drafts-sidebar-menu-icon", {
-        ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
-            const $popper = $(instance.popper);
-            $popper.addClass("drafts-popover");
-            popover_menus.popover_instances.drafts = instance;
-            assert(instance.reference instanceof HTMLElement);
-            ui_util.show_left_sidebar_menu_icon(instance.reference);
+    popover_menus.register_popover_menu(
+        ".drafts-sidebar-menu-icon",
+        {
+            ...popover_menus.left_sidebar_tippy_options,
+            onMount(instance) {
+                const $popper = $(instance.popper);
+                $popper.addClass("drafts-popover");
+                popover_menus.popover_instances.drafts = instance;
+                assert(instance.reference instanceof HTMLElement);
+                ui_util.show_left_sidebar_menu_icon(instance.reference);
 
-            $popper.one("click", "#delete_all_drafts_sidebar", () => {
-                drafts.confirm_delete_all_drafts();
-                popover_menus.hide_current_popover_if_visible(instance);
-            });
-        },
-        onShow(instance) {
-            popovers.hide_all();
+                $popper.one("click", "#delete_all_drafts_sidebar", () => {
+                    drafts.confirm_delete_all_drafts();
+                    popover_menus.hide_current_popover_if_visible(instance);
+                });
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                popovers.hide_all();
 
-            if (drafts.draft_model.getDraftCount() === 0) {
-                return false;
-            }
+                if (drafts.draft_model.getDraftCount() === 0) {
+                    return false;
+                }
 
-            instance.setContent(ui_util.parse_html(render_left_sidebar_drafts_popover({})));
-            return undefined;
+                instance.setContent(ui_util.parse_html(render_left_sidebar_drafts_popover({})));
+                return undefined;
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.drafts = null;
+                ui_util.hide_left_sidebar_menu_icon();
+            },
         },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.drafts = null;
-            ui_util.hide_left_sidebar_menu_icon();
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
     // Inbox popover
-    popover_menus.register_popover_menu(".inbox-sidebar-menu-icon", {
-        ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
-            const $popper = $(instance.popper);
-            popover_menus.popover_instances.left_sidebar_inbox_popover = instance;
-            assert(instance.reference instanceof HTMLElement);
-            ui_util.show_left_sidebar_menu_icon(instance.reference);
+    popover_menus.register_popover_menu(
+        ".inbox-sidebar-menu-icon",
+        {
+            ...popover_menus.left_sidebar_tippy_options,
+            onMount(instance) {
+                const $popper = $(instance.popper);
+                popover_menus.popover_instances.left_sidebar_inbox_popover = instance;
+                assert(instance.reference instanceof HTMLElement);
+                ui_util.show_left_sidebar_menu_icon(instance.reference);
 
-            $popper.one(
-                "click",
-                ".mark_all_messages_as_read",
-                {instance},
-                register_mark_all_read_handler,
-            );
+                $popper.one(
+                    "click",
+                    ".mark_all_messages_as_read",
+                    {instance},
+                    register_mark_all_read_handler,
+                );
 
-            $popper.one(
-                "click",
-                ".toggle_display_unread_message_count",
-                {instance},
-                register_toggle_unread_message_count,
-            );
+                $popper.one(
+                    "click",
+                    ".toggle_display_unread_message_count",
+                    {instance},
+                    register_toggle_unread_message_count,
+                );
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                popovers.hide_all();
+                const view_code = settings_config.web_home_view_values.inbox.code;
+                const counts = unread.get_counts();
+                const unread_messages_present =
+                    counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_left_sidebar_inbox_popover({
+                            is_home_view: user_settings.web_home_view === view_code,
+                            view_code,
+                            show_unread_count: user_settings.web_left_sidebar_unreads_count_summary,
+                            unread_messages_present,
+                        }),
+                    ),
+                );
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.left_sidebar_inbox_popover = null;
+                ui_util.hide_left_sidebar_menu_icon();
+            },
         },
-        onShow(instance) {
-            popovers.hide_all();
-            const view_code = settings_config.web_home_view_values.inbox.code;
-            const counts = unread.get_counts();
-            const unread_messages_present =
-                counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;
-            instance.setContent(
-                ui_util.parse_html(
-                    render_left_sidebar_inbox_popover({
-                        is_home_view: user_settings.web_home_view === view_code,
-                        view_code,
-                        show_unread_count: user_settings.web_left_sidebar_unreads_count_summary,
-                        unread_messages_present,
-                    }),
-                ),
-            );
-        },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.left_sidebar_inbox_popover = null;
-            ui_util.hide_left_sidebar_menu_icon();
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
     // Combined feed popover
-    popover_menus.register_popover_menu(".all-messages-sidebar-menu-icon", {
-        ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
-            const $popper = $(instance.popper);
-            $popper.one(
-                "click",
-                ".mark_all_messages_as_read",
-                {instance},
-                register_mark_all_read_handler,
-            );
+    popover_menus.register_popover_menu(
+        ".all-messages-sidebar-menu-icon",
+        {
+            ...popover_menus.left_sidebar_tippy_options,
+            onMount(instance) {
+                const $popper = $(instance.popper);
+                $popper.one(
+                    "click",
+                    ".mark_all_messages_as_read",
+                    {instance},
+                    register_mark_all_read_handler,
+                );
 
-            $popper.one(
-                "click",
-                ".toggle_display_unread_message_count",
-                {instance},
-                register_toggle_unread_message_count,
-            );
-        },
-        onShow(instance) {
-            popover_menus.popover_instances.left_sidebar_all_messages_popover = instance;
-            assert(instance.reference instanceof HTMLElement);
-            ui_util.show_left_sidebar_menu_icon(instance.reference);
-            popovers.hide_all();
-            const view_code = settings_config.web_home_view_values.all_messages.code;
-            const counts = unread.get_counts();
-            const unread_messages_present =
-                counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;
+                $popper.one(
+                    "click",
+                    ".toggle_display_unread_message_count",
+                    {instance},
+                    register_toggle_unread_message_count,
+                );
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                popover_menus.popover_instances.left_sidebar_all_messages_popover = instance;
+                assert(instance.reference instanceof HTMLElement);
+                ui_util.show_left_sidebar_menu_icon(instance.reference);
+                popovers.hide_all();
+                const view_code = settings_config.web_home_view_values.all_messages.code;
+                const counts = unread.get_counts();
+                const unread_messages_present =
+                    counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;
 
-            instance.setContent(
-                ui_util.parse_html(
-                    render_left_sidebar_all_messages_popover({
-                        is_home_view: user_settings.web_home_view === view_code,
-                        view_code,
-                        show_unread_count: user_settings.web_left_sidebar_unreads_count_summary,
-                        unread_messages_present,
-                    }),
-                ),
-            );
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_left_sidebar_all_messages_popover({
+                            is_home_view: user_settings.web_home_view === view_code,
+                            view_code,
+                            show_unread_count: user_settings.web_left_sidebar_unreads_count_summary,
+                            unread_messages_present,
+                        }),
+                    ),
+                );
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.left_sidebar_all_messages_popover = null;
+                ui_util.hide_left_sidebar_menu_icon();
+            },
         },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.left_sidebar_all_messages_popover = null;
-            ui_util.hide_left_sidebar_menu_icon();
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
     // Recent view popover
-    popover_menus.register_popover_menu(".recent-view-sidebar-menu-icon", {
-        ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
-            const $popper = $(instance.popper);
-            $popper.one(
-                "click",
-                ".mark_all_messages_as_read",
-                {instance},
-                register_mark_all_read_handler,
-            );
+    popover_menus.register_popover_menu(
+        ".recent-view-sidebar-menu-icon",
+        {
+            ...popover_menus.left_sidebar_tippy_options,
+            onMount(instance) {
+                const $popper = $(instance.popper);
+                $popper.one(
+                    "click",
+                    ".mark_all_messages_as_read",
+                    {instance},
+                    register_mark_all_read_handler,
+                );
 
-            $popper.one(
-                "click",
-                ".toggle_display_unread_message_count",
-                {instance},
-                register_toggle_unread_message_count,
-            );
+                $popper.one(
+                    "click",
+                    ".toggle_display_unread_message_count",
+                    {instance},
+                    register_toggle_unread_message_count,
+                );
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                popover_menus.popover_instances.left_sidebar_recent_view_popover = instance;
+                assert(instance.reference instanceof HTMLElement);
+                ui_util.show_left_sidebar_menu_icon(instance.reference);
+                popovers.hide_all();
+                const view_code = settings_config.web_home_view_values.recent.code;
+                const counts = unread.get_counts();
+                const unread_messages_present =
+                    counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_left_sidebar_recent_view_popover({
+                            is_home_view: user_settings.web_home_view === view_code,
+                            view_code,
+                            show_unread_count: user_settings.web_left_sidebar_unreads_count_summary,
+                            unread_messages_present,
+                        }),
+                    ),
+                );
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.left_sidebar_recent_view_popover = null;
+                ui_util.hide_left_sidebar_menu_icon();
+            },
         },
-        onShow(instance) {
-            popover_menus.popover_instances.left_sidebar_recent_view_popover = instance;
-            assert(instance.reference instanceof HTMLElement);
-            ui_util.show_left_sidebar_menu_icon(instance.reference);
-            popovers.hide_all();
-            const view_code = settings_config.web_home_view_values.recent.code;
-            const counts = unread.get_counts();
-            const unread_messages_present =
-                counts.home_unread_messages + counts.muted_topic_unread_messages_count > 0;
-            instance.setContent(
-                ui_util.parse_html(
-                    render_left_sidebar_recent_view_popover({
-                        is_home_view: user_settings.web_home_view === view_code,
-                        view_code,
-                        show_unread_count: user_settings.web_left_sidebar_unreads_count_summary,
-                        unread_messages_present,
-                    }),
-                ),
-            );
-        },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.left_sidebar_recent_view_popover = null;
-            ui_util.hide_left_sidebar_menu_icon();
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
-    popover_menus.register_popover_menu(".left-sidebar-navigation-menu-icon", {
-        ...popover_menus.left_sidebar_tippy_options,
-        onMount(instance) {
-            const $popper = $(instance.popper);
+    popover_menus.register_popover_menu(
+        ".left-sidebar-navigation-menu-icon",
+        {
+            ...popover_menus.left_sidebar_tippy_options,
+            onMount(instance) {
+                const $popper = $(instance.popper);
 
-            $popper.one(
-                "click",
-                ".mark_all_messages_as_read",
-                {instance},
-                register_mark_all_read_handler,
-            );
+                $popper.one(
+                    "click",
+                    ".mark_all_messages_as_read",
+                    {instance},
+                    register_mark_all_read_handler,
+                );
 
-            $popper.one(
-                "click",
-                ".toggle_display_unread_message_count",
-                {instance},
-                register_toggle_unread_message_count,
-            );
-        },
-        onShow(instance) {
-            const built_in_popover_condensed_views =
-                left_sidebar_navigation_area.get_built_in_popover_condensed_views();
-            const unread_count = unread.get_counts();
-            const unread_messages_present = unread_count.home_unread_messages > 0;
-            const show_unread_count = user_settings.web_left_sidebar_unreads_count_summary;
-            const is_home_view_active = window.location.hash === "#" + user_settings.web_home_view;
+                $popper.one(
+                    "click",
+                    ".toggle_display_unread_message_count",
+                    {instance},
+                    register_toggle_unread_message_count,
+                );
+                popover_menus.focus_popover(instance);
+            },
+            onShow(instance) {
+                const built_in_popover_condensed_views =
+                    left_sidebar_navigation_area.get_built_in_popover_condensed_views();
+                const unread_count = unread.get_counts();
+                const unread_messages_present = unread_count.home_unread_messages > 0;
+                const show_unread_count = user_settings.web_left_sidebar_unreads_count_summary;
+                const is_home_view_active =
+                    window.location.hash === "#" + user_settings.web_home_view;
 
-            popovers.hide_all();
-            instance.setContent(
-                ui_util.parse_html(
-                    render_left_sidebar_views_popover({
-                        views: built_in_popover_condensed_views,
-                        is_home_view_active,
-                        unread_messages_present,
-                        show_unread_count,
-                    }),
-                ),
-            );
+                popovers.hide_all();
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_left_sidebar_views_popover({
+                            views: built_in_popover_condensed_views,
+                            is_home_view_active,
+                            unread_messages_present,
+                            show_unread_count,
+                        }),
+                    ),
+                );
+            },
+            onHidden(instance) {
+                instance.destroy();
+                popover_menus.popover_instances.top_left_sidebar = null;
+            },
         },
-        onHidden(instance) {
-            instance.destroy();
-            popover_menus.popover_instances.top_left_sidebar = null;
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
     common_click_handlers();
 }

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -6,6 +6,7 @@ import * as drafts from "./drafts.ts";
 import {$t} from "./i18n.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import * as settings_data from "./settings_data.ts";
+import {disconnect_toggle_class, observe_toggle_class} from "./sidebar_tooltip_helpers.ts";
 import * as starred_messages from "./starred_messages.ts";
 import {
     EXTRA_LONG_HOVER_DELAY,
@@ -15,24 +16,6 @@ import {
 } from "./tippyjs.ts";
 import * as unread from "./unread.ts";
 import {user_settings} from "./user_settings.ts";
-
-// Watches the reference element's class for changes while a tooltip is
-// visible, so the content stays accurate when the element is toggled via
-// keyboard (or any other path) without hiding the tooltip first.
-const class_observers = new WeakMap<tippy.Instance, MutationObserver>();
-function observe_toggle_class(instance: tippy.Instance, update: () => void): void {
-    update();
-    const observer = new MutationObserver(update);
-    observer.observe(instance.reference, {
-        attributes: true,
-        attributeFilter: ["class"],
-    });
-    class_observers.set(instance, observer);
-}
-function disconnect_toggle_class(instance: tippy.Instance): void {
-    class_observers.get(instance)?.disconnect();
-    class_observers.delete(instance);
-}
 
 export function initialize(): void {
     tippy.delegate("body", {
@@ -228,28 +211,6 @@ export function initialize(): void {
                     instance.setContent($t({defaultMessage: "Collapse folder"}));
                 } else {
                     instance.setContent($t({defaultMessage: "Expand folder"}));
-                }
-            });
-        },
-        delay: EXTRA_LONG_HOVER_DELAY,
-        appendTo: () => document.body,
-        onHidden(instance) {
-            disconnect_toggle_class(instance);
-            instance.destroy();
-        },
-    });
-
-    // This is actually for the right sidebar, but putting it here because it has
-    // shared logic.
-    tippy.delegate("body", {
-        target: ".section-toggle-tooltip-target",
-        onShow(instance) {
-            const $toggle = $(instance.reference);
-            observe_toggle_class(instance, () => {
-                if ($toggle.hasClass("rotate-icon-down")) {
-                    instance.setContent($t({defaultMessage: "Collapse section"}));
-                } else {
-                    instance.setContent($t({defaultMessage: "Expand section"}));
                 }
             });
         },

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -37,6 +37,7 @@ type PopoverName =
     | "color_picker_popover"
     | "show_folders_sidebar"
     | "show_folders_inbox"
+    | "folder_actions"
     | "send_later_options";
 
 export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
@@ -62,6 +63,7 @@ export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
     color_picker_popover: null,
     show_folders_sidebar: null,
     show_folders_inbox: null,
+    folder_actions: null,
     send_later_options: null,
 };
 

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -436,16 +436,22 @@ function get_props_for_popover_centering(
     };
 }
 
+// Returns the element to focus when a keyboard-opened popover closes,
+// given the popover's reference element. Return undefined to fall back
+// to focusing the reference itself.
+export type GetFocusReturnElement = (reference: HTMLElement) => HTMLElement | undefined;
+
 // Toggles a popover menu directly; intended for use in keyboard
 // shortcuts and similar alternative ways to open a popover menu.
 export function toggle_popover_menu(
     target: tippy.ReferenceElement,
     popover_props: Partial<tippy.Props>,
     options?: {
-        show_as_overlay_on_mobile: boolean;
-        show_as_overlay_always: boolean;
+        show_as_overlay_on_mobile?: boolean;
+        show_as_overlay_always?: boolean;
         // Only works for elements which are in message feed.
         message_feed_overlay_detection?: boolean;
+        get_focus_return_element?: GetFocusReturnElement;
     },
 ): tippy.Instance {
     const instance = target._tippy;
@@ -498,12 +504,41 @@ export function toggle_popover_menu(
         ];
     }
 
-    return tippy.default(target, {
+    const props = {
         ...default_popover_props,
         showOnCreate: true,
         ...popover_props,
         ...mobile_popover_props,
-    });
+    };
+
+    // If the popover was opened via keyboard, restore focus to
+    // the appropriate element when the popover closes (e.g., on Escape).
+    // We check the active element rather than the target, since for some
+    // popovers (e.g., buddy list) the reference element is a parent
+    // container rather than the focused icon itself.
+    const opened_via_keyboard = document.activeElement?.matches(":focus-visible") === true;
+    if (opened_via_keyboard) {
+        const on_hidden = props.onHidden;
+        props.onHidden = (instance: tippy.Instance) => {
+            if (on_hidden) {
+                on_hidden.call(props, instance);
+            }
+            // Only restore focus if nothing else has claimed it. When a menu
+            // item opens a modal or otherwise moves focus itself, we shouldn't
+            // stomp over that — and focusing a tooltipped reference here
+            // would cause its tooltip to pop open unexpectedly.
+            if (document.activeElement !== document.body) {
+                return;
+            }
+            if (instance.reference instanceof HTMLElement) {
+                const focus_target =
+                    options?.get_focus_return_element?.(instance.reference) ?? instance.reference;
+                focus_target.focus();
+            }
+        };
+    }
+
+    return tippy.default(target, props);
 }
 
 export type RegisterOptions = {
@@ -511,6 +546,7 @@ export type RegisterOptions = {
     // pressed. Use this for targets that are reachable via keyboard
     // navigation.
     also_trigger_on_enter?: boolean;
+    get_focus_return_element?: GetFocusReturnElement;
 };
 
 // Main function to define a popover menu, opened via clicking on the
@@ -535,7 +571,7 @@ export function register_popover_menu(
     $("body").on("click", target, function (this: HTMLElement, e) {
         e.preventDefault();
         e.stopPropagation();
-        toggle_popover(this, popover_props);
+        toggle_popover(this, popover_props, options);
     });
 
     if (options.also_trigger_on_enter) {
@@ -543,14 +579,18 @@ export function register_popover_menu(
             if (keydown_util.is_enter_event(e)) {
                 e.preventDefault();
                 e.stopPropagation();
-                toggle_popover(this, popover_props);
+                toggle_popover(this, popover_props, options);
             }
         });
     }
 }
 
-function toggle_popover(element: HTMLElement, popover_props: Partial<tippy.Props>): void {
-    const instance = toggle_popover_menu(element, popover_props);
+function toggle_popover(
+    element: HTMLElement,
+    popover_props: Partial<tippy.Props>,
+    options: RegisterOptions,
+): void {
+    const instance = toggle_popover_menu(element, popover_props, options);
     // Hide popovers when user clicks on an element which navigates user to a link.
     // We don't explicitly handle these clicks per element and let browser handle them but in doing so,
     // we are not able to hide the popover which we would do otherwise.

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -7,6 +7,7 @@ import assert from "minimalistic-assert";
 import * as tippy from "tippy.js";
 
 import * as blueslip from "./blueslip.ts";
+import * as keydown_util from "./keydown_util.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as modals from "./modals.ts";
 import * as overlays from "./overlays.ts";
@@ -505,9 +506,20 @@ export function toggle_popover_menu(
     });
 }
 
+export type RegisterOptions = {
+    // Also open the popover when the target is focused and Enter is
+    // pressed. Use this for targets that are reachable via keyboard
+    // navigation.
+    also_trigger_on_enter?: boolean;
+};
+
 // Main function to define a popover menu, opened via clicking on the
 // target selector.
-export function register_popover_menu(target: string, popover_props: Partial<tippy.Props>): void {
+export function register_popover_menu(
+    target: string,
+    popover_props: Partial<tippy.Props>,
+    options: RegisterOptions = {},
+): void {
     // For some elements, such as the click target to open the message
     // actions menu, we want to avoid propagating the click event to
     // parent elements. Tippy's built-in `delegate` method does not
@@ -523,15 +535,28 @@ export function register_popover_menu(target: string, popover_props: Partial<tip
     $("body").on("click", target, function (this: HTMLElement, e) {
         e.preventDefault();
         e.stopPropagation();
+        toggle_popover(this, popover_props);
+    });
 
-        // Hide popovers when user clicks on an element which navigates user to a link.
-        // We don't explicitly handle these clicks per element and let browser handle them but in doing so,
-        // we are not able to hide the popover which we would do otherwise.
-        const instance = toggle_popover_menu(this, popover_props);
-        const $popper = $(instance.popper);
-        $popper.on("click", "a[href]", () => {
-            hide_current_popover_if_visible(instance);
+    if (options.also_trigger_on_enter) {
+        $("body").on("keydown", target, function (this: HTMLElement, e) {
+            if (keydown_util.is_enter_event(e)) {
+                e.preventDefault();
+                e.stopPropagation();
+                toggle_popover(this, popover_props);
+            }
         });
+    }
+}
+
+function toggle_popover(element: HTMLElement, popover_props: Partial<tippy.Props>): void {
+    const instance = toggle_popover_menu(element, popover_props);
+    // Hide popovers when user clicks on an element which navigates user to a link.
+    // We don't explicitly handle these clicks per element and let browser handle them but in doing so,
+    // we are not able to hide the popover which we would do otherwise.
+    const $popper = $(instance.popper);
+    $popper.on("click", "a[href]", () => {
+        hide_current_popover_if_visible(instance);
     });
 }
 

--- a/web/src/sidebar_tooltip_helpers.ts
+++ b/web/src/sidebar_tooltip_helpers.ts
@@ -1,0 +1,19 @@
+import type * as tippy from "tippy.js";
+
+// Watches the reference element's class for changes while a tooltip is
+// visible, so the content stays accurate when the element is toggled via
+// keyboard (or any other path) without hiding the tooltip first.
+const class_observers = new WeakMap<tippy.Instance, MutationObserver>();
+export function observe_toggle_class(instance: tippy.Instance, update: () => void): void {
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(instance.reference, {
+        attributes: true,
+        attributeFilter: ["class"],
+    });
+    class_observers.set(instance, observer);
+}
+export function disconnect_toggle_class(instance: tippy.Instance): void {
+    class_observers.get(instance)?.disconnect();
+    class_observers.delete(instance);
+}

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -443,33 +443,37 @@ export function initialize_right_sidebar(): void {
         }
     }
 
-    popover_menus.register_popover_menu("#buddy-list-menu-icon", {
-        theme: "popover-menu",
-        placement: "right",
-        onCreate(instance) {
-            popover_menus.popover_instances.buddy_list = instance;
-            instance.setContent(
-                ui_util.parse_html(
-                    render_buddy_list_popover({
-                        display_style_options: settings_config.user_list_style_values,
-                        can_invite_users:
-                            settings_data.user_can_invite_users_by_email() ||
-                            settings_data.user_can_create_multiuse_invite(),
-                    }),
-                ),
-            );
+    popover_menus.register_popover_menu(
+        "#buddy-list-menu-icon",
+        {
+            theme: "popover-menu",
+            placement: "right",
+            onCreate(instance) {
+                popover_menus.popover_instances.buddy_list = instance;
+                instance.setContent(
+                    ui_util.parse_html(
+                        render_buddy_list_popover({
+                            display_style_options: settings_config.user_list_style_values,
+                            can_invite_users:
+                                settings_data.user_can_invite_users_by_email() ||
+                                settings_data.user_can_create_multiuse_invite(),
+                        }),
+                    ),
+                );
+            },
+            onMount() {
+                const current_user_list_style =
+                    settings_preferences.user_settings_panel.settings_object.user_list_style;
+                $("#buddy-list-actions-menu-popover")
+                    .find(`.user_list_style_choice[value=${current_user_list_style}]`)
+                    .prop("checked", true);
+            },
+            onHidden() {
+                close_buddy_list_popover();
+            },
         },
-        onMount() {
-            const current_user_list_style =
-                settings_preferences.user_settings_panel.settings_object.user_list_style;
-            $("#buddy-list-actions-menu-popover")
-                .find(`.user_list_style_choice[value=${current_user_list_style}]`)
-                .prop("checked", true);
-        },
-        onHidden() {
-            close_buddy_list_popover();
-        },
-    });
+        {also_trigger_on_enter: true},
+    );
 
     $("body").on(
         "click",

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -1,10 +1,12 @@
 import $ from "jquery";
 import _ from "lodash";
+import assert from "minimalistic-assert";
 
 import render_left_sidebar from "../templates/left_sidebar.hbs";
 import render_buddy_list_popover from "../templates/popovers/buddy_list_popover.hbs";
 import render_right_sidebar from "../templates/right_sidebar.hbs";
 
+import * as blueslip from "./blueslip.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as channel from "./channel.ts";
 import * as compose_ui from "./compose_ui.ts";
@@ -668,6 +670,111 @@ const update_left_sidebar_for_search = _.throttle(() => {
     }
 }, 50);
 
+function focus_left_sidebar_row($row: JQuery): void {
+    // For header rows, focus the section toggle icon.
+    if ($row.hasClass("left-sidebar-section-header")) {
+        util.the($row.find(".sidebar-heading-icon")).focus({preventScroll: true});
+        return;
+    }
+    // For focusable rows, either they have an <a> tag that gets
+    // focus, or a tabindex="0" label directly on them. Determine
+    // which case we're in and focus the appropriate element.
+    const $link = $row.find("a");
+    if ($link.length > 0) {
+        util.the($link).focus({preventScroll: true});
+    } else if (util.the($row).tabIndex === 0) {
+        util.the($row).focus({preventScroll: true});
+    } else {
+        blueslip.error("Left sidebar row has no focusable child", {
+            class: util.the($row).className,
+        });
+    }
+}
+
+// Given the currently-focused element and arrow-key direction, return the row
+// we should land on, or undefined to do nothing. The returned row is where we
+// sync the cursor; if focus was already in a navigable row, we sync to it and
+// then step one further in `direction`.
+function resolve_left_sidebar_arrow_target(
+    $active: JQuery,
+    direction: "up" | "down",
+): JQuery | undefined {
+    const $row = $active.closest(".top_left_row, .bottom_left_row, .left-sidebar-section-header");
+    if ($row.length > 0) {
+        // Focus is inside a navigable row (a VIEWS entry, a channel/topic/DM
+        // row, or a section header). Return that row; the caller syncs the
+        // cursor to it and then steps prev/next, since the cursor already
+        // knows which rows are visible.
+        return $row;
+    }
+    if ($active.closest("#subscribe-to-more-streams").length > 0 && direction === "up") {
+        // Focus is on the "Browse channels" / "Create a channel" link, which
+        // sits below all channel rows. ArrowDown has nowhere to go; ArrowUp
+        // lands on the last visible row.
+        return all_rows().last();
+    }
+    // Focus isn't on anything we navigate between (e.g. an inline action
+    // button inside a row that we don't special-case). Do nothing.
+    return undefined;
+}
+
+// Handle arrow key navigation when a left sidebar element has Tab focus,
+// so that Tab and arrow key navigation stay in sync. Three steps:
+//   (a) resolve which row we should land on,
+//   (b) sync the cursor to it,
+//   (c) move DOM focus to it.
+function handle_left_sidebar_arrow_navigation(e: JQuery.KeyDownEvent): void {
+    if (e.key === "Tab") {
+        // Tab is handled by the browser, but we clear the cursor highlight
+        // so it doesn't remain painted on the arrow-navigated row after
+        // focus moves elsewhere.
+        left_sidebar_cursor.clear();
+        return;
+    }
+    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
+        return;
+    }
+    if (e.altKey || e.ctrlKey || e.shiftKey || !(document.activeElement instanceof HTMLElement)) {
+        return;
+    }
+
+    // Search inputs have their own arrow key handlers.
+    const $active = $(document.activeElement);
+    if (
+        $active.is(".left-sidebar-search-input, .direct-messages-list-filter, #topic_filter_query")
+    ) {
+        return;
+    }
+
+    const direction = e.key === "ArrowDown" ? "down" : "up";
+    const $landing_row = resolve_left_sidebar_arrow_target($active, direction);
+    if ($landing_row === undefined || $landing_row.length === 0) {
+        return;
+    }
+
+    left_sidebar_cursor.set_is_highlight_visible(true);
+    left_sidebar_cursor.go_to($landing_row);
+
+    // If focus was already inside a navigable row, we landed on *that* row;
+    // step the cursor one further in the arrow direction.
+    if (
+        $active.closest(".top_left_row, .bottom_left_row, .left-sidebar-section-header").length > 0
+    ) {
+        if (direction === "down") {
+            left_sidebar_cursor.next();
+        } else {
+            left_sidebar_cursor.prev();
+        }
+    }
+
+    const $new_row = left_sidebar_cursor.get_key();
+    assert($new_row !== undefined);
+    focus_left_sidebar_row($new_row);
+
+    e.preventDefault();
+    e.stopPropagation();
+}
+
 function focus_left_sidebar_filter(e: JQuery.ClickEvent): void {
     left_sidebar_cursor.reset();
     e.stopPropagation();
@@ -737,6 +844,16 @@ export function set_event_handlers(): void {
                 left_sidebar_cursor.next();
                 return true;
             },
+            Tab() {
+                // If the user navigated to a row with arrow keys, Tab should focus
+                // that row instead of the next element in DOM order.
+                const $row = left_sidebar_cursor.get_key();
+                if ($row !== undefined && left_sidebar_cursor.is_highlight_visible) {
+                    focus_left_sidebar_row($row);
+                }
+                left_sidebar_cursor.clear();
+                return false;
+            },
         },
     });
 
@@ -745,6 +862,10 @@ export function set_event_handlers(): void {
         left_sidebar_cursor.clear();
     });
     $search_input.on("input", update_left_sidebar_for_search);
+
+    // Handle arrow key navigation when a sidebar element has Tab
+    // focus, so that Tab and arrow key navigation stay in sync.
+    $("#left-sidebar").on("keydown", handle_left_sidebar_arrow_navigation);
 }
 
 export function initiate_search(): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1316,7 +1316,7 @@ export function initialize({
     initialize_tippy_tooltips();
     set_event_handlers({show_channel_feed});
 
-    $("#stream_filters").on("click", ".show-more-topics", (e) => {
+    function on_show_more_topics(e: JQuery.ClickEvent | JQuery.KeyDownEvent): void {
         zoom_in();
         // We define the focus behavior for the topic list search box
         // outside of the `zoom_in` method, since we want the focus
@@ -1327,6 +1327,16 @@ export function initialize({
 
         e.preventDefault();
         e.stopPropagation();
+    }
+
+    $("#stream_filters").on("click", ".show-more-topics", (e) => {
+        on_show_more_topics(e);
+    });
+
+    $("#stream_filters").on("keydown", ".show-more-topics", (e) => {
+        if (keydown_util.is_enter_event(e)) {
+            on_show_more_topics(e);
+        }
     });
 
     $("body").on("click", ".zoom-in-topics .left-sidebar-modal-close-area", (e) => {
@@ -1525,7 +1535,10 @@ export function set_event_handlers({
         on_sidebar_channel_click(stream_id, e, show_channel_feed);
     });
 
-    function on_click_new_topic(element: HTMLElement, e: JQuery.ClickEvent): void {
+    function on_new_topic_press(
+        element: HTMLElement,
+        e: JQuery.ClickEvent | JQuery.KeyDownEvent,
+    ): void {
         e.stopPropagation();
         e.preventDefault();
         const stream_id = Number.parseInt(element.getAttribute("data-stream-id")!, 10);
@@ -1547,14 +1560,34 @@ export function set_event_handlers({
     }
 
     $("#stream_filters").on("click", ".channel-new-topic-button", function (this: HTMLElement, e) {
-        on_click_new_topic(this, e);
+        on_new_topic_press(this, e);
     });
+
+    $("#stream_filters").on(
+        "keydown",
+        ".channel-new-topic-button",
+        function (this: HTMLElement, e) {
+            if (keydown_util.is_enter_event(e)) {
+                on_new_topic_press(this, e);
+            }
+        },
+    );
 
     $("#left-sidebar-modal").on(
         "click",
         "#more-topics-modal .channel-new-topic-button, #more-topics-modal .zoomed-new-topic",
         function (this: HTMLElement, e) {
-            on_click_new_topic(this, e);
+            on_new_topic_press(this, e);
+        },
+    );
+
+    $("#left-sidebar-modal").on(
+        "keydown",
+        "#more-topics-modal .channel-new-topic-button, #more-topics-modal .zoomed-new-topic",
+        function (this: HTMLElement, e) {
+            if (keydown_util.is_enter_event(e)) {
+                on_new_topic_press(this, e);
+            }
         },
     );
 
@@ -1630,6 +1663,19 @@ export function set_event_handlers({
         function (this: HTMLElement, e: JQuery.ClickEvent) {
             e.stopPropagation();
             toggle_inactive_or_muted_channels($(this).closest(".stream-list-section-container"));
+        },
+    );
+
+    $("#streams_list").on(
+        "keydown",
+        ".stream-list-toggle-inactive-or-muted-channels",
+        function (this: HTMLElement, e: JQuery.KeyDownEvent) {
+            if (keydown_util.is_enter_event(e)) {
+                e.stopPropagation();
+                toggle_inactive_or_muted_channels(
+                    $(this).closest(".stream-list-section-container"),
+                );
+            }
         },
     );
 }

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -21,6 +21,7 @@ import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
+import * as keydown_util from "./keydown_util.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
@@ -1223,7 +1224,10 @@ export async function build_move_topic_to_stream_popover(
 }
 
 export function initialize(): void {
-    function on_sidebar_menu_icon_click(element: HTMLElement, e: JQuery.ClickEvent): void {
+    function on_sidebar_menu_icon_press(
+        element: HTMLElement,
+        e: JQuery.ClickEvent | JQuery.KeyDownEvent,
+    ): void {
         e.preventDefault();
         const $stream_li = $(element).parents("li");
         const stream_id = elem_to_stream_id($stream_li);
@@ -1236,14 +1240,34 @@ export function initialize(): void {
         e.stopPropagation();
     }
     $("#stream_filters").on("click", ".stream-sidebar-menu-icon", function (this: HTMLElement, e) {
-        on_sidebar_menu_icon_click(this, e);
+        on_sidebar_menu_icon_press(this, e);
     });
+
+    $("#stream_filters").on(
+        "keydown",
+        ".stream-sidebar-menu-icon",
+        function (this: HTMLElement, e) {
+            if (keydown_util.is_enter_event(e)) {
+                on_sidebar_menu_icon_press(this, e);
+            }
+        },
+    );
 
     $("#left-sidebar-modal").on(
         "click",
         "#more-topics-modal .stream-sidebar-menu-icon",
         function (this: HTMLElement, e) {
-            on_sidebar_menu_icon_click(this, e);
+            on_sidebar_menu_icon_press(this, e);
+        },
+    );
+
+    $("#left-sidebar-modal").on(
+        "keydown",
+        "#more-topics-modal .stream-sidebar-menu-icon",
+        function (this: HTMLElement, e) {
+            if (keydown_util.is_enter_event(e)) {
+                on_sidebar_menu_icon_press(this, e);
+            }
         },
     );
 

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -145,97 +145,104 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
         show_go_to_list_of_topics,
     });
 
-    popover_menus.toggle_popover_menu(elt, {
-        // Add a delay to separate `hideOnClick` and `onShow` so that
-        // `onShow` is called after `hideOnClick`.
-        // See https://github.com/atomiks/tippyjs/issues/230 for more details.
-        delay: [100, 0],
-        ...left_sidebar_tippy_options,
-        onCreate(instance) {
-            const $popover = $(instance.popper);
-            $popover.addClass("stream-popover-root");
-            instance.setContent(ui_util.parse_html(content));
-        },
-        onMount(instance) {
-            popover_menus.focus_popover(instance);
-            const $popper = $(instance.popper);
-            popover_menus.popover_instances.stream_actions_popover = instance;
-            ui_util.show_left_sidebar_menu_icon(elt);
+    popover_menus.toggle_popover_menu(
+        elt,
+        {
+            // Add a delay to separate `hideOnClick` and `onShow` so that
+            // `onShow` is called after `hideOnClick`.
+            // See https://github.com/atomiks/tippyjs/issues/230 for more details.
+            delay: [100, 0],
+            ...left_sidebar_tippy_options,
+            onCreate(instance) {
+                const $popover = $(instance.popper);
+                $popover.addClass("stream-popover-root");
+                instance.setContent(ui_util.parse_html(content));
+            },
+            onMount(instance) {
+                popover_menus.focus_popover(instance);
+                const $popper = $(instance.popper);
+                popover_menus.popover_instances.stream_actions_popover = instance;
+                ui_util.show_left_sidebar_menu_icon(elt);
 
-            // Go to channel feed instead of first topic.
-            $popper.on("click", ".stream-popover-go-to-channel-feed", (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                const sub = stream_popover_sub(e);
-                hide_stream_popover(instance);
-                message_view.show(
-                    [
-                        {
-                            operator: "channel",
-                            operand: sub.stream_id.toString(),
-                        },
-                    ],
-                    {trigger: "stream-popover"},
-                );
-            });
-
-            $popper.on("click", ".stream-popover-go-to-list-of-topics", (e) => {
-                e.stopPropagation();
-                hide_stream_popover(instance);
-            });
-
-            // Pin/unpin
-            $popper.on("click", ".pin_to_top", (e) => {
-                const sub = stream_popover_sub(e);
-                hide_stream_popover(instance);
-                stream_settings_ui.toggle_pin_to_top_stream(sub);
-                e.stopPropagation();
-            });
-
-            // Mark all messages in stream as read
-            $popper.on("click", ".mark_stream_as_read", (e) => {
-                const sub = stream_popover_sub(e);
-                hide_stream_popover(instance);
-                unread_ops.mark_stream_as_read(sub.stream_id);
-                e.stopPropagation();
-            });
-
-            // Mark all messages in stream as unread
-            $popper.on("click", ".mark_stream_as_unread", (e) => {
-                const sub = stream_popover_sub(e);
-                hide_stream_popover(instance);
-                unread_ops.mark_stream_as_unread(sub.stream_id);
-                e.stopPropagation();
-            });
-
-            // Mute/unmute
-            $popper.on("click", ".toggle_stream_muted", (e) => {
-                const sub = stream_popover_sub(e);
-                hide_stream_popover(instance);
-                stream_settings_api.set_stream_property(sub, {
-                    property: "is_muted",
-                    value: !sub.is_muted,
+                // Go to channel feed instead of first topic.
+                $popper.on("click", ".stream-popover-go-to-channel-feed", (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const sub = stream_popover_sub(e);
+                    hide_stream_popover(instance);
+                    message_view.show(
+                        [
+                            {
+                                operator: "channel",
+                                operand: sub.stream_id.toString(),
+                            },
+                        ],
+                        {trigger: "stream-popover"},
+                    );
                 });
-                e.stopPropagation();
-            });
 
-            // Unsubscribe
-            $popper.on("click", ".popover_sub_unsub_button", (e) => {
-                const sub = stream_popover_sub(e);
+                $popper.on("click", ".stream-popover-go-to-list-of-topics", (e) => {
+                    e.stopPropagation();
+                    hide_stream_popover(instance);
+                });
+
+                // Pin/unpin
+                $popper.on("click", ".pin_to_top", (e) => {
+                    const sub = stream_popover_sub(e);
+                    hide_stream_popover(instance);
+                    stream_settings_ui.toggle_pin_to_top_stream(sub);
+                    e.stopPropagation();
+                });
+
+                // Mark all messages in stream as read
+                $popper.on("click", ".mark_stream_as_read", (e) => {
+                    const sub = stream_popover_sub(e);
+                    hide_stream_popover(instance);
+                    unread_ops.mark_stream_as_read(sub.stream_id);
+                    e.stopPropagation();
+                });
+
+                // Mark all messages in stream as unread
+                $popper.on("click", ".mark_stream_as_unread", (e) => {
+                    const sub = stream_popover_sub(e);
+                    hide_stream_popover(instance);
+                    unread_ops.mark_stream_as_unread(sub.stream_id);
+                    e.stopPropagation();
+                });
+
+                // Mute/unmute
+                $popper.on("click", ".toggle_stream_muted", (e) => {
+                    const sub = stream_popover_sub(e);
+                    hide_stream_popover(instance);
+                    stream_settings_api.set_stream_property(sub, {
+                        property: "is_muted",
+                        value: !sub.is_muted,
+                    });
+                    e.stopPropagation();
+                });
+
+                // Unsubscribe
+                $popper.on("click", ".popover_sub_unsub_button", (e) => {
+                    const sub = stream_popover_sub(e);
+                    hide_stream_popover(instance);
+                    stream_settings_components.sub_or_unsub(sub);
+                    e.preventDefault();
+                    e.stopPropagation();
+                });
+
+                $popper.on("click", ".copy_stream_link", function (this: HTMLElement) {
+                    void clipboard_handler.popover_copy_link_to_clipboard(instance, $(this));
+                });
+            },
+            onHidden(instance) {
                 hide_stream_popover(instance);
-                stream_settings_components.sub_or_unsub(sub);
-                e.preventDefault();
-                e.stopPropagation();
-            });
-
-            $popper.on("click", ".copy_stream_link", function (this: HTMLElement) {
-                void clipboard_handler.popover_copy_link_to_clipboard(instance, $(this));
-            });
+            },
         },
-        onHidden(instance) {
-            hide_stream_popover(instance);
+        {
+            get_focus_return_element: (reference) =>
+                util.the($(reference).closest(".selectable_sidebar_block")),
         },
-    });
+    );
 }
 
 async function get_message_placement_from_server(

--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -270,6 +270,10 @@ export function initialize(): void {
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
-        {also_trigger_on_enter: true},
+        {
+            also_trigger_on_enter: true,
+            get_focus_return_element: (reference) =>
+                util.the($(reference).closest(".topic-box, .selectable_sidebar_block")),
+        },
     );
 }

--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -270,5 +270,6 @@ export function initialize(): void {
                 ui_util.hide_left_sidebar_menu_icon();
             },
         },
+        {also_trigger_on_enter: true},
     );
 }

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -23,6 +23,7 @@ import * as dialog_widget from "./dialog_widget.ts";
 import {is_overlay_hash} from "./hash_parser.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
+import * as keydown_util from "./keydown_util.ts";
 import * as message_lists from "./message_lists.ts";
 import {user_can_send_direct_message} from "./message_util.ts";
 import * as message_view from "./message_view.ts";
@@ -479,6 +480,8 @@ function show_user_card_popover(
                 load_medium_avatar(user, $popover.find(".popover-menu-user-avatar"));
                 init_email_clipboard();
                 init_email_tooltip(user);
+                // Focus the first menu action, skipping avatar/status links above it.
+                $popover.find(".link-item .popover-menu-link").first().trigger("focus");
             },
         },
         {
@@ -933,6 +936,15 @@ function register_click_handlers(): void {
         const $target = $(e.currentTarget).closest("li");
 
         toggle_sidebar_user_card_popover($target);
+    });
+
+    $(".buddy-list-section").on("keydown", ".user-list-sidebar-menu-icon", (e) => {
+        if (keydown_util.is_enter_event(e)) {
+            e.stopPropagation();
+            const $target = $(e.currentTarget).closest(".user_sidebar_entry");
+
+            toggle_sidebar_user_card_popover($target);
+        }
     });
 
     $(".buddy-list-section").on("click", ".user-profile-picture", (e) => {

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -487,6 +487,8 @@ function show_user_card_popover(
         {
             show_as_overlay_on_mobile: true,
             show_as_overlay_always: show_as_overlay,
+            get_focus_return_element: (reference) =>
+                the($(reference).closest(".user_sidebar_entry").find(".user-presence-link")),
         },
     );
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -68,6 +68,11 @@
         cursor: pointer;
     }
 
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
+        outline-offset: -2px;
+    }
+
     .add_stream_icon {
         /* We display as flex to center the icon while
            keeping the entire highlighted area clickable. */
@@ -430,6 +435,11 @@
             color: var(--color-vdots-hover);
             background-color: var(--color-background-sidebar-action-hover);
         }
+
+        &:focus-visible {
+            outline: 2px solid var(--color-outline-focus);
+            outline-offset: -2px;
+        }
     }
 }
 
@@ -487,7 +497,8 @@
         visibility: hidden;
     }
 
-    .add-stream-icon-container:focus-visible .add_stream_icon {
+    .add-stream-icon-container:focus-visible .add_stream_icon,
+    &:focus-within .add_stream_icon {
         visibility: visible;
     }
 
@@ -831,7 +842,8 @@
     }
 }
 
-.stream-list-toggle-inactive-or-muted-channels.highlighted_row {
+.stream-list-toggle-inactive-or-muted-channels.highlighted_row,
+.stream-list-toggle-inactive-or-muted-channels:focus-visible {
     outline: 2px solid var(--color-outline-focus);
     outline-offset: -2px;
     background-color: var(--color-background-sidebar-action-heading-hover);
@@ -2143,6 +2155,15 @@ li.active-sub-filter {
         /* Show dots on touchscreens in a less distracting,
            lighter shade. */
         color: var(--color-vdots-hint);
+    }
+}
+
+.bottom_left_row .sidebar-menu-icon,
+.bottom_left_row .channel-new-topic-button,
+.top_left_row .sidebar-menu-icon,
+.stream-list-section-container .sidebar-menu-icon {
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -776,6 +776,18 @@
     }
 }
 
+/* Arrow-key sidebar navigation focuses the toggle icon inside a
+   section header row while also applying .highlighted_row to the row
+   itself. Suppress the inner outline in that case to avoid showing
+   two nested focus rings on the same row. The IDs are needed to win
+   over the ID-scoped :focus-visible rules on the Views and DM
+   toggle icons above. */
+.highlighted_row #toggle-direct-messages-section-icon:focus-visible,
+.highlighted_row #toggle-top-left-navigation-area-icon:focus-visible,
+.highlighted_row .stream-list-section-toggle:focus-visible {
+    outline: 0;
+}
+
 .active-direct-messages-section {
     background-color: var(--color-background-active-narrow-filter);
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -2147,17 +2147,21 @@ li.active-sub-filter {
 }
 
 /*
-    When you hover over list items, we hover
-    the vdots in light gray.
+    When you hover over or keyboard-highlight a list
+    item's menu icon, we give it a purple background.
 
     The stream icon should always display when
-    any topic is hovered, which is why it gets
-    a more specific selector here.
+    any topic is hovered/highlighted, which is why
+    it gets a more specific selector here.
 */
-#stream_filters li:hover .stream-sidebar-menu-icon,
-.top_left_row:hover .sidebar-menu-icon,
-.bottom_left_row:hover .sidebar-menu-icon,
-#stream_filters .stream-list-subsection-header:hover .sidebar-menu-icon,
+#stream_filters
+    li:is(:hover, :focus-within, :has(.highlighted_row))
+    .stream-sidebar-menu-icon,
+.top_left_row:is(:hover, :focus-within, .highlighted_row) .sidebar-menu-icon,
+.bottom_left_row:is(:hover, :focus-within, .highlighted_row) .sidebar-menu-icon,
+#stream_filters
+    .stream-list-subsection-header:is(:hover, :focus-within, .highlighted_row)
+    .sidebar-menu-icon,
 .app-main .column-left .left-sidebar .left_sidebar_menu_icon_visible {
     /* We push against `display: none` with
        `display: flex` because the sidebar vdots

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -95,6 +95,10 @@
             font-size: 1.0625em;
         }
 
+        &:focus-visible {
+            outline: 2px solid var(--color-outline-focus);
+        }
+
         /*
         Hover does not work for touch-based devices like mobile phones.
         Hence the icons does not appear, making the user unaware of its

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -133,7 +133,7 @@
         visibility: hidden;
     }
 
-    li:hover {
+    li:is(:hover, :focus-within, .highlighted_user) {
         .user-list-sidebar-menu-icon {
             visibility: visible;
         }
@@ -148,6 +148,7 @@
         padding: 0;
 
         &:hover,
+        &:focus-within,
         &.narrow-filter:has(a.user-presence-link:focus-visible),
         &.highlighted_user {
             background-color: var(--color-buddy-list-highlighted-user);

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -5,10 +5,10 @@
                 <input type="text" class="input-element left-sidebar-search-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
             {{/components/input_wrapper}}
         </div>
-        <span id="add_streams_button" class="add-stream-icon-container hidden-for-spectators">
+        <span id="add_streams_button" class="add-stream-icon-container hidden-for-spectators" tabindex="0">
             <i id="streams_inline_icon" class="add_stream_icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
         </span>
-        <span class="sidebar-menu-icon channel-folders-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-label="{{t 'Show channel folders'}}"></i></span>
+        <span class="sidebar-menu-icon channel-folders-sidebar-menu-icon hidden-for-spectators" tabindex="0"><i class="zulip-icon zulip-icon-more-vertical" aria-label="{{t 'Show channel folders'}}"></i></span>
     </div>
     <ul id="left-sidebar-empty-list-message" class="hidden">
         {{> empty_list_widget_for_list
@@ -45,7 +45,7 @@
                 <a class="show-all-direct-messages tippy-left-sidebar-tooltip-no-label-delay" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
                     <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
                 </a>
-                <span class="compose-new-direct-message tippy-left-sidebar-tooltip-no-label-delay auto-hide-left-sidebar-overlay" data-tooltip-template-id="new_direct_message_button_tooltip_template">
+                <span class="compose-new-direct-message tippy-left-sidebar-tooltip-no-label-delay auto-hide-left-sidebar-overlay" tabindex="0" data-tooltip-template-id="new_direct_message_button_tooltip_template">
                     <i class="left-sidebar-new-direct-message-icon zulip-icon zulip-icon-square-plus" aria-label="{{t 'Start a new DM' }}"></i>
                 </span>
             </div>

--- a/web/templates/left_sidebar_expanded_view_item.hbs
+++ b/web/templates/left_sidebar_expanded_view_item.hbs
@@ -17,6 +17,6 @@
         {{/if}}
     </a>
     {{#if menu_icon_class}}
-        <span class="arrow sidebar-menu-icon {{menu_icon_class}} hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-label="{{menu_aria_label}}"></i></span>
+        <span class="arrow sidebar-menu-icon {{menu_icon_class}} hidden-for-spectators" tabindex="0"><i class="zulip-icon zulip-icon-more-vertical" aria-label="{{menu_aria_label}}"></i></span>
     {{/if}}
 </li>

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -35,6 +35,6 @@
         <span class="unread_count {{#if (eq num_unread 0)}}hide{{/if}}">{{#unless (eq num_unread 0)}}{{num_unread}}{{/unless}}</span>
     </div>
     {{#unless user_list_style.WITH_AVATAR}}
-    <span class="sidebar-menu-icon user-list-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+    <span class="sidebar-menu-icon user-list-sidebar-menu-icon" tabindex="0"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
     {{/unless}}
 </li>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -5,7 +5,7 @@
                 {{#> components/input_wrapper input_type="filter-input" id="userlist-header-search" icon="search" input_button_icon="close"}}
                     <input type="text" class="input-element user-list-filter" autocomplete="off" placeholder="{{t 'Filter users' }}" />
                 {{/components/input_wrapper}}
-                <span id="buddy-list-menu-icon" class="user-list-sidebar-menu-icon">
+                <span id="buddy-list-menu-icon" class="user-list-sidebar-menu-icon" tabindex="0">
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                 </span>
             </div>
@@ -26,7 +26,7 @@
                 </div>
                 <div id="buddy_list_wrapper_padding"></div>
                 <div class="invite-user-shortcut">
-                    <a class="invite-user-link right-sidebar-wrappable-text-container" role="button">
+                    <a class="invite-user-link right-sidebar-wrappable-text-container" role="button" tabindex="0">
                         <span class="right-sidebar-wrappable-text-inner">
                             {{t 'Invite to organization' }}
                         </span>

--- a/web/templates/show_inactive_or_muted_channels.hbs
+++ b/web/templates/show_inactive_or_muted_channels.hbs
@@ -1,4 +1,4 @@
-<div class="stream-list-toggle-inactive-or-muted-channels bottom_left_row">
+<div class="stream-list-toggle-inactive-or-muted-channels bottom_left_row" tabindex="0">
     <div class="show-inactive-or-muted-channels sidebar-topic-action-heading">
         <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
         <div class="stream-list-toggle-inactive-or-muted-channels-text">

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -1,6 +1,6 @@
 <div id="stream-list-{{id}}-container" data-section-id="{{id}}" class="stream-list-section-container">
     <div class="left-sidebar-section-header stream-list-subsection-header">
-        <i class="stream-list-section-toggle zulip-icon zulip-icon-heading-triangle-right rotate-icon-down folder-toggle-tooltip-target" tabindex="0" role="button"></i>
+        <i class="stream-list-section-toggle sidebar-heading-icon zulip-icon zulip-icon-heading-triangle-right rotate-icon-down folder-toggle-tooltip-target" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title">
             {{section_title}}
         </h4>

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -17,7 +17,7 @@
             </span>
         </div>
         {{#if show_folder_action_icon}}
-        <span class="sidebar-menu-icon folder-section-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+        <span class="sidebar-menu-icon folder-section-sidebar-menu-icon" tabindex="0"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
         {{/if}}
     </div>
     <ul id="stream-list-{{id}}" class="stream-list-section"></ul>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -11,7 +11,7 @@
 
             <div class="left-sidebar-controls">
                 {{#if can_post_messages}}
-                <div class="channel-new-topic-button hidden-for-spectators auto-hide-left-sidebar-overlay" data-tippy-content="{{#if (or is_empty_topic_only_channel cannot_create_topics_in_channel)}}{{t 'New message'}}{{else}}{{t 'Start a new topic'}}{{/if}}" data-stream-id="{{id}}">
+                <div class="channel-new-topic-button hidden-for-spectators auto-hide-left-sidebar-overlay" tabindex="0"  data-tippy-content="{{#if (or is_empty_topic_only_channel cannot_create_topics_in_channel)}}{{t 'New message'}}{{else}}{{t 'Start a new topic'}}{{/if}}" data-stream-id="{{id}}">
                     <i class="channel-new-topic-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
                 </div>
                 {{/if}}
@@ -25,7 +25,7 @@
                 </span>
             </div>
 
-            <span class="sidebar-menu-icon stream-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+            <span class="sidebar-menu-icon stream-sidebar-menu-icon" tabindex="0"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
         </a>
     </div>
     {{#if for_modal}}<div class="topic-list-scroll-container" data-simplebar data-simplebar-tab-index="-1"></div>{{/if}}

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -18,7 +18,7 @@
                 {{unread}}
             </span>
         </div>
-        <span class="sidebar-menu-icon topic-sidebar-menu-icon">
+        <span class="sidebar-menu-icon topic-sidebar-menu-icon" tabindex="0">
             <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
         </span>
     </a>


### PR DESCRIPTION
 Fixes #25391.

  This PR makes the left and right sidebars fully keyboard-navigable,
  so users can tab through sidebar elements, open menus with Enter,
  and return to where they were after dismissing a popover.

  **Tooltip fixes:**
  - Fix DM section tooltip ("Collapse/Expand direct messages") not showing on page load, because `#direct-messages-modal` was missing the `no-display` class in the initial template.
  - Update toggle tooltips immediately after collapsing/expanding sections (Views, DMs, channel folders, buddy list), so the tooltip text stays accurate when toggling via keyboard while the tooltip is visible.

  **Keyboard navigation for section toggles:**
  - Channel folder toggles: add `tabindex`, `role="button"`, Enter handler, focus styles, and tooltip.
  - Buddy list section toggles (users matching view, participants, other users): same treatment.

  **Three-dot menu icons and action buttons:**
  - Add `tabindex="0"` to all sidebar menu icons (channels, topics, views, folders, buddy list) and action buttons (new topic, create channel, show all DMs, compose DM, show inactive/muted channels).
  - Add Enter keydown handlers where needed (for elements without `role="button"` that don't get synthetic click events).
  - Add `also_trigger_on_enter` parameter to `register_popover_menu` so that the menus can get opened with Enter key as well.

  **Popover keyboard focus:**
  - Focus the first item in a popover when it opens via keyboard, so arrow keys and Enter work immediately.
  - When a popover closes, return focus to the sidebar row if the popover was opened with the keyboard.