### PR TITLE
message_edit: Inherit follow status on partial moves.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1229,6 +1229,30 @@ def do_update_message(
         target_stream = message_edit_request.target_stream
         target_topic = message_edit_request.target_topic_name
 
+        if message_edit_request.is_message_moved:
+            user_ids_following_original_topic = {
+                user_topic.user_profile_id
+                for user_topic in get_users_with_user_topic_visibility_policy(
+                    stream_being_edited.id, orig_topic_name
+                )
+                if user_topic.visibility_policy == UserTopic.VisibilityPolicy.FOLLOWED
+            }
+            user_ids_with_moved_messages = set(
+                changed_messages.values_list("sender_id", flat=True)
+            )
+            user_ids_to_follow_target = user_ids_following_original_topic & user_ids_with_moved_messages
+
+            if message_edit_request.is_stream_edited:
+                user_ids_to_follow_target -= {user.id for user in users_losing_access}
+
+            if user_ids_to_follow_target:
+                bulk_do_set_user_topic_visibility_policy(
+                    list(UserProfile.objects.filter(id__in=user_ids_to_follow_target)),
+                    target_stream,
+                    target_topic,
+                    visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED,
+                )
+
         assert target_stream.recipient_id is not None
 
         messages_in_target_topic = messages_for_topic(

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -1298,6 +1298,63 @@ class MessageMoveTopicTest(ZulipTestCase):
             )
             self.assert_length(orjson.loads(assert_is_not_none(msg.edit_history)), 1)
 
+    def test_partial_move_inherits_follow_status_for_moved_authors(self) -> None:
+        self.login("iago")
+
+        stream_name = "Denmark"
+        stream = get_stream(stream_name, self.example_user("iago").realm)
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+
+        self.subscribe(hamlet, stream_name)
+        self.subscribe(iago, stream_name)
+
+        orig_topic = "topic1"
+        target_topic = "topic1 split"
+
+        first_message_id = self.send_stream_message(hamlet, stream_name, topic_name=orig_topic)
+        split_from_message_id = self.send_stream_message(hamlet, stream_name, topic_name=orig_topic)
+        moved_author_message_id = self.send_stream_message(iago, stream_name, topic_name=orig_topic)
+
+        do_set_user_topic_visibility_policy(
+            iago,
+            stream,
+            orig_topic,
+            visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED,
+        )
+
+        self.assert_has_visibility_policy(
+            iago, orig_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        self.assert_has_visibility_policy(
+            iago, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED, expected=False
+        )
+
+        check_update_message(
+            user_profile=iago,
+            message_id=split_from_message_id,
+            stream_id=None,
+            topic_name=target_topic,
+            propagate_mode="change_later",
+            send_notification_to_old_thread=False,
+            send_notification_to_new_thread=False,
+            content=None,
+        )
+
+        self.check_topic(first_message_id, topic_name=orig_topic)
+        self.check_topic(split_from_message_id, topic_name=target_topic)
+        self.check_topic(moved_author_message_id, topic_name=target_topic)
+
+        self.assert_has_visibility_policy(
+            iago, orig_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        self.assert_has_visibility_policy(
+            iago, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        self.assert_has_visibility_policy(
+            hamlet, target_topic, stream, UserTopic.VisibilityPolicy.FOLLOWED, expected=False
+        )
+
     def test_propagate_topic_forward(self) -> None:
         self.login("hamlet")
         id1 = self.send_stream_message(self.example_user("hamlet"), "Denmark", topic_name="topic1")


### PR DESCRIPTION
Carry FOLLOWED to the destination topic for authors of moved messages who were already following the source topic, and add a regression test covering partial topic splits.

For partial topic moves (`change_one`/`change_later`), Zulip currently auto-follows mainly based on who moved the first message into the target topic. This can miss users who were already following the source topic and whose own messages were moved into the new topic.

This change adds a targeted rule for message-move edits:
- Find users who are FOLLOWED on the source topic.
- Intersect with authors of moved messages.
- Set FOLLOWED on the destination topic for that set.
- Keep source-topic FOLLOWED state unchanged in partial-move scenarios.

Also added a regression test:
- `test_partial_move_inherits_follow_status_for_moved_authors`
- Reproduces a split-topic flow where the actor follows the source topic and their message is moved; verifies destination topic gets FOLLOWED and source topic remains FOLLOWED.

Fixes: https://github.com/zulip/zulip/issues/35224

**How changes were tested:**

- Ran syntax validation:
  - `/opt/homebrew/bin/python3 -m py_compile zerver/actions/message_edit.py zerver/tests/test_message_move_topic.py`
- Manually reviewed control flow in `do_update_message()` around the message-move partial branch.
- Manually reviewed regression test logic for the issue reproduction path.

Note: I could not run `./tools/test-backend` locally due this machine’s Zulip dev-environment mismatch (the local venv interpreter/tooling setup does not satisfy the runner’s environment checks).

**Screenshots and screen captures:**

Not applicable; this change does not affect UI.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>