### PR TITLE
user_group_settings: Fix edit button appearing when not useable.

### DIFF
--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -280,9 +280,9 @@ function update_general_panel_ui(group: UserGroup): void {
     const $edit_container = get_edit_container(group.id);
 
     if (settings_data.can_manage_user_group(group.id)) {
-        $edit_container.find(".group-description-field .button-group").show();
+        $edit_container.find(".group-description-field #open_group_info_modal").show();
     } else {
-        $edit_container.find(".group-description-field .button-group").hide();
+        $edit_container.find(".group-description-field #open_group_info_modal").hide();
     }
     update_user_group_title_buttons(group);
     update_group_permission_settings_elements(group);


### PR DESCRIPTION
Previously the edit user group button next to the description field always shows even if the user doesn't have permission to  manage the group.

While making [this](https://github.com/zulip/zulip/pull/37488#issuecomment-4144374570) change specifically, I removed the `button-groups` wrapper for the edit user group button but didn't update the button select code in `user_group_edit.ts`, which targets the edit button using the `button-groups` wrapper.

**Screenshots and screen captures:**

  | Before | After |
  |--------|--------|
  | <img width="862" height="250" alt="image" src="https://github.com/user-attachments/assets/f5f43cba-c8dc-472b-b190-64ac3393e15d" /> | <img width="862" height="260" alt="image" src="https://github.com/user-attachments/assets/f5f3ac8b-da4a-4c04-9915-13d8888c4d07" />|
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
