### PR TITLE
stripe: Pass event_time in get_billable_licenses_for_customer.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -3927,7 +3927,7 @@ class BillingSession(ABC):
         if licenses is not None and customer.exempt_from_license_number_check:
             return licenses
 
-        current_license_count = self.get_current_billed_license_count()
+        current_license_count = self.get_current_billed_license_count(event_time)
         min_licenses_for_plan = self.min_licenses_for_plan(tier)
         if customer.exempt_from_license_number_check:  # nocoverage
             billed_licenses = current_license_count


### PR DESCRIPTION
The `event_time` parameter here was missed in the refactor of `get_billable_licenses_for_customer` in #38789.

*relevant diff from changes in https://github.com/zulip/zulip/commit/ec9ada65f2068f26d29fbc5a2c516e54ff56586c*:
```diff
-        current_licenses_count = self.current_counts_for_billed_users(event_time).workplace_users
+        current_license_count = self.get_current_billed_license_count()
```
---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
