### PR TITLE
custom_profile_fields: Fix delete modal for select options

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -403,35 +403,14 @@ export const select_field_data_schema = z.record(
 );
 export type SelectFieldData = z.output<typeof select_field_data_schema>;
 
-function read_select_field_data_from_form(
-    $profile_field_form: JQuery,
-    old_field_data: unknown,
-): SelectFieldData {
+function read_select_field_data_from_form($profile_field_form: JQuery): SelectFieldData {
     const field_data: SelectFieldData = {};
     let field_order = 1;
 
-    const old_option_value_map = new Map<string, string>();
-    if (old_field_data !== undefined) {
-        for (const [value, choice] of Object.entries(
-            select_field_data_schema.parse(old_field_data),
-        )) {
-            assert(typeof choice !== "string");
-            old_option_value_map.set(choice.text, value);
-        }
-    }
     $profile_field_form.find("div.choice-row").each(function (this: HTMLElement) {
         const text = util.the($(this).find("input")).value;
         if (text) {
-            let value = old_option_value_map.get(text);
-            if (value !== undefined) {
-                // Resetting the data-value in the form is
-                // important if the user removed an option string
-                // and then added it back again before saving
-                // changes.
-                $(this).attr("data-value", value);
-            } else {
-                value = $(this).attr("data-value")!;
-            }
+            const value = $(this).attr("data-value")!;
             field_data[value] = {text, order: field_order.toString()};
             field_order += 1;
         }
@@ -486,7 +465,7 @@ export function read_field_data_from_form(
 
     // Only the following field types support associated field data.
     if (field_type_id === field_types.DROPDOWN.id) {
-        return read_select_field_data_from_form($profile_field_form, old_field_data);
+        return read_select_field_data_from_form($profile_field_form);
     } else if (field_type_id === field_types.EXTERNAL_ACCOUNT.id) {
         const parsed_old_field_data = old_field_data
             ? external_account_field_schema.parse(old_field_data)


### PR DESCRIPTION
Previously, if an admin deleted an option in a select custom profile field and then typed the same text into a new option, the frontend would silently link them together using the old data-value. This caused two bugs:
1. Deleting and recreating an option bypassed the delete confirmation modal.
2. The frontend allowed saving duplicate choices because they were mapped to the same underlying data-value before being sent to the server.

This commit removes old_field_data from read_select_field_data_from_form so the UI treats matching text as a brand-new option, resolving both issues.

Fixes #29879.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**


https://github.com/user-attachments/assets/3a9994a8-c7ed-44ed-8785-dcb4c182ad7d


https://github.com/user-attachments/assets/de55cc27-f0a1-4144-bf0d-39891a63eebd


https://github.com/user-attachments/assets/13258d93-0d6f-42ee-a95f-fc9c56649df7


https://github.com/user-attachments/assets/4fe492b0-1408-4cd6-805b-f956bbf85b80



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
