### PR TITLE
[ai] message_fetch: Mark visible messages read after confirming newest.

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -29,6 +29,7 @@ import {narrow_operator_schema} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_list from "./stream_list.ts";
+import * as unread_ops from "./unread_ops.ts";
 import * as util from "./util.ts";
 
 export const message_ids_response_schema = z.object({
@@ -266,6 +267,16 @@ function get_messages_success(data: MessageFetchResponse, opts: MessageFetchOpti
     }
 
     process_result(data, opts);
+
+    if (current_fetch_found_newest && opts.msg_list === message_lists.current) {
+        // Now that we've confirmed we have the newest messages in
+        // this view, re-check whether the visible messages should
+        // be marked as read. Without this, a fetch that completes
+        // after narrow activation (with no subsequent scroll, focus
+        // change, or new-message event) would leave messages unread
+        // even though the user is looking at the bottom of the view.
+        unread_ops.process_visible();
+    }
 }
 
 // This function modifies the narrow data to use integer IDs instead of


### PR DESCRIPTION
discussion: [#issues > need to scroll to read message when navigating from inbox](https://chat.zulip.org/#narrow/channel/9-issues/topic/need.20to.20scroll.20to.20read.20message.20when.20navigating.20from.20inbox/with/2432506)

## Summary

`unread_ops.process_visible()` gates auto-mark-as-read on `is_fetched_end_rendered()` and `bottom_rendered_message_visible()`, but it is only invoked from a handful of trigger sites: narrow activation, scroll end, new-message events, window focus, and keyboard navigation. A background `message_fetch` that later confirms `has_found_newest=true` is not one of them.

This creates an observable gap: a user narrows to a view whose initial fetch lags, the bottom is visible, but because `has_found_newest` hasn't been confirmed at the moment `process_visible()` ran during narrow activation, the messages stay unread until the user scrolls, refocuses the window, or a new message arrives.

This PR adds a trigger on the transition to `has_found_newest` for the current message list, symmetric to the existing `maybe_resume_reading_for_near_view()` call on the `has_found_oldest` transition a few lines above.

All existing gates (`can_mark_messages_read`, `reading_prevented`, `/near/` gating, viewport/focus checks) remain inside `process_visible()`, so this is a re-check rather than a forced mark.

## Additional cases found during audit (not fixed here)

While investigating, I audited the codebase for the same class of bug — gates in the mark-as-read pipeline transitioning from blocked → allowed without a trigger firing. The following cases exist but were intentionally left unfixed to avoid being overly aggressive about marking messages as read:

- **Setting change `web_mark_read_on_scroll_policy`** (`server_events_dispatch.js:~1036`): flipping from `never`/`conversation_only` to `always` while at the bottom of a view does not re-check.
- **Overlay/modal close** (`overlays.ts:close_overlay`, `modals.ts:close`): `viewport_is_visible_and_focused()` goes false → true when an overlay/modal closes, with no re-check.
- **Messages moved into current narrow without narrow change** (`message_events.ts`): an edit moving a message into the visible narrow adds and rerenders but does not call `process_visible()`.
- **Window resize** (low severity): making the window taller can flip `bottom_rendered_message_visible()` false → true without a scroll.

These are flagged for reviewer visibility — happy to address any of them in a follow-up if maintainers feel they should be.

---

I asked claude to audit for how messages in a view were automatically marked as read and pointed it where the bug might be. The performed additional audit to look for similar bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)