### PR TITLE
outgoing_webhooks: Separate command and text fields for Slack interface.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -104,6 +104,15 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
         return None
 
 
+def _slack_command_and_text(content: str, bot_full_name: str) -> list[tuple[str, str]]:
+    mention = f"@**{bot_full_name}**"
+    if content.startswith(mention):
+        text = content[len(mention) :].strip()
+        command = "/" + bot_full_name.replace(" ", "_").lower()
+        return [("command", command), ("text", text)]
+    return [("text", content)]
+
+
 class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
     @override
     def make_request(self, base_url: str, event: dict[str, Any], realm: Realm) -> Response | None:
@@ -137,7 +146,7 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
+            *_slack_command_and_text(event["command"], event["message"]["sender_full_name"]),
             ("trigger_word", event["trigger"]),
             ("service_id", event["user_profile_id"]),
         ]

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -13,6 +13,7 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.outgoing_webhook import (
     GenericOutgoingWebhookService,
     SlackOutgoingWebhookService,
+    _slack_command_and_text,
     do_rest_call,
     fail_with_message,
 )
@@ -720,3 +721,21 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
         # by the response_not_required option.
         last_message = self.get_last_message()
         self.assertEqual(last_message.id, stream_message_id)
+
+
+class TestSlackCommandAndText(ZulipTestCase):
+    def test_message_with_bot_mention(self) -> None:
+        result = _slack_command_and_text("@**my bot** do something", "my bot")
+        self.assertEqual(result, [("command", "/my_bot"), ("text", "do something")])
+
+    def test_message_without_bot_mention(self) -> None:
+        result = _slack_command_and_text("just a message", "my bot")
+        self.assertEqual(result, [("text", "just a message")])
+
+    def test_message_with_only_bot_mention(self) -> None:
+        result = _slack_command_and_text("@**my bot**", "my bot")
+        self.assertEqual(result, [("command", "/my_bot"), ("text", "")])
+
+    def test_message_with_wrong_bot_mention(self) -> None:
+        result = _slack_command_and_text("@**other bot** do something", "my bot")
+        self.assertEqual(result, [("text", "@**other bot** do something")])


### PR DESCRIPTION
Fixes #19589

When a message sent to a Slack-compatible outgoing webhook bot starts
with a bot mention (e.g. `@**botname**`), we now parse it into:
- `command` field: `/botname` (slash-command format)
- `text` field: the remaining message text

Previously, the full message including the bot mention was placed in
the `text` field with no `command` field, which broke Slack-compatible
integrations like GitLab slash commands.

**How changes were tested:**
Added unit tests in `test_outgoing_webhook_system.py` covering:
- Message with bot mention (command + text split correctly)
- Message without bot mention (text field only)
- Message with only bot mention (empty text)
- Message with a different bot mention (no split)

**Self-review checklist**
- [x] Changes are self-contained and explained
- [x] Commit message follows Zulip's guidelines
- [x] Tests added for new behavior
- [x] No UI changes (no screenshots needed)