### PR TITLE
markdown: Add support for Asana Desktop deeplinks.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -101,8 +101,9 @@ html_safelisted_schemes = (
     "wtai",
     "xmpp",
     "zotero",
+    "asanadesktop",
 )
-auto_linked_schemes = ["https?", "hansoft", "obsidian", "zotero"]
+auto_linked_schemes = ["https?", "hansoft", "obsidian", "zotero", "asanadesktop"]
 allowed_schemes = ("http", "https", "ftp", "file", "mid", *html_safelisted_schemes)
 
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1090,6 +1090,11 @@
       "name": "RFC2392 mid links with part ID (markdown syntax)",
       "input": "[message](mid:960830.1639@XIson.com/partA.960830.1639@XIson.com)",
       "expected_output": "<p><a href=\"mid:960830.1639@XIson.com/partA.960830.1639@XIson.com\">message</a></p>"
+    },
+    {
+      "name": "explicit_link_asana_desktop",
+      "input": "[Asana Task](asanadesktop://task/123456789)",
+      "expected_output": "<p><a href=\"asanadesktop://task/123456789\">Asana Task</a></p>"
     }
   ],
   "linkify_tests": [
@@ -1482,6 +1487,11 @@
       "hansoft://Project/Task/12345",
       "<p>%s</p>",
       "hansoft://Project/Task/12345"
+    ],
+    [
+      "asanadesktop://task/123456789",
+      "<p>%s</p>",
+      "asanadesktop://task/123456789"
     ]
   ]
 }


### PR DESCRIPTION
Currently, users cannot click on `asanadesktop://` links in Zulip messages to open tasks directly in the Asana desktop app because the scheme is not recognized by the markdown parser.

Following the approach used for other desktop apps like Obsidian and Hansoft, this PR adds `asanadesktop` to both `html_safelisted_schemes` and `auto_linked_schemes` in `zerver/lib/markdown/__init__.py`. This allows Asana URLs to linkify automatically and fully supports explicit Markdown link syntax.

Fixes: #38739.

**How changes were tested:**
* Added test cases to `zerver/tests/fixtures/markdown_test_cases.json` for both explicit linking (`[text](asanadesktop://...)`) and auto-linking.
* Ran `./tools/test-backend zerver/tests/test_markdown.py` and the full backend test suite to ensure all markdown rules pass.
* Manually tested in the local development environment by sending `asanadesktop://task/12345` and `[Asana](asanadesktop://task/12345)` in the compose box and verifying they render as valid, clickable links that trigger the browser's app-handler prompt.


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
1. Before
<img width="892" height="349" alt="image" src="https://github.com/user-attachments/assets/ce309d64-398e-4359-81bf-55374210e52d" />

2. After
<img width="887" height="306" alt="image" src="https://github.com/user-attachments/assets/4ff6fcc0-235e-40c3-8e29-dff6e0dd0240" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
