### PR TITLE
[ai] people: Reduce `get_by_email` usage and use user IDs

### DIFF
--- a/web/src/compose_fade.ts
+++ b/web/src/compose_fade.ts
@@ -3,13 +3,12 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import * as compose_fade_helper from "./compose_fade_helper.ts";
+import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_state from "./compose_state.ts";
 import type {MessageGroup} from "./message_list_view.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_viewport from "./message_viewport.ts";
-import * as people from "./people.ts";
 import * as rows from "./rows.ts";
-import * as util from "./util.ts";
 
 let normal_display = false;
 
@@ -32,15 +31,9 @@ export function set_focused_recipient(msg_type?: "private" | "stream"): void {
             };
         }
     } else if (msg_type === "private") {
-        // Normalize the recipient list so it matches the one used when
-        // adding the message (see message_helper.process_new_message()).
-        const reply_to = util.normalize_recipients(
-            compose_state.private_message_recipient_emails(),
-        );
-        const to_user_ids = people.reply_to_to_user_ids_string(reply_to);
+        const to_user_ids = compose_pm_pill.get_user_ids_string();
         focused_recipient = {
             type: msg_type,
-            reply_to,
             to_user_ids,
         };
     }
@@ -85,7 +78,7 @@ function fade_messages(): void {
             if (
                 message_lists.current !== expected_msg_list ||
                 !compose_state.composing() ||
-                compose_state.private_message_recipient_emails() !== expected_recipient
+                compose_pm_pill.get_user_ids_string() !== expected_recipient
             ) {
                 return;
             }
@@ -103,7 +96,7 @@ function fade_messages(): void {
         },
         0,
         message_lists.current,
-        compose_state.private_message_recipient_emails(),
+        compose_pm_pill.get_user_ids_string(),
     );
 }
 

--- a/web/src/compose_fade_helper.ts
+++ b/web/src/compose_fade_helper.ts
@@ -47,5 +47,5 @@ export function want_normal_display(): boolean {
         }
     }
 
-    return focused_recipient.type === "private" && focused_recipient.reply_to === "";
+    return focused_recipient.type === "private" && !focused_recipient.to_user_ids;
 }

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -63,18 +63,6 @@ export function set_from_typeahead(person: User): void {
     });
 }
 
-export function set_from_emails(value: string): void {
-    // value is something like "alice@example.com,bob@example.com"
-    clear();
-    if (value === "") {
-        return;
-    }
-    const user_ids_string = people.emails_strings_to_user_ids_string(value);
-    if (user_ids_string) {
-        widget.appendValue(user_ids_string);
-    }
-}
-
 export function set_from_user_ids(value: number[], skip_pill_callbacks: boolean): void {
     clear();
     for (const user_id of value) {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -1,7 +1,6 @@
 import $ from "jquery";
 
 import * as compose_pm_pill from "./compose_pm_pill.ts";
-import * as people from "./people.ts";
 import * as stream_data from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
 
@@ -236,13 +235,7 @@ export function focus_in_empty_compose(
     return false;
 }
 
-export function private_message_recipient_emails(): string;
-export function private_message_recipient_emails(value: string): undefined;
-export function private_message_recipient_emails(value?: string): string | undefined {
-    if (typeof value === "string") {
-        compose_pm_pill.set_from_emails(value);
-        return undefined;
-    }
+export function private_message_recipient_emails(): string {
     return compose_pm_pill.get_emails();
 }
 
@@ -276,18 +269,6 @@ export function has_full_recipient(): boolean {
         return stream_id() !== undefined && has_topic;
     }
     return private_message_recipient_ids().length > 0;
-}
-
-export function update_email(user_id: number, new_email: string): void {
-    let reply_to = private_message_recipient_emails();
-
-    if (!reply_to) {
-        return;
-    }
-
-    reply_to = people.update_email_in_reply_to(reply_to, user_id, new_email);
-
-    private_message_recipient_emails(reply_to);
 }
 
 let _can_restore_drafts = true;

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1640,7 +1640,7 @@ function update_closed_compose_text($row: JQuery, is_header_row: boolean): void 
 }
 
 export function get_focused_row_message(): {message?: Message | undefined} & (
-    | {msg_type: "private"; private_message_recipient?: string}
+    | {msg_type: "private"; private_message_recipient_ids?: number[]}
     | {msg_type: "stream"; stream_id: number; topic?: string}
     | {msg_type?: never}
 ) {
@@ -1679,11 +1679,11 @@ export function get_focused_row_message(): {message?: Message | undefined} & (
         assert(row_info !== undefined);
         const message = message_store.get(row_info.latest_msg_id);
         if (message === undefined) {
-            const recipients = people.user_ids_string_to_emails_string(row_info.user_ids_string);
-            assert(recipients !== undefined);
             return {
                 msg_type: "private",
-                private_message_recipient: recipients,
+                private_message_recipient_ids: people.user_ids_string_to_ids_array(
+                    row_info.user_ids_string,
+                ),
             };
         }
         return {message};

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -304,28 +304,6 @@ export function direct_message_group_string(message: Message): string | undefine
     return user_ids.join(",");
 }
 
-export function user_ids_string_to_emails_string(user_ids_string: string): string | undefined {
-    const user_ids = split_to_ints(user_ids_string);
-    return user_ids_to_emails_string(user_ids);
-}
-
-export function user_ids_to_emails_string(user_ids: number[]): string | undefined {
-    const sorted_ids = sort_user_ids_by_username(user_ids);
-    const emails = util.try_parse_as_truthy(
-        sorted_ids.map((user_id) => {
-            const person = people_by_user_id_dict.get(user_id);
-            return person?.email.toLowerCase();
-        }),
-    );
-
-    if (emails === undefined) {
-        blueslip.warn("Unknown user ids: " + user_ids.join(","));
-        return undefined;
-    }
-
-    return emails.join(",");
-}
-
 export function user_ids_string_to_ids_array(user_ids_string: string): number[] {
     const user_ids = user_ids_string.length === 0 ? [] : user_ids_string.split(",");
     const ids = user_ids.map((user_id_string) => {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -378,16 +378,6 @@ export function get_participants_from_user_ids_string(user_ids_string: string): 
     return user_ids;
 }
 
-export function emails_strings_to_user_ids_array(emails_string: string): number[] | undefined {
-    const user_ids_string = emails_strings_to_user_ids_string(emails_string);
-    if (user_ids_string === undefined) {
-        return undefined;
-    }
-
-    const user_ids_array = user_ids_string_to_ids_array(user_ids_string);
-    return user_ids_array;
-}
-
 export function user_ids_to_full_names_string(user_ids: number[]): string {
     const sorted_names = user_ids.map((user_id) => {
         const person = maybe_get_user_by_id(user_id);
@@ -421,11 +411,6 @@ export function get_user_time(user_id: number): string | undefined {
 export function get_user_type(user_id: number): string | undefined {
     const user_profile = get_by_user_id(user_id);
     return settings_config.user_role_map.get(user_profile.role);
-}
-
-export function emails_strings_to_user_ids_string(emails_string: string): string | undefined {
-    const emails = emails_string.split(",").map((email) => email.trim());
-    return email_list_to_user_ids_string(emails);
 }
 
 export function emails_string_to_user_ids(emails_string: string): number[] {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1026,31 +1026,6 @@ export function is_valid_user_id_for_compose(user_id: number, ignore_missing = f
     return true;
 }
 
-export function is_valid_email_for_compose(email: string): boolean {
-    if (is_cross_realm_email(email)) {
-        return true;
-    }
-
-    const person = get_by_email(email);
-    if (!person || person.is_inaccessible_user) {
-        return false;
-    }
-
-    // we allow deactivated users in compose so that
-    // one can attempt to reply to threads that contained them.
-    return true;
-}
-
-export function is_valid_bulk_emails_for_compose(emails: string[]): boolean {
-    // Returns false if at least one of the emails is invalid.
-    return emails.every((email) => {
-        if (!is_valid_email_for_compose(email)) {
-            return false;
-        }
-        return true;
-    });
-}
-
 export function is_valid_bulk_user_ids_for_compose(
     user_ids: number[],
     ignore_missing = true,
@@ -1243,14 +1218,6 @@ export function get_active_user_ids(): number[] {
 
 export function get_non_active_realm_users(): User[] {
     return [...non_active_user_dict.values()];
-}
-
-export function is_cross_realm_email(email: string): boolean {
-    const person = get_by_email(email);
-    if (!person) {
-        return false;
-    }
-    return cross_realm_dict.has(person.user_id);
 }
 
 export function get_recipient_count(person: User | PseudoMentionUser): number {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -249,40 +249,11 @@ export function sort_user_ids_by_username(user_ids: number[]): number[] {
     return name_id_dict.map(({user_id}) => user_id);
 }
 
-// A function that sorts Email according to the user's full name
-export function sort_emails_by_username(emails: string[]): (string | undefined)[] {
-    const user_ids = emails.map((email) => get_user_id(email));
-    const name_email_dict = user_ids.map((user_id, index) => ({
-        name:
-            user_id !== undefined && people_by_user_id_dict.has(user_id)
-                ? people_by_user_id_dict.get(user_id)?.full_name
-                : "?",
-        email: emails[index],
-    }));
-    name_email_dict.sort((a, b) => util.strcmp(a.name!, b.name!));
-    return name_email_dict.map(({email}) => email);
-}
-
 export function get_visible_email(user: User): string {
     if (user.delivery_email) {
         return user.delivery_email;
     }
     return user.email;
-}
-
-export function get_user_id(email: string): number | undefined {
-    const person = get_by_email(email);
-    if (person === undefined) {
-        blueslip.error("Unknown email for get_user_id", {email});
-        return undefined;
-    }
-    const user_id = person.user_id;
-    if (!user_id) {
-        blueslip.error("No user_id found for email", {email});
-        return undefined;
-    }
-
-    return user_id;
 }
 
 export function maybe_get_user_id_by_email(email: string): number | undefined {
@@ -339,10 +310,11 @@ export function user_ids_string_to_emails_string(user_ids_string: string): strin
 }
 
 export function user_ids_to_emails_string(user_ids: number[]): string | undefined {
-    let emails = util.try_parse_as_truthy(
-        user_ids.map((user_id) => {
+    const sorted_ids = sort_user_ids_by_username(user_ids);
+    const emails = util.try_parse_as_truthy(
+        sorted_ids.map((user_id) => {
             const person = people_by_user_id_dict.get(user_id);
-            return person?.email;
+            return person?.email.toLowerCase();
         }),
     );
 
@@ -351,9 +323,7 @@ export function user_ids_to_emails_string(user_ids: number[]): string | undefine
         return undefined;
     }
 
-    emails = emails.map((email) => email.toLowerCase());
-
-    return sort_emails_by_username(emails).join(",");
+    return emails.join(",");
 }
 
 export function user_ids_string_to_ids_array(user_ids_string: string): number[] {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -695,38 +695,6 @@ export function pm_with_url(message: Message | MessageWithBooleans): string | un
     return url;
 }
 
-export function update_email_in_reply_to(
-    reply_to: string,
-    user_id: number,
-    new_email: string,
-): string {
-    // We try to replace an old email with a new email in a reply_to,
-    // but we try to avoid changing the reply_to if we don't have to,
-    // and we don't warn on any errors.
-    let emails = reply_to.split(",");
-
-    const persons = util.try_parse_as_truthy(emails.map((email) => people_dict.get(email.trim())));
-
-    if (persons === undefined) {
-        return reply_to;
-    }
-
-    const needs_patch = persons.some((person) => person.user_id === user_id);
-
-    if (!needs_patch) {
-        return reply_to;
-    }
-
-    emails = persons.map((person) => {
-        if (person.user_id === user_id) {
-            return new_email;
-        }
-        return person.email;
-    });
-
-    return emails.join(",");
-}
-
 export function filter_other_guest_ids(user_ids: number[]): number[] {
     return util.sorted_ids(
         user_ids.filter((id) => id !== current_user.user_id && get_by_user_id(id)?.is_guest),

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -515,27 +515,6 @@ export function pm_reply_user_string(message: Message | MessageWithBooleans): st
     return user_ids.join(",");
 }
 
-export function pm_reply_to(message: Message): string | undefined {
-    const user_ids = pm_with_user_ids(message);
-
-    if (!user_ids) {
-        return undefined;
-    }
-
-    const emails = user_ids.map((user_id) => {
-        const person = people_by_user_id_dict.get(user_id);
-        if (!person) {
-            blueslip.error("Unknown user id in message", {user_id});
-            return "?";
-        }
-        return person.email;
-    });
-
-    const reply_to = sort_emails_by_username(emails).join(",");
-
-    return reply_to;
-}
-
 export function sorted_other_user_ids(user_ids: number[]): number[] {
     // This excludes your own user id unless you're the only user
     // (i.e. you sent a message to yourself).

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -388,28 +388,6 @@ export function emails_strings_to_user_ids_array(emails_string: string): number[
     return user_ids_array;
 }
 
-export function reply_to_to_user_ids_string(emails_string: string): string | undefined {
-    // This is basically emails_strings_to_user_ids_string
-    // without blueslip warnings, since it can be called with
-    // invalid data.
-    const emails = emails_string.split(",");
-
-    let user_ids = util.try_parse_as_truthy(
-        emails.map((email) => {
-            const person = get_by_email(email);
-            return person?.user_id;
-        }),
-    );
-
-    if (user_ids === undefined) {
-        return undefined;
-    }
-
-    user_ids = util.sorted_ids(user_ids);
-
-    return user_ids.join(",");
-}
-
 export function user_ids_to_full_names_string(user_ids: number[]): string {
     const sorted_names = user_ids.map((user_id) => {
         const person = maybe_get_user_by_id(user_id);

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -1100,25 +1100,22 @@ export let get_suggestions = function (
     // Handle spaces in person name in new suggestions only. Checks if the last operator is 'search'
     // and the second last operator in search_terms is one out of person_suggestion_ops.
     // e.g for `sender:Ted sm`, initially last = {operator: 'search', operand: 'sm'....}
-    // and second last is {operator: 'sender', operand: 'sm'....}. If the second last operand
-    // is an email of a user, both of these terms remain unchanged. Otherwise search operator
-    // will be deleted and new last will become {operator:'sender', operand: 'Ted sm`....}.
+    // and second last is {operator: 'sender', operand: 'Ted'....}. The search operator
+    // will be deleted and new last will become {operator:'sender', operand: 'Ted sm'....}.
     if (
         text_search_terms.length > 1 &&
         last.operator === "search" &&
         person_suggestion_ops.includes(text_search_terms.at(-2)!.operator)
     ) {
         const person_op = text_search_terms.at(-2)!;
-        if (!people.reply_to_to_user_ids_string(person_op.operand)) {
-            last = {
-                operator: person_op.operator,
-                operand: person_op.operand + " " + last.operand,
-                negated: person_op.negated,
-            };
-            text_search_terms.splice(-2);
-            text_search_terms.push(last);
-            all_search_terms = [...pill_search_terms, ...text_search_terms];
-        }
+        last = {
+            operator: person_op.operator,
+            operand: person_op.operand + " " + last.operand,
+            negated: person_op.negated,
+        };
+        text_search_terms.splice(-2);
+        text_search_terms.push(last);
+        all_search_terms = [...pill_search_terms, ...text_search_terms];
     }
     const valid_base_text_search_terms = text_search_terms
         .slice(0, -1)

--- a/web/src/transmit.ts
+++ b/web/src/transmit.ts
@@ -148,15 +148,15 @@ export function reply_message(message: Message, content: string): void {
     }
 
     if (message.type === "private") {
-        const pm_recipient = people.pm_reply_to(message);
-        assert(pm_recipient !== undefined);
+        const user_ids = people.pm_with_user_ids(message);
+        assert(user_ids !== undefined);
 
         const reply: SendMessageData = {
             type: "private",
             local_id,
             sender_id,
             queue_id,
-            to: JSON.stringify(pm_recipient.split(",")),
+            to: JSON.stringify(user_ids),
             content,
         };
 

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -11,7 +11,6 @@ import * as blueslip from "./blueslip.ts";
 import * as bot_data from "./bot_data.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
-import * as compose_state from "./compose_state.ts";
 import * as message_live_update from "./message_live_update.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
 import * as people from "./people.ts";
@@ -74,7 +73,6 @@ export const update_person = function update(event: UserUpdate): void {
         const new_email = event.new_email;
 
         people.update_email(user_id, new_email);
-        compose_state.update_email(user_id, new_email);
 
         if (people.is_my_user_id(event.user_id)) {
             current_user.email = new_email;

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -76,7 +76,7 @@ export function extract_pm_recipients(recipients: string): string[] {
 // When the type is "private", properties from to_user_ids might be undefined.
 // See https://github.com/zulip/zulip/pull/23032#discussion_r1038480596.
 export type Recipient =
-    | {type: "private"; to_user_ids?: string | undefined; reply_to: string}
+    | {type: "private"; to_user_ids?: string | undefined}
     | ({type: "stream"} & StreamTopic);
 
 export const same_recipient = function util_same_recipient(a?: Recipient, b?: Recipient): boolean {

--- a/web/tests/compose_fade.test.cjs
+++ b/web/tests/compose_fade.test.cjs
@@ -131,14 +131,13 @@ run_test("want_normal_display", ({override, override_rewire}) => {
     // Private message with no recipient.
     compose_fade_helper.set_focused_recipient({
         type: "private",
-        reply_to: "",
     });
     assert.ok(compose_fade_helper.want_normal_display());
 
     // Private message with a recipient.
     compose_fade_helper.set_focused_recipient({
         type: "private",
-        reply_to: "hello@zulip.com",
+        to_user_ids: "31",
     });
     assert.ok(!compose_fade_helper.want_normal_display());
 });

--- a/web/tests/compose_pm_pill.test.cjs
+++ b/web/tests/compose_pm_pill.test.cjs
@@ -65,25 +65,13 @@ run_test("pills", ({override}) => {
     };
     pills.items = () => [...all_pills.values()];
 
-    let text_cleared;
-    pills.clear_text = () => {
-        text_cleared = true;
-    };
+    pills.clear_text = () => {};
 
-    let pills_cleared;
     pills.clear = () => {
-        pills_cleared = true;
         pills = {
             pill: {},
         };
         all_pills.clear();
-    };
-
-    let appendValue_called;
-    pills.appendValue = function (value) {
-        appendValue_called = true;
-        assert.equal(value, othello.user_id.toString());
-        this.appendValidatedData(othello);
     };
 
     function test_create_item(handler) {
@@ -156,13 +144,7 @@ run_test("pills", ({override}) => {
 
     test_create_item(create_item_handler);
 
-    compose_pm_pill.set_from_emails("othello@example.com");
-    assert.ok(compose_pm_pill.widget);
-
-    assert.ok(pills_cleared);
-    assert.ok(appendValue_called);
-    assert.ok(text_cleared);
-
+    compose_pm_pill.clear();
     compose_pm_pill.set_from_typeahead(me);
     compose_pm_pill.set_from_typeahead(othello);
 

--- a/web/tests/compose_state.test.cjs
+++ b/web/tests/compose_state.test.cjs
@@ -17,14 +17,7 @@ const realm = make_realm();
 set_realm(realm);
 
 run_test("private_message_recipient_emails", ({override}) => {
-    let emails;
-    override(compose_pm_pill, "set_from_emails", (value) => {
-        emails = value;
-    });
-
-    override(compose_pm_pill, "get_emails", () => emails);
-
-    compose_state.private_message_recipient_emails("fred@fred.org");
+    override(compose_pm_pill, "get_emails", () => "fred@fred.org");
     assert.equal(compose_state.private_message_recipient_emails(), "fred@fred.org");
 });
 

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -188,7 +188,6 @@ test_ui("validate", ({mock_template, override}) => {
 
     initialize_pm_pill(mock_template);
     add_content_to_compose_box();
-    compose_state.private_message_recipient_emails("");
     let pm_recipient_error_rendered = false;
     override(realm, "realm_direct_message_permission_group", everyone.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
@@ -205,7 +204,7 @@ test_ui("validate", ({mock_template, override}) => {
     pm_recipient_error_rendered = false;
 
     people.add_active_user(bob);
-    compose_state.private_message_recipient_emails("bob@example.com");
+    compose_state.set_private_message_recipient_ids([bob.user_id]);
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
 
@@ -235,13 +234,13 @@ test_ui("validate", ({mock_template, override}) => {
 
     initialize_pm_pill(mock_template);
     add_content_to_compose_box();
-    compose_state.private_message_recipient_emails("welcome-bot@example.com");
+    compose_state.set_private_message_recipient_ids([welcome_bot.user_id]);
     $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(compose_validate.validate());
 
     // For this first block, we should fail due to empty compose.
     initialize_pm_pill(mock_template);
-    compose_state.private_message_recipient_emails("welcome-bot@example.com");
+    compose_state.set_private_message_recipient_ids([welcome_bot.user_id]);
     $("textarea#compose-textarea").removeClass("invalid");
     assert.ok(!compose_validate.validate());
     assert.ok(!$("#compose-send-button .loader").visible());
@@ -920,7 +919,7 @@ test_ui("test_warn_if_guest_in_dm_recipient", ({mock_template, override}) => {
 
     compose_state.set_message_type("private");
     initialize_pm_pill(mock_template);
-    compose_state.private_message_recipient_emails("guest@example.com");
+    compose_state.set_private_message_recipient_ids([guest.user_id]);
     const classname = compose_banner.CLASSNAMES.guest_in_dm_recipient_warning;
     let $banner = $(`#compose_banners .${CSS.escape(classname)}`);
 
@@ -953,7 +952,7 @@ test_ui("test_warn_if_guest_in_dm_recipient", ({mock_template, override}) => {
     people.add_active_user(new_guest);
 
     initialize_pm_pill(mock_template);
-    compose_state.private_message_recipient_emails("guest@example.com, new_guest@example.com");
+    compose_state.set_private_message_recipient_ids([guest.user_id, new_guest.user_id]);
     $.reset_selector(`#compose_banners .${CSS.escape(classname)}`);
     $banner = $(`#compose_banners .${CSS.escape(classname)}`);
     const $banner_content = $(`#compose_banners .${CSS.escape(classname)} .banner_content`);

--- a/web/tests/direct_message_group_data.test.cjs
+++ b/web/tests/direct_message_group_data.test.cjs
@@ -48,10 +48,7 @@ const norbert = create_user({
 people.initialize_current_user(me.user_id);
 
 run_test("direct_message_group_data.process_loaded_messages", () => {
-    const direct_message_group1 = "jill@zulip.com,norbert@zulip.com";
     const timestamp1 = 1382479029; // older
-
-    const direct_message_group2 = "alice@zulip.com,fred@zulip.com";
     const timestamp2 = 1382479033; // newer
 
     const old_timestamp = 1382479000;
@@ -84,10 +81,8 @@ run_test("direct_message_group_data.process_loaded_messages", () => {
 
     direct_message_group_data.process_loaded_messages(messages);
 
-    const user_ids_string1 = people.emails_strings_to_user_ids_string(direct_message_group1);
-    const user_ids_string2 = people.emails_strings_to_user_ids_string(direct_message_group2);
     assert.deepEqual(direct_message_group_data.get_direct_message_groups(), [
-        user_ids_string2,
-        user_ids_string1,
+        `${alice.user_id},${fred.user_id}`,
+        `${jill.user_id},${norbert.user_id}`,
     ]);
 });

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -1643,12 +1643,6 @@ run_test("sort_by_username", () => {
         people.sort_user_ids_by_username([maria.user_id, cedar.user_id, leo.user_id]),
         [cedar.user_id, leo.user_id, maria.user_id],
     );
-
-    assert.deepEqual(people.sort_emails_by_username([maria.email, cedar.email, leo.email]), [
-        cedar.email,
-        leo.email,
-        maria.email,
-    ]);
 });
 
 run_test("get_users_that_match_role_ids", () => {

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -966,10 +966,6 @@ run_test("multi_user_methods", () => {
     user_ids = people.slug_to_user_ids("402,401-group");
     assert.deepEqual(user_ids, [402, 401]);
 
-    emails_string = "emp402@example.com,EMP401@EXAMPLE.COM";
-    let user_ids_string = people.emails_strings_to_user_ids_string(emails_string);
-    assert.equal(user_ids_string, "401,402");
-
     assert.equal(people.user_ids_string_to_slug("401,402"), "401,402-group");
     assert.equal(people.user_ids_string_to_slug("402"), "402-whatever-402");
     assert.equal(people.user_ids_to_slug([401, 402]), "401,402-group");
@@ -1511,19 +1507,6 @@ run_test("is_valid_full_name_and_user_id", () => {
     assert.ok(!people.is_valid_full_name_and_user_id("bogus", 99));
     assert.ok(!people.is_valid_full_name_and_user_id(me.full_name, 99));
     assert.ok(people.is_valid_full_name_and_user_id(me.full_name, me.user_id));
-});
-
-run_test("emails_strings_to_user_ids_array", () => {
-    initialize();
-    people.add_active_user(steven);
-    people.add_active_user(maria);
-
-    let user_ids = people.emails_strings_to_user_ids_array(`${steven.email},${maria.email}`);
-    assert.deepEqual(user_ids, [steven.user_id, maria.user_id]);
-
-    blueslip.expect("warn", "Unknown emails");
-    user_ids = people.emails_strings_to_user_ids_array("dummyuser@example.com");
-    assert.equal(user_ids, undefined);
 });
 
 run_test("get_visible_email", () => {

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -957,7 +957,7 @@ run_test("multi_user_methods", () => {
     assert.equal(emp401.user_id, 401);
     assert.equal(emp402.user_id, 402);
 
-    let emails_string = people.user_ids_string_to_emails_string("402,401");
+    const emails_string = people.user_ids_string_to_emails_string("402,401");
     assert.equal(emails_string, "emp401@example.com,emp402@example.com");
 
     let user_ids = people.slug_to_user_ids("402,401");
@@ -1065,7 +1065,6 @@ run_test("message_methods", () => {
     };
     assert.equal(people.pm_with_url(message), "#narrow/dm/301,302-group");
     assert.equal(people.pm_perma_link(message), "#narrow/dm/30,301,302-group");
-    assert.equal(people.pm_reply_to(message), "charles@example.com,Athens@example.com");
     assert.equal(people.small_avatar_url(message), "http://charles.com/foo.png");
 
     message = {
@@ -1075,7 +1074,6 @@ run_test("message_methods", () => {
     };
     assert.equal(people.pm_with_url(message), "#narrow/dm/302-Maria-Athens");
     assert.equal(people.pm_perma_link(message), "#narrow/dm/30,302-dm");
-    assert.equal(people.pm_reply_to(message), "Athens@example.com");
     assert.equal(people.small_avatar_url(message), "legacy.png");
 
     message = {
@@ -1125,7 +1123,6 @@ run_test("message_methods", () => {
     assert.equal(people.all_user_ids_in_pm(message), undefined);
 
     // Test undefined user_ids
-    assert.equal(people.pm_reply_to(message), undefined);
     assert.equal(people.pm_reply_user_string(message), undefined);
     assert.equal(people.pm_with_url(message), undefined);
 

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -1292,22 +1292,6 @@ run_test("updates", () => {
     assert.equal(person.user_id, user_id);
 });
 
-run_test("update_email_in_reply_to", () => {
-    initialize();
-    people.add_active_user(charles);
-    people.add_active_user(maria);
-
-    let reply_to = "    charles@example.com,   athens@example.com";
-    assert.equal(people.update_email_in_reply_to(reply_to, 9999, "whatever"), reply_to);
-    assert.equal(
-        people.update_email_in_reply_to(reply_to, maria.user_id, "maria@example.com"),
-        "charles@example.com,maria@example.com",
-    );
-
-    reply_to = "    charles@example.com,   athens@example.com, invalid@example.com";
-    assert.equal(people.update_email_in_reply_to(reply_to, 9999, "whatever"), reply_to);
-});
-
 run_test("track_duplicate_full_names", () => {
     initialize();
     people.add_active_user(maria);

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -957,9 +957,6 @@ run_test("multi_user_methods", () => {
     assert.equal(emp401.user_id, 401);
     assert.equal(emp402.user_id, 402);
 
-    const emails_string = people.user_ids_string_to_emails_string("402,401");
-    assert.equal(emails_string, "emp401@example.com,emp402@example.com");
-
     let user_ids = people.slug_to_user_ids("402,401");
     assert.deepEqual(user_ids, [402, 401]);
 

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -970,11 +970,6 @@ run_test("multi_user_methods", () => {
     let user_ids_string = people.emails_strings_to_user_ids_string(emails_string);
     assert.equal(user_ids_string, "401,402");
 
-    user_ids_string = people.reply_to_to_user_ids_string(emails_string);
-    assert.equal(user_ids_string, "401,402");
-
-    assert.equal(people.reply_to_to_user_ids_string("invalid@example.com"), undefined);
-
     assert.equal(people.user_ids_string_to_slug("401,402"), "401,402-group");
     assert.equal(people.user_ids_string_to_slug("402"), "402-whatever-402");
     assert.equal(people.user_ids_to_slug([401, 402]), "401,402-group");

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -340,7 +340,6 @@ run_test("basics", ({override}) => {
     const active_user_ids = people.get_active_user_ids().toSorted();
     assert.deepEqual(active_user_ids, [me.user_id, isaac.user_id]);
     assert.equal(people.is_active_user_or_system_bot(isaac.user_id), true);
-    assert.ok(people.is_valid_email_for_compose(isaac.email));
     assert.ok(people.is_valid_user_id_for_compose(isaac.user_id));
 
     let bot_user_ids = people.get_bot_ids();
@@ -352,7 +351,6 @@ run_test("basics", ({override}) => {
     assert.equal(people.get_non_active_user_ids_count([isaac.user_id]), 1);
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(people.is_active_user_or_system_bot(isaac.user_id), false);
-    assert.equal(people.is_valid_email_for_compose(isaac.email), true);
     assert.equal(people.is_valid_user_id_for_compose(isaac.user_id), true);
 
     people.add_active_user(bot_botson);
@@ -417,9 +415,6 @@ run_test("basics", ({override}) => {
     // The current user should still be there
     person = people.get_by_email("me@example.com");
     assert.equal(person.full_name, "Me Myself");
-
-    // Test undefined people
-    assert.equal(people.is_cross_realm_email("invalid@example.com"), false);
 
     // Test is_my_user_id function
     assert.equal(people.is_my_user_id(me.user_id), true);
@@ -1277,7 +1272,6 @@ run_test("updates", () => {
 
     // Do sanity checks on our data.
     assert.equal(people.get_by_email(old_email).user_id, user_id);
-    assert.ok(!people.is_cross_realm_email(old_email));
 
     assert.equal(people.get_by_email(new_email), undefined);
 
@@ -1286,7 +1280,6 @@ run_test("updates", () => {
 
     // Now look up using the new email.
     assert.equal(people.get_by_email(new_email).user_id, user_id);
-    assert.ok(!people.is_cross_realm_email(new_email));
 
     const all_people = get_all_persons();
     assert.equal(all_people.length, 3);
@@ -1425,18 +1418,11 @@ run_test("initialize", () => {
     people.initialize(current_user.user_id, params, user_group_params);
 
     assert.equal(people.is_active_user_or_system_bot(17), true);
-    assert.ok(people.is_cross_realm_email("bot@example.com"));
-    assert.ok(people.is_valid_email_for_compose("bot@example.com"));
     assert.ok(people.is_valid_user_id_for_compose(test_bot.user_id));
-    assert.ok(people.is_valid_email_for_compose("alice@example.com"));
     assert.ok(people.is_valid_user_id_for_compose(alice.user_id));
-    assert.ok(people.is_valid_email_for_compose("retiree@example.com"));
     assert.ok(people.is_valid_user_id_for_compose(retiree.user_id));
-    assert.ok(!people.is_valid_email_for_compose("totally-bogus-username@example.com"));
     blueslip.expect("error", "Unknown user_id in maybe_get_user_by_id");
     assert.ok(!people.is_valid_user_id_for_compose(9999));
-    assert.ok(people.is_valid_bulk_emails_for_compose(["bot@example.com", "alice@example.com"]));
-    assert.ok(!people.is_valid_bulk_emails_for_compose(["not@valid.com", "alice@example.com"]));
     assert.ok(people.is_valid_bulk_user_ids_for_compose([17, 16, 15]));
     blueslip.reset();
     blueslip.expect("error", "Unknown user_id in maybe_get_user_by_id");

--- a/web/tests/people_errors.test.cjs
+++ b/web/tests/people_errors.test.cjs
@@ -74,9 +74,6 @@ run_test("blueslip", () => {
     });
     people.add_active_user(person);
 
-    blueslip.expect("warn", "Unknown user ids: 1,2");
-    people.user_ids_string_to_emails_string("1,2");
-
     blueslip.expect("warn", "Unknown emails");
     people.email_list_to_user_ids_string([unknown_email]);
 

--- a/web/tests/people_errors.test.cjs
+++ b/web/tests/people_errors.test.cjs
@@ -66,7 +66,7 @@ run_test("blueslip", () => {
     blueslip.expect("error", "Unknown user_id");
     people.get_actual_name_from_user_id(9999);
 
-    blueslip.expect("error", "Unknown email for get_user_id", 2);
+    blueslip.expect("error", "Unknown email for get_user_id");
     people.get_user_id(unknown_email);
 
     blueslip.expect("warn", "No user_id provided");
@@ -87,7 +87,7 @@ run_test("blueslip", () => {
     blueslip.expect("warn", "Unknown emails");
     people.email_list_to_user_ids_string([unknown_email]);
 
-    let message = {
+    const message = {
         type: "private",
         display_recipient: [],
         sender_id: me.user_id,
@@ -96,29 +96,6 @@ run_test("blueslip", () => {
     people.pm_with_user_ids(message);
     people.all_user_ids_in_pm(message);
     assert.equal(people.pm_perma_link(message), undefined);
-
-    const charles = make_user({
-        email: "charles@example.com",
-        user_id: 451,
-        full_name: "Charles Dickens",
-        avatar_url: "charles.com/foo.png",
-    });
-    const maria = make_user({
-        email: "athens@example.com",
-        user_id: 452,
-        full_name: "Maria Athens",
-    });
-    people.add_active_user(charles);
-    people.add_active_user(maria);
-
-    message = {
-        type: "private",
-        display_recipient: [{id: maria.user_id}, {id: 42}, {id: charles.user_id}],
-        sender_id: charles.user_id,
-    };
-    blueslip.expect("error", "Unknown user id in message");
-    const reply_to = people.pm_reply_to(message);
-    assert.ok(reply_to.includes("?"));
 
     blueslip.expect("error", "Unknown user_id in maybe_get_user_by_id");
     blueslip.expect("error", "Unknown people in message");
@@ -129,5 +106,5 @@ run_test("blueslip", () => {
     assert.equal(people.my_custom_profile_data(undefined), undefined);
 
     blueslip.expect("error", "Trying to set undefined field id");
-    people.set_custom_profile_field_data(maria.user_id, {});
+    people.set_custom_profile_field_data(me.user_id, {});
 });

--- a/web/tests/people_errors.test.cjs
+++ b/web/tests/people_errors.test.cjs
@@ -66,9 +66,6 @@ run_test("blueslip", () => {
     blueslip.expect("error", "Unknown user_id");
     people.get_actual_name_from_user_id(9999);
 
-    blueslip.expect("error", "Unknown email for get_user_id");
-    people.get_user_id(unknown_email);
-
     blueslip.expect("warn", "No user_id provided");
     const person = make_user({
         email: "person@example.com",
@@ -76,10 +73,6 @@ run_test("blueslip", () => {
         full_name: "Person Person",
     });
     people.add_active_user(person);
-
-    blueslip.expect("error", "No user_id found for email");
-    const user_id = people.get_user_id("person@example.com");
-    assert.equal(user_id, undefined);
 
     blueslip.expect("warn", "Unknown user ids: 1,2");
     people.user_ids_string_to_emails_string("1,2");

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -1032,13 +1032,17 @@ test("people_suggestions", ({override}) => {
     suggestions = get_suggestions(query);
     assert.deepEqual(suggestions, expected);
 
+    // The search bar typeahead always converts person operators to
+    // user_id-based pills, so raw email operands are not reachable.
+    // Both valid and invalid emails get merged with the trailing
+    // search term, producing no person match.
     query = "sender:ted@zulip.com new";
-    expected = ["new"];
+    expected = [];
     suggestions = get_suggestions(query);
     assert.deepEqual(suggestions, expected);
 
     query = "sender:ted@tulip.com new";
-    expected = []; // Invalid email
+    expected = [];
     suggestions = get_suggestions(query);
     assert.deepEqual(suggestions, expected);
 });

--- a/web/tests/transmit.test.cjs
+++ b/web/tests/transmit.test.cjs
@@ -209,7 +209,7 @@ run_test("reply_message_private", ({override}) => {
         queue_id: 177,
         local_id: "199",
         type: "private",
-        to: '["fred@example.com"]',
+        to: `[${fred.user_id}]`,
         content: "hello",
     });
 });

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -579,9 +579,9 @@ test("sort_recipients", () => {
     const subscriber_email_1 = "b_user_2@zulip.net";
     const subscriber_email_2 = "b_user_3@zulip.net";
     const subscriber_email_3 = "b_bot@example.com";
-    peer_data.add_subscriber(1, people.get_user_id(subscriber_email_1));
-    peer_data.add_subscriber(1, people.get_user_id(subscriber_email_2));
-    peer_data.add_subscriber(1, people.get_user_id(subscriber_email_3));
+    peer_data.add_subscriber(1, b_user_2.user_id);
+    peer_data.add_subscriber(1, b_user_3.user_id);
+    peer_data.add_subscriber(1, b_bot.user_id);
 
     // For splitting based on whether a direct message was sent
     pm_conversations.set_partner(5);

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -57,9 +57,6 @@ buddy_list.buddy_list = buddy_data;
 mock_esm("../src/activity_ui", {
     redraw() {},
 });
-mock_esm("../src/compose_state", {
-    update_email() {},
-});
 mock_esm("../src/settings", {
     update_lock_icon_in_sidebar() {},
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
See [#api design > defer loading user data @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/defer.20loading.20user.20data/near/2426907) for more context.

There are 2 `get_by_email` use left in production

1. It is used by `email_list_to_user_ids_string`, in turn used by `emails_string_to_user_ids` which is being used in fix_buggy_drafts under this note:

```
 // TODO/compatibility: We should eventually be able to delete this. But
            // probably not anytime soon. Once you can no longer upgrade to `main` without
            // first upgrading to 11.0, we can be certain clients that have actually logged
            // in have experienced this conversion code... but even after that, a client
            // may still have old-style drafts for several months.
            if (draft.type === "private") {
                if (draft.private_message_recipient_ids === undefined) {
                    assert(draft.private_message_recipient !== undefined);
                    draft.private_message_recipient_ids = people.emails_string_to_user_ids(
                        draft.private_message_recipient,
                    );
                    delete draft.private_message_recipient;
                }
                valid_drafts[draft_id] = {
                    ...draft,
                    private_message_recipient_ids: draft.private_message_recipient_ids,
                };
                continue;
            }
 ```

2. maybe_get_user_id_by_email

- get_user_id_for_mention_button uses this, we need this to check legacy rendered markdown before we cut over to `data-user-id`.
- Same with the use in user_card_popover.ts where we handle legacy `data-user-email`.

**How changes were tested:**


1. compose_fade: Use user_ids directly instead of email round-trip.
- Start writing a DM, navigate to other DMs/topics and check that the fade works. 
- Do the same with a channel message
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

2. search: Remove unreachable email validation in person operand check.

- Typing raw `dm:aaron@zulip.com,zoe@zulip.com` did not work in main, nor it does in the new PR.
- Pasting`dm:aaron@zulip.com new` and pressing enter gave error on main, so does it in the new PR.
- Pasting `dm:aaron@zulip.com ` shows aaron as a user in the dropdown, pressing enter selects that pill, converts it into a used id based pill and then the search is made, this worked before and does now as well.

3. transmit: Send user_ids instead of emails for DM replies.
- Quote a message and check that the quote message gets populated in the compose box.

4. For `inbox: Fix DM reply from inbox when message is not in store.`:
I applied this patch to both the current PR branch and main. On main, going to the inbox view, focusing on a DM row and pressing `r` to reply would open an empty recipient list in the compose box, while for the current branch, the users would populate as expected. 

```diff
 diff --git a/web/src/inbox_ui.ts b/web/src/inbox_ui.ts
  --- a/web/src/inbox_ui.ts
  +++ b/web/src/inbox_ui.ts
  @@ -1680,1 +1680,1 @@
  -        const message = message_store.get(row_info.latest_msg_id);
  +        const message = undefined; // TEMPORARY: force fallback path for manual testing
 ```

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
