### PR TITLE
compose: Fix preview area bottom cut-off after fullscreen collapse.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -551,9 +551,17 @@ export function make_compose_box_original_size(): void {
 
     // Again initialise the compose textarea as it was destroyed
     // when compose box was made full screen
-    autosize($("textarea#compose-textarea"));
+    const $compose_textarea = $<HTMLTextAreaElement>("textarea#compose-textarea");
+    autosize($compose_textarea);
 
-    $("textarea#compose-textarea").trigger("focus");
+    // If the preview area is open, reset the min-height for it to
+    // ensure a smooth back-and-forth for toggling preview mode.
+    const $preview_message_area = $("#compose .preview_message_area");
+    if ($preview_message_area.length > 0) {
+        const edit_height = $compose_textarea.height();
+        $preview_message_area.css({"min-height": edit_height + "px"});
+    }
+    $compose_textarea.trigger("focus");
 }
 
 export function handle_scrolling_formatting_buttons(event: JQuery.ScrollEvent): void {

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -683,6 +683,8 @@ run_test("test_compose_height_changes", ({override, override_rewire}) => {
     assert.ok(autosize_destroyed);
     assert.ok(compose_box_top_set);
 
+    $("textarea#compose-textarea").set_height(100);
+    $("#compose .preview_message_area").set_height(100);
     compose_ui.make_compose_box_original_size();
     assert.ok(!$("#compose").hasClass("compose-fullscreen"));
     assert.ok(!compose_ui.is_expanded());


### PR DESCRIPTION
When the compose box is expanded to full screen mode, then switched to preview mode, and then collapsed the compose box, the preview area gets cut off from the bottom. This happens because an inline `min-height` set during fullscreen remains on the preview element after collapsing.


Fixes: [#issues > Cut-off of compose box](https://chat.zulip.org/#narrow/channel/9-issues/topic/Cut-off.20of.20compose.20box/with/2418230)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="1918" height="878" alt="Screenshot 2026-04-04 120630" src="https://github.com/user-attachments/assets/ab85b439-a714-4087-bb68-975e4264a41a" />|<img width="1919" height="827" alt="Screenshot 2026-04-04 120700" src="https://github.com/user-attachments/assets/acc8e6a8-7adb-44c6-b76e-43afa4486521" />|

| Before | After |
|--------|-------|
|<img width="1027" height="350" alt="Screenshot 2026-04-04 120749" src="https://github.com/user-attachments/assets/48c3e626-3768-4c92-b4ea-91725d74bc1c" />|<img width="1029" height="198" alt="Screenshot 2026-04-04 120857" src="https://github.com/user-attachments/assets/3561e529-42a9-40a3-bc02-4c7625ed704b" />|

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/0f3d9f8b-4202-4eb3-8c0d-b9050d0013df" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/544916c4-0b2e-4f56-b394-b26c62670af8" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
