### PR TITLE
css: Apply margin to user profile modal container instead of only profile tab.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -259,9 +259,11 @@
         line-height: 1;
     }
 
-    #profile-tab {
+    .tabcontent {
         margin: 1px 5px 0;
+    }
 
+    #profile-tab {
         & li.custom_user_field {
             display: block;
         }


### PR DESCRIPTION
Previously, the margin was applied only to #profile-tab, causing inconsistent spacing across different user profile tabs.

Moved the margin to tabcontent class so it applies uniformly to the all the tabs, ensuring consistent layout across all tabs.

Fixes: [#user questions > profile pictures](https://chat.zulip.org/#narrow/channel/138-user-questions/topic/profile.20pictures/with/2162946)


<details>
<summary>Screenshots and screen captures</summary>

## Channel tab
| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/6b17d01d-3742-46f0-bd33-52d9c8991632) | ![image-after](https://github.com/user-attachments/assets/f6634230-cdab-4027-98e0-effaad3e66bc)

## User Groups tab
| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/26cca2b7-3552-44f0-9f41-f97998af11c7) | ![image-after](https://github.com/user-attachments/assets/28731d14-8b5f-4454-bed3-1d7089bb4a2f)




## Edit Profile tab
| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/e0bff06c-890a-4057-a071-a7b9ddedf133) | ![image-after](https://github.com/user-attachments/assets/2e5ebd4c-b2a4-4b8b-b0d5-b5cd80fffa76)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
