### PR TITLE
custom-profile-fields: Fix subtype of old twitter fields.

### DIFF
--- a/zerver/migrations/0795_rename_old_twitter_profile_fields.py
+++ b/zerver/migrations/0795_rename_old_twitter_profile_fields.py
@@ -1,0 +1,30 @@
+import orjson
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+
+def update_twitter_to_x(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    CustomProfileField = apps.get_model("zerver", "CustomProfileField")
+    EXTERNAL_ACCOUNT = 7
+
+    old_value = orjson.dumps({"subtype": "twitter"}).decode()
+    new_value = orjson.dumps({"subtype": "x"}).decode()
+
+    CustomProfileField.objects.filter(
+        name="Twitter", field_type=EXTERNAL_ACCOUNT, field_data=old_value
+    ).update(name="X username", field_data=new_value, hint="")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0794_alter_directmessagegroup_recipient_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_twitter_to_x,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]


### PR DESCRIPTION
Initially twitter custom profile fields had name set to "Twitter", which was then changed to "Twitter username" in c355934179f68, but we did not migrate existing fields then.

300c72e2a5637e added a migration to change name and subtype of fields with "Twitter username" as name and as a result we missed changing it for old "Twitter" fields. This commit adds a migration to fix both name and subtype of old "Twitter" fields.

We also update the hint to be empty text as we do not have any hint for twitter fields since c355934179f68.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
