### PR TITLE
left_sidebar: Don't auto scroll in already expanded channel.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1270,6 +1270,8 @@ export function handle_narrow_activated(
     change_hash: boolean,
     show_more_topics: boolean,
 ): void {
+    const previously_expanded_stream_id = topic_list.active_stream_id();
+
     // Zoom out, if needed, so that get_stream_li returns the correct
     // value when calling update_stream_sidebar_for_narrow.
     if (!change_hash && is_zoomed_in() && !show_more_topics) {
@@ -1281,7 +1283,11 @@ export function handle_narrow_activated(
         zoom_in();
     }
 
-    scroll_stream_into_view();
+    // Do not auto scroll when switching topics in an already expanded channel.
+    const info = get_sidebar_stream_topic_info(filter);
+    if (info.stream_id !== previously_expanded_stream_id) {
+        scroll_stream_into_view();
+    }
 }
 
 export function handle_message_view_deactivated(): void {


### PR DESCRIPTION
In #38123, we changed the code to scroll to show all topics when activating a narrow, but we forgot to account for the case where the channel was already expanded. This caused jump in the scroll state of the user as reported in
https://chat.zulip.org/#narrow/channel/138-user-questions/topic/Clicking.20topic.20auto-scrolls.20sidebar.20when.20channel.20not.20in.20view/with/2427100


**How changes were tested:**
In addition to the before and after screenshots, I did one simple check of checking for regressions by clicking on the recent conversations topic and ensureing that show all topics is displayed when invoked that way.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Before:
![before_scroll_show_topics](https://github.com/user-attachments/assets/0ce5f027-3f65-4bbf-9b5f-038b129806b8)

After:
![after_scroll_show_topics](https://github.com/user-attachments/assets/be14609c-5be4-4e1f-9ffe-1a87c6a022ac)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
