### PR TITLE
[ai] Update /integrations and /communities styles

### DIFF
--- a/templates/corporate/communities.html
+++ b/templates/corporate/communities.html
@@ -36,14 +36,12 @@
                         <i class="fa fa-angle-down" aria-hidden="true"></i>
                     </div>
                     <div class="dropdown-list">
-                        <a href="#all">
-                            <h4 class="realm-category selected" data-category="all">All</h4>
+                        <a href="#all" class="realm-category selected" data-category="all">
+                            {% trans %}All{% endtrans %}
                         </a>
                         {% for org_type in org_types.keys() %}
-                        <a href="#{{ org_type }}">
-                            <h4 class="realm-category" data-category="{{ org_type }}">
-                                {{ org_types[org_type]["name"] }}
-                            </h4>
+                        <a href="#{{ org_type }}" class="realm-category" data-category="{{ org_type }}">
+                            {{ org_types[org_type]["name"] }}
                         </a>
                         {% endfor %}
                     </div>
@@ -52,14 +50,12 @@
                 <div class="catalog">
                     <div class="integration-categories-sidebar">
                         <h3>{% trans %}Categories{% endtrans %}</h3>
-                        <a href="#all">
-                            <h4 data-category="all" class="realm-category selected">{% trans %}All{% endtrans %}</h4>
+                        <a href="#all" data-category="all" class="realm-category selected">
+                            {% trans %}All{% endtrans %}
                         </a>
                         {% for org_type in org_types.keys() %}
-                        <a href="#{{ org_type }}">
-                            <h4 data-category="{{ org_type }}" class="realm-category">
-                                {{  org_types[org_type]["name"] }}
-                            </h4>
+                        <a href="#{{ org_type }}" data-category="{{ org_type }}" class="realm-category">
+                            {{ org_types[org_type]["name"] }}
                         </a>
                         {% endfor %}
                     </div>

--- a/templates/corporate/communities.html
+++ b/templates/corporate/communities.html
@@ -12,7 +12,6 @@
 {% block portico_content %}
 
 {% include 'zerver/marketing_nav.html' %}
-{% include 'zerver/gradients.html' %}
 
 <div class="portico-landing integrations communities">
     <div class="main">

--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -22,14 +22,14 @@
                             {% trans %}Over {{integrations_count_display}} native integrations.{% endtrans %}
                         </h1>
                     </header>
-                    <h2 class="portico-page-subheading">
+                    <p class="portico-page-subheading">
                         {% trans %}
                         And hundreds more through
                         <a href="/integrations/zapier">Zapier</a>
                         and
                         <a href="/integrations/ifttt">IFTTT</a>.
                         {% endtrans %}
-                    </h2>
+                    </p>
                 </div>
 
                 <div id="integration-search">
@@ -51,25 +51,23 @@
                         <i class="fa fa-angle-down" aria-hidden="true"></i>
                     </div>
                     <div class="dropdown-list">
-                        <a href="/integrations/">
-                            <h4 class="integration-category {% if selected_category_slug == 'all' %}selected{% endif %}" data-category="all">All</h4>
+                        <a href="/integrations/" class="integration-category {% if selected_category_slug == 'all' %}selected{% endif %}" data-category="all">
+                            {% trans %}All{% endtrans %}
                         </a>
                         {% for category in categories_dict.keys() %}
-                        <a href="/integrations/category/{{ category }}">
-                            <h4 class="integration-category {% if selected_category_slug == category %}selected{% endif %}" data-category="{{ category }}">
-                                {{ categories_dict[category] }}
-                            </h4>
+                        <a href="/integrations/category/{{ category }}" class="integration-category {% if selected_category_slug == category %}selected{% endif %}" data-category="{{ category }}">
+                            {{ categories_dict[category] }}
                         </a>
                         {% endfor %}
-                        <h4 class="heading">{% trans %}Custom integrations{% endtrans %}</h4>
+                        <h3 class="heading">{% trans %}Custom integrations{% endtrans %}</h3>
                         <a href="https://zulip.readthedocs.io/en/latest/webhooks/incoming-webhooks-overview.html">
-                            <h4>{% trans %}Incoming webhooks{% endtrans %}</h4>
+                            {% trans %}Incoming webhooks{% endtrans %}
                         </a>
                         <a href="/help/writing-bots">
-                            <h4>{% trans %}Interactive bots{% endtrans %}</h4>
+                            {% trans %}Interactive bots{% endtrans %}
                         </a>
                         <a href="/api/rest">
-                            <h4>{% trans %}REST API{% endtrans %}</h4>
+                            {% trans %}REST API{% endtrans %}
                         </a>
                     </div>
                 </div>
@@ -77,25 +75,23 @@
                 <div class="catalog">
                     <div class="integration-categories-sidebar">
                         <h3>{% trans %}Categories{% endtrans %}</h3>
-                        <a href="/integrations/">
-                            <h4 data-category="all" class="integration-category {% if selected_category_slug == 'all' %}selected{% endif %}">{% trans %}All{% endtrans %}</h4>
+                        <a href="/integrations/" data-category="all" class="integration-category {% if selected_category_slug == 'all' %}selected{% endif %}">
+                            {% trans %}All{% endtrans %}
                         </a>
                         {% for category in categories_dict.keys() %}
-                        <a href="/integrations/category/{{ category }}">
-                            <h4 data-category="{{ category }}" class="integration-category {% if selected_category_slug == category %}selected{% endif %}">
-                                {{ categories_dict[category] }}
-                            </h4>
+                        <a href="/integrations/category/{{ category }}" data-category="{{ category }}" class="integration-category {% if selected_category_slug == category %}selected{% endif %}">
+                            {{ categories_dict[category] }}
                         </a>
                         {% endfor %}
                         <h3>{% trans %}Custom integrations{% endtrans %}</h3>
                         <a href="https://zulip.readthedocs.io/en/latest/webhooks/incoming-webhooks-overview.html">
-                            <h4>{% trans %}Incoming webhooks{% endtrans %}</h4>
+                            {% trans %}Incoming webhooks{% endtrans %}
                         </a>
                         <a href="/help/writing-bots">
-                            <h4>{% trans %}Interactive bots{% endtrans %}</h4>
+                            {% trans %}Interactive bots{% endtrans %}
                         </a>
                         <a href="/api/rest">
-                            <h4>{% trans %}REST API{% endtrans %}</h4>
+                            {% trans %}REST API{% endtrans %}
                         </a>
                     </div>
 

--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -36,7 +36,7 @@
                 <div id="integration-search">
                     <div class="searchbar">
                         <div class="searchbar-reset">
-                            <i class="fa fa-search" aria-hidden="true"></i>
+                            <i class="zulip-icon zulip-icon-search" aria-hidden="true"></i>
                             <input type="text" class="search_input" placeholder="{{ _('Search integrations') }}"/>
                         </div>
                     </div>

--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -10,7 +10,6 @@
 {% block portico_content %}
 
 {% include 'zerver/marketing_nav.html' %}
-{% include 'zerver/gradients.html' %}
 {% import 'zerver/integrations/macros.html' as integration_macros %}
 
 <div class="portico-landing integrations">

--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -106,18 +106,16 @@
                             {{ integration_macros.render_integration_lozenge(integration) }}
                         </a>
                         {% endfor %}
-                        <hr />
                         <div class="integration-request center">
                             <p>Don't see an integration you need? We'd love to help.</p>
-                            <a href="/api/integrations-overview" class="button green">
-                                Create your own
-                            </a>
-                            <span class="integration-divider">
-                                or
-                            </span>
-                            <a href="/help/request-an-integration" class="button green">
-                                Request an integration
-                            </a>
+                            <div class="hero-buttons center">
+                                <a href="/api/integrations-overview" class="button">
+                                    Create your own
+                                </a>
+                                <a href="/help/request-an-integration" class="button">
+                                    Request an integration
+                                </a>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -88,7 +88,6 @@
                             </h4>
                         </a>
                         {% endfor %}
-                        <hr />
                         <h3>{% trans %}Custom integrations{% endtrans %}</h3>
                         <a href="https://zulip.readthedocs.io/en/latest/webhooks/incoming-webhooks-overview.html">
                             <h4>{% trans %}Incoming webhooks{% endtrans %}</h4>

--- a/templates/zerver/integrations/doc.html
+++ b/templates/zerver/integrations/doc.html
@@ -30,8 +30,8 @@
                         </div>
                         {% endif %}
                         {{ integration_macros.render_integration_lozenge(selected_integration, is_doc_view=true) }}
-                        <a href="/integrations/{% if return_category_slug != 'all' %}category/{{ return_category_slug }}{% endif %}" id="integration-list-link" class="no-underline">
-                            <i class="fa fa-arrow-circle-left" aria-hidden="true"></i><span class="integrations-back-to-list-label">Back to list</span>
+                        <a href="/integrations/{% if return_category_slug != 'all' %}category/{{ return_category_slug }}{% endif %}" id="integration-list-link">
+                            <i class="zulip-icon zulip-icon-arrow-left" aria-hidden="true"></i><span class="integrations-back-label-long">{% trans %}Back to list{% endtrans %}</span><span class="integrations-back-label-short">{% trans %}Back{% endtrans %}</span>
                         </a>
                     </div>
 

--- a/templates/zerver/integrations/doc.html
+++ b/templates/zerver/integrations/doc.html
@@ -10,7 +10,6 @@
 {% block portico_content %}
 
 {% include 'zerver/marketing_nav.html' %}
-{% include 'zerver/gradients.html' %}
 {% import 'zerver/integrations/macros.html' as integration_macros %}
 
 <div class="portico-landing integrations">

--- a/web/src/bundles/integrations_bundle.ts
+++ b/web/src/bundles/integrations_bundle.ts
@@ -1,0 +1,8 @@
+import "./common.ts";
+import "../portico/header.ts";
+import "../portico/google-analytics.ts";
+import "../../styles/portico/portico_variables.css";
+import "../../styles/components.css";
+import "../../styles/portico/navbar.css";
+import "../../styles/portico/footer.css";
+import "../../styles/portico/markdown.css";

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -1,12 +1,6 @@
-:root {
-    --color-integrations-light-blue-border: hsl(208deg 46% 93%);
-    --color-integrations-border-green: hsl(170deg 47% 53%);
-    --color-integrations-hover-green: hsl(170deg 65% 85%);
-    --color-integrations-text-green: hsl(170deg 72% 32%);
-    --color-integrations-category-text: hsl(219deg 23% 33%);
-}
-
 .portico-landing.integrations {
+    --color-integrations-category-text: hsl(223deg 6% 35%);
+
     color: hsl(0deg 0% 27%);
     font-weight: normal;
 
@@ -70,8 +64,18 @@
         }
     }
 
+    /* Left-align the header block with the cards column, so the title,
+       subtitle, and search box don't spill into the sidebar area. The
+       sidebar column below takes 230px (200 sidebar + 30 gutter), so
+       we pad the header block to start at the same x-position as the
+       cards. At narrow widths, the sidebar is hidden and the header
+       reverts to its original near-full-width layout. */
     .integration-main-text {
-        padding: 0 15px;
+        padding: 0 30px 0 260px;
+
+        @media (width <= 1000px) {
+            padding: 0 30px;
+        }
     }
 
     .portico-page-heading {
@@ -79,74 +83,84 @@
         font-weight: 300;
         line-height: 1.2;
         text-align: center;
+        /* When the heading wraps to multiple lines at narrow widths,
+           balance the line widths so the top line doesn't end up much
+           longer than the bottom (which makes a centered title look
+           visually off-center). */
+        text-wrap: balance;
     }
 
     .portico-page-subheading {
         font-weight: 400;
         font-size: 1.1em;
-        color: hsl(0deg 0% 67%);
+        color: hsl(0deg 0% 40%);
         line-height: 1.2;
         text-align: center;
     }
 
+    /* Markdown-style blue links used in the page subheading and in
+       content areas that render user-facing text. */
+    .portico-page-subheading a {
+        color: var(--color-link);
+        text-decoration: underline;
+        text-decoration-color: var(--color-link-underline);
+        text-underline-offset: 0.1176em;
+
+        &:hover {
+            color: var(--color-link-hover);
+            text-decoration-color: var(--color-link-underline-hover);
+        }
+    }
+
     #integration-search {
         margin-bottom: 30px;
+        padding: 0 30px 0 260px;
+
+        @media (width <= 1000px) {
+            padding: 0 30px;
+        }
 
         .searchbar {
-            width: calc(100% - 40px);
             display: flex;
             justify-content: center;
             margin: 30px auto 0;
 
             .searchbar-reset {
                 position: relative;
+                width: 100%;
+                max-width: 500px;
 
                 .search_input {
-                    box-shadow: 0 0 7px 2px hsl(0deg 0% 0% / 3%);
-
+                    /* border-box so width:100% includes the 70px of
+                       horizontal padding; otherwise the search box
+                       overflows its 500px cap by padding width. */
+                    box-sizing: border-box;
                     font-size: 1em;
                     font-family: inherit;
 
-                    width: 500px;
+                    width: 100%;
                     height: 45px;
                     padding: 0 20px 0 50px;
-                    border-radius: 40px;
-                    border: 1px solid
-                        var(--color-integrations-light-blue-border);
+                    border-radius: 5px;
+                    border: 1px solid hsl(0deg 0% 80%);
                     display: block;
                     color: hsl(0deg 0% 33%);
                     margin-bottom: 10px;
                     transition: border-color linear 0.2s;
 
                     &:focus {
-                        border-color: var(--color-integrations-border-green);
+                        border-color: var(--color-link);
                         outline: 0;
                     }
-
-                    @media (width <= 768px) {
-                        width: 375px;
-                        margin: 0 auto;
-                    }
-
-                    @media (width <= 550px) {
-                        width: calc(100% - 80px);
-                    }
                 }
 
-                & i.fa-search {
+                & .zulip-icon-search {
                     position: absolute;
-                    left: 20px;
+                    left: 18px;
                     top: 13px;
-                    font-size: 19px;
-                    color: var(--color-integrations-border-green);
-                }
-
-                @media (width <= 768px) {
-                    width: 445px;
-                }
-
-                @media (width <= 550px) {
-                    width: 100%;
+                    font-size: 18px;
+                    color: hsl(0deg 0% 53%);
+                    pointer-events: none;
                 }
             }
         }

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -30,6 +30,13 @@
         background-color: hsl(0deg 0% 100%);
 
         & img {
+            /* Replace the Bootstrap image reset that the new
+               integrations_bundle no longer provides. Without these,
+               images embedded in integration instructions render at
+               their natural size and overflow the content column. */
+            max-width: 100%;
+            height: auto;
+            vertical-align: middle;
             box-shadow: none;
             border: none;
         }
@@ -293,6 +300,14 @@
 
         @media (width <= 906px) {
             text-align: center;
+        }
+
+        /* The lozenge cards are wrapped in bare <a> tags, which
+           inherit the browser-default underline. Suppress it so
+           the underline doesn't peek through the whitespace gaps
+           between inline-block cards as visible dashes. */
+        & > a {
+            text-decoration: none;
         }
     }
 

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -97,6 +97,15 @@ html:has(.portico-landing.integrations) {
         @media (width <= 450px) {
             padding: 40px 0 20px;
         }
+
+        /* On doc pages at narrow widths the header is a compact
+           logo + name + back row, so it needs less top breathing
+           room than the catalog page's tall heading block. */
+        &:has(#integration-instructions-group) {
+            @media (width <= 1000px) {
+                padding-top: 25px;
+            }
+        }
     }
 
     & ol li {
@@ -620,6 +629,7 @@ html:has(.portico-landing.integrations) {
                     border: none;
 
                     display: flex !important;
+                    align-items: center;
                     justify-content: space-between;
                     height: auto;
                     width: auto;
@@ -627,12 +637,17 @@ html:has(.portico-landing.integrations) {
                     padding: unset;
 
                     .integration-logo {
+                        /* Override the shared catalog-card rule at
+                           `@media (width <= 830px)` that shrinks logos
+                           to 45px — the doc-page header should keep the
+                           full-size logo at every width. */
+                        height: 60px;
                         margin: 0;
                     }
 
                     .integration-name {
                         font-size: 1.2em !important;
-                        margin-left: 20px;
+                        margin: 0 0 0 20px;
                     }
                 }
             }
@@ -722,11 +737,11 @@ html:has(.portico-landing.integrations) {
                 flex-direction: row;
                 justify-content: space-between;
                 align-items: center;
-                margin-bottom: 20px;
+                margin-bottom: 12px;
                 /* Drop the column-gutter padding on the right so
                    the back-link reaches the card's right edge
                    instead of sitting 30 px inside it. */
-                padding: 0 0 20px;
+                padding: 0 0 12px;
                 border-bottom: 1px solid hsl(0deg 0% 88%);
             }
 
@@ -758,6 +773,10 @@ html:has(.portico-landing.integrations) {
 
             @media (width <= 1000px) {
                 margin-left: 0;
+
+                & h1:first-child {
+                    margin-top: 0;
+                }
             }
         }
 

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -129,7 +129,8 @@
 
     /* Markdown-style blue links used in the page subheading and in
        content areas that render user-facing text. */
-    .portico-page-subheading a {
+    .portico-page-subheading a,
+    .integration-instructions a {
         color: var(--color-link);
         text-decoration: underline;
         text-decoration-color: var(--color-link-underline);
@@ -661,9 +662,6 @@
 
         @media (width <= 768px) {
             flex-direction: column;
-        }
-
-        @media (width <= 450px) {
             padding: 0 25px;
         }
     }

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -3,6 +3,12 @@
 
     color: hsl(0deg 0% 27%);
     font-weight: normal;
+    /* Extra gradient space below the main card before the footer.
+       This is padding-bottom on .portico-landing (not margin-bottom
+       on .main), so the blue gradient background fills the space
+       instead of margin-collapsing through to an invisible external
+       gap. */
+    padding-bottom: 60px;
 
     & h1,
     h2,
@@ -22,6 +28,13 @@
         margin: 0 auto;
         border-radius: 10px;
         background-color: hsl(0deg 0% 100%);
+
+        /* The catalog page gets a gray content area so the white
+           integration cards stand out. Specific integration doc pages
+           keep the default white content background. */
+        &:has(.catalog) {
+            background-color: hsl(0deg 0% 96%);
+        }
 
         & img {
             /* Replace the Bootstrap image reset that the new
@@ -49,14 +62,17 @@
     }
 
     .padded-content {
-        padding: 50px 0;
+        /* `.integration-request` already supplies 20px of bottom
+           padding, so we only need a small bottom gap here to give
+           the buttons breathing room inside the gray card. */
+        padding: 50px 0 20px;
 
         .inner-content {
             min-height: 870px;
         }
 
         @media (width <= 450px) {
-            padding: 40px 0;
+            padding: 40px 0 20px;
         }
     }
 
@@ -172,6 +188,11 @@
     }
 
     .catalog {
+        /* `flow-root` makes .catalog a new block formatting context
+           that contains the floated sidebar, so when a category has
+           few cards the sidebar doesn't overflow past .catalog's
+           bottom into the page background below. */
+        display: flow-root;
         margin-top: 20px;
         padding: 0 30px;
         min-height: 500px;
@@ -348,7 +369,7 @@
         overflow: hidden;
         text-align: left;
 
-        @media (width <= 906px) {
+        @media (width <= 1000px) {
             text-align: center;
         }
 
@@ -368,7 +389,8 @@
         padding: 0 4px;
         margin: 7px 5px;
         border-radius: 5px;
-        border: 1px solid var(--color-integrations-light-blue-border);
+        border: 1px solid hsl(0deg 0% 88%);
+        background-color: hsl(0deg 0% 100%);
         color: var(--color-integrations-category-text);
         text-align: center;
         transition: 0.3s ease;
@@ -379,7 +401,7 @@
         }
 
         &:hover {
-            border-color: var(--color-integrations-border-green);
+            border-color: hsl(0deg 0% 73%);
         }
 
         .integration-secondary-line-text {

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -36,7 +36,6 @@
 
         @media (width <= 768px) {
             width: calc(100% - 50px);
-            margin: 0 auto;
         }
 
         @media (width <= 450px) {
@@ -49,15 +48,6 @@
 
         .inner-content {
             min-height: 870px;
-
-            .show {
-                opacity: 1;
-                pointer-events: all;
-            }
-
-            @media (width <= 500px) {
-                height: auto;
-            }
         }
 
         @media (width <= 450px) {
@@ -82,11 +72,6 @@
         font-weight: 300;
         line-height: 1.2;
         text-align: center;
-        border-bottom: none;
-
-        & a {
-            color: inherit;
-        }
     }
 
     .portico-page-subheading {
@@ -597,7 +582,6 @@
 
 .portico-landing.integrations.communities {
     .main {
-        visibility: visible;
         max-width: 900px;
     }
 

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -369,7 +369,8 @@
            cleanly instead of showing a rounded-to-straight seam.
            jQuery's `slideToggle` sets `style="display: block"` inline
            on the list when open, which we detect via :has(). */
-        &:has(.dropdown-list[style*="display: block"]) .integration-toggle-categories-dropdown {
+        &:has(.dropdown-list[style*="display: block"])
+            .integration-toggle-categories-dropdown {
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;
         }
@@ -534,12 +535,28 @@
         .integration-instruction-block {
             display: flex;
             flex-direction: column;
+            /* Let the left column size to its widest child (the logo
+               box, or a long category pill) plus a right-padding
+               gutter. The instructions column uses `flex: 1` to fill
+               the remaining space. */
+            flex-shrink: 0;
+            padding-right: 30px;
 
             .integration-lozenge {
                 width: 125px;
                 height: auto;
                 padding: 0 5px 20px;
-                margin: 0 21px 20px;
+                /* Align the top of the logo card with the visible
+                   cap-height of the title's first character. This
+                   `margin-top` is tuned so that the card's top edge
+                   sits on the same horizontal line as the top of
+                   the "Z" (or equivalent cap-height glyph) in the
+                   h1 title, not on its typographic ascender line.
+                   The value balances the 15px top margin the shared
+                   markdown rules give h1 plus the half-leading and
+                   ascender offset that sit above the visible glyph
+                   in Source Sans 3 VF at the h1's font-size. */
+                margin: 25px 21px 20px;
                 order: 1;
 
                 .integration-category,
@@ -547,7 +564,7 @@
                     display: none;
                 }
 
-                @media (width <= 768px) {
+                @media (width <= 1000px) {
                     border: none;
 
                     display: flex !important;
@@ -578,26 +595,35 @@
 
             .categories {
                 order: 2;
+                /* Left-align the pills with the logo box above, which
+                   has `margin: 0 21px 20px` on `.integration-lozenge`. */
+                margin-left: 21px;
+
+                /* Each category is its own <a> wrapping an <h3>. Lay
+                   them out as a vertical flex column so the pills are
+                   sized to their content (like in-app pills) instead
+                   of stretching to a fixed width. */
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+
+                & a {
+                    text-decoration: none;
+                }
 
                 .integration-category,
                 .realm-category {
-                    font-size: 0.9em;
+                    font-size: 0.95em;
                     font-weight: 400;
-                    padding: 6px 3px;
-                    margin: 7px 0;
-                    width: 165px;
-                    text-align: center;
-                    border-radius: 5px;
-                    transition: 0.3s ease;
-                    transition-property: background-color, color;
-                    background-color: var(
-                        --color-integrations-light-blue-border
-                    );
-                    color: var(--color-integrations-category-text);
+                    padding: 5px 14px;
+                    margin: 0 0 6px;
+                    border-radius: 14px;
+                    background-color: hsl(210deg 94% 42% / 10%);
+                    color: hsl(210deg 70% 35%);
 
                     &:hover {
-                        background-color: var(--color-integrations-hover-green);
-                        color: var(--color-integrations-text-green);
+                        background-color: hsl(210deg 94% 42% / 17%);
+                        color: hsl(210deg 70% 28%);
                     }
                 }
             }
@@ -605,36 +631,54 @@
             #integration-list-link {
                 margin-left: 30px;
                 order: 3;
+                color: var(--color-integrations-category-text);
+                text-decoration: none;
+                display: flex;
+                align-items: center;
 
-                .integrations-back-to-list-label {
-                    display: inline-block;
-                    margin-left: 5px;
+                .zulip-icon-arrow-left {
+                    font-size: 16px;
+                    margin-right: 5px;
+                }
 
-                    @media (width >= 768px) {
-                        margin-top: 15px;
+                /* Show "Back to list" on wide screens, "Back" on
+                   narrow where space is limited. */
+                .integrations-back-label-short {
+                    display: none;
+                }
+
+                @media (width <= 1000px) {
+                    .integrations-back-label-long {
+                        display: none;
                     }
 
-                    @media (width <= 768px) {
-                        display: none;
+                    .integrations-back-label-short {
+                        display: inline;
                     }
                 }
 
-                @media (width <= 768px) {
-                    font-size: 22px;
+                &:hover {
+                    color: hsl(223deg 6% 15%);
+                }
+
+                @media (width >= 1000px) {
+                    margin-top: 15px;
                 }
             }
 
-            @media (width <= 768px) {
+            @media (width <= 1000px) {
                 flex-direction: row;
                 justify-content: space-between;
                 align-items: center;
                 margin-bottom: 20px;
-                padding-bottom: 20px;
-                border-bottom: 1px solid
-                    var(--color-integrations-light-blue-border);
+                /* Drop the column-gutter padding on the right so
+                   the back-link reaches the card's right edge
+                   instead of sitting 30 px inside it. */
+                padding: 0 0 20px;
+                border-bottom: 1px solid hsl(0deg 0% 88%);
             }
 
-            @media (width <= 768px) {
+            @media (width <= 1000px) {
                 .name {
                     display: block;
                 }
@@ -651,18 +695,30 @@
                 font-style: italic;
             }
 
-            @media (width >= 768px) {
-                width: calc(100% - 200px);
+            @media (width >= 1000px) {
+                /* Fill whatever space the left column leaves after
+                   sizing to its widest child. min-width: 0 lets the
+                   column shrink below its intrinsic content size when
+                   the viewport is narrow. */
+                flex: 1;
+                min-width: 0;
             }
 
-            @media (width <= 768px) {
+            @media (width <= 1000px) {
                 margin-left: 0;
             }
         }
 
-        @media (width <= 768px) {
+        @media (width <= 1000px) {
             flex-direction: column;
+        }
+
+        @media (width <= 768px) {
             padding: 0 25px;
+        }
+
+        @media (width <= 450px) {
+            padding: 0 12px;
         }
     }
 }

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -1,3 +1,17 @@
+/* Override `width: 100vw` from marketing_page.css, which makes
+   html wider than the visible content area when a classic scrollbar
+   is present — the CSS `vw` unit always includes the scrollbar's
+   width. That shifts every centered element rightward by half the
+   scrollbar width, producing asymmetric side margins on the gradient.
+   `scrollbar-gutter: stable` reserves gutter space even when no
+   scrollbar is shown, preventing layout jiggle when switching between
+   categories whose heights differ enough to add or remove the
+   vertical scrollbar. */
+html:has(.portico-landing.integrations) {
+    width: auto;
+    scrollbar-gutter: stable;
+}
+
 .portico-landing.integrations {
     --color-integrations-category-text: hsl(223deg 6% 35%);
 

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -10,6 +10,15 @@
        gap. */
     padding-bottom: 60px;
 
+    /* Modern blue gradient background, matching /plans and the homepage.
+       This replaces the complex multi-layer gradient system from
+       zerver/gradients.html (which is no longer included on these pages). */
+    background: linear-gradient(
+        180deg,
+        var(--color-background-gradient-start) 0%,
+        var(--color-background-gradient-end) 100%
+    );
+
     & h1,
     h2,
     h3 {

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -130,7 +130,8 @@
     /* Markdown-style blue links used in the page subheading and in
        content areas that render user-facing text. */
     .portico-page-subheading a,
-    .integration-instructions a {
+    .integration-instructions a,
+    .eligible_realm_end_notice a {
         color: var(--color-link);
         text-decoration: underline;
         text-decoration-color: var(--color-link-underline);
@@ -763,7 +764,7 @@
             border-radius: 4px;
 
             &:hover {
-                border: 1px solid hsl(167deg 34% 56%);
+                border: 1px solid hsl(0deg 0% 73%);
             }
 
             .eligible_realm_logo {
@@ -804,6 +805,8 @@
 
         & hr {
             margin: 10px 0;
+            border: 0;
+            border-top: 1px solid hsl(0deg 0% 93%);
         }
 
         .eligible_realm_end_notice {

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -236,10 +236,8 @@
             }
 
             & a {
+                display: block;
                 text-decoration: none;
-            }
-
-            & h4 {
                 font-weight: 400;
                 font-size: 0.95em;
                 padding: 6px 10px;
@@ -268,14 +266,6 @@
     .integration-categories-dropdown {
         display: none;
 
-        .heading {
-            font-weight: 600;
-        }
-
-        & a {
-            text-decoration: none;
-        }
-
         /* Match the search box at narrow widths: the outer container
            takes 30px horizontal padding, and the inner elements
            (toggle + list) cap at 500px and center within the content
@@ -286,11 +276,16 @@
             margin: 0;
             padding: 0 30px;
 
-            & h3,
-            h4 {
+            & h3 {
                 font-weight: 400;
+                font-size: 1.1em;
+                text-align: left;
                 margin: 0;
                 padding: 12px 20px;
+
+                &.heading {
+                    font-weight: 600;
+                }
             }
 
             .integration-toggle-categories-dropdown,
@@ -342,26 +337,24 @@
                 border-top: 0;
                 border-radius: 0 0 5px 5px;
                 overflow: hidden;
-            }
 
-            & h3 {
-                font-size: 1.1em;
-                text-align: left;
-            }
+                & a {
+                    display: block;
+                    text-decoration: none;
+                    font-weight: 400;
+                    font-size: 1em;
+                    padding: 12px 20px;
+                    color: var(--color-integrations-category-text);
 
-            & h4 {
-                font-size: 1em;
-                color: var(--color-integrations-category-text);
+                    &:hover {
+                        color: hsl(223deg 6% 15%);
+                    }
 
-                &:hover {
-                    color: hsl(223deg 6% 15%);
-                }
-
-                &.selected {
-                    background-color: hsl(0deg 0% 100%);
-                    color: hsl(223deg 6% 25%);
-                    font-weight: 600;
-                }
+                    &.selected {
+                        background-color: hsl(0deg 0% 100%);
+                        color: hsl(223deg 6% 25%);
+                        font-weight: 600;
+                    }
             }
         }
 

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -496,30 +496,23 @@
 
     .integration-request {
         font-size: 1em;
-        padding: 10px 0;
+        /* Generous top/bottom padding so the "Don't see an integration
+           you need?" section has visible breathing room between the
+           last row of cards above and the section content below. */
+        padding: 40px 0 20px;
 
         & p {
-            padding-bottom: 10px;
+            margin: 0 0 20px;
         }
 
-        .button {
-            padding: 11px 25px;
-            margin: 0 auto;
-            font-size: 0.9em;
-        }
-    }
-
-    @media (width <= 550px) {
-        .button {
+        /* Lay out the /why-zulip-style hero-buttons as a centered
+           flex row, since the flex rule in marketing_page.css is
+           scoped to .why-page and its siblings. */
+        .hero-buttons {
             display: flex;
-            flex-wrap: wrap;
-            width: 170px;
+            flex-flow: row wrap;
             justify-content: center;
         }
-    }
-
-    .integration-divider {
-        padding: 11px 15px 0;
     }
 
     /* -- integration instructions -- */

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -109,12 +109,15 @@ html:has(.portico-landing.integrations) {
 
     /* Left-align the header block with the cards column, so the title,
        subtitle, and search box don't spill into the sidebar area. The
-       sidebar column below takes 230px (200 sidebar + 30 gutter), so
-       we pad the header block to start at the same x-position as the
-       cards. At narrow widths, the sidebar is hidden and the header
-       reverts to its original near-full-width layout. */
+       sidebar column below takes 230 px (200 sidebar + 30 gutter),
+       and the first visible `.integration-lozenge` sits another 5 px
+       further right due to its own horizontal margin, so we pad the
+       header block to start at 265 px from the main card's left edge
+       to land on the card's visible left edge. At narrow widths, the
+       sidebar is hidden and the header reverts to its original
+       near-full-width layout. */
     .integration-main-text {
-        padding: 0 30px 0 260px;
+        padding: 0 30px 0 265px;
 
         @media (width <= 1000px) {
             padding: 0 30px;
@@ -131,6 +134,13 @@ html:has(.portico-landing.integrations) {
            longer than the bottom (which makes a centered title look
            visually off-center). */
         text-wrap: balance;
+
+        /* At widths where the sidebar is visible, left-align the
+           title so its left edge matches the left edge of the cards
+           column below. */
+        @media (width > 1000px) {
+            text-align: left;
+        }
     }
 
     .portico-page-subheading {
@@ -139,6 +149,10 @@ html:has(.portico-landing.integrations) {
         color: hsl(0deg 0% 40%);
         line-height: 1.2;
         text-align: center;
+
+        @media (width > 1000px) {
+            text-align: left;
+        }
     }
 
     /* Markdown-style blue links used in the page subheading and in
@@ -159,7 +173,7 @@ html:has(.portico-landing.integrations) {
 
     #integration-search {
         margin-bottom: 30px;
-        padding: 0 30px 0 260px;
+        padding: 0 30px 0 265px;
 
         @media (width <= 1000px) {
             padding: 0 30px;
@@ -170,6 +184,13 @@ html:has(.portico-landing.integrations) {
             display: flex;
             justify-content: center;
             margin: 30px auto 0;
+
+            /* At widths where the sidebar is visible, left-align the
+               search box so its left edge matches the left edge of
+               the cards column below. */
+            @media (width > 1000px) {
+                justify-content: flex-start;
+            }
 
             .searchbar-reset {
                 position: relative;
@@ -267,7 +288,11 @@ html:has(.portico-landing.integrations) {
                 &.selected {
                     background-color: hsl(0deg 0% 100%);
                     color: hsl(223deg 6% 25%);
-                    font-weight: 600;
+                    /* !important is needed to override the
+                       `.portico-landing a:not(.button) {
+                       font-weight: inherit !important }` rule
+                       in marketing_page.css. */
+                    font-weight: 600 !important;
                 }
             }
 
@@ -367,8 +392,9 @@ html:has(.portico-landing.integrations) {
                     &.selected {
                         background-color: hsl(0deg 0% 100%);
                         color: hsl(223deg 6% 25%);
-                        font-weight: 600;
+                        font-weight: 600 !important;
                     }
+                }
             }
         }
 
@@ -520,17 +546,35 @@ html:has(.portico-landing.integrations) {
            last row of cards above and the section content below. */
         padding: 40px 0 20px;
 
+        /* At widths where the header is left-aligned, left-align
+           the bottom section to match. The 5px left padding lines
+           up the text with the visible card edges, since each
+           `.integration-lozenge` has a 5px horizontal margin. */
+        @media (width > 1000px) {
+            text-align: left;
+            padding-left: 5px;
+        }
+
         & p {
             margin: 0 0 20px;
         }
 
-        /* Lay out the /why-zulip-style hero-buttons as a centered
-           flex row, since the flex rule in marketing_page.css is
-           scoped to .why-page and its siblings. */
+        /* Lay out the /why-zulip-style hero-buttons as a flex row,
+           since the flex rule in marketing_page.css is scoped to
+           .why-page and its siblings. Centered at narrow widths,
+           left-aligned at wide widths to match the header. */
         .hero-buttons {
             display: flex;
             flex-flow: row wrap;
             justify-content: center;
+
+            @media (width > 1000px) {
+                justify-content: flex-start;
+                /* Each .button has 10px margin from marketing_page.css,
+                   which pushes its visible border right of the text
+                   above. Pull the flex container left to compensate. */
+                margin-left: -10px;
+            }
         }
     }
 
@@ -734,6 +778,19 @@ html:has(.portico-landing.integrations) {
 .portico-landing.integrations.communities {
     .main {
         max-width: 900px;
+    }
+
+    /* `.eligible_realm` has no horizontal margin, unlike
+       `.integration-lozenge` which has a 5 px left/right margin, so
+       the communities heading needs 5 px less left padding than the
+       integrations heading to line up with the first realm's visible
+       left edge. */
+    .integration-main-text {
+        padding-left: 260px;
+
+        @media (width <= 1000px) {
+            padding-left: 30px;
+        }
     }
 
     .portico-page-heading {

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -35,7 +35,11 @@
             border: none;
         }
 
-        @media (width <= 768px) {
+        /* Below 1000px the sidebar is hidden, so narrow the main's
+           own side margins at the same breakpoint. This keeps the
+           "blue gradient strip" on each side of the main card
+           consistently sized across the two primary layouts. */
+        @media (width <= 1000px) {
             width: calc(100% - 50px);
         }
 
@@ -118,6 +122,7 @@
 
         @media (width <= 1000px) {
             padding: 0 30px;
+            margin-bottom: 10px;
         }
 
         .searchbar {
@@ -186,52 +191,86 @@
             }
 
             & h3 {
-                font-weight: 400;
+                font-weight: 700;
                 font-size: 1.1em;
-                margin: 0;
+                margin: 0 0 5px;
+                color: var(--color-integrations-category-text);
+            }
+
+            /* Visually separate "Custom integrations" (the second h3)
+               from the last category pill above it. */
+            & h3 ~ h3 {
+                margin-top: 20px;
+            }
+
+            & a {
+                text-decoration: none;
             }
 
             & h4 {
                 font-weight: 400;
                 font-size: 0.95em;
-                padding: 6px 10px 3px;
-                margin: 3px 0;
+                padding: 6px 10px;
+                margin: 2px 0;
                 border-radius: 5px;
-                transition: 0.3s ease;
-                transition-property: background-color, color;
                 color: var(--color-integrations-category-text);
+                cursor: pointer;
 
-                &.selected,
                 &:hover {
-                    background-color: var(--color-integrations-hover-green);
-                    color: var(--color-integrations-text-green);
-                    cursor: pointer;
+                    color: hsl(223deg 6% 15%);
+                }
+
+                &.selected {
+                    background-color: hsl(0deg 0% 100%);
+                    color: hsl(223deg 6% 25%);
+                    font-weight: 600;
                 }
             }
 
-            @media (width <= 906px) {
+            @media (width <= 1000px) {
                 display: none;
             }
         }
     }
 
     .integration-categories-dropdown {
-        margin: 30px auto;
         display: none;
 
         .heading {
             font-weight: 600;
         }
 
-        @media (width <= 906px) {
+        & a {
+            text-decoration: none;
+        }
+
+        /* Match the search box at narrow widths: the outer container
+           takes 30px horizontal padding, and the inner elements
+           (toggle + list) cap at 500px and center within the content
+           area — mirroring the `#integration-search { padding: 0 30px }`
+           + `.searchbar-reset { max-width: 500px }` structure. */
+        @media (width <= 1000px) {
             display: block;
-            width: 670px;
+            margin: 0;
+            padding: 0 30px;
 
             & h3,
             h4 {
                 font-weight: 400;
                 margin: 0;
                 padding: 12px 20px;
+            }
+
+            .integration-toggle-categories-dropdown,
+            .dropdown-list {
+                /* border-box so the 1px border is included in the
+                   500px cap, matching the search input's dimensions
+                   exactly. */
+                box-sizing: border-box;
+                width: 100%;
+                max-width: 500px;
+                margin-left: auto;
+                margin-right: auto;
             }
 
             .integration-toggle-categories-dropdown {
@@ -241,9 +280,14 @@
                 padding: 0;
                 align-items: center;
                 justify-content: space-between;
-                margin-left: 25px;
-                margin-right: 25px;
-                border: 1px solid var(--color-integrations-light-blue-border);
+                /* White background so the toggle button stands out
+                   from the gray catalog content area, matching the
+                   white-highlight selected pill in the wide-window
+                   sidebar. */
+                background-color: hsl(0deg 0% 100%);
+                border: 1px solid hsl(0deg 0% 80%);
+                /* Match the rounded corners of the search input. */
+                border-radius: 5px;
             }
 
             & i {
@@ -251,60 +295,52 @@
                 font-size: 24px;
             }
 
+            /* The outer box is on the list container, so the items
+               inside have no borders and no dividers between them.
+               `border-top: 0` lets the list visually continue the
+               toggle's bottom edge without a double line. Only the
+               bottom corners are rounded; `overflow: hidden` clips
+               the selected item's white background so it doesn't
+               extend past the rounded border at the bottom. */
             .dropdown-list {
                 display: none;
                 cursor: pointer;
                 padding: 0;
-                margin-left: 25px;
-                margin-right: 25px;
+                border: 1px solid hsl(0deg 0% 80%);
+                border-top: 0;
+                border-radius: 0 0 5px 5px;
+                overflow: hidden;
             }
 
             & h3 {
-                font-size: 1em;
+                font-size: 1.1em;
                 text-align: left;
             }
 
             & h4 {
-                border-left: 1px solid
-                    var(--color-integrations-light-blue-border);
-                border-right: 1px solid
-                    var(--color-integrations-light-blue-border);
-                border-bottom: 1px solid
-                    var(--color-integrations-light-blue-border);
-                transition: 0.3s ease;
-                transition-property: background-color, color;
-                font-size: 0.9em;
+                font-size: 1em;
+                color: var(--color-integrations-category-text);
 
-                &.selected,
                 &:hover {
-                    background-color: var(--color-integrations-hover-green);
-                    color: var(--color-integrations-text-green);
+                    color: hsl(223deg 6% 15%);
+                }
+
+                &.selected {
+                    background-color: hsl(0deg 0% 100%);
+                    color: hsl(223deg 6% 25%);
+                    font-weight: 600;
                 }
             }
         }
 
-        @media (width <= 830px) {
-            width: 666px;
-        }
-
-        @media (width <= 786px) {
-            width: 509px;
-        }
-
-        @media (width <= 768px) {
-            width: 666px;
-        }
-
-        @media (width <= 686px) {
-            width: 509px;
-        }
-
-        @media (width <= 578px) {
-            width: 351px;
-        }
-
-        @media (width <= 357px) {
-            width: 299px;
+        /* While the dropdown list is open, square the toggle's
+           bottom corners so they meet the list's straight top edge
+           cleanly instead of showing a rounded-to-straight seam.
+           jQuery's `slideToggle` sets `style="display: block"` inline
+           on the list when open, which we detect via :has(). */
+        &:has(.dropdown-list[style*="display: block"]) .integration-toggle-categories-dropdown {
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
         }
     }
 

--- a/web/styles/portico/legacy_portico.css
+++ b/web/styles/portico/legacy_portico.css
@@ -317,49 +317,11 @@ html {
         padding-top: 10px;
     }
 
-    /* Restore element styles that Bootstrap previously provided. */
-    & p {
-        margin: 0 0 10px;
-    }
-
-    & p:empty {
-        margin: 0;
-    }
-
-    & h1 {
-        margin-top: 15px;
-    }
-
-    & h4 {
-        margin: 15px 0 5px;
-    }
-
-    & hr {
-        margin: 20px 0;
-        border: 0;
-        border-top: 1px solid hsl(0deg 0% 93%);
-    }
-
-    & ul,
-    ol {
-        padding: 0;
-    }
-
-    & pre {
-        padding: 9.5px;
-        margin: 0 0 10px;
-        word-break: break-all;
-        line-height: 20px;
-        background-color: hsl(0deg 0% 96%);
-        border: 1px solid hsl(0deg 0% 0% / 15%);
-        border-radius: 4px;
-    }
-
-    .tabbed-section .blocks pre {
-        margin: 0;
-        padding-top: 0;
-        padding-bottom: 0;
-    }
+    /* Element-level styles for paragraphs, headings, lists, code
+       blocks, and horizontal rules live in portico/markdown.css
+       under `.help .markdown, .integration-instructions` so that
+       both the help bundle and the integrations bundle share a
+       single source of truth. */
 
     /* Match the link styling from marketing/case-study pages. */
     & a {
@@ -373,10 +335,6 @@ html {
             color: var(--color-link-hover);
             text-decoration-color: var(--color-link-underline-hover);
         }
-
-        & code {
-            color: var(--color-link);
-        }
     }
 
     & ol > li::before {
@@ -385,10 +343,6 @@ html {
 
     .copy-to-clipboard-button:focus {
         outline-color: var(--color-link);
-    }
-
-    .tabbed-section ul.nav li.active {
-        color: var(--color-link);
     }
 
     .api-field-type {

--- a/web/styles/portico/legacy_portico.css
+++ b/web/styles/portico/legacy_portico.css
@@ -337,10 +337,6 @@ html {
         }
     }
 
-    & ol > li::before {
-        background-color: var(--color-link);
-    }
-
     .copy-to-clipboard-button:focus {
         outline-color: var(--color-link);
     }

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -488,8 +488,24 @@
             border-radius: 0 6px 6px;
         }
 
+        /* A "no-tabs" section is a degenerate zero-tabs wrapper that
+           just holds flowing markdown content. The border and radius
+           on `.blocks` exist to visually group a tab bar with the
+           content below it, which is meaningless when there's no tab
+           bar — it just draws a random frame around a subset of the
+           content. Drop the frame in that case.
+
+           Reset padding to 0 and use `margin-block` instead so that
+           the top/bottom margins collapse with adjacent paragraphs,
+           the first list item's margin, etc. — that gives a natural,
+           single breathing-room gap of ~20 px instead of stacking
+           the preceding paragraph's 10 px margin on top of the
+           block's own space. */
         &.no-tabs .blocks {
-            border-radius: 6px;
+            padding: 0;
+            margin-block: 20px;
+            border: 0;
+            border-radius: 0;
         }
 
         &.no-tabs .blocks > .tab-content,

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -460,7 +460,7 @@
                 cursor: pointer;
 
                 &.active {
-                    color: hsl(176deg 46% 41%);
+                    color: var(--color-link);
                     margin-bottom: -1px;
 
                     border: 1px solid hsl(0deg 0% 87%);
@@ -509,5 +509,72 @@
             line-height: 1.25;
             margin-bottom: 0;
         }
+    }
+}
+
+/* Shared element-level styling for pages that render markdown as
+   content documentation: /help and /api pages (under `.help .markdown`)
+   and integration doc pages (under `.integration-instructions`).
+   Keeping these rules in one place lets both the help bundle and the
+   integrations bundle depend on a single source of truth — markdown.css
+   is already loaded by both. Marketing pages (which also load this
+   file but don't match either selector) are intentionally unaffected,
+   because their layouts rely on different defaults for lists,
+   paragraph margins, and so on. */
+.help .markdown,
+.integration-instructions {
+    & p {
+        margin: 0 0 10px;
+    }
+
+    & p:empty {
+        margin: 0;
+    }
+
+    & h1 {
+        margin-top: 15px;
+    }
+
+    & h4 {
+        margin: 15px 0 5px;
+    }
+
+    & hr {
+        margin: 20px 0;
+        border: 0;
+        border-top: 1px solid hsl(0deg 0% 93%);
+    }
+
+    /* Reset the browser-default left padding on lists so numbered
+       items and bullets align with surrounding paragraphs. */
+    & ul,
+    & ol {
+        padding: 0;
+    }
+
+    /* Fenced code blocks: light gray card with a subtle border and
+       rounded corners. The 15px vertical margins give surrounding
+       paragraphs visible breathing room around the code card, which
+       a tighter 10px bottom margin (and 0 top) was not providing.
+       The explicit font-size matches the `pre code` rule in .markdown
+       above and ensures code blocks render at the same size whether
+       the codehilite wraps content in <code> or not (some integration
+       pages generate bare <pre> without a <code> child). */
+    & pre {
+        padding: 9.5px;
+        margin: 15px 0;
+        font-family: "Source Code Pro", monospace;
+        font-size: 14px;
+        color: hsl(0deg 0% 0%);
+        word-break: break-all;
+        line-height: 20px;
+        background-color: hsl(0deg 0% 96%);
+        border: 1px solid hsl(0deg 0% 0% / 15%);
+        border-radius: 4px;
+    }
+
+    /* Inline `<code>` inside a link inherits the link color. */
+    & a code {
+        color: var(--color-link);
     }
 }

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -167,7 +167,7 @@
                 vertical-align: top;
                 padding: 3px 6.5px 3px 7.5px;
                 margin-right: 5px;
-                background-color: hsl(170deg 48% 54%);
+                background-color: var(--color-link);
                 color: hsl(0deg 0% 100%);
                 border-radius: 100%;
                 font-size: 0.9em;

--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -77,16 +77,16 @@
         "./styles/portico/comparison_table.css"
     ],
     "integrations": [
-        "./src/bundles/legacy_portico_bundle.ts",
+        "./src/bundles/integrations_bundle.ts",
         "./src/portico/integrations.ts",
-        "./styles/portico/legacy_landing_page.css",
+        "./styles/portico/marketing_page.css",
         "./styles/portico/integrations.css",
         "./src/portico/help.ts"
     ],
     "communities": [
-        "./src/bundles/legacy_portico_bundle.ts",
+        "./src/bundles/integrations_bundle.ts",
         "./src/portico/communities.ts",
-        "./styles/portico/legacy_landing_page.css",
+        "./styles/portico/marketing_page.css",
         "./styles/portico/integrations.css"
     ],
     "signup": [

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -445,7 +445,7 @@ class DocPageTest(ZulipTestCase):
         result = self._test(
             "/integrations/asana?category=project-management",
             expected_strings=[
-                '<a href="/integrations/category/project-management" id="integration-list-link" class="no-underline">'
+                '<a href="/integrations/category/project-management" id="integration-list-link"'
             ],
         )
 
@@ -453,9 +453,7 @@ class DocPageTest(ZulipTestCase):
             "/integrations/asana?category=nonexistent_category",
         )
         self.assert_not_in_success_response(
-            [
-                '<a href="/integrations/category/project-management" id="integration-list-link" class="no-underline">'
-            ],
+            ['<a href="/integrations/category/project-management" id="integration-list-link"'],
             response,
         )
 
@@ -464,9 +462,7 @@ class DocPageTest(ZulipTestCase):
             "/integrations/asana?category=communication",
         )
         self.assert_not_in_success_response(
-            [
-                '<a href="/integrations/category/project-management" id="integration-list-link" class="no-underline">'
-            ],
+            ['<a href="/integrations/category/project-management" id="integration-list-link"'],
             response,
         )
 


### PR DESCRIPTION
Discussion: [#design > /integrations and /communities design update](https://chat.zulip.org/#narrow/channel/101-design/topic/.2Fintegrations.20and.20.2Fcommunities.20design.20update/with/2433373)

# Notes
- I'm not sure how to get data in /communities in dev, so I wasn't able to test it with an non-empty catalog (it's restyled along the same lines).


# Claude's description

Fixes: #38904.                                                                                                           
                                         
  ## Why                                                                                                                   
                                                                                                                           
  The `/integrations/`, `/integrations/<integration>`, and `/communities/`                                                 
  pages were built on a legacy bundle (`legacy_portico_bundle.ts` +
  Bootstrap + `legacy_landing_page.css`) with a teal-heavy design                                                          
  language that's out of step with the rest of Zulip's modernized                                                          
  marketing pages (`/plans`, `/why-zulip`, the homepage). They also                                                        
  drew from a six-layer gradient overlay system (`gradients.html`)                                                         
  whose yellow sunburst blended with the blue layers to produce a                                                          
  visibly green tint — and which couldn't be recolored scopedly                                                            
  without affecting unrelated pages.                                                                                       
                                                                                                                           
  This PR redesigns these pages to match the modern aesthetic,                                                             
  drops Bootstrap from their bundle, and consolidates the shared                                                           
  markdown content rules so integration doc pages and `/api` / `/help`                                                     
  pages depend on a single source of truth.                                                                                
                                                                                                                           
  ## What changed, by commit                                                                                               
                                                                                                                           
  1. **Remove pre-existing dead CSS rules from integrations.css.**                                                         
     Prep cleanup. No visual change.
  2. **Drop Bootstrap and legacy CSS for modern bundle.** New                                                              
     `integrations_bundle.ts` imports only the modern header,                                                              
     `portico_variables.css`, `components.css`, `navbar.css`,                                                              
     `footer.css`, and `markdown.css`. The webpack `integrations`                                                          
     and `communities` entries drop `legacy_landing_page.css` in                                                           
     favor of `marketing_page.css`, which already provides the same                                                        
     base element styles without its cascade conflicts (e.g.,                                                              
     `.button { font-size: 0.7em }` in legacy overriding the modern                                                        
     `18px`). An explicit `img` reset replaces the Bootstrap `img`                                                         
     defaults that would otherwise be lost. In the same commit,                                                            
     the generic element-level markdown content rules (paragraph                                                           
     margins, heading margins, `hr`, list-padding reset, fenced                                                            
     code block backgrounds) move from `.help .markdown` in                                                                
     `legacy_portico.css` to a shared scope                                                                                
     `.help .markdown, .integration-instructions` in                                                                       
     `portico/markdown.css` — so `help_bundle.ts` and       
     `integrations_bundle.ts` depend on a single source of truth                                                           
     and integration doc pages never lose their code block  
     rendering even mid-series. Marketing pages match neither                                                              
     selector and are unaffected.                                                                                          
  3. **Restyle page heading, subtitle, and search box.** Heading                                                           
     uses the modern thin weight; subtitle links styled blue;                                                              
     search box gets a neutral gray border and blue focus ring,                                                            
     matching `/api` pages. Cleans up unused teal color variables.                                                         
  4. **Restyle category sidebar to match /api pages.** Sidebar                                                             
     links use the same highlighted-pill style `/api` uses; the                                                            
     teal border treatment is gone. Raises the narrow-window                                                               
     breakpoint from 906 px to 1000 px so the sidebar always has                                                           
     room for its longest category label on one line.                                                                      
  5. **Restyle integration cards with gray background.** Gray card                                                         
     content area (matching `/api`'s sidebar gray) so white                                                                
     integration cards stand out. Plain gray card border; darker                                                           
     gray on hover; no teal. `.catalog` becomes `display: flow-root`                                                       
     so short categories don't leave the floated sidebar poking                                                            
     out past the card.                                                                                                    
  6. **Restyle bottom buttons to match /why-zulip.** Wraps the                                                             
     "Create your own" / "Request an integration" buttons in a                                                             
     `.hero-buttons.center` flex container, drops the "or" divider,                                                        
     and centers the text inside the buttons.                                                                              
  7. **Replace gradient overlays with simple blue gradient.** Drops                                                        
     the `gradients.html` include (six absolutely positioned overlay                                                       
     divs producing an unintentionally green tint) in favor of a                                                           
     single modern blue `linear-gradient` on                                                                               
     `.portico-landing.integrations`.                                                                                      
  8. **Replace default teal list markers with blue in markdown.css.**                                                      
     Numbered-list circle markers were hardcoded teal; switches to                                                         
     `var(--color-link)` (blue) globally so they match everywhere                                                          
     `.markdown` is used.                                                                                                  
  9. **Style doc page instructions to match /api pages.** Applies                                                          
     the blue link color to `.integration-instructions a`,                                                                 
     alongside the existing `.portico-page-subheading a` rule.                                                             
  10. **Restyle doc page navigation and category pills.** Logo
      card (125 px), in-app-style category pills, `arrow-left`                                                             
      icon for "Back to list". Doc page content gets a white card                                                          
      (via `.main:has(.catalog)` scoping) so the gray-card rule                                                            
      only applies on the catalog page. The logo card's top edge                                                           
      aligns with the visible cap-height of the title's first                                                              
      character — verified pixel-perfect via a canvas probe that                                                           
      renders the "Z" glyph in the same font and measures the                                                              
      first row with ink (23 px above alphabetic baseline), then                                                           
      compares to a zero-size `vertical-align: baseline` marker                                                            
      span to find the page-y of the baseline: the logo card top                                                           
      and the glyph cap top both land at y=195 (delta = 0.0). The                                                          
      side-by-side layout now only applies at viewports wider than                                                         
      1000 px; at smaller widths the doc page uses a stacked layout                                                        
      (logo row on top, full-width instructions below), so mid-range                                                       
      viewports like 768–1000 px don't leave the instructions column                                                       
      cramped next to a fixed-width logo column.                                                                           
  11. **Restyle communities page to match integrations redesign.**                                                         
      Picks up the same visual language via the shared                                                                     
      `.portico-landing.integrations` scope; communities overrides                                                         
      only the max-width.                                                                                                  
  12. **Simplify heading semantics on catalog and communities.**                                                           
      The catalog and communities pages previously used `<h2>` /                                                           
      `<h4>` liberally for non-heading content (taglines, category                                                         
      links, custom-integration links), producing a confusing 17+                                                          
      heading document outline. Subtitle becomes `<p>`, category                                                           
      `<a><h4></h4></a>` wrappers become bare `<a>` elements, and                                                          
      the custom-integrations section header moves to `<h3>` to                                                            
      match its sibling. No visual change; CSS is scoped to the                                                            
      sidebar/dropdown so this doesn't affect any other page.                                                              
  13. Stabilize horizontal position across scrollbar toggles. Override html { width: 100vw } from marketing_page.css with width: auto; scrollbar-gutter: stable scoped to integrations pages via :has(). Eliminates both the horizontal jump between categories and the visual asymmetry when a classic scrollbar is present.                                                                  
  14. **Drop frame around no-tabs tabbed sections.** The markdown                                                          
      preprocessor wraps `{start_tabs}...{end_tabs}` blocks with no                                                        
      `{tab|...}` markers in a `.tabbed-section.no-tabs`. The                                                              
      existing `.tabbed-section .blocks` rule draws a 1 px border                                                          
      and 10 px padding to visually group a tab bar with its                                                               
      content — but when there are no tabs (as on every integration                                                        
      doc page), the frame just outlines a random subset of the                                                            
      instructions. Override `.tabbed-section.no-tabs .blocks` to                                                          
      drop the frame and use `margin-block: 20px` so adjacent                                                              
      content gets natural breathing room via margin collapsing.                                                           
      Also scope the `.tabbed-section .blocks pre { margin: 0 }`                                                           
      override to `.has-tabs` only so pre blocks in integration                                                            
      instructions get the normal 15 px margins instead of being                                                           
      flushed against a nonexistent tab frame.                                                                             
  15. **Left-align header block with the cards column on wide.** At                                                        
      widths where the sidebar is visible (> 1000 px), the catalog                                                         
      and communities page title, subtitle, and search box were                                                            
      horizontally centered within a header container that had been                                                        
      padded to the cards column's width. Visually this looked                                                             
      like the title was floating mid-column rather than anchoring                                                         
      to the cards grid below. Switch to left-aligning those three                                                         
      elements so each one's left edge lines up with the visible                                                           
      left edge of the first card in the grid below.                                                                       
                                                                                                                           
      The padding-left value is tuned to the actual rendered card                                                          
      edge, not the card-grid container edge: `.integration-lozenge`                                                       
      has `margin: 7px 5px`, so integration cards sit 5 px to the                                                          
      right of their `.integration-lozenges` parent — the header                                                           
      padding-left is 265 px to match. `.eligible_realm` on                                                                
      communities has no horizontal margin, so the communities                                                             
      page overrides padding-left to 260 px so its heading lines                                                           
      up with the realm-row border. At ≤ 1000 px both pages revert                                                         
      to centered, since the sidebarless stacked layout looks right                                                        
      centered.                                                                                                            
                                                                                                                           
      Kept as a standalone commit so it's easy to revert if we                                                             
      decide centered is better.  
16. Keep full-size logo on doc pages at all widths. Override the shared catalog-card rule that shrinks logos to 45 
  px at narrow viewports. Vertically center the name and back link, reduce top padding and separator spacing for a      
  tighter header row at narrow widths 
                                                                                                                       
  ## Test plan                                                                                                             
<details><summary>Details</summary>
<p>

 - [x] `./tools/lint` — clean on all tracked files.                                                                       
  - [x] `./tools/test-backend zerver.tests.test_docs` — passes.
  - [x] `./tools/test-js-with-puppeteer _claude_final_review` —                                                            
        generates the 9-screenshot review set.                                                                             
  - [x] `/integrations/` at 1400 × 1024 — navbar, heading, search,                                                         
        sidebar highlight, card grid, bottom buttons, blue gradient.                                                       
  - [x] `/integrations/category/entertainment` — short category,                                                           
        sidebar contained by `.catalog`, blue gap below main card                                                          
        before navy footer.                                                                                                
  - [x] `/integrations/` at 640 × 1024 — sidebar replaced by
        dropdown, search and dropdown matching widths.                                                                     
  - [x] `/integrations/` at 640 × 1400 with dropdown open — list                                                           
        item styling, dropdown toggle with squared bottom corners.                                                         
  - [x] `/integrations/github` at 1400 — doc page without code                                                             
        blocks. Logo card top aligned with title cap-height;                                                               
        `← Back to list` with `arrow-left` icon; category pills                                                            
        stacked.                                                                                                           
  - [x] `/integrations/capistrano` at 1400 — doc page **with** a                                                           
        code block. Code card with subtle border and rounded                                                               
        corners; 15 px vertical breathing room; no redundant frame                                                         
        around numbered instructions.                                                                                      
  - [x] `/integrations/capistrano` at 640 — stacked layout. Logo                                                           
        row on top with back-link flush against the card's right                                                           
        edge, instructions filling the full card width below,                                                              
        symmetric blue gradient on both sides of the card.                                                                 
  - [x] `/integrations/capistrano` at 800, 900, 1000 — confirmed                                                           
        these narrow-to-mid viewports also use the stacked layout                                                          
        instead of cramming a fixed-width logo column next to a                                                            
        narrow instructions column.                                                                                        
  - [x] `/api/api-keys` — regression check. Tabbed sections still                                                          
        have their frames (they're `.has-tabs`); top-of-page code                                                          
        block unchanged.                                                                                                   
  - [x] `/communities/` at 1400 and 640 — matching visual language.                                                        
  - [x] `/jobs/` — regression check that the                                                                               
        `portico/markdown.css` refactor didn't affect marketing                                                            
        pages. Its `.markdown ul` padding and `.markdown p` margin                                                         
        still come from `marketing_page.css`'s own resets.                                                                 
  - [x] Title-to-cap alignment verified via canvas probe:                                                                  
        `logo_card_top == title_first_char_cap_top == 195.0`,                                                              
        `delta = 0.0`.                                                                                                     
  - [x] Horizontal stability across scrollbar toggles verified by                                                          
        simulating body-width shrink at 1400 × 1024: `.main.left`                                                          
        stays at 115.0 in both states.          
  - [x] Header alignment verified programmatically via Puppeteer                                                           
        measurements at 1400 × 1024:                                                                                       
        - `/integrations/`: title, subtitle, search box, and                                                               
          `.integration-lozenge` all at `left = 380`.                                                                      
        - `/communities/`: title, subtitle, and `.eligible_realms`                                                         
          all at `left = 510`.        
</p>
</details>                                                                                            
             
                                                                                                                           
  ## Screenshots                                            
  
<details><summary>  9 before/after pairs</summary>
<p>

<img width="1400" height="1024" alt="review-01-catalog-wide-old" src="https://github.com/user-attachments/assets/2a206239-1a25-40f9-904a-6266f8a28f8d" />
<img width="1400" height="1024" alt="review-01-catalog-wide-updated" src="https://github.com/user-attachments/assets/3d33b226-b30a-4cdb-9cf1-73ac5aa3e79a" />
<img width="1400" height="1667" alt="review-02-catalog-short-category-old" src="https://github.com/user-attachments/assets/ae2d3d7c-9ff1-4cb5-a371-94a592a043d2" />
<img width="1385" height="1788" alt="review-02-catalog-short-category-updated" src="https://github.com/user-attachments/assets/8b2704f7-2dc4-4a09-b666-6f3e4a90735f" />
<img width="640" height="1024" alt="review-03-catalog-narrow-old" src="https://github.com/user-attachments/assets/c2808669-2940-4aa5-8444-638ca8548660" />
<img width="640" height="1024" alt="review-03-catalog-narrow-updated" src="https://github.com/user-attachments/assets/82a6af04-7a36-415d-8427-385c0edfb238" />
<img width="640" height="1685" alt="review-04-catalog-narrow-dropdown-old" src="https://github.com/user-attachments/assets/6eb7696f-90b2-4205-85a8-5308f8b10b41" />
<img width="640" height="1645" alt="review-04-catalog-narrow-dropdown-updated" src="https://github.com/user-attachments/assets/cdfb04d9-a123-4906-ba67-8c4da333eb1d" />
<img width="1400" height="1024" alt="review-05-doc-github-old" src="https://github.com/user-attachments/assets/c55f72fc-2a6e-4ae8-afbe-b90c0a2813e4" />
<img width="1400" height="1024" alt="review-05-doc-github-updated" src="https://github.com/user-attachments/assets/23acb8cc-28f9-43f3-b508-aaa6ab4b3666" />
<img width="1400" height="1024" alt="review-06-doc-capistrano-old" src="https://github.com/user-attachments/assets/b52eadbd-39d5-484f-b3bc-911df3fcc09d" />
<img width="1400" height="1024" alt="review-06-doc-capistrano-updated" src="https://github.com/user-attachments/assets/4fef2366-d719-40ed-b3b2-f00f85b60aab" />
<img width="1400" height="1024" alt="review-07-doc-github-actions-old" src="https://github.com/user-attachments/assets/a1038746-62a5-4b78-8c4b-e64d86928312" />
<img width="1400" height="1024" alt="review-07-doc-github-actions-updated" src="https://github.com/user-attachments/assets/5e91287d-4af2-4fc6-86c3-84ad6efb882f" />
<img width="640" height="1200" alt="review-08-doc-capistrano-narrow-old" src="https://github.com/user-attachments/assets/fa0780a1-5035-4929-b02b-16f3f996c5b1" />
<img width="640" height="1200" alt="review-08-doc-capistrano-narrow-updated" src="https://github.com/user-attachments/assets/a0bedc7d-59c6-4941-9ba1-a012f5fe21ca" />
<img width="1400" height="1024" alt="review-09-communities-old" src="https://github.com/user-attachments/assets/b4295626-9e30-4305-8721-8c350f9e1bd1" />
<img width="1400" height="1024" alt="review-09-communities-updated" src="https://github.com/user-attachments/assets/6c0adde5-2307-4926-bd62-af8467992531" />


</p>
</details> 
                                                                                                                                     
                                                                                                                           
  ## Open questions
                                                                                                                           
  - **Title-to-glyph alignment is font-metric-sensitive.** The                                                             
    25 px logo `margin-top` that produces pixel-perfect alignment
    is derived from:                                                                                                       
    - The shared                                                                                                           
      `.help .markdown, .integration-instructions h1 { margin-top: 15px }`                                                 
      rule (set in commit 2)                                                                                               
    - The `h1[id]::before` scroll-anchor pseudo in                                                                         
      `portico/markdown.css` (pulls -30 px through margin                                                                  
      collapse)                                                                                                            
    - Source Sans 3 VF's cap-height ratio at the h1 font-size                                                              
      (~23 px above the alphabetic baseline)                                                                               
                                                                                                                           
    A future change to any of those will shift the value.                                                                                                                                  
  - **Link color consolidation not done.**                                                                                 
    `.integration-instructions a` in `integrations.css` still                                                              
    lives in the same rule as `.portico-page-subheading a` and                                                             
    `.eligible_realm_end_notice a`, alongside the equivalent                                                               
    `.help .markdown a` rule in `legacy_portico.css`. All four                                                             
    produce the same blue result. Folding the                                                                              
    `.integration-instructions a` portion into the shared                                                                  
    `.help .markdown, .integration-instructions` rule in                                                                   
    `portico/markdown.css` would let both bundles depend on one                                                            
    source of truth for link styling too. Kept as a follow-up.                                                             
                                                                                                                           
  ## Self-review checklist                                                                                                 

<details><summary>Details</summary>
<p>

  - [x] The PR addresses the points in #38904.                                                                             
  - [x] Each commit is independently safe to deploy — the shared
        markdown rules move in the same commit that drops                                                                  
        `legacy_portico.css` from the integrations bundle, so no
        mid-series commit leaves integration doc pages with                                                                
        regressed code block rendering.                                                                                    
  - [x] Tests pass locally (lint clean on tracked files; backend                                                           
        `test_integration_doc_endpoints` passes; visual                                                                    
        verification via Puppeteer).                                                                                       
  - [x] Code follows existing patterns: `integrations_bundle.ts`                                                           
        mirrors `help_bundle.ts` / `marketing_page_bundle.ts`;                                                             
        shared markdown rules live next to existing `.markdown`                                                            
        rules in `portico/markdown.css`.                                                                                   
  - [x] Names are clear and greppable                                                                                      
        (`.integration-instruction-block`,                  
        `.integration-categories-sidebar`, etc.).                                                                          
  - [x] Commit messages are concise and explain *why*; each commit                                                         
        is a minimal coherent idea.                                                                                        
  - [x] No debugging code or temporary comments remain.                                                                    
  - [x] Type annotations complete.                                                                                         
  - [x] User-facing strings are tagged for translation (unchanged                                                          
        from pre-PR state; only markup structure changed, not                                                              
        visible text).                                                                                                     
  - [x] No secrets or credentials hardcoded.                                                                               
  - [x] Documentation check: no user-facing docs required — this                                                           
        is a cosmetic redesign with no changed behavior.                                                                   
  - [x] Refactoring is complete: `git grep` confirms no leftover                                                           
        references to the dropped `gradients.html` include,                                                                
        `legacy_landing_page.css`, or the removed teal color                                                               
        variables on these pages.                                                                                          
  - [x] Security audit: CSS-only changes in the core of the                                                                
        redesign; no XSS risk. The heading semantic refactor                                                               
        (commit 12) only changes `<h2>` → `<p>` and `<h4>` → `<a>`                                                         
        in existing templates without introducing any                                                                      
        user-controlled HTML.  

</p>
</details>                                                                                                                            
