### PR TITLE
more_pms: Align unread count with rest of the unread counts.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -686,15 +686,18 @@
 
         & li#show-more-direct-messages {
             color: var(--color-text-sidebar-action-heading);
-            font-size: var(--font-size-sidebar-action-heading);
-            font-weight: var(--font-weight-sidebar-action-heading);
-            font-variant: var(--font-variant-sidebar-action-heading);
-            text-transform: var(--text-transform-sidebar-action-heading);
             cursor: pointer;
             /* The 'more conversations' line has no icons,
                so vertically align the text with the unread
                count, when one appears there. */
             align-items: baseline;
+
+            .dm-name {
+                font-size: var(--font-size-sidebar-action-heading);
+                font-weight: var(--font-weight-sidebar-action-heading);
+                font-variant: var(--font-variant-sidebar-action-heading);
+                text-transform: var(--text-transform-sidebar-action-heading);
+            }
 
             &:hover {
                 background-color: var(

--- a/web/templates/more_pms.hbs
+++ b/web/templates/more_pms.hbs
@@ -1,6 +1,8 @@
 <li id="show-more-direct-messages" class="dm-list-item dm-box bottom_left_row {{#if (eq more_conversations_unread_count 0)}}zero-dm-unreads{{/if}}">
     <a class="dm-name trigger-click-on-enter" tabindex="0">{{t "more conversations" }}</a>
-    <span class="unread_count {{#if (eq more_conversations_unread_count 0)}}zero_count{{/if}}">
-        {{more_conversations_unread_count}}
-    </span>
+    <div class="dm-markers-and-unreads">
+        <span class="unread_count {{#if (eq more_conversations_unread_count 0)}}zero_count{{/if}}">
+            {{more_conversations_unread_count}}
+        </span>
+    </div>
 </li>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [#issues > 🎯 "more conversations" unread count alignment](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20.22more.20conversations.22.20unread.20count.20alignment/with/2428379)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
https://www.diffchecker.com/image-compare/OG4LRjD2/

Before:
<img width="313" height="174" alt="more_dms_before_2" src="https://github.com/user-attachments/assets/57ce6b2f-69bb-4675-8394-7ce182e560c5" />

After:
<img width="313" height="174" alt="more_dms_after_2" src="https://github.com/user-attachments/assets/5051bd0f-3e66-4188-9175-8ce41f7ee75c" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
