### PR TITLE
 user-groups: Fix missing EVERYONE_ON_INTERNET in permission check.

### DIFF
--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -1277,6 +1277,9 @@ def check_user_has_permission_by_role(
     if system_group_name == SystemGroups.NOBODY:
         return False
 
+    if system_group_name == SystemGroups.EVERYONE_ON_INTERNET:
+        return True
+
     if system_group_name == SystemGroups.EVERYONE:
         return True
 

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -718,6 +718,15 @@ class UserGroupTestCase(ZulipTestCase):
             check_user_has_permission_by_role(polonius, everyone_group.id, system_groups_name_dict)
         )
 
+        internet_group = NamedUserGroup.objects.get(
+            name=SystemGroups.EVERYONE_ON_INTERNET,
+            realm_for_sharding=realm,
+            is_system_group=True,
+        )
+        self.assertTrue(
+            check_user_has_permission_by_role(polonius, internet_group.id, system_groups_name_dict)
+        )
+
     def test_user_group_ids_to_user_groups(self) -> None:
         realm = get_realm("zulip")
         hamletcharacters_group = NamedUserGroup.objects.get(


### PR DESCRIPTION
`check_user_has_permission_by_role` had no case for the EVERYONE_ON_INTERNET system group. Because the guest rejection check came before EVERYONE_ON_INTERNET was matched, guest users were incorrectly denied permissions when a setting was configured to allow everyone on the internet.
