### PR TITLE
[ai] recent_view: Fix tooltip getting clipped when only 1 convo left.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1163,6 +1163,18 @@
     --recent-view-participants-padding-x-start: 0.25em; /* 4px at 16px / 1em */
     --recent-view-table-border-radius: 5px;
     --recent-view-table-border-bottom-width: 1px;
+    /* Inner radius used on the last row's corner cells, so they
+       hug the container's rounded bottom corners. Derived from
+       the outer radius minus the border widths, which lets it
+       track dark mode's wider side border. */
+    --recent-view-table-inner-radius: calc(
+            var(--recent-view-table-border-radius) -
+                var(--recent-view-table-border-side-width)
+        )
+        calc(
+            var(--recent-view-table-border-radius) -
+                var(--recent-view-table-border-bottom-width)
+        );
     --color-border-recent-view-row: light-dark(
         hsl(0deg 0% 87%),
         hsl(0deg 0% 0% / 20%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1156,11 +1156,13 @@
     );
 
     /* Recent view */
-    --recent-view-body-border-width: 1px;
+    --recent-view-table-border-side-width: 1px;
     --recent-view-max-avatars: 4;
     --recent-view-participant-item-width: 1.5em; /* 24px at 16px / 1em */
     --recent-view-participant-item-padding-x: 0.0938em; /* 1.5px at 16px / 1em */
     --recent-view-participants-padding-x-start: 0.25em; /* 4px at 16px / 1em */
+    --recent-view-table-border-radius: 5px;
+    --recent-view-table-border-bottom-width: 1px;
     --color-border-recent-view-row: light-dark(
         hsl(0deg 0% 87%),
         hsl(0deg 0% 0% / 20%)
@@ -3188,7 +3190,7 @@
 
     /* Zulip resizer handle svg */
     --svg-resize-handle: url("../images/resize-handle-white.svg");
-    --recent-view-body-border-width: 0.1875em; /* 3px at 16px/1em */
+    --recent-view-table-border-side-width: 0.1875em; /* 3px at 16px/1em */
 }
 
 @media screen {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -111,8 +111,6 @@
     }
 
     #recent-view-content-table {
-        border-bottom-width: 1px;
-
         .unread_topic a {
             font-weight: 400;
         }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -34,7 +34,6 @@
     border-bottom-width: var(--recent-view-table-border-bottom-width);
     border-radius: 0 0 var(--recent-view-table-border-radius)
         var(--recent-view-table-border-radius);
-    overflow: hidden;
 }
 
 #recent_view {
@@ -444,6 +443,22 @@
             background-color: var(--color-background-recent-view-row);
         }
 
+        /* Round the last row's bottom corners to hug the
+           container's rounded bottom corners. */
+        &:last-child {
+            & td:first-child {
+                border-bottom-left-radius: var(
+                    --recent-view-table-inner-radius
+                );
+            }
+
+            & td:last-child {
+                border-bottom-right-radius: var(
+                    --recent-view-table-inner-radius
+                );
+            }
+        }
+
         /* Avoid annoying, confusing hover-state when scrolling on
            touch devices like iPad that treat a tap-and-hold/swipe
            as a hover. */
@@ -821,6 +836,15 @@
             .recent_topic_timestamp,
             thead .last_msg_time_header {
                 display: none;
+            }
+
+            /* With the timestamp cell hidden, the topic name cell
+               is the last visible one in the row, so round its
+               bottom-right corner too. */
+            tr:last-child .recent_topic_name {
+                border-bottom-right-radius: var(
+                    --recent-view-table-inner-radius
+                );
             }
         }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -28,10 +28,12 @@
 }
 
 #recent-view-content-table {
-    border: var(--recent-view-body-border-width) solid
+    border: var(--recent-view-table-border-side-width) solid
         var(--color-border-recent-view-table);
     border-top: none;
-    border-radius: 0 0 5px 5px;
+    border-bottom-width: var(--recent-view-table-border-bottom-width);
+    border-radius: 0 0 var(--recent-view-table-border-radius)
+        var(--recent-view-table-border-radius);
     overflow: hidden;
 }
 
@@ -606,7 +608,7 @@
         .recent-view-header-wrapper {
             /* 0.75em left padding, 1px header width */
             --recent-view-channel-row-header-minus-body: calc(
-                0.75em + var(--recent-view-body-border-width) - 1px
+                0.75em + var(--recent-view-table-border-side-width) - 1px
             );
             /* Match the row grid so "Channel" and "Conversation" sort
                spans align with channel and topic text in rows. Sort

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -435,18 +435,25 @@
     }
 
     & tr {
-        background-color: var(--color-background-recent-view-row);
+        /* Put background on the cells, not tr. Border radius does not work
+           on tr, it works only on td. We want to set the border radius of
+           the last row in accordance to the border radius of the table so
+           that we don't need to use overflow hidden to keep the background
+           from spilling out. */
+        & td {
+            background-color: var(--color-background-recent-view-row);
+        }
 
         /* Avoid annoying, confusing hover-state when scrolling on
            touch devices like iPad that treat a tap-and-hold/swipe
            as a hover. */
         @media (hover: hover) and (pointer: fine) {
-            &:hover {
+            &:hover td {
                 background-color: var(--color-background-recent-view-row-hover);
+            }
 
-                .change_visibility_policy .recent-view-row-topic-menu {
-                    opacity: 0.4;
-                }
+            &:hover .change_visibility_policy .recent-view-row-topic-menu {
+                opacity: 0.4;
             }
         }
     }
@@ -459,7 +466,9 @@
     }
 
     .unread_topic {
-        background-color: var(--color-background-recent-view-unread-row);
+        & td {
+            background-color: var(--color-background-recent-view-unread-row);
+        }
 
         & a {
             color: var(--color-recent-view-link-unread);
@@ -470,7 +479,7 @@
            touch devices like iPad that treat a tap-and-hold/swipe
            as a hover. */
         @media (hover: hover) and (pointer: fine) {
-            &:hover {
+            &:hover td {
                 background-color: var(
                     --color-background-recent-view-unread-row-hover
                 );


### PR DESCRIPTION
Fixes [#issues > "Mark as read" tooltip gone if only one unread topic remains](https://chat.zulip.org/#narrow/channel/9-issues/topic/.22Mark.20as.20read.22.20tooltip.20gone.20if.20only.20one.20unread.20topic.20remains/with/2430013). The table header also uses the overflow hidden approach, I have not changed that one, since the current approach seems more complex (and a bit more brittle) than that and there doesn't seem to be a reason to convert that.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="828" height="126" alt="Screenshot 2026-04-10 at 6 30 59 PM" src="https://github.com/user-attachments/assets/1e626a9c-612b-4af3-8c0a-66bf4dd425de" />

The change is not void of regression, but it is very small. It is coming from the blue line on the left of the row. All linked names point to an image comparison link, for which all have similar results and below and no other diff. The last two examples (multi row) don't have that unread blue line, and they are exactly the same image.

<img width="1913" height="724" alt="Screenshot 2026-04-10 at 6 28 45 PM" src="https://github.com/user-attachments/assets/16162ba5-9252-47f5-a7c1-9d54f859c48f" />
<img width="1913" height="724" alt="Screenshot 2026-04-10 at 6 28 31 PM" src="https://github.com/user-attachments/assets/503a51ba-5f14-4c5a-8ca1-60af5ca88005" />

-------------


| Name | Before | After |
|------|--------|-------|
| [time_hidden_light](https://www.diffchecker.com/image-compare/yyNuTUOc/) | <img width="585" height="127" alt="time_hidden_light_before" src="https://github.com/user-attachments/assets/a357b3c9-846c-4348-b408-cde127292d34" /> | <img width="585" height="127" alt="time_hidden_light_after" src="https://github.com/user-attachments/assets/6dda57e1-6565-4b0c-8f82-6700a50e34a5" /> |
| [time_hidden_dark](https://www.diffchecker.com/image-compare/3g1gMt09/) | <img width="584" height="126" alt="time_hidden_dark_before_1" src="https://github.com/user-attachments/assets/0ffef2c2-ff85-42cb-902a-fb82a87c8da2" /> | <img width="584" height="126" alt="time_hidden_dark_after_1" src="https://github.com/user-attachments/assets/a9c07cbd-b970-430d-9e53-f72c9c3c9019" /> |
| [participants_row_hidden_light](https://www.diffchecker.com/image-compare/bwHhczcA/) | <img width="596" height="146" alt="participants_row_hidden_light_before" src="https://github.com/user-attachments/assets/168f4cde-e567-4577-9db1-82f5f232e991" /> | <img width="596" height="146" alt="participants_row_hidden_light_after" src="https://github.com/user-attachments/assets/714a229f-7908-458e-b43a-58ac686dfa7b" /> |
| [participants_row_hidden_dark](https://www.diffchecker.com/image-compare/raZl7dqH/) | <img width="596" height="146" alt="participants_row_hidden_dark_before" src="https://github.com/user-attachments/assets/55ecf3e0-a97a-4303-b8bc-5cbccffafdf0" /> | <img width="596" height="146" alt="participants_row_hidden_dark_after" src="https://github.com/user-attachments/assets/90eadeb9-5f66-4352-98fe-798e726cd48a" /> |
| [dark_mode_14px](https://www.diffchecker.com/image-compare/1dvp7F1Z/) | <img width="813" height="82" alt="dark_mode_14px_before" src="https://github.com/user-attachments/assets/75fea32f-b378-4e99-9f5d-a19edd35fefe" /> | <img width="813" height="82" alt="dark_mode_14px_after" src="https://github.com/user-attachments/assets/daa65a0f-8539-46c7-a286-0c9361acd85a" /> |
| [light_mode_14px](https://www.diffchecker.com/image-compare/tOIxmFuX/) | <img width="813" height="82" alt="light_mode_14px_before" src="https://github.com/user-attachments/assets/3b2bfd27-ac11-4f9c-964e-469aa53e6262" /> | <img width="813" height="82" alt="light_mode_14px_after" src="https://github.com/user-attachments/assets/5a49b9e4-b32f-4ccd-b4ae-8218a033ee81" /> |
| [dark_mode_18px](https://www.diffchecker.com/image-compare/J7fjgB3r/) | <img width="1051" height="145" alt="dark_mode_18px_before" src="https://github.com/user-attachments/assets/075a1d8f-658a-4f38-a7e0-8af2e9410959" /> | <img width="1051" height="145" alt="dark_mode_18px_after" src="https://github.com/user-attachments/assets/311f1ff2-6047-47f3-863b-36bc345092a3" /> |
| [light_mode_18px](https://www.diffchecker.com/image-compare/XM0aEL21/) | <img width="1051" height="145" alt="light_mode_18px_before" src="https://github.com/user-attachments/assets/eb298c09-5ac0-4b9f-b24e-582dacb32f34" /> | <img width="1051" height="145" alt="light_mode_18px_after" src="https://github.com/user-attachments/assets/3d4e7f2d-2193-4ed3-9ec2-d48fece8212c" /> |
| [light_mode_16px](https://www.diffchecker.com/image-compare/FlZpMHwD/) | <img width="929" height="128" alt="light_mode_16px_before" src="https://github.com/user-attachments/assets/1ea85055-7cd8-4896-848d-35b3979623e6" /> | <img width="929" height="128" alt="light_mode_16px_after" src="https://github.com/user-attachments/assets/c34592e2-6c33-4243-a554-e0bce4981933" /> |
| [dark_mode_16px](https://www.diffchecker.com/image-compare/oe6cftvV/) | <img width="929" height="128" alt="dark_mode_16px_before" src="https://github.com/user-attachments/assets/9e478d69-860f-4c1f-966a-672364a821f7" /> | <img width="929" height="128" alt="dark_mode_16px_after" src="https://github.com/user-attachments/assets/673e4c3b-3fa9-4cc1-9fc0-a6541c0d75ce" /> |
| [Multi row dark](https://www.diffchecker.com/image-compare/nz2XHeyg/) | <img width="933" height="222" alt="multirow_dark_before" src="https://github.com/user-attachments/assets/cef6e4ec-a007-4009-ae1c-a873d77abeb6" /> | <img width="933" height="222" alt="multirow_dark_after" src="https://github.com/user-attachments/assets/deff4bd5-db92-4cb1-8834-84505e935db4" /> |
| [Multi row light](https://www.diffchecker.com/image-compare/fyCcoNjU/) |<img width="933" height="222" alt="multirow_light_after" src="https://github.com/user-attachments/assets/4a6b7a7d-42e1-47c4-bdd2-3035332025c2" /> | <img width="933" height="222" alt="multirow_light_before" src="https://github.com/user-attachments/assets/802cd3f4-91b1-4ee2-bb25-4217add6efc5" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
