### PR TITLE
help: Clarify topic status icons and auto-follow/mute options.

### DIFF
--- a/starlight_help/src/content/docs/follow-a-topic.mdx
+++ b/starlight_help/src/content/docs/follow-a-topic.mdx
@@ -4,6 +4,7 @@ title: Follow a topic
 
 import {Steps, TabItem, Tabs} from "@astrojs/starlight/components";
 
+import FlattenedList from "../../components/FlattenedList.astro";
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import KeyboardTip from "../../components/KeyboardTip.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
@@ -11,31 +12,40 @@ import AutomaticallyFollowTopics from "../include/_AutomaticallyFollowTopics.mdx
 import ConfigureNotificationsForFollowedTopics from "../include/_ConfigureNotificationsForFollowedTopics.mdx";
 import ConfigureTopicNotificationsDesktopWeb from "../include/_ConfigureTopicNotificationsDesktopWeb.mdx";
 import FilterFollowedLeftSidebar from "../include/_FilterFollowedLeftSidebar.mdx";
+import FollowUnmuteOptions from "../include/_FollowUnmuteOptions.mdx";
 import FollowedTopicWorkflows from "../include/_FollowedTopicWorkflows.mdx";
 import GoToInbox from "../include/_GoToInbox.mdx";
 import ManageConfiguredTopicsDesktopWeb from "../include/_ManageConfiguredTopicsDesktopWeb.mdx";
 import ManageConfiguredTopicsMobile from "../include/_ManageConfiguredTopicsMobile.mdx";
 import TopicLongPressMenu from "../include/_TopicLongPressMenu.mdx";
 
+import FollowIcon from "~icons/zulip-icon/follow"
 import SearchIcon from "~icons/zulip-icon/search";
 
-Zulip lets you follow topics you are interested in. You can follow or unfollow
-any topic. You can also configure Zulip to automatically follow topics you start
-or participate in. Participating in a topic means sending a message,
-[reacting](/help/emoji-reactions) with an emoji, or participating in a
-[poll](/help/create-a-poll). You can also automatically follow topics where you
-are [mentioned](/help/mention-a-user-or-group).
+Zulip lets you follow topics you are interested in, which helps you see when you
+have unread messages you care about. You can [follow or
+unfollow](#follow-or-unfollow-a-topic) any topic, and choose which topics you'd
+like to follow automatically:
 
-It's easy to prioritize catching up on followed topics. You can:
+<FlattenedList>
+  <FollowUnmuteOptions />
+
+  * Topics where you are [mentioned](/help/mention-a-user-or-group).
+</FlattenedList>
+
+Followed topics are marked with <FollowIcon /> in the [left
+sidebar](/help/left-sidebar), [inbox](/help/inbox), and elsewhere. It's easy to
+prioritize catching up on followed topics. You can:
 
 * [Configure](/help/follow-a-topic#configure-notifications-for-followed-topics)
   how you get notified about new messages for topics you follow.
 * Use the <kbd>Shift</kbd> + <kbd>N</kbd> [keyboard
   shortcut](/help/keyboard-shortcuts) to go to the next unread followed topic.
-* Filter the [**Inbox**](/help/inbox) and [**Recent
-  conversations**](/help/recent-conversations) views to only show followed
-  topics.
-* See which topics you are following in the **left sidebar**.
+* Filter to view only followed topics in the [inbox](/help/inbox), [recent
+  conversations](/help/recent-conversations), and [list of topics in a
+  channel](/help/list-of-topics).
+* Filter to view only followed topics when [viewing all topics in a
+  channel](/help/left-sidebar#show-all-topics-in-a-channel) in the left sidebar.
 
 You can use followed topics for a variety of workflows:
 

--- a/starlight_help/src/content/include/_ConfigureTopicNotificationsDesktopWeb.mdx
+++ b/starlight_help/src/content/include/_ConfigureTopicNotificationsDesktopWeb.mdx
@@ -15,8 +15,8 @@ import UnmuteIcon from "~icons/zulip-icon/unmute";
 
 <ZulipTip>
   You can also configure notifications by clicking the topic notifications
-  status icon (<MuteIcon />,
-  <InheritIcon />,
-  <UnmuteIcon />, or
-  <FollowIcon />) wherever it appears.
+  status icon (<MuteIcon /> for mute,
+  <InheritIcon /> for default,
+  <UnmuteIcon /> for unmute, or
+  <FollowIcon /> for follow) wherever it appears.
 </ZulipTip>

--- a/starlight_help/src/content/include/_FollowUnmuteOptions.mdx
+++ b/starlight_help/src/content/include/_FollowUnmuteOptions.mdx
@@ -1,0 +1,5 @@
+* Topics you start.
+* Topics you send a message to.
+* Topics you participate in by sending a message,
+  [reacting](/help/emoji-reactions) with an emoji, or responding to a
+  [poll](/help/create-a-poll).

--- a/starlight_help/src/content/include/_MuteUnmuteIntro.mdx
+++ b/starlight_help/src/content/include/_MuteUnmuteIntro.mdx
@@ -1,11 +1,16 @@
 import ZulipNote from "../../components/ZulipNote.astro";
+import FollowUnmuteOptions from "../include/_FollowUnmuteOptions.mdx";
+
+import MuteIcon from "~icons/zulip-icon/mute"
 
 Zulip lets you mute topics and channels to avoid receiving notifications for messages
 you are not interested in. Muting a channel effectively mutes all topics in
 that channel. You can also manually **mute** a topic in an unmuted channel, or
 **unmute** a topic in a muted channel.
 
-Muting has the following effects:
+In unmuted channels, muted topics are marked with <MuteIcon /> in the [left
+sidebar](/help/left-sidebar), [inbox](/help/inbox), and elsewhere. Muting has
+the following effects:
 
 * Messages in muted topics do not generate notifications (including [alert
   word](/help/dm-mention-alert-notifications#alert-words) notifications), unless
@@ -20,6 +25,12 @@ Muting has the following effects:
 * In the desktop/web app, muted topics are sorted to the bottom of their
   channel, and muted channels appear in a collapsible section at the bottom of
   their channel folder in the left sidebar.
+
+To avoid missing messages you care about, you can choose which topics you'd like
+to [unmute
+automatically](/help/mute-a-topic#automatically-unmute-topics-in-muted-channels):
+
+<FollowUnmuteOptions />
 
 You can search muted messages using the `is:muted` [search
 filter](/help/search-for-messages#search-by-message-status), or exclude them


### PR DESCRIPTION
Fixes: [#user questions > mute vs default vs unmute vs follow](https://chat.zulip.org/#narrow/channel/138-user-questions/topic/mute.20vs.20default.20vs.20unmute.20vs.20follow/with/2390111)

## Notes
- We usually don't list dropdown options, but I felt that it was worth describing them in the intros here. The previous version sort of did so for followed topics (in the intro paragraph).

# https://zulip.com/help/follow-a-topic
<img width="1594" height="992" alt="Screenshot 2026-04-05 at 22 03 34@2x" src="https://github.com/user-attachments/assets/4329de14-0341-4b6a-a5b0-3e4629a9773c" />

# https://zulip.com/help/mute-a-topic
(also https://zulip.com/help/mute-a-channel)

<img width="1546" height="1454" alt="Screenshot 2026-04-05 at 22 33 11@2x" src="https://github.com/user-attachments/assets/aa5cadee-8f93-461a-9da1-572c329079d2" />
<img width="1508" height="914" alt="Screenshot 2026-04-05 at 22 33 20@2x" src="https://github.com/user-attachments/assets/2034c7cc-86a2-4fe0-8007-391da03d5ef8" />
