### PR TITLE
custom_profile_fields: Refactor internal constants and update docs.

### DIFF
--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -32,9 +32,9 @@ export function append_custom_profile_fields(element_id: string, user_id: number
     const all_field_types = realm.custom_profile_field_types;
 
     const all_field_template_types = new Map([
-        [all_field_types.LONG_TEXT.id, "text"],
+        [all_field_types.PARAGRAPH.id, "text"],
         [all_field_types.SHORT_TEXT.id, "text"],
-        [all_field_types.SELECT.id, "select"],
+        [all_field_types.DROPDOWN.id, "select"],
         [all_field_types.USER.id, "user"],
         [all_field_types.DATE.id, "date"],
         [all_field_types.EXTERNAL_ACCOUNT.id, "text"],
@@ -48,7 +48,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
             rendered_value: "",
         };
         const editable_by_user = current_user.is_admin || field.editable_by_user;
-        const is_select_field = field.type === all_field_types.SELECT.id;
+        const is_select_field = field.type === all_field_types.DROPDOWN.id;
         const field_choices = [];
 
         if (is_select_field) {
@@ -68,7 +68,7 @@ export function append_custom_profile_fields(element_id: string, user_id: number
             field,
             field_type: all_field_template_types.get(field.type),
             field_value,
-            is_long_text_field: field.type === all_field_types.LONG_TEXT.id,
+            is_long_text_field: field.type === all_field_types.PARAGRAPH.id,
             is_user_field: field.type === all_field_types.USER.id,
             is_date_field: field.type === all_field_types.DATE.id,
             is_url_field: field.type === all_field_types.URL.id,

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -485,7 +485,7 @@ export function read_field_data_from_form(
     const field_types = realm.custom_profile_field_types;
 
     // Only the following field types support associated field data.
-    if (field_type_id === field_types.SELECT.id) {
+    if (field_type_id === field_types.DROPDOWN.id) {
         return read_select_field_data_from_form($profile_field_form, old_field_data);
     } else if (field_type_id === field_types.EXTERNAL_ACCOUNT.id) {
         const parsed_old_field_data = old_field_data

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -303,7 +303,7 @@ function update_form_for_field_type_selection(): void {
             $("#profile_field_hint").val(default_hint);
             break;
         }
-        case field_types.SELECT.id: {
+        case field_types.DROPDOWN.id: {
             $("#profile_field_choices_row").show();
         }
     }
@@ -612,7 +612,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
         field_data = JSON.parse(field.field_data);
     }
     let choices: FieldChoice[] = [];
-    if (field.type === field_types.SELECT.id) {
+    if (field.type === field_types.DROPDOWN.id) {
         const select_field_data = settings_components.select_field_data_schema.parse(field_data);
         choices = parse_field_choices_from_field_data(select_field_data);
     }
@@ -627,7 +627,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
             required: field.required,
             editable_by_user: field.editable_by_user,
             use_for_user_matching: field.use_for_user_matching,
-            is_select_field: field.type === field_types.SELECT.id,
+            is_select_field: field.type === field_types.DROPDOWN.id,
             is_external_account_field: field.type === field_types.EXTERNAL_ACCOUNT.id,
             valid_to_display_in_summary: is_valid_to_display_in_summary(field.type),
             valid_to_use_for_user_matching: is_valid_to_use_for_user_matching(field.type),
@@ -649,7 +649,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
                 .addClass("display_in_profile_summary_tooltip disabled_label");
         }
 
-        if (field.type === field_types.SELECT.id) {
+        if (field.type === field_types.DROPDOWN.id) {
             set_up_select_field_edit_form($profile_field_form, field);
         }
 
@@ -729,7 +729,7 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
             dialog_widget.submit_api_request(channel.patch, url, data, opts);
         }
 
-        if (field.type === field_types.SELECT.id && data["field_data"] !== undefined) {
+        if (field.type === field_types.DROPDOWN.id && data["field_data"] !== undefined) {
             const new_values = new Set(
                 Object.keys(
                     settings_components.select_field_data_schema.parse(
@@ -874,7 +874,7 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
         },
         modifier_html(profile_field) {
             let choices: FieldChoice[] = [];
-            if (profile_field.field_data && profile_field.type === field_types.SELECT.id) {
+            if (profile_field.field_data && profile_field.type === field_types.DROPDOWN.id) {
                 const field_data = settings_components.select_field_data_schema.parse(
                     JSON.parse(profile_field.field_data),
                 );
@@ -891,7 +891,7 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
                     hint: profile_field.hint,
                     type: field_type_id_to_string(profile_field.type),
                     choices,
-                    is_select_field: profile_field.type === field_types.SELECT.id,
+                    is_select_field: profile_field.type === field_types.DROPDOWN.id,
                     is_external_account_field:
                         profile_field.type === field_types.EXTERNAL_ACCOUNT.id,
                     display_in_profile_summary,

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -122,13 +122,6 @@ let order: number[] = [];
 export function field_type_id_to_string(type_id: number): string | undefined {
     for (const field_type of Object.values(realm.custom_profile_field_types)) {
         if (field_type.id === type_id) {
-            // Few necessary modifications in field-type-name for
-            // table-list view of custom fields UI in org settings
-            if (field_type.name === "Date picker") {
-                return "Date";
-            } else if (field_type.name === "Person picker") {
-                return "Person";
-            }
             return field_type.name;
         }
     }

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -382,9 +382,9 @@ const current_user_schema = z.object({
 
 const custom_profile_field_types_schema = z.object({
     SHORT_TEXT: z.object({id: z.number(), name: z.string()}),
-    LONG_TEXT: z.object({id: z.number(), name: z.string()}),
+    PARAGRAPH: z.object({id: z.number(), name: z.string()}),
     DATE: z.object({id: z.number(), name: z.string()}),
-    SELECT: z.object({id: z.number(), name: z.string()}),
+    DROPDOWN: z.object({id: z.number(), name: z.string()}),
     URL: z.object({id: z.number(), name: z.string()}),
     EXTERNAL_ACCOUNT: z.object({id: z.number(), name: z.string()}),
     USER: z.object({id: z.number(), name: z.string()}),

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -489,7 +489,7 @@ export function get_custom_profile_field_data(
         is_user_field: false,
         is_link: field_type === field_types.URL.id,
         is_external_account: field_type === field_types.EXTERNAL_ACCOUNT.id,
-        is_long_text: field_type === field_types.LONG_TEXT.id,
+        is_long_text: field_type === field_types.PARAGRAPH.id,
         type: field_type,
         display_in_profile_summary: field.display_in_profile_summary,
         required: field.required,
@@ -506,7 +506,7 @@ export function get_custom_profile_field_data(
             profile_field.is_user_field = true;
             profile_field.value = field_value.value;
             break;
-        case field_types.SELECT.id: {
+        case field_types.DROPDOWN.id: {
             const field_choice_dict = settings_components.select_field_data_schema.parse(
                 JSON.parse(field.field_data),
             );
@@ -514,7 +514,7 @@ export function get_custom_profile_field_data(
             break;
         }
         case field_types.SHORT_TEXT.id:
-        case field_types.LONG_TEXT.id:
+        case field_types.PARAGRAPH.id:
             profile_field.value = field_value.value;
             profile_field.rendered_value = field_value.rendered_value;
             break;

--- a/web/tests/settings_profile_fields.test.cjs
+++ b/web/tests/settings_profile_fields.test.cjs
@@ -10,15 +10,15 @@ const loading = mock_esm("../src/loading");
 
 const SHORT_TEXT_ID = 1;
 
-const SELECT_ID = 3;
+const DROPDOWN_ID = 3;
 const EXTERNAL_ACCOUNT_ID = 7;
-const LONG_TEXT_ID = 2;
+const PARAGRAPH_ID = 2;
 const USER_FIELD_ID = 6;
 
 const SHORT_TEXT_NAME = "Short text";
-const SELECT_NAME = "Dropdown";
+const DROPDOWN_NAME = "Dropdown";
 const EXTERNAL_ACCOUNT_NAME = "External account";
-const LONG_TEXT_NAME = "Paragraph";
+const PARAGRAPH_NAME = "Paragraph";
 const USER_FIELD_NAME = "Person";
 
 const custom_profile_field_types = {
@@ -26,17 +26,17 @@ const custom_profile_field_types = {
         id: SHORT_TEXT_ID,
         name: SHORT_TEXT_NAME,
     },
-    SELECT: {
-        id: SELECT_ID,
-        name: SELECT_NAME,
+    DROPDOWN: {
+        id: DROPDOWN_ID,
+        name: DROPDOWN_NAME,
     },
     EXTERNAL_ACCOUNT: {
         id: EXTERNAL_ACCOUNT_ID,
         name: EXTERNAL_ACCOUNT_NAME,
     },
-    LONG_TEXT: {
-        id: LONG_TEXT_ID,
-        name: LONG_TEXT_NAME,
+    PARAGRAPH: {
+        id: PARAGRAPH_ID,
+        name: PARAGRAPH_NAME,
     },
     USER: {
         id: USER_FIELD_ID,
@@ -105,7 +105,7 @@ run_test("populate_profile_fields", ({mock_template, override}) => {
             required: false,
         },
         {
-            type: SELECT_ID,
+            type: DROPDOWN_ID,
             id: 30,
             name: "meal",
             hint: "lunch",
@@ -171,7 +171,7 @@ run_test("populate_profile_fields", ({mock_template, override}) => {
                 id: 30,
                 name: "meal",
                 hint: "lunch",
-                type: SELECT_NAME,
+                type: DROPDOWN_NAME,
                 choices: [
                     {order: "0", value: "0", text: "lunch"},
                     {order: "1", value: "1", text: "dinner"},

--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -74,7 +74,7 @@ def try_add_realm_custom_profile_field(
     )
     custom_profile_field.hint = hint
     if custom_profile_field.field_type in (
-        CustomProfileField.SELECT,
+        CustomProfileField.DROPDOWN,
         CustomProfileField.EXTERNAL_ACCOUNT,
     ):
         custom_profile_field.field_data = orjson.dumps(field_data or {}).decode()
@@ -137,12 +137,12 @@ def try_update_realm_custom_profile_field(
         field.use_for_user_matching = use_for_user_matching
 
     if field.field_type in (
-        CustomProfileField.SELECT,
+        CustomProfileField.DROPDOWN,
         CustomProfileField.EXTERNAL_ACCOUNT,
     ):
         # If field_data is None, field_data is unchanged and there is no need for
         # comparing field_data values.
-        if field_data is not None and field.field_type == CustomProfileField.SELECT:
+        if field_data is not None and field.field_type == CustomProfileField.DROPDOWN:
             remove_custom_profile_field_value_if_required(field, field_data)
 
         # If field.field_data is the default empty string, we will set field_data
@@ -246,7 +246,7 @@ def get_custom_profile_field_display_value(field_value: CustomProfileFieldValue)
         return ""
     type = field_value.field.field_type
 
-    if type == CustomProfileField.SELECT:
+    if type == CustomProfileField.DROPDOWN:
         field_data_dict = orjson.loads(field_value.field.field_data)
         value_key = field_value.value
         return field_data_dict[value_key]["text"]

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -527,7 +527,7 @@ def validate_user_custom_profile_field(
     if field_type in validators:
         validator = validators[field_type]
         return validator(var_name, value)
-    elif field_type == CustomProfileField.SELECT:
+    elif field_type == CustomProfileField.DROPDOWN:
         choice_field_validator = CustomProfileField.SELECT_FIELD_VALIDATORS[field_type]
         field_data = field.field_data
         # Put an assertion so that mypy doesn't complain.

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -90,8 +90,8 @@ class CustomProfileField(models.Model):
     editable_by_user = models.BooleanField(default=True, db_default=True)
 
     SHORT_TEXT = 1
-    LONG_TEXT = 2
-    SELECT = 3
+    PARAGRAPH = 2
+    DROPDOWN = 3
     DATE = 4
     URL = 5
     USER = 6
@@ -99,10 +99,10 @@ class CustomProfileField(models.Model):
     PRONOUNS = 8
 
     # These are the fields whose validators require more than var_name
-    # and value argument. i.e. SELECT require field_data, USER require
+    # and value argument. i.e. DROPDOWN require field_data, USER require
     # realm as argument.
     SELECT_FIELD_TYPE_DATA: list[ExtendedFieldElement] = [
-        (SELECT, gettext_lazy("Dropdown"), validate_select_field, str, "SELECT"),
+        (DROPDOWN, gettext_lazy("Dropdown"), validate_select_field, str, "DROPDOWN"),
     ]
     USER_FIELD_TYPE_DATA: list[UserFieldElement] = [
         (USER, gettext_lazy("Users"), check_valid_user_ids, orjson.loads, "USER"),
@@ -118,7 +118,7 @@ class CustomProfileField(models.Model):
     FIELD_TYPE_DATA: list[FieldElement] = [
         # Type, display name, validator, converter, keyword
         (SHORT_TEXT, gettext_lazy("Short text"), check_short_string, str, "SHORT_TEXT"),
-        (LONG_TEXT, gettext_lazy("Paragraph"), check_long_string, str, "LONG_TEXT"),
+        (PARAGRAPH, gettext_lazy("Paragraph"), check_long_string, str, "PARAGRAPH"),
         (DATE, gettext_lazy("Date"), check_date, str, "DATE"),
         (URL, gettext_lazy("Link"), check_url, str, "URL"),
         (
@@ -153,8 +153,8 @@ class CustomProfileField(models.Model):
     # A JSON blob of any additional data needed to define the field beyond
     # type/name/hint.
     #
-    # The format depends on the type.  Field types SHORT_TEXT, LONG_TEXT,
-    # DATE, URL, and USER leave this empty.  Fields of type SELECT store the
+    # The format depends on the type.  Field types SHORT_TEXT, PARAGRAPH,
+    # DATE, URL, and USER leave this empty.  Fields of type DROPDOWN store the
     # choices' descriptions.
     #
     # Note: There is no performance overhead of using TextField in PostgreSQL.
@@ -187,7 +187,7 @@ class CustomProfileField(models.Model):
         return data_as_dict
 
     def is_renderable(self) -> bool:
-        if self.field_type in [CustomProfileField.SHORT_TEXT, CustomProfileField.LONG_TEXT]:
+        if self.field_type in [CustomProfileField.SHORT_TEXT, CustomProfileField.PARAGRAPH]:
             return True
         return False
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17858,9 +17858,9 @@ paths:
                             property itself. The current supported field types are as follows:
 
                             - `SHORT_TEXT`
-                            - `LONG_TEXT`
+                            - `PARAGRAPH`
                             - `DATE` for date-based fields.
-                            - `SELECT` for a list of options.
+                            - `DROPDOWN` for a list of options.
                             - `URL` for links.
                             - `EXTERNAL_ACCOUNT` for external accounts.
                             - `USER` for selecting a user for the field.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14786,9 +14786,9 @@ paths:
                     - **1**: Short text
                     - **2**: Paragraph
                     - **3**: Dropdown
-                    - **4**: Date picker
+                    - **4**: Date
                     - **5**: Link
-                    - **6**: Person picker
+                    - **6**: Users
                     - **7**: External account
                     - **8**: Pronouns
 
@@ -14819,7 +14819,7 @@ paths:
                     At most 2 profile fields may have this property be true in a given
                     organization.
 
-                    The "Person picker" profile field is not supported, but that is likely to
+                    The "Users" profile field is not supported, but that is likely to
                     be temporary.
 
                     [profile-field-types]: /help/custom-profile-fields#profile-field-types
@@ -27166,9 +27166,9 @@ components:
             - **1**: Short text
             - **2**: Paragraph
             - **3**: Dropdown
-            - **4**: Date picker
+            - **4**: Date
             - **5**: Link
-            - **6**: Person picker
+            - **6**: Users
             - **7**: External account
             - **8**: Pronouns
 
@@ -27203,7 +27203,7 @@ components:
           description: |
             Whether the custom profile field, display or not on the user card.
 
-            Must be false for `Person picker`
+            Must be false for `Users`
             [profile field types](/help/custom-profile-fields#profile-field-types).
 
             This field is only included when its value is `true`.

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -96,7 +96,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         data["name"] = "Phone"
         data["hint"] = "Contact number"
-        data["field_type"] = CustomProfileField.LONG_TEXT
+        data["field_type"] = CustomProfileField.PARAGRAPH
         data["use_for_user_matching"] = "true"
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_error(result, "Field type not supported for use for user matching.")
@@ -105,7 +105,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.login("iago")
         data: dict[str, str | int] = {}
         data["name"] = "Favorite programming language"
-        data["field_type"] = CustomProfileField.SELECT
+        data["field_type"] = CustomProfileField.DROPDOWN
 
         data["field_data"] = "invalid"
         result = self.client_post("/json/realm/profile_fields", info=data)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1728,7 +1728,7 @@ class NormalActionsTest(BaseAction):
 
         with self.verify_action() as events:
             try_add_realm_custom_profile_field(
-                realm=realm, name="Expertise", field_type=CustomProfileField.LONG_TEXT
+                realm=realm, name="Expertise", field_type=CustomProfileField.PARAGRAPH
             )
         check_custom_profile_fields("events[0]", events[0])
 

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -52,7 +52,7 @@ def validate_field_name_and_hint(name: str, hint: str) -> None:
 
 def validate_custom_field_data(field_type: int, field_data: ProfileFieldData) -> None:
     try:
-        if field_type == CustomProfileField.SELECT:
+        if field_type == CustomProfileField.DROPDOWN:
             # Choice type field must have at least have one choice
             if len(field_data) < 1:
                 raise JsonableError(_("Field must have at least one choice."))

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -797,7 +797,7 @@ class Command(ZulipBaseCommand):
             biography = try_add_realm_custom_profile_field(
                 zulip_realm,
                 "Biography",
-                CustomProfileField.LONG_TEXT,
+                CustomProfileField.PARAGRAPH,
                 hint="What are you known for?",
             )
             favorite_food = try_add_realm_custom_profile_field(
@@ -811,7 +811,7 @@ class Command(ZulipBaseCommand):
                 "1": {"text": "Emacs", "order": "2"},
             }
             favorite_editor = try_add_realm_custom_profile_field(
-                zulip_realm, "Favorite editor", CustomProfileField.SELECT, field_data=field_data
+                zulip_realm, "Favorite editor", CustomProfileField.DROPDOWN, field_data=field_data
             )
             birthday = try_add_realm_custom_profile_field(
                 zulip_realm, "Birthday", CustomProfileField.DATE

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1781,7 +1781,7 @@ def validate_custom_profile_field_data_for_sync(
         # a mostly-successful sync instead of failing with an error.
         text_field_max_length = {
             CustomProfileField.SHORT_TEXT: SHORT_STRING_MAX_LENGTH,
-            CustomProfileField.LONG_TEXT: LONG_STRING_MAX_LENGTH,
+            CustomProfileField.PARAGRAPH: LONG_STRING_MAX_LENGTH,
         }.get(field.field_type)
         if (
             isinstance(value, str)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR rebases #37430 against main. 
It also removed 3 additional files accidently added in the 3rd commit:
- web/src/composebox_typeahead.ts
- web/src/typeahead_helper.ts
- web/tests/typeahead_helper.test.cjs

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1590" height="1009" alt="image" src="https://github.com/user-attachments/assets/32b3ac38-dc27-4d18-be04-8203b571c171" />
<img width="801" height="705" alt="image" src="https://github.com/user-attachments/assets/29513148-d2e7-49ba-b1eb-55b5b06781f2" />
Have also verified by creating fields using "Date", "Users", and "Paragraph" types.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
