### PR TITLE
forward: Use link text instead of link syntax.

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -341,32 +341,32 @@ function generate_sender_only_quote_context(message: Message): string {
 function generate_channel_message_quote_context(message: Message): string {
     assert(message.type === "stream");
     const sender_mention = generate_sender_mention(message);
-    const link = internal_url.by_stream_topic_url(
+    const topic_url = internal_url.by_stream_topic_url(
         message.stream_id,
         message.topic,
         sub_store.maybe_get_stream_name,
         message.id,
     );
     const channel_name = sub_store.maybe_get_stream_name(message.stream_id)!;
-    const topic_link_syntax = topic_link_util.get_stream_topic_link_syntax(
+    const topic_link_text = topic_link_util.get_stream_topic_link_syntax(
         channel_name,
         message.topic,
         true,
     );
     // Final message looks like:
-    //     @_**Iago|5** [said](link to message) in [#channel > topic](link to topic):
+    //     @_**Iago|5** [said](link to message) in [#channel > topic](topic URL):
     //     ```quote
     //     message content
     //     ```
     // Keep syntax in sync with channel message reminder format in zerver/lib/reminders.py
     return $t(
         {
-            defaultMessage: "{username} [said]({link_to_message}) in {topic_link_syntax}:",
+            defaultMessage: "{username} [said]({link_to_message}) in {topic_link}:",
         },
         {
             username: sender_mention,
             link_to_message: hash_util.by_conversation_and_time_url(message),
-            topic_link_syntax: topic_link_util.as_markdown_link_syntax(topic_link_syntax, link),
+            topic_link: topic_link_util.as_markdown_link_syntax(topic_link_text, topic_url),
         },
     );
 }

--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -126,7 +126,7 @@ export function get_fallback_markdown_link(
     stream_name: string,
     topic_name?: string,
     message_id?: string,
-    only_link_syntax = false,
+    only_link_text = false,
 ): string {
     // Helper that should only be called by other methods in this file.
 
@@ -138,23 +138,25 @@ export function get_fallback_markdown_link(
         topic_name,
         message_id,
     });
-    return only_link_syntax
-        ? label_text_markdown
-        : as_markdown_link_syntax(label_text_markdown, url);
+    return only_link_text ? label_text_markdown : as_markdown_link_syntax(label_text_markdown, url);
 }
 
 export function get_stream_topic_link_syntax(
     stream_name: string,
     topic_name: string,
-    only_link_syntax = false,
+    only_link_text = false,
 ): string {
     // If the topic/stream name would produce an invalid #**stream>topic** syntax, fall back
-    // to markdown link syntax. If only_link_syntax is true, only the link label is returned.
+    // to markdown link syntax. If only_link_text is true, only the link label is returned.
     if (
         will_produce_broken_stream_topic_link(topic_name) ||
         will_produce_broken_stream_topic_link(stream_name)
     ) {
-        return get_fallback_markdown_link(stream_name, topic_name, undefined, only_link_syntax);
+        return get_fallback_markdown_link(stream_name, topic_name, undefined, only_link_text);
+    }
+
+    if (only_link_text) {
+        return `#${stream_name} > ${topic_name}`;
     }
     return `#**${stream_name}>${topic_name}**`;
 }

--- a/web/tests/lib/compose_helpers.cjs
+++ b/web/tests/lib/compose_helpers.cjs
@@ -189,8 +189,8 @@ function forward_channel_message_template(opts) {
     const {sender_full_name, sender_id, id, topic} = selected_message;
     const near_url = `http://zulip.zulipdev.com/#narrow/channel/${stream_id}-${channel_name}/topic/${topic}/near/${id}`;
     const with_url = `#narrow/channel/${stream_id}-${channel_name}/topic/${topic}/with/${id}`;
-    const topic_link_syntax = `[#**${channel_name}>${topic}**](${with_url})`;
-    return `translated: @_**${sender_full_name}|${sender_id}** [said](${near_url}) in ${topic_link_syntax}:
+    const topic_link = `[#${channel_name} > ${topic}](${with_url})`;
+    return `translated: @_**${sender_full_name}|${sender_id}** [said](${near_url}) in ${topic_link}:
 ${fence}quote
 ${content}
 ${fence}`;


### PR DESCRIPTION
Also refactored some code to clearly distinguish
between link text(`#channel>topic`), link syntax(`#**channel>topic**`), topic URL, and link(`[link text](URL)`).

Fixes: https://chat.zulip.org/#narrow/channel/101-design/topic/Quoting.2FForwarding.20multiple.20messages.20.2337878/near/2428023

Tested by generating forward links for valid and [invalid ](https://github.com/zulip/zulip/blob/14312963de0bb7793c781e5da3599bd5a9d23aa9/web/src/topic_link_util.ts#L14)topic/channel names.


