### PR TITLE
[ai] sidebars: Allow keyboard to toggle sidebar sections.

### DIFF
--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -178,15 +178,16 @@ export function initialize(): void {
     tippy.delegate("body", {
         target: ".views-tooltip-target",
         onShow(instance) {
-            if ($("#toggle-top-left-navigation-area-icon").hasClass("rotate-icon-down")) {
-                instance.setContent(
-                    $t({
-                        defaultMessage: "Collapse views",
-                    }),
-                );
-            } else {
-                instance.setContent($t({defaultMessage: "Expand views"}));
-            }
+            observe_toggle_class(instance, () => {
+                if ($("#toggle-top-left-navigation-area-icon").hasClass("rotate-icon-down")) {
+                    instance.setContent($t({defaultMessage: "Collapse views"}));
+                } else {
+                    instance.setContent($t({defaultMessage: "Expand views"}));
+                }
+            });
+        },
+        onHidden(instance) {
+            disconnect_toggle_class(instance);
         },
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
@@ -201,20 +202,19 @@ export function initialize(): void {
                 return false;
             }
 
-            if ($("#toggle-direct-messages-section-icon").hasClass("rotate-icon-down")) {
-                instance.setContent(
-                    $t({
-                        defaultMessage: "Collapse direct messages",
-                    }),
-                );
-            } else {
-                instance.setContent($t({defaultMessage: "Expand direct messages"}));
-            }
+            observe_toggle_class(instance, () => {
+                if ($("#toggle-direct-messages-section-icon").hasClass("rotate-icon-down")) {
+                    instance.setContent($t({defaultMessage: "Collapse direct messages"}));
+                } else {
+                    instance.setContent($t({defaultMessage: "Expand direct messages"}));
+                }
+            });
             return undefined;
         },
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
         onHidden(instance) {
+            disconnect_toggle_class(instance);
             instance.destroy();
         },
     });

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -239,6 +239,28 @@ export function initialize(): void {
         },
     });
 
+    // This is actually for the right sidebar, but putting it here because it has
+    // shared logic.
+    tippy.delegate("body", {
+        target: ".section-toggle-tooltip-target",
+        onShow(instance) {
+            const $toggle = $(instance.reference);
+            observe_toggle_class(instance, () => {
+                if ($toggle.hasClass("rotate-icon-down")) {
+                    instance.setContent($t({defaultMessage: "Collapse section"}));
+                } else {
+                    instance.setContent($t({defaultMessage: "Expand section"}));
+                }
+            });
+        },
+        delay: EXTRA_LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onHidden(instance) {
+            disconnect_toggle_class(instance);
+            instance.destroy();
+        },
+    });
+
     tippy.delegate("body", {
         target: ".header-main .column-left .left-sidebar-toggle-button",
         delay: LONG_HOVER_DELAY,

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -16,6 +16,24 @@ import {
 import * as unread from "./unread.ts";
 import {user_settings} from "./user_settings.ts";
 
+// Watches the reference element's class for changes while a tooltip is
+// visible, so the content stays accurate when the element is toggled via
+// keyboard (or any other path) without hiding the tooltip first.
+const class_observers = new WeakMap<tippy.Instance, MutationObserver>();
+function observe_toggle_class(instance: tippy.Instance, update: () => void): void {
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(instance.reference, {
+        attributes: true,
+        attributeFilter: ["class"],
+    });
+    class_observers.set(instance, observer);
+}
+function disconnect_toggle_class(instance: tippy.Instance): void {
+    class_observers.get(instance)?.disconnect();
+    class_observers.delete(instance);
+}
+
 export function initialize(): void {
     tippy.delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
@@ -197,6 +215,26 @@ export function initialize(): void {
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
         onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
+        target: ".folder-toggle-tooltip-target",
+        onShow(instance) {
+            const $toggle = $(instance.reference);
+            observe_toggle_class(instance, () => {
+                if ($toggle.hasClass("rotate-icon-down")) {
+                    instance.setContent($t({defaultMessage: "Collapse folder"}));
+                } else {
+                    instance.setContent($t({defaultMessage: "Expand folder"}));
+                }
+            });
+        },
+        delay: EXTRA_LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onHidden(instance) {
+            disconnect_toggle_class(instance);
             instance.destroy();
         },
     });

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -401,14 +401,39 @@ export function initialize_right_sidebar(): void {
         },
     );
 
+    $("#buddy-list-users-matching-view-container").on(
+        "keydown",
+        ".buddy-list-section-toggle",
+        (e) => {
+            if (keydown_util.is_enter_event(e)) {
+                e.stopPropagation();
+                buddy_list.toggle_users_matching_view_section();
+            }
+        },
+    );
+
     $("#buddy-list-participants-container").on("click", ".buddy-list-subsection-header", (e) => {
         e.stopPropagation();
         buddy_list.toggle_participants_section();
     });
 
+    $("#buddy-list-participants-container").on("keydown", ".buddy-list-section-toggle", (e) => {
+        if (keydown_util.is_enter_event(e)) {
+            e.stopPropagation();
+            buddy_list.toggle_participants_section();
+        }
+    });
+
     $("#buddy-list-other-users-container").on("click", ".buddy-list-subsection-header", (e) => {
         e.stopPropagation();
         buddy_list.toggle_other_users_section();
+    });
+
+    $("#buddy-list-other-users-container").on("keydown", ".buddy-list-section-toggle", (e) => {
+        if (keydown_util.is_enter_event(e)) {
+            e.stopPropagation();
+            buddy_list.toggle_other_users_section();
+        }
     });
 
     function close_buddy_list_popover(): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1602,6 +1602,17 @@ export function set_event_handlers({
     );
 
     $("#streams_list").on(
+        "keydown",
+        ".stream-list-section-container .stream-list-section-toggle",
+        function (this: HTMLElement, e: JQuery.KeyDownEvent) {
+            if (keydown_util.is_enter_event(e)) {
+                e.stopPropagation();
+                toggle_section_collapse($(this).closest(".stream-list-section-container"));
+            }
+        },
+    );
+
+    $("#streams_list").on(
         "click",
         ".stream-list-section-container .add-stream-icon-container",
         (e) => {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -747,6 +747,16 @@
     }
 }
 
+.stream-list-section-toggle {
+    &:focus {
+        outline: 0;
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
+    }
+}
+
 .active-direct-messages-section {
     background-color: var(--color-background-active-narrow-filter);
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -46,6 +46,14 @@
     justify-self: center;
     color: var(--color-text-sidebar-heading);
     opacity: var(--opacity-sidebar-heading-icon);
+
+    &:focus {
+        outline: 0;
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
+    }
 }
 
 .buddy-list-section-container {

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,4 +1,4 @@
-<i class="buddy-list-section-toggle zulip-icon zulip-icon-heading-triangle-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>
+<i class="buddy-list-section-toggle section-toggle-tooltip-target zulip-icon zulip-icon-heading-triangle-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" tabindex="0" role="button"></i>
 <h5 id="{{id}}" class="buddy-list-heading no-style hidden-for-spectators">
     <span class="buddy-list-heading-text">{{header_text}}</span>
     {{!-- Hide the count until we have fetched data to display the correct count --}}

--- a/web/templates/stream_list_section_container.hbs
+++ b/web/templates/stream_list_section_container.hbs
@@ -1,6 +1,6 @@
 <div id="stream-list-{{id}}-container" data-section-id="{{id}}" class="stream-list-section-container">
     <div class="left-sidebar-section-header stream-list-subsection-header">
-        <i class="stream-list-section-toggle zulip-icon zulip-icon-heading-triangle-right rotate-icon-down" aria-hidden="true"></i>
+        <i class="stream-list-section-toggle zulip-icon zulip-icon-heading-triangle-right rotate-icon-down folder-toggle-tooltip-target" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title">
             {{section_title}}
         </h4>


### PR DESCRIPTION
Prep for #38815.

This PR adds keyboard support for toggling collapsible sections in both sidebars.                                                                                                                
                                                                                                                                   
**Left sidebar:** Channel folder headers and the Views/DMs section toggles can now be collapsed/expanded with Enter when focused via keyboard. Tooltip text updates immediately after toggling to reflect the new state.
                                                                                                                                   
**Right sidebar:** Buddy list section headers (participants, users matching view, other users) can now be toggled with Enter when focused.                                                                                                                    
  
Both use the same pattern: `tabindex="0"` on the toggle icon elements, with Enter keydown handlers that trigger the existing toggle logic.           