### PR TITLE
markdown: Fix explicit links containing quotes and parentheses.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2012,6 +2012,58 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
         super().__init__(pattern, zmd)
         self.zmd = zmd
 
+    @override
+    def getLink(self, data: str, index: int) -> tuple[str, str | None, int, bool]:
+        """
+        Zulip override: Python-Markdown's default getLink crashes if a URL contains
+        both parentheses and a single/double quote (e.g., [text](https://example.com/a'b(c)d)).
+        We temporarily URL-encode quotes that are clearly part of the URL (before any space)
+        so the upstream parser doesn't mistake them for the start of a title string.
+        """
+        m = self.RE_LINK.match(data, pos=index)
+
+        if m and not m.group(1):
+            # Manual scan to find the matching closing parenthesis
+            bracket_count = 0
+            end_index = -1
+            for i in range(index, len(data)):
+                if data[i] == "(":
+                    bracket_count += 1
+                elif data[i] == ")":
+                    bracket_count -= 1
+                    if bracket_count == 0:
+                        end_index = i
+                        break
+
+            if end_index != -1:
+                url_content = data[index + 1 : end_index]
+
+                space_idx = url_content.find(" ")
+                if space_idx == -1:
+                    url_part = url_content
+                    title_part = ""
+                else:
+                    url_part = url_content[:space_idx]
+                    title_part = url_content[space_idx:]
+
+                if "'" in url_part or '"' in url_part:
+                    safe_url_part = url_part.replace("'", "%27").replace('"', "%22")
+                    safe_url_content = safe_url_part + title_part
+                    safe_data = data[: index + 1] + safe_url_content + data[end_index:]
+
+                    href, title, new_index, handled = super().getLink(safe_data, index)
+                    if handled and href:
+                        href = href.replace("%27", "'").replace("%22", '"')
+
+                        # Fix the index shift! Subtract the extra characters we added
+                        # so we don't accidentally eat the text that follows the link.
+                        length_diff = len(safe_data) - len(data)
+                        new_index -= length_diff
+
+                    return href, title, new_index, handled
+
+        return super().getLink(data, index)
+
     def zulip_specific_link_changes(self, el: Element) -> None | Element:
         href = el.get("href")
         assert href is not None

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1090,6 +1090,12 @@
       "name": "RFC2392 mid links with part ID (markdown syntax)",
       "input": "[message](mid:960830.1639@XIson.com/partA.960830.1639@XIson.com)",
       "expected_output": "<p><a href=\"mid:960830.1639@XIson.com/partA.960830.1639@XIson.com\">message</a></p>"
+    },
+    {
+      "name": "explicit_link_with_quote_and_parentheses",
+      "input": "Hello [a link](https://example.com/as'd/23-(23-23)-23/aa) and some more text",
+      "expected_output": "<p>Hello <a href=\"https://example.com/as'd/23-(23-23)-23/aa\">a link</a> and some more text</p>",
+      "marked_expected_output": "<p>Hello <a href=\"https://example.com/as'd/23-(23-23\">a link</a>-23/aa) and some more text</p>"
     }
   ],
   "linkify_tests": [


### PR DESCRIPTION

When a user explicitly links text using standard Markdown syntax `[text](url)`, the upstream `python-markdown` parser's `getLink` function fails if the URL contains *both* parentheses and a single/double quote (e.g., `[a link](https://example.com/a'b/(c))`). It falsely assumes the quote marks the start of a link title, fails to balance the parentheses, and silently aborts, leaving the raw markdown string unparsed.

Instead of rewriting the entire upstream `getLink` function, this PR overrides `getLink` inside Zulip's `LinkInlineProcessor` to perform a targeted pre-processing step:
- It isolates the string inside the parentheses.
- It looks for quotes that appear *before* any spaces (meaning they are part of the URL, not a Markdown title).
- It temporarily URL-encodes those quotes (e.g., `'` to `%27` and `"` to `%22`) so the upstream parser safely ignores them.
- After the upstream parser successfully extracts the link, it decodes the quotes back into the `href` attribute.
- **Crucially**, it adjusts the returned string index by subtracting the length difference caused by the temporary encoding, preventing the parser from accidentally swallowing subsequent text (the "index shift" bug).

Fixes: #34547

**How changes were tested:**
* Added a regression test to `zerver/tests/fixtures/markdown_test_cases.json` using the exact failing string from the issue.
* Ran `./tools/test-backend zerver/tests/test_markdown.py` and the full backend test suite to ensure this override does not break standard Markdown links, titled links, or other edge cases.
* Manually tested in the development environment. Verified that trailing text is preserved perfectly (e.g., `...a) and some more text`) confirming the index shift math is correct.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots:**
1. Before
<img width="895" height="235" alt="image" src="https://github.com/user-attachments/assets/c4e0388d-98b3-4ee7-ab5b-916916bce4a9" />


2. After
<img width="894" height="395" alt="Screenshot 2026-04-04 at 11 13 18 PM" src="https://github.com/user-attachments/assets/5ea540a0-9fef-4b57-a663-7c762c2ce96d" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
