### PR TITLE
Fix emoji clipping in sidebar topics

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1827,7 +1827,7 @@ li.active-sub-filter {
         /* Break overflowing words as necessary. */
         overflow-wrap: break-word;
 
-        line-height: var(--line-height-sidebar-topic-inner);
+        line-height: 1.4;
         /* To avoid clipping the tops of certain characters,
            we set the top space with padding. But to make the
            line-clamp effect work, we set the bottom space


### PR DESCRIPTION
Fixes #38264

While testing topic names in the left sidebar, I noticed that emojis were getting slightly clipped vertically. This appeared to be due to a restrictive line-height value applied to `.sidebar-topic-name-inner`.

Since emojis typically render slightly taller than regular text, the existing line-height was not providing enough vertical space. Updating the line-height resolves the clipping while keeping the overall layout unchanged.

**How changes were tested:**

- Created topic names containing emojis
- Verified that emojis are no longer clipped in the sidebar
- Checked that regular text rendering remains unaffected

**Screenshots and screen captures:**

No screenshots included since this is a minor visual fix and the change is limited to line-height adjustment.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Followed the AI use policy

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans
- [x] Highlights technical choices and bugs encountered
- [ ] Calls out remaining decisions and concerns
- [ ] Automated tests verify logic where appropriate

Individual commits are ready for review.

- [x] Each commit is a coherent idea
- [x] Commit message explains reasoning and motivation

Completed manual review and testing of the following:

- [x] Visual appearance of the changes
- [x] Responsiveness and internationalization
- [x] Strings and tooltips
- [x] End-to-end functionality of interactions
- [ ] Corner cases and error conditions
</details>