### PR TITLE
Fix popover alignment and highlight active button on open.

### DIFF
--- a/web/src/gear_menu.ts
+++ b/web/src/gear_menu.ts
@@ -98,7 +98,7 @@ export function initialize(): void {
     popover_menus.register_popover_menu("#gear-menu", {
         theme: "popover-menu",
         placement: "bottom",
-        offset: [-50, 0],
+        offset: popover_menus.NAVBAR_POPOVER_OFFSET,
         popperOptions: {
             strategy: "fixed",
             modifiers: [

--- a/web/src/navbar_help_menu.ts
+++ b/web/src/navbar_help_menu.ts
@@ -11,7 +11,7 @@ export function initialize(): void {
     popover_menus.register_popover_menu("#help-menu", {
         theme: "popover-menu",
         placement: "bottom",
-        offset: [-50, 0],
+        offset: popover_menus.NAVBAR_POPOVER_OFFSET,
         // The strategy: "fixed"; and eventlisteners modifier option
         // ensure that the personal menu does not modify its position
         // or disappear when user zooms the page.

--- a/web/src/personal_menu_popover.ts
+++ b/web/src/personal_menu_popover.ts
@@ -17,7 +17,7 @@ export function initialize(): void {
     popover_menus.register_popover_menu("#personal-menu", {
         theme: "popover-menu",
         placement: "bottom",
-        offset: [-50, 0],
+        offset: popover_menus.NAVBAR_POPOVER_OFFSET,
         // The strategy: "fixed"; and eventlisteners modifier option
         // ensure that the personal menu does not modify its position
         // or disappear when user zooms the page.

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -68,6 +68,7 @@ export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
 // Font size in em for popover derived from popover font size being
 // 15px at base font size of 14px.
 export const POPOVER_FONT_SIZE_IN_EM = 1.0714;
+export const NAVBAR_POPOVER_OFFSET: [number, number] = [0, 7];
 
 /* Keyboard UI functions */
 export function popover_items_handle_keyboard(key: string, $items?: JQuery): void {


### PR DESCRIPTION
The navbar menus (personal, gear, and help) had `offset [-50, 0]`, which was shifting the popover away from the center. Changed to `offset [0, 7]` and added a small vertical gap so the arrow no longer overlaps the icon.

Also, the `active-navbar-menu` class was already being added/removed in `onShow`/`onHidden` across all three `.ts` files(`personal_menu_popover.ts`, `gear_menu.ts`, and `navbar_help_menu.ts`), but had no CSS. Added a nested CSS inside `.header-button.` in `zulip.css` so the button stays highlighted when its menu is open.

Fixes: [#issues > tooltip arrow appearing above profile picture](https://chat.zulip.org/#narrow/channel/9-issues/topic/tooltip.20arrow.20appearing.20above.20profile.20picture/with/2428500)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**


| Before | After |
|--------|-------|
|<img width="776" height="213" alt="Screenshot 2026-04-13 214620" src="https://github.com/user-attachments/assets/36395173-79de-4f12-aad3-a5fc88666c31" />|<img width="803" height="260" alt="Screenshot 2026-04-14 002002" src="https://github.com/user-attachments/assets/80063e09-fbc7-4f4c-a96d-b5f4195da8b8" />|

| Before | After |
|--------|-------|
|<img width="827" height="197" alt="Screenshot 2026-04-13 214750" src="https://github.com/user-attachments/assets/53cd7b2b-982e-4968-9bcf-245291ea12a1" />|<img width="808" height="285" alt="Screenshot 2026-04-14 002039" src="https://github.com/user-attachments/assets/10dc72ab-aa7a-49f9-b27a-09f5d58fccd5" />|

| Before | After |
|--------|-------|
|<img width="827" height="208" alt="Screenshot 2026-04-13 214758" src="https://github.com/user-attachments/assets/0834fc50-506c-4ad9-8203-a6892f0686cd" />|<img width="801" height="270" alt="Screenshot 2026-04-14 002129" src="https://github.com/user-attachments/assets/c184d235-1fcc-42ef-95d9-7bfb83352ab7" />|

| Before | After |
|--------|-------|
|<img width="620" height="617" alt="Screenshot 2026-04-07 182147" src="https://github.com/user-attachments/assets/3bcdf8cf-2eeb-4ccf-ae37-f5e54c85dba6" />|<img width="576" height="619" alt="Screenshot 2026-04-14 002225" src="https://github.com/user-attachments/assets/5cc12777-b971-4ae5-8778-ae45615c3968" />|

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/bdf09aff-25c6-4be8-b76f-a92ca1ade339" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/cdf7e54a-efbc-477e-9df5-7cff7f1aa6d0" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
