### PR TITLE
settings: Enable caching template loader

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -648,15 +648,6 @@ else:
 # TEMPLATES SETTINGS
 ########################################################################
 
-# List of callables that know how to import templates from various sources.
-LOADERS: list[str | tuple[object, ...]] = [
-    "django.template.loaders.filesystem.Loader",
-    "django.template.loaders.app_directories.Loader",
-]
-if PRODUCTION:
-    # Template caching is a significant performance win in production.
-    LOADERS = [("django.template.loaders.cached.Loader", LOADERS)]
-
 base_template_engine_settings: dict[str, Any] = {
     "BACKEND": "django.template.backends.jinja2.Jinja2",
     "OPTIONS": {
@@ -711,7 +702,12 @@ non_html_template_engine_settings["OPTIONS"].update(
 two_factor_template_options = deepcopy(default_template_engine_settings["OPTIONS"])
 del two_factor_template_options["environment"]
 del two_factor_template_options["extensions"]
-two_factor_template_options["loaders"] = ["zproject.template_loaders.TwoFactorLoader"]
+two_factor_template_options["loaders"] = [
+    (
+        "django.template.loaders.cached.Loader",
+        ["zproject.template_loaders.TwoFactorLoader"],
+    )
+]
 
 two_factor_template_engine_settings = {
     "NAME": "Two_Factor",


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: This PR fixes the issue around using a cached template loader in development.

Since Zulip has mostly moved to Jinja2 templates, caching is already handled at the framework level, so there isn’t much left to change. This PR just cleans up the remaining edge cases:
(1) It removes the LOADERS setting from `zproject/computed_settings.py`, which is now outdated since Django templates aren’t used in most places anymore.
(2) It correctly applies the cached loader to `two_factor_template_options["loaders"]`, which is the only part still relying on Django templates.

Also, since modern Django supports reliable template auto-reloading `(django.template.autoreload)`, using the cached loader here is safe and doesn’t affect the development experience.

Fixes: #627


**How changes were tested:**
I verified through the Django documentation and Zulip’s codebase history that template caching is already handled by the Jinja backend.
I also confirmed that the LOADERS setting was no longer in use, so I removed it as part of the cleanup. For the remaining Django template usage, I applied django.template.loaders.cached.Loader in computed_settings.py where it’s actually needed.
Finally, I tested the developer workflow to make sure Django still correctly reloads templates on file changes, and confirmed that cached outputs are flushed as expected.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
