### PR TITLE
api-docs: Clean up unordered list formatting in API changelog.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -114,7 +114,7 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 473**
 
-- [`POST /users/{user_id}/status`](/api/update-status-for-user): Bots
+* [`POST /users/{user_id}/status`](/api/update-status-for-user): Bots
   with administrator permissions can now use this endpoint.
 
 **Feature level 472**
@@ -240,7 +240,7 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 457**
 
-[`GET /events`](/api/get-events): `delete_message` events are now
+* [`GET /events`](/api/get-events): `delete_message` events are now
   sent to the user who deletes the message only if they have content
   access to the messages' recipient, and the `message_ids` list only
   includes IDs of the messages that they can access.
@@ -263,7 +263,7 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 454**
 
-- [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults)
+* [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults)
   [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
   [`PATCH /settings`](/api/update-settings): Changed the `web_home_view`
   value for the recent view to "recent".
@@ -575,7 +575,7 @@ No changes; API feature level used for the Zulip 11.0 release.
   `zulip_message_ids`.
 * Mobile push notification payloads for FCM to for new messages no
   longer contain the (unused) `content_truncated` boolean field.
-- E2EE mobile push notification payloads now have a [modernized and
+* E2EE mobile push notification payloads now have a [modernized and
   documented format](/api/mobile-notifications).
 
 **Feature level 412**
@@ -638,7 +638,7 @@ No changes; API feature level used for the Zulip 11.0 release.
   `can_delete_own_message_group` parameter to support setting and
   changing the user group whose members can delete the messages they have sent
   in the channel.
-- [`POST /users/{user_id}/status`](/api/update-status-for-user): Added
+* [`POST /users/{user_id}/status`](/api/update-status-for-user): Added
   new API endpoint for an administrator to update the status for
   another user.
 
@@ -1012,7 +1012,7 @@ No changes; feature level used for Zulip 10.0 release.
   the field is not present. Clients should use this field, rather than
   parsing the message object's `edit_history` array, to display an
   indicator that the message has been moved.
- * [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),
+* [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),
   [`GET /messages/{message_id}`](/api/get-message): The
   `last_edit_timestamp` field on message objects is only present if the
   message's content has been edited. Previously, this field was present
@@ -1298,9 +1298,9 @@ No changes; feature level used for Zulip 10.0 release.
 
 **Feature level 340**
 
-[`PATCH /user_groups/{user_group_id}`](/api/update-user-group): All
-the permission settings and description can now be updated for
-deactivated groups.
+* [`PATCH /user_groups/{user_group_id}`](/api/update-user-group): All
+  the permission settings and description can now be updated for
+  deactivated groups.
 
 **Feature level 339**
 


### PR DESCRIPTION
Cleans up a few inconsistencies with the unordered lists for feature level entries in the API changelog.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1502" height="238" alt="Screenshot From 2026-04-09 15-45-45" src="https://github.com/user-attachments/assets/3c8f9593-fada-4812-9e4c-098c66631ec3" /> | <img width="1502" height="248" alt="Screenshot From 2026-04-09 15-46-56" src="https://github.com/user-attachments/assets/d512b69f-7779-4b7a-be82-dc96c5c94522" /> |
| <img width="1502" height="176" alt="Screenshot From 2026-04-09 15-48-23" src="https://github.com/user-attachments/assets/99ddaaa5-c51f-4c76-a802-442dc28bff3b" /> | <img width="1502" height="188" alt="Screenshot From 2026-04-09 15-48-36" src="https://github.com/user-attachments/assets/b07ff248-efe5-455a-b0ef-87186c839b34" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
