### PR TITLE
webhooks/pagerduty: Expand PagerDuty support for V3 events.

### DIFF
--- a/zerver/webhooks/pagerduty/fixtures/annotated_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/annotated_v3.json
@@ -1,0 +1,29 @@
+{
+    "event": {
+        "id": "01GI0KTE33V5QXBVIJDEVJFUNE",
+        "event_type": "incident.annotated",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:18:59.674Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "id": "PEMJB6G",
+            "content": "Running KILL on long-running queries from the reporting-service.",
+            "trimmed": false,
+            "type": "incident_note"
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/conference_bridge_updated_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/conference_bridge_updated_v3.json
@@ -1,0 +1,28 @@
+{
+    "event": {
+        "id": "01GI0KX5GCRKLDQFLNMGZ30JV2",
+        "event_type": "incident.conference_bridge.updated",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:20:15.274Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "conference_numbers": null,
+            "conference_url": "https://example.com/123-456-789",
+            "type": "incident_conference_bridge"
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/delegated_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/delegated_v3.json
@@ -1,0 +1,65 @@
+{
+    "event": {
+        "id": "01GI0KCK1VJGU2A90B814E1RF0",
+        "event_type": "incident.delegated",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:13:20.295Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "id": "Q3B15VLMF3ASBD",
+            "type": "incident",
+            "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "number": 5,
+            "status": "triggered",
+            "incident_key": "d387d7bd2e0a4294a5307339dfe1669a",
+            "created_at": "2026-04-01T02:07:30Z",
+            "reopened_at": null,
+            "title": "Critical: Checkout API High Latency",
+            "service": {
+                "id": "PLVTM9H",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/PLVTM9H",
+                "html_url": "https://harsh0303.pagerduty.com/services/PLVTM9H",
+                "summary": "Default Service"
+            },
+            "assignees": [
+                {
+                    "id": "PXRUEF2",
+                    "type": "user_reference",
+                    "self": "https://api.pagerduty.com/users/PXRUEF2",
+                    "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+                    "summary": "Harsh Santwani"
+                }
+            ],
+            "escalation_policy": {
+                "id": "P3RAX8S",
+                "type": "escalation_policy_reference",
+                "self": "https://api.pagerduty.com/escalation_policies/P3RAX8S",
+                "html_url": "https://harsh0303.pagerduty.com/escalation_policies/P3RAX8S",
+                "summary": "APIs-ep"
+            },
+            "teams": [],
+            "priority": {
+                "id": "P12CAYR",
+                "type": "priority_reference",
+                "self": "https://api.pagerduty.com/priorities/P12CAYR",
+                "html_url": "https://harsh0303.pagerduty.com/account/settings/incidents",
+                "summary": "P1"
+            },
+            "urgency": "high",
+            "conference_bridge": null,
+            "resolve_reason": null,
+            "incident_type": {
+                "name": "major_default"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/escalate_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/escalate_v3.json
@@ -1,0 +1,65 @@
+{
+    "event": {
+        "id": "01GI0JWUU28G8XE5M6IIT4BZ39",
+        "event_type": "incident.escalated",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:08:04.642Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "id": "Q3B15VLMF3ASBD",
+            "type": "incident",
+            "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "number": 5,
+            "status": "triggered",
+            "incident_key": "d387d7bd2e0a4294a5307339dfe1669a",
+            "created_at": "2026-04-01T02:07:30Z",
+            "reopened_at": null,
+            "title": "Critical: Checkout API High Latency",
+            "service": {
+                "id": "PLVTM9H",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/PLVTM9H",
+                "html_url": "https://harsh0303.pagerduty.com/services/PLVTM9H",
+                "summary": "Default Service"
+            },
+            "assignees": [
+                {
+                    "id": "PXRUEF2",
+                    "type": "user_reference",
+                    "self": "https://api.pagerduty.com/users/PXRUEF2",
+                    "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+                    "summary": "Harsh Santwani"
+                }
+            ],
+            "escalation_policy": {
+                "id": "P1EUYO0",
+                "type": "escalation_policy_reference",
+                "self": "https://api.pagerduty.com/escalation_policies/P1EUYO0",
+                "html_url": "https://harsh0303.pagerduty.com/escalation_policies/P1EUYO0",
+                "summary": "Default"
+            },
+            "teams": [],
+            "priority": {
+                "id": "P12CAYR",
+                "type": "priority_reference",
+                "self": "https://api.pagerduty.com/priorities/P12CAYR",
+                "html_url": "https://harsh0303.pagerduty.com/account/settings/incidents",
+                "summary": "P1"
+            },
+            "urgency": "high",
+            "conference_bridge": null,
+            "resolve_reason": null,
+            "incident_type": {
+                "name": "major_default"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/priority_updated_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/priority_updated_v3.json
@@ -1,0 +1,65 @@
+{
+    "event": {
+        "id": "01GI0KJAEAC3CFEOFSC8BIJF3O",
+        "event_type": "incident.priority_updated",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:15:36.315Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "id": "Q3B15VLMF3ASBD",
+            "type": "incident",
+            "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "number": 5,
+            "status": "triggered",
+            "incident_key": "d387d7bd2e0a4294a5307339dfe1669a",
+            "created_at": "2026-04-01T02:07:30Z",
+            "reopened_at": null,
+            "title": "Critical: Checkout API High Latency",
+            "service": {
+                "id": "PLVTM9H",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/PLVTM9H",
+                "html_url": "https://harsh0303.pagerduty.com/services/PLVTM9H",
+                "summary": "Default Service"
+            },
+            "assignees": [
+                {
+                    "id": "PXRUEF2",
+                    "type": "user_reference",
+                    "self": "https://api.pagerduty.com/users/PXRUEF2",
+                    "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+                    "summary": "Harsh Santwani"
+                }
+            ],
+            "escalation_policy": {
+                "id": "P3RAX8S",
+                "type": "escalation_policy_reference",
+                "self": "https://api.pagerduty.com/escalation_policies/P3RAX8S",
+                "html_url": "https://harsh0303.pagerduty.com/escalation_policies/P3RAX8S",
+                "summary": "APIs-ep"
+            },
+            "teams": [],
+            "priority": {
+                "id": "PJLLAIY",
+                "type": "priority_reference",
+                "self": "https://api.pagerduty.com/priorities/PJLLAIY",
+                "html_url": "https://harsh0303.pagerduty.com/account/settings/incidents",
+                "summary": "P2"
+            },
+            "urgency": "high",
+            "conference_bridge": null,
+            "resolve_reason": null,
+            "incident_type": {
+                "name": "major_default"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/reopened_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/reopened_v3.json
@@ -1,0 +1,65 @@
+{
+    "event": {
+        "id": "01GI0KHLHVH4YZ44BJY1VLT6F2",
+        "event_type": "incident.reopened",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:15:02.274Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "id": "Q05XJA8GDXGOB3",
+            "type": "incident",
+            "self": "https://api.pagerduty.com/incidents/Q05XJA8GDXGOB3",
+            "html_url": "https://harsh0303.pagerduty.com/incidents/Q05XJA8GDXGOB3",
+            "number": 4,
+            "status": "triggered",
+            "incident_key": "07261e18031d41268a16c774c1892cae",
+            "created_at": "2026-03-30T13:37:07Z",
+            "reopened_at": "2026-04-01T02:15:01Z",
+            "title": "Test Incident 2",
+            "service": {
+                "id": "PLVTM9H",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/PLVTM9H",
+                "html_url": "https://harsh0303.pagerduty.com/services/PLVTM9H",
+                "summary": "Default Service"
+            },
+            "assignees": [
+                {
+                    "id": "PXRUEF2",
+                    "type": "user_reference",
+                    "self": "https://api.pagerduty.com/users/PXRUEF2",
+                    "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+                    "summary": "Harsh Santwani"
+                }
+            ],
+            "escalation_policy": {
+                "id": "P3RAX8S",
+                "type": "escalation_policy_reference",
+                "self": "https://api.pagerduty.com/escalation_policies/P3RAX8S",
+                "html_url": "https://harsh0303.pagerduty.com/escalation_policies/P3RAX8S",
+                "summary": "APIs-ep"
+            },
+            "teams": [],
+            "priority": {
+                "id": "PGPAA68",
+                "type": "priority_reference",
+                "self": "https://api.pagerduty.com/priorities/PGPAA68",
+                "html_url": "https://harsh0303.pagerduty.com/account/settings/incidents",
+                "summary": "P3"
+            },
+            "urgency": "low",
+            "conference_bridge": null,
+            "resolve_reason": null,
+            "incident_type": {
+                "name": "security_default"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/responder_added.json
+++ b/zerver/webhooks/pagerduty/fixtures/responder_added.json
@@ -1,0 +1,42 @@
+{
+    "event": {
+        "id": "01GI0KX4BFZXPEDNCS4USCAH22",
+        "event_type": "incident.responder.added",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:20:14.737Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "user": {
+                "id": "PXRUEF2",
+                "type": "user_reference",
+                "self": "https://api.pagerduty.com/users/PXRUEF2",
+                "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+                "summary": "Harsh Santwani"
+            },
+            "escalation_policy": {
+                "id": "P3RAX8S",
+                "type": "escalation_policy_reference",
+                "self": "https://api.pagerduty.com/escalation_policies/P3RAX8S",
+                "html_url": "https://harsh0303.pagerduty.com/escalation_policies/P3RAX8S",
+                "summary": "APIs-ep"
+            },
+            "message": "Please help with \"Critical: Checkout API High Latency\"",
+            "state": "pending",
+            "type": "incident_responder"
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/responder_replied_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/responder_replied_v3.json
@@ -1,0 +1,36 @@
+{
+    "event": {
+        "id": "01GI0L22UIJYVH9Y2II3TNPVER",
+        "event_type": "incident.responder.replied",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:21:54.532Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "user": {
+                "id": "PXRUEF2",
+                "type": "user_reference",
+                "self": "https://api.pagerduty.com/users/PXRUEF2",
+                "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+                "summary": "Harsh Santwani"
+            },
+            "escalation_policy": null,
+            "message": "Checking now. Investigating DB locks on cluster-01 and reviewing latency metrics in Datadog. Will update in 5 mins.\n",
+            "state": "accepted",
+            "type": "incident_responder"
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/service_updated_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/service_updated_v3.json
@@ -1,0 +1,68 @@
+{
+    "event": {
+        "id": "01GI0LMGIAVNHQJISNPO1RZRT5",
+        "event_type": "incident.service_updated",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:28:44.634Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "id": "Q3B15VLMF3ASBD",
+            "type": "incident",
+            "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+            "number": 5,
+            "status": "triggered",
+            "incident_key": "d387d7bd2e0a4294a5307339dfe1669a",
+            "created_at": "2026-04-01T02:07:30Z",
+            "reopened_at": null,
+            "title": "Critical: Checkout API High Latency",
+            "service": {
+                "id": "P844A2S",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/P844A2S",
+                "html_url": "https://harsh0303.pagerduty.com/services/P844A2S",
+                "summary": "APIs"
+            },
+            "assignees": [
+                {
+                    "id": "PXRUEF2",
+                    "type": "user_reference",
+                    "self": "https://api.pagerduty.com/users/PXRUEF2",
+                    "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+                    "summary": "Harsh Santwani"
+                }
+            ],
+            "escalation_policy": {
+                "id": "P3RAX8S",
+                "type": "escalation_policy_reference",
+                "self": "https://api.pagerduty.com/escalation_policies/P3RAX8S",
+                "html_url": "https://harsh0303.pagerduty.com/escalation_policies/P3RAX8S",
+                "summary": "APIs-ep"
+            },
+            "teams": [],
+            "priority": {
+                "id": "PJLLAIY",
+                "type": "priority_reference",
+                "self": "https://api.pagerduty.com/priorities/PJLLAIY",
+                "html_url": "https://harsh0303.pagerduty.com/account/settings/incidents",
+                "summary": "P2"
+            },
+            "urgency": "high",
+            "conference_bridge": {
+                "conference_url": "https://example.com/123-456-789-10",
+                "conference_number": null
+            },
+            "resolve_reason": null,
+            "incident_type": {
+                "name": "major_default"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/status_updated_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/status_updated_v3.json
@@ -1,0 +1,29 @@
+{
+    "event": {
+        "id": "01GI0KPHX6I892N2PFKDLH25XK",
+        "event_type": "incident.status_update_published",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:17:41.211Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "id": "PE8VDWS",
+            "message": "Investigating a P1 incident with the Checkout API in us-east-1. Customers may see 504 errors or delays during purchase. We've identified a database lock and are working on a fix. Expected remediation within 30 minutes; next update at 08:15 UTC.",
+            "trimmed": false,
+            "type": "incident_status_update"
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/workflow_completed_no_summary_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/workflow_completed_no_summary_v3.json
@@ -1,0 +1,43 @@
+{
+    "event": {
+        "id": "32743191412443541367815146404898342710",
+        "event_type": "incident.workflow.completed",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:52:43.174Z",
+        "agent": null,
+        "client": null,
+        "data": {
+            "id": "PU3WKIK",
+            "type": "incident_workflow_instance",
+            "summary": "",
+            "incident_workflow": {
+                "id": "POWB54R",
+                "type": "incident_workflow_reference",
+                "self": "https://api.pagerduty.com/incident_workflows/POWB54R",
+                "html_url": "https://harsh0303.pagerduty.com/incident-workflows/workflows/POWB54R",
+                "summary": "Incident WorkFlow"
+            },
+            "workflow_trigger": {
+                "id": "79fa2676-dc6b-4055-bc7f-b4ff47a30e93",
+                "type": "workflow_trigger_reference",
+                "self": "https://api.pagerduty.com/incident_workflows/triggers/79fa2676-dc6b-4055-bc7f-b4ff47a30e93",
+                "html_url": null,
+                "summary": "Incident Completion Trigger"
+            },
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "service": {
+                "id": "P844A2S",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/P844A2S",
+                "html_url": "https://harsh0303.pagerduty.com/services/P844A2S",
+                "summary": "APIs"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/workflow_completed_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/workflow_completed_v3.json
@@ -1,0 +1,43 @@
+{
+    "event": {
+        "id": "32743191412443541367815146404898342710",
+        "event_type": "incident.workflow.completed",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:52:43.174Z",
+        "agent": null,
+        "client": null,
+        "data": {
+            "id": "PU3WKIK",
+            "type": "incident_workflow_instance",
+            "summary": "Manually Started",
+            "incident_workflow": {
+                "id": "POWB54R",
+                "type": "incident_workflow_reference",
+                "self": "https://api.pagerduty.com/incident_workflows/POWB54R",
+                "html_url": "https://harsh0303.pagerduty.com/incident-workflows/workflows/POWB54R",
+                "summary": "Incident WorkFlow"
+            },
+            "workflow_trigger": {
+                "id": "79fa2676-dc6b-4055-bc7f-b4ff47a30e93",
+                "type": "workflow_trigger_reference",
+                "self": "https://api.pagerduty.com/incident_workflows/triggers/79fa2676-dc6b-4055-bc7f-b4ff47a30e93",
+                "html_url": null,
+                "summary": "Incident Completion Trigger"
+            },
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "service": {
+                "id": "P844A2S",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/P844A2S",
+                "html_url": "https://harsh0303.pagerduty.com/services/P844A2S",
+                "summary": "APIs"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/fixtures/workflow_started_v3.json
+++ b/zerver/webhooks/pagerduty/fixtures/workflow_started_v3.json
@@ -1,0 +1,49 @@
+{
+    "event": {
+        "id": "32743190385439511823355034091750713370",
+        "event_type": "incident.workflow.started",
+        "resource_type": "incident",
+        "occurred_at": "2026-04-01T02:51:47.500Z",
+        "agent": {
+            "id": "PXRUEF2",
+            "type": "user_reference",
+            "self": "https://api.pagerduty.com/users/PXRUEF2",
+            "html_url": "https://harsh0303.pagerduty.com/users/PXRUEF2",
+            "summary": "Harsh Santwani"
+        },
+        "client": null,
+        "data": {
+            "id": "PU3WKIK",
+            "type": "incident_workflow_instance",
+            "summary": "Manually Started",
+            "incident_workflow": {
+                "id": "POWB54R",
+                "type": "incident_workflow_reference",
+                "self": "https://api.pagerduty.com/incident_workflows/POWB54R",
+                "html_url": "https://harsh0303.pagerduty.com/incident-workflows/workflows/POWB54R",
+                "summary": "Incident WorkFlow"
+            },
+            "workflow_trigger": {
+                "id": "79fa2676-dc6b-4055-bc7f-b4ff47a30e93",
+                "type": "workflow_trigger_reference",
+                "self": "https://api.pagerduty.com/incident_workflows/triggers/79fa2676-dc6b-4055-bc7f-b4ff47a30e93",
+                "html_url": null,
+                "summary": "Manual Incident Trigger"
+            },
+            "incident": {
+                "id": "Q3B15VLMF3ASBD",
+                "type": "incident_reference",
+                "self": "https://api.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "html_url": "https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD",
+                "summary": "Critical: Checkout API High Latency"
+            },
+            "service": {
+                "id": "P844A2S",
+                "type": "service_reference",
+                "self": "https://api.pagerduty.com/services/P844A2S",
+                "html_url": "https://harsh0303.pagerduty.com/services/P844A2S",
+                "summary": "APIs"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/pagerduty/tests.py
+++ b/zerver/webhooks/pagerduty/tests.py
@@ -72,6 +72,96 @@ class PagerDutyHookTests(WebhookTestCase):
         expected_message = "Incident [48219](https://dropbox.pagerduty.com/incidents/PJKGZF9) resolved.\n\n``` quote\nmp_error_block_down_critical\u2119\u01b4\n```"
         self.check_webhook("mp_fail", "Incident 48219", expected_message)
 
+    def test_escalated_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency (#5)](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) escalated to [Harsh Santwani](https://harsh0303.pagerduty.com/users/PXRUEF2)."
+        self.check_webhook(
+            "escalate_v3", "Incident Critical: Checkout API High Latency (#5)", expected_message
+        )
+
+    def test_delegated_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency (#5)](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) delegated; current escalation policy is [APIs-ep](https://harsh0303.pagerduty.com/escalation_policies/P3RAX8S) and current assignee is [Harsh Santwani](https://harsh0303.pagerduty.com/users/PXRUEF2)."
+        self.check_webhook(
+            "delegated_v3", "Incident Critical: Checkout API High Latency (#5)", expected_message
+        )
+
+    def test_reopened_v3(self) -> None:
+        expected_message = "Incident [Test Incident 2 (#4)](https://harsh0303.pagerduty.com/incidents/Q05XJA8GDXGOB3) reopened."
+        self.check_webhook("reopened_v3", "Incident Test Incident 2 (#4)", expected_message)
+
+    def test_priority_updated_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency (#5)](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) priority updated to P2"
+        self.check_webhook(
+            "priority_updated_v3",
+            "Incident Critical: Checkout API High Latency (#5)",
+            expected_message,
+        )
+
+    def test_status_updated_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) status update published: Investigating a P1 incident with the Checkout API in us-east-1. Customers may see 504 errors or delays during purchase. We've identified a database lock and are working on a fix. Expected remediation within 30 minutes; next update at 08:15 UTC."
+        self.check_webhook(
+            "status_updated_v3", "Incident Critical: Checkout API High Latency", expected_message
+        )
+
+    def test_annotated_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) annotated with: Running KILL on long-running queries from the reporting-service."
+        self.check_webhook(
+            "annotated_v3", "Incident Critical: Checkout API High Latency", expected_message
+        )
+
+    def test_responder_added_v3(self) -> None:
+        expected_message = 'Responder [Harsh Santwani](https://harsh0303.pagerduty.com/users/PXRUEF2) added to incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD).\n\n``` quote\nPlease help with "Critical: Checkout API High Latency"\n```'
+        self.check_webhook(
+            "responder_added", "Incident Critical: Checkout API High Latency", expected_message
+        )
+
+    def test_responder_replied_v3(self) -> None:
+        expected_message = "Responder [Harsh Santwani](https://harsh0303.pagerduty.com/users/PXRUEF2) replied to incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD).\n\n``` quote\nChecking now. Investigating DB locks on cluster-01 and reviewing latency metrics in Datadog. Will update in 5 mins.\n\n```"
+        self.check_webhook(
+            "responder_replied_v3",
+            "Incident Critical: Checkout API High Latency",
+            expected_message,
+        )
+
+    def test_conference_bridge_updated_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) conference bridge updated: https://example.com/123-456-789"
+        self.check_webhook(
+            "conference_bridge_updated_v3",
+            "Incident Critical: Checkout API High Latency",
+            expected_message,
+        )
+
+    def test_service_updated_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency (#5)](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) service updated to APIs"
+        self.check_webhook(
+            "service_updated_v3",
+            "Incident Critical: Checkout API High Latency (#5)",
+            expected_message,
+        )
+
+    def test_workflow_started_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) workflow started: Incident WorkFlow (Manually Started)"
+        self.check_webhook(
+            "workflow_started_v3",
+            "Incident Critical: Checkout API High Latency",
+            expected_message,
+        )
+
+    def test_workflow_completed_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) workflow completed: Incident WorkFlow (Manually Started)"
+        self.check_webhook(
+            "workflow_completed_v3",
+            "Incident Critical: Checkout API High Latency",
+            expected_message,
+        )
+
+    def test_workflow_completed_no_summary_v3(self) -> None:
+        expected_message = "Incident [Critical: Checkout API High Latency](https://harsh0303.pagerduty.com/incidents/Q3B15VLMF3ASBD) workflow completed: Incident WorkFlow"
+        self.check_webhook(
+            "workflow_completed_no_summary_v3",
+            "Incident Critical: Checkout API High Latency",
+            expected_message,
+        )
+
     def test_unsupported_webhook_event(self) -> None:
         for version in range(1, 4):
             payload = self.get_body(f"unsupported_v{version}")

--- a/zerver/webhooks/pagerduty/view.py
+++ b/zerver/webhooks/pagerduty/view.py
@@ -7,7 +7,7 @@ from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_int, check_none_or, check_string
+from zerver.lib.validator import WildValue, check_dict, check_int, check_none_or, check_string
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -30,21 +30,25 @@ PAGER_DUTY_EVENT_NAMES_V2 = {
     "incident.assign": "assigned",
 }
 
-PAGER_DUTY_EVENT_NAMES_V3 = {
-    "incident.triggered": "triggered",
-    "incident.acknowledged": "acknowledged",
-    "incident.unacknowledged": "unacknowledged",
-    "incident.resolved": "resolved",
-    "incident.reassigned": "reassigned",
-}
-
 ALL_EVENT_TYPES = [
+    "triggered",
+    "acknowledged",
+    "unacknowledged",
     "resolved",
     "assigned",
-    "unacknowledged",
-    "acknowledged",
-    "triggered",
     "reassigned",
+    "escalated",
+    "delegated",
+    "reopened",
+    "priority updated",
+    "status updated",
+    "annotated",
+    "responder added",
+    "responder replied",
+    "conference bridge updated",
+    "service updated",
+    "workflow started",
+    "workflow completed",
 ]
 
 AGENT_TEMPLATE = "[{username}]({url})"
@@ -81,6 +85,87 @@ Incident [{incident_num_title}]({incident_url}) resolved.
 
 {trigger_message}
 """.strip()
+
+INCIDENT_ESCALATED = (
+    """Incident [{incident_num_title}]({incident_url}) escalated to {assignee_info}."""
+)
+
+INCIDENT_DELEGATED = """Incident [{incident_num_title}]({incident_url}) delegated; {escalation_policy_clause}current assignee is {assignee_info}."""
+
+INCIDENT_REOPENED = """Incident [{incident_num_title}]({incident_url}) reopened."""
+
+INCIDENT_PRIORITY_UPDATED = (
+    """Incident [{incident_num_title}]({incident_url}) priority updated to {event_details}"""
+)
+
+INCIDENT_STATUS_UPDATED = (
+    """Incident [{incident_num_title}]({incident_url}) status update published: {event_details}"""
+)
+
+INCIDENT_ANNOTATED = (
+    """Incident [{incident_num_title}]({incident_url}) annotated with: {event_details}"""
+)
+
+INCIDENT_RESPONDER_ADDED = """Responder {assignee_info} added to incident [{incident_num_title}]({incident_url}).
+
+``` quote
+{event_details}
+```"""
+
+INCIDENT_RESPONDER_REPLIED = """Responder {assignee_info} replied to incident [{incident_num_title}]({incident_url}).
+
+``` quote
+{event_details}
+```"""
+
+INCIDENT_CONFERENCE_BRIDGE_UPDATED = (
+    """Incident [{incident_num_title}]({incident_url}) conference bridge updated: {event_details}"""
+)
+
+INCIDENT_SERVICE_UPDATED = (
+    """Incident [{incident_num_title}]({incident_url}) service updated to {event_details}"""
+)
+
+INCIDENT_WORKFLOW_STARTED = (
+    """Incident [{incident_num_title}]({incident_url}) workflow started: {event_details}"""
+)
+
+INCIDENT_WORKFLOW_COMPLETED = (
+    """Incident [{incident_num_title}]({incident_url}) workflow completed: {event_details}"""
+)
+
+INCIDENT_WITH_SERVICE_EVENT_TYPES = {
+    "incident.trigger",
+    "incident.triggered",
+    "incident.unacknowledge",
+    "incident.unacknowledged",
+}
+
+INCIDENT_RESOLVED_EVENT_TYPES = {"incident.resolve", "incident.resolved"}
+INCIDENT_ASSIGNED_EVENT_TYPES = {"incident.assign", "incident.reassigned"}
+
+PAGER_DUTY_V3_EVENT_MAPPER: dict[str, tuple[str, str]] = {
+    "incident.triggered": ("triggered", INCIDENT_WITH_SERVICE_AND_ASSIGNEE),
+    "incident.acknowledged": ("acknowledged", INCIDENT_WITH_ASSIGNEE),
+    "incident.unacknowledged": ("unacknowledged", INCIDENT_WITH_SERVICE_AND_ASSIGNEE),
+    "incident.resolved": ("resolved", INCIDENT_RESOLVED),
+    "incident.reassigned": ("reassigned", INCIDENT_ASSIGNED),
+    "incident.escalated": ("escalated", INCIDENT_ESCALATED),
+    "incident.delegated": ("delegated", INCIDENT_DELEGATED),
+    "incident.reopened": ("reopened", INCIDENT_REOPENED),
+    "incident.priority_updated": ("priority updated", INCIDENT_PRIORITY_UPDATED),
+    "incident.status_update_published": ("status updated", INCIDENT_STATUS_UPDATED),
+    "incident.annotated": ("annotated", INCIDENT_ANNOTATED),
+    "incident.responder.added": ("responder added", INCIDENT_RESPONDER_ADDED),
+    "incident.responder.replied": ("responder replied", INCIDENT_RESPONDER_REPLIED),
+    "incident.conference_bridge.updated": (
+        "conference bridge updated",
+        INCIDENT_CONFERENCE_BRIDGE_UPDATED,
+    ),
+    "incident.service_updated": ("service updated", INCIDENT_SERVICE_UPDATED),
+    "incident.workflow.started": ("workflow started", INCIDENT_WORKFLOW_STARTED),
+    "incident.workflow.completed": ("workflow completed", INCIDENT_WORKFLOW_COMPLETED),
+}
 
 
 def build_pagerduty_formatdict(message: WildValue) -> FormatDictType:
@@ -163,39 +248,104 @@ def build_pagerduty_formatdict_v2(message: WildValue) -> FormatDictType:
     return format_dict
 
 
+def get_v3_event_details(event_type: str, data: WildValue) -> str:
+    """Extract event-specific detail text for V3 events."""
+    match event_type:
+        case "incident.priority_updated":
+            priority = data.get("priority")
+            if priority:
+                return priority["summary"].tame(check_string)
+        case "incident.status_update_published":
+            return data["message"].tame(check_string)
+        case "incident.annotated":
+            return data["content"].tame(check_string)
+        case "incident.responder.added" | "incident.responder.replied":
+            return data["message"].tame(check_string)
+        case "incident.conference_bridge.updated":
+            conference_url = data.get("conference_url")
+            if conference_url:
+                return conference_url.tame(check_string)
+        case "incident.service_updated":
+            service = data.get("service")
+            if service:
+                return service["summary"].tame(check_string)
+        case "incident.workflow.started" | "incident.workflow.completed":
+            workflow = data["incident_workflow"]["summary"].tame(check_string)
+            summary = data.get("summary", "").tame(check_string)
+            if summary:
+                return f"{workflow} ({summary})"
+            return workflow
+        case _:
+            pass
+    return ""
+
+
 def build_pagerduty_formatdict_v3(event: WildValue) -> FormatDictType:
     format_dict: FormatDictType = {}
-    format_dict["action"] = PAGER_DUTY_EVENT_NAMES_V3[event["event_type"].tame(check_string)]
+    event_type = event["event_type"].tame(check_string)
+    action, _ = PAGER_DUTY_V3_EVENT_MAPPER[event_type]
+    format_dict["action"] = action
 
-    format_dict["incident_id"] = event["data"]["id"].tame(check_string)
-    format_dict["incident_url"] = event["data"]["html_url"].tame(check_string)
-    format_dict["incident_num_title"] = NUM_TITLE.format(
-        incident_num=event["data"]["number"].tame(check_int),
-        incident_title=event["data"]["title"].tame(check_string),
-    )
+    data = event["data"]
+    incident = data.get("incident")
+    if incident:
+        format_dict["incident_id"] = incident["id"].tame(check_string)
+        format_dict["incident_url"] = incident["html_url"].tame(check_string)
+        format_dict["incident_num_title"] = incident["summary"].tame(check_string)
+    else:
+        format_dict["incident_id"] = data["id"].tame(check_string)
+        format_dict["incident_url"] = data["html_url"].tame(check_string)
+        format_dict["incident_num_title"] = NUM_TITLE.format(
+            incident_num=data["number"].tame(check_int),
+            incident_title=data["title"].tame(check_string),
+        )
 
-    format_dict["service_name"] = event["data"]["service"]["summary"].tame(check_string)
-    format_dict["service_url"] = event["data"]["service"]["html_url"].tame(check_string)
+    service = data.get("service")
+    if service:
+        format_dict["service_name"] = service["summary"].tame(check_string)
+        format_dict["service_url"] = service["html_url"].tame(check_string)
+    else:
+        format_dict["service_name"] = ""
+        format_dict["service_url"] = ""
 
-    assignees = event["data"]["assignees"]
+    assignees = data.get("assignees")
     if assignees:
         assignee = assignees[0]
         format_dict["assignee_info"] = AGENT_TEMPLATE.format(
             username=assignee["summary"].tame(check_string),
             url=assignee["html_url"].tame(check_string),
         )
+    elif data.get("user"):
+        user = data["user"]
+        format_dict["assignee_info"] = AGENT_TEMPLATE.format(
+            username=user["summary"].tame(check_string),
+            url=user["html_url"].tame(check_string),
+        )
     else:
         format_dict["assignee_info"] = "nobody"
 
-    agent = event.get("agent")
+    escalation_policy = data.get("escalation_policy")
+    if escalation_policy:
+        format_dict["escalation_policy_clause"] = (
+            "current escalation policy is [{name}]({url}) and ".format(
+                name=escalation_policy["summary"].tame(check_string),
+                url=escalation_policy["html_url"].tame(check_string),
+            )
+        )
+    else:
+        format_dict["escalation_policy_clause"] = ""
+
+    agent = event.get("agent").tame(
+        check_none_or(check_dict([("summary", check_string), ("html_url", check_string)]))
+    )
     if agent is not None:
         format_dict["agent_info"] = AGENT_TEMPLATE.format(
-            username=agent["summary"].tame(check_string),
-            url=agent["html_url"].tame(check_string),
+            username=agent["summary"],
+            url=agent["html_url"],
         )
 
-    # V3 doesn't have trigger_message
     format_dict["trigger_message"] = ""
+    format_dict["event_details"] = get_v3_event_details(event_type, data)
 
     return format_dict
 
@@ -206,27 +356,27 @@ def send_formatted_pagerduty(
     message_type: str,
     format_dict: FormatDictType,
 ) -> None:
-    if message_type in (
-        "incident.trigger",
-        "incident.triggered",
-        "incident.unacknowledge",
-        "incident.unacknowledged",
-    ):
+    if message_type in INCIDENT_WITH_SERVICE_EVENT_TYPES:
         template = INCIDENT_WITH_SERVICE_AND_ASSIGNEE
-    elif message_type in ("incident.resolve", "incident.resolved"):
+    elif message_type in INCIDENT_ASSIGNED_EVENT_TYPES:
+        template = INCIDENT_ASSIGNED
+    elif message_type in INCIDENT_RESOLVED_EVENT_TYPES:
         if "agent_info" in format_dict:
             template = INCIDENT_RESOLVED_WITH_AGENT
         else:
             template = INCIDENT_RESOLVED
-    elif message_type in ("incident.assign", "incident.reassigned"):
-        template = INCIDENT_ASSIGNED
     else:
-        template = INCIDENT_WITH_ASSIGNEE
+        event_config = PAGER_DUTY_V3_EVENT_MAPPER.get(message_type)
+        if event_config is not None:
+            _, template = event_config
+        else:
+            template = INCIDENT_WITH_ASSIGNEE
 
     topic_name = "Incident {incident_num_title}".format(**format_dict)
     body = template.format(**format_dict)
-    assert isinstance(format_dict["action"], str)
-    check_send_webhook_message(request, user_profile, topic_name, body, format_dict["action"])
+    action = format_dict["action"]
+    assert isinstance(action, str)
+    check_send_webhook_message(request, user_profile, topic_name, body, action)
 
 
 @webhook_view("PagerDuty", all_event_types=ALL_EVENT_TYPES)
@@ -272,7 +422,7 @@ def api_pagerduty_webhook(
             event = payload["event"]
             event_type = event.get("event_type").tame(check_none_or(check_string))
 
-            if event_type not in PAGER_DUTY_EVENT_NAMES_V3:
+            if event_type not in PAGER_DUTY_V3_EVENT_MAPPER:
                 raise UnsupportedWebhookEventTypeError(event_type)
 
             format_dict = build_pagerduty_formatdict_v3(event)


### PR DESCRIPTION
This PR is a follow-up to #38714 and extends PagerDuty webhook support to handle additional V3 incident events using V3 payload fixtures.

Added support for:

- `incident.escalated`
- `incident.delegated`
- `incident.reopened`
- `incident.priority_updated`
- `incident.status_update_published`
- `incident.annotated`
- `incident.responder.added`
- `incident.responder.replied`
- `incident.conference_bridge.updated`
- `incident.service_updated`
- `incident.workflow.started`
- `incident.workflow.completed`

Existing V3 events (`triggered`, `acknowledged`, `unacknowledged`, `resolved`, `reassigned`) continue to work as before.

### Changes

- added event-specific templates for the newly supported V3 events 
- added `PAGER_DUTY_V3_EVENT_MAPPER` to map each V3 `event_type` to its Zulip action name and template
- added `get_v3_event_details()` to extract event-specific detail text for the subset of V3 events that carry additional context
- extended `build_pagerduty_formatdict_v3()` to support both V3 payload shapes:
  - incident fields directly under `data`
  - incident fields nested under `data.incident`
- handled nullable or optional V3 fields such as `agent`, `service`, `user`, and `escalation_policy`

### Temporary Compatibility Bridge
Because this branch is being developed separately while #38714 is still part of the PagerDuty cleanup flow, the current implementation keeps a small compatibility bridge with the existing structure on `main`: `build_pagerduty_formatdict_v3()` currently sets both:

- `trigger_message = ""`
- `event_details = get_v3_event_details(...)`

This keeps the existing shared templates working while allowing the newly added V3 events to use event-specific rendering. After rebasing onto the final post- #38714` PagerDuty structure, this can be simplified.

### Delegated Event Wording

`incident.delegated` is phrased more explicitly than the other new events.

The PagerDuty delegation payload reflects the incident’s current state after the change, rather than a precise before/after diff of what target was selected in the UI. Because of that, the delegated message reports the current escalation policy and current assignee rather than making a stronger claim about exactly what the incident was delegated to.

<img width="732" height="72" alt="image" src="https://github.com/user-attachments/assets/06e9f138-cdaa-4a77-8ef7-2351f16d43f2" />


If there is a preferred house style for this event, I’m happy to adjust the wording.

```bash
./tools/test-backend zerver.webhooks.pagerduty.tests.PagerDutyHookTests
./tools/lint --skip=gitlint zerver/webhooks/pagerduty/view.py zerver/webhooks/pagerduty/tests.py
```
**How changes were tested:**

**Screenshots and screen captures:**
<img width="718" height="167" alt="image" src="https://github.com/user-attachments/assets/7db51307-29a1-4e83-a21e-cf357bbd5fd6" />

<img width="706" height="244" alt="image" src="https://github.com/user-attachments/assets/7a5a60ad-a920-4996-960c-7071e63d02c6" />

<img width="713" height="109" alt="image" src="https://github.com/user-attachments/assets/8f856de9-2b49-4c36-98df-d59c4b1f56b4" />

<img width="714" height="43" alt="image" src="https://github.com/user-attachments/assets/b9d45d53-95a1-4f54-ac17-b3787a188e4c" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
