### PR TITLE
message_actions: Show "expand message" for partially collapsed messages.

### DIFF
--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -194,11 +194,7 @@ export function initialize({
                 assert(message_lists.current !== undefined);
                 const message = message_lists.current.get(message_id);
                 assert(message !== undefined);
-                if (message.collapsed) {
-                    condense.uncollapse(message);
-                } else {
-                    condense.collapse(message);
-                }
+                condense.toggle_collapse(message);
                 e.preventDefault();
                 e.stopPropagation();
                 popover_menus.hide_current_popover_if_visible(instance);

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -147,6 +147,7 @@ type BillingInfo = {
 
 export function get_actions_popover_content_context(message_id: number): ActionPopoverContext {
     assert(message_lists.current !== undefined);
+    const $message_row = message_lists.current.get_row(message_id);
     const message = message_lists.current.get(message_id);
     assert(message !== undefined);
     const not_spectator = !page_params.is_spectator;
@@ -223,9 +224,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         return true;
     };
 
-    function is_add_reaction_icon_visible(): boolean {
-        assert(message_lists.current !== undefined);
-        const $message_row = message_lists.current.get_row(message_id);
+    function is_add_reaction_icon_visible($message_row: JQuery): boolean {
         const $reaction_button = $message_row.find(".message_controls .reaction_button");
         return $reaction_button.length === 1 && $reaction_button.css("display") !== "none";
     }
@@ -235,7 +234,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
     // popover if it is not displayed.
     const should_display_add_reaction_option =
         !message.is_me_message &&
-        !is_add_reaction_icon_visible() &&
+        !is_add_reaction_icon_visible($message_row) &&
         not_spectator &&
         !(stream_id && stream_data.is_stream_archived_by_id(stream_id));
 

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -196,13 +196,20 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         stream_id = message.stream_id;
     }
 
-    // Disabling this for /me messages is a temporary workaround
-    // for the fact that we don't have a styling for how that
+    // Disabling these for /me messages is a workaround for
+    // the fact that we don't have a styling for how that
     // should look.  See also condense.js.
-    const should_display_collapse =
-        !message.locally_echoed && !message.is_me_message && !message.collapsed && not_spectator;
-    const should_display_uncollapse =
-        !message.locally_echoed && !message.is_me_message && message.collapsed;
+    function maybe_show_collapse_uncollapse(message: Message): boolean {
+        return !message.locally_echoed && !message.is_me_message && not_spectator;
+    }
+
+    let should_display_collapse = false;
+    let should_display_uncollapse = false;
+    if (maybe_show_collapse_uncollapse(message)) {
+        const message_condensed = $message_row.find(".message_content").hasClass("condensed");
+        should_display_collapse = !message.collapsed && !message_condensed;
+        should_display_uncollapse = message.collapsed || message_condensed;
+    }
 
     const should_display_quote_message = not_spectator;
 

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -185,14 +185,13 @@ export function get_actions_popover_content_context(message_id: number): ActionP
     // To work around #22893, we also only offer the option if the
     // fetch_status data structure means we'll be able to mark
     // everything below the current message as read correctly.
-    const not_stream_message = message.type !== "stream";
-    const subscribed_to_stream =
-        message.type === "stream" && stream_data.is_subscribed(message.stream_id);
+    const stream_message = message.type === "stream";
+    const subscribed_to_stream = stream_message && stream_data.is_subscribed(message.stream_id);
     const should_display_mark_as_unread =
-        !message.unread && not_spectator && (not_stream_message || subscribed_to_stream);
+        !message.unread && not_spectator && (!stream_message || subscribed_to_stream);
 
     let stream_id;
-    if (!not_stream_message) {
+    if (stream_message) {
         stream_id = message.stream_id;
     }
 

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -32,6 +32,15 @@ function MessageListView() {
         clear_rendering_state: noop,
         get_row: () => ({
             find(selector) {
+                if (selector === ".message_content") {
+                    return {
+                        hasClass(class_name) {
+                            assert.equal(class_name, "condensed");
+                            return false;
+                        },
+                    };
+                }
+
                 assert.equal(selector, ".message_controls .reaction_button");
                 return {
                     length: 1,


### PR DESCRIPTION
Previously, when a message was partially collapsed, the message actions menu displayed a "collapse" option.

This PR updates the behavior so that partially collapsed messages now show an "expand message" option instead.


Fixes: [#issues > show more shortcut collapses the whole message](https://chat.zulip.org/#narrow/channel/9-issues/topic/show.20more.20shortcut.20collapses.20the.20whole.20message/with/2428463)

**Screenshots and screen captures:**

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/a58c1da1-dd4c-4247-a43a-ba283eacc653) | ![image-after](https://github.com/user-attachments/assets/8c309af0-e9f1-4d3a-a6ab-f95709c3c476)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
