### PR TITLE
drafts: Fix incorrect draft selection on Enter.

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -192,7 +192,7 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
         if (focused_draft_id !== undefined) {
             restore_draft(focused_draft_id);
         } else {
-            const first_draft = draft_id_arrow.at(-1);
+            const first_draft = draft_id_arrow.at(0);
             assert(first_draft !== undefined);
             restore_draft(first_draft);
         }


### PR DESCRIPTION
When opening the drafts overlay and pressing Enter the last draft was opened instead of the visually highlighted first draft.Fix this by updating the fallback to use the first draft when no element is focused.

<!-- Describe your pull request here.-->

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20drafts.20keyboard.20navigation.20bug/with/2427199)[#issues > 🎯 drafts keyboard navigation bug](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20drafts.20keyboard.20navigation.20bug/with/2427199)

**How changes were tested:**
Visually tested and confirmed the behaviour 
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**


https://github.com/user-attachments/assets/8f8ec016-bb9a-4edf-bc1a-108c688c9e10




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
