### PR TITLE
message_header: Avoid narrowing when selecting a channel/dm recipient.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -548,17 +548,24 @@ export function initialize(): void {
         return nearest.id;
     }
 
-    $("#message_feed_container").on("click", ".narrows_by_topic", function (this: HTMLElement, e) {
-        if (e.metaKey || e.ctrlKey || e.shiftKey) {
-            return;
-        }
-        e.preventDefault();
-        if (mouse_drag.is_drag(e)) {
-            return;
-        }
-        const row_id = get_row_id_for_narrowing(this);
-        message_view.narrow_by_topic(row_id, {trigger: "message header"});
-    });
+    $("#message_feed_container").on(
+        "click",
+        ".narrows_by_topic, .narrows_by_recipient",
+        function (this: HTMLElement, e) {
+            if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                return;
+            }
+            if (mouse_drag.is_drag(e)) {
+                e.preventDefault();
+                return;
+            }
+            if ($(this).hasClass("narrows_by_topic")) {
+                e.preventDefault();
+                const row_id = get_row_id_for_narrowing(this);
+                message_view.narrow_by_topic(row_id, {trigger: "message header"});
+            }
+        },
+    );
 
     // SIDEBARS
     $("body").on("click", ".compose-new-direct-message", (e) => {


### PR DESCRIPTION
Selecting channel in message header:
| Before | After |
|----|-----|
|![before(channel)](https://github.com/user-attachments/assets/2bdb0fe1-83b2-4e1f-9396-7ea513b9f739)|![after(channel)](https://github.com/user-attachments/assets/0f6c6bec-5045-40e9-831d-e955cb947ae1)|


Private message header:
| Before | After |
|-----|-----|
| ![before(dm)](https://github.com/user-attachments/assets/9e1d42dc-ae81-4fa1-85c7-000857fed0e3)| ![after(dm)](https://github.com/user-attachments/assets/361d644a-79a1-4b4f-aa53-91bd8ca0165e)|