### PR TITLE
import/export: Handle `FillState` table.

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -266,8 +266,6 @@ class AnalyticsTestCase(ZulipTestCase):
             self.assertEqual(table._default_manager.filter(**kwargs).count(), 1)
         self.assert_length(arg_values, table._default_manager.count())
 
-
-class TestProcessCountStat(AnalyticsTestCase):
     def make_dummy_count_stat(self, property: str) -> CountStat:
         query = lambda kwargs: SQL(
             """
@@ -288,6 +286,8 @@ class TestProcessCountStat(AnalyticsTestCase):
         self.assertEqual(fill_state.end_time, end_time)
         self.assertEqual(fill_state.state, state)
 
+
+class TestProcessCountStat(AnalyticsTestCase):
     def test_process_stat(self) -> None:
         # process new stat
         current_time = installation_epoch() + self.HOUR

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -36,7 +36,7 @@ from django.utils.timezone import now as timezone_now
 from psycopg2 import sql
 
 import zerver.lib.upload
-from analytics.models import RealmCount, StreamCount, UserCount
+from analytics.models import FillState, RealmCount, StreamCount, UserCount
 from scripts.lib.zulip_tools import TIMESTAMP_FORMAT
 from version import ZULIP_VERSION
 from zerver.lib.avatar_hash import user_avatar_base_path_from_ids
@@ -283,8 +283,6 @@ NON_EXPORTED_TABLES = {
     # total of all the realmcount values on the server.  Might need to
     # recompute it after a fillstate import.
     "analytics_installationcount",
-    # Fillstate will require some cleverness to do the right partial export.
-    "analytics_fillstate",
     # These are for unfinished features; we'll want to add them to the
     # export before they reach full production status.
     "zerver_defaultstreamgroup",
@@ -331,6 +329,7 @@ ANALYTICS_TABLES = {
     "analytics_realmcount",
     "analytics_streamcount",
     "analytics_usercount",
+    "analytics_fillstate",
 }
 
 
@@ -2987,6 +2986,13 @@ def export_analytics_tables(realm: Realm, output_dir: Path) -> None:
     write_table_data(output_file=export_file, data=response)
 
 
+def custom_fetch_fillstate(response: TableData, context: Context) -> None:
+    """
+    FillState is a global table, so we can't fetch by realm filtering.
+    """
+    response["analytics_fillstate"] = make_raw(FillState.objects.order_by("id").iterator())
+
+
 def get_analytics_config() -> Config:
     # The Config function defines what data to export for the
     # analytics.json file in a full-realm export.
@@ -3015,6 +3021,13 @@ def get_analytics_config() -> Config:
         model=StreamCount,
         normal_parent=analytics_config,
         include_rows="realm_id__in",
+    )
+
+    Config(
+        table="analytics_fillstate",
+        model=FillState,
+        virtual_parent=analytics_config,
+        custom_fetch=custom_fetch_fillstate,
     )
 
     return analytics_config

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -23,7 +23,8 @@ from psycopg2.extras import execute_values
 from psycopg2.sql import SQL, Identifier
 from typing_extensions import override
 
-from analytics.models import RealmCount, StreamCount, UserCount
+from analytics.lib.counts import do_drop_all_analytics_tables
+from analytics.models import FillState, RealmCount, StreamCount, UserCount
 from version import ZULIP_VERSION
 from zerver.actions.create_realm import set_default_for_realm_permission_group_settings
 from zerver.actions.realm_settings import (
@@ -50,7 +51,11 @@ from zerver.lib.parallel import run_parallel, run_parallel_queue
 from zerver.lib.partial import partial
 from zerver.lib.push_notifications import sends_notifications_directly
 from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
-from zerver.lib.server_initialization import create_internal_realm, server_initialized
+from zerver.lib.server_initialization import (
+    create_internal_realm,
+    server_initialized,
+    server_is_initialized_and_has_no_other_realm,
+)
 from zerver.lib.streams import (
     get_stream_permission_default_group,
     render_stream_description,
@@ -190,6 +195,7 @@ ID_MAP: dict[str, dict[int, int]] = {
     "analytics_realmcount": {},
     "analytics_streamcount": {},
     "analytics_usercount": {},
+    "analytics_fillstate": {},
     "realmuserdefault": {},
     "scheduledmessage": {},
     "onboardingusermessage": {},
@@ -2602,6 +2608,34 @@ def create_image_attachments(realm: Realm, attachment_data: ImportedTableData) -
         maybe_thumbnail(pyvips_source, content_type, path_id, realm.id, skip_events=True)
 
 
+def import_analytics_fillstate(data: ImportedTableData, realm: Realm) -> None:
+    # This currently only handles the scenario where there are no other
+    # realms in the server.
+    #
+    # TODO: This doesn't yet handle scenarios where there are other realms
+    #       in the server and the server's FillState is different from the
+    #       one we're currently importing. See #13486 for plans on how to
+    #       handle the other scenarios.
+    #
+    #       One of the plans mentioned in #13486 was adding support for
+    #       running process_count_stat only on the imported realm and
+    #       getting it in sync with the server's FillState if the server
+    #       is ahead.
+    #
+    #       The main blockers for that approach is that, we currently have
+    #       no solution for how to update FillState and InstallationCount
+    #       tables for realm-specific process_count_stat operations.
+
+    if server_is_initialized_and_has_no_other_realm(realm):
+        # Clear out any stale analytics rows from cases like:
+        # * Previous manual test runs.
+        # * update_analytics_tables cronjob that runs on an initialized server
+        #   before the first realm is imported.
+        do_drop_all_analytics_tables()
+        update_model_ids(FillState, data, "analytics_fillstate")
+        bulk_import_model(data, FillState)
+
+
 def import_analytics_data(realm: Realm, import_dir: Path, crossrealm_user_ids: set[int]) -> None:
     analytics_filename = os.path.join(import_dir, "analytics.json")
     if not os.path.exists(analytics_filename):
@@ -2610,6 +2644,13 @@ def import_analytics_data(realm: Realm, import_dir: Path, crossrealm_user_ids: s
     logging.info("Importing analytics data from %s", analytics_filename)
     with open(analytics_filename, "rb") as f:
         data = orjson.loads(f.read())
+
+    # Import FillState first: on an empty server, it clears out any
+    # stale analytics rows, which must happen before we import the
+    # *Count tables below.
+    if "analytics_fillstate" in data:
+        fix_datetime_fields(data, "analytics_fillstate")
+        import_analytics_fillstate(data, realm)
 
     # Process the data through the fixer functions.
     fix_datetime_fields(data, "analytics_realmcount")

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from argparse import ArgumentParser, BooleanOptionalAction, RawTextHelpFormatter, _ActionsContainer
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import reduce, wraps
 from typing import Any, Protocol
@@ -80,6 +81,38 @@ def skip_unless_locked(handle_func: HandleMethod) -> HandleMethod:
             handle_func(self, *args, **kwargs)
 
     return our_handle
+
+
+def mutually_exclusive_with(
+    conflicting_handle: HandleMethod,
+) -> Callable[[HandleMethod], HandleMethod]:
+    """Prevent this command from overlapping with conflicting_handle's
+    command: take that command's lock for our whole run, exiting with
+    an error if it is already held.  Exclusion works in both
+    directions -- we refuse to start while it runs, and while we hold
+    its lock the conflicting command (which must itself be wrapped in
+    abort_unless_locked or skip_unless_locked) will abort or skip."""
+
+    def decorator(handle_func: HandleMethod) -> HandleMethod:
+        @wraps(handle_func)
+        def our_handle(self: BaseCommand, *args: Any, **kwargs: Any) -> None:
+            path = lockfile_path(conflicting_handle)
+            with lockfile_nonblocking(path) as lock_acquired:
+                if not lock_acquired:
+                    conflicting_name = conflicting_handle.__module__.split(".")[-1]
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Process '{conflicting_name}' is currently running "
+                            f"(lock {path} is held). "
+                            f"Please wait until it has finished before trying again."
+                        )
+                    )
+                    sys.exit(1)
+                handle_func(self, *args, **kwargs)
+
+        return our_handle
+
+    return decorator
 
 
 def abort_cron_during_deploy(handle_func: HandleMethod) -> HandleMethod:

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from argparse import ArgumentParser, BooleanOptionalAction, RawTextHelpFormatter, _ActionsContainer
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import reduce, wraps
 from typing import Any, Protocol
@@ -80,6 +81,35 @@ def skip_unless_locked(handle_func: HandleMethod) -> HandleMethod:
             handle_func(self, *args, **kwargs)
 
     return our_handle
+
+
+def mutually_exclusive_with(
+    conflicting_handle: HandleMethod,
+) -> Callable[[HandleMethod], HandleMethod]:
+    """Prevent this command from overlapping with `conflicting_handle`.
+    To achieve mutual exclusion, `conflicting_handle` must be wrapped in
+    `abort_unless_locked` or `skip_unless_locked`."""
+
+    def decorator(handle_func: HandleMethod) -> HandleMethod:
+        @wraps(handle_func)
+        def our_handle(self: BaseCommand, *args: Any, **kwargs: Any) -> None:
+            path = lockfile_path(conflicting_handle)
+            with lockfile_nonblocking(path) as lock_acquired:
+                if not lock_acquired:
+                    conflicting_name = conflicting_handle.__module__.split(".")[-1]
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Process '{conflicting_name}' is currently running "
+                            f"(lock {path} is held). "
+                            f"Please wait until it has finished before trying again."
+                        )
+                    )
+                    sys.exit(1)
+                handle_func(self, *args, **kwargs)
+
+        return our_handle
+
+    return decorator
 
 
 def abort_cron_during_deploy(handle_func: HandleMethod) -> HandleMethod:

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -99,3 +99,11 @@ def create_users(
         tos_version=tos_version,
         is_imported_stub=is_imported_stub,
     )
+
+
+def server_is_initialized_and_has_no_other_realm(realm: Realm) -> bool:
+    # This is mainly used during import to check if the server has
+    # any Realm other than the one currently being imported.
+    return not Realm.objects.exclude(
+        string_id__in=[settings.SYSTEM_BOT_REALM, realm.string_id]
+    ).exists()

--- a/zerver/management/commands/import.py
+++ b/zerver/management/commands/import.py
@@ -11,9 +11,12 @@ from django.core.management import call_command
 from django.core.management.base import CommandError, CommandParser
 from typing_extensions import override
 
+from analytics.management.commands.update_analytics_counts import (
+    Command as UpdateAnalyticsCountsCommand,
+)
 from zerver.forms import OverridableValidationError, check_subdomain_available
 from zerver.lib.import_realm import do_import_realm
-from zerver.lib.management import ZulipBaseCommand
+from zerver.lib.management import ZulipBaseCommand, mutually_exclusive_with
 
 
 class Command(ZulipBaseCommand):
@@ -61,7 +64,11 @@ import a database dump from one or more JSON files."""
         call_command("flush", verbosity=0, skip_checks=True, interactive=False)
         subprocess.check_call([os.path.join(settings.DEPLOY_ROOT, "scripts/setup/flush-memcached")])
 
+    # Importing FillState and the *Count tables would race with a
+    # concurrently running update_analytics_counts; holding its lock
+    # for the duration of the import makes the cron job abort instead.
     @override
+    @mutually_exclusive_with(UpdateAnalyticsCountsCommand.handle)
     def handle(self, *args: Any, **options: Any) -> None:
         num_processes = int(options["processes"])
         if num_processes < 1:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -3970,3 +3970,99 @@ class AnalyticsImportExportTest(AnalyticsTestCase, ExportFile):
             [[stat.property, "private_stream", 1, current_time]],
         )
         self.assertFillStateEquals(stat, current_time)
+
+    def test_installation_count_not_accurate_after_importing_another_realm(self) -> None:
+        """
+        This tracks a bug where if a new realm and its *Count tables
+        are imported, the server's InstallationCount table is
+        not updated and is wrong.
+        """
+        current_time = self.TIME_ZERO
+        stat = COUNT_STATS["messages_sent:message_type:day"]
+        self.current_property = stat.property
+
+        do_drop_all_analytics_tables()
+
+        # Send a message in default_realm and process stats.
+        public_channel = self.create_stream_with_recipient()[1]
+        exported_message = self.create_message(self.shylock, public_channel)
+        process_count_stat(stat, current_time)
+
+        self.assertTableState(
+            RealmCount,
+            ["property", "subgroup", "value", "end_time"],
+            [[stat.property, "public_stream", 1, current_time]],
+        )
+        self.assertTableState(
+            InstallationCount,
+            ["property", "subgroup", "value", "end_time"],
+            [[stat.property, "public_stream", 1, current_time]],
+        )
+
+        self.export_realm_and_create_auditlog(self.default_realm)
+
+        # Now we prepare the "new" server. Bump current_time, drop the
+        # analytics tables, and delete the messages we created in the
+        # exported realm earlier to make sure we don't re-log them in this
+        # "new" server. This is mainly for easier comparison/testing later
+        # on.
+        current_time += self.DAY
+        exported_message.delete()
+        do_drop_all_analytics_tables()
+        self.default_realm.delete()
+
+        # Switch to a different realm to simulate activity in the new server.
+        lear_realm = get_realm("lear")
+        # This makes sure we're logging the stats in a fixed/predictable time
+        # frame. See the setup() in AnalyticsTestCase.
+        lear_realm.date_created = self.TIME_ZERO - 2 * self.DAY
+        lear_realm.save()
+        self.default_realm = lear_realm
+
+        lear_private_channel = self.create_stream_with_recipient(
+            invite_only=True, realm=lear_realm
+        )[1]
+        lear_user = UserProfile.objects.filter(
+            realm=lear_realm, is_active=True, is_bot=False
+        ).first()
+        assert lear_user is not None
+        self.create_message(lear_user, lear_private_channel, date_sent=current_time - self.HOUR)
+        self.create_message(lear_user, lear_private_channel, date_sent=current_time - self.HOUR)
+
+        process_count_stat(stat, current_time)
+
+        # InstallationCount only reflects lear realm's 2 messages.
+        lear_realm_installation_count = [
+            stat.property,
+            "private_stream",
+            2,
+            current_time,
+        ]
+        self.assertTableState(
+            InstallationCount,
+            ["property", "subgroup", "value", "end_time"],
+            [lear_realm_installation_count],
+        )
+
+        # Import the previously exported realm with a public message
+        # and a row of RealmCount.
+        with self.assertLogs(level="INFO"):
+            imported_realm = do_import_realm(get_output_dir(), "test-zulip")
+
+        # RealmCount now has rows from both the imported realm and lear realm.
+        self.assertTableState(
+            RealmCount,
+            ["property", "subgroup", "value", "end_time", "realm"],
+            [
+                [stat.property, "public_stream", 1, current_time - self.DAY, imported_realm],
+                [stat.property, "private_stream", 2, current_time, lear_realm],
+            ],
+        )
+
+        # But, InstallationCount is NOT updated by the import, it still only reflects
+        # lear realm's 2 messages, not 3 (+ 1 from import).
+        self.assertTableState(
+            InstallationCount,
+            ["property", "subgroup", "value", "end_time"],
+            [lear_realm_installation_count],
+        )

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -411,11 +411,6 @@ class ExportFile(ZulipTestCase):
                 stale_migrations = [mig for mig in installed_app if mig.endswith(stale_migration)]
         self.assert_length(stale_migrations, 0)
 
-
-class RealmImportExportTest(ExportFile):
-    def create_user_and_login(self, email: str, realm: Realm) -> None:
-        self.register(email, "test", subdomain=realm.subdomain)
-
     def export_realm(
         self,
         realm: Realm,
@@ -453,6 +448,11 @@ class RealmImportExportTest(ExportFile):
             event_time=timezone_now(),
         )
         self.export_realm(original_realm, export_type, exportable_user_ids)
+
+
+class RealmImportExportTest(ExportFile):
+    def create_user_and_login(self, email: str, realm: Realm) -> None:
+        self.register(email, "test", subdomain=realm.subdomain)
 
     def test_export_files_from_local(self) -> None:
         user = self.example_user("hamlet")

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -18,7 +18,9 @@ from django.forms.models import model_to_dict
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
-from analytics.models import UserCount
+from analytics.lib.counts import COUNT_STATS, do_drop_all_analytics_tables, process_count_stat
+from analytics.models import FillState, InstallationCount, RealmCount, UserCount
+from analytics.tests.test_counts import AnalyticsTestCase
 from version import ZULIP_VERSION
 from zerver.actions.alert_words import do_add_alert_words
 from zerver.actions.create_user import do_create_user
@@ -41,7 +43,7 @@ from zerver.actions.user_activity import do_update_user_activity_interval
 from zerver.actions.user_settings import do_change_user_delivery_email, do_change_user_setting
 from zerver.actions.user_status import do_update_user_status
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
-from zerver.actions.users import do_deactivate_user
+from zerver.actions.users import do_change_user_role, do_deactivate_user
 from zerver.lib import import_realm, upload
 from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.bot_config import set_bot_config
@@ -3831,3 +3833,140 @@ class GetFKFieldNameTest(ZulipTestCase):
         self.assertEqual(get_fk_field_name(UserProfile, Realm), "realm")
         self.assertEqual(get_fk_field_name(Reaction, Stream), None)
         self.assertEqual(get_fk_field_name(Message, UserProfile), "sender")
+
+
+class AnalyticsImportExportTest(AnalyticsTestCase, ExportFile):
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        # There must be at least one realm owner user for a realm to be
+        # successfully imported.
+        user = self.create_user()
+        do_change_user_role(user, UserProfile.ROLE_REALM_OWNER, acting_user=None, notify=True)
+        self.shylock = user
+
+    def test_migrate_fillstate_to_empty_server(self) -> None:
+        current_time = self.TIME_ZERO
+
+        # Log a stat in the original realm before exporting it.
+        stat = COUNT_STATS["messages_sent:message_type:day"]
+        self.current_property = stat.property
+
+        public_channel = self.create_stream_with_recipient()[1]
+        self.create_message(self.shylock, public_channel)
+
+        process_count_stat(stat, current_time)
+        self.assertFillStateEquals(stat, current_time)
+        self.assertTableState(
+            RealmCount,
+            ["property", "subgroup", "value", "end_time"],
+            [[stat.property, "public_stream", 1, current_time]],
+        )
+
+        self.export_realm_and_create_auditlog(self.default_realm)
+
+        # Empty the server.
+        do_drop_all_analytics_tables()
+        self.assertEqual(FillState.objects.filter(property=stat.property).count(), 0)
+        Realm.objects.all().exclude(string_id=settings.SYSTEM_BOT_REALM).delete()
+
+        with self.assertLogs(level="INFO"):
+            # Update self.default_realm since the count-related helper methods
+            # use that variable.
+            self.default_realm = do_import_realm(get_output_dir(), "test-zulip")
+
+        # Bump current time a day to log a new Count entry.
+        current_time += self.DAY
+        imported_shylock = UserProfile.objects.get(
+            delivery_email=self.shylock.delivery_email, realm=self.default_realm
+        )
+
+        # FillState is imported and process_count_stat properly logs new rows.
+        private_channel = self.create_stream_with_recipient(
+            invite_only=True, date_created=self.TIME_ZERO + self.HOUR
+        )[1]
+        self.create_message(imported_shylock, private_channel, date_sent=self.TIME_ZERO + self.HOUR)
+        process_count_stat(stat, current_time)
+
+        self.assertTableState(
+            RealmCount,
+            ["property", "subgroup", "value", "end_time"],
+            [
+                [stat.property, "public_stream", 1, current_time - self.DAY],
+                [stat.property, "private_stream", 1, current_time],
+            ],
+        )
+        self.assertFillStateEquals(stat, current_time)
+
+    def test_migrate_fillstate_to_empty_server_with_stale_counts(self) -> None:
+        current_time = self.TIME_ZERO
+
+        # Log a stat in the original realm before exporting it.
+        stat = COUNT_STATS["messages_sent:message_type:day"]
+        self.current_property = stat.property
+
+        public_channel = self.create_stream_with_recipient()[1]
+        self.create_message(self.shylock, public_channel)
+
+        process_count_stat(stat, current_time)
+        self.assertFillStateEquals(stat, current_time)
+        self.assertTableState(
+            RealmCount,
+            ["property", "subgroup", "value", "end_time"],
+            [[stat.property, "public_stream", 1, current_time]],
+        )
+
+        self.export_realm_and_create_auditlog(self.default_realm)
+
+        # Delete all realms excluding the system bot realm but make sure there
+        # are stale Count rows. Unlike RealmCount, the InstallationCount row
+        # has no realm foreign key, so it survives the realm deletion and can
+        # only be cleared by the import itself.
+        RealmCount.objects.create(
+            property="whatever",
+            subgroup=None,
+            value=123,
+            realm=self.default_realm,
+            end_time=current_time,
+        )
+        InstallationCount.objects.create(
+            property="whatever",
+            subgroup=None,
+            value=123,
+            end_time=current_time,
+        )
+        self.assertEqual(FillState.objects.filter(property=stat.property).count(), 1)
+        Realm.objects.all().exclude(string_id=settings.SYSTEM_BOT_REALM).delete()
+
+        # The rest of the test should result exactly the same as
+        # test_migrate_fillstate_to_empty_server.
+        with self.assertLogs(level="INFO"):
+            self.default_realm = do_import_realm(get_output_dir(), "test-zulip")
+
+        current_time += self.DAY
+        imported_shylock = UserProfile.objects.get(
+            delivery_email=self.shylock.delivery_email, realm=self.default_realm
+        )
+
+        private_channel = self.create_stream_with_recipient(
+            invite_only=True, date_created=self.TIME_ZERO + self.HOUR
+        )[1]
+        self.create_message(imported_shylock, private_channel, date_sent=self.TIME_ZERO + self.HOUR)
+        process_count_stat(stat, current_time)
+
+        # The stale RealmCount and InstallationCount rows we created
+        # earlier are gone.
+        self.assertTableState(
+            RealmCount,
+            ["property", "subgroup", "value", "end_time"],
+            [
+                [stat.property, "public_stream", 1, current_time - self.DAY],
+                [stat.property, "private_stream", 1, current_time],
+            ],
+        )
+        self.assertTableState(
+            InstallationCount,
+            ["property", "subgroup", "value", "end_time"],
+            [[stat.property, "private_stream", 1, current_time]],
+        )
+        self.assertFillStateEquals(stat, current_time)

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -3,6 +3,7 @@ import os
 import re
 import tempfile
 from datetime import timedelta
+from io import StringIO
 from typing import Any
 from unittest import mock, skipUnless
 from unittest.mock import MagicMock, call, patch
@@ -20,7 +21,7 @@ from typing_extensions import override
 from confirmation.models import Confirmation, generate_realm_creation_url
 from zerver.actions.create_user import do_create_user
 from zerver.actions.user_settings import do_change_user_setting
-from zerver.lib.management import ZulipBaseCommand, skip_unless_locked
+from zerver.lib.management import ZulipBaseCommand, mutually_exclusive_with, skip_unless_locked
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_message, stdout_suppressed
 from zerver.models import Realm, RealmAuditLog, Recipient, UserProfile
@@ -406,6 +407,44 @@ class TestSkipUnlessLocked(ZulipTestCase):
                 fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 handle(command)
             self.assertEqual(ran, [])
+
+
+class TestMutuallyExclusiveWith(ZulipTestCase):
+    def test_abort_when_conflicting_lock_is_held(self) -> None:
+        ran = []
+
+        def conflicting_handle(self: BaseCommand, *args: Any, **kwargs: Any) -> None: ...
+
+        # Simulate a handle function belonging to another command
+        # module, whose lockfile name is derived from that module.
+        conflicting_handle.__module__ = "zerver.management.commands.conflicting_command"
+
+        @mutually_exclusive_with(conflicting_handle)
+        def handle(self: BaseCommand, *args: Any, **kwargs: Any) -> None:
+            ran.append(True)
+
+        stdout = StringIO()
+        command = BaseCommand(stdout=stdout)
+        with tempfile.TemporaryDirectory() as lock_dir, self.settings(LOCKFILE_DIRECTORY=lock_dir):
+            # With the conflicting command's lock free, the wrapped
+            # command runs.
+            handle(command)
+            self.assertEqual(ran, [True])
+
+            # While the conflicting command's lock is held, the command
+            # aborts with an error explaining what is blocking it.
+            ran.clear()
+            lock_path = os.path.join(lock_dir, "conflicting_command.lock")
+            with open(lock_path, "w") as held:
+                fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                with self.assertRaises(SystemExit):
+                    handle(command)
+            self.assertEqual(ran, [])
+            self.assertIn(
+                f"Process 'conflicting_command' is currently running (lock {lock_path} is held). "
+                "Please wait until it has finished before trying again.",
+                stdout.getvalue(),
+            )
 
 
 class TestPasswordRestEmail(ZulipTestCase):

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -446,6 +446,26 @@ class TestMutuallyExclusiveWith(ZulipTestCase):
                 stdout.getvalue(),
             )
 
+    def test_import_blocked_by_update_analytics_counts(self) -> None:
+        stdout = StringIO()
+        with tempfile.TemporaryDirectory() as lock_dir, self.settings(LOCKFILE_DIRECTORY=lock_dir):
+            # With the lock free, the import command runs normally,
+            # here far enough to reject the nonexistent export path.
+            with self.assertRaisesRegex(CommandError, "Directory not found"):
+                call_command("import", "newimport", "/nonexistent", stdout=stdout)
+
+            # While update_analytics_counts holds its lock, the import
+            # command aborts instead.
+            lock_path = os.path.join(lock_dir, "update_analytics_counts.lock")
+            with open(lock_path, "w") as held:
+                fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                with self.assertRaises(SystemExit):
+                    call_command("import", "newimport", "/nonexistent", stdout=stdout)
+            self.assertIn(
+                "Process 'update_analytics_counts' is currently running",
+                stdout.getvalue(),
+            )
+
 
 class TestPasswordRestEmail(ZulipTestCase):
     COMMAND_NAME = "send_password_reset_email"


### PR DESCRIPTION
Importing to an empty server now doesn't create a desync between the server's `FillState` table and the actual state of count stats.

Fixes part of #13486:
>  In the common case where the new server is currently empty, we can just export and then import FillState from the old server, as a quick partial solution.

**Manual test plan:**
1. Run `update_analytics_counts`
2. Export the analytics realm
3. Delete all realms except zulipinternal
4. Run `clear_analytics_tables`
5. Import the analytics realm
6. Run `update_analytics_counts`, it should work properly.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
