### PR TITLE
run-dev: Handle PermissionError from os.setpgrp().

### DIFF
--- a/tools/run-dev
+++ b/tools/run-dev
@@ -154,7 +154,13 @@ if options.clear_memcached:
 
 # Set up a new process group, so that we can later kill run{server,tornado}
 # and all of the processes they spawn.
-os.setpgrp()
+try:
+    os.setpgrp()
+except PermissionError:
+    # Some non-interactive SSH execution modes (e.g., `vagrant ssh -c`) can
+    # disallow creating a new process group. Continue without it so developers
+    # can still start the dev services in constrained environments.
+    pass
 
 # Save pid of parent process to the pid file. It can be used later by
 # tools/stop-run-dev to kill the server without having to find the

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import asyncio
+import contextlib
 import errno
 import logging
 import os
@@ -154,13 +155,11 @@ if options.clear_memcached:
 
 # Set up a new process group, so that we can later kill run{server,tornado}
 # and all of the processes they spawn.
-try:
-    os.setpgrp()
-except PermissionError:
+with contextlib.suppress(PermissionError):
     # Some non-interactive SSH execution modes (e.g., `vagrant ssh -c`) can
     # disallow creating a new process group. Continue without it so developers
     # can still start the dev services in constrained environments.
-    pass
+    os.setpgrp()
 
 # Save pid of parent process to the pid file. It can be used later by
 # tools/stop-run-dev to kill the server without having to find the


### PR DESCRIPTION
Wrap process-group setup in `try/except PermissionError` so `run-dev` can continue in constrained non-interactive environments such as some `vagrant ssh -c` workflows.

`tools/run-dev` currently calls `os.setpgrp()` unconditionally before writing the PID file and starting services. In some non-interactive SSH execution contexts, that call can raise `PermissionError` and stop local development startup entirely.

This change keeps the normal behavior in environments where `os.setpgrp()` succeeds, while gracefully continuing startup when that specific operation is not permitted.

Fixes: Local `run-dev` startup failure when `os.setpgrp()` raises `PermissionError` in constrained non-interactive environments.

**How changes were tested:**

- Ran `python3 -m py_compile tools/run-dev`
- Manually reviewed the updated control flow to confirm that the default behavior is unchanged when `os.setpgrp()` succeeds
- Verified that the fallback only applies to `PermissionError`

**Screenshots and screen captures:**

Not applicable; this change does not affect the UI.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>