### PR TITLE
search: Fix missing outer spacing when search pills wrap.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -259,7 +259,7 @@
         /* Override style for .pill-container that isn't relevant for search. */
         border: none;
         grid-template:
-            "search-icon search-pills search-close" var(--search-box-height)
+            "search-icon search-pills search-close" var(--height-input-pill)
             ". search-pills ." auto / var(--search-left-padding) minmax(0, 1fr)
             1.75em; /* 28px at 16px em */
         align-content: center;
@@ -269,8 +269,10 @@
         &.pill-container {
             background: inherit;
             gap: 0;
-            /* Override padding. */
-            padding: 0;
+            padding: calc(
+                    (var(--search-box-height) - var(--height-input-pill)) / 2
+                )
+                0;
         }
 
         .pill {


### PR DESCRIPTION
Fixes: #35426.

When multiple search pills wrap onto a second line, they appear cramped against the container edges because the grid row height consumed the full `--search-box-height`, leaving no room for vertical padding.

This uses `--height-input-pill` as the grid row height instead, and adds calculated vertical padding to center the pills — an approach suggested by @evykassirer in [PR #36449 review](https://github.com/zulip/zulip/pull/36449#discussion_r1924419582). Unlike #38496, this preserves the single-line search box height.

The padding uses `calc((var(--search-box-height) - var(--height-input-pill)) / 2)`, which adapts correctly to the shorter search box on small viewports via the existing media query on `--search-box-height`.

**How changes were tested:**

Tested locally by adding multiple search filters until pills wrap to a second line, and verified spacing in both single-line and multi-line states. Also verified that the shorter viewport media query still works correctly.

**Screenshots and screen captures:**

### Multi-line pills (focused) at 900×700 viewport:

| Before | After |
| --- | --- |
| <img width="1600" height="1309" alt="image" src="https://github.com/user-attachments/assets/d03071e4-0c10-4b8b-94bd-6b7d1f282e36" />| <img width="1600" height="1309" alt="image" src="https://github.com/user-attachments/assets/3ff01427-0e6a-4043-9eb1-f0d8ac8875f0" /> |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>