### PR TITLE
typeahead: Fix multi-word queries not matching names with diacritics.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -222,7 +222,7 @@ export class Typeahead<ItemType extends string | object> {
     items: number;
     matcher: (item: ItemType, query: string) => boolean;
     sorter: (items: ItemType[], query: string) => ItemType[];
-    item_html: (item: ItemType, query: string) => string | undefined;
+    item_html: (query: string) => (item: ItemType) => string | undefined;
     updater: (
         item: ItemType,
         query: string,
@@ -590,10 +590,11 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     render(final_items: ItemType[], matching_items: ItemType[]): this {
+        const render_item = this.item_html(this.query);
         const $items: JQuery[] = final_items.map((item) => {
             const $i = $(ITEM_HTML);
             this.values.set(the($i), item);
-            const item_html = this.item_html(item, this.query) ?? "";
+            const item_html = render_item(item) ?? "";
             const $item_html = $i.find("a").html(item_html);
 
             const option_label_html = this.option_label(matching_items, item);
@@ -952,7 +953,7 @@ export class Typeahead<ItemType extends string | object> {
  * =========================== */
 
 type TypeaheadOptions<ItemType> = {
-    item_html: (item: ItemType, query: string) => string | undefined;
+    item_html: (query: string) => (item: ItemType) => string | undefined;
     items?: number;
     source: (query: string, input_element: TypeaheadInputElement) => ItemType[];
     // optional options

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -220,7 +220,7 @@ export type TypeaheadInputElement =
 export class Typeahead<ItemType extends string | object> {
     input_element: TypeaheadInputElement;
     items: number;
-    matcher: (item: ItemType, query: string) => boolean;
+    matcher: (query: string) => (item: ItemType) => boolean;
     sorter: (items: ItemType[], query: string) => ItemType[];
     item_html: (query: string) => (item: ItemType) => string | undefined;
     updater: (
@@ -282,7 +282,7 @@ export class Typeahead<ItemType extends string | object> {
             assert(!this.input_element.$element.is("[contenteditable]"));
         }
         this.items = options.items ?? MAX_ITEMS;
-        this.matcher = options.matcher ?? ((item, query) => this.defaultMatcher(item, query));
+        this.matcher = options.matcher ?? ((query) => (item) => this.defaultMatcher(item, query));
         this.sorter = options.sorter;
         this.item_html = options.item_html;
         this.updater = options.updater ?? ((items) => this.defaultUpdater(items));
@@ -564,7 +564,7 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     process(items: ItemType[]): this {
-        const matching_items = $.grep(items, (item) => this.matcher(item, this.query));
+        const matching_items = $.grep(items, this.matcher(this.query));
 
         const final_items = this.sorter(matching_items, this.query);
 
@@ -964,7 +964,7 @@ type TypeaheadOptions<ItemType> = {
     footer_html?: (matching_items: ItemType[]) => string | false;
     helpOnEmptyStrings?: boolean;
     hideOnEmptyAfterBackspace?: boolean;
-    matcher?: (item: ItemType, query: string) => boolean;
+    matcher?: (query: string) => (item: ItemType) => boolean;
     on_escape?: () => void;
     clear_typeahead_tooltip?: () => void;
     openInputFieldOnKeyUp?: () => void;

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1543,9 +1543,8 @@ export function initialize_topic_edit_typeahead(
                 });
             };
         },
-        matcher(item: string, query: string): boolean {
-            const matcher = get_topic_matcher(query);
-            return matcher(item);
+        matcher(query: string): (item: string) => boolean {
+            return get_topic_matcher(query);
         },
         sorter(items: string[], query: string): string[] {
             const stream_id = stream_data.get_stream_id(stream_name);
@@ -1630,8 +1629,8 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
             // inside the typeahead library.
             source: get_candidates,
             item_html: content_item_html,
-            matcher() {
-                return true;
+            matcher(_query: string) {
+                return () => true;
             },
             sorter(items) {
                 return items;
@@ -1734,12 +1733,14 @@ export function initialize({
                 return typeahead_helper.render_person_or_user_group(item);
             };
         },
-        matcher(item: UserPillData | string, query: string): boolean {
-            if (typeof item === "string") {
-                const matcher = get_topic_matcher(query);
-                return matcher(item);
-            }
-            return true;
+        matcher(query: string): (item: UserPillData | string) => boolean {
+            const topic_matcher = get_topic_matcher(query);
+            return (item: UserPillData | string): boolean => {
+                if (typeof item === "string") {
+                    return topic_matcher(item);
+                }
+                return true;
+            };
         },
         sorter(items: (UserPillData | string)[], query: string): (UserPillData | string)[] {
             const topic_items: string[] = [];
@@ -1825,8 +1826,8 @@ export function initialize({
             return (item: UserGroupPillData | UserPillData) =>
                 typeahead_helper.render_person_or_user_group(item);
         },
-        matcher(): boolean {
-            return true;
+        matcher(_query: string) {
+            return () => true;
         },
         sorter(items: (UserGroupPillData | UserPillData)[]): (UserGroupPillData | UserPillData)[] {
             return items;

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1232,41 +1232,45 @@ export function get_candidates(
     return [];
 }
 
-export function content_item_html(item: TypeaheadSuggestion): string | undefined {
-    switch (item.type) {
-        case "emoji":
-            return typeahead_helper.render_emoji(item);
-        case "user_group":
-        case "user":
-        case "broadcast":
-            return typeahead_helper.render_person_or_user_group(item, token);
-        case "slash":
-            return typeahead_helper.render_typeahead_item({
-                primary: item.text,
-                secondary: item.info,
-            });
-        case "stream":
-            return typeahead_helper.render_stream(item);
-        case "syntax":
-            return typeahead_helper.render_typeahead_item({
-                primary: item.language,
-                is_default_language:
-                    item.language !== "" &&
-                    item.language === realm.realm_default_code_block_language,
-            });
-        case "topic_jump":
-            return typeahead_helper.render_typeahead_item({primary: item.message});
-        case "topic_list": {
-            if (item.is_channel_link) {
-                return typeahead_helper.render_stream(item.stream_data);
+export function content_item_html(
+    _query: string,
+): (item: TypeaheadSuggestion) => string | undefined {
+    return function (item: TypeaheadSuggestion): string | undefined {
+        switch (item.type) {
+            case "emoji":
+                return typeahead_helper.render_emoji(item);
+            case "user_group":
+            case "user":
+            case "broadcast":
+                return typeahead_helper.render_person_or_user_group(item, token);
+            case "slash":
+                return typeahead_helper.render_typeahead_item({
+                    primary: item.text,
+                    secondary: item.info,
+                });
+            case "stream":
+                return typeahead_helper.render_stream(item);
+            case "syntax":
+                return typeahead_helper.render_typeahead_item({
+                    primary: item.language,
+                    is_default_language:
+                        item.language !== "" &&
+                        item.language === realm.realm_default_code_block_language,
+                });
+            case "topic_jump":
+                return typeahead_helper.render_typeahead_item({primary: item.message});
+            case "topic_list": {
+                if (item.is_channel_link) {
+                    return typeahead_helper.render_stream(item.stream_data);
+                }
+                return typeahead_helper.render_stream_topic(item);
             }
-            return typeahead_helper.render_stream_topic(item);
+            case "time_jump":
+                return typeahead_helper.render_typeahead_item({primary: item.message});
+            default:
+                return undefined;
         }
-        case "time_jump":
-            return typeahead_helper.render_typeahead_item({primary: item.message});
-        default:
-            return undefined;
-    }
+    };
 }
 
 export function content_typeahead_selected(
@@ -1529,13 +1533,15 @@ export function initialize_topic_edit_typeahead(
     };
     return new Typeahead(bootstrap_typeahead_input, {
         dropup,
-        item_html(item: string): string {
-            const is_empty_string_topic = item === "";
-            const topic_display_name = util.get_final_topic_display_name(item);
-            return typeahead_helper.render_typeahead_item({
-                primary: topic_display_name,
-                is_empty_string_topic,
-            });
+        item_html(_query: string): (item: string) => string {
+            return function (item: string): string {
+                const is_empty_string_topic = item === "";
+                const topic_display_name = util.get_final_topic_display_name(item);
+                return typeahead_helper.render_typeahead_item({
+                    primary: topic_display_name,
+                    is_empty_string_topic,
+                });
+            };
         },
         matcher(item: string, query: string): boolean {
             const matcher = get_topic_matcher(query);
@@ -1715,16 +1721,18 @@ export function initialize({
             return [...people_candidates, ...topics];
         },
         items: max_num_items,
-        item_html(item: string | UserPillData): string {
-            if (typeof item === "string") {
-                const is_empty_string_topic = item === "";
-                const topic_display_name = util.get_final_topic_display_name(item);
-                return typeahead_helper.render_typeahead_item({
-                    primary: topic_display_name,
-                    is_empty_string_topic,
-                });
-            }
-            return typeahead_helper.render_person_or_user_group(item);
+        item_html(_query: string): (item: string | UserPillData) => string {
+            return function (item: string | UserPillData): string {
+                if (typeof item === "string") {
+                    const is_empty_string_topic = item === "";
+                    const topic_display_name = util.get_final_topic_display_name(item);
+                    return typeahead_helper.render_typeahead_item({
+                        primary: topic_display_name,
+                        is_empty_string_topic,
+                    });
+                }
+                return typeahead_helper.render_person_or_user_group(item);
+            };
         },
         matcher(item: UserPillData | string, query: string): boolean {
             if (typeof item === "string") {
@@ -1813,8 +1821,9 @@ export function initialize({
         source: get_pm_people,
         items: max_num_items,
         dropup: true,
-        item_html(item: UserGroupPillData | UserPillData) {
-            return typeahead_helper.render_person_or_user_group(item);
+        item_html(_query: string): (item: UserGroupPillData | UserPillData) => string {
+            return (item: UserGroupPillData | UserPillData) =>
+                typeahead_helper.render_person_or_user_group(item);
         },
         matcher(): boolean {
             return true;

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -214,30 +214,48 @@ export function get_language_matcher(query: string): (language: string) => boole
 
 export function get_stream_matcher(query: string): (stream: StreamPillData) => boolean {
     // Case-insensitive.
-    query = typeahead.clean_query_lowercase(query);
+    query = typeahead.clean_query_lowercase(query, false);
+    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     return function (stream: StreamPillData) {
-        return typeahead_helper.query_matches_stream_name(query, stream);
+        return typeahead_helper.query_matches_stream_name(query, stream, should_remove_diacritics);
     };
 }
 
 export function get_slash_matcher(query: string): (item: SlashCommand) => boolean {
-    query = typeahead.clean_query_lowercase(query);
+    query = typeahead.clean_query_lowercase(query, false);
+    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     return function (item: SlashCommand) {
         return (
-            typeahead.query_matches_string_in_order(query, item.name, " ") ||
-            typeahead.query_matches_string_in_order(query, item.aliases, " ")
+            typeahead.query_matches_string_in_order(
+                query,
+                item.name,
+                " ",
+                should_remove_diacritics,
+            ) ||
+            typeahead.query_matches_string_in_order(
+                query,
+                item.aliases,
+                " ",
+                should_remove_diacritics,
+            )
         );
     };
 }
 
 function get_topic_matcher(query: string): (topic: string) => boolean {
-    query = typeahead.clean_query_lowercase(query);
+    query = typeahead.clean_query_lowercase(query, false);
+    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     return function (topic: string): boolean {
         const topic_display_name = util.get_final_topic_display_name(topic);
-        return typeahead.query_matches_string_in_order(query, topic_display_name, " ");
+        return typeahead.query_matches_string_in_order(
+            query,
+            topic_display_name,
+            " ",
+            should_remove_diacritics,
+        );
     };
 }
 
@@ -686,17 +704,13 @@ function filter_persons<T>(
 }
 
 export function get_person_suggestion_for_topic_typeahead(query: string): UserPillData[] {
-    query = typeahead.clean_query_lowercase(query);
+    query = typeahead.clean_query_lowercase(query, false);
+    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
-    const filterer = (person_items: UserPillData[]): UserPillData[] => {
-        const should_remove_diacritics = people.should_remove_diacritics_for_query(
-            query.toLowerCase(),
-        );
-
-        return person_items.filter((item) =>
+    const filterer = (person_items: UserPillData[]): UserPillData[] =>
+        person_items.filter((item) =>
             typeahead_helper.query_matches_person_name(query, item, should_remove_diacritics, true),
         );
-    };
 
     const current_narrow_participant_ids = message_lists.current?.data.participants.visible();
 
@@ -751,7 +765,8 @@ export function get_person_suggestions(
     opts: PersonSuggestionOpts,
     exclude_non_welcome_bots = false,
 ): (UserOrMentionPillData | UserGroupPillData)[] {
-    query = typeahead.clean_query_lowercase(query);
+    query = typeahead.clean_query_lowercase(query, false);
+    const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
     let groups: UserGroup[];
     if (opts.filter_groups_for_mention) {
@@ -790,7 +805,7 @@ export function get_person_suggestions(
     }));
 
     const filtered_groups = group_pill_data.filter((item) =>
-        typeahead_helper.query_matches_group_name(query, item),
+        typeahead_helper.query_matches_group_name(query, item, should_remove_diacritics),
     );
 
     const user = people.get_from_unique_full_name(query);
@@ -842,9 +857,6 @@ export function get_person_suggestions(
         broadcast_items: UserOrMentionPillData[],
     ): UserOrMentionPillData[] {
         const suggestion_items: UserOrMentionPillData[] = [...person_items, ...broadcast_items];
-        const should_remove_diacritics = people.should_remove_diacritics_for_query(
-            query.toLowerCase(),
-        );
 
         return suggestion_items.filter((item) =>
             typeahead_helper.query_matches_person(
@@ -1233,8 +1245,9 @@ export function get_candidates(
 }
 
 export function content_item_html(
-    _query: string,
+    query: string,
 ): (item: TypeaheadSuggestion) => string | undefined {
+    const should_remove_diacritics = !typeahead.contains_diacritics(query);
     return function (item: TypeaheadSuggestion): string | undefined {
         switch (item.type) {
             case "emoji":
@@ -1242,7 +1255,10 @@ export function content_item_html(
             case "user_group":
             case "user":
             case "broadcast":
-                return typeahead_helper.render_person_or_user_group(item, token);
+                return typeahead_helper.render_person_or_user_group(item, {
+                    query: token,
+                    should_remove_diacritics,
+                });
             case "slash":
                 return typeahead_helper.render_typeahead_item({
                     primary: item.text,

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -417,8 +417,9 @@ export function initialize_custom_pronouns_type_fields(element_id: string): void
                 sorter(items, query) {
                     return bootstrap_typeahead.defaultSorter(items, query);
                 },
-                item_html(item) {
-                    return typeahead_helper.render_typeahead_item({primary: item});
+                item_html(_query: string) {
+                    return (item: string) =>
+                        typeahead_helper.render_typeahead_item({primary: item});
                 },
             });
         });

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1170,11 +1170,9 @@ export function get_people_for_search_bar(query: string): User[] {
 
 export function should_remove_diacritics_for_query(query_lower_case: string): boolean {
     // We only do diacritic-sensitive matching for queries that do not
-    // contain diacritics themselves.
-    //
-    // TODO: This check is too strict; ideally we'd check for presence
-    // of diacritics; punctuation should not be relevant.
-    return /^[a-z]+$/.test(query_lower_case);
+    // contain diacritics themselves. Spaces and other punctuation are
+    // irrelevant to this check.
+    return typeahead.remove_diacritics(query_lower_case) === query_lower_case;
 }
 
 export function maybe_remove_diacritics_from_name(

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1168,19 +1168,12 @@ export function get_people_for_search_bar(query: string): User[] {
     return filter_all_persons(pred);
 }
 
-export function should_remove_diacritics_for_query(query_lower_case: string): boolean {
-    // We only do diacritic-sensitive matching for queries that do not
-    // contain diacritics themselves. Spaces and other punctuation are
-    // irrelevant to this check.
-    return typeahead.remove_diacritics(query_lower_case) === query_lower_case;
-}
-
 export function maybe_remove_diacritics_from_name(
     user: User,
     should_remove_diacritics: boolean,
 ): string {
     // Callers should compute should_remove_diacritics using
-    // should_remove_diacritics_for_query. It's fastest if the caller
+    // contains_diacritics. It's fastest if the caller
     // computes that once outside the loop over all users.
     if (should_remove_diacritics) {
         // Reuse removed diacritics version of the `full_name` if
@@ -1194,7 +1187,7 @@ export function maybe_remove_diacritics_from_name(
 export function build_termlet_matcher(termlet: string): (user: User) => boolean {
     // Note: termlets are required to be lower case.
     termlet = termlet.trim();
-    const should_remove_diacritics = should_remove_diacritics_for_query(termlet);
+    const should_remove_diacritics = !typeahead.contains_diacritics(termlet);
 
     return function (user: User): boolean {
         const full_name = maybe_remove_diacritics_from_name(user, should_remove_diacritics);

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -7,6 +7,7 @@ import * as people from "./people.ts";
 import type {User} from "./people.ts";
 import * as stream_pill from "./stream_pill.ts";
 import type {StreamPillData, StreamPillWidget} from "./stream_pill.ts";
+import * as typeahead from "./typeahead.ts";
 import * as typeahead_helper from "./typeahead_helper.ts";
 import type {CombinedPillContainer, GroupSettingPillContainer} from "./typeahead_helper.ts";
 import * as user_group_pill from "./user_group_pill.ts";
@@ -26,8 +27,12 @@ function person_matcher(
     );
 }
 
-function group_matcher(query: string, item: UserGroupPillData): boolean {
-    return typeahead_helper.query_matches_group_name(query, item);
+function group_matcher(
+    query: string,
+    item: UserGroupPillData,
+    should_remove_diacritics: boolean,
+): boolean {
+    return typeahead_helper.query_matches_group_name(query, item, should_remove_diacritics);
 }
 
 type TypeaheadItem = UserGroupPillData | StreamPillData | UserPillData;
@@ -55,8 +60,7 @@ export function set_up_user(
             return (item: UserPillData) => typeahead_helper.render_person(item);
         },
         matcher(query: string): (item: UserPillData) => boolean {
-            query = query.toLowerCase();
-            query = query.replaceAll("\u00A0", " ");
+            query = typeahead.clean_query_lowercase(query, false);
             const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
             return (item: UserPillData) => person_matcher(query, item, should_remove_diacritics);
         },
@@ -156,10 +160,11 @@ export function set_up_user_group(
             return (item: UserGroupPillData) => typeahead_helper.render_user_group(item);
         },
         matcher(query: string): (item: UserGroupPillData) => boolean {
-            query = query.toLowerCase();
-            query = query.replaceAll("\u00A0", " ");
+            query = typeahead.clean_query_lowercase(query, false);
+            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
 
-            return (item: UserGroupPillData) => group_matcher(query, item);
+            return (item: UserGroupPillData) =>
+                group_matcher(query, item, should_remove_diacritics);
         },
         sorter(matches: UserGroupPillData[], query: string): UserGroupPillData[] {
             return typeahead_helper.sort_user_groups(matches, query);
@@ -211,14 +216,13 @@ export function set_up_group_setting_typeahead(
             };
         },
         matcher(query: string): (item: GroupSettingTypeaheadItem) => boolean {
-            query = query.toLowerCase();
-            query = query.replaceAll("\u00A0", " ");
+            query = typeahead.clean_query_lowercase(query, false);
             const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
 
             return (item: GroupSettingTypeaheadItem): boolean => {
                 let matches = false;
                 if (item.type === "user_group") {
-                    matches = matches || group_matcher(query, item);
+                    matches = matches || group_matcher(query, item, should_remove_diacritics);
                 }
 
                 if (item.type === "user") {
@@ -360,8 +364,7 @@ export function set_up_combined(
             };
         },
         matcher(query: string): (item: TypeaheadItem) => boolean {
-            query = query.toLowerCase();
-            query = query.replaceAll("\u00A0", " ");
+            query = typeahead.clean_query_lowercase(query, false);
             const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
 
             return (item: TypeaheadItem): boolean => {
@@ -373,14 +376,14 @@ export function set_up_combined(
                 if (include_user_groups && query.startsWith("@")) {
                     if (item.type === "user_group") {
                         const normalized_query = query.slice(1);
-                        return group_matcher(normalized_query, item);
+                        return group_matcher(normalized_query, item, should_remove_diacritics);
                     }
                     return false;
                 }
 
                 let matches = false;
                 if (include_user_groups && item.type === "user_group") {
-                    matches = group_matcher(query, item);
+                    matches = group_matcher(query, item, should_remove_diacritics);
                 }
 
                 if (include_users && item.type === "user") {

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -15,10 +15,14 @@ import type {UserGroup} from "./user_groups.ts";
 import * as user_pill from "./user_pill.ts";
 import type {UserPillData, UserPillWidget} from "./user_pill.ts";
 
-function person_matcher(query: string, item: UserPillData): boolean {
+function person_matcher(
+    query: string,
+    item: UserPillData,
+    should_remove_diacritics: boolean,
+): boolean {
     return (
         people.is_known_user_id(item.user.user_id) &&
-        typeahead_helper.query_matches_person(query, item)
+        typeahead_helper.query_matches_person(query, item, should_remove_diacritics)
     );
 }
 
@@ -53,7 +57,8 @@ export function set_up_user(
         matcher(query: string): (item: UserPillData) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
-            return (item: UserPillData) => person_matcher(query, item);
+            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
+            return (item: UserPillData) => person_matcher(query, item, should_remove_diacritics);
         },
         sorter(matches: UserPillData[], query: string): UserPillData[] {
             const users = matches.filter((match) => people.is_known_user_id(match.user.user_id));
@@ -208,6 +213,7 @@ export function set_up_group_setting_typeahead(
         matcher(query: string): (item: GroupSettingTypeaheadItem) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
+            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
 
             return (item: GroupSettingTypeaheadItem): boolean => {
                 let matches = false;
@@ -216,7 +222,7 @@ export function set_up_group_setting_typeahead(
                 }
 
                 if (item.type === "user") {
-                    matches = matches || person_matcher(query, item);
+                    matches = matches || person_matcher(query, item, should_remove_diacritics);
                 }
                 return matches;
             };
@@ -356,6 +362,7 @@ export function set_up_combined(
         matcher(query: string): (item: TypeaheadItem) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
+            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
 
             return (item: TypeaheadItem): boolean => {
                 if (include_streams(query) && item.type === "stream") {
@@ -377,7 +384,7 @@ export function set_up_combined(
                 }
 
                 if (include_users && item.type === "user") {
-                    matches = matches || person_matcher(query, item);
+                    matches = matches || person_matcher(query, item, should_remove_diacritics);
                 }
                 return matches;
             };

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -47,8 +47,8 @@ export function set_up_user(
         source(_query: string): UserPillData[] {
             return user_pill.typeahead_source(pills, exclude_bots);
         },
-        item_html(item: UserPillData, _query: string): string {
-            return typeahead_helper.render_person(item);
+        item_html(_query: string): (item: UserPillData) => string {
+            return (item: UserPillData) => typeahead_helper.render_person(item);
         },
         matcher(item: UserPillData, query: string): boolean {
             query = query.toLowerCase();
@@ -96,8 +96,8 @@ export function set_up_stream(
         source(_query: string): StreamPillData[] {
             return stream_pill.typeahead_source(pills, opts.invite_streams);
         },
-        item_html(item: StreamPillData, _query: string): string {
-            return typeahead_helper.render_stream(item);
+        item_html(_query: string): (item: StreamPillData) => string {
+            return (item: StreamPillData) => typeahead_helper.render_stream(item);
         },
         matcher(item: StreamPillData, query: string): boolean {
             query = query.toLowerCase();
@@ -147,8 +147,8 @@ export function set_up_user_group(
                 .user_group_source()
                 .map((user_group) => ({type: "user_group", ...user_group}));
         },
-        item_html(item: UserGroupPillData, _query: string): string {
-            return typeahead_helper.render_user_group(item);
+        item_html(_query: string): (item: UserGroupPillData) => string {
+            return (item: UserGroupPillData) => typeahead_helper.render_user_group(item);
         },
         matcher(item: UserGroupPillData, query: string): boolean {
             query = query.toLowerCase();
@@ -194,13 +194,15 @@ export function set_up_group_setting_typeahead(
 
             return source;
         },
-        item_html(item: GroupSettingTypeaheadItem, _query: string): string {
-            if (item.type === "user_group") {
-                return typeahead_helper.render_user_group(item);
-            }
+        item_html(_query: string): (item: GroupSettingTypeaheadItem) => string {
+            return (item: GroupSettingTypeaheadItem): string => {
+                if (item.type === "user_group") {
+                    return typeahead_helper.render_user_group(item);
+                }
 
-            assert(item.type === "user");
-            return typeahead_helper.render_person(item);
+                assert(item.type === "user");
+                return typeahead_helper.render_person(item);
+            };
         },
         matcher(item: GroupSettingTypeaheadItem, query: string): boolean {
             query = query.toLowerCase();
@@ -330,21 +332,23 @@ export function set_up_combined(
             }
             return source;
         },
-        item_html(item: TypeaheadItem, query: string): string {
-            if (include_streams(query) && item.type === "stream") {
-                return typeahead_helper.render_stream(item);
-            }
+        item_html(query: string): (item: TypeaheadItem) => string {
+            return (item: TypeaheadItem): string => {
+                if (include_streams(query) && item.type === "stream") {
+                    return typeahead_helper.render_stream(item);
+                }
 
-            if (include_user_groups && item.type === "user_group") {
-                return typeahead_helper.render_user_group(item);
-            }
+                if (include_user_groups && item.type === "user_group") {
+                    return typeahead_helper.render_user_group(item);
+                }
 
-            // After reaching this point, it is sure
-            // that given item is a person. So this
-            // handles `include_users` cases along with
-            // default cases.
-            assert(item.type === "user");
-            return typeahead_helper.render_person(item);
+                // After reaching this point, it is sure
+                // that given item is a person. So this
+                // handles `include_users` cases along with
+                // default cases.
+                assert(item.type === "user");
+                return typeahead_helper.render_person(item);
+            };
         },
         matcher(item: TypeaheadItem, query: string): boolean {
             query = query.toLowerCase();

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -50,10 +50,10 @@ export function set_up_user(
         item_html(_query: string): (item: UserPillData) => string {
             return (item: UserPillData) => typeahead_helper.render_person(item);
         },
-        matcher(item: UserPillData, query: string): boolean {
+        matcher(query: string): (item: UserPillData) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
-            return person_matcher(query, item);
+            return (item: UserPillData) => person_matcher(query, item);
         },
         sorter(matches: UserPillData[], query: string): UserPillData[] {
             const users = matches.filter((match) => people.is_known_user_id(match.user.user_id));
@@ -99,14 +99,14 @@ export function set_up_stream(
         item_html(_query: string): (item: StreamPillData) => string {
             return (item: StreamPillData) => typeahead_helper.render_stream(item);
         },
-        matcher(item: StreamPillData, query: string): boolean {
+        matcher(query: string): (item: StreamPillData) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
             query = query.trim();
             if (query.startsWith("#")) {
                 query = query.slice(1);
             }
-            return item.name.toLowerCase().includes(query);
+            return (item: StreamPillData) => item.name.toLowerCase().includes(query);
         },
         sorter(matches: StreamPillData[], query: string): StreamPillData[] {
             const stream_matches: StreamPillData[] = [];
@@ -150,10 +150,11 @@ export function set_up_user_group(
         item_html(_query: string): (item: UserGroupPillData) => string {
             return (item: UserGroupPillData) => typeahead_helper.render_user_group(item);
         },
-        matcher(item: UserGroupPillData, query: string): boolean {
+        matcher(query: string): (item: UserGroupPillData) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
-            return group_matcher(query, item);
+
+            return (item: UserGroupPillData) => group_matcher(query, item);
         },
         sorter(matches: UserGroupPillData[], query: string): UserGroupPillData[] {
             return typeahead_helper.sort_user_groups(matches, query);
@@ -204,19 +205,21 @@ export function set_up_group_setting_typeahead(
                 return typeahead_helper.render_person(item);
             };
         },
-        matcher(item: GroupSettingTypeaheadItem, query: string): boolean {
+        matcher(query: string): (item: GroupSettingTypeaheadItem) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
 
-            let matches = false;
-            if (item.type === "user_group") {
-                matches = matches || group_matcher(query, item);
-            }
+            return (item: GroupSettingTypeaheadItem): boolean => {
+                let matches = false;
+                if (item.type === "user_group") {
+                    matches = matches || group_matcher(query, item);
+                }
 
-            if (item.type === "user") {
-                matches = matches || person_matcher(query, item);
-            }
-            return matches;
+                if (item.type === "user") {
+                    matches = matches || person_matcher(query, item);
+                }
+                return matches;
+            };
         },
         sorter(matches: GroupSettingTypeaheadItem[], query: string): GroupSettingTypeaheadItem[] {
             const users: UserPillData[] = [];
@@ -350,32 +353,34 @@ export function set_up_combined(
                 return typeahead_helper.render_person(item);
             };
         },
-        matcher(item: TypeaheadItem, query: string): boolean {
+        matcher(query: string): (item: TypeaheadItem) => boolean {
             query = query.toLowerCase();
             query = query.replaceAll("\u00A0", " ");
 
-            if (include_streams(query) && item.type === "stream") {
-                query = query.trim().slice(1);
-                return item.name.toLowerCase().includes(query);
-            }
-
-            if (include_user_groups && query.startsWith("@")) {
-                if (item.type === "user_group") {
-                    const normalized_query = query.slice(1);
-                    return group_matcher(normalized_query, item);
+            return (item: TypeaheadItem): boolean => {
+                if (include_streams(query) && item.type === "stream") {
+                    const stream_query = query.trim().slice(1);
+                    return item.name.toLowerCase().includes(stream_query);
                 }
-                return false;
-            }
 
-            let matches = false;
-            if (include_user_groups && item.type === "user_group") {
-                matches = group_matcher(query, item);
-            }
+                if (include_user_groups && query.startsWith("@")) {
+                    if (item.type === "user_group") {
+                        const normalized_query = query.slice(1);
+                        return group_matcher(normalized_query, item);
+                    }
+                    return false;
+                }
 
-            if (include_users && item.type === "user") {
-                matches = matches || person_matcher(query, item);
-            }
-            return matches;
+                let matches = false;
+                if (include_user_groups && item.type === "user_group") {
+                    matches = group_matcher(query, item);
+                }
+
+                if (include_users && item.type === "user") {
+                    matches = matches || person_matcher(query, item);
+                }
+                return matches;
+            };
         },
         sorter(matches: TypeaheadItem[], query: string): TypeaheadItem[] {
             if (include_streams(query)) {

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -61,7 +61,7 @@ export function set_up_user(
         },
         matcher(query: string): (item: UserPillData) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
+            const should_remove_diacritics = !typeahead.contains_diacritics(query);
             return (item: UserPillData) => person_matcher(query, item, should_remove_diacritics);
         },
         sorter(matches: UserPillData[], query: string): UserPillData[] {
@@ -161,7 +161,7 @@ export function set_up_user_group(
         },
         matcher(query: string): (item: UserGroupPillData) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
+            const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
             return (item: UserGroupPillData) =>
                 group_matcher(query, item, should_remove_diacritics);
@@ -217,7 +217,7 @@ export function set_up_group_setting_typeahead(
         },
         matcher(query: string): (item: GroupSettingTypeaheadItem) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
+            const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
             return (item: GroupSettingTypeaheadItem): boolean => {
                 let matches = false;
@@ -365,7 +365,7 @@ export function set_up_combined(
         },
         matcher(query: string): (item: TypeaheadItem) => boolean {
             query = typeahead.clean_query_lowercase(query, false);
-            const should_remove_diacritics = people.should_remove_diacritics_for_query(query);
+            const should_remove_diacritics = !typeahead.contains_diacritics(query);
 
             return (item: TypeaheadItem): boolean => {
                 if (include_streams(query) && item.type === "stream") {

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -215,8 +215,8 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
         helpOnEmptyStrings: true,
         stopAdvance: true,
         requireHighlight: false,
-        item_html(item: string, query: string): string {
-            return search_pill.generate_pills_html(item, query);
+        item_html(query: string): (item: string) => string {
+            return (item: string) => search_pill.generate_pills_html(item, query);
         },
         // When the user starts typing new search operands,
         // we want to highlight the first typeahead row by default

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -233,8 +233,8 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
             const text_terms = Filter.parse(search_bar_text);
             return text_terms.at(-1)?.operator === "search";
         },
-        matcher(): boolean {
-            return true;
+        matcher(_query: string) {
+            return () => true;
         },
         updater(search_string: string): string {
             if (search_string) {

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -165,8 +165,9 @@ function build_page(): void {
             return [...language_labels.keys()];
         },
         helpOnEmptyStrings: true,
-        item_html: (item: string): string =>
-            render_typeahead_item({primary: language_labels.get(item)}),
+        item_html(_query: string): (item: string) => string {
+            return (item: string) => render_typeahead_item({primary: language_labels.get(item)});
+        },
         matcher(item: string, query: string): boolean {
             const q = query.trim().toLowerCase();
             return item.toLowerCase().startsWith(q);

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -168,9 +168,9 @@ function build_page(): void {
         item_html(_query: string): (item: string) => string {
             return (item: string) => render_typeahead_item({primary: language_labels.get(item)});
         },
-        matcher(item: string, query: string): boolean {
+        matcher(query: string): (item: string) => boolean {
             const q = query.trim().toLowerCase();
-            return item.toLowerCase().startsWith(q);
+            return (item: string) => item.toLowerCase().startsWith(q);
         },
         sorter(items: string[], query: string): string[] {
             return bootstrap_typeahead.defaultSorter(items, query);

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -16,7 +16,7 @@ export type TopicFilterPillWidget = InputPillContainer<TopicFilterPill>;
 
 type TopicFilterTypeaheadOptions = {
     item_html: (query: string) => (item: TopicFilterPill) => string | undefined;
-    matcher: (item: TopicFilterPill, query: string) => boolean;
+    matcher: (query: string) => (item: TopicFilterPill) => boolean;
     sorter: (items: TopicFilterPill[], query: string) => TopicFilterPill[];
     stopAdvance: boolean;
     dropup: boolean;
@@ -51,14 +51,13 @@ export function get_typeahead_base_options(): TopicFilterTypeaheadOptions {
         item_html(_query: string) {
             return (item: TopicFilterPill) => typeahead_helper.render_topic_state(item.label);
         },
-        matcher(item: TopicFilterPill, query: string) {
+        matcher(query: string) {
             // This basically only matches if `is:` is in the query.
-            return (
+            return (item: TopicFilterPill) =>
                 query.includes(":") &&
                 (item.syntax.toLowerCase().startsWith(query.toLowerCase()) ||
                     (item.syntax.startsWith("-") &&
-                        item.syntax.slice(1).toLowerCase().startsWith(query.toLowerCase())))
-            );
+                        item.syntax.slice(1).toLowerCase().startsWith(query.toLowerCase())));
         },
         sorter(items: TopicFilterPill[], _query: string) {
             // This sort order places "Unresolved topics" first

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -15,7 +15,7 @@ export type TopicFilterPill = {
 export type TopicFilterPillWidget = InputPillContainer<TopicFilterPill>;
 
 type TopicFilterTypeaheadOptions = {
-    item_html: (item: TopicFilterPill, query: string) => string | undefined;
+    item_html: (query: string) => (item: TopicFilterPill) => string | undefined;
     matcher: (item: TopicFilterPill, query: string) => boolean;
     sorter: (items: TopicFilterPill[], query: string) => TopicFilterPill[];
     stopAdvance: boolean;
@@ -48,8 +48,8 @@ export const filter_options: TopicFilterPill[] = [
 
 export function get_typeahead_base_options(): TopicFilterTypeaheadOptions {
     return {
-        item_html(item: TopicFilterPill, _query: string) {
-            return typeahead_helper.render_topic_state(item.label);
+        item_html(_query: string) {
+            return (item: TopicFilterPill) => typeahead_helper.render_topic_state(item.label);
         },
         matcher(item: TopicFilterPill, query: string) {
             // This basically only matches if `is:` is in the query.

--- a/web/src/typeahead.ts
+++ b/web/src/typeahead.ts
@@ -71,6 +71,10 @@ export function remove_diacritics(s: string): string {
     return s.normalize("NFKD").replaceAll(unicode_marks, "");
 }
 
+export function contains_diacritics(s: string): boolean {
+    return remove_diacritics(s) !== s;
+}
+
 export function last_prefix_match(prefix: string, words: string[]): number | null {
     // This function takes in a lexicographically sorted array of `words`,
     // and a `prefix` string. It uses binary search to compute the index
@@ -104,11 +108,11 @@ export function query_matches_string_in_order(
     query: string,
     source_str: string,
     split_char: string,
+    should_remove_diacritics: boolean,
 ): boolean {
     query = query.toLowerCase();
     source_str = source_str.toLowerCase();
 
-    const should_remove_diacritics = /^[a-z]+$/.test(query);
     if (should_remove_diacritics) {
         source_str = remove_diacritics(source_str);
     }
@@ -202,8 +206,10 @@ export function query_matches_string_in_any_order(
     return true;
 }
 
-function clean_query(query: string): string {
-    query = remove_diacritics(query);
+function clean_query(query: string, should_remove_diacritics: boolean): string {
+    if (should_remove_diacritics) {
+        query = remove_diacritics(query);
+    }
     // When `abc ` with a space at the end is typed in
     // a content-editable widget such as the composebox
     // direct message section, the space at the end was
@@ -214,9 +220,9 @@ function clean_query(query: string): string {
     return query;
 }
 
-export function clean_query_lowercase(query: string): string {
+export function clean_query_lowercase(query: string, remove_diacritics = true): string {
     query = query.toLowerCase();
-    query = clean_query(query);
+    query = clean_query(query, remove_diacritics);
     return query;
 }
 
@@ -229,13 +235,17 @@ export const parse_unicode_emoji_code = (code: string): string =>
 export function get_emoji_matcher(query: string): (emoji: EmojiSuggestion) => boolean {
     // replace spaces with underscores for emoji matching
     query = query.replaceAll(" ", "_");
-    query = clean_query_lowercase(query);
+    query = clean_query_lowercase(query, false);
+    const should_remove_diacritics = !contains_diacritics(query);
 
     return function (emoji) {
         const matches_emoji_literal =
             emoji.reaction_type === "unicode_emoji" &&
             parse_unicode_emoji_code(emoji.emoji_code) === query;
-        return matches_emoji_literal || query_matches_string_in_order(query, emoji.emoji_name, "_");
+        return (
+            matches_emoji_literal ||
+            query_matches_string_in_order(query, emoji.emoji_name, "_", should_remove_diacritics)
+        );
     };
 }
 

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -1079,11 +1079,10 @@ export function rewire_sort_user_groups(value: typeof sort_user_groups): void {
 export function query_matches_person_name(
     query: string,
     person: UserPillData,
-    should_remove_diacritics?: boolean,
+    should_remove_diacritics: boolean,
     match_prefix?: boolean,
 ): boolean {
     query = query.toLowerCase();
-    should_remove_diacritics ??= people.should_remove_diacritics_for_query(query);
 
     const full_name = people.maybe_remove_diacritics_from_name(
         person.user,
@@ -1101,7 +1100,7 @@ export function query_matches_person_name(
 export function query_matches_person(
     query: string,
     person: UserPillData | UserOrMentionPillData,
-    should_remove_diacritics?: boolean,
+    should_remove_diacritics: boolean,
     match_prefix?: boolean,
     allow_custom_profile_field_matching = false,
 ): boolean {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -95,7 +95,10 @@ export function rewire_render_typeahead_item(value: typeof render_typeahead_item
 
 export let render_person = (
     person: UserPillData | UserOrMentionPillData,
-    query?: string,
+    opts?: {
+        query: string;
+        should_remove_diacritics: boolean;
+    },
 ): string => {
     if (person.type === "broadcast") {
         return render_typeahead_item({
@@ -119,11 +122,12 @@ export let render_person = (
     // If both the email and a custom profile field match the query, show both.
     let secondary_text = person.user.delivery_email;
 
-    if (query) {
+    if (opts) {
         const email_matches = typeahead.query_matches_string_in_order(
-            query,
+            opts.query,
             secondary_text ?? "",
             "",
+            opts.should_remove_diacritics,
         );
         let matched_custom_field;
 
@@ -134,7 +138,14 @@ export let render_person = (
 
             const value = people.get_custom_profile_data(person.user.user_id, field.id)?.value;
 
-            if (typeahead.query_matches_string_in_order(query, value ?? "", "")) {
+            if (
+                typeahead.query_matches_string_in_order(
+                    opts.query,
+                    value ?? "",
+                    "",
+                    opts.should_remove_diacritics,
+                )
+            ) {
                 matched_custom_field = value;
                 break;
             }
@@ -190,13 +201,16 @@ export function rewire_render_user_group(value: typeof render_user_group): void 
 
 export function render_person_or_user_group(
     item: UserGroupPillData | UserPillData | UserOrMentionPillData,
-    query?: string,
+    opts?: {
+        query: string;
+        should_remove_diacritics: boolean;
+    },
 ): string {
     if (item.type === "user_group") {
         return render_user_group(item);
     }
 
-    return render_person(item, query);
+    return render_person(item, opts);
 }
 
 export let render_stream = (stream: StreamData): string =>
@@ -1106,7 +1120,12 @@ export function query_matches_person(
 ): boolean {
     if (
         person.type === "broadcast" &&
-        typeahead.query_matches_string_in_order(query, person.user.full_name, " ")
+        typeahead.query_matches_string_in_order(
+            query,
+            person.user.full_name,
+            " ",
+            should_remove_diacritics,
+        )
     ) {
         return true;
     }
@@ -1122,7 +1141,14 @@ export function query_matches_person(
                 if (field.use_for_user_matching) {
                     const field_value =
                         people.get_custom_profile_data(person.user.user_id, field.id)?.value ?? "";
-                    if (typeahead.query_matches_string_in_order(query, field_value, " ")) {
+                    if (
+                        typeahead.query_matches_string_in_order(
+                            query,
+                            field_value,
+                            " ",
+                            should_remove_diacritics,
+                        )
+                    ) {
                         return true;
                     }
                 }
@@ -1134,28 +1160,44 @@ export function query_matches_person(
                 query,
                 people.get_visible_email(person.user),
                 " ",
+                should_remove_diacritics,
             );
         }
     }
     return false;
 }
 
-export function query_matches_stream_name(query: string, stream: StreamPillData): boolean {
-    return typeahead.query_matches_string_in_order(query, stream.name, " ");
+export function query_matches_stream_name(
+    query: string,
+    stream: StreamPillData,
+    should_remove_diacritics: boolean,
+): boolean {
+    return typeahead.query_matches_string_in_order(
+        query,
+        stream.name,
+        " ",
+        should_remove_diacritics,
+    );
 }
 
-export function query_matches_group_name(query: string, user_group: UserGroupPillData): boolean {
+export function query_matches_group_name(
+    query: string,
+    user_group: UserGroupPillData,
+    should_remove_diacritics: boolean,
+): boolean {
     if (user_group.name === "role:members") {
         return (
             typeahead.query_matches_string_in_order(
                 query,
                 user_groups.get_display_group_name(user_group.name),
                 "",
+                should_remove_diacritics,
             ) ||
             typeahead.query_matches_string_in_order(
                 query,
                 settings_config.alternate_members_group_typeahead_matching_name,
                 "",
+                should_remove_diacritics,
             )
         );
     }
@@ -1163,5 +1205,6 @@ export function query_matches_group_name(query: string, user_group: UserGroupPil
         query,
         user_groups.get_display_group_name(user_group.name),
         "",
+        should_remove_diacritics,
     );
 }

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1299,7 +1299,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 // options.item_html()
                 options.query = "Kro";
-                actual_value = options.item_html("kronor");
+                actual_value = options.item_html()("kronor");
                 expected_value =
                     '<div class="typeahead-content">\n' +
                     '    <div class="typeahead-text-container">\n' +
@@ -1309,7 +1309,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 // Highlighted content should be escaped.
                 options.query = "<";
-                actual_value = options.item_html("<&>");
+                actual_value = options.item_html()("<&>");
                 expected_value =
                     '<div class="typeahead-content">\n' +
                     '    <div class="typeahead-text-container">\n' +
@@ -1318,7 +1318,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 assert.equal(actual_value, expected_value);
 
                 options.query = "even m";
-                actual_value = options.item_html("even more ice");
+                actual_value = options.item_html()("even more ice");
                 expected_value =
                     '<div class="typeahead-content">\n' +
                     '    <div class="typeahead-text-container">\n' +
@@ -1562,7 +1562,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 // content_item_html.
                 ct.get_or_set_completing_for_tests("mention");
                 ct.get_or_set_token_for_testing("othello");
-                actual_value = options.item_html(othello_item);
+                actual_value = options.item_html()(othello_item);
                 expected_value =
                     '<div class="typeahead-content">\n' +
                     '        <div class="typeahead-image">\n' +
@@ -1579,7 +1579,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 ct.get_or_set_completing_for_tests("mention");
                 ct.get_or_set_token_for_testing("hamletcharacters");
-                actual_value = options.item_html(hamletcharacters);
+                actual_value = options.item_html()(hamletcharacters);
                 expected_value =
                     '<div class="typeahead-content">\n' +
                     '        <i class="typeahead-image zulip-icon zulip-icon-user-group" aria-hidden="true"></i>\n' +
@@ -2382,7 +2382,7 @@ test("content_item_html", ({override_rewire}) => {
         assert.deepEqual(item, emoji);
         th_render_typeahead_item_called = true;
     });
-    ct.content_item_html(emoji);
+    ct.content_item_html()(emoji);
 
     ct.get_or_set_completing_for_tests("mention");
     let th_render_person_called = false;
@@ -2390,14 +2390,14 @@ test("content_item_html", ({override_rewire}) => {
         assert.deepEqual(person, othello_item);
         th_render_person_called = true;
     });
-    ct.content_item_html(othello_item);
+    ct.content_item_html()(othello_item);
 
     let th_render_user_group_called = false;
     override_rewire(typeahead_helper, "render_user_group", (user_group) => {
         assert.deepEqual(user_group, backend);
         th_render_user_group_called = true;
     });
-    ct.content_item_html(backend);
+    ct.content_item_html()(backend);
 
     // We don't have any fancy rendering for slash commands yet.
     ct.get_or_set_completing_for_tests("slash");
@@ -2414,7 +2414,7 @@ test("content_item_html", ({override_rewire}) => {
         });
         th_render_slash_command_called = true;
     });
-    ct.content_item_html(me_slash);
+    ct.content_item_html()(me_slash);
 
     ct.get_or_set_completing_for_tests("stream");
     let th_render_stream_called = false;
@@ -2422,7 +2422,7 @@ test("content_item_html", ({override_rewire}) => {
         assert.deepEqual(stream, denmark_stream);
         th_render_stream_called = true;
     });
-    ct.content_item_html(denmark_stream);
+    ct.content_item_html()(denmark_stream);
 
     ct.get_or_set_completing_for_tests("syntax");
     th_render_typeahead_item_called = false;
@@ -2433,7 +2433,7 @@ test("content_item_html", ({override_rewire}) => {
         });
         th_render_typeahead_item_called = true;
     });
-    ct.content_item_html({type: "syntax", language: "py"});
+    ct.content_item_html()({type: "syntax", language: "py"});
 
     // Verify that all stub functions have been called.
     assert.ok(th_render_typeahead_item_called);

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1407,7 +1407,13 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 function matcher(query, person) {
                     query = typeahead.clean_query_lowercase(query);
-                    return typeahead_helper.query_matches_person(query, person);
+                    const should_remove_diacritics =
+                        people.should_remove_diacritics_for_query(query);
+                    return typeahead_helper.query_matches_person(
+                        query,
+                        person,
+                        should_remove_diacritics,
+                    );
                 }
 
                 let query;
@@ -1426,6 +1432,12 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 assert.equal(matcher(query, gael_item), true);
 
                 query = "gaël";
+                assert.equal(matcher(query, gael_item), true);
+
+                query = "gaël twi";
+                assert.equal(matcher(query, gael_item), true);
+
+                query = "gael twi";
                 assert.equal(matcher(query, gael_item), true);
 
                 // Don't make suggestions if the last name only has whitespaces

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1406,7 +1406,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 assert.deepEqual(actual_value, expected_value);
 
                 function matcher(query, person) {
-                    query = typeahead.clean_query_lowercase(query);
+                    query = typeahead.clean_query_lowercase(query, false);
                     const should_remove_diacritics =
                         people.should_remove_diacritics_for_query(query);
                     return typeahead_helper.query_matches_person(
@@ -1574,7 +1574,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 // content_item_html.
                 ct.get_or_set_completing_for_tests("mention");
                 ct.get_or_set_token_for_testing("othello");
-                actual_value = options.item_html()(othello_item);
+                actual_value = options.item_html("othello")(othello_item);
                 expected_value =
                     '<div class="typeahead-content">\n' +
                     '        <div class="typeahead-image">\n' +
@@ -1591,7 +1591,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 ct.get_or_set_completing_for_tests("mention");
                 ct.get_or_set_token_for_testing("hamletcharacters");
-                actual_value = options.item_html()(hamletcharacters);
+                actual_value = options.item_html("hamletcharacters")(hamletcharacters);
                 expected_value =
                     '<div class="typeahead-content">\n' +
                     '        <i class="typeahead-image zulip-icon zulip-icon-user-group" aria-hidden="true"></i>\n' +
@@ -2394,22 +2394,23 @@ test("content_item_html", ({override_rewire}) => {
         assert.deepEqual(item, emoji);
         th_render_typeahead_item_called = true;
     });
-    ct.content_item_html()(emoji);
+    ct.content_item_html("")(emoji);
 
     ct.get_or_set_completing_for_tests("mention");
     let th_render_person_called = false;
-    override_rewire(typeahead_helper, "render_person", (person) => {
+    override_rewire(typeahead_helper, "render_person", (person, opts) => {
         assert.deepEqual(person, othello_item);
+        assert.ok(opts === undefined || typeof opts === "object");
         th_render_person_called = true;
     });
-    ct.content_item_html()(othello_item);
+    ct.content_item_html("")(othello_item);
 
     let th_render_user_group_called = false;
     override_rewire(typeahead_helper, "render_user_group", (user_group) => {
         assert.deepEqual(user_group, backend);
         th_render_user_group_called = true;
     });
-    ct.content_item_html()(backend);
+    ct.content_item_html("")(backend);
 
     // We don't have any fancy rendering for slash commands yet.
     ct.get_or_set_completing_for_tests("slash");
@@ -2426,7 +2427,7 @@ test("content_item_html", ({override_rewire}) => {
         });
         th_render_slash_command_called = true;
     });
-    ct.content_item_html()(me_slash);
+    ct.content_item_html("")(me_slash);
 
     ct.get_or_set_completing_for_tests("stream");
     let th_render_stream_called = false;
@@ -2434,7 +2435,7 @@ test("content_item_html", ({override_rewire}) => {
         assert.deepEqual(stream, denmark_stream);
         th_render_stream_called = true;
     });
-    ct.content_item_html()(denmark_stream);
+    ct.content_item_html("")(denmark_stream);
 
     ct.get_or_set_completing_for_tests("syntax");
     th_render_typeahead_item_called = false;
@@ -2445,7 +2446,7 @@ test("content_item_html", ({override_rewire}) => {
         });
         th_render_typeahead_item_called = true;
     });
-    ct.content_item_html()({type: "syntax", language: "py"});
+    ct.content_item_html("")({type: "syntax", language: "py"});
 
     // Verify that all stub functions have been called.
     assert.ok(th_render_typeahead_item_called);

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1407,8 +1407,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
                 function matcher(query, person) {
                     query = typeahead.clean_query_lowercase(query, false);
-                    const should_remove_diacritics =
-                        people.should_remove_diacritics_for_query(query);
+                    const should_remove_diacritics = !typeahead.contains_diacritics(query);
                     return typeahead_helper.query_matches_person(
                         query,
                         person,

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -857,6 +857,18 @@ run_test("filtered_users", () => {
     filtered_people = people.filter_people_by_search_terms(users, "ëm");
     assert.equal(filtered_people.size, 1);
     assert.ok(filtered_people.has(noah.user_id));
+
+    // Multi-word query should ignore diacritics when the query
+    // itself has no diacritics.
+    filtered_people = people.filter_people_by_search_terms(users, "nooa em");
+    assert.equal(filtered_people.size, 2);
+    assert.ok(filtered_people.has(noah.user_id));
+    assert.ok(filtered_people.has(plain_noah.user_id));
+
+    // Multi-word query with diacritics should match only Nöôáàh
+    filtered_people = people.filter_people_by_search_terms(users, "nöôáàh Ëme");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(noah.user_id));
 });
 
 run_test("dm_matches_search_string", () => {

--- a/web/tests/pill_typeahead.test.cjs
+++ b/web/tests/pill_typeahead.test.cjs
@@ -201,9 +201,9 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
 
         (function test_matcher() {
             let result;
-            result = config.matcher(me_item, person_query);
+            result = config.matcher(person_query)(me_item);
             assert.ok(result);
-            result = config.matcher(jill_item, person_query);
+            result = config.matcher(person_query)(jill_item);
             assert.ok(!result);
         })();
 
@@ -293,9 +293,9 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
 
         (function test_matcher() {
             let result;
-            result = config.matcher(denmark_item, stream_query);
+            result = config.matcher(stream_query)(denmark_item);
             assert.ok(result);
-            result = config.matcher(sweden_item, stream_query);
+            result = config.matcher(stream_query)(sweden_item);
             assert.ok(!result);
         })();
 
@@ -385,9 +385,9 @@ run_test("set_up_user_group", ({mock_template, override, override_rewire}) => {
 
         (function test_matcher() {
             let result;
-            result = config.matcher(testers_item, group_query);
+            result = config.matcher(group_query)(testers_item);
             assert.ok(result);
-            result = config.matcher(admins_item, group_query);
+            result = config.matcher(group_query)(admins_item);
             assert.ok(!result);
         })();
 
@@ -507,9 +507,9 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         (function test_matcher() {
             let result;
             if (opts.stream) {
-                result = config.matcher(denmark_item, stream_query);
+                result = config.matcher(stream_query)(denmark_item);
                 assert.ok(result);
-                result = config.matcher(sweden_item, stream_query);
+                result = config.matcher(stream_query)(sweden_item);
                 assert.ok(!result);
             }
             if (opts.user_group && opts.user) {
@@ -518,36 +518,36 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 or group is returned. */
 
                 // group query, with correct item.
-                result = config.matcher(testers_item, group_query);
+                result = config.matcher(group_query)(testers_item);
                 assert.ok(result);
                 // group query, with wrong item.
-                result = config.matcher(admins_item, group_query);
+                result = config.matcher(group_query)(admins_item);
                 assert.ok(!result);
                 // person query with correct item.
-                result = config.matcher(me_item, person_query);
+                result = config.matcher(person_query)(me_item);
                 assert.ok(result);
                 // person query with wrong item.
-                result = config.matcher(jill_item, person_query);
+                result = config.matcher(person_query)(jill_item);
                 assert.ok(!result);
                 // @-prefixed query matches groups only.
-                result = config.matcher(testers_item, "@" + group_query);
+                result = config.matcher("@" + group_query)(testers_item);
                 assert.ok(result);
-                result = config.matcher(admins_item, "@admins");
+                result = config.matcher("@admins")(admins_item);
                 assert.ok(result);
                 // @-prefixed query must NOT match users.
-                result = config.matcher(me_item, "@" + person_query);
+                result = config.matcher("@" + person_query)(me_item);
                 assert.ok(!result);
             }
             if (opts.user_group && !opts.user) {
-                result = config.matcher(testers_item, group_query);
+                result = config.matcher(group_query)(testers_item);
                 assert.ok(result);
-                result = config.matcher(admins_item, group_query);
+                result = config.matcher(group_query)(admins_item);
                 assert.ok(!result);
             }
             if (opts.user && !opts.user_group) {
-                result = config.matcher(me_item, person_query);
+                result = config.matcher(person_query)(me_item);
                 assert.ok(result);
-                result = config.matcher(jill_item, person_query);
+                result = config.matcher(person_query)(jill_item);
                 assert.ok(!result);
             }
         })();
@@ -801,16 +801,16 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
         (function test_matcher() {
             let result;
             // group query, with correct item.
-            result = config.matcher(testers_item, group_query);
+            result = config.matcher(group_query)(testers_item);
             assert.ok(result);
             // group query, with wrong item.
-            result = config.matcher(admins_item, group_query);
+            result = config.matcher(group_query)(admins_item);
             assert.ok(!result);
             // person query with correct item.
-            result = config.matcher(me_item, person_query);
+            result = config.matcher(person_query)(me_item);
             assert.ok(result);
             // person query with wrong item.
-            result = config.matcher(jill_item, person_query);
+            result = config.matcher(person_query)(jill_item);
             assert.ok(!result);
         })();
 

--- a/web/tests/pill_typeahead.test.cjs
+++ b/web/tests/pill_typeahead.test.cjs
@@ -196,7 +196,7 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
         const person_query = "me";
 
         (function test_item_html() {
-            assert.equal(config.item_html(me_item, person_query), "<rendered-person-stub>");
+            assert.equal(config.item_html(person_query)(me_item), "<rendered-person-stub>");
         })();
 
         (function test_matcher() {
@@ -288,7 +288,7 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
         const stream_query = "#denmark";
 
         (function test_item_html() {
-            assert.equal(config.item_html(denmark_item, stream_query), "<rendered-stream-stub>");
+            assert.equal(config.item_html(stream_query)(denmark_item), "<rendered-stream-stub>");
         })();
 
         (function test_matcher() {
@@ -380,7 +380,7 @@ run_test("set_up_user_group", ({mock_template, override, override_rewire}) => {
         const group_query = "testers";
 
         (function test_item_html() {
-            assert.equal(config.item_html(testers_item, group_query), "<rendered-group-stub>");
+            assert.equal(config.item_html(group_query)(testers_item), "<rendered-group-stub>");
         })();
 
         (function test_matcher() {
@@ -486,21 +486,21 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
             if (opts.stream) {
                 // Test stream item_html for widgets that allow stream pills.
                 assert.equal(
-                    config.item_html(denmark_item, stream_query),
+                    config.item_html(stream_query)(denmark_item),
                     "<rendered-stream-stub>",
                 );
             }
             if (opts.user_group && opts.user) {
                 // If user is also allowed along with user_group
                 // then we should check that each of them rendered correctly.
-                assert.equal(config.item_html(testers_item, group_query), "<rendered-group-stub>");
-                assert.equal(config.item_html(me_item, person_query), "<rendered-person-stub>");
+                assert.equal(config.item_html(group_query)(testers_item), "<rendered-group-stub>");
+                assert.equal(config.item_html(person_query)(me_item), "<rendered-person-stub>");
             }
             if (opts.user && !opts.user_group) {
-                assert.equal(config.item_html(me_item, person_query), "<rendered-person-stub>");
+                assert.equal(config.item_html(person_query)(me_item), "<rendered-person-stub>");
             }
             if (!opts.user && opts.user_group) {
-                assert.equal(config.item_html(testers_item, group_query), "<rendered-group-stub>");
+                assert.equal(config.item_html(group_query)(testers_item), "<rendered-group-stub>");
             }
         })();
 
@@ -794,8 +794,8 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
         (function test_item_html() {
             // If user is also allowed along with user_group
             // then we should check that each of them rendered correctly.
-            assert.equal(config.item_html(testers_item, group_query), "<rendered-group-stub>");
-            assert.equal(config.item_html(me_item, person_query), "<rendered-person-stub>");
+            assert.equal(config.item_html(group_query)(testers_item), "<rendered-group-stub>");
+            assert.equal(config.item_html(person_query)(me_item), "<rendered-person-stub>");
         })();
 
         (function test_matcher() {

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -82,7 +82,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
         assert.equal(input_element.$element[0], $search_query_box[0]);
         assert.equal(opts.items, 999);
         assert.equal(opts.helpOnEmptyStrings, true);
-        assert.equal(opts.matcher(), true);
+        assert.equal(opts.matcher("")(), true);
 
         return {
             lookup() {

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -101,10 +101,10 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
 
             /* Test highlighter */
             let expected_value = `<div class="search_list_item">\n            <div class="description">Search for dm</div>\n    \n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[0], "dm"), expected_value);
+            assert.equal(opts.item_html("dm")(search_suggestions[0]), expected_value);
 
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class='pill ' tabindex=0>\n    <span class="pill-label">\n        <span class="pill-value">\ndm:\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n</span>\n            <div class="description">Direct messages with</div>\n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[1], "dm"), expected_value);
+            assert.equal(opts.item_html("dm")(search_suggestions[1]), expected_value);
 
             /* Test sorter */
             assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);
@@ -116,12 +116,12 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             /* Test highlighter */
             let description_html = "Search for ver";
             let expected_value = `<div class="search_list_item">\n            <div class="description">Search for ver</div>\n    \n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[0], "ver"), expected_value);
+            assert.equal(opts.item_html("ver")(search_suggestions[0]), expected_value);
 
             const search_string = "channel: Verona";
             description_html = "Messages in #Verona";
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class='pill ' tabindex=0>\n    <span class="pill-label">\n        <span class="pill-value">\n${search_string}\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n    </div>\n</div>\n</span>\n            <div class="description">${description_html}</div>\n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[1], "ver"), expected_value);
+            assert.equal(opts.item_html("ver")(search_suggestions[1]), expected_value);
 
             /* Test sorter */
             assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);
@@ -138,17 +138,17 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             /* Test highlighter */
             const description_html = "Search for zo";
             let expected_value = `<div class="search_list_item">\n            <div class="description">${description_html}</div>\n    \n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[0], "zo"), expected_value);
+            assert.equal(opts.item_html("zo")(search_suggestions[0]), expected_value);
 
             override(realm, "realm_enable_guest_user_indicator", true);
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">sender:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[1], "zo"), expected_value);
+            assert.equal(opts.item_html("zo")(search_suggestions[1]), expected_value);
 
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[2], "zo"), expected_value);
+            assert.equal(opts.item_html("zo")(search_suggestions[2]), expected_value);
 
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class="user-pill-container pill" tabindex=0>\n    <span class="pill-label">dm-including:\n    </span>\n        <div class="pill" data-user-id="3">\n            <img class="pill-image" src="/avatar/3" />\n            <div class="pill-image-border"></div>\n            <span class="pill-label">\n                <span class="pill-value">Zoe</span></span>\n            <div class="exit">\n                <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n            </div>\n        </div>\n</div>\n</span>\n    \n</div>\n`;
-            assert.equal(opts.item_html(search_suggestions[3], "zo"), expected_value);
+            assert.equal(opts.item_html("zo")(search_suggestions[3]), expected_value);
 
             /* Test sorter */
             assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);

--- a/web/tests/typeahead.test.cjs
+++ b/web/tests/typeahead.test.cjs
@@ -75,6 +75,44 @@ run_test("get_emoji_matcher: spaces equivalent to underscores", () => {
     assert_equivalent("traffic l");
 });
 
+run_test("query_matches_string_in_order", () => {
+    function assert_matches(query, source, split_char) {
+        const should_remove_diacritics = !typeahead.contains_diacritics(query);
+        assert.equal(
+            typeahead.query_matches_string_in_order(
+                query,
+                source,
+                split_char,
+                should_remove_diacritics,
+            ),
+            true,
+        );
+    }
+    function assert_no_match(query, source, split_char) {
+        const should_remove_diacritics = !typeahead.contains_diacritics(query);
+        assert.equal(
+            typeahead.query_matches_string_in_order(
+                query,
+                source,
+                split_char,
+                should_remove_diacritics,
+            ),
+            false,
+        );
+    }
+
+    // Query without diacritics should match source with diacritics.
+    assert_matches("jose mar", "José María", " ");
+    assert_matches("maria gon", "María González", " ");
+    assert_matches("jose", "José María", " ");
+
+    // Query with diacritics does diacritic-sensitive matching
+    assert_matches("josé", "José María", " ");
+    assert_no_match("josé", "Jose Maria", " ");
+    assert_matches("josé mar", "José María", " ");
+    assert_no_match("josé mar", "Jose Maria", " ");
+});
+
 run_test("triage", () => {
     const alice = {name: "alice"};
     const alicia = {name: "Alicia"};

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -1693,7 +1693,10 @@ test("render_person shows value of custom profile fields in secondary", ({
         return "typeahead-item-stub";
     });
 
-    assert.equal(th.render_person(a_user_item, "Alpha"), "typeahead-item-stub");
+    assert.equal(
+        th.render_person(a_user_item, {query: "Alpha", should_remove_diacritics: true}),
+        "typeahead-item-stub",
+    );
     assert.ok(rendered);
 });
 
@@ -1727,7 +1730,10 @@ test("render_person shows both email and custom profile fields as secondary if b
         return "typeahead-item-stub";
     });
 
-    assert.equal(th.render_person(a_user_item, "a_user"), "typeahead-item-stub");
+    assert.equal(
+        th.render_person(a_user_item, {query: "a_user", should_remove_diacritics: true}),
+        "typeahead-item-stub",
+    );
     assert.ok(rendered);
 });
 
@@ -1762,7 +1768,10 @@ test("render_person skips custom profile fields not used for user matching", ({
         return "typeahead-item-stub";
     });
 
-    assert.equal(th.render_person(a_user_item, "Alpha"), "typeahead-item-stub");
+    assert.equal(
+        th.render_person(a_user_item, {query: "Alpha", should_remove_diacritics: true}),
+        "typeahead-item-stub",
+    );
     assert.ok(rendered);
 });
 


### PR DESCRIPTION
The `should_remove_diacritics_for_query` function used the regex `/^[a-z]+$/` to decide whether to strip diacritics from names before matching which was introduced in d030adde30ca802538c0f449888329edf1e2f008. This regex rejects queries containing spaces, so typing a multi-word query like "jose mar" disabled diacritic removal entirely, causing "José Maria" to not match.

We fix this in both by checking whether the query itself contains diacritics. The `clean_query_lowercase` also removes any diacritics from query before we can decide if we should remove diacritics from source str.

Fixes: [#issues > 🎯non-ASCII names like "María" not found in compose dropdown @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AFnon-ASCII.20names.20like.20.22Mar.C3.ADa.22.20not.20found.20in.20compose.20dropdown/near/2424452)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="400" height="147" alt="image" src="https://github.com/user-attachments/assets/39d40159-bcc7-473e-b2ac-030b618ce6b0" />|<img width="400" height="147" alt="Screenshot from 2026-04-07 22-33-25" src="https://github.com/user-attachments/assets/ee2a0b62-5d77-4269-a6cf-69884269f37c" />|
|<img width="400" height="147" alt="image" src="https://github.com/user-attachments/assets/4f905677-267b-4999-a72f-24259b6f5938" />|<img width="400" height="147" alt="image" src="https://github.com/user-attachments/assets/0255ed5b-ec3a-4dbe-a5db-23bec6bcd344" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
