### PR TITLE
demo-orgs: Update tests for create_demo_organization_owner helper.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -339,18 +339,12 @@ class HomeTest(ZulipTestCase):
         self.assertCountEqual(page_params["state_data"]["realm_bots"][0], realm_bots_expected_keys)
 
     def test_home_demo_organization(self) -> None:
-        realm = get_realm("zulip")
-
-        # We construct a scheduled deletion date that's definitely in
-        # the future, regardless of how long ago the Zulip realm was
-        # created.
-        realm.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(days=1)
-        realm.save()
-        self.login("hamlet")
+        demo_organization_owner = self.create_demo_organization_owner()
+        realm = demo_organization_owner.realm
 
         # Verify succeeds once logged-in
         with queries_captured(), patch("zerver.lib.cache.cache_set"):
-            result = self._get_home_page(stream="Denmark")
+            result = self._get_home_page(subdomain=realm.subdomain, stream="Zulip")
             self.check_rendered_logged_in_app(result)
 
         page_params = self._get_page_params(result)
@@ -654,14 +648,15 @@ class HomeTest(ZulipTestCase):
         html = result.content.decode()
         self.assertIn("test_stream_7", html)
 
-    def _get_home_page(self, **kwargs: Any) -> "TestHttpResponse":
+    def _get_home_page(self, subdomain: str | None = None, **kwargs: Any) -> "TestHttpResponse":
         queue_data = EventQueueData(queue_id="test-queue-id", idle_queue_timeout_secs=600)
         with (
             patch("zerver.lib.events.request_event_queue", return_value=queue_data),
             patch("zerver.lib.events.get_user_events", return_value=[]),
         ):
-            result = self.client_get("/", dict(**kwargs))
-        return result
+            if subdomain:
+                return self.client_get("/", dict(**kwargs), subdomain=subdomain)
+            return self.client_get("/", dict(**kwargs))
 
     def _sanity_check(self, result: "TestHttpResponse") -> None:
         """

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -2,7 +2,6 @@ import base64
 import random
 import re
 from collections.abc import Sequence
-from datetime import timedelta
 from email.headerregistry import Address
 from unittest import mock
 from unittest.mock import patch
@@ -13,7 +12,6 @@ from django.conf import settings
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 from django.test import override_settings
-from django.utils.timezone import now as timezone_now
 from django_stubs_ext import StrPromise
 
 from zerver.actions.create_user import do_create_user
@@ -96,19 +94,13 @@ class TestMessageNotificationEmails(ZulipTestCase):
         m.assert_not_called()
 
     def test_demo_organization_owner_email_not_set(self) -> None:
-        realm = get_realm("zulip")
-        realm.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(days=30)
-        realm.save()
-
-        # Demo organization owner's don't have an email address set initially
-        desdemona = self.example_user("desdemona")
-        desdemona.delivery_email = ""
-        desdemona.save()
+        demo_organization_owner = self.create_demo_organization_owner()
+        realm = demo_organization_owner.realm
 
         notification_bot = self.notification_bot(realm)
         internal_send_private_message(
             sender=notification_bot,
-            recipient_user=desdemona,
+            recipient_user=demo_organization_owner,
             content="Notification bot message",
         )
         message = self.get_last_message()
@@ -119,7 +111,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
             "zerver.lib.email_notifications.do_send_missedmessage_events_reply_in_zulip"
         ) as m:
             handle_missedmessage_emails(
-                desdemona.id,
+                demo_organization_owner.id,
                 {message.id: MissedMessageData(trigger=NotificationTriggers.DIRECT_MESSAGE)},
             )
         m.assert_not_called()

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -271,32 +271,19 @@ class RealmTest(ZulipTestCase):
         self.assertNotEqual(realm.description, new_description)
 
     def test_demo_organization_invite_required(self) -> None:
-        realm = get_realm("zulip")
-        self.assertFalse(realm.invite_required)
+        demo_organization_owner = self.create_demo_organization_owner()
+        realm = demo_organization_owner.realm
 
-        self.login("desdemona")
-        data = dict(invite_required="true")
-        result = self.client_patch("/json/realm", data)
-        self.assert_json_success(result)
-        realm.refresh_from_db()
+        # Demo organization owners must configure an email to invite
+        # other users.
         self.assertTrue(realm.invite_required)
-
-        # Update realm to be a demo organization
-        realm.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(days=30)
-        realm.save()
-
-        # Demo organization owner's don't have an email address set initially
-        desdemona = self.example_user("desdemona")
-        desdemona.delivery_email = ""
-        desdemona.save()
-
         data = dict(invite_required="false")
-        result = self.client_patch("/json/realm", data)
+        result = self.client_patch("/json/realm", data, subdomain=realm.subdomain)
         self.assert_json_error(result, "Configure owner account email address.")
 
-        desdemona.delivery_email = "desdemona@zulip.com"
-        desdemona.save()
-        result = self.client_patch("/json/realm", data)
+        demo_organization_owner.delivery_email = "test-demo-owner@zulip.com"
+        demo_organization_owner.save()
+        result = self.client_patch("/json/realm", data, subdomain=realm.subdomain)
         self.assert_json_success(result)
         realm.refresh_from_db()
         self.assertFalse(realm.invite_required)
@@ -1472,61 +1459,50 @@ class RealmTest(ZulipTestCase):
             mock_scrub_realm.assert_called_once_with(zephyr, acting_user=None)
 
     def test_delete_expired_demo_organizations(self) -> None:
-        zulip = get_realm("zulip")
-        assert not zulip.deactivated
-        assert zulip.demo_organization_scheduled_deletion_date is None
+        demo_organization_owner = self.create_demo_organization_owner()
+        demo_organization = demo_organization_owner.realm
+        assert not demo_organization.deactivated
 
+        # Before deletion date, demo organization is not deleted.
         with mock.patch(
             "zerver.actions.realm_settings.do_deactivate_realm"
         ) as mock_deactivate_realm:
             delete_expired_demo_organizations()
             mock_deactivate_realm.assert_not_called()
-
-        # Add scheduled demo organization deletion date
-        zulip.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(days=4)
-        zulip.save()
-
-        # Before deletion date
-        with mock.patch(
-            "zerver.actions.realm_settings.do_deactivate_realm"
-        ) as mock_deactivate_realm:
-            delete_expired_demo_organizations()
-            mock_deactivate_realm.assert_not_called()
-
-        # After deletion date, when owner email is set.
-        with (
-            time_machine.travel(timezone_now() + timedelta(days=5), tick=False),
-            mock.patch(
-                "zerver.actions.realm_settings.do_deactivate_realm"
-            ) as mock_deactivate_realm,
-        ):
-            delete_expired_demo_organizations()
-            mock_deactivate_realm.assert_called_once_with(
-                realm=zulip,
-                acting_user=None,
-                deactivation_reason="demo_expired",
-                deletion_delay_days=0,
-                email_owners=True,
-            )
 
         # After deletion date, when owner email is not set.
-        desdemona = self.example_user("desdemona")
-        desdemona.delivery_email = ""
-        desdemona.save()
-
         with (
-            time_machine.travel(timezone_now() + timedelta(days=5), tick=False),
+            time_machine.travel(timezone_now() + timedelta(days=31), tick=False),
             mock.patch(
                 "zerver.actions.realm_settings.do_deactivate_realm"
             ) as mock_deactivate_realm,
         ):
             delete_expired_demo_organizations()
             mock_deactivate_realm.assert_called_once_with(
-                realm=zulip,
+                realm=demo_organization,
                 acting_user=None,
                 deactivation_reason="demo_expired",
                 deletion_delay_days=0,
                 email_owners=False,
+            )
+
+        demo_organization_owner.delivery_email = "test-demo-owner@zulip.com"
+        demo_organization_owner.save()
+
+        # After deletion date, when owner email is set.
+        with (
+            time_machine.travel(timezone_now() + timedelta(days=31), tick=False),
+            mock.patch(
+                "zerver.actions.realm_settings.do_deactivate_realm"
+            ) as mock_deactivate_realm,
+        ):
+            delete_expired_demo_organizations()
+            mock_deactivate_realm.assert_called_once_with(
+                realm=demo_organization,
+                acting_user=None,
+                deactivation_reason="demo_expired",
+                deletion_delay_days=0,
+                email_owners=True,
             )
 
     def test_initial_plan_type(self) -> None:


### PR DESCRIPTION
Follow-up to #38779.

**Notes**:
- Updates backend tests that are using the Zulip dev org and Desdemona/Hamlet to test demo organization behavior.
- Remaining backend tests that do not use this helper:
  - `test_docs`: This test confirms when `demo_organization_scheduled_deletion_date` is not `None`, the Zulip organization is not shown on the communities directory, which seems fine to leave as is.
  - `test_signup`: This test is the dev environment endpoint for creating a demo organization.
  - `test_realm_creation`: These realm creation tests already are generating a demo organization, and therefore seem fine to leave as is.

```console
$ git grep -c demo_org zerver/tests/
zerver/tests/test_bots.py:2
zerver/tests/test_docs.py:1
zerver/tests/test_email_change.py:2
zerver/tests/test_home.py:3
zerver/tests/test_message_notification_emails.py:2
zerver/tests/test_realm.py:20
zerver/tests/test_realm_creation.py:4
zerver/tests/test_signup.py:2

```

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
