### PR TITLE
popover: Improve schedule reminder popover textarea behavior.

### DIFF
--- a/web/src/compose_send_menu_popover.ts
+++ b/web/src/compose_send_menu_popover.ts
@@ -1,3 +1,4 @@
+import autosize from "autosize";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as tippy from "tippy.js";
@@ -83,6 +84,18 @@ export function open_schedule_message_menu(
                 );
             }
             const $popper = $(instance.popper);
+            const $reminder_note_textarea = $popper.find<HTMLTextAreaElement>(
+                "textarea.schedule-reminder-note",
+            );
+
+            if ($reminder_note_textarea.length > 0) {
+                $reminder_note_textarea.off("autosize:resized").on("autosize:resized", () => {
+                    // Keep popper visible in viewport when textarea height increases.
+                    void instance.popperInstance?.update();
+                });
+                autosize($reminder_note_textarea);
+            }
+
             const message_schedule_callback = (time: string | number): void => {
                 if (remind_message_id !== undefined) {
                     do_schedule_reminder(

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -555,13 +555,23 @@ function handle_popover_events(event_name: string): boolean {
     }
 
     if (popover_menu_visible_instance) {
+        const $focused_element = $(":focus");
+        const focus_in_textarea = $focused_element.is("textarea");
+        const focused_element = $focused_element[0];
+        const focus_in_textarea_at_end =
+            focus_in_textarea &&
+            event_name === "down_arrow" &&
+            focused_element instanceof HTMLTextAreaElement &&
+            focused_element.selectionStart === focused_element.value.length &&
+            focused_element.selectionEnd === focused_element.value.length;
         if (
             // Allow all hotkeys except for `down_arrow` and `up_arrow`
             // to be handled by the browser.
-            // Added to handle `schedule-reminder-note` textarea.
+            // The `down_arrow` key is specifically intercepted when the cursor
+            // is at the end of a textarea to enable popover navigation.
             processing_text() &&
-            event_name !== "down_arrow" &&
-            event_name !== "up_arrow"
+            ((focus_in_textarea && !focus_in_textarea_at_end) ||
+                (event_name !== "down_arrow" && event_name !== "up_arrow"))
         ) {
             return false;
         }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -753,6 +753,7 @@
     /* Input padding and border variables */
     --input-horizontal-padding: 6px;
     --input-vertical-padding: 4px;
+    --schedule-reminder-note-padding: 3px;
     --input-border-width: 1px;
 
     /* Message date divider variables */

--- a/web/styles/scheduled_messages.css
+++ b/web/styles/scheduled_messages.css
@@ -21,13 +21,18 @@
 }
 
 .schedule-reminder-note {
-    /* Horizontal resizing in the popover doesn't look good at all. */
-    resize: vertical;
+    resize: none;
     width: 100%;
     min-width: 10em;
-    padding: 3px;
-    /* We set the minimum height of textarea to be enough for two lines of text. */
+    padding: var(--schedule-reminder-note-padding);
+    /* Set the minimum height such that we start out with 2 lines of text. */
     min-height: calc(2em * var(--base-line-height-unitless));
+    /* Set the maximum height of textarea to be enough for 10 lines of text. */
+    max-height: calc(
+        (10em * var(--base-line-height-unitless)) +
+            (2 * var(--schedule-reminder-note-padding))
+    );
+    overflow-y: auto;
 
     background-color: var(--background-color-textarea);
 

--- a/web/templates/popovers/schedule_message_popover.hbs
+++ b/web/templates/popovers/schedule_message_popover.hbs
@@ -12,7 +12,7 @@
         {{#if is_reminder}}
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="text-item popover-menu-list-item schedule-reminder-note-item">
-            <textarea class="schedule-reminder-note"  placeholder="{{t 'Note'}}" tabindex="0"
+            <textarea class="schedule-reminder-note settings-textarea"  placeholder="{{t 'Note'}}" tabindex="0"
               maxlength="{{max_reminder_note_length}}"
               ></textarea>
         </li>


### PR DESCRIPTION
- Set the schedule reminder note textarea to show a fixed 10-line visible area while allowing longer notes via vertical scrolling.
- Update popover positioning so the schedule reminder popover is repositioned when it would otherwise overflow the viewport.
- Adds the `settings_textarea` class to the textarea in the schedule reminder popover so it matches the styling of other textareas.
- Update behavior to allow normal cursor movement within the textarea, and only intercept `down_arrow` for popover navigation when the cursor is at the end of the textarea.

Fixes: #38920

**How changes were tested:** 
Manually, visual changes

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Screenshots and screen captures:</summary>

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/9e99956c-16eb-4a2a-b3eb-174f801d1cf3) | ![image-after](https://github.com/user-attachments/assets/98edf83a-edc3-4507-a5dc-395aa754f79a)

## schedule textarea with max text field height (10 lines):

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/9e99956c-16eb-4a2a-b3eb-174f801d1cf3) | ![image-after](https://github.com/user-attachments/assets/61221856-2d6d-4ca6-ad9a-8de94b2ee792)


## Schedule message popover behavior:

https://github.com/user-attachments/assets/f2e070ac-2e11-48ed-b813-0427b6cda724

## Schedule message popover repositions when not visible

https://github.com/user-attachments/assets/2165e1df-aa01-4579-8b42-83a993ec3d9d

## Navigation in schedule reminder popover


https://github.com/user-attachments/assets/84941c95-0e33-4392-b335-1d4ed02f976b


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
