### PR TITLE
search: Enable substring matching in any order for unspaced scripts

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1201,15 +1201,26 @@ export function maybe_remove_diacritics_from_name(
     return user.full_name;
 }
 
-export function build_termlet_matcher(termlet: string): (user: User) => boolean {
+export function build_termlet_matcher(
+    termlet: string,
+    is_unspaced = false,
+): (user: User) => boolean {
     // Note: termlets are required to be lower case.
     termlet = termlet.trim();
     const should_remove_diacritics = !typeahead.contains_diacritics(termlet);
 
     return function (user: User): boolean {
-        const full_name = maybe_remove_diacritics_from_name(user, should_remove_diacritics);
+        const full_name = maybe_remove_diacritics_from_name(
+            user,
+            should_remove_diacritics,
+        ).toLowerCase();
 
-        const names = full_name.toLowerCase().split(" ");
+        if (is_unspaced) {
+            const name_without_spaces = full_name.replaceAll(/\s+/g, "");
+            return name_without_spaces.includes(termlet);
+        }
+
+        const names = full_name.split(" ");
 
         return names.some((name) => name.startsWith(termlet));
     };
@@ -1218,8 +1229,12 @@ export function build_termlet_matcher(termlet: string): (user: User) => boolean 
 export function build_person_matcher(query: string): (user: User) => boolean {
     query = query.trim();
 
+    const is_unspaced_query = typeahead.has_unspaced_script(query);
+
     const termlets = query.toLowerCase().split(/\s+/);
-    const termlet_matchers = termlets.map((termlet) => build_termlet_matcher(termlet));
+    const termlet_matchers = termlets.map((termlet) =>
+        build_termlet_matcher(termlet, is_unspaced_query),
+    );
 
     return function (user: User): boolean {
         if (String(user.user_id).startsWith(query)) {

--- a/web/src/typeahead.ts
+++ b/web/src/typeahead.ts
@@ -104,6 +104,19 @@ export function last_prefix_match(prefix: string, words: string[]): number | nul
     return null;
 }
 
+// Scripts that don't typically use spaces for word separation.
+const UNSPACED_SCRIPT_NAMES = ["Han", "Hiragana", "Katakana", "Thai", "Lao"];
+
+// Constructs: /[\p{Script=Han}\p{Script=Hiragana}...]/u
+const unspaced_scripts_regex = new RegExp(
+    `[${UNSPACED_SCRIPT_NAMES.map((s) => `\\p{Script=${s}}`).join("")}]`,
+    "u",
+);
+
+export function has_unspaced_script(text: string): boolean {
+    return unspaced_scripts_regex.test(text);
+}
+
 export function query_matches_string_in_order(
     query: string,
     source_str: string,

--- a/web/src/typeahead.ts
+++ b/web/src/typeahead.ts
@@ -181,6 +181,12 @@ export function query_matches_string_in_any_order(
     query = query.toLowerCase();
     query = remove_diacritics(query);
 
+    if (has_unspaced_script(query)) {
+        const source_without_spaces = source_str.replaceAll(/\s+/g, "");
+        const search_words = query.split(/\s+/).filter(Boolean);
+        return search_words.every((search_word) => source_without_spaces.includes(search_word));
+    }
+
     const search_words = query.split(split_char).filter(Boolean);
     const source_words = source_str.split(split_char).filter(Boolean);
     if (search_words.length > source_words.length) {

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -297,6 +297,24 @@ const imported_user = {
     is_imported_stub: true,
 };
 
+const japanese_user = make_user({
+    email: "jpn@example.com",
+    user_id: 1206,
+    full_name: "田中　太郎",
+});
+
+const thai_user = make_user({
+    email: "thai@example.com",
+    user_id: 1207,
+    full_name: "สมชาย ใจดี",
+});
+
+const lao_user = make_user({
+    email: "lao@example.com",
+    user_id: 1208,
+    full_name: "ສົມຊາຍ ໃຈດີ",
+});
+
 function get_all_persons() {
     return people.filter_all_persons(() => true);
 }
@@ -828,6 +846,9 @@ run_test("filtered_users", () => {
     people.add_active_user(linus);
     people.add_active_user(noah);
     people.add_active_user(plain_noah);
+    people.add_active_user(japanese_user);
+    people.add_active_user(thai_user);
+    people.add_active_user(lao_user);
 
     const search_term = "a";
     const users = people.get_realm_users();
@@ -838,7 +859,7 @@ run_test("filtered_users", () => {
     assert.ok(!filtered_people.has(charles.user_id));
 
     filtered_people = people.filter_people_by_search_terms(users, "");
-    assert.equal(filtered_people.size, 7);
+    assert.equal(filtered_people.size, 10);
 
     filtered_people = people.filter_people_by_search_terms(users, "ltorv");
     assert.equal(filtered_people.size, 1);
@@ -872,6 +893,45 @@ run_test("filtered_users", () => {
     filtered_people = people.filter_people_by_search_terms(users, "nöôáàh Ëme");
     assert.equal(filtered_people.size, 1);
     assert.ok(filtered_people.has(noah.user_id));
+
+    // Test unspaced scripts (Han) and full-width space normalization
+    filtered_people = people.filter_people_by_search_terms(users, "田中太郎");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(japanese_user.user_id));
+
+    filtered_people = people.filter_people_by_search_terms(users, "田中　太郎");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(japanese_user.user_id));
+
+    filtered_people = people.filter_people_by_search_terms(users, "郎");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(japanese_user.user_id));
+
+    // Test Thai (Unspaced script)
+    filtered_people = people.filter_people_by_search_terms(users, "สมชายใจ");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(thai_user.user_id));
+
+    filtered_people = people.filter_people_by_search_terms(users, "สมชาย ใจดี");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(thai_user.user_id));
+
+    filtered_people = people.filter_people_by_search_terms(users, "ดี");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(thai_user.user_id));
+
+    // Test Lao (Unspaced script)
+    filtered_people = people.filter_people_by_search_terms(users, "ສົມຊາຍໃຈດີ");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(lao_user.user_id));
+
+    filtered_people = people.filter_people_by_search_terms(users, "ສົມຊາຍ ໃຈດີ");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(lao_user.user_id));
+
+    filtered_people = people.filter_people_by_search_terms(users, "ດີ");
+    assert.equal(filtered_people.size, 1);
+    assert.ok(filtered_people.has(lao_user.user_id));
 });
 
 run_test("dm_matches_search_string", () => {

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -602,3 +602,68 @@ test("initialize", ({override}) => {
 
     assert.ok(!stream_list_sort.is_filtering_inactives());
 });
+
+test("search unspaced scripts (Han, Thai, Lao)", () => {
+    // Japanese users sometimes use full-width spaces, so we test with a full-width space.
+    const japanese_stream = make_stream({
+        subscribed: true,
+        name: "お知らせ　プロジェクト",
+        stream_id: 200,
+        pin_to_top: false,
+        is_recently_active: true,
+        is_muted: false,
+    });
+
+    const thai_stream = make_stream({
+        subscribed: true,
+        name: "ประกาศ โครงการ",
+        stream_id: 201,
+        pin_to_top: false,
+        is_recently_active: true,
+        is_muted: false,
+    });
+
+    const lao_stream = make_stream({
+        subscribed: true,
+        name: "ປະກາດ ໂຄງການ",
+        stream_id: 202,
+        pin_to_top: false,
+        is_recently_active: true,
+        is_muted: false,
+    });
+
+    stream_data.add_sub_for_tests(japanese_stream);
+    stream_data.add_sub_for_tests(thai_stream);
+    stream_data.add_sub_for_tests(lao_stream);
+
+    // Test Japanese
+    let sorted_sections = sort_groups("お知らせプロジェクト").sections;
+    assert.deepEqual(sorted_sections[1].id, "normal-streams");
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [japanese_stream.stream_id]);
+
+    sorted_sections = sort_groups("お知らせ　プロジェクト").sections;
+    assert.deepEqual(sorted_sections[1].id, "normal-streams");
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [japanese_stream.stream_id]);
+
+    sorted_sections = sort_groups("ト").sections;
+    assert.deepEqual(sorted_sections[1].id, "normal-streams");
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [japanese_stream.stream_id]);
+
+    // Test Thai
+    sorted_sections = sort_groups("ประกาศโครง").sections;
+    assert.deepEqual(sorted_sections[1].id, "normal-streams");
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [thai_stream.stream_id]);
+
+    sorted_sections = sort_groups("ง").sections;
+    assert.deepEqual(sorted_sections[1].id, "normal-streams");
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [thai_stream.stream_id]);
+
+    // Test Lao
+    sorted_sections = sort_groups("ປະກາດໂຄງ").sections;
+    assert.deepEqual(sorted_sections[1].id, "normal-streams");
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [lao_stream.stream_id]);
+
+    sorted_sections = sort_groups("ງ").sections;
+    assert.deepEqual(sorted_sections[1].id, "normal-streams");
+    assert.deepEqual(sorted_sections[1].default_visible_streams, [lao_stream.stream_id]);
+});

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -583,3 +583,34 @@ test("get_list_info with specific topics and searches", () => {
     list_info = get_list_info(true, "nonexistent");
     assert.equal(list_info.items.length, 0);
 });
+
+test("get_list_info with unspaced scripts", () => {
+    let list_info;
+
+    function add_topic_message(topic_name, message_id) {
+        stream_topic_history.add_message({
+            stream_id: general.stream_id,
+            topic_name,
+            message_id,
+        });
+    }
+
+    add_topic_message("テスト中", 1001);
+    add_topic_message("การทดสอบ", 1002);
+    add_topic_message("ການທົດສອບ", 1003);
+
+    // Test Japanese
+    list_info = get_list_info(true, "中");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "テスト中");
+
+    // Test Thai
+    list_info = get_list_info(true, "สอบ");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "การทดสอบ");
+
+    // Test Lao
+    list_info = get_list_info(true, "ສອບ");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "ການທົດສອບ");
+});

--- a/web/tests/typeahead.test.cjs
+++ b/web/tests/typeahead.test.cjs
@@ -113,6 +113,60 @@ run_test("query_matches_string_in_order", () => {
     assert_no_match("josé mar", "Jose Maria", " ");
 });
 
+run_test("query_matches_string_in_any_order", () => {
+    // Test standard behavior for spaced languages (e.g., English)
+    assert.equal(typeahead.query_matches_string_in_any_order("cd ef", "ab cd ef", " "), true);
+    assert.equal(typeahead.query_matches_string_in_any_order("b cd", "ab cd ef", " "), false);
+
+    // Test substring matching for unspaced scripts
+    // Japanese (Hiragana/Katakana/Han)
+    assert.equal(typeahead.query_matches_string_in_any_order("らせ", "お知らせ", " "), true);
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("ット", "チャット開発環境", " "),
+        true,
+    );
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("開発", "チャット開発環境", " "),
+        true,
+    );
+
+    // Thai
+    assert.equal(typeahead.query_matches_string_in_any_order("สอบ", "การทดสอบ", " "), true);
+
+    // Lao
+    assert.equal(typeahead.query_matches_string_in_any_order("ສອບ", "ການທົດສອບ", " "), true);
+
+    // Test "in any order" matching for unspaced scripts
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("開発 環境", "Zulip開発環境", " "),
+        true,
+    );
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("環境 開発", "Zulip開発環境", " "),
+        true,
+    );
+
+    // Test mixed scripts (spaced and unspaced) matching
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("Zulip 開発", "Zulip開発環境", " "),
+        true,
+    );
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("開発 Zulip", "Zulip開発環境", " "),
+        true,
+    );
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("開発 ip", "Zulip開発環境", " "),
+        true,
+    );
+
+    // Test tokenization with full-width spaces
+    assert.equal(
+        typeahead.query_matches_string_in_any_order("Zulip　開発", "Zulip開発環境", " "),
+        true,
+    );
+});
+
 run_test("triage", () => {
     const alice = {name: "alice"};
     const alicia = {name: "Alicia"};


### PR DESCRIPTION
This PR introduces partial match search for unspaced scripts (Han, Hiragana, Katakana, Thai, Lao.) and improves the search UX.

Previously in Zulip, partial matching for unspaced scripts was not functioning, making user and channel searches difficult. This modification resolves that fundamental problem and also realizes "in any order" search similar to English.

### Key Changes

1. **Implementation of logic according to the target:** Implemented partial match logic for unspaced scripts in `typeahead.ts` (`query_matches_string_in_any_order`), which is the common engine for channel and topic searches, and in `people.ts` for user search, which has its own mechanism.
2. **Full-width space support:** By utilizing the fact that JavaScript regex (`\s`) supports full-width spaces, both standard and full-width spaces are completely removed from the search target before matching. This ensures that pure partial matching functions accurately without noise, even for users who include full-width spaces in their registered display names.
3. **"In any order" matching:** When the search query contains unspaced characters, the query is split into an array of tokens by spaces. By checking if all unspaced tokens are included in the search target (spaces removed), searches entered in any order such as `環境 開発` will correctly hit `Zulip開発環境`.
4. **Mixed language support:** If the search query contains even a single unspaced character, the entire query (including any spaced script tokens like English words) is evaluated using substring matching. This ensures that names where different script types are connected without spaces, such as "Zulip開発" or "活用Zulip", can be successfully matched by queries like "開発 ip" or "ip 活用". Note that for queries that do not contain any unspaced characters (e.g., pure English searches), the standard prefix matching behavior is fully maintained.

### Note on Testing

- Conducted manual testing in a local environment and confirmed that partial match search works correctly in both user search and channel/topic search.
- Confirmed that there is no negative impact on the standard English search logic (prefix matching).
- All existing frontend tests (`tools/test-js-with-node`) have passed.


## **Screenshots and screen captures:**

### **Right Side Bar (User Search)**

| Before | After |
| :---: | :---: |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/060579ae-15f8-47c9-af97-ab1897892b21" /> | <img width="273" alt="image" src="https://github.com/user-attachments/assets/14c2f68a-c01e-4292-9a90-a6df7a5c6204" /> |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/55a6d8ee-5f90-4bc6-a257-1e096261f2ac" /> | <img width="276" alt="image" src="https://github.com/user-attachments/assets/fc0fdeb5-7014-40db-8ede-7e92f5dd9df3" /> |

**Behavior of mixed queries (unspaced characters and spaced scripts)**
| Search with word start (Prefix-like) | Search with word middle (Substring-like) |
| :---: | :---: |
| <img width="313" height="82" alt="image" src="https://github.com/user-attachments/assets/e70ebfae-29d4-47f3-834a-2d53e2f2ee74" /> | <img width="317" height="87" alt="image" src="https://github.com/user-attachments/assets/0f235477-2ef9-4c66-815f-9f8a604416ff" /> |


### **Left Side Bar (Channel Search)**

| Before | After |
| :---: | :---: |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/43a074bf-17dd-41a5-b18c-9b69951f2d51" /> | <img width="309" alt="image" src="https://github.com/user-attachments/assets/116ac22d-c5ea-4a6e-b7bb-4f6a7e090d29" /> |

**Behavior of mixed queries (unspaced characters and spaced scripts)**
| Search with word start (Prefix-like) | Search with word middle (Substring-like) |
| :---: | :---: |
| <img width="320" height="129" alt="image" src="https://github.com/user-attachments/assets/7590ff21-0531-45b1-81d7-a1e3116c0ce2" /> | <img width="307" height="129" alt="image" src="https://github.com/user-attachments/assets/f6426816-83e0-4f9f-a9e1-9ce9d97aed9f" /> |
| <img width="318" height="129" alt="image" src="https://github.com/user-attachments/assets/d66edb5a-20fb-401c-9fc3-cc8dda07c26a" /> | <img width="316" height="128" alt="image" src="https://github.com/user-attachments/assets/4e7c8944-42f2-44fa-bde2-e4f41660d238" /> |

## **Confirmation: Substring matching is NOT applied to English text**
This confirms that standard English search behavior (prefix matching) remains completely unaffected by this PR.

| User List (Existing users) | Search Result (Partial match) |
| :---: | :---: |
| <img width="273" alt="User list" src="https://github.com/user-attachments/assets/c3baee6c-a5e0-4155-9680-54f7587e65a1" /> | <img width="265" alt="Partial search result" src="https://github.com/user-attachments/assets/494e7aa6-859e-4836-a785-24be3fd01b52" /> |
| *Target users exist in the list.* | *Yields no results when searching by a partial string.* |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
