### PR TITLE
messages: Add icons to 'show more'/'show less' buttons.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -342,6 +342,11 @@
             );
             scale: 0.98;
         }
+
+        .zulip-icon {
+            vertical-align: -3px;
+            margin-right: 4px;
+        }
     }
 
     &.content_edit_mode .message_length_controller {

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -5,6 +5,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{else if (eq toggle_type "condenser")}}
@@ -14,6 +15,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{/if}}


### PR DESCRIPTION
Previously, there were no icons for '`Show more` and '`Show less`  button 
This PR adds the zulip-icon-expand icon to 'Show more' button and zulip-icon-collapse icon to 'Show less' button.

Fixes #38844.



**How changes were tested:**
Tested manually by running locally
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
**Before**:
<img width="1426" height="160" alt="574317945-3ece77f7-a51e-4305-aa41-f1f4ab99513e" src="https://github.com/user-attachments/assets/32287dcb-68fd-4205-8258-c3dc571475af" />

**After:**

<img width="828" height="68" alt="Screenshot 2026-04-07 223355" src="https://github.com/user-attachments/assets/86b4d044-b9eb-4f42-a03e-994115e2ae64" />
<img width="920" height="74" alt="Screenshot 2026-04-07 223347" src="https://github.com/user-attachments/assets/f067c47f-3da8-4521-9c83-e367b5f2b2f2" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

