### PR TITLE
user_topics: Replace dict[str, Any] with UserTopicEvent TypedDict.

### DIFF
--- a/zerver/actions/user_topics.py
+++ b/zerver/actions/user_topics.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from typing import Any
+from typing import Literal
 
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
+from typing_extensions import TypedDict
 
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import maybe_rename_general_chat_to_empty_topic
@@ -12,6 +13,14 @@ from zerver.lib.user_topics import (
 )
 from zerver.models import Stream, UserProfile
 from zerver.tornado.django_api import send_event_on_commit
+
+
+class UserTopicEvent(TypedDict):
+    type: Literal["user_topic"]
+    stream_id: int
+    topic_name: str
+    last_updated: float
+    visibility_policy: int
 
 
 @transaction.atomic(savepoint=False)
@@ -54,7 +63,7 @@ def bulk_do_set_user_topic_visibility_policy(
             )
             send_event_on_commit(user_profile.realm, muted_topics_event, [user_profile.id])
 
-        user_topic_event: dict[str, Any] = {
+        user_topic_event: UserTopicEvent = {
             "type": "user_topic",
             "stream_id": stream.id,
             "topic_name": topic_name,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR replaces the `dict[str, Any]` in `user_topic_event`
with a properly typed `UserTopicEvent` TypedDict in
`zerver/actions/user_topics.py`. It is part of an effort for the GSoC
project idea "Replace hundreds of dict[str, Any] types with modern
dataclasses" to promote type safety and future maintainability.

Fixes: <!-- Issue link, or clear description.-->
Changes made:
- Added `UserTopicEvent` TypedDict in `zerver/actions/user_topics.py`.
- Replaced `dict[str, Any]` annotation on `user_topic_event` with
  `UserTopicEvent`.

**How changes were tested:**
- ./tools/test-backend zerver.tests.test_user_topics
- ./tools/run-mypy zerver/actions/user_topics.py
- ./tools/lint zerver/actions/user_topics.py

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
N/A

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
