### PR TITLE
github: Add status emojis to webhook events.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -145,7 +145,7 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("deployment", TOPIC_DEPLOYMENT, expected_message)
 
     def test_deployment_status_msg(self) -> None:
-        expected_message = "Deployment changed status to success."
+        expected_message = "Deployment changed status to success :thumbs_up:."
         self.check_webhook("deployment_status", TOPIC_DEPLOYMENT, expected_message)
 
     def test_fork_msg(self) -> None:
@@ -380,20 +380,20 @@ class GitHubWebhookTest(WebhookTestCase):
 
     def test_page_build_msg(self) -> None:
         expected_message = (
-            "GitHub Pages build, triggered by baxterthehacker, has finished building."
+            "GitHub Pages build, triggered by baxterthehacker, has finished building :thumbs_up:."
         )
         self.check_webhook("page_build", TOPIC_REPO, expected_message)
 
     def test_page_build_errored_msg(self) -> None:
-        expected_message = "GitHub Pages build, triggered by baxterthehacker, has failed: \n``` quote\nSomething went wrong.\n```."
+        expected_message = "GitHub Pages build, triggered by baxterthehacker, has failed: \n``` quote\nSomething went wrong.\n``` :thumbs_down:."
         self.check_webhook("page_build__errored", TOPIC_REPO, expected_message)
 
     def test_status_msg(self) -> None:
-        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success."
+        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success :thumbs_up:."
         self.check_webhook("status", TOPIC_REPO, expected_message)
 
     def test_status_with_target_url_msg(self) -> None:
-        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status)."
+        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status) :thumbs_up:."
         self.check_webhook("status__with_target_url", TOPIC_REPO, expected_message)
 
     def test_pull_request_review_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -257,11 +257,37 @@ def get_deployment_body(helper: Helper) -> str:
     return f"{get_sender_name(helper)} created new deployment."
 
 
+STATUS_EMOJI = {
+    "error": ":thumbs_down:",
+    "failure": ":thumbs_down:",
+    "pending": ":counterclockwise:",
+    "success": ":thumbs_up:",
+}
+
+DEPLOYMENT_STATUS_EMOJI = {
+    "error": ":thumbs_down:",
+    "failure": ":thumbs_down:",
+    "in_progress": ":counterclockwise:",
+    "pending": ":counterclockwise:",
+    "success": ":thumbs_up:",
+}
+
+PAGE_BUILD_STATUS_EMOJI = {
+    "building": ":counterclockwise:",
+    "built": ":thumbs_up:",
+    "errored": ":thumbs_down:",
+}
+
+
 def get_change_deployment_status_body(helper: Helper) -> str:
     payload = helper.payload
-    return "Deployment changed status to {}.".format(
-        payload["deployment_status"]["state"].tame(check_string),
-    )
+    status = payload["deployment_status"]["state"].tame(check_string)
+    emoji = DEPLOYMENT_STATUS_EMOJI.get(status)
+
+    if emoji is not None:
+        return f"Deployment changed status to {status} {emoji}."
+
+    return f"Deployment changed status to {status}."
 
 
 def get_create_or_delete_body(action: str, helper: Helper) -> str:
@@ -565,6 +591,7 @@ def get_page_build_body(helper: Helper) -> str:
     payload = helper.payload
     build = payload["build"]
     status = build["status"].tame(check_string)
+    emoji = PAGE_BUILD_STATUS_EMOJI.get(status)
     actions = {
         "null": "has yet to be built",
         "building": "is being built",
@@ -582,6 +609,9 @@ def get_page_build_body(helper: Helper) -> str:
             ),
         )
 
+    if emoji is not None:
+        action = f"{action} {emoji}"
+
     return "GitHub Pages build, triggered by {}, {}.".format(
         payload["build"]["pusher"]["login"].tame(check_string),
         action,
@@ -590,17 +620,22 @@ def get_page_build_body(helper: Helper) -> str:
 
 def get_status_body(helper: Helper) -> str:
     payload = helper.payload
+    state = payload["state"].tame(check_string)
     if payload["target_url"]:
         status = "[{}]({})".format(
-            payload["state"].tame(check_string),
+            state,
             payload["target_url"].tame(check_string),
         )
     else:
-        status = payload["state"].tame(check_string)
+        status = state
+
+    emoji = STATUS_EMOJI.get(state)
+    status_description = status if emoji is None else f"{status} {emoji}"
+
     return "[{}]({}) changed its status to {}.".format(
         get_short_sha(payload["sha"].tame(check_string)),
         payload["commit"]["html_url"].tame(check_string),
-        status,
+        status_description,
     )
 
 


### PR DESCRIPTION
Add status emojis to remaining GitHub webhook status-style messages so outcomes are easier to scan at a glance.

This change adds emoji markers to:
- deployment status updates
- GitHub Pages build status updates
- commit status updates

It uses existing Zulip-style webhook emojis (`:thumbs_up:`, `:thumbs_down:`, `:counterclockwise:`) and preserves existing message structure beyond the status indicator additions.

Details:
- Added status-to-emoji maps for deployment status, page build status, and commit status state.
- Updated message generation in:
  - `get_change_deployment_status_body`
  - `get_page_build_body`
  - `get_status_body`
- Updated corresponding GitHub webhook tests to match the new output.

Fixes: https://github.com/zulip/zulip/issues/37250

**How changes were tested:**

- Ran syntax validation:
  - `/opt/homebrew/bin/python3 -m py_compile zerver/webhooks/github/view.py zerver/webhooks/github/tests.py`
- Manually reviewed expected-message updates for impacted webhook fixtures/tests.
- Verified no unrelated webhook paths were changed.

Note: I could not run `./tools/test-backend` locally due this machine’s Zulip dev-environment mismatch (local venv interpreter/tooling setup does not satisfy the runner’s environment checks).

**Screenshots and screen captures:**

Not applicable; this change does not affect UI.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>