### PR TITLE
email: Filter deactivated users from group DM replies.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -504,7 +504,25 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         recipient_str = stream.name
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         display_recipient = get_display_recipient(recipient)
-        emails = [user_dict["email"] for user_dict in display_recipient]
+        # Get recipient IDs, excluding the sender
+        recipient_user_ids = [
+            user_dict["id"] for user_dict in display_recipient if user_dict["id"] != user_profile.id
+        ]
+        # Bulk fetch user profiles and filter to active users only
+        emails = list(
+            UserProfile.objects.filter(id__in=recipient_user_ids, is_active=True).values_list(
+                "email", flat=True
+            )
+        )
+
+        if not emails:
+            logger.info(
+                "Dropping missed-message email reply for group DM from user %s: "
+                "no active recipients remain.",
+                user_profile.id,
+            )
+            return
+
         recipient_str = ", ".join(emails)
         internal_send_group_direct_message(user_profile.realm, user_profile, body, emails=emails)
     else:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1275,6 +1275,19 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
 
 class TestMissedMessageEmailMessages(ZulipTestCase):
+    def create_and_process_mock_email(
+        self, sender_email: str, to_address: str, body: str = "Reply body", subject: str = "Reply"
+    ) -> None:
+        """Helper to reduce boilerplate when simulating incoming email replies."""
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content(body)
+        incoming_valid_message["Subject"] = subject
+        incoming_valid_message["From"] = sender_email
+        incoming_valid_message["To"] = to_address
+        incoming_valid_message["Reply-to"] = sender_email
+        process_message(incoming_valid_message)
+
+    @override_settings(PREFER_DIRECT_MESSAGE_GROUP=False)
     def test_receive_missed_personal_message_email_messages(self) -> None:
         # Build dummy messages for message notification email reply.
         # Have Hamlet send Othello a direct message. Othello will
@@ -1344,16 +1357,13 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         # token for looking up who did reply.
         mm_address = create_missed_message_address(user_profile, usermessage.message)
 
-        incoming_valid_message = EmailMessage()
-        incoming_valid_message.set_content("TestMissedGroupDirectMessageEmailMessages body")
-
-        incoming_valid_message["Subject"] = "TestMissedGroupDirectMessageEmailMessages subject"
-        incoming_valid_message["From"] = self.example_email("cordelia")
-        incoming_valid_message["To"] = mm_address
-        incoming_valid_message["Reply-to"] = self.example_email("cordelia")
-
         with self.assert_database_query_count(22):
-            process_message(incoming_valid_message)
+            self.create_and_process_mock_email(
+                sender_email=self.example_email("cordelia"),
+                to_address=mm_address,
+                body="TestMissedGroupDirectMessageEmailMessages body",
+                subject="TestMissedGroupDirectMessageEmailMessages subject",
+            )
 
         # Confirm Iago received the message.
         user_profile = self.example_user("iago")
@@ -1369,6 +1379,133 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
         self.assertEqual(message.sender, self.example_user("cordelia"))
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
+    def test_receive_missed_group_direct_message_with_deactivated_recipient(self) -> None:
+        # Build dummy messages for message notification email reply.
+        # Have Othello send Iago and Cordelia a group direct message.
+        # Deactivate Iago, then Cordelia replies via email.
+        # Othello should receive the message, Iago should not.
+
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        othello = self.example_user("othello")
+
+        # Othello sends a group DM to Cordelia and Iago
+        self.login("othello")
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "private",
+                "content": "test_receive_missed_message_email_messages",
+                "to": orjson.dumps([cordelia.id, iago.id]).decode(),
+            },
+        )
+        self.assert_json_success(result)
+
+        usermessage = most_recent_usermessage(cordelia)
+
+        # Create the missed message address for Cordelia
+        mm_address = create_missed_message_address(cordelia, usermessage.message)
+
+        # Capture Iago's last message before deactivation
+        iago_last_message_before = most_recent_message(iago)
+
+        # Deactivate Iago
+        do_deactivate_user(iago, acting_user=None)
+
+        self.create_and_process_mock_email(
+            sender_email=self.example_email("cordelia"),
+            to_address=mm_address,
+            body="TestMissedGroupDirectMessageWithDeactivatedRecipient body",
+            subject="TestMissedGroupDirectMessageWithDeactivatedRecipient subject",
+        )
+
+        # Confirm Othello received the message.
+        # Since only Othello remains active (Iago is deactivated and Cordelia is
+        # the sender), the message becomes a PERSONAL DM, not a group DM.
+        message = most_recent_message(othello)
+        self.assertEqual(
+            message.content,
+            "TestMissedGroupDirectMessageWithDeactivatedRecipient body",
+        )
+        self.assertEqual(message.sender, cordelia)
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
+        # Confirm deactivated Iago did NOT receive the new message
+        iago_last_message_after = most_recent_message(iago)
+        self.assertEqual(iago_last_message_before.id, iago_last_message_after.id)
+
+    def test_receive_missed_group_direct_message_all_recipients_deactivated(self) -> None:
+        # Test the early-return path when all recipients (except sender) are deactivated.
+        # Hamlet sends a group DM to Cordelia and Iago, then both are deactivated.
+        # Hamlet replies via email - should be safely dropped with no exception.
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+
+        self.login("hamlet")
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "private",
+                "content": "group dm",
+                "to": orjson.dumps([cordelia.id, iago.id]).decode(),
+            },
+        )
+        self.assert_json_success(result)
+
+        usermessage = most_recent_usermessage(hamlet)
+        mm_address = create_missed_message_address(hamlet, usermessage.message)
+
+        # Deactivate ALL other recipients
+        do_deactivate_user(cordelia, acting_user=None)
+        do_deactivate_user(iago, acting_user=None)
+
+        # Capture last message before attempting reply
+        last_message_before = self.get_last_message()
+
+        self.create_and_process_mock_email(
+            sender_email=hamlet.delivery_email, to_address=mm_address
+        )
+
+        # No new message should be delivered
+        self.assertEqual(last_message_before.id, self.get_last_message().id)
+
+    def test_receive_missed_group_direct_message_remains_group_dm(self) -> None:
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        othello = self.example_user("othello")
+        hamlet = self.example_user("hamlet")
+
+        # Hamlet sends a group DM to Cordelia, Iago, and Othello
+        self.login("hamlet")
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "private",
+                "content": "test group dm remains group",
+                "to": orjson.dumps([cordelia.id, iago.id, othello.id]).decode(),
+            },
+        )
+        self.assert_json_success(result)
+        usermessage = most_recent_usermessage(cordelia)
+        mm_address = create_missed_message_address(cordelia, usermessage.message)
+
+        # Deactivate only Iago (leaves 3 active participants)
+        do_deactivate_user(iago, acting_user=None)
+
+        # Cordelia replies via email using the new helper
+        self.create_and_process_mock_email(
+            sender_email=self.example_email("cordelia"),
+            to_address=mm_address,
+            body="Reply keeping it a group DM",
+        )
+
+        # Verify Hamlet received it and it is STILL a group DM
+        message = most_recent_message(hamlet)
+        self.assertEqual(message.content, "Reply keeping it a group DM")
+        self.assertEqual(message.sender, cordelia)
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_receive_missed_stream_message_email_messages(self) -> None:


### PR DESCRIPTION
This PR adresses comments left by @prakhar1144 in #37449.

Fixes #35273.

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
