### PR TITLE
message_preview: Do not show tooltip for compose/edit preview.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -390,7 +390,11 @@ export function initialize(): void {
         },
     });
 
-    message_list_tooltip(".media-image-element", {
+    // Disable tooltip in compose box and message edit preview. Scrolling over a
+    // large image caused the tooltip to go out of its container and made it look
+    // like it was floating in the app. Since the tooltip was not that useful for
+    // this case, we chose to remove it instead.
+    message_list_tooltip(".media-image-element:not(.preview_content *)", {
         // Add a short delay so the user can mouseover several inline images without
         // tooltips showing and hiding rapidly
         delay: [300, 20],


### PR DESCRIPTION
This PR changes this for both message edit preview and compose box preview

Scrolling over a large image caused the tooltip to go out of its container and made it look like it was floating in the app. Since the tooltip was not that useful for this case, we chose to remove it instead.

<!-- Describe your pull request here.-->

Fixes [#issues > 📂 floating tooltip in compose box preview](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20floating.20tooltip.20in.20compose.20box.20preview/with/2429820)

**How changes were tested:**
In addition to the screenshot, I checked the following media images to have the tooltip:
- Message feed
- Scheduled messages
- Drafts
- Reminders
- Edit history.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



**Screenshots and screen captures:**
(No need for before screenshot since we are removing the tooltip)

After:
Message edit preview:
<img width="837" height="498" alt="Screenshot 2026-04-10 at 12 02 27 PM" src="https://github.com/user-attachments/assets/db3c7ff0-daad-4084-b399-15e3b597b7e2" />


Compose preview:
<img width="837" height="333" alt="Screenshot 2026-04-10 at 11 49 50 AM" src="https://github.com/user-attachments/assets/d1a58561-d834-46b2-b200-aae90b66a09e" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
