### PR TITLE
overlays: Avoid closing settings when <select> is active.

### DIFF
--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -198,6 +198,20 @@ export function initialize(): void {
 
         const target_name = $target.attr("data-overlay")!;
 
+        // When a native <select> dropdown is open inside the settings overlay,
+        // the browser can retarget the click event to the overlay backdrop.
+        // Avoid treating that click as an "outside click" that closes settings.
+        if (target_name === "settings" && $target.is("div.overlay")) {
+            const active_element = document.activeElement;
+            if (
+                active_element !== null &&
+                $(active_element).is("select") &&
+                $(active_element).closest("#settings_overlay_container").length === 1
+            ) {
+                return;
+            }
+        }
+
         close_overlay(target_name);
 
         e.preventDefault();

--- a/web/tests/overlays.test.cjs
+++ b/web/tests/overlays.test.cjs
@@ -1,0 +1,58 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+const $ = require("./lib/zjquery.cjs");
+
+mock_esm("../src/mouse_drag", {
+    is_drag: () => false,
+});
+
+mock_esm("../src/overlay_util", {
+    disable_scrolling() {},
+    enable_scrolling() {},
+});
+
+run_test("settings overlay does not close on backdrop click when select is open", () => {
+    const overlays = zrequire("overlays");
+
+    // Minimal DOM-ish setup required by overlays.open_overlay/close_overlay.
+    $(".app");
+    $("#navbar-fixed-container");
+
+    const $settings_overlay = $("#settings_overlay_container");
+    $settings_overlay.attr("data-overlay", "settings");
+    $settings_overlay.set_matches("div.overlay", true);
+    $settings_overlay.set_matches(".exit, .exit-sign, .overlay-content, .exit span", false);
+    $settings_overlay.addClass("overlay");
+
+    let overlay_closed = false;
+    overlays.open_overlay({
+        name: "settings",
+        $overlay: $settings_overlay,
+        on_close() {
+            overlay_closed = true;
+        },
+    });
+    assert.ok($settings_overlay.hasClass("show"));
+
+    const $select = $.create("#test_select");
+    $select.set_matches("select", true);
+    $select.set_closest_results("#settings_overlay_container", [$settings_overlay[0]]);
+    set_global("document", {
+        activeElement: $select[0],
+    });
+
+    overlays.initialize();
+    const handler = $("body").get_on_handler("click", "div.overlay, div.overlay .exit");
+    handler({target: $settings_overlay[0]});
+
+    assert.ok($settings_overlay.hasClass("show"));
+    assert.equal(overlay_closed, false);
+
+    overlays.close_overlay("settings");
+    assert.equal(overlay_closed, true);
+});
+

--- a/web/tests/overlays.test.cjs
+++ b/web/tests/overlays.test.cjs
@@ -55,4 +55,3 @@ run_test("settings overlay does not close on backdrop click when select is open"
     overlays.close_overlay("settings");
     assert.equal(overlay_closed, true);
 });
-


### PR DESCRIPTION
Fixes: #33464.

## Summary
Some browsers retarget clicks to the overlay backdrop while a native `<select>`
dropdown is open, which can make the settings overlay interpret a click in the
empty area below the left panel as a backdrop click and close.

This change skips closing the settings overlay on backdrop clicks when the
active element is a `<select>` inside the settings overlay, and adds a node test
to prevent regressions.

## Test plan
- [ ] Run `./tools/test-js-with-node web/tests/overlays.test.cjs` (in the Zulip dev/Vagrant environment)