### PR TITLE
[ai] gif_picker: Enable resize for the GIF picker.

### DIFF
--- a/web/src/box_resize.ts
+++ b/web/src/box_resize.ts
@@ -1,0 +1,126 @@
+// Attach resize handles to a centered box. The caller keeps the box
+// centered (via CSS, or via the `on_resize` callback for a Tippy
+// overlay that needs `popperInstance.update()` after each change).
+// Because the box stays centered, dragging one edge by `delta` grows
+// the box by `2 * delta` so the cursor tracks the dragged edge.
+// Size bounds and any mobile-disable behavior live in CSS.
+
+type Direction =
+    | "top"
+    | "right"
+    | "bottom"
+    | "left"
+    | "top_left"
+    | "top_right"
+    | "bottom_left"
+    | "bottom_right";
+
+type HandleSpec = {
+    grows_width: boolean;
+    grows_height: boolean;
+    // -1 for handles on the left/top edge, whose pointer moves in the
+    // negative direction to grow the box.
+    dx_sign: 1 | -1;
+    dy_sign: 1 | -1;
+};
+
+const HANDLE_SPECS: Record<Direction, HandleSpec> = {
+    right: {grows_width: true, grows_height: false, dx_sign: 1, dy_sign: 1},
+    left: {grows_width: true, grows_height: false, dx_sign: -1, dy_sign: 1},
+    bottom: {grows_width: false, grows_height: true, dx_sign: 1, dy_sign: 1},
+    top: {grows_width: false, grows_height: true, dx_sign: 1, dy_sign: -1},
+    bottom_right: {grows_width: true, grows_height: true, dx_sign: 1, dy_sign: 1},
+    bottom_left: {grows_width: true, grows_height: true, dx_sign: -1, dy_sign: 1},
+    top_right: {grows_width: true, grows_height: true, dx_sign: 1, dy_sign: -1},
+    top_left: {grows_width: true, grows_height: true, dx_sign: -1, dy_sign: -1},
+};
+
+export function make_resizable(
+    box: HTMLElement,
+    directions: Direction[],
+    on_resize?: () => void,
+): () => void {
+    const handles: HTMLElement[] = [];
+    for (const direction of directions) {
+        const handle = document.createElement("div");
+        handle.classList.add(
+            "resizable-box-handle",
+            `resizable-box-handle-${direction.replaceAll("_", "-")}`,
+        );
+        attach_handle(handle, box, HANDLE_SPECS[direction], on_resize);
+        box.append(handle);
+        handles.push(handle);
+    }
+    return () => {
+        for (const handle of handles) {
+            handle.remove();
+        }
+    };
+}
+
+function parse_px_bound(value: string, fallback: number): number {
+    if (value === "" || value === "auto" || value === "none") {
+        return fallback;
+    }
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+}
+
+function attach_handle(
+    handle: HTMLElement,
+    box: HTMLElement,
+    spec: HandleSpec,
+    on_resize: (() => void) | undefined,
+): void {
+    let start_x = 0;
+    let start_y = 0;
+    let start_width = 0;
+    let start_height = 0;
+
+    function on_pointer_move(e: PointerEvent): void {
+        // Clamp against CSS bounds so dragging past min/max doesn't
+        // build up an invisible overshoot the user then has to drag
+        // back through before the box starts responding again.
+        const style = getComputedStyle(box);
+        if (spec.grows_width) {
+            const delta = spec.dx_sign * (e.clientX - start_x);
+            const min_width = parse_px_bound(style.minWidth, 0);
+            const max_width = parse_px_bound(style.maxWidth, Number.POSITIVE_INFINITY);
+            box.style.width = `${clamp(start_width + 2 * delta, min_width, max_width)}px`;
+        }
+        if (spec.grows_height) {
+            const delta = spec.dy_sign * (e.clientY - start_y);
+            const min_height = parse_px_bound(style.minHeight, 0);
+            const max_height = parse_px_bound(style.maxHeight, Number.POSITIVE_INFINITY);
+            box.style.height = `${clamp(start_height + 2 * delta, min_height, max_height)}px`;
+        }
+        on_resize?.();
+    }
+
+    function end_drag(e: PointerEvent): void {
+        handle.releasePointerCapture(e.pointerId);
+        handle.removeEventListener("pointermove", on_pointer_move);
+        handle.removeEventListener("pointerup", end_drag);
+        // `pointercancel` fires when the browser takes the gesture
+        // away from us (palm rejection, alt-tab, etc.); without
+        // cleaning up, `pointermove` would keep resizing the box.
+        handle.removeEventListener("pointercancel", end_drag);
+    }
+
+    handle.addEventListener("pointerdown", (e: PointerEvent) => {
+        e.preventDefault();
+        const rect = box.getBoundingClientRect();
+        start_x = e.clientX;
+        start_y = e.clientY;
+        start_width = rect.width;
+        start_height = rect.height;
+        handle.setPointerCapture(e.pointerId);
+        handle.addEventListener("pointermove", on_pointer_move);
+        handle.addEventListener("pointerup", end_drag);
+        handle.addEventListener("pointercancel", end_drag);
+    });
+}

--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -50,6 +50,7 @@ import "../../styles/user_circles.css";
 import "../../styles/left_sidebar.css";
 import "../../styles/right_sidebar.css";
 import "../../styles/lightbox.css";
+import "../../styles/box_resize.css";
 import "../../styles/popovers.css";
 import "../../styles/recent_view.css";
 import "../../styles/typing_notifications.css";

--- a/web/src/gif_picker_ui.ts
+++ b/web/src/gif_picker_ui.ts
@@ -178,6 +178,17 @@ function render_gifs_to_grid(urls: GifInfoUrl[], next_page: boolean): void {
     }
 }
 
+function load_next_page(): void {
+    if (network.is_loading_more_gifs()) {
+        return;
+    }
+    if (current_search_term === undefined || current_search_term.length === 0) {
+        render_featured_gifs(true);
+    } else {
+        update_grid_with_search_term(current_search_term, true);
+    }
+}
+
 function recenter_overlay(): void {
     void popover_instance?.popperInstance?.update();
 }
@@ -302,14 +313,7 @@ function toggle_picker_popover(target: HTMLElement): void {
                         scroll_element.scrollTop + scroll_element.clientHeight >
                         scroll_element.scrollHeight - scroll_element.clientHeight
                     ) {
-                        if (network.is_loading_more_gifs()) {
-                            return;
-                        }
-                        if (current_search_term === undefined) {
-                            render_featured_gifs(true);
-                            return;
-                        }
-                        update_grid_with_search_term(current_search_term, true);
+                        load_next_page();
                     }
                 });
             },

--- a/web/src/gif_picker_ui.ts
+++ b/web/src/gif_picker_ui.ts
@@ -179,9 +179,6 @@ function render_gifs_to_grid(urls: GifInfoUrl[], next_page: boolean): void {
 }
 
 function load_next_page(): void {
-    if (network.is_loading_more_gifs()) {
-        return;
-    }
     if (current_search_term === undefined || current_search_term.length === 0) {
         render_featured_gifs(true);
     } else {

--- a/web/src/gif_picker_ui.ts
+++ b/web/src/gif_picker_ui.ts
@@ -62,6 +62,25 @@ function focus_gif_at_index(index: number): void {
     $target_gif.trigger("focus");
 }
 
+function get_gifs_per_row(): number {
+    assert(popover_instance !== undefined);
+    const gif_elements = popover_instance.popper.querySelectorAll<HTMLElement>(".gif-picker-gif");
+    if (gif_elements.length === 0) {
+        return 0;
+    }
+    // The column count varies with resize and responsive CSS, so count
+    // elements sharing the first element's top offset.
+    const first_row_top = gif_elements[0]!.getBoundingClientRect().top;
+    let count = 0;
+    for (const gif_element of gif_elements) {
+        if (gif_element.getBoundingClientRect().top !== first_row_top) {
+            break;
+        }
+        count += 1;
+    }
+    return count;
+}
+
 function handle_keyboard_navigation_on_gif(e: JQuery.KeyDownEvent): void {
     e.stopPropagation();
     assert(e.currentTarget instanceof HTMLElement);
@@ -83,6 +102,7 @@ function handle_keyboard_navigation_on_gif(e: JQuery.KeyDownEvent): void {
     }
 
     const curr_gif_index = Number.parseInt(e.currentTarget.dataset["gifIndex"]!, 10);
+    const gifs_per_row = get_gifs_per_row();
     switch (key) {
         case "ArrowRight": {
             focus_gif_at_index(curr_gif_index + 1);
@@ -93,11 +113,11 @@ function handle_keyboard_navigation_on_gif(e: JQuery.KeyDownEvent): void {
             break;
         }
         case "ArrowUp": {
-            focus_gif_at_index(curr_gif_index - 2);
+            focus_gif_at_index(curr_gif_index - gifs_per_row);
             break;
         }
         case "ArrowDown": {
-            focus_gif_at_index(curr_gif_index + 2);
+            focus_gif_at_index(curr_gif_index + gifs_per_row);
             break;
         }
     }

--- a/web/src/gif_picker_ui.ts
+++ b/web/src/gif_picker_ui.ts
@@ -7,14 +7,19 @@ import render_gif_picker_gif from "../templates/gif_picker_gif.hbs";
 import render_no_gif_results from "../templates/no_gif_results.hbs";
 
 import type {GifInfoUrl, GifNetwork} from "./abstract_gif_network.ts";
+import {make_resizable} from "./box_resize.ts";
 import {ComposeIconSession} from "./compose_icon_session.ts";
 import * as gif_picker_popover_content from "./gif_picker_popover_content.ts";
 import * as gif_state from "./gif_state.ts";
 import * as giphy_network from "./giphy_network.ts";
 import * as klipy_network from "./klipy_network.ts";
+import * as modals from "./modals.ts";
+import * as overlay_util from "./overlay_util.ts";
+import * as overlays from "./overlays.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as tenor_network from "./tenor_network.ts";
+import * as util from "./util.ts";
 
 // Only used if popover called from edit message, otherwise it is `undefined`.
 let compose_icon_session: ComposeIconSession | undefined;
@@ -23,6 +28,7 @@ let current_search_term: undefined | string;
 // Stores the index of the last GIF that is part of the grid.
 let last_gif_index = -1;
 let network: GifNetwork;
+let resizable_grid_cleanup: (() => void) | undefined;
 
 function is_editing_existing_message(): boolean {
     if (compose_icon_session === undefined) {
@@ -146,6 +152,7 @@ function render_gifs_to_grid(urls: GifInfoUrl[], next_page: boolean): void {
         if (urls.length === 0) {
             const no_gif_results_html = render_no_gif_results();
             $popper.find(".gif-picker-content").html(no_gif_results_html);
+            recenter_overlay();
             return;
         }
     }
@@ -163,7 +170,16 @@ function render_gifs_to_grid(urls: GifInfoUrl[], next_page: boolean): void {
     } else {
         $popper.find(".gif-scrolling-container .simplebar-content-wrapper").scrollTop(0);
         $popper.find(".gif-picker-content").html(gif_grid_html);
+        // On the initial render, Tippy positioned the popover before
+        // the grid's `height: 70dvh` had settled, so the `translate3d`
+        // is computed against a smaller box and the final-sized box
+        // overflows at the bottom. Re-run popper with the final size.
+        recenter_overlay();
     }
+}
+
+function recenter_overlay(): void {
+    void popover_instance?.popperInstance?.update();
 }
 
 function render_featured_gifs(next_page: boolean): void {
@@ -205,21 +221,6 @@ function toggle_picker_popover(target: HTMLElement): void {
         target,
         {
             theme: "popover-menu",
-            placement: "top",
-            popperOptions: {
-                modifiers: [
-                    {
-                        // The placement is set to top by default, and we use
-                        // bottom and left configurations as fallback, which is
-                        // useful for scenarios when opening the picker while editing
-                        // messages near the top of the viewport.
-                        name: "flip",
-                        options: {
-                            fallbackPlacements: ["bottom", "left"],
-                        },
-                    },
-                ],
-            },
             onCreate(instance) {
                 const provider = network.get_provider();
                 instance.setContent(gif_picker_popover_content.get_gif_popover_content(provider));
@@ -229,6 +230,12 @@ function toggle_picker_popover(target: HTMLElement): void {
             },
             onShow(instance) {
                 popover_instance = instance;
+                // Clicking the compose GIF icon outside an overlay or
+                // modal would close the overlay/modal first, so we
+                // should never show the picker with one open.
+                assert(!overlays.any_active());
+                assert(!modals.any_active());
+                overlay_util.disable_scrolling();
                 const $popper = $(instance.popper).trigger("focus");
                 const debounced_search = _.debounce((search_term: string) => {
                     update_grid_with_search_term(search_term);
@@ -253,6 +260,34 @@ function toggle_picker_popover(target: HTMLElement): void {
                 $popper.on("keydown", ".gif-picker-gif", handle_keyboard_navigation_on_gif);
             },
             onMount(instance) {
+                const grid = instance.popper.querySelector<HTMLElement>(".gif-grid-in-popover")!;
+                // On mobile devices, the picker fills the viewport and
+                // resize is disabled — 10px touch targets are too small
+                // for fingers, and there's no real estate to gain. We
+                // gate on device class (userAgent) rather than viewport
+                // width so a desktop user with a narrow window still
+                // gets the resizable picker.
+                if (util.is_mobile()) {
+                    grid.classList.add("is-mobile-device");
+                } else {
+                    resizable_grid_cleanup = make_resizable(
+                        grid,
+                        [
+                            "top",
+                            "right",
+                            "bottom",
+                            "left",
+                            "top_left",
+                            "top_right",
+                            "bottom_left",
+                            "bottom_right",
+                        ],
+                        // Re-center the overlay against the new size.
+                        () => {
+                            void instance.popperInstance?.update();
+                        },
+                    );
+                }
                 render_featured_gifs(false);
                 const $popper = $(instance.popper);
                 $popper.find("#gif-search-query").trigger("focus");
@@ -280,11 +315,16 @@ function toggle_picker_popover(target: HTMLElement): void {
             },
             onHidden() {
                 hide_picker_popover();
+                resizable_grid_cleanup?.();
+                resizable_grid_cleanup = undefined;
+                overlay_util.enable_scrolling();
             },
         },
         {
             show_as_overlay_on_mobile: true,
-            show_as_overlay_always: false,
+            // A centered overlay sidesteps popper-anchor edge cases near
+            // the viewport top, and lets resize work symmetrically.
+            show_as_overlay_always: true,
         },
     );
 }

--- a/web/src/gif_picker_ui.ts
+++ b/web/src/gif_picker_ui.ts
@@ -29,6 +29,7 @@ let current_search_term: undefined | string;
 let last_gif_index = -1;
 let network: GifNetwork;
 let resizable_grid_cleanup: (() => void) | undefined;
+let fill_observer: ResizeObserver | undefined;
 
 function is_editing_existing_message(): boolean {
     if (compose_icon_session === undefined) {
@@ -137,6 +138,8 @@ export function hide_picker_popover(): boolean {
         popover_instance = undefined;
         current_search_term = undefined;
         network.abandon();
+        fill_observer?.disconnect();
+        fill_observer = undefined;
         return true;
     }
     return false;
@@ -313,6 +316,49 @@ function toggle_picker_popover(target: HTMLElement): void {
                         load_next_page();
                     }
                 });
+
+                // Keep fetching while the grid doesn't fill the
+                // visible area. Both inputs to that check — the grid
+                // content's size (which grows as images load and new
+                // pages are appended) and the scroll container's
+                // viewport (which changes on resize) — are observed
+                // here so we react to all three drivers without
+                // hand-rolled image-load plumbing.
+                //
+                // Debounce: `grid-auto-rows: auto` against images
+                // sized with `height: 100%` creates circular sizing
+                // that collapses each row to zero until the image's
+                // intrinsic size resolves, so `scrollHeight`
+                // underreports the filled area while a batch is
+                // loading and the observer fires on every progressive
+                // image load. Waiting briefly lets the layout settle
+                // before we decide whether to fetch; otherwise a
+                // single underfilled page stampedes several more
+                // pagination requests before the first batch paints.
+                //
+                // Termination: once `scrollHeight > clientHeight` the
+                // check short-circuits; once the source is exhausted
+                // no new content arrives so ResizeObserver stops
+                // firing; further pagination is guarded by
+                // `is_loading_more_gifs` in the callees. Before the
+                // initial fetch has rendered, `last_gif_index < 0`
+                // and we hold off — firing `load_next_page` in that
+                // window would race the initial request (which is
+                // not yet covered by the pagination guard) and
+                // dispatch a duplicate offset=0 fetch.
+                const grid_content = $popper.find(".gif-picker-content")[0]!;
+                const check_fill = _.debounce(() => {
+                    if (
+                        popover_instance !== undefined &&
+                        last_gif_index >= 0 &&
+                        scroll_element.scrollHeight <= scroll_element.clientHeight
+                    ) {
+                        load_next_page();
+                    }
+                }, 200);
+                fill_observer = new ResizeObserver(check_fill);
+                fill_observer.observe(scroll_element);
+                fill_observer.observe(grid_content);
             },
             onHidden() {
                 hide_picker_popover();

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -169,6 +169,12 @@
        Chrome 105) that do not support dynamic viewport
        units. 100% is the legacy full-height value. */
     --full-height-dynamic-viewport: 100%;
+
+    /* Exposed so callers can reserve matching padding on a
+       resizable box, keeping handles out of the clickable content
+       area. Consumed by box_resize.css. */
+    --resizable-box-handle-size: 10px;
+
     --gif-scroll-container-height: 80vh;
 
     @supports (height: 100dvh) {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -175,11 +175,51 @@
        area. Consumed by box_resize.css. */
     --resizable-box-handle-size: 10px;
 
-    --gif-scroll-container-height: 80vh;
+    /* GIF picker overlay: resize bounds are expressed in columns so
+       the picker resizes to useful sizes. Tweaking these retunes the
+       bounds, grid columns, and gap together. */
+    --gif-picker-gif-column-min-width: 200px;
+    --gif-picker-gif-column-gap: 6px;
+    /* Horizontal chrome inside .gif-grid-in-popover around the grid
+       columns, measured against its border-box. Breakdown: 3px × 2
+       .gif-scrolling-container margin, 2px × 2 .gif-picker-content
+       padding, and handle-size padding on each side reserved for
+       resize handles. SimpleBar's scrollbar is a positioned overlay
+       and doesn't take content width, so nothing extra is reserved
+       for it. Keep in sync with popovers.css. */
+    --gif-picker-grid-horizontal-chrome: calc(
+        10px + 2 * var(--resizable-box-handle-size)
+    );
+    --gif-picker-viewport-safe-margin: 20px;
+
+    /* Min = 1 column. Max = 5 columns, capped at viewport minus safe
+       margins. */
+    --gif-picker-grid-min-width: calc(
+        var(--gif-picker-gif-column-min-width) +
+            var(--gif-picker-grid-horizontal-chrome)
+    );
+    --gif-picker-grid-max-width: min(
+        calc(
+            5 * var(--gif-picker-gif-column-min-width) + 4 *
+                var(--gif-picker-gif-column-gap) +
+                var(--gif-picker-grid-horizontal-chrome)
+        ),
+        calc(100vw - 2 * var(--gif-picker-viewport-safe-margin))
+    );
+    /* Room for the search input, one row of GIFs, the footer, and
+       the outer handle-size padding on the top and bottom. */
+    --gif-picker-grid-min-height: calc(
+        300px + 2 * var(--resizable-box-handle-size)
+    );
+    --gif-picker-grid-max-height: calc(
+        100vh - 2 * var(--gif-picker-viewport-safe-margin)
+    );
 
     @supports (height: 100dvh) {
         --full-height-dynamic-viewport: 100dvh;
-        --gif-scroll-container-height: 80dvh;
+        --gif-picker-grid-max-height: calc(
+            100dvh - 2 * var(--gif-picker-viewport-safe-margin)
+        );
     }
 
     /*

--- a/web/styles/box_resize.css
+++ b/web/styles/box_resize.css
@@ -1,0 +1,73 @@
+.resizable-box-handle {
+    position: absolute;
+    user-select: none;
+    touch-action: none;
+    background: transparent;
+
+    &.resizable-box-handle-top,
+    &.resizable-box-handle-bottom {
+        left: 0;
+        width: 100%;
+        height: var(--resizable-box-handle-size);
+        cursor: row-resize;
+    }
+
+    &.resizable-box-handle-left,
+    &.resizable-box-handle-right {
+        top: 0;
+        width: var(--resizable-box-handle-size);
+        height: 100%;
+        cursor: col-resize;
+    }
+
+    &.resizable-box-handle-top {
+        top: 0;
+    }
+
+    &.resizable-box-handle-bottom {
+        bottom: 0;
+    }
+
+    &.resizable-box-handle-left {
+        left: 0;
+    }
+
+    &.resizable-box-handle-right {
+        right: 0;
+    }
+
+    /* Corners sit above edges so they win pointer events in the
+       overlap region. */
+    &.resizable-box-handle-top-left,
+    &.resizable-box-handle-top-right,
+    &.resizable-box-handle-bottom-left,
+    &.resizable-box-handle-bottom-right {
+        width: var(--resizable-box-handle-size);
+        height: var(--resizable-box-handle-size);
+        z-index: 1;
+    }
+
+    &.resizable-box-handle-top-left {
+        top: 0;
+        left: 0;
+        cursor: nwse-resize;
+    }
+
+    &.resizable-box-handle-bottom-right {
+        bottom: 0;
+        right: 0;
+        cursor: nwse-resize;
+    }
+
+    &.resizable-box-handle-top-right {
+        top: 0;
+        right: 0;
+        cursor: nesw-resize;
+    }
+
+    &.resizable-box-handle-bottom-left {
+        bottom: 0;
+        left: 0;
+        cursor: nesw-resize;
+    }
+}

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -498,13 +498,47 @@ ul.popover-group-menu-member-list {
 }
 
 .gif-grid-in-popover {
-    width: 90vw;
-    /* 6px `.gif-scroll-container` horizontal margin + 6px is the extra gutter space
-       + 4px padding between gif columns. Our max-width is calculated based on this so the
-       max width of the GIFs becomes 250px */
-    max-width: 516px;
+    /* Anchor resize handles to this element's padding box so they
+       stay inside the popover. */
+    position: relative;
+    /* So width / min-width / max-width refer to the total visible
+       box, including the handle-size padding added below; the viewport
+       safe-margin caps then compare apples-to-apples. */
+    box-sizing: border-box;
+    /* Initial width: four columns. On narrow viewports, `max-width`
+       caps this at what fits. Users can drag between one and five
+       columns. */
+    width: calc(
+        4 * var(--gif-picker-gif-column-min-width) + 3 *
+            var(--gif-picker-gif-column-gap) +
+            var(--gif-picker-grid-horizontal-chrome)
+    );
+    height: 70dvh;
+    min-width: var(--gif-picker-grid-min-width);
+    min-height: var(--gif-picker-grid-min-height);
+    max-width: var(--gif-picker-grid-max-width);
+    max-height: var(--gif-picker-grid-max-height);
+
+    /* On mobile devices (userAgent-based, see gif_picker_ui.ts), fill
+       the viewport and drop the handle-size padding since resize is
+       disabled. Gating on device class rather than viewport width
+       lets a desktop user on a narrow window keep the resizable
+       picker. */
+    &.is-mobile-device {
+        width: calc(100vw - 2 * var(--gif-picker-viewport-safe-margin));
+        height: calc(100dvh - 2 * var(--gif-picker-viewport-safe-margin));
+        min-width: 0;
+        min-height: 0;
+        max-width: none;
+        max-height: none;
+        padding: 0;
+    }
+
     border: 0;
-    padding: 0;
+    /* Reserve a strip equal to the resize handle size on every side
+       so the handles don't overlap clickable GIFs, the search input,
+       or the inner scrollbar. */
+    padding: var(--resizable-box-handle-size);
 
     .gif-search-container {
         margin: 4px 4px 2px;
@@ -519,9 +553,19 @@ ul.popover-group-menu-member-list {
 
     .gif-picker-content {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        /* Reflow to more columns as the picker enlarges, using the
+           same min column width as the container resize bounds. */
+        grid-template-columns: repeat(
+            auto-fit,
+            minmax(var(--gif-picker-gif-column-min-width), 1fr)
+        );
         grid-auto-rows: auto;
-        gap: 6px;
+        gap: var(--gif-picker-gif-column-gap);
+
+        @media (width < $md_min) {
+            /* Allow narrower columns on mobile so two can fit on a phone. */
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        }
 
         /* Meant to prevent outline overflow when the GIF
        is focused. */
@@ -547,23 +591,55 @@ ul.popover-group-menu-member-list {
         }
     }
 
-    .gif-scrolling-container {
-        overflow: hidden auto;
-        height: var(--gif-scroll-container-height);
-        max-height: 500px;
-        margin: 2px 3px;
-        padding: 5px 0;
+    .popover-inner {
+        /* Fill .gif-grid-in-popover so the scrolling container takes
+           the space left over after the search input. */
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+
+        .gif-scrolling-container {
+            flex: 1 1 auto;
+            /* `min-height: 0` lets this flex item shrink below its
+               content's intrinsic height, so the scroll area can
+               be shorter than the grid it contains. */
+            min-height: 0;
+            /* SimpleBar's `.simplebar-wrapper` uses `height: inherit`
+               to pick up its host's *computed* height; when the host
+               is `height: auto` (the default on a flex item),
+               SimpleBar falls back to an "auto height" mode that
+               disables its internal scroll. Setting `height: 100%`
+               here gives the wrapper a resolvable percentage instead,
+               so SimpleBar drives scrolling against the flex-computed
+               height. SimpleBar also reads this element's `overflow-y`
+               and suppresses its own scrollbar if it's `hidden`, so
+               we use `overflow: hidden auto` to allow Y scrolling while
+               still blocking any horizontal overflow. */
+            height: 100%;
+            overflow: hidden auto;
+            margin: 2px 3px;
+            padding: 5px 0;
+        }
     }
 
     .popover-footer {
-        text-align: center;
+        /* We center the attribution image with flex so it doesn't
+           pick up a baseline descender gap, and set flex-shrink: 0 so
+           the flex layout on `.popover-inner` can't squeeze the
+           footer below the image's own height. */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
         background-color: hsl(0deg 0% 0%);
         /* The border radius corresponds to the default radius value from `tippy-box`. */
         border-radius: 0 0 4px 4px;
 
-        /* This prevents the footer from experiencing height
-           fluctuations at the moment when the image is uploaded. */
-        min-height: 25px;
+        /* The GIPHY image is 200×42 natural, rendered at 120px wide
+           (so ~25px tall); 34px gives the image a little breathing
+           room and keeps the footer from collapsing before the image
+           has loaded. */
+        min-height: 34px;
 
         & img {
             width: 120px;

--- a/web/tests/box_resize.test.cjs
+++ b/web/tests/box_resize.test.cjs
@@ -1,0 +1,230 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {JSDOM} = require("jsdom");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const {window} = new JSDOM("");
+// Only assign globals our library actually reads (document and
+// getComputedStyle). `global.HTMLElement` is intentionally NOT
+// overwritten: index.cjs already points it at its own JSDOM's
+// HTMLElement, and later tests such as `compose_paste.test.cjs`
+// rely on `instanceof HTMLElement` matching elements parsed via
+// their DOMParser.
+global.document = window.document;
+global.getComputedStyle = window.getComputedStyle.bind(window);
+
+// `setPointerCapture` / `releasePointerCapture` are not implemented by
+// jsdom; stub them on this test's own HTMLElement prototype so our
+// pointer event handlers can call them without throwing. We avoid
+// stubbing on `global.HTMLElement` since that prototype is shared
+// with other tests.
+window.HTMLElement.prototype.setPointerCapture = function () {};
+window.HTMLElement.prototype.releasePointerCapture = function () {};
+
+const box_resize = zrequire("box_resize");
+
+function make_box() {
+    const box = document.createElement("div");
+    // Provide a predictable starting rect so tests don't depend on
+    // jsdom's layout (which is a no-op).
+    let current_rect = {width: 100, height: 80};
+    box.getBoundingClientRect = () => ({
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: current_rect.width,
+        bottom: current_rect.height,
+        width: current_rect.width,
+        height: current_rect.height,
+    });
+    box.set_rect = (width, height) => {
+        current_rect = {width, height};
+    };
+    return box;
+}
+
+function fire(handle, type, {clientX = 0, clientY = 0, pointerId = 1} = {}) {
+    const event = new window.Event(type, {bubbles: true, cancelable: true});
+    Object.assign(event, {clientX, clientY, pointerId});
+    handle.dispatchEvent(event);
+    return event;
+}
+
+run_test("make_resizable creates one handle per direction with expected class", () => {
+    const box = make_box();
+    box_resize.make_resizable(box, ["top", "right", "bottom_left"]);
+
+    assert.equal(box.children.length, 3);
+    const classes = [...box.children].map((h) => h.className);
+    assert.ok(classes[0].includes("resizable-box-handle-top"));
+    assert.ok(classes[1].includes("resizable-box-handle-right"));
+    assert.ok(classes[2].includes("resizable-box-handle-bottom-left"));
+    // Underscores in the direction are converted to hyphens for the class.
+    assert.ok(!classes[2].includes("bottom_left"));
+});
+
+run_test("cleanup removes the handles it added", () => {
+    const box = make_box();
+    const existing_child = document.createElement("span");
+    box.append(existing_child);
+
+    const cleanup = box_resize.make_resizable(box, ["right", "bottom"]);
+    assert.equal(box.children.length, 3);
+
+    cleanup();
+    assert.equal(box.children.length, 1);
+    assert.equal(box.children[0], existing_child);
+});
+
+run_test("right handle grows width by 2 * dx and does not touch height", () => {
+    const box = make_box();
+    box.set_rect(100, 80);
+    box_resize.make_resizable(box, ["right"]);
+    const handle = box.children[0];
+
+    fire(handle, "pointerdown", {clientX: 50, clientY: 40});
+    fire(handle, "pointermove", {clientX: 60, clientY: 45});
+
+    // Dragging right by 10: box grows by 20 (10 on each side, centered).
+    assert.equal(box.style.width, "120px");
+    // `height` is left untouched by an edge-only handle.
+    assert.equal(box.style.height, "");
+});
+
+run_test("left handle grows width when pointer moves leftward", () => {
+    const box = make_box();
+    box.set_rect(100, 80);
+    box_resize.make_resizable(box, ["left"]);
+    const handle = box.children[0];
+
+    fire(handle, "pointerdown", {clientX: 50, clientY: 40});
+    // Dragging the left edge 15px to the left: the box grows symmetrically
+    // by 30px total.
+    fire(handle, "pointermove", {clientX: 35, clientY: 40});
+
+    assert.equal(box.style.width, "130px");
+});
+
+run_test("top handle grows height when pointer moves upward", () => {
+    const box = make_box();
+    box.set_rect(100, 80);
+    box_resize.make_resizable(box, ["top"]);
+    const handle = box.children[0];
+
+    fire(handle, "pointerdown", {clientX: 50, clientY: 40});
+    fire(handle, "pointermove", {clientX: 50, clientY: 30});
+
+    // Dragging the top edge up by 10 => height grows by 20.
+    assert.equal(box.style.height, "100px");
+    assert.equal(box.style.width, "");
+});
+
+run_test("corner handle grows both dimensions with correct signs", () => {
+    const box = make_box();
+    box.set_rect(200, 100);
+    box_resize.make_resizable(box, ["top_left"]);
+    const handle = box.children[0];
+
+    fire(handle, "pointerdown", {clientX: 50, clientY: 50});
+    // Move 5 left, 8 up: both dx_sign and dy_sign are -1 for top_left,
+    // so width grows by 2*5 = 10 and height grows by 2*8 = 16.
+    fire(handle, "pointermove", {clientX: 45, clientY: 42});
+
+    assert.equal(box.style.width, "210px");
+    assert.equal(box.style.height, "116px");
+});
+
+run_test("on_resize callback fires once per pointermove after pointerdown", () => {
+    const box = make_box();
+    box.set_rect(100, 80);
+    let call_count = 0;
+    box_resize.make_resizable(box, ["bottom_right"], () => {
+        call_count += 1;
+    });
+    const handle = box.children[0];
+
+    fire(handle, "pointerdown", {clientX: 0, clientY: 0});
+    assert.equal(call_count, 0);
+    fire(handle, "pointermove", {clientX: 5, clientY: 5});
+    fire(handle, "pointermove", {clientX: 10, clientY: 10});
+    assert.equal(call_count, 2);
+
+    fire(handle, "pointerup", {clientX: 10, clientY: 10});
+    fire(handle, "pointermove", {clientX: 20, clientY: 20});
+    assert.equal(call_count, 2);
+});
+
+run_test("pointerup stops subsequent pointermove events from resizing", () => {
+    const box = make_box();
+    box.set_rect(100, 80);
+    box_resize.make_resizable(box, ["right"]);
+    const handle = box.children[0];
+
+    fire(handle, "pointerdown", {clientX: 50, clientY: 40});
+    fire(handle, "pointermove", {clientX: 60, clientY: 40});
+    assert.equal(box.style.width, "120px");
+
+    fire(handle, "pointerup", {clientX: 60, clientY: 40});
+    fire(handle, "pointermove", {clientX: 200, clientY: 40});
+    // Width should not have changed after pointerup.
+    assert.equal(box.style.width, "120px");
+});
+
+run_test("pointercancel stops subsequent pointermove events from resizing", () => {
+    const box = make_box();
+    box.set_rect(100, 80);
+    box_resize.make_resizable(box, ["right"]);
+    const handle = box.children[0];
+
+    fire(handle, "pointerdown", {clientX: 50, clientY: 40});
+    fire(handle, "pointermove", {clientX: 60, clientY: 40});
+    assert.equal(box.style.width, "120px");
+
+    // The browser can take the gesture away at any time; we must
+    // tear the listeners down or subsequent moves would keep resizing.
+    fire(handle, "pointercancel", {clientX: 60, clientY: 40});
+    fire(handle, "pointermove", {clientX: 200, clientY: 40});
+    assert.equal(box.style.width, "120px");
+});
+
+run_test("resize clamps to CSS min and max bounds during a single drag", () => {
+    const box = make_box();
+    box.set_rect(100, 80);
+    // Jsdom does not resolve the element's real computed style from a
+    // stylesheet, so we stub getComputedStyle to return the min/max
+    // bounds we want to test against. The library only calls it on
+    // `box`, so we don't need a passthrough.
+    const original_get_computed_style = global.getComputedStyle;
+    global.getComputedStyle = () => ({
+        minWidth: "60px",
+        maxWidth: "140px",
+        minHeight: "0px",
+        maxHeight: "none",
+    });
+
+    try {
+        box_resize.make_resizable(box, ["right"]);
+        const handle = box.children[0];
+
+        fire(handle, "pointerdown", {clientX: 50, clientY: 40});
+
+        // Overshoot the max: raw would be 100 + 2*100 = 300, clamp to 140.
+        fire(handle, "pointermove", {clientX: 150, clientY: 40});
+        assert.equal(box.style.width, "140px");
+
+        // Pull back within bounds: raw is 100 + 2*10 = 120, no clamp.
+        fire(handle, "pointermove", {clientX: 60, clientY: 40});
+        assert.equal(box.style.width, "120px");
+
+        // Undershoot the min: raw would be 100 - 2*40 = 20, clamp to 60.
+        fire(handle, "pointermove", {clientX: 10, clientY: 40});
+        assert.equal(box.style.width, "60px");
+    } finally {
+        global.getComputedStyle = original_get_computed_style;
+    }
+});


### PR DESCRIPTION
Fixes: #38057.

## Summary

Make the GIF picker resizable. Key design decisions:

- **Centered overlay, not anchored popper.** `show_as_overlay_always:
  true` + the popper `flip` modifier dropped. Anchoring had edge-case
  placement issues near the top of the viewport while editing
  messages, and flip fallbacks would shift the popper mid-drag.
- **Grow-from-center geometry.** Since the box stays centered, each
  pointermove applies `2 × delta` to the dimension so the cursor
  tracks the dragged edge. The `on_resize` callback calls
  `popperInstance.update()` to re-center against the new size.
- **Bounds and mobile-disable live in CSS, not JS.** The
  `box_resize` library never reads the viewport or listens for
  window resize events. This keeps it small and sidesteps
  stale-baseline and popper-reconciliation bugs common in more
  ambitious resize designs.
- **Bounds expressed in GIF columns.** 1–5 columns, capped at
  `100vw − 2 × safe-margin` so the picker never overflows a narrow
  window. Tweaking column tunables in `app_variables.css` retunes
  bounds, grid columns, and gap together.
- **`util.is_mobile()` (userAgent) gates mobile behavior, not a
  viewport breakpoint.** A desktop user on a narrow window keeps
  the resizable picker; actual phones/tablets get the viewport-
  filling overlay regardless of orientation. On mobile, resize is
  disabled — 10px touch targets are too small for fingers, and
  there's no real estate to gain on a screen already filled.
- **Extra `popperInstance.update()` after initial content render.**
  Tippy positions the overlay before `height: 70dvh` has settled,
  so without this the final-sized box overflows at the bottom.

### Relative to #38192

#38192 takes a JS-driven approach: `box_resize` reads
`window.innerWidth`, listens for window `resize` events, checks
`media_breakpoints_num.md` for mobile, and has an
`attach_proportional_window_resize` helper to re-scale the box when
the window changes. This PR moves all of that into CSS: size bounds
are `min/max-width/height` rules in viewport units, so the browser
handles window resize for free; no JS resize listener, no
stale-baseline reconciliation, and `box_resize.ts` stays at ~127
lines vs. #38192's 349. Mobile gating uses `util.is_mobile()` so a
narrow desktop window still gets the resizable picker.

## Resize bounds

| Dimension | Desktop | Mobile (`util.is_mobile()`) |
| --- | --- | --- |
| Width | resize: 1–5 cols, further capped at `100vw − 40 px` | fixed at `100vw − 40 px` |
| Initial width | 4 cols | `100vw − 40 px` |
| Height | resize: 300 px – `100dvh − 40 px` | fixed at `100dvh − 40 px` |
| Initial height | `70dvh` | `100dvh − 40 px` |
| Grid reflow | `auto-fit, minmax(200 px, 1fr)` | `auto-fit, minmax(150 px, 1fr)` so two tiles fit on narrow phones |
| Resize handles | 8 (4 edges + 4 corners) | none; resize disabled |

The 300 px height minimum covers the search input, one row of GIFs,
and the footer. The `100vw/dvh − 40 px` cap leaves a 20 px safe
margin on each side so the overlay never touches the viewport edge.
Keyboard arrow-key navigation computes the current column count at
runtime (previously hardcoded to 2) so up/down keep working across
reflows.

## Screenshots

### Default picker, light theme
 <img width="1507" height="1495" alt="image" src="https://github.com/user-attachments/assets/455c1526-afbf-4554-b897-12a9c1cc19af" /> 

### Default picker, dark theme
<img width="1371" height="1254" alt="image" src="https://github.com/user-attachments/assets/72cd7016-63dd-4d84-ab20-f0cc7ed7e0b2" /> 

### Resized to minimum (1 column)

<img width="1257" height="1537" alt="image" src="https://github.com/user-attachments/assets/94b62888-def5-4cee-8a85-aec28bb39f9f" /> 

### Resized to maximum (5 columns)
<img width="1733" height="1347" alt="image" src="https://github.com/user-attachments/assets/90a57e68-c355-4088-adb6-9033eee8da73" /> 

### Mobile viewport (`width < $md_min`)
<img width="901" height="1668" alt="image" src="https://github.com/user-attachments/assets/6e684d0e-e025-4134-9012-74ff2f5d0fc8" />

## Test plan

- [x] Manual: verify resize from each of the 4 edges and 4 corners
      on desktop Chrome and Firefox, in both light and dark themes.
- [x] Manual: verify the overlay stays centered during drag (no
      drift) and that drag delta of `N` px grows the matching
      dimension by `2N` px.
- [x] Manual: verify the picker reflows between 1 and 5 columns as
      the user resizes, and that columns never overflow the
      viewport at the maximum size on a narrow window.
- [x] Manual: verify keyboard navigation with ArrowUp/ArrowDown
      works correctly across reflows (1, 2, 3, 4, 5 columns).
- [x] Manual: verify the mobile layout (`width < $md_min`) fills
      the viewport and does not render resize handles.
- [x] Manual: open the picker while editing an existing message
      near the top of the viewport and confirm the old popper
      edge-case no longer applies.

---

Asked claude to implement the behaviour in #38192.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


