### PR TITLE
Compose unedited draft keyboard exit

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -466,7 +466,10 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
     }
     // This has to happen after we insert the content, so that the next "input" event
     // is from user input.
-    if (restoring_last_draft) {
+    const should_mark_unedited_restored_draft =
+        restoring_last_draft ||
+        (opts.content !== undefined && opts.draft_id !== undefined && opts.draft_id !== "");
+    if (should_mark_unedited_restored_draft) {
         compose_state.set_is_content_unedited_restored_draft(true);
     }
 

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -235,6 +235,24 @@ export function focus_in_empty_compose(
     return false;
 }
 
+export function focus_in_unedited_restored_draft_at_end(): boolean {
+    if (
+        !composing() ||
+        !get_is_content_unedited_restored_draft() ||
+        is_recipient_edited_manually()
+    ) {
+        return false;
+    }
+
+    if (document.activeElement?.id !== "compose-textarea") {
+        return false;
+    }
+
+    const $textarea = $("textarea#compose-textarea");
+    const text = untrimmed_message_content();
+    return $textarea.caret() === text.length;
+}
+
 export function private_message_recipient_emails(): string {
     return compose_pm_pill.get_emails();
 }

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -16,6 +16,7 @@ import * as compose_send_menu_popover from "./compose_send_menu_popover.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_textarea from "./compose_textarea.ts";
 import * as compose_tooltips from "./compose_tooltips.ts";
+import * as compose_ui from "./compose_ui.ts";
 import * as condense from "./condense.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as deprecated_feature_notice from "./deprecated_feature_notice.ts";
@@ -1045,7 +1046,10 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             ((event_name === "down_arrow" || event_name === "page_down" || event_name === "end") &&
                 compose_state.focus_in_empty_compose()) ||
             ((event_name === "up_arrow" || event_name === "page_up" || event_name === "home") &&
-                compose_state.focus_in_empty_compose(true))
+                compose_state.focus_in_empty_compose(true)) ||
+            ((event_name === "down_arrow" || event_name === "page_down" || event_name === "end") &&
+                compose_state.focus_in_unedited_restored_draft_at_end() &&
+                !compose_ui.compose_textarea_typeahead?.shown)
         ) {
             compose_actions.cancel();
             // don't return, as we still want it to be picked up by the code below

--- a/web/src/reload_setup.ts
+++ b/web/src/reload_setup.ts
@@ -80,7 +80,11 @@ export function initialize(): void {
             if (draft === false) {
                 blueslip.warn("Tried to restore a draft that didn't exist.");
             } else {
-                compose_actions.start({...draft, message_type: draft.type});
+                compose_actions.start({
+                    ...draft,
+                    message_type: draft.type,
+                    draft_id: data.compose_active_draft_id,
+                });
                 if (data.compose_active_draft_send_immediately) {
                     compose.finish();
                 }

--- a/web/tests/compose_state.test.cjs
+++ b/web/tests/compose_state.test.cjs
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 
 const {make_realm} = require("./lib/example_realm.cjs");
 const {make_stream} = require("./lib/example_stream.cjs");
-const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 
@@ -50,4 +50,34 @@ run_test("has_full_recipient", ({override}) => {
 
     compose_state.set_private_message_recipient_ids([123]);
     assert.equal(compose_state.has_full_recipient(), true);
+});
+
+run_test("focus_in_unedited_restored_draft_at_end", () => {
+    set_global("document", {
+        activeElement: {id: "compose-textarea"},
+    });
+
+    const $textarea = $("textarea#compose-textarea");
+    compose_state.set_message_type("stream");
+    compose_state.set_is_content_unedited_restored_draft(true);
+    compose_state.set_recipient_edited_manually(false);
+
+    $textarea.val("draft");
+    $textarea.caret(5);
+    assert.equal(compose_state.focus_in_unedited_restored_draft_at_end(), true);
+
+    $textarea.caret(0);
+    assert.equal(compose_state.focus_in_unedited_restored_draft_at_end(), false);
+
+    $textarea.caret(5);
+    compose_state.set_is_content_unedited_restored_draft(false);
+    assert.equal(compose_state.focus_in_unedited_restored_draft_at_end(), false);
+
+    compose_state.set_is_content_unedited_restored_draft(true);
+    compose_state.set_recipient_edited_manually(true);
+    assert.equal(compose_state.focus_in_unedited_restored_draft_at_end(), false);
+
+    compose_state.set_recipient_edited_manually(false);
+    compose_state.set_message_type(undefined);
+    compose_state.set_is_content_unedited_restored_draft(false);
 });


### PR DESCRIPTION
## Summary

When compose shows **restored draft** text the user has **not edited**, pressing **Down**, **Page Down**, or **End** while focus is in the message body and the caret is at the **end** now **closes compose**, using the same pattern as for an **empty** compose box (including **not** returning early from the hotkey handler so the keypress still drives **message list** navigation).

`is_content_unedited_restored_draft` is set not only for **auto-restored last draft**, but whenever compose starts with **body content and a draft id** (e.g. opening from the **Drafts** overlay). **`reload_setup`** passes **`draft_id`** when restoring compose after a reload so that path matches.

### Differences from the issue text

The issue describes accidentally opening a draft while navigating the feed, but it does not spell out whether the behavior should apply only to **auto-restored last drafts** or to **any** draft opened with unchanged body text (e.g. from the Drafts overlay or after reload). This PR implements the latter: any compose session where the body was loaded from a saved draft and **not edited** in the textarea (with the usual guards: **caret at end**, **recipient not manually changed**, **mention typeahead closed**) gets the same **Down / Page Down / End** escape behavior. **Page Down** and **End** are included for parity with the existing empty-compose shortcut, though the issue only mentioned the **Down** arrow.

Fixes #38846.

## How changes were tested

- `./tools/test-js-with-node compose_state.test.cjs`
- `./tools/lint` (including Prettier on touched files)
- **Manual (dev server):** restore a draft (caret at end, no edits) → Down / Page Down / End closes compose and moves the feed; typing or changing recipients disables the shortcut; with `@` mention typeahead open → Down does not close compose.

## Screenshots and screen captures

**Before:** Compose open with restored draft (`"This is a draft message"`), **#Rome** / topic **last database was slowly**, caret at **end** of body (initial state for testing the shortcut).
<img width="1918" height="970" alt="Screenshot 2026-04-07 174355" src="https://github.com/user-attachments/assets/8edcab13-fd24-4c41-afdf-da62a2c09818" />
**After:** Same narrow with compose **closed**; user back in the message feed (draft still saved e.g. Drafts count as appropriate).
<img width="1916" height="920" alt="Screenshot 2026-04-07 174411" src="https://github.com/user-attachments/assets/9710c408-4fb9-40d0-9242-473f30c686d7" />
<!-- Attach: Screenshot 2026-04-07 174355, Screenshot 2026-04-07 174411 (or your uploaded images) -->

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

**Communicate decisions, questions, and potential concerns.**

- [x] Explains differences from previous plans (e.g. issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns. <!-- set [x] if you added any in the PR thread -->
- [x] Automated tests verify logic where appropriate.

**Individual commits** (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

**Completed manual review and testing**

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>