### PR TITLE
compose: Skip blank lines when applying list formatting.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -887,15 +887,12 @@ export let format_text = (
 
     const format_list = (type: string): void => {
         let is_marked: (line: string) => boolean;
-        let mark: (line: string, i: number) => string;
         let strip_marking: (line: string) => string;
         if (type === "bulleted") {
             is_marked = bulleted_numbered_list_util.is_bulleted;
-            mark = (line: string) => "- " + line;
             strip_marking = bulleted_numbered_list_util.strip_bullet;
         } else {
             is_marked = bulleted_numbered_list_util.is_numbered;
-            mark = (line, i) => i + 1 + ". " + line;
             strip_marking = bulleted_numbered_list_util.strip_numbering;
         }
         // We toggle complete lines even when they are partially selected (and just selecting the
@@ -906,10 +903,23 @@ export let format_text = (
         // If there is even a single unmarked line selected, we mark all.
         const should_mark = selected_lines.split("\n").some((line) => !is_marked(line));
         if (should_mark) {
-            selected_lines = selected_lines
-                .split("\n")
-                .map((line, i) => mark(line, i))
-                .join("\n");
+            const lines = selected_lines.split("\n");
+            const processed_lines = [];
+            let counter = 1;
+            for (const line of lines) {
+                if (line.trim() === "") {
+                    processed_lines.push(line);
+                } else {
+                    if (type === "bulleted") {
+                        processed_lines.push("- " + line);
+                    } else {
+                        processed_lines.push(counter + ". " + line);
+                        counter += 1;
+                    }
+                }
+            }
+            selected_lines = processed_lines.join("\n");
+
             // We always ensure a blank line after the list, as we want
             // a clean separation between the list and the rest of the text, especially
             // when the markdown is rendered.

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -818,7 +818,12 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
 
     init_textarea_state("<\nfirst_item\nsecond_item>");
     compose_ui.format_text($textarea, "bulleted");
-    assert.equal(get_textarea_state(), "<- \n- first_item\n- second_item>");
+    assert.equal(get_textarea_state(), "<\n- first_item\n- second_item>");
+
+    // Blank lines between items should be skipped during bulleted list formatting
+    init_textarea_state("<\nfirst_item\n\nsecond_item\n\nthird_item>");
+    compose_ui.format_text($textarea, "bulleted");
+    assert.equal(get_textarea_state(), "<\n- first_item\n\n- second_item\n\n- third_item>");
 
     // Toggling off bulleted list
     init_textarea_state("<- first_item\n- second_item>");
@@ -851,6 +856,11 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
         get_textarea_state(),
         "before_first\n<1. first_item\n2. second_item>\n\nafter_last",
     );
+
+    // Blank lines between items should be skipped, counter increments only on non-blank lines
+    init_textarea_state("<\nfirst_item\n\nsecond_item\n\nthird_item>");
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(get_textarea_state(), "<\n1. first_item\n\n2. second_item\n\n3. third_item>");
 
     // Toggling off numbered list
     init_textarea_state("<1. first_item\n2. second_item>");


### PR DESCRIPTION
This PR changes list formatting to skip blank lines when applying bulleted or numbered lists. Blank lines are left untouched, and numbered lists increment only on non‑blank lines

Fixes: [#issues > List formatting includes blank lines](https://chat.zulip.org/#narrow/channel/9-issues/topic/List.20formatting.20includes.20blank.20lines/with/2420225)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="840" height="840" alt="Screenshot 2026-04-07 153342" src="https://github.com/user-attachments/assets/d3a1af2f-3c8c-4108-858d-f86807539286" />|<img width="843" height="837" alt="Screenshot 2026-04-07 153302" src="https://github.com/user-attachments/assets/126c03ab-7baa-4607-b5b4-bf947d07e3bb" />|

| Before | After |
|--------|-------|
|<img width="844" height="837" alt="Screenshot 2026-04-07 153456" src="https://github.com/user-attachments/assets/605d4399-be9d-43c3-b20f-1efee6975bc8" />|<img width="844" height="839" alt="Screenshot 2026-04-07 153439" src="https://github.com/user-attachments/assets/9db2f472-2202-4d37-9f27-eec20f8b1bfd" />|


| Before | After |
|--------|-------|
|<img width="844" height="829" alt="Screenshot 2026-04-07 153615" src="https://github.com/user-attachments/assets/08f89e2a-f6f9-431c-be4b-052f0bc33335" />|<img width="839" height="834" alt="Screenshot 2026-04-07 153602" src="https://github.com/user-attachments/assets/4f84ee85-6307-44f2-a212-ce4182391cad" />|

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/a6169e1d-2646-444f-8cbf-6abfa67b8378" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/1d4e1638-871b-4689-b4c3-3f2195c26b54" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
