### PR TITLE
backends: Fix SAML crash when name is in IdP config.

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -3387,7 +3387,8 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
                 raise AuthMissingParameter(self, "RelayState.idp")
             # Use the only configured IDP
             idp_name = next(iter(enabled_idps))
-        idp_config = enabled_idps[idp_name]
+        idp_config = dict(enabled_idps[idp_name])
+        idp_config.pop("name", None)
         return ZulipSAMLIdentityProvider(self, idp_name, **idp_config)
 
     @override


### PR DESCRIPTION
Fixes #38887.

**The problem:** `SAMLIdentityProvider.__init__()` accepts `name` as a positional argument. When `SOCIAL_AUTH_SAML_ENABLED_IDPS` includes a `"name"` key in an IdP config dict (as shown in the [social-auth docs](https://python-social-auth.readthedocs.io/en/latest/backends/saml.html)), passing it via `**idp_config` causes `TypeError: got multiple values for argument "name"`.

**Root cause:** In `get_idp()`, `idp_name` is passed as the second positional argument (mapping to `name`), and `**idp_config` may also contain `"name"` from the config dict.

**Fix:** Pop `"name"` from the config dict before unpacking it as kwargs. A shallow copy of the dict is made to avoid mutating the original settings dict.

**How changes were tested:**
- Verified the fix resolves the `TypeError` by testing with a config dict containing `"name"`.
- Confirmed existing configs without `"name"` continue to work unchanged.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines)
- [x] Explains differences from previous plans
- [x] Highlights technical choices and bugs encountered
- [x] Automated tests verify logic where appropriate

Individual commits are ready for review:

- [x] Each commit is a coherent idea
- [x] Commit message(s) explain reasoning and motivation for changes
</details>