### PR TITLE
WIP: icons: Replace FontAwesome icons with Zulip SVG icons in stream/message UI

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -956,14 +956,14 @@ function setup_page(callback: () => void): void {
                 },
                 {
                     label_html: render_stream_sorter_toggle_label({
-                        icon_class: "fa fa-user-o",
+                        icon_class: "zulip-icon zulip-icon-user",
                         tooltip: $t({defaultMessage: "Sort by number of subscribers"}),
                     }),
                     key: "by-subscriber-count",
                 },
                 {
                     label_html: render_stream_sorter_toggle_label({
-                        icon_class: "fa fa-bar-chart",
+                        icon_class: "zulip-icon zulip-icon-bar-chart",
                         tooltip: $t({defaultMessage: "Sort by estimated weekly traffic"}),
                     }),
                     key: "by-weekly-traffic",

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -100,11 +100,11 @@
         margin: 0;
 
         .help_link_widget,
-        .fa {
+        .zulip-icon {
             margin: 0;
         }
 
-        .fa-question-circle-o {
+        .zulip-icon-question {
             /* Override relative position for sake of
                Chrome paint bug that keeps the circle
                visible when ellipses are showing. */
@@ -114,8 +114,7 @@
         .help_link_widget {
             /* With relative positioning no longer
                in effect, we vertically align the
-               help icon with an inline-block assist,
-               which is present on the .fa class. */
+               help icon using inline-block alignment. */
             vertical-align: middle;
         }
     }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -398,7 +398,7 @@
             padding-right: 0;
         }
 
-        .fa-user {
+        .zulip-icon-user {
             opacity: 0.7;
         }
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -31,7 +31,7 @@ a.help_link_widget {
     color: inherit;
     margin-left: 3px;
 
-    .fa-question-circle-o {
+    .zulip-icon-question {
         position: relative;
         top: 1px;
     }

--- a/web/templates/help_link_widget.hbs
+++ b/web/templates/help_link_widget.hbs
@@ -1,3 +1,3 @@
-<a class="help_link_widget" href="{{ link }}" target="_blank" rel="noopener noreferrer">
-    <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+<a class="help_link_widget" href="{{ link }}" target="_blank" rel="noopener noreferrer" aria-label="{{t 'Help'}}">
+    <i class="zulip-icon zulip-icon-question" aria-hidden="true"></i>
 </a>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -1,6 +1,6 @@
 <div class="history-limited-box">
     <p>
-        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+        <i class="zulip-icon zulip-icon-exclamation-circle" aria-hidden="true"></i>
         {{#tr}}
         Some older messages are unavailable.
         <z-link>Upgrade your organization</z-link>
@@ -11,7 +11,7 @@
 </div>
 <div class="all-messages-search-caution hidden-for-spectators" hidden>
     <p>
-        <i class="all-messages-search-caution-icon fa fa-exclamation-circle" aria-hidden="true"></i>
+        <i class="all-messages-search-caution-icon zulip-icon zulip-icon-exclamation-circle" aria-hidden="true"></i>
         {{#tr}}
         End of results from your
         <z-link>history</z-link>.

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -240,7 +240,7 @@
             {{#if can_unmute}}
                 <li role="none" class="popover-menu-list-item link-item">
                     <a role="menuitem" class="sidebar-popover-unmute-user popover-menu-link hidden-for-spectators" tabindex="0">
-                        <i class="popover-menu-icon fa fa-eye" aria-hidden="true"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-eye" aria-hidden="true"></i>
                         {{#if is_bot}}
                             <span class="popover-menu-label">{{t "Unmute this bot" }}</span>
                         {{else}}

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -59,7 +59,7 @@
             {{#each senders}}
                 {{#if this.is_muted}}
                 <li class="recent_view_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{t 'Muted user'}}" data-user-id="{{this.user_id}}">
-                    <span><i class="fa fa-user recent_view_participant_overflow"></i></span>
+                    <span><i class="zulip-icon zulip-icon-user recent_view_participant_overflow" aria-hidden="true"></i></span>
                 </li>
                 {{else}}
                 <li class="recent_view_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{this.full_name}}" data-user-id="{{this.user_id}}">

--- a/web/templates/stream_settings/browse_streams_list_item.hbs
+++ b/web/templates/stream_settings/browse_streams_list_item.hbs
@@ -57,7 +57,7 @@
             <div class="description rendered_markdown" data-no-description="{{t 'No description.'}}">{{rendered_markdown rendered_description}}</div>
             {{#if is_old_stream}}
             <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Estimated messages per week' }}">
-                <i class="fa fa-bar-chart"></i>
+                <i class="zulip-icon zulip-icon-bar-chart" aria-hidden="true"></i>
                 <span class="stream-message-count-text">{{stream_weekly_traffic}}</span>
             </div>
             {{else}}

--- a/web/templates/stream_settings/subscriber_count.hbs
+++ b/web/templates/stream_settings/subscriber_count.hbs
@@ -1,6 +1,6 @@
-<i class="fa fa-user-o" aria-hidden="true"></i>
+<i class="zulip-icon zulip-icon-user" aria-hidden="true"></i>
 {{#if can_access_subscribers}}
 <span class="subscriber-count-text">{{numberFormat subscriber_count}}</span>
 {{else}}
-<i class="subscriber-count-lock fa fa-lock" aria-hidden="true"></i>
+<i class="subscriber-count-lock zulip-icon zulip-icon-lock" aria-hidden="true"></i>
 {{/if}}

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -1,11 +1,11 @@
 <div class="poll-widget">
     <div class="poll-widget-header-area">
         <h4 class="poll-question-header"></h4>
-        <i class="fa fa-pencil poll-edit-question"></i>
+        {{> ../components/icon_button icon="pencil" intent="neutral" custom_classes="poll-edit-question" aria-label=(t "Edit question")}}
         <div class="poll-question-bar">
             <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
-            <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
-            <button class="poll-question-check"><i class="fa fa-check"></i></button>
+            <button class="poll-question-remove" aria-label="{{t 'Cancel edit'}}"><i class="zulip-icon zulip-icon-x" aria-hidden="true"></i></button>
+            <button class="poll-question-check" aria-label="{{t 'Save'}}"><i class="zulip-icon zulip-icon-check" aria-hidden="true"></i></button>
         </div>
     </div>
     <div class="poll-please-wait">

--- a/web/templates/widgets/poll_widget_example.hbs
+++ b/web/templates/widgets/poll_widget_example.hbs
@@ -1,6 +1,6 @@
 <div class="poll-widget">
     <h4 class="poll-question-header">{{t "What did you drink this morning?"}}</h4>
-    <i class="fa fa-pencil poll-edit-question"></i>
+    <i class="zulip-icon zulip-icon-pencil poll-edit-question" aria-hidden="true"></i>
     <ul class="poll-widget">
         <li>
             <button class="poll-vote">

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -1,11 +1,11 @@
 <div class="todo-widget">
     <div class="todo-widget-header-area">
         <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
-        <i class="fa fa-pencil todo-edit-task-list-title"></i>
+        {{> ../components/icon_button icon="pencil" intent="neutral" custom_classes="todo-edit-task-list-title" aria-label=(t "Edit task list title")}}
         <div class="todo-task-list-title-bar">
             <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
-            <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
-            <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
+            <button class="todo-task-list-title-remove" aria-label="{{t 'Cancel edit'}}"><i class="zulip-icon zulip-icon-x" aria-hidden="true"></i></button>
+            <button class="todo-task-list-title-check" aria-label="{{t 'Save'}}"><i class="zulip-icon zulip-icon-check" aria-hidden="true"></i></button>
         </div>
     </div>
     <ul class="todo-widget">


### PR DESCRIPTION


Replaces fa-user-o, fa-lock, fa-bar-chart, fa-question-circle-o, fa-exclamation-circle, fa-eye, and fa-user with their zulip-icon equivalents across stream settings, help link widget, message feed error banners, recent view participant list, and user card popover.

Converts standalone fa-pencil icons in poll and todo widgets to proper icon_button components, and replaces fa-remove/fa-check inside the corresponding edit bars with zulip-icon-x/zulip-icon-check.

Updates matching CSS selectors in message_view_header.css and recent_view.css.

Fixes part of #36224.

<!-- Describe your pull request here.-->



**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
