### PR TITLE
drafts: Fix initial focus in drafts overlay.

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -457,7 +457,12 @@ export function launch(): void {
         !messages_overlay_ui.try_set_initial_element(restore_id, keyboard_handling_context)
     ) {
         const first_element_id = [...narrow_drafts, ...other_drafts][0]?.draft_id;
-        messages_overlay_ui.set_initial_element(first_element_id, keyboard_handling_context);
+        // Delay focus initialization until the overlay DOM is fully rendered.
+        // Otherwise, get_focused_element_id() returns undefined and the focus
+        // may not be applied.
+        setTimeout(() => {
+            messages_overlay_ui.set_initial_element(first_element_id, keyboard_handling_context);
+        }, 0);
     }
     setup_event_handlers();
     setup_bulk_actions_handlers();

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -87,9 +87,9 @@ stream_data.add_sub_for_tests(stream_B);
 stream_data.add_sub_for_tests(stream_1);
 stream_data.add_sub_for_tests(stream_2);
 
-const setTimeout_delay = 3000;
+const setTimeout_delay = new Set([0, 3000]);
 set_global("setTimeout", (f, delay) => {
-    assert.equal(delay, setTimeout_delay);
+    assert.ok(setTimeout_delay.has(delay));
     f();
 });
 const markdown = mock_esm("../src/markdown", {


### PR DESCRIPTION
When opening the drafts overlay, the initial focus was set before the overlay was fully rendered. As a result, the browser did not apply the focus, causing get_focused_element_id() to return undefined when we press Enter for the first time after opening the overlay. I have added delay to ensure the focus is initialized after the overlay is fully rendered.

<!-- Describe your pull request here.-->

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20drafts.20keyboard.20navigation.20bug/with/2427199)[#issues > 🎯 drafts keyboard navigation bug](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20drafts.20keyboard.20navigation.20bug/with/2427199)

**How changes were tested:**
Updated the test and also verified by testing manually. 

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
