### PR TITLE
click_handlers: Open message actions popover on right-click.

### DIFF
--- a/starlight_help/src/content/docs/message-actions.mdx
+++ b/starlight_help/src/content/docs/message-actions.mdx
@@ -5,6 +5,7 @@ title: Message actions
 import {TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
+import ZulipTip from "../../components/ZulipTip.astro";
 import MessageActionsMenu from "../include/_MessageActionsMenu.mdx";
 import MessageLongPressMenu from "../include/_MessageLongPressMenu.mdx";
 
@@ -33,6 +34,10 @@ In the mobile app, the message actions menu lets you:
     <FlattenedSteps>
       <MessageActionsMenu />
     </FlattenedSteps>
+
+    <ZulipTip>
+      You can also **Right-click** a message to open the message actions menu.
+    </ZulipTip>
   </TabItem>
 
   <TabItem label="Mobile">

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -18,6 +18,7 @@ import * as emoji_picker from "./emoji_picker.ts";
 import * as flatpickr from "./flatpickr.ts";
 import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
+import * as message_actions_popover from "./message_actions_popover.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
@@ -242,6 +243,53 @@ export function initialize(): void {
     // selection function which will open the compose box  and select the message.
     if (!util.is_mobile()) {
         $("#main_div").on("click", ".messagebox", select_message_function);
+    }
+
+    // Right-click opens the message actions popover at the cursor instead of the
+    // browser's context menu.
+    if (!util.is_mobile()) {
+        $("#main_div").on("contextmenu", ".messagebox", function (e) {
+            assert(e.target instanceof Element);
+            const $target = $(e.target);
+
+            if (document.getSelection()?.type === "Range") {
+                // The browser's context menu is more useful for selected
+                // text (copy, translate, search).
+                return;
+            }
+
+            if (is_clickable_message_element($target)) {
+                // Elements with their own click behavior keep the browser's
+                // native context menu rather than opening the popover.
+                return;
+            }
+
+            const $row = $(this).closest(".message_row");
+            const id = rows.id($row);
+            const message = message_store.get(id);
+            if (
+                message === undefined ||
+                message.locally_echoed ||
+                message_edit.currently_editing_messages.has(id)
+            ) {
+                // Failed sends lack the menu button and edits replace it, so
+                // leave the browser's native context menu in place rather than
+                // suppressing it for a popover we won't open.
+                return;
+            }
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            assert(message_lists.current !== undefined);
+            message_lists.current.select_id(id);
+
+            message_actions_popover.open_message_actions_popover_at_position(
+                $row,
+                e.clientX,
+                e.clientY,
+            );
+        });
     }
 
     $("#main_div").on("click", ".star_container", function (e) {

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -47,6 +47,52 @@ import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
+type RightClickSelectionContext = {
+    use_browser_context_menu: boolean;
+    quote?: compose_reply.SelectionQuote;
+};
+
+let right_click_selection_context: RightClickSelectionContext | undefined;
+
+// Determine when right-click (x, y) lands on the selected text, so a right-click on
+// selected text keeps the browser's menu while one on nearby blank space still
+// opens ours. We test the text-node rects, not Range.getClientRects(), which
+// spans the blank block area around a fully selected paragraph or code block.
+function selection_contains_text_at_point(selection: Selection, x: number, y: number): boolean {
+    for (let i = 0; i < selection.rangeCount; i += 1) {
+        // Firefox splits a multi-message selection into several ranges.
+        const range = selection.getRangeAt(i);
+        const root = range.commonAncestorContainer;
+        const text_nodes: Node[] = [];
+        if (root.nodeType === Node.TEXT_NODE) {
+            text_nodes.push(root);
+        } else {
+            // Walks every text node under the common ancestor, not just the
+            // selected ones, but this runs once per right-click, so it's not
+            // worth scoping out the extra nodes in a multi-message selection.
+            const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+            for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+                text_nodes.push(node);
+            }
+        }
+        for (const node of text_nodes) {
+            if (!range.intersectsNode(node)) {
+                continue;
+            }
+            const text_range = compose_reply.get_range_intersection_with_element(range, node);
+            for (const rect of text_range.getClientRects()) {
+                if (rect.width === 0 || rect.height === 0) {
+                    continue;
+                }
+                if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 export function initialize(): void {
     // MESSAGE CLICKING
 
@@ -248,13 +294,61 @@ export function initialize(): void {
     // Right-click opens the message actions popover at the cursor instead of the
     // browser's context menu.
     if (!util.is_mobile()) {
+        $("#main_div").on("mousedown", ".messagebox", (e) => {
+            // A keyboard-invoked context menu (Menu key / Shift+F10) fires no
+            // mousedown, so leaving the context unset here lets its contextmenu
+            // fall through to the browser's native menu.
+            right_click_selection_context = undefined;
+            if (e.button !== 2) {
+                return;
+            }
+
+            // Capture the selection now, while it's still intact — the browser
+            // would otherwise mutate it before the contextmenu event fires.
+            const selection = window.getSelection();
+            if (selection?.type !== "Range" || selection.toString() === "") {
+                // A right-click with no text selected still opens our popover,
+                // just without a quote.
+                right_click_selection_context = {use_browser_context_menu: false};
+                return;
+            }
+
+            // A right-click outside the selection would otherwise collapse it;
+            // preventing the mousedown default keeps the highlight visible (and
+            // available to quote) without suppressing the contextmenu event.
+            e.preventDefault();
+
+            const use_browser_context_menu = selection_contains_text_at_point(
+                selection,
+                e.clientX,
+                e.clientY,
+            );
+            const quote = use_browser_context_menu
+                ? undefined
+                : compose_reply.get_quote_from_single_message_selection(selection);
+            right_click_selection_context = {
+                use_browser_context_menu,
+                ...(quote !== undefined && {quote}),
+            };
+        });
+
+        $(document).on("contextmenu", () => {
+            right_click_selection_context = undefined;
+        });
+
         $("#main_div").on("contextmenu", ".messagebox", function (e) {
             assert(e.target instanceof Element);
             const $target = $(e.target);
+            const selection_context = right_click_selection_context;
+            right_click_selection_context = undefined;
 
-            if (document.getSelection()?.type === "Range") {
-                // The browser's context menu is more useful for selected
-                // text (copy, translate, search).
+            if (selection_context === undefined || selection_context.use_browser_context_menu) {
+                // Leave the browser's native context menu (copy, translate,
+                // search) in place when it's more useful or the only option:
+                // a keyboard-invoked context menu (Menu key / Shift+F10) fires
+                // no right-click mousedown, so there's no cursor to anchor our
+                // popover to; and a right-click landing on selected text is
+                // better served by the browser's own menu.
                 return;
             }
 
@@ -284,10 +378,16 @@ export function initialize(): void {
             assert(message_lists.current !== undefined);
             message_lists.current.select_id(id);
 
+            const quote_content =
+                selection_context.quote?.message_id === id
+                    ? selection_context.quote.content
+                    : undefined;
+
             message_actions_popover.open_message_actions_popover_at_position(
                 $row,
                 e.clientX,
                 e.clientY,
+                quote_content,
             );
         });
     }

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -18,6 +18,7 @@ import * as emoji_picker from "./emoji_picker.ts";
 import * as flatpickr from "./flatpickr.ts";
 import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
+import * as message_actions_popover from "./message_actions_popover.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
@@ -242,6 +243,54 @@ export function initialize(): void {
     // selection function which will open the compose box  and select the message.
     if (!util.is_mobile()) {
         $("#main_div").on("click", ".messagebox", select_message_function);
+    }
+
+    // Right-click on a message body opens the message actions popover at the
+    // cursor instead of the browser's context menu. Only the message content
+    //  area is handled here which does not include sender name, reactions etc.
+    if (!util.is_mobile()) {
+        $("#main_div").on("contextmenu", ".message_content", function (e) {
+            assert(e.target instanceof Element);
+            const $target = $(e.target);
+
+            if (document.getSelection()?.type === "Range") {
+                // The browser's context menu is more useful for selected
+                // text (copy, translate, search).
+                return;
+            }
+
+            if (is_clickable_message_element($target)) {
+                // Elements with their own click behavior keep the browser's
+                // native context menu rather than opening the popover.
+                return;
+            }
+
+            const $row = $(this).closest(".message_row");
+            const id = rows.id($row);
+            const message = message_store.get(id);
+            if (
+                message === undefined ||
+                message.locally_echoed ||
+                message_edit.currently_editing_messages.has(id)
+            ) {
+                // Failed sends lack the menu button and edits replace it, so
+                // leave the browser's native context menu in place rather than
+                // suppressing it for a popover we won't open.
+                return;
+            }
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            assert(message_lists.current !== undefined);
+            message_lists.current.select_id(id);
+
+            message_actions_popover.open_message_actions_popover_at_position(
+                $row,
+                e.clientX,
+                e.clientY,
+            );
+        });
     }
 
     $("#main_div").on("click", ".star_container", function (e) {

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -47,6 +47,52 @@ import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
+type RightClickSelectionContext = {
+    use_browser_context_menu: boolean;
+    quote_menu_selection?: compose_reply.QuoteMenuSelection;
+};
+
+let right_click_selection_context: RightClickSelectionContext | undefined;
+
+// Determine when right-click (x, y) lands on the selected text, so a right-click on
+// selected text keeps the browser's menu while one on nearby blank space still
+// opens ours. We test the text-node rects, not Range.getClientRects(), which
+// spans the blank block area around a fully selected paragraph or code block.
+function selection_contains_text_at_point(selection: Selection, x: number, y: number): boolean {
+    for (let i = 0; i < selection.rangeCount; i += 1) {
+        // Firefox splits a multi-message selection into several ranges.
+        const range = selection.getRangeAt(i);
+        const root = range.commonAncestorContainer;
+        const text_nodes: Node[] = [];
+        if (root.nodeType === Node.TEXT_NODE) {
+            text_nodes.push(root);
+        } else {
+            // Walks every text node under the common ancestor, not just the
+            // selected ones, but this runs once per right-click, so it's not
+            // worth scoping out the extra nodes in a multi-message selection.
+            const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+            for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+                text_nodes.push(node);
+            }
+        }
+        for (const node of text_nodes) {
+            if (!range.intersectsNode(node)) {
+                continue;
+            }
+            const text_range = compose_reply.get_range_intersection_with_element(range, node);
+            for (const rect of text_range.getClientRects()) {
+                if (rect.width === 0 || rect.height === 0) {
+                    continue;
+                }
+                if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 export function initialize(): void {
     // MESSAGE CLICKING
 
@@ -249,13 +295,61 @@ export function initialize(): void {
     // cursor instead of the browser's context menu. Only the message content
     //  area is handled here which does not include sender name, reactions etc.
     if (!util.is_mobile()) {
+        $("#main_div").on("mousedown", ".message_content", (e) => {
+            // A keyboard-invoked context menu (Menu key / Shift+F10) fires no
+            // mousedown, so leaving the context unset here lets its contextmenu
+            // fall through to the browser's native menu.
+            right_click_selection_context = undefined;
+            if (e.button !== 2) {
+                return;
+            }
+
+            // Capture the selection now, while it's still intact — the browser
+            // would otherwise mutate it before the contextmenu event fires.
+            const selection = window.getSelection();
+            if (selection?.type !== "Range" || selection.toString() === "") {
+                // A right-click with no text selected still opens our popover,
+                // just without a quote.
+                right_click_selection_context = {use_browser_context_menu: false};
+                return;
+            }
+
+            // A right-click outside the selection would otherwise collapse it;
+            // preventing the mousedown default keeps the highlight visible (and
+            // available to quote) without suppressing the contextmenu event.
+            e.preventDefault();
+
+            const message_id = rows.id($(e.currentTarget).closest(".message_row"));
+            const selected_message_ids = compose_reply.get_highlighted_message_ids(selection) ?? [];
+            const use_browser_context_menu =
+                !selected_message_ids.includes(message_id) ||
+                selection_contains_text_at_point(selection, e.clientX, e.clientY);
+            const quote_menu_selection = use_browser_context_menu
+                ? undefined
+                : compose_reply.get_quote_menu_selection(message_id);
+            right_click_selection_context = {
+                use_browser_context_menu,
+                ...(quote_menu_selection !== undefined && {quote_menu_selection}),
+            };
+        });
+
+        $(document).on("contextmenu", () => {
+            right_click_selection_context = undefined;
+        });
+
         $("#main_div").on("contextmenu", ".message_content", function (e) {
             assert(e.target instanceof Element);
             const $target = $(e.target);
+            const selection_context = right_click_selection_context;
+            right_click_selection_context = undefined;
 
-            if (document.getSelection()?.type === "Range") {
-                // The browser's context menu is more useful for selected
-                // text (copy, translate, search).
+            if (selection_context === undefined || selection_context.use_browser_context_menu) {
+                // Leave the browser's native context menu (copy, translate,
+                // search) in place when it's more useful or the only option:
+                // a keyboard-invoked context menu (Menu key / Shift+F10) fires
+                // no right-click mousedown, so there's no cursor to anchor our
+                // popover to; and a right-click landing on selected text is
+                // better served by the browser's own menu.
                 return;
             }
 
@@ -289,6 +383,7 @@ export function initialize(): void {
                 $row,
                 e.clientX,
                 e.clientY,
+                selection_context.quote_menu_selection,
             );
         });
     }

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -227,6 +227,20 @@ export function rewire_get_highlighted_message_ids(
     get_highlighted_message_ids = value;
 }
 
+export type SelectionQuote = {message_id: number; content: string};
+
+export function get_quote_from_single_message_selection(
+    selection = window.getSelection(),
+): SelectionQuote | undefined {
+    const highlighted_message_ids = get_highlighted_message_ids(selection);
+    if (highlighted_message_ids?.length !== 1) {
+        return undefined;
+    }
+    const message_id = highlighted_message_ids[0];
+    assert(message_id !== undefined);
+    return {message_id, content: get_message_selection(selection)};
+}
+
 function get_quote_target_for_single_message(opts: {
     message_id?: number;
     quote_content?: string | undefined;
@@ -807,7 +821,7 @@ function extract_range_html(range: Range, preserve_ancestors = false): string {
     return temp_div.innerHTML;
 }
 
-function get_range_intersection_with_element(range: Range, element: Node): Range {
+export function get_range_intersection_with_element(range: Range, element: Node): Range {
     // Returns a new range that is a subset of range and is inside element.
     const intersection = document.createRange();
     intersection.selectNodeContents(element);

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -870,7 +870,7 @@ function extract_range_html(range: Range, preserve_ancestors = false): string {
     return temp_div.innerHTML;
 }
 
-function get_range_intersection_with_element(range: Range, element: Node): Range {
+export function get_range_intersection_with_element(range: Range, element: Node): Range {
     // Returns a new range that is a subset of range and is inside element.
     const intersection = document.createRange();
     intersection.selectNodeContents(element);

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -27,6 +27,8 @@ import {the} from "./util.ts";
 
 let message_actions_popover_keyboard_toggle = false;
 
+let message_actions_popover_props: Partial<tippy.Props> | undefined;
+
 function get_action_menu_menu_items(): JQuery {
     return $("[data-tippy-root] #message-actions-menu-dropdown li:not(.divider) a");
 }
@@ -36,6 +38,20 @@ function focus_first_action_popover_item(): void {
     // Our popup menus act kind of funny when you mix keyboard and mouse.
     const $items = get_action_menu_menu_items();
     popover_menus.focus_first_popover_item($items);
+}
+
+export function open_message_actions_popover_at_position($row: JQuery, x: number, y: number): void {
+    if (popovers.any_active()) {
+        popovers.hide_all();
+    }
+
+    assert(message_actions_popover_props !== undefined);
+    const button = the($row.find(".message-actions-menu-button"));
+    popover_menus.toggle_popover_menu(button, message_actions_popover_props, {
+        show_as_overlay_on_mobile: false,
+        show_as_overlay_always: false,
+        mouse_position: {x, y},
+    });
 }
 
 export function toggle_message_actions_menu(message: Message): boolean {
@@ -75,7 +91,7 @@ export function initialize({
         target: tippy.ReferenceElement,
     ) => void;
 }): void {
-    popover_menus.register_popover_menu(".actions_hover .message-actions-menu-button", {
+    message_actions_popover_props = {
         theme: "popover-menu",
         placement: "bottom",
         popperOptions: {
@@ -261,5 +277,9 @@ export function initialize({
             popover_menus.popover_instances.message_actions = null;
             message_actions_popover_keyboard_toggle = false;
         },
-    });
+    };
+    popover_menus.register_popover_menu(
+        ".actions_hover .message-actions-menu-button",
+        message_actions_popover_props,
+    );
 }

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -29,6 +29,8 @@ let message_actions_popover_keyboard_toggle = false;
 
 let message_actions_popover_props: Partial<tippy.Props> | undefined;
 
+let quote_content_for_next_open: string | undefined;
+
 function get_action_menu_menu_items(): JQuery {
     return $("[data-tippy-root] #message-actions-menu-dropdown li:not(.divider) a");
 }
@@ -40,10 +42,17 @@ function focus_first_action_popover_item(): void {
     popover_menus.focus_first_popover_item($items);
 }
 
-export function open_message_actions_popover_at_position($row: JQuery, x: number, y: number): void {
+export function open_message_actions_popover_at_position(
+    $row: JQuery,
+    x: number,
+    y: number,
+    quote_content?: string,
+): void {
     if (popovers.any_active()) {
         popovers.hide_all();
     }
+
+    quote_content_for_next_open = quote_content;
 
     assert(message_actions_popover_props !== undefined);
     const button = the($row.find(".message-actions-menu-button"));
@@ -117,19 +126,16 @@ export function initialize({
         onMount(instance) {
             const $row = $(instance.reference).closest(".message_row");
             const message_id = rows.id($row);
-            let quote_content: string | undefined;
-            const highlighted_message_ids = compose_reply.get_highlighted_message_ids();
-            if (
-                highlighted_message_ids &&
-                highlighted_message_ids?.length === 1 &&
-                highlighted_message_ids[0] === message_id
-            ) {
-                // If the user has selected text within this message, quote only that.
-                // We track the selection right now, before the popover option for Quote
-                // and reply is clicked, since by then the selection is lost, due to the
-                // change in focus.
-                quote_content = compose_reply.get_message_selection();
-            }
+            // If the user has selected text within this message, quote only that.
+            // We track the selection right now, before the popover option for Quote
+            // and reply is clicked, since by then the selection is lost, due to the
+            // change in focus. The right-click path may pass the same content captured
+            // before the browser had a chance to drop the selection.
+            const selection_quote = compose_reply.get_quote_from_single_message_selection();
+            const quote_content =
+                quote_content_for_next_open ??
+                (selection_quote?.message_id === message_id ? selection_quote.content : undefined);
+            quote_content_for_next_open = undefined;
             if (message_actions_popover_keyboard_toggle) {
                 focus_first_action_popover_item();
                 message_actions_popover_keyboard_toggle = false;
@@ -276,6 +282,7 @@ export function initialize({
             instance.destroy();
             popover_menus.popover_instances.message_actions = null;
             message_actions_popover_keyboard_toggle = false;
+            quote_content_for_next_open = undefined;
         },
     };
     popover_menus.register_popover_menu(

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -82,10 +82,23 @@ function focus_first_action_popover_item(): void {
     popover_menus.focus_first_popover_item($items);
 }
 
-export function open_message_actions_popover_at_position($row: JQuery, x: number, y: number): void {
+export function open_message_actions_popover_at_position(
+    $row: JQuery,
+    x: number,
+    y: number,
+    quote_menu_selection?: compose_reply.QuoteMenuSelection,
+): void {
     if (popovers.any_active()) {
         popovers.hide_all();
     }
+
+    // The right-click that opens this menu destroys the selection before we
+    // get here, so its handler reads it on mousedown and hands it to us in the
+    // same slot the ⋮ button's mousedown fills.
+    quote_menu_selection_at_button_mousedown =
+        quote_menu_selection === undefined
+            ? undefined
+            : {message_id: rows.id($row), quote_menu_selection};
 
     assert(message_actions_popover_props !== undefined);
     const button = the($row.find(".message-actions-menu-button"));

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -38,6 +38,7 @@ const quote_menu_selection_by_instance = new WeakMap<
     tippy.Instance,
     compose_reply.QuoteMenuSelection
 >();
+let message_actions_popover_props: Partial<tippy.Props> | undefined;
 
 function get_action_menu_menu_items(): JQuery {
     return $("[data-tippy-root] #message-actions-menu-dropdown li:not(.divider) a");
@@ -79,6 +80,20 @@ function focus_first_action_popover_item(): void {
     // Our popup menus act kind of funny when you mix keyboard and mouse.
     const $items = get_action_menu_menu_items();
     popover_menus.focus_first_popover_item($items);
+}
+
+export function open_message_actions_popover_at_position($row: JQuery, x: number, y: number): void {
+    if (popovers.any_active()) {
+        popovers.hide_all();
+    }
+
+    assert(message_actions_popover_props !== undefined);
+    const button = the($row.find(".message-actions-menu-button"));
+    popover_menus.toggle_popover_menu(button, message_actions_popover_props, {
+        show_as_overlay_on_mobile: false,
+        show_as_overlay_always: false,
+        mouse_position: {x, y},
+    });
 }
 
 export function toggle_message_actions_menu(message: Message): boolean {
@@ -139,7 +154,7 @@ export function initialize({
         },
     );
 
-    popover_menus.register_popover_menu(".actions_hover .message-actions-menu-button", {
+    message_actions_popover_props = {
         theme: "popover-menu",
         placement: "bottom",
         popperOptions: {
@@ -313,5 +328,9 @@ export function initialize({
             popover_menus.popover_instances.message_actions = null;
             message_actions_popover_keyboard_toggle = false;
         },
-    });
+    };
+    popover_menus.register_popover_menu(
+        ".actions_hover .message-actions-menu-button",
+        message_actions_popover_props,
+    );
 }

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -275,7 +275,6 @@ export const default_popover_props: Partial<tippy.Props> = {
                         return;
                     }
 
-                    const $reference = $(state.elements.reference);
                     // Hide popover if the reference element is below another element.
                     //
                     // We only care about the reference element if it is inside the message feed since
@@ -284,13 +283,36 @@ export const default_popover_props: Partial<tippy.Props> = {
                     // to live with if we take elements outside message feed into account.
                     // Since `.sticky_header` is inside `#message_feed_container`, we allow popovers from reference inside
                     // `.sticky_header` to be visible.
+                    //
+                    // Popovers anchored to the cursor (e.g. the right-click message
+                    // actions menu) position against a Popper virtual reference; its
+                    // `contextElement` is the real DOM node we anchored to, which we use
+                    // to locate the popover in the feed, and its `getBoundingClientRect`
+                    // gives the anchored point we test for occlusion below.
+                    const reference = state.elements.reference;
+                    const reference_node =
+                        reference instanceof Element ? reference : reference.contextElement;
+
+                    // Popper never flags a virtual reference `reference-hidden` (its rect
+                    // stays on-screen), so close it ourselves once its anchor leaves the DOM.
                     if (
-                        $reference.parents("#message_feed_container, .sticky_header").length !== 1
+                        !(reference instanceof Element) &&
+                        reference_node !== undefined &&
+                        !reference_node.isConnected
+                    ) {
+                        hide_current_popover_if_visible(instance);
+                        return;
+                    }
+
+                    if (
+                        reference_node === undefined ||
+                        $(reference_node).parents("#message_feed_container, .sticky_header")
+                            .length !== 1
                     ) {
                         return;
                     }
 
-                    const reference_rect = util.the($reference).getBoundingClientRect();
+                    const reference_rect = reference.getBoundingClientRect();
                     // This is the logic we want but since it is too expensive to run
                     // on every scroll, we run a cheaper version of this to just check if
                     // compose, sticky header or navbar are not obscuring the reference
@@ -304,8 +326,8 @@ export const default_popover_props: Partial<tippy.Props> = {
                     // );
                     // if (
                     //     !topmost_element ||
-                    //     ($(topmost_element).closest($reference).length === 0 &&
-                    //         $(topmost_element).find($reference).length === 0)
+                    //     ($(topmost_element).closest($(reference_node)).length === 0 &&
+                    //         $(topmost_element).find($(reference_node)).length === 0)
                     // ) {
                     //     instance.hide();
                     // }
@@ -441,6 +463,39 @@ function get_props_for_popover_centering(
 // to focusing the reference itself.
 export type GetFocusReturnElement = (reference: HTMLElement) => HTMLElement | undefined;
 
+function get_props_for_popover_at_mouse_position(
+    reference: tippy.ReferenceElement,
+    x: number,
+    y: number,
+): Partial<tippy.Props> {
+    // Pin the menu to the cursor as an offset from the reference element,
+    // and preserve the default modifiers the spread below would otherwise
+    // drop, so the popover still tears down when its reference is removed.
+    const reference_rect = reference.getBoundingClientRect();
+    const offset_x = x - reference_rect.left;
+    const offset_y = y - reference_rect.top;
+    return {
+        getReferenceClientRect() {
+            const rect = reference.getBoundingClientRect();
+            return new DOMRect(rect.left + offset_x, rect.top + offset_y, 0, 0);
+        },
+        // Top-left of the menu meets the cursor; if it overflows, flip
+        // through the remaining corners the way browser context menus do.
+        placement: "bottom-start",
+        popperOptions: {
+            modifiers: [
+                ...default_popover_props.popperOptions!.modifiers!,
+                {
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: ["top-start", "bottom-end", "top-end"],
+                    },
+                },
+            ],
+        },
+    };
+}
+
 // Toggles a popover menu directly; intended for use in keyboard
 // shortcuts and similar alternative ways to open a popover menu.
 export function toggle_popover_menu(
@@ -452,6 +507,7 @@ export function toggle_popover_menu(
         // Only works for elements which are in message feed.
         message_feed_overlay_detection?: boolean;
         get_focus_return_element?: GetFocusReturnElement;
+        mouse_position?: {x: number; y: number};
     },
 ): tippy.Instance {
     const instance = target._tippy;
@@ -467,6 +523,11 @@ export function toggle_popover_menu(
     }
 
     let mobile_popover_props = {};
+    let mouse_position_props = {};
+    if (options?.mouse_position !== undefined) {
+        const {x, y} = options.mouse_position;
+        mouse_position_props = get_props_for_popover_at_mouse_position(target, x, y);
+    }
 
     // If the window is mobile-sized, we will render the
     // popover centered on the screen as an overlay.
@@ -497,19 +558,26 @@ export function toggle_popover_menu(
         };
     }
 
-    if (popover_props.popperOptions?.modifiers) {
-        popover_props.popperOptions.modifiers = [
-            ...default_popover_props.popperOptions!.modifiers!,
-            ...popover_props.popperOptions.modifiers,
-        ];
-    }
-
     const props = {
         ...default_popover_props,
         showOnCreate: true,
         ...popover_props,
         ...mobile_popover_props,
+        ...mouse_position_props,
     };
+
+    if (
+        props.popperOptions === popover_props.popperOptions &&
+        popover_props.popperOptions?.modifiers
+    ) {
+        props.popperOptions = {
+            ...popover_props.popperOptions,
+            modifiers: [
+                ...default_popover_props.popperOptions!.modifiers!,
+                ...popover_props.popperOptions.modifiers,
+            ],
+        };
+    }
 
     // If the popover was opened via keyboard, restore focus to
     // the appropriate element when the popover closes (e.g., on Escape).


### PR DESCRIPTION
Fixes: #38845.

Right-clicking on a message body now opens the message actions popover anchored at the cursor, instead of the browser's default context menu. The browser's native context menu is preserved when:

- Text is selected (for copy, translate, search, etc.)
- The target is a link, image, video, or audio element (for "Open in new tab", "Save image as", etc.)



**How changes were tested:**

- Verified right-click opens message actions popover on plain message body
- Verified browser context menu preserved for text selections, links, images, video, and audio
- Verified no popover for messages being edited

**Screenshots and screen captures:**
<img width="1920" height="1080" alt="Screenshot From 2026-06-20 13-41-15" src="https://github.com/user-attachments/assets/f30823ef-d60d-4855-90d0-913f068ac586" />

https://github.com/user-attachments/assets/e8dcdd45-114a-449e-ba0f-8dcae88ac1f4

Help Center:
<img width="691" height="447" alt="image" src="https://github.com/user-attachments/assets/4020cde2-7999-4171-9d97-b228f9843d46" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
