### PR TITLE
compose: Make compose banner keyboard accessible.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -400,7 +400,23 @@ export function initialize(): void {
         tippy_props: {
             offset: [-10, 5],
         },
-        tab_moves_focus_to_target() {
+        tab_moves_focus_to_target(e: JQuery.KeyDownEvent): string | undefined {
+            if (e.shiftKey) {
+                const $last_banner = $("#compose_banners .main-view-banner").last();
+                if ($last_banner.length === 0) {
+                    return undefined;
+                }
+                // The close button is the last element in compose banner, so we return
+                // this if it exists or else check for action buttons.
+                if ($last_banner.find(".main-view-banner-close-button").length > 0) {
+                    return "#compose_banners .main-view-banner-close-button:last";
+                }
+                if ($last_banner.find(".main-view-banner-action-button").length > 0) {
+                    return "#compose_banners .main-view-banner-action-button:last";
+                }
+                return undefined;
+            }
+
             if (compose_state.get_message_type() === "stream") {
                 return "#stream_message_recipient_topic";
             }

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -393,6 +393,34 @@ export function initialize(): void {
         });
     }
 
+    // Trap Tab/Shift+Tab focus within #compose-container so keyboard navigation
+    // doesn't leave the compose box when it is open.
+    $("#compose-container").on("keydown", (e) => {
+        if (e.key !== "Tab" || !compose_state.composing()) {
+            return;
+        }
+
+        const $compose_container = $("#compose-container");
+        const visible_focusable_elements = [
+            ...$compose_container.find("input, textarea, button, .input, a[href], a[tabindex='0']"),
+        ].filter(
+            (element) =>
+                element.getClientRects().length > 0 &&
+                $(element).css("visibility") !== "hidden" &&
+                !$(element).is(":disabled"),
+        );
+
+        if (e.shiftKey) {
+            if (document.activeElement === visible_focusable_elements[0]) {
+                e.preventDefault();
+            }
+        } else {
+            if (document.activeElement === visible_focusable_elements.at(-1)) {
+                e.preventDefault();
+            }
+        }
+    });
+
     // Click event binding for "Attach files" button
     // Triggers a click on a hidden file input field
 

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -94,7 +94,7 @@ export type DropdownWidgetOptions = {
     // with a keyboard trigger or not.
     dropdown_triggered_via_keyboard?: boolean;
     // When this is set, pressing tab will move focus to the target element.
-    tab_moves_focus_to_target?: string | (() => string);
+    tab_moves_focus_to_target?: (event: JQuery.KeyDownEvent) => string | undefined;
     search_placeholder_text?: string;
     sort_list_by_filter_value?: (items: Option[], filter_value: string) => Option[];
 };
@@ -140,7 +140,7 @@ export class DropdownWidget {
     prefer_top_start_placement: boolean;
     dropdown_triggered_via_keyboard: boolean;
     keep_focus_on_search: boolean;
-    tab_moves_focus_to_target: string | (() => string) | undefined;
+    tab_moves_focus_to_target: ((event: JQuery.KeyDownEvent) => string | undefined) | undefined;
     current_hover_index: number;
 
     // TODO: This is only used in one widget, with no implementation
@@ -602,15 +602,16 @@ export class DropdownWidget {
 
                         case "Tab":
                             if (this.tab_moves_focus_to_target) {
+                                // Prevent focus from leaving the dropdown even when no target
+                                // is available.
                                 e.preventDefault();
                                 e.stopPropagation();
-                                popover_menus.hide_current_popover_if_visible(instance);
-                                this.current_hover_index = 0;
-                                const target =
-                                    typeof this.tab_moves_focus_to_target === "function"
-                                        ? this.tab_moves_focus_to_target()
-                                        : this.tab_moves_focus_to_target;
-                                $(target).trigger("focus");
+                                const target = this.tab_moves_focus_to_target(e);
+                                if (target !== undefined) {
+                                    popover_menus.hide_current_popover_if_visible(instance);
+                                    this.current_hover_index = 0;
+                                    $(target).trigger("focus");
+                                }
                             } else if (!this.hide_search_box && this.keep_focus_on_search) {
                                 e.preventDefault();
                                 e.stopPropagation();

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -201,6 +201,15 @@
         /* Align to compose controls; that's 112px width,
            plus 4px of grid gap for 116px here. */
         margin-right: calc(var(--compose-send-controls-width) + 4px);
+
+        .main-view-banner {
+            padding-right: 4px;
+
+            .main-view-banner-close-button {
+                outline-offset: 0;
+                border-radius: 4px;
+            }
+        }
     }
 }
 

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -19,6 +19,6 @@
     {{#if hide_close_button}}
     {{!-- hide_close_button is null by default, and false if explicitly set as false. --}}
     {{else}}
-    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button" tabindex="0"></a>
     {{/if}}
 </div>

--- a/web/templates/compose_banner/guest_in_dm_recipient_warning.hbs
+++ b/web/templates/compose_banner/guest_in_dm_recipient_warning.hbs
@@ -2,5 +2,5 @@
     <p class="banner_content">
         {{banner_text}}
     </p>
-    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button" tabindex="0"></a>
 </div>

--- a/web/templates/compose_banner/long_paste_options.hbs
+++ b/web/templates/compose_banner/long_paste_options.hbs
@@ -10,5 +10,5 @@
         <button class="main-view-banner-action-button convert-to-file right_edge">{{t 'Yes, convert'}}</button>
         {{/if}}
     </div>
-    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button" tabindex="0"></a>
 </div>

--- a/web/templates/compose_banner/message_sent_banner.hbs
+++ b/web/templates/compose_banner/message_sent_banner.hbs
@@ -21,5 +21,5 @@
             <span class="action-button-label">{{ action_button_text }}</span>
         </button>
     {{/if}}
-    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button" tabindex="0"></a>
 </div>

--- a/web/templates/compose_banner/success_message_scheduled_banner.hbs
+++ b/web/templates/compose_banner/success_message_scheduled_banner.hbs
@@ -11,5 +11,5 @@
         </p>
         <button class="main-view-banner-action-button undo_scheduled_message" >{{t "Undo"}}</button>
     </div>
-    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button" tabindex="0"></a>
 </div>

--- a/web/templates/compose_banner/upload_banner.hbs
+++ b/web/templates/compose_banner/upload_banner.hbs
@@ -4,5 +4,5 @@
     {{#if is_upload_process_tracker}}
         <button class="upload_banner_cancel_button">{{t 'Cancel' }}</button>
     {{/if}}
-    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button" tabindex="0"></a>
 </div>


### PR DESCRIPTION
Compose banners are currently not reachable by keyboard, Shift+tab from compose recipient dropdown doesn't move focus to compose banner if visible. This PR changes:
- makes Shift+tab move focus to compose banner from compose recipient dropdown.
- makes close button focusable
- Trap focus inside open compose box for tab and shift+tab.
<!-- Describe your pull request here.-->

Fixes: [#issues > keyboard navigation after pasting large text @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20navigation.20after.20pasting.20large.20text/near/2427893)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-04-15 02-51-50.webm](https://github.com/user-attachments/assets/1a7eaee7-f22b-45c1-8535-b49be4ea8b35)

<img width="282" height="142" alt="image" src="https://github.com/user-attachments/assets/48a475e0-2a81-4520-9e41-bb91c8270e19" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
