### PR TITLE
api: Sort keys in JSON API responses alphabetically.

### DIFF
--- a/zerver/lib/response.py
+++ b/zerver/lib/response.py
@@ -52,7 +52,9 @@ class MutableJsonResponse(HttpResponse):
             # helps us avoid relying on the particular serialization used by orjson.
             self.content = orjson.dumps(
                 self._data,
-                option=orjson.OPT_APPEND_NEWLINE | orjson.OPT_PASSTHROUGH_DATETIME,
+                option=orjson.OPT_APPEND_NEWLINE
+                | orjson.OPT_PASSTHROUGH_DATETIME
+                | orjson.OPT_SORT_KEYS,
             )
         return super().content
 
@@ -89,7 +91,8 @@ def json_unauthorized(
 def json_method_not_allowed(methods: list[str]) -> HttpResponseNotAllowed:
     resp = HttpResponseNotAllowed(methods)
     resp.content = orjson.dumps(
-        {"result": "error", "msg": "Method Not Allowed", "allowed_methods": methods}
+        {"result": "error", "msg": "Method Not Allowed", "allowed_methods": methods},
+        option=orjson.OPT_SORT_KEYS,
     )
     return resp
 


### PR DESCRIPTION
Fixes #17428.

This adds `orjson.OPT_SORT_KEYS` to the serialization options at the two places in `zerver/lib/response.py` where API responses are serialized to JSON:

1. **`MutableJsonResponse.content` getter** — the central serialization path used by `json_success()`, `json_response()`, and
   `json_response_from_error()`, covering all standard API responses.

2. **`json_method_not_allowed()`** — which uses a separate  `orjson.dumps()` call that bypasses `MutableJsonResponse`.

This ensures all JSON API responses have their keys sorted alphabetically, improving readability when debugging API responses and aligning the actual response key ordering with the sorted ordering already used in our `/api` documentation examples.

### Demo


https://github.com/user-attachments/assets/41e6bb1a-645d-4bc8-89e1-a2087b88cb08


**Before:** Keys in arbitrary insertion order.
**After:** Keys sorted alphabetically (`code`, `msg`, `result`, etc.).

### Testing

- All backend tests pass — existing tests use `orjson.loads()` which
  parses JSON into Python dicts where key order is irrelevant.
- Verified manually on local dev server by hitting
  `/api/v1/server_settings` and `/json/users/me`.
