### PR TITLE
stream_create: Add shake animation when channel name hits character limit

### DIFF
--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -695,12 +695,12 @@ export function initialize(): void {
         if (topic.length > realm.max_topic_length) {
             topic = topic.slice(0, realm.max_topic_length);
             compose_state.topic(topic);
-            $("input#stream_message_recipient_topic").addClass("shake");
+            $("input#stream_message_recipient_topic").addClass("input-validation-shake");
         }
     }
 
     $("input#stream_message_recipient_topic").on("animationend", function () {
-        $(this).removeClass("shake");
+        $(this).removeClass("input-validation-shake");
     });
 
     $("input#stream_message_recipient_topic").on("input", () => {

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -752,12 +752,12 @@ export function initialize(): void {
         if (topic.length > realm.max_topic_length) {
             topic = topic.slice(0, realm.max_topic_length);
             compose_state.topic(topic);
-            $("input#stream_message_recipient_topic").addClass("shake");
+            $("input#stream_message_recipient_topic").addClass("input-validation-shake");
         }
     }
 
     $("input#stream_message_recipient_topic").on("animationend", function () {
-        $(this).removeClass("shake");
+        $(this).removeClass("input-validation-shake");
     });
 
     $("input#stream_message_recipient_topic").on("input", () => {

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -147,7 +147,7 @@ export function create<ItemType extends {type: string}>(
             const existing_items = funcs.items();
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
             if (!item) {
-                store.$input.addClass("shake");
+                store.$input.addClass("input-validation-shake");
 
                 if (store.show_outline_on_invalid_input) {
                     store.$parent.addClass("invalid");
@@ -461,7 +461,7 @@ export function create<ItemType extends {type: string}>(
         // when the shake animation is applied to the ".input" on invalid input,
         // we want to remove the class when finished automatically.
         store.$parent.on("animationend", ".input", function () {
-            $(this).removeClass("shake");
+            $(this).removeClass("input-validation-shake");
         });
 
         // replace formatted input with plaintext to allow for sane copy-paste

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -150,7 +150,7 @@ export function create<ItemType extends {type: string}>(
             const existing_items = funcs.items();
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
             if (!item) {
-                store.$input.addClass("shake");
+                store.$input.addClass("input-validation-shake");
 
                 if (store.show_outline_on_invalid_input) {
                     store.$parent.addClass("invalid");
@@ -474,7 +474,7 @@ export function create<ItemType extends {type: string}>(
         // when the shake animation is applied to the ".input" on invalid input,
         // we want to remove the class when finished automatically.
         store.$parent.on("animationend", ".input", function () {
-            $(this).removeClass("shake");
+            $(this).removeClass("input-validation-shake");
         });
 
         // replace formatted input with plaintext to allow for sane copy-paste

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -111,7 +111,7 @@ function convert_search_text_to_terms(
             if (shake_pill_if_invalid) {
                 // The shake animation will show if there is any invalid term in the,
                 // search bar, even if it's not what the user just typed or selected.
-                $("#search_query").addClass("shake");
+                $("#search_query").addClass("input-validation-shake");
             }
             return undefined;
         }

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -521,7 +521,7 @@ export function set_search_bar_contents(
     }
     set_search_bar_text(search_bar_text_strings.join(" "));
     if (invalid_inputs.length > 0) {
-        $("#search_query").addClass("shake");
+        $("#search_query").addClass("input-validation-shake");
     }
 }
 

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -538,7 +538,7 @@ export function set_search_bar_contents(
     }
     set_search_bar_text(search_bar_text_strings.join(" "));
     if (invalid_inputs.length > 0) {
-        $("#search_query").addClass("shake");
+        $("#search_query").addClass("input-validation-shake");
     }
 }
 

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -646,12 +646,12 @@ export function set_up_handlers(): void {
         if (channel_name.length > realm.max_stream_name_length) {
             channel_name = channel_name.slice(0, realm.max_stream_name_length);
             $channel_input.val(channel_name);
-            $channel_input.addClass("shake");
+            $channel_input.addClass("input-validation-shake");
         }
         stream_name_error.pre_validate(channel_name);
     }
     $("input#create_stream_name").on("animationend", function () {
-        $(this).removeClass("shake");
+        $(this).removeClass("input-validation-shake");
     });
     $container.on("input", "#create_stream_name", () => {
         handle_channel_name_length_limit();

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -640,11 +640,27 @@ export function set_up_handlers(): void {
         }
     });
 
+    function handle_channel_name_length_limit(): void {
+        const $channel_input = $<HTMLInputElement>("input#create_stream_name");
+        let channel_name = $channel_input.val()!.trim();
+        if (channel_name.length > realm.max_stream_name_length) {
+            channel_name = channel_name.slice(0, realm.max_stream_name_length);
+            $channel_input.val(channel_name);
+            $channel_input.addClass("shake");
+        }
+        stream_name_error.pre_validate(channel_name);
+    }
+    $("input#create_stream_name").on("animationend", function () {
+        $(this).removeClass("shake");
+    });
     $container.on("input", "#create_stream_name", () => {
-        const stream_name = $<HTMLInputElement>("input#create_stream_name").val()!.trim();
-
-        // This is an inexpensive check.
-        stream_name_error.pre_validate(stream_name);
+        handle_channel_name_length_limit();
+    });
+    $container.on("paste", "#create_stream_name", () => {
+        /* setTimeout is needed to allow the pasted content to be
+           added to the input before checking the channel name length limit,
+           since the paste event fires before the input value is updated. */
+        setTimeout(handle_channel_name_length_limit, 0);
     });
 
     // Do not allow the user to enter newline characters while typing out the

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -651,12 +651,12 @@ export function set_up_handlers(): void {
         if (channel_name.length > realm.max_stream_name_length) {
             channel_name = channel_name.slice(0, realm.max_stream_name_length);
             $channel_input.val(channel_name);
-            $channel_input.addClass("shake");
+            $channel_input.addClass("input-validation-shake");
         }
         stream_name_error.pre_validate(channel_name);
     }
     $("input#create_stream_name").on("animationend", function () {
-        $(this).removeClass("shake");
+        $(this).removeClass("input-validation-shake");
     });
     $container.on("input", "#create_stream_name", () => {
         handle_channel_name_length_limit();

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -645,11 +645,27 @@ export function set_up_handlers(): void {
         }
     });
 
+    function handle_channel_name_length_limit(): void {
+        const $channel_input = $<HTMLInputElement>("input#create_stream_name");
+        let channel_name = $channel_input.val()!.trim();
+        if (channel_name.length > realm.max_stream_name_length) {
+            channel_name = channel_name.slice(0, realm.max_stream_name_length);
+            $channel_input.val(channel_name);
+            $channel_input.addClass("shake");
+        }
+        stream_name_error.pre_validate(channel_name);
+    }
+    $("input#create_stream_name").on("animationend", function () {
+        $(this).removeClass("shake");
+    });
     $container.on("input", "#create_stream_name", () => {
-        const stream_name = $<HTMLInputElement>("input#create_stream_name").val()!.trim();
-
-        // This is an inexpensive check.
-        stream_name_error.pre_validate(stream_name);
+        handle_channel_name_length_limit();
+    });
+    $container.on("paste", "#create_stream_name", () => {
+        /* setTimeout is needed to allow the pasted content to be
+           added to the input before checking the channel name length limit,
+           since the paste event fires before the input value is updated. */
+        setTimeout(handle_channel_name_length_limit, 0);
     });
 
     // Do not allow the user to enter newline characters while typing out the

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1646,7 +1646,7 @@ export function initialize(): void {
         const $alert_box = $("#user-profile-groups-tab .user-profile-group-list-alert");
         const item = $("#user-group-to-add .pill-container .input").text().trim();
         if (item) {
-            $("#user-group-to-add .pill-container .input").addClass("shake");
+            $("#user-group-to-add .pill-container .input").addClass("input-validation-shake");
             if (
                 $("#user-group-to-add .pill-container .input").hasClass(
                     "show-outline-on-invalid-input",

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1641,7 +1641,7 @@ export function initialize(): void {
         const $alert_box = $("#user-profile-groups-tab .user-profile-group-list-alert");
         const item = $("#user-group-to-add .pill-container .input").text().trim();
         if (item) {
-            $("#user-group-to-add .pill-container .input").addClass("shake");
+            $("#user-group-to-add .pill-container .input").addClass("input-validation-shake");
             if (
                 $("#user-group-to-add .pill-container .input").hasClass(
                     "show-outline-on-invalid-input",

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1146,13 +1146,6 @@ textarea.new_message_textarea {
         &.empty-topic-display::placeholder {
             color: var(--color-compose-recipient-box-text-color);
         }
-
-        &.shake {
-            animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-            transform: translate3d(0, 0, 0);
-            backface-visibility: hidden;
-            perspective: 1000px;
-        }
     }
 
     #topic-not-mandatory-placeholder {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1184,13 +1184,6 @@ textarea.new_message_textarea {
         &.empty-topic-display::placeholder {
             color: var(--color-compose-recipient-box-text-color);
         }
-
-        &.shake {
-            animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-            transform: translate3d(0, 0, 0);
-            backface-visibility: hidden;
-            perspective: 1000px;
-        }
     }
 
     #topic-not-mandatory-placeholder {

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -211,13 +211,6 @@
         flex: 1 1 auto;
 
         outline: none;
-
-        &.shake {
-            animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-            transform: translate3d(0, 0, 0);
-            backface-visibility: hidden;
-            perspective: 1000px;
-        }
     }
 
     &.not-editable-by-user {
@@ -467,27 +460,4 @@
     display: flex;
     align-items: center;
     justify-content: center;
-}
-
-@keyframes shake {
-    10%,
-    90% {
-        transform: translate3d(-1px, 0, 0);
-    }
-
-    20%,
-    80% {
-        transform: translate3d(2px, 0, 0);
-    }
-
-    30%,
-    50%,
-    70% {
-        transform: translate3d(-3px, 0, 0);
-    }
-
-    40%,
-    60% {
-        transform: translate3d(3px, 0, 0);
-    }
 }

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -217,13 +217,6 @@
         flex: 1 1 auto;
 
         outline: none;
-
-        &.shake {
-            animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-            transform: translate3d(0, 0, 0);
-            backface-visibility: hidden;
-            perspective: 1000px;
-        }
     }
 
     &.not-editable-by-user {
@@ -474,27 +467,4 @@
     display: flex;
     align-items: center;
     justify-content: center;
-}
-
-@keyframes shake {
-    10%,
-    90% {
-        transform: translate3d(-1px, 0, 0);
-    }
-
-    20%,
-    80% {
-        transform: translate3d(2px, 0, 0);
-    }
-
-    30%,
-    50%,
-    70% {
-        transform: translate3d(-3px, 0, 0);
-    }
-
-    40%,
-    60% {
-        transform: translate3d(3px, 0, 0);
-    }
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1631,10 +1631,3 @@ h4.user_group_setting_subsection_title {
         }
     }
 }
-
-#create_stream_name.shake {
-    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-    transform: translate3d(0, 0, 0);
-    backface-visibility: hidden;
-    perspective: 1000px;
-}

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1631,3 +1631,10 @@ h4.user_group_setting_subsection_title {
         }
     }
 }
+
+#create_stream_name.shake {
+    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
+    perspective: 1000px;
+}

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1775,3 +1775,10 @@
         }
     }
 }
+
+#create_stream_name.shake {
+    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
+    perspective: 1000px;
+}

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1775,10 +1775,3 @@
         }
     }
 }
-
-#create_stream_name.shake {
-    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-    transform: translate3d(0, 0, 0);
-    backface-visibility: hidden;
-    perspective: 1000px;
-}

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2556,3 +2556,33 @@ body:not(.spectator-view) {
         outline: none;
     }
 }
+
+.input-validation-shake {
+    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
+    perspective: 1000px;
+}
+
+@keyframes shake {
+    10%,
+    90% {
+        transform: translate3d(-1px, 0, 0);
+    }
+
+    20%,
+    80% {
+        transform: translate3d(2px, 0, 0);
+    }
+
+    30%,
+    50%,
+    70% {
+        transform: translate3d(-4px, 0, 0);
+    }
+
+    40%,
+    60% {
+        transform: translate3d(4px, 0, 0);
+    }
+}

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2572,3 +2572,33 @@ body:not(.spectator-view) {
         outline: none;
     }
 }
+
+.input-validation-shake {
+    animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
+    perspective: 1000px;
+}
+
+@keyframes shake {
+    10%,
+    90% {
+        transform: translate3d(-1px, 0, 0);
+    }
+
+    20%,
+    80% {
+        transform: translate3d(2px, 0, 0);
+    }
+
+    30%,
+    50%,
+    70% {
+        transform: translate3d(-4px, 0, 0);
+    }
+
+    40%,
+    60% {
+        transform: translate3d(4px, 0, 0);
+    }
+}

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -11,7 +11,7 @@
                             {{t "Channel name" }}
                         </label>
                         <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
-                          placeholder="{{t 'Channel name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
+                          placeholder="{{t 'Channel name' }}" value="" autocomplete="off" />
                         <div id="stream_name_error" class="stream_creation_error"></div>
                     </section>
                     <section id="create_stream_description_container">

--- a/web/tests/input_pill.test.cjs
+++ b/web/tests/input_pill.test.cjs
@@ -521,7 +521,7 @@ run_test("misc things", () => {
     const input_stub = {
         to_$: () => ({
             removeClass(cls) {
-                assert.equal(cls, "shake");
+                assert.equal(cls, "input-validation-shake");
                 shake_class_removed = true;
             },
         }),


### PR DESCRIPTION
When users type or paste a channel name longer than 60 characters, the input silently stops accepting text without any visual feedback, confusing users who don't know why input stopped.

Added shake animation to the channel name input field when the character limit is reached, reusing the existing shake animation pattern already used in topic names (https://github.com/zulip/zulip/pull/37955). The maxlength attribute is removed from the template so the input event fires when users exceed the limit, allowing the shake animation to trigger. animationend event is used to remove the shake class cleanly.

**How changes were tested:**
Tested typing and pasting text beyond the 60-character limit in the channel.

**Screenshots and screen captures:**
Pasting text:
Before:
https://github.com/user-attachments/assets/b4b21fd7-6fe5-4a3a-9aa2-22e9cec16c06

After:
https://github.com/user-attachments/assets/08f6c7f4-049d-45bb-817e-e258a042b161

Typing text:
Before:
https://github.com/user-attachments/assets/909a1ebf-22c2-4533-9fa7-72d6f4929058

After :
https://github.com/user-attachments/assets/64deae6a-f33b-44d0-8dbb-d0ce9a04791b

CZO Thread: [here](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20creation.3A.20no.20visual.20feedback.20when.20channel.20name.20hits)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
