### PR TITLE
api: Support subscribing/unsubscribing from channels by ID.

### DIFF
--- a/web/src/stream_settings_components.ts
+++ b/web/src/stream_settings_components.ts
@@ -262,7 +262,8 @@ function ajaxUnsubscribe(
     $stream_row: JQuery | undefined,
     $button_elem: JQuery | undefined,
 ): void {
-    // TODO: use stream_id when backend supports it
+    // Unsubscribe by stream ID for resilience against stream renames
+    // and name collisions (e.g., from HipChat imports).
     if ($stream_row !== undefined) {
         display_subscribe_toggle_spinner($stream_row);
     }
@@ -271,7 +272,7 @@ function ajaxUnsubscribe(
     }
     void channel.del({
         url: "/json/users/me/subscriptions",
-        data: {subscriptions: JSON.stringify([sub.name])},
+        data: {subscriptions: JSON.stringify([sub.stream_id])},
         success() {
             $(".stream_change_property_info").hide();
             // The rest of the work is done via the unsubscribe event we will get

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -74,6 +74,9 @@ class StreamDict(TypedDict, total=False):
         - we use it to create a stream
         - we use it to specify a stream
 
+    For stream lookup, either 'name' or 'stream_id' can be provided.
+    When 'stream_id' is present, it takes precedence for looking up
+    existing streams. Stream creation always requires 'name'.
 
     It's possible we want a smaller type to use
     for removing streams, but it would complicate
@@ -84,6 +87,7 @@ class StreamDict(TypedDict, total=False):
     """
 
     name: str
+    stream_id: int
     description: str
     invite_only: bool
     is_web_public: bool
@@ -1628,43 +1632,87 @@ def list_to_streams(
 ) -> tuple[list[Stream], list[Stream]]:
     """Converts list of dicts to a list of Streams, validating input in the process
 
-    For each stream name, we validate it to ensure it meets our
-    requirements for a proper stream name using check_stream_name.
+    For each stream entry, we accept either a stream name or stream ID.
+    When 'stream_id' is present, it is used for lookup (resilient to stream
+    renames). When only 'name' is present, we use name-based lookup and
+    optionally create the stream if autocreate is True.
 
     This function in autocreate mode should be atomic: either an exception will be raised
     during a precheck, or all the streams specified will have been created if applicable.
 
     @param streams_raw The list of stream dictionaries to process;
       names should already be stripped of whitespace by the caller.
+      Each dict should contain either 'name' (str) or 'stream_id' (int).
     @param user_profile The user for whom we are retrieving the streams
     @param autocreate Whether we should create streams if they don't already exist
     """
-    # Validate all streams, getting extant ones, then get-or-creating the rest.
+    # Separate streams into ID-based and name-based lookups.
+    # When stream_id is present, it takes precedence for lookup.
+    id_based_dicts: list[StreamDict] = []
+    name_based_dicts: list[StreamDict] = []
 
-    stream_set = {stream_dict["name"] for stream_dict in streams_raw}
+    for stream_dict in streams_raw:
+        if "stream_id" in stream_dict:
+            id_based_dicts.append(stream_dict)
+        else:
+            name_based_dicts.append(stream_dict)
 
-    for stream_name in stream_set:
+    existing_streams: list[Stream] = []
+    missing_stream_dicts: list[StreamDict] = []
+
+    # --- Process name-based lookups (existing behavior) ---
+    stream_name_set = {stream_dict["name"] for stream_dict in name_based_dicts}
+
+    for stream_name in stream_name_set:
         # Stream names should already have been stripped by the
         # caller, but it makes sense to verify anyway.
         assert stream_name == stream_name.strip()
         check_stream_name(stream_name)
 
-    existing_streams: list[Stream] = []
-    missing_stream_dicts: list[StreamDict] = []
-    existing_stream_map = bulk_get_streams(user_profile.realm, stream_set)
+    existing_stream_map = bulk_get_streams(user_profile.realm, stream_name_set)
 
-    if unsubscribing_others and not bulk_can_remove_subscribers_from_streams(
-        list(existing_stream_map.values()), user_profile
-    ):
-        raise JsonableError(_("Insufficient permission"))
-
-    for stream_dict in streams_raw:
+    for stream_dict in name_based_dicts:
         stream_name = stream_dict["name"]
         stream = existing_stream_map.get(stream_name.lower())
         if stream is None:
             missing_stream_dicts.append(stream_dict)
         else:
             existing_streams.append(stream)
+
+    # --- Process ID-based lookups ---
+    if id_based_dicts:
+        stream_id_set = {stream_dict["stream_id"] for stream_dict in id_based_dicts}
+        # Use select_related consistent with bulk_get_streams for the
+        # fields needed by downstream callers.
+        streams_by_id = Stream.objects.filter(
+            id__in=stream_id_set, realm=user_profile.realm
+        ).select_related("can_send_message_group", "can_send_message_group__named_user_group")
+        id_stream_map = {stream.id: stream for stream in streams_by_id}
+
+        missing_ids: list[int] = []
+        for stream_dict in id_based_dicts:
+            stream_id = stream_dict["stream_id"]
+            stream = id_stream_map.get(stream_id)
+            if stream is None:
+                missing_ids.append(stream_id)
+            else:
+                existing_streams.append(stream)
+
+        # Streams looked up by ID cannot be autocreated — always error.
+        if missing_ids:
+            raise JsonableError(
+                _("Invalid channel ID: {channel_id}").format(
+                    channel_id=missing_ids[0],
+                )
+            )
+
+    # Check permissions for unsubscribing on behalf of other users.
+    # This runs after lookups so we check permissions on all
+    # resolved streams (both ID-based and name-based).
+    if unsubscribing_others and not bulk_can_remove_subscribers_from_streams(
+        existing_streams, user_profile
+    ):
+        raise JsonableError(_("Insufficient permission"))
 
     if len(missing_stream_dicts) == 0:
         # This is the happy path for callers who expected all of these

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12655,6 +12655,11 @@ paths:
                     exist a new channel is created. The description of the channel created can
                     be specified by setting the dictionary key `description` with an
                     appropriate value.
+
+                    **Changes**: Before Zulip 12.0 (feature level XXX),
+                    only the `name` property was supported in each dictionary and
+                    it was required. Now, either `name` or `stream_id` (or both)
+                    can be provided, and `stream_id` is preferred for existing channels.
                   type: array
                   items:
                     type: object
@@ -12663,11 +12668,20 @@ paths:
                       name:
                         type: string
                         description: |
-                          The name of the channel.
+                          The name of the channel. Required when creating a new channel.
+                          Optional when `stream_id` is provided for an existing channel.
 
                           Clients should use the `max_stream_name_length` returned by the
                           [`POST /register`](/api/register-queue) endpoint to determine
                           the maximum channel name length.
+                      stream_id:
+                        type: integer
+                        description: |
+                          The ID of an existing channel to subscribe to. When provided,
+                          the channel is looked up by ID rather than name, which is
+                          resilient to channel renames and name collisions.
+
+                          **Changes**: New in Zulip 12.0 (feature level XXX).
                       description:
                         type: string
                         description: |
@@ -12679,8 +12693,6 @@ paths:
                           Clients should use the `max_stream_description_length` returned
                           by the [`POST /register`](/api/register-queue) endpoint to
                           determine the maximum channel description length.
-                    required:
-                      - name
                     example:
                       no-description:
                         value: {"name": "Verona"}
@@ -12940,10 +12952,16 @@ paths:
               properties:
                 delete:
                   description: |
-                    A list of channel names to unsubscribe from.
+                    A list of channel names (strings) or channel IDs (integers)
+                    to unsubscribe from.
+
+                    **Changes**: Before Zulip 12.0 (feature level XXX),
+                    only channel names (strings) were supported.
                   type: array
                   items:
-                    type: string
+                    oneOf:
+                      - type: string
+                      - type: integer
                   example: ["Verona", "Denmark"]
                 add:
                   description: |
@@ -12957,6 +12975,8 @@ paths:
                     properties:
                       name:
                         type: string
+                      stream_id:
+                        type: integer
                       color:
                         type: string
                       description:
@@ -13125,11 +13145,17 @@ paths:
               properties:
                 subscriptions:
                   description: |
-                    A list of channel names to unsubscribe from. This parameter is called
+                    A list of channel names (strings) or channel IDs (integers)
+                    to unsubscribe from. This parameter is called
                     `streams` in our Python API.
+
+                    **Changes**: Before Zulip 12.0 (feature level XXX),
+                    only channel names (strings) were supported.
                   type: array
                   items:
-                    type: string
+                    oneOf:
+                      - type: string
+                      - type: integer
                   example: ["Verona", "Denmark"]
                 principals:
                   $ref: "#/components/schemas/Principals"

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3445,6 +3445,147 @@ class SubscriptionRestApiTest(ZulipTestCase):
         streams = self.get_streams(user)
         self.assertTrue("my_test_stream_1" not in streams)
 
+    def test_basic_add_delete_by_id(self) -> None:
+        """Test that the PATCH endpoint accepts stream IDs in the delete list."""
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        # add by name (stream creation always uses name)
+        request = {
+            "add": orjson.dumps([{"name": "my_test_stream_by_id"}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+        streams = self.get_streams(user)
+        self.assertIn("my_test_stream_by_id", streams)
+
+        # get the stream ID
+        stream = get_stream("my_test_stream_by_id", user.realm)
+
+        # delete by ID
+        request = {
+            "delete": orjson.dumps([stream.id]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+        streams = self.get_streams(user)
+        self.assertNotIn("my_test_stream_by_id", streams)
+
+    def test_subscribe_by_stream_id(self) -> None:
+        """Test that POST /users/me/subscriptions accepts stream_id in dicts."""
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        # First, create the stream by subscribing via name.
+        request = {
+            "add": orjson.dumps([{"name": "test_sub_by_id_stream"}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        stream = get_stream("test_sub_by_id_stream", user.realm)
+
+        # Unsubscribe first so we can re-subscribe by ID.
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps([stream.id]).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertNotIn("test_sub_by_id_stream", self.get_streams(user))
+
+        # Now subscribe by stream_id only (no name).
+        result = self.client_post(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps([{"stream_id": stream.id}]).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertIn("test_sub_by_id_stream", self.get_streams(user))
+
+    def test_subscribe_by_stream_id_via_patch(self) -> None:
+        """Test that PATCH add accepts stream_id in subscription dicts."""
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        # Create the stream.
+        request = {
+            "add": orjson.dumps([{"name": "test_patch_sub_by_id"}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+
+        stream = get_stream("test_patch_sub_by_id", user.realm)
+
+        # Unsubscribe so we can re-subscribe via PATCH.
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps([stream.id]).decode()},
+        )
+        self.assert_json_success(result)
+
+        # Re-subscribe by stream_id via PATCH.
+        request = {
+            "add": orjson.dumps([{"stream_id": stream.id}]).decode(),
+        }
+        result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
+        self.assert_json_success(result)
+        self.assertIn("test_patch_sub_by_id", self.get_streams(user))
+
+    def test_unsubscribe_by_stream_id(self) -> None:
+        """Test that DELETE /users/me/subscriptions accepts stream IDs."""
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        stream_name = "test_unsub_by_id"
+        self.make_stream(stream_name)
+        self.subscribe(user, stream_name)
+
+        stream = get_stream(stream_name, user.realm)
+
+        # Unsubscribe using stream ID
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps([stream.id]).decode()},
+        )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 1)
+        self.assertEqual(json["removed"][0], stream_name)
+
+    def test_unsubscribe_by_invalid_stream_id(self) -> None:
+        """Test that unsubscribing with a non-existent stream ID returns an error."""
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        # Use a stream ID that doesn't exist
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps([99999]).decode()},
+        )
+        self.assert_json_error(result, "Invalid channel ID: 99999")
+
+    def test_unsubscribe_by_mixed_id_and_name(self) -> None:
+        """Test that a single unsubscribe call can mix stream IDs and names."""
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        stream_name_1 = "mixed_unsub_stream_1"
+        stream_name_2 = "mixed_unsub_stream_2"
+        self.make_stream(stream_name_1)
+        self.make_stream(stream_name_2)
+        self.subscribe(user, stream_name_1)
+        self.subscribe(user, stream_name_2)
+
+        stream_1 = get_stream(stream_name_1, user.realm)
+
+        # Unsubscribe: stream_1 by ID, stream_2 by name
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps([stream_1.id, stream_name_2]).decode()},
+        )
+        json = self.assert_json_success(result)
+        self.assert_length(json["removed"], 2)
+        self.assertIn(stream_name_1, json["removed"])
+        self.assertIn(stream_name_2, json["removed"])
+
     def test_add_with_color(self) -> None:
         user = self.example_user("hamlet")
         self.login_user(user)
@@ -3523,7 +3664,10 @@ class SubscriptionRestApiTest(ZulipTestCase):
             ["foo"],
             "Invalid add[0]: Input should be a valid dictionary or instance of AddSubscriptionData",
         )
-        check_for_error([{"bogus": "foo"}], 'add[0]["name"] field is missing: Field required')
+        check_for_error(
+            [{"bogus": "foo"}],
+            'Invalid add[0]: Value error, One of "name" or "stream_id" must be provided',
+        )
         check_for_error([{"name": {}}], 'add[0]["name"] is not a string')
 
     def test_bad_principals(self) -> None:
@@ -3545,7 +3689,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
             "delete": orjson.dumps([{"name": "my_test_stream_1"}]).decode(),
         }
         result = self.api_patch(user, "/api/v1/users/me/subscriptions", request)
-        self.assert_json_error(result, "delete[0] is not a string")
+        self.assert_json_error(result, 'delete[0]["str"] is not a string')
 
     def test_add_or_delete_not_specified(self) -> None:
         user = self.example_user("hamlet")

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -553,12 +553,15 @@ def list_subscriptions_backend(
 
 
 class AddSubscriptionData(BaseModel):
-    name: str
+    name: str | None = None
+    stream_id: int | None = None
     color: str | None = None
     description: ChannelDescription = None
 
     @model_validator(mode="after")
     def validate_terms(self) -> "AddSubscriptionData":
+        if self.name is None and self.stream_id is None:
+            raise ValueError('One of "name" or "stream_id" must be provided')
         if self.color is not None:
             self.color = check_color("add.color", self.color)
         return self
@@ -570,7 +573,7 @@ def update_subscriptions_backend(
     user_profile: UserProfile,
     *,
     add: Json[list[AddSubscriptionData]] | None = None,
-    delete: Json[list[str]] | None = None,
+    delete: Json[list[str | int]] | None = None,
 ) -> HttpResponse:
     if delete is None:
         delete = []
@@ -611,13 +614,16 @@ def remove_subscriptions_backend(
     user_profile: UserProfile,
     *,
     principals: Json[list[str] | list[int]] | None = None,
-    streams_raw: Annotated[Json[list[str]], ApiParamConfig("subscriptions")],
+    streams_raw: Annotated[Json[list[str | int]], ApiParamConfig("subscriptions")],
 ) -> HttpResponse:
     realm = user_profile.realm
 
-    streams_as_dict: list[StreamDict] = [
-        {"name": stream_name.strip()} for stream_name in streams_raw
-    ]
+    streams_as_dict: list[StreamDict] = []
+    for stream in streams_raw:
+        if isinstance(stream, int):
+            streams_as_dict.append({"stream_id": stream})
+        else:
+            streams_as_dict.append({"name": stream.strip()})
 
     unsubscribing_others = False
     if principals:
@@ -852,10 +858,22 @@ def add_subscriptions_backend(
         # 'color' field is optional
         # check for its presence in the streams_raw first
         if stream_obj.color is not None:
-            color_map[stream_obj.name] = stream_obj.color
+            # Use stream name as color_map key when available,
+            # fall back to stream_id string for ID-only subscriptions.
+            color_key = (
+                stream_obj.name if stream_obj.name is not None else str(stream_obj.stream_id)
+            )
+            color_map[color_key] = stream_obj.color
 
         stream_dict_copy: StreamDict = {}
-        stream_dict_copy["name"] = stream_obj.name.strip()
+
+        # Support subscribing by stream_id (for existing streams) or
+        # by name (for existing or new streams). When stream_id is
+        # provided, list_to_streams will use it for lookup.
+        if stream_obj.stream_id is not None:
+            stream_dict_copy["stream_id"] = stream_obj.stream_id
+        if stream_obj.name is not None:
+            stream_dict_copy["name"] = stream_obj.name.strip()
 
         if stream_obj.description is not None:
             stream_dict_copy["description"] = stream_obj.description


### PR DESCRIPTION
Fixes #10744.

## Summary

The subscribe/unsubscribe APIs previously accessed channels only by name, which caused a real bug when third-party imports (e.g., HipChat) created duplicate channel names — one active, one archived. The API would match both, silently subscribing/unsubscribing users from the wrong channel.

This PR updates the API to accept **channel IDs (integers)** alongside channel names (strings), and switches the frontend to send IDs for resilience against renames and name collisions.

## Changes

### Backend
- **`zerver/lib/streams.py`**: Added optional `stream_id` to `StreamDict` and refactored `list_to_streams` to support both ID-based and name-based lookups.
- **`zerver/views/streams.py`**: Updated `remove_subscriptions_backend` and `update_subscriptions_backend` to accept `list[str | int]`. Added optional `stream_id` to `AddSubscriptionData` for the subscribe endpoint.

### Frontend
- **`web/src/stream_settings_components.ts`**: `ajaxUnsubscribe` now sends `sub.stream_id` instead of `sub.name`.

### API Documentation
- **`zerver/openapi/zulip.yaml`**: Updated schemas for POST, PATCH, and DELETE `/users/me/subscriptions` to document the new stream ID support.

### Tests
- Added 4 new tests: `test_basic_add_delete_by_id`, `test_unsubscribe_by_stream_id`, `test_unsubscribe_by_invalid_stream_id`,
  `test_unsubscribe_by_mixed_id_and_name`.
- Updated 2 existing tests for new validation error messages.
- All 129 tests in `test_subs.py` pass. mypy: 0 errors in 2073 files.

## Demo

### Unsubscribe via Network Tab (Frontend sends stream ID)

https://github.com/user-attachments/assets/35483106-4131-4ac0-84d0-62e96a4db728



### API Testing via Terminal (curl)


https://github.com/user-attachments/assets/1998a533-3416-4ce9-b622-c82aa78ebf47

