### PR TITLE
custom_profile_fields: Fix delete modal crash.

### DIFF
--- a/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
@@ -20,7 +20,7 @@
     {{/if}}
 </div>
 <ul class="modal-options-list">
-    {{#each deleted_values}}
+    {{#each (object_values deleted_values)}}
         <li>{{this}}</li>
     {{/each}}
 </ul>


### PR DESCRIPTION
The delete confirmation modal crashed with a BlueslipError because deleted_values was passed as a dictionary.
This PR uses the object_values Handlebars helper to convert the dictionary to an array within the template, fixing the crash.

<!-- Describe your pull request here.-->

Fixes: [#issues > BlueslipError when deleting-options from custom profilefield](https://chat.zulip.org/#narrow/channel/9-issues/topic/BlueslipError.20when.20deleting-options.20from.20custom.20profilefield/with/2426827)<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/13bd383f-ab37-4559-81dd-55b563b6993e



https://github.com/user-attachments/assets/e5fe701a-f4be-4fa0-aa60-0e14d9049a70


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
