### PR TITLE
custom_profile_fields: Fix date field cross icon(X) visible state and tooltip arrow.

### DIFF
--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -376,16 +376,6 @@ export function initialize_custom_date_type_fields(
         });
 
     $(element_id)
-        .find<HTMLInputElement>(".custom_user_field input.datepicker")
-        .on("mouseenter", function () {
-            if ($(this).val()!.length <= 0) {
-                $(this).parent().find(".remove_date").hide();
-            } else {
-                $(this).parent().find(".remove_date").show();
-            }
-        });
-
-    $(element_id)
         .find(".custom_user_field .remove_date")
         .on("click", function () {
             const $custom_user_field = $(this).parent().find(".custom_user_field_value");

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -245,6 +245,14 @@ export function format_date(date: Date | undefined, format: string): string {
     return flatpickr.formatDate(date, format);
 }
 
+// The "has-date" class controls the clear-date button's visibility,
+// so derive it from the visible alt input's value.
+function update_has_date_class($custom_user_field: JQuery): void {
+    const has_value =
+        $custom_user_field.find<HTMLInputElement>(".date-field-alt-input").val()!.length > 0;
+    $custom_user_field.toggleClass("has-date", has_value);
+}
+
 export function initialize_custom_date_type_fields(
     element_id: string,
     user_id: number,
@@ -286,9 +294,7 @@ export function initialize_custom_date_type_fields(
             );
             const original_value = people.get_custom_profile_data(user_id, field_id)?.value ?? "";
             instance.setDate(original_value);
-            $input_elem
-                .closest(".custom_user_field")
-                .toggleClass("has-date", original_value !== "");
+            update_has_date_class($input_elem.closest(".custom_user_field"));
             if (!for_profile_settings_panel) {
                 // Trigger "input" event so that save button state can
                 // be toggled in "Manage user" modal.
@@ -353,11 +359,7 @@ export function initialize_custom_date_type_fields(
         },
         onChange(_selected_dates, date_str, instance) {
             update_date(instance, date_str);
-            if (date_str !== "Invalid Date") {
-                $(instance.element)
-                    .closest(".custom_user_field")
-                    .toggleClass("has-date", date_str !== "");
-            }
+            update_has_date_class($(instance.element).closest(".custom_user_field"));
         },
     });
 
@@ -400,22 +402,20 @@ export function initialize_custom_date_type_fields(
             const $displayed_input = $(this).parent().find(".date-field-alt-input");
             $displayed_input.val("");
             $custom_user_field.val("");
-            $(this).closest(".custom_user_field").removeClass("has-date");
+            update_has_date_class($(this).closest(".custom_user_field"));
             $custom_user_field.trigger("input");
         });
 
     $(element_id)
         .find<HTMLInputElement>("input.date-field-alt-input")
         .on("input", function () {
-            const has_value = $(this).val()!.length > 0;
-            $(this).closest(".custom_user_field").toggleClass("has-date", has_value);
+            update_has_date_class($(this).closest(".custom_user_field"));
         });
 
     $(element_id)
-        .find<HTMLInputElement>(".custom_user_field .custom_user_field_value.datepicker")
+        .find(".custom_user_field .datepicker")
         .each(function () {
-            const has_value = $(this).val()!.length > 0;
-            $(this).closest(".custom_user_field").toggleClass("has-date", has_value);
+            update_has_date_class($(this).closest(".custom_user_field"));
         });
 }
 

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -286,6 +286,9 @@ export function initialize_custom_date_type_fields(
             );
             const original_value = people.get_custom_profile_data(user_id, field_id)?.value ?? "";
             instance.setDate(original_value);
+            $input_elem
+                .closest(".custom_user_field")
+                .toggleClass("has-date", original_value !== "");
             if (!for_profile_settings_panel) {
                 // Trigger "input" event so that save button state can
                 // be toggled in "Manage user" modal.
@@ -340,6 +343,11 @@ export function initialize_custom_date_type_fields(
         allowInvalidPreload: true,
         onChange(_selected_dates, date_str, instance) {
             update_date(instance, date_str);
+            if (date_str !== "Invalid Date") {
+                $(instance.element)
+                    .closest(".custom_user_field")
+                    .toggleClass("has-date", date_str !== "");
+            }
         },
     });
 
@@ -382,7 +390,22 @@ export function initialize_custom_date_type_fields(
             const $displayed_input = $(this).parent().find(".date-field-alt-input");
             $displayed_input.val("");
             $custom_user_field.val("");
+            $(this).closest(".custom_user_field").removeClass("has-date");
             $custom_user_field.trigger("input");
+        });
+
+    $(element_id)
+        .find<HTMLInputElement>("input.date-field-alt-input")
+        .on("input", function () {
+            const has_value = $(this).val()!.length > 0;
+            $(this).closest(".custom_user_field").toggleClass("has-date", has_value);
+        });
+
+    $(element_id)
+        .find<HTMLInputElement>(".custom_user_field .custom_user_field_value.datepicker")
+        .each(function () {
+            const has_value = $(this).val()!.length > 0;
+            $(this).closest(".custom_user_field").toggleClass("has-date", has_value);
         });
 }
 

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -329,7 +329,6 @@ export function initialize_custom_date_type_fields(
         altInputClass: "date-field-alt-input " + common_class_name,
         altFormat: "F j, Y",
         allowInput: true,
-        static: true,
         // This helps us in accepting inputs in other formats
         // like MM/DD/YYYY and basically any other format
         // which is accepted by Date.
@@ -341,6 +340,17 @@ export function initialize_custom_date_type_fields(
         // values.
         formatDate: format_date,
         allowInvalidPreload: true,
+        // Close the date picker on scroll, since flatpickr leaves the
+        // open calendar in place and it would drift away from the input.
+        onOpen(_selected_dates, _date_str, instance) {
+            window.addEventListener(
+                "scroll",
+                () => {
+                    instance.close();
+                },
+                {capture: true, once: true},
+            );
+        },
         onChange(_selected_dates, date_str, instance) {
             update_date(instance, date_str);
             if (date_str !== "Invalid Date") {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1729,7 +1729,7 @@ label.preferences-radio-choice-label {
             resize: vertical;
         }
 
-        &:hover .remove_date {
+        &.has-date:hover .remove_date {
             display: inline-flex;
         }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -913,7 +913,7 @@ input[type="checkbox"] {
     align-items: center;
     width: var(--modal-input-width);
 
-    .flatpickr-wrapper {
+    input.date-field-alt-input {
         grid-column: datepicker-start / close-button-end;
         grid-row: close-button;
     }


### PR DESCRIPTION
This PR fixes two minor bugs in the custom profile date field.

**Bug 1: Cross (X) icon incorrect visibility**
The cross icon showed when no date was saved/entered (on page load) and also triggered a save call when clicked, even with no date entered.

Fixed by:
- Adding a `has-date` CSS class to `.custom_user_field` when a date is selected/cleared via `onChange` callback
- Initializing `has-date` class on page load and updating CSS to show the cross icon only when the `has-date` class is present
- Removing the JS `mouseenter` handler since CSS already handles hover visibility

**Bug 2: Tooltip arrow appearing at the bottom of the date selector**
`Flatpickr` shows a tooltip arrow at the bottom left of the calendar, where it serves no purpose.

Fixed by: hiding the arrow via CSS override in `zulip.css`.

Fixes: [#issues > Cross (x) Icon on Favorite Date Shows 'Saving' unnecessarily](https://chat.zulip.org/#narrow/channel/9-issues/topic/Cross.20.28x.29.20Icon.20on.20Favorite.20Date.20Shows.20.27Saving.27.20unnecessarily/with/2428541)

Fixes: #38929


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="614" height="195" alt="Screenshot 2026-04-09 143531" src="https://github.com/user-attachments/assets/f992c43c-3e88-4b4b-b879-53ecb210031d" />|<img width="630" height="198" alt="Screenshot 2026-04-09 143839" src="https://github.com/user-attachments/assets/3645f44e-e108-411d-b43b-0d6578a9ef48" />|

| Before | After |
|--------|-------|
|<img width="587" height="579" alt="Screenshot 2026-04-07 193734" src="https://github.com/user-attachments/assets/f1fb47ab-ba38-4fb2-9646-5a550d77efd6" />|<img width="614" height="547" alt="Screenshot 2026-04-09 143703" src="https://github.com/user-attachments/assets/7964fa65-80b1-44fc-bc92-aa2f8f45014a" />|

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/dbf1da95-577e-4735-920c-f544d89414b2" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/31780ff1-9d76-462b-b8dd-626d7db654f3" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
