### PR TITLE
[ai] stream-create: Use CSS flex layout for subscriber list height.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -157,64 +157,6 @@ export function resize_bottom_whitespace(): void {
     }
 }
 
-export function resize_stream_creation_subscribers_list(): void {
-    // Calculates the height of the subscribers list in stream creation form.
-    // This prevents the stream settings from overflowing the container and
-    // having a scroll bar.
-
-    if ($("#channels_overlay_container").find(".two-pane-settings-overlay.show").length === 0) {
-        // Don't run if stream settings overlay is not open.
-        return;
-    }
-
-    if ($("#stream_creation_form .subscribers_container").css("display") === "none") {
-        // Don't run if the subscribers section of the stream creation form is
-        // not open.
-        return;
-    }
-
-    const $container = $("#stream_creation_form .two-pane-settings-creation-simplebar-container");
-    const $choose_subscribers_title = $container.find(".new-stream-subscribers-title");
-    const $pill_input_container = $container.find(".subscriber_list_settings");
-    const $subscribers_list_header = $container.find(".create_stream_subscriber_list_header");
-
-    const elements_above_subscribers_list = [
-        $choose_subscribers_title,
-        $pill_input_container,
-        $subscribers_list_header,
-    ];
-
-    let total_height_of_elements_above_subscribers_list = 0;
-    for (const $elem of elements_above_subscribers_list) {
-        const outer_height = $elem.outerHeight(true) ?? 0;
-        total_height_of_elements_above_subscribers_list += outer_height;
-    }
-
-    const susbcribers_list_container_bottom_border_width = 1;
-    const stream_creation_body_padding = 15;
-    const stream_creation_section_bottom_margin = 20;
-
-    // The two elements whose height is being calculated below
-    // are error elements. If no error is shown, consider height
-    // as 0.
-    const stream_subscription_error_height = $("#stream_subscription_error").height() ?? 0;
-    const $stream_creation_error = $container.find(".stream_create_info");
-    const stream_creation_error_height =
-        $stream_creation_error.css("display") !== "none"
-            ? $stream_creation_error.outerHeight(true)!
-            : 0;
-
-    const subscribers_list_height =
-        $container.height()! -
-        total_height_of_elements_above_subscribers_list -
-        stream_creation_body_padding -
-        stream_creation_section_bottom_margin -
-        stream_subscription_error_height -
-        stream_creation_error_height -
-        susbcribers_list_container_bottom_border_width;
-    $(":root").css("--new-stream-subscriber-list-max-height", `${subscribers_list_height}px`);
-}
-
 export function resize_stream_filters_container(): void {
     resize_bottom_whitespace();
     $("#left_sidebar_scroll_container").css("max-height", get_stream_filters_max_height());
@@ -355,5 +297,4 @@ export function resize_page_components(): void {
     resize_settings_overlay($("#channels_overlay_container"));
     resize_settings_creation_overlay($("#groups_overlay_container"));
     resize_settings_creation_overlay($("#channels_overlay_container"));
-    resize_stream_creation_subscribers_list();
 }

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -505,9 +505,7 @@ export function show_new_stream_modal(): void {
         }
     }
 
-    const $add_subscribers_container = $(
-        "#stream_creation_form .subscriber_list_settings",
-    ).expectOne();
+    const $add_subscribers_container = $("#stream_creation_form .subscriber_list_add").expectOne();
 
     stream_ui_updates.enable_or_disable_add_subscribers_elements(
         $add_subscribers_container,

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -13,7 +13,6 @@ import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as loading from "./loading.ts";
 import * as onboarding_steps from "./onboarding_steps.ts";
-import * as resize from "./resize.ts";
 import * as settings_components from "./settings_components.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
@@ -297,7 +296,6 @@ function create_stream(): void {
             $t_html({defaultMessage: "The channel description cannot contain newline characters."}),
             $(".stream_create_info"),
         );
-        resize.resize_stream_creation_subscribers_list();
         return;
     }
     const subscriptions = JSON.stringify([{name: stream_name, description}]);
@@ -437,7 +435,6 @@ function create_stream(): void {
                     xhr,
                     $(".stream_create_info"),
                 );
-                resize.resize_stream_creation_subscribers_list();
             }
             loading.destroy_indicator($("#stream_creating_indicator"));
         },
@@ -467,7 +464,6 @@ function clear_error_display(): void {
     stream_name_error.clear_errors();
     $(".stream_create_info").hide();
     stream_subscription_error.clear_errors();
-    resize.resize_stream_creation_subscribers_list();
 }
 
 export function show_new_stream_modal(): void {

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -505,7 +505,9 @@ export function show_new_stream_modal(): void {
         }
     }
 
-    const $add_subscribers_container = $("#stream_creation_form .subscriber_list_add").expectOne();
+    const $add_subscribers_container = $(
+        "#stream_creation_form .add_subscribers_container",
+    ).expectOne();
 
     stream_ui_updates.enable_or_disable_add_subscribers_elements(
         $add_subscribers_container,

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -7,7 +7,6 @@ import * as add_subscribers_pill from "./add_subscribers_pill.ts";
 import * as ListWidget from "./list_widget.ts";
 import type {ListWidget as ListWidgetType} from "./list_widget.ts";
 import * as people from "./people.ts";
-import * as resize from "./resize.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_create_subscribers_data from "./stream_create_subscribers_data.ts";
 import type {CombinedPillContainer} from "./typeahead_helper.ts";
@@ -54,28 +53,18 @@ function build_pill_widget({
     const $pill_container = $parent_container.find(".pill-container");
     const get_potential_subscribers = stream_create_subscribers_data.get_potential_subscribers;
     const get_user_groups = user_groups.get_all_realm_user_groups;
-    const on_pill_create = (user_ids: number[]): void => {
-        add_user_ids(user_ids);
-        resize.resize_stream_creation_subscribers_list();
-    };
-    const on_pill_remove = (user_ids: number[]): void => {
-        sync_user_ids(user_ids);
-        resize.resize_stream_creation_subscribers_list();
-    };
-
     return add_subscribers_pill.create({
         $pill_container,
         get_potential_subscribers,
         get_user_groups,
         with_add_button: false,
-        onPillCreateAction: on_pill_create,
+        onPillCreateAction: add_user_ids,
         // It is better to sync the current set of user ids in the input
         // instead of removing user_ids from the user_ids_set, otherwise
         // we'll have to have more complex logic of when to remove
         // a user and when not to depending upon their group, channel
         // and individual pills.
-        onPillRemoveAction: on_pill_remove,
-        onTextInputCallback: resize.resize_stream_creation_subscribers_list,
+        onPillRemoveAction: sync_user_ids,
     });
 }
 

--- a/web/src/stream_settings_components.ts
+++ b/web/src/stream_settings_components.ts
@@ -134,7 +134,10 @@ export const show_subs_pane = {
         $("#stream-creation").show();
         resize.resize_settings_overlay($("#channels_overlay_container"));
         resize.resize_settings_creation_overlay($("#channels_overlay_container"));
-        resize.resize_stream_creation_subscribers_list();
+        $("#stream_creation_form .two-pane-settings-creation-simplebar-container").toggleClass(
+            "subscribers-visible",
+            container_name === "subscribers_container",
+        );
     },
 };
 

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -493,7 +493,7 @@ export function update_add_subscriptions_elements(sub: SettingsSubscription): vo
     }
 
     // We are only concerned with the Subscribers tab for editing streams.
-    const $add_subscribers_container = $(".edit_subscribers_for_stream .subscriber_list_add");
+    const $add_subscribers_container = $(".edit_subscribers_for_stream .add_subscribers_container");
 
     if (current_user.is_guest) {
         // For guest users, we just hide the add_subscribers feature.
@@ -557,9 +557,9 @@ export function enable_or_disable_add_subscribers_elements(
     if (enable_elem) {
         const tippy_container: tippy.ReferenceElement = $container_elem[0]!;
         tippy_container._tippy?.destroy();
-        $container_elem.find(".add_subscribers_container").removeClass("add_subscribers_disabled");
+        $container_elem.removeClass("add_subscribers_disabled");
     } else {
-        $container_elem.find(".add_subscribers_container").addClass("add_subscribers_disabled");
+        $container_elem.addClass("add_subscribers_disabled");
     }
 
     if (!stream_creation) {

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -501,6 +501,7 @@ export function update_add_subscriptions_elements(sub: SettingsSubscription): vo
         $(
             ".subscriber_list_settings_container .send_notification_to_new_subscribers_container",
         ).hide();
+        $(".subscriber_list_settings_container .add-subscribers-subtitle").hide();
         $add_subscribers_container.hide();
         return;
     }

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -493,7 +493,7 @@ export function update_add_subscriptions_elements(sub: SettingsSubscription): vo
     }
 
     // We are only concerned with the Subscribers tab for editing streams.
-    const $add_subscribers_container = $(".edit_subscribers_for_stream .subscriber_list_settings");
+    const $add_subscribers_container = $(".edit_subscribers_for_stream .subscriber_list_add");
 
     if (current_user.is_guest) {
         // For guest users, we just hide the add_subscribers feature.
@@ -551,14 +551,12 @@ export function enable_or_disable_add_subscribers_elements(
     stream_creation = false,
 ): void {
     const $input_element = $container_elem.find(".input").expectOne();
-    const $add_subscribers_container = $<tippy.PopperElement>(
-        ".edit_subscribers_for_stream .subscriber_list_settings",
-    );
 
     $input_element.prop("contenteditable", enable_elem);
 
     if (enable_elem) {
-        $add_subscribers_container[0]?._tippy?.destroy();
+        const tippy_container: tippy.ReferenceElement = $container_elem[0]!;
+        tippy_container._tippy?.destroy();
         $container_elem.find(".add_subscribers_container").removeClass("add_subscribers_disabled");
     } else {
         $container_elem.find(".add_subscribers_container").addClass("add_subscribers_disabled");

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -695,7 +695,6 @@
     This value will be overridden when stream settings is opened.
     */
     --stream-subscriber-list-max-height: 100%;
-    --new-stream-subscriber-list-max-height: 100%;
     /*
       Reusable dimensions and offsets.
     */

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -286,6 +286,39 @@ h4.user_group_setting_subsection_title {
 
 .add_subscribers_container {
     width: 100%;
+
+    /* Set minimum height so that at least one row of pills is visible. */
+    min-height: calc(
+        var(--height-input-pill) + 2 *
+            var(--outer-spacing-input-pill-container) + 2px
+    );
+
+    .subscriber-input-scrollable-container {
+        max-height: 30vh;
+        height: 100%;
+        /* This makes sure that the element not takes the 100% space
+           and only takes the space remaining after button's width. */
+        flex: 1;
+        min-width: 0;
+
+        .simplebar-content {
+            /* Render as a flex container so whitespace-only text nodes around
+               .pill-container are not rendered as anonymous flex items.
+               Otherwise those text nodes contribute line box height to
+               scrollHeight, which triggers simplebar to show a scrollbar even
+               when the pill-container fits its visible area. */
+            display: flex;
+        }
+
+        .pill-container {
+            /* Subtract the total padding and border width from both width and height. */
+            width: calc(100% - 15px);
+            height: calc(100% - 6px);
+            /* Reserve space for the 11px simplebar vertical track so
+               pills don't overlap the scrollbar. */
+            padding-right: 11px;
+        }
+    }
 }
 
 .member_list_add {
@@ -1414,6 +1447,11 @@ h4.user_group_setting_subsection_title {
            .subscriber_list_container instead. */
         border-left: none;
         border-right: none;
+        /* This is slightly larger than the height required to show at least one
+           subscriber row is shown along with the table header. It is not easy
+           to calculate exact height since it depends whether the user has
+           permission to remove subscribers or not. */
+        min-height: 4.7em;
 
         .subscriber_list_container {
             box-sizing: border-box;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -284,7 +284,7 @@ h4.user_group_setting_subsection_title {
     padding-right: 8px;
 }
 
-.subscriber_list_add {
+.add_subscribers_container {
     width: 100%;
 }
 
@@ -1085,7 +1085,7 @@ h4.user_group_setting_subsection_title {
     color: hsl(0deg 0% 67%);
 }
 
-.subscriber_list_add .add_subscribers_disabled,
+.add_subscribers_container.add_subscribers_disabled,
 .member_list_settings .add_members_disabled {
     cursor: not-allowed;
 
@@ -1095,7 +1095,7 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-.subscriber_list_add,
+.add_subscribers_container,
 .member_list_settings {
     & button[disabled] {
         pointer-events: none;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -284,7 +284,10 @@ h4.user_group_setting_subsection_title {
     padding-right: 8px;
 }
 
-.subscriber_list_add,
+.subscriber_list_add {
+    width: 100%;
+}
+
 .member_list_add {
     width: 100%;
     margin: 0 0 10px;
@@ -373,6 +376,10 @@ h4.user_group_setting_subsection_title {
     tab content. This shifts the checkbox 2px right, but the effect
     on alignment is negligible. */
     padding-left: 2px;
+}
+
+#stream_settings .add-subscribers-subtitle {
+    margin-bottom: 10px;
 }
 
 .choose-subscribers-label {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1085,7 +1085,7 @@ h4.user_group_setting_subsection_title {
     color: hsl(0deg 0% 67%);
 }
 
-.subscriber_list_settings .add_subscribers_disabled,
+.subscriber_list_add .add_subscribers_disabled,
 .member_list_settings .add_members_disabled {
     cursor: not-allowed;
 
@@ -1095,7 +1095,7 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-.subscriber_list_settings,
+.subscriber_list_add,
 .member_list_settings {
     & button[disabled] {
         pointer-events: none;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -274,10 +274,6 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-#stream_creation_form .subscriber_list_container {
-    max-height: var(--new-stream-subscriber-list-max-height);
-}
-
 .subscriber-name,
 .subscriber-email {
     padding: 5px;
@@ -1364,34 +1360,66 @@ h4.user_group_setting_subsection_title {
                 .subscriber_list_settings_container {
                     height: 100%;
                 }
+            }
+        }
+    }
 
-                .subscriber_list_settings_container .subscriber-list-box {
-                    /* flex: 1 takes remaining space after the auto-sized siblings. */
-                    flex: 1;
-                    overflow: hidden;
-                    /* Hide borders here since they would extend to the
-                       full flex item height; they are redeclared on
-                       .subscriber_list_container instead. */
-                    border-left: none;
-                    border-right: none;
+    .two-pane-settings-creation-simplebar-container.subscribers-visible {
+        /* When the subscribers step is visible in the stream creation form,
+        disable simplebar on the outer container and use flex layout so
+        only the subscriber list table scrolls via its own simplebar. */
+        overflow-y: hidden;
 
-                    .subscriber_list_container {
-                        box-sizing: border-box;
-                        max-height: 100%;
-                        /* overflow: clip prevents the native scrollbar that would otherwise
-                           appear because the simplebar placeholder can overflow the
-                           container. Unlike overflow: hidden, clip does not disable
-                           simplebar (simplebar only disables on overflow: hidden). */
-                        overflow: clip;
-                        border-left: 1px solid
-                            var(--color-border-table-subscriber-list);
-                        border-right: 1px solid
-                            var(--color-border-table-subscriber-list);
-                        border-top-left-radius: 4px;
-                        border-top-right-radius: 4px;
+        .simplebar-content:has(> .stream-creation-body) {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+
+            .stream-creation-body {
+                flex: 1;
+                overflow: hidden;
+
+                .subscribers_container {
+                    height: 100%;
+                    display: flex;
+                    flex-direction: column;
+
+                    .stream_create_add_subscriber_container,
+                    #people_to_add {
+                        flex: 1;
+                        overflow: hidden;
+                        display: flex;
+                        flex-direction: column;
                     }
                 }
             }
+        }
+    }
+
+    #stream_settings.subscribers-tab-active .subscriber-list-box,
+    .two-pane-settings-creation-simplebar-container.subscribers-visible
+        .subscriber-list-box {
+        /* flex: 1 takes remaining space after the auto-sized siblings. */
+        flex: 1;
+        overflow: hidden;
+        /* Hide borders here since they would extend to the
+           full flex item height; they are redeclared on
+           .subscriber_list_container instead. */
+        border-left: none;
+        border-right: none;
+
+        .subscriber_list_container {
+            box-sizing: border-box;
+            max-height: 100%;
+            /* overflow: clip prevents the native scrollbar that would otherwise
+               appear because the simplebar placeholder can overflow the
+               container. Unlike overflow: hidden, clip does not disable
+               simplebar (simplebar only disables on overflow: hidden). */
+            overflow: clip;
+            border-left: 1px solid var(--color-border-table-subscriber-list);
+            border-right: 1px solid var(--color-border-table-subscriber-list);
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
         }
     }
 

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -1,8 +1,10 @@
 <div class="add_subscribers_container add-button-container">
-    <div class="pill-container person_picker">
-        <div class="input" contenteditable="true"
-          data-placeholder="{{t 'Add subscribers.' }}">
-            {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
+    <div class="subscriber-input-scrollable-container" data-simplebar>
+        <div class="pill-container person_picker">
+            <div class="input" contenteditable="true"
+              data-placeholder="{{t 'Add subscribers.' }}">
+                {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
+            </div>
         </div>
     </div>
     {{#if (not hide_add_button)}}

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -24,13 +24,3 @@
         </div>
     {{/if}}
 </div>
-<div class="add-subscribers-subtitle">
-    {{#tr}}
-        Enter a <z-user-roles-link>user role</z-user-roles-link>,
-        <z-user-groups-link>user group</z-user-groups-link>,
-        or <z-channel-link>#channel</z-channel-link> to add multiple users at once.
-        {{#*inline "z-user-roles-link"}}<a href="/help/user-roles" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-        {{#*inline "z-user-groups-link"}}<a href="/help/user-groups" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-        {{#*inline "z-channel-link"}}<a href="/help/introduction-to-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-    {{/tr}}
-</div>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -1,6 +1,4 @@
-<div class="subscriber_list_add">
-    {{> add_subscribers_form hide_add_button=true}}
-</div>
+{{> add_subscribers_form hide_add_button=true}}
 
 <div class="add-subscribers-subtitle">
     {{#tr}}

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -4,6 +4,17 @@
     </div>
 </div>
 
+<div class="add-subscribers-subtitle">
+    {{#tr}}
+        Enter a <z-user-roles-link>user role</z-user-roles-link>,
+        <z-user-groups-link>user group</z-user-groups-link>,
+        or <z-channel-link>#channel</z-channel-link> to add multiple users at once.
+        {{#*inline "z-user-roles-link"}}<a href="/help/user-roles" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-user-groups-link"}}<a href="/help/user-groups" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-channel-link"}}<a href="/help/introduction-to-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+    {{/tr}}
+</div>
+
 <div class="create_stream_subscriber_list_header">
     <div class="subscribers-heading">
         <h4 class="stream_setting_subsection_title">{{t 'Subscribers preview' }}</h4>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -1,7 +1,5 @@
-<div class="subscriber_list_settings">
-    <div class="subscriber_list_add">
-        {{> add_subscribers_form hide_add_button=true}}
-    </div>
+<div class="subscriber_list_add">
+    {{> add_subscribers_form hide_add_button=true}}
 </div>
 
 <div class="add-subscribers-subtitle">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -2,11 +2,9 @@
     <h4 class="stream_setting_subsection_title add-subscribers-heading">
         {{t "Add subscribers" }}
     </h4>
-    <div class="subscriber_list_settings">
-        <div class="subscriber_list_add">
-            <div class="stream_subscription_request_result banner-wrapper"></div>
-            {{> add_subscribers_form .}}
-        </div>
+    <div class="subscriber_list_add">
+        <div class="stream_subscription_request_result banner-wrapper"></div>
+        {{> add_subscribers_form .}}
     </div>
     <div class="add-subscribers-subtitle">
         {{#tr}}

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -3,9 +3,7 @@
         {{t "Add subscribers" }}
     </h4>
     <div class="stream_subscription_request_result banner-wrapper"></div>
-    <div class="subscriber_list_add">
-        {{> add_subscribers_form .}}
-    </div>
+    {{> add_subscribers_form .}}
     <div class="add-subscribers-subtitle">
         {{#tr}}
             Enter a <z-user-roles-link>user role</z-user-roles-link>,

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -8,6 +8,16 @@
             {{> add_subscribers_form .}}
         </div>
     </div>
+    <div class="add-subscribers-subtitle">
+        {{#tr}}
+            Enter a <z-user-roles-link>user role</z-user-roles-link>,
+            <z-user-groups-link>user group</z-user-groups-link>,
+            or <z-channel-link>#channel</z-channel-link> to add multiple users at once.
+            {{#*inline "z-user-roles-link"}}<a href="/help/user-roles" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{#*inline "z-user-groups-link"}}<a href="/help/user-groups" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{#*inline "z-channel-link"}}<a href="/help/introduction-to-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    </div>
     <div class="subsection-parent send_notification_to_new_subscribers_container">
         {{> ./../settings/settings_checkbox
           setting_name="send_notification_to_new_subscribers"

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -2,8 +2,8 @@
     <h4 class="stream_setting_subsection_title add-subscribers-heading">
         {{t "Add subscribers" }}
     </h4>
+    <div class="stream_subscription_request_result banner-wrapper"></div>
     <div class="subscriber_list_add">
-        <div class="stream_subscription_request_result banner-wrapper"></div>
         {{> add_subscribers_form .}}
     </div>
     <div class="add-subscribers-subtitle">


### PR DESCRIPTION
Replace the JS-based `resize_stream_creation_subscribers_list` function with a pure CSS solution. The old approach required calling the resize function from many places whenever any element above the subscriber table changed height, which was fragile and buggy.

When the subscribers tab is active, a `subscribers-visible` class is toggled on `.two-pane-settings-creation-simplebar-container`. This sets `overflow-y: hidden` to disable simplebar on the outer panel, then uses a flex layout chain to distribute the available height so only the subscriber list table scrolls via its own simplebar.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-04-15 12-56-30.webm](https://github.com/user-attachments/assets/2b20827e-f06e-41c8-988e-994943bc6085)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
