### PR TITLE
message-move: Improve time limit error for "change_all" moves.

### DIFF
--- a/api_docs/unmerged.d/ZF-a6120e.md
+++ b/api_docs/unmerged.d/ZF-a6120e.md
@@ -1,0 +1,6 @@
+* [`PATCH /messages/{message_id}`](/api/update-message): For requests with
+  `"propagate_mode": "change_all"` from users who are not administrators
+  or moderators, the `"code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED"` error
+  response is now also returned when the target message itself is past
+  the time limit, as long as at least one message in the topic is within
+  the limit.

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1512,6 +1512,9 @@ def check_time_limit_for_change_all_propagate_mode(
         # We return if all messages are allowed to move.
         return
 
+    if len(messages_allowed_to_move) == 0:
+        raise JsonableError(_("The time limit for moving this topic has passed."))
+
     raise MessageMoveError(
         first_message_id_allowed_to_move=messages_allowed_to_move[0],
         total_messages_in_topic=total_messages_requested_to_move,
@@ -1639,6 +1642,7 @@ def check_stream_topic_edit_permissions(
     if (
         user_profile.realm.move_messages_within_stream_limit_seconds is not None
         and not user_profile.is_moderator
+        and message_edit_request.propagate_mode != "change_all"
     ):
         deadline_seconds = (
             user_profile.realm.move_messages_within_stream_limit_seconds + edit_limit_buffer
@@ -1767,6 +1771,7 @@ def check_update_message(
             if (
                 user_profile.realm.move_messages_between_streams_limit_seconds is not None
                 and not user_profile.is_moderator
+                and propagate_mode != "change_all"
             ):
                 deadline_seconds = (
                     user_profile.realm.move_messages_between_streams_limit_seconds

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10743,10 +10743,9 @@ paths:
                           }
                         description: |
                           A special failed JSON response (`"code": "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED"`)
-                          for when the user has permission to move
-                          the target message, but asked to move all messages in a topic
-                          (`"propagate_mode": "change_all"`) and the user does not have permission
-                          to move the entire topic.
+                          for when the user asked to move all messages in a topic
+                          (`"propagate_mode": "change_all"`) and the user can move at least one message
+                          but does not have permission to move the entire topic.
 
                           This happens when the topic contains some messages that are older than an
                           applicable time limit for the requested topic move (see
@@ -10788,7 +10787,13 @@ paths:
                           of a topic that they have access to, without this error or any confirmation
                           dialog.
 
-                          **Changes**: New in Zulip 7.0 (feature level 172).
+                          **Changes**: Before Zulip 13.0 (feature level ZF-a6120e), this error
+                          response was only returned when the request's target message was
+                          itself within the time limit. As of this feature level, it is also
+                          returned when the target message is past the limit but at least one
+                          message in the topic is within it.
+
+                          New in Zulip 7.0 (feature level 172).
 
                           [private-channels]: /help/channel-permissions#private-channels
                   - allOf:

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -230,6 +230,26 @@ class MessageMoveStreamTest(ZulipTestCase):
             messages = get_topic_messages(user_profile, new_stream, new_topic_name)
             self.assert_length(messages, 0)
 
+            # Using an older message (id2) for the request still reports
+            # how many recent messages can be moved, rather than rejecting
+            # outright.
+            result = self.client_patch(
+                f"/json/messages/{id2}",
+                params_dict,
+            )
+            self.assert_json_error(
+                result,
+                "You only have permission to move the 3/5 most recent messages in this topic.",
+            )
+
+            # Check message count in old topic and/or stream.
+            messages = get_topic_messages(user_profile, old_stream, old_topic_name)
+            self.assert_length(messages, 5)
+
+            # Check message count in new topic and/or stream.
+            messages = get_topic_messages(user_profile, new_stream, new_topic_name)
+            self.assert_length(messages, 0)
+
             json = orjson.loads(result.content)
             first_message_id_allowed_to_move = json["first_message_id_allowed_to_move"]
 
@@ -1021,6 +1041,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             user: UserProfile,
             old_stream: Stream,
             new_stream: Stream,
+            propagate_mode: str = "change_all",
             *,
             expect_error_message: str | None = None,
         ) -> None:
@@ -1029,7 +1050,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 "/json/messages/" + str(msg_id),
                 {
                     "stream_id": new_stream.id,
-                    "propagate_mode": "change_all",
+                    "propagate_mode": propagate_mode,
                     "send_notification_to_new_thread": orjson.dumps(False).decode(),
                 },
             )
@@ -1056,6 +1077,14 @@ class MessageMoveStreamTest(ZulipTestCase):
             cordelia,
             test_stream_1,
             test_stream_2,
+            expect_error_message="You only have permission to move the 2/3 most recent messages in this topic.",
+        )
+
+        check_move_message_to_stream(
+            cordelia,
+            test_stream_1,
+            test_stream_2,
+            propagate_mode="change_one",
             expect_error_message="The time limit for editing this message's channel has passed",
         )
 

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -1494,6 +1494,22 @@ class MessageMoveTopicTest(ZulipTestCase):
             "You only have permission to move the 2/5 most recent messages in this topic.",
         )
 
+        # Using an older message (id3) for the request still reports
+        # how many recent messages can be moved, rather than rejecting
+        # outright.
+        result = self.client_patch(
+            f"/json/messages/{id3}",
+            {
+                "topic": "edited",
+                "propagate_mode": "change_all",
+                "send_notification_to_new_thread": "false",
+            },
+        )
+        self.assert_json_error(
+            result,
+            "You only have permission to move the 2/5 most recent messages in this topic.",
+        )
+
     def test_notify_new_topic(self) -> None:
         user_profile = self.example_user("iago")
         self.login("iago")
@@ -2664,9 +2680,7 @@ class MessageMoveTopicTest(ZulipTestCase):
                 "propagate_mode": "change_all",
             },
         )
-        self.assert_json_error(
-            result, "The time limit for editing this message's topic has passed."
-        )
+        self.assert_json_error(result, "The time limit for moving this topic has passed.")
 
         result = self.resolve_topic_containing_message(
             cordelia,
@@ -2879,9 +2893,7 @@ class MessageMoveTopicTest(ZulipTestCase):
                 "propagate_mode": "change_all",
             },
         )
-        self.assert_json_error(
-            result, "The time limit for editing this message's topic has passed."
-        )
+        self.assert_json_error(result, "The time limit for moving this topic has passed.")
 
         result = self.resolve_topic_containing_message(
             hamlet,


### PR DESCRIPTION
Previously, when a message move request was made with propagate_mode="change_all" using a message that had passed the time limit, the error was "The time limit for editing this message's topic/channel has passed." — the same generic error used for single-message edits. We do have code to return how many messages can be moved along with the first movable message ID, but it only ran when the request message itself was within the time limit.

Skip the per-message time limit check for "change_all" requests and let check_time_limit_for_change_all_propagate_mode handle them, so the response always reports how many messages can be moved even when the request message is past the deadline. This lets clients fall back to "change_later" with the returned message ID to move the allowed messages.

When no messages in the topic can be moved, the error is now "The time limit for moving this topic has passed." instead of "The time limit for editing this message's topic has passed.", making it clear that the entire topic is past the deadline and avoiding the confusing "this message's" phrasing when the move was triggered from the topic popover or message header row from the webapp UI and not from a particular message related UI.

[#api design > partially move messages as per time limit setting @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/partially.20move.20messages.20as.20per.20time.20limit.20setting/near/2429218)

[#issues > 📂 Confusing error when moving too-old topic #38930 @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Confusing.20error.20when.20moving.20too-old.20topic.20.2338930/near/2425185)

Fixes #38930

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
