### PR TITLE
message_edit: Restore message state after saving a message.

### DIFF
--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -269,6 +269,15 @@ export function condense_and_collapse(elems: JQuery): void {
             $content.removeClass("could-be-condensed");
         }
 
+        // Completely hide the message and replace it with a "Show more"
+        // button if the user has collapsed it. This check must come first
+        // so that collapsed takes priority over condensed state.
+        if (message.collapsed) {
+            $content.addClass("collapsed");
+            show_message_expander($(elem));
+            continue;
+        }
+
         // If message.condensed is defined, then the user has manually
         // specified whether this message should be expanded or condensed.
         if (message.condensed === true) {
@@ -287,13 +296,6 @@ export function condense_and_collapse(elems: JQuery): void {
         } else {
             $content.removeClass("condensed");
             hide_message_length_toggle($(elem));
-        }
-
-        // Completely hide the message and replace it with a "Show more"
-        // button if the user has collapsed it.
-        if (message.collapsed) {
-            $content.addClass("collapsed");
-            show_message_expander($(elem));
         }
     }
 }

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1139,7 +1139,10 @@ export function end_message_row_edit($row: JQuery): void {
         message_lists.current.hide_edit_message($row);
         compose_call_session_manager.abandon_session(message.id.toString());
     }
-    if ($row.find(".could-be-condensed").length > 0) {
+
+    if (message?.collapsed) {
+        condense.show_message_expander($row);
+    } else if ($row.find(".could-be-condensed").length > 0) {
         if ($row.find(".condensed").length > 0) {
             condense.show_message_expander($row);
         } else {


### PR DESCRIPTION
This first commit ensures the message is always restored correctly after edit and reflects the proper state based on the message’s condensed, collapsed and expanded condition.

Fixes: [#issues > bugs with editing collapsed messages](https://chat.zulip.org/#narrow/channel/9-issues/topic/bugs.20with.20editing.20collapsed.20messages/with/2434019)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Shorter messages:
| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/321c886c-6295-4016-9e0f-1b8dfe3b9a62) | ![image-after](https://github.com/user-attachments/assets/9a30db6d-3fcb-4584-a33a-c4813feeea74)

Longer Messages:

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/0fb7ab06-42fd-46eb-9b0a-f99c741c6c61) | ![image-after](https://github.com/user-attachments/assets/9026cb64-2546-4392-adab-75915406f789)

States preserved after editing.

https://github.com/user-attachments/assets/0cae0bdf-a4d9-428d-b6ce-9b184a7f9498

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
