### PR TITLE
group/stream-settings: Make description field's label open edit modal.

### DIFF
--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -251,12 +251,12 @@ function update_user_group_title_buttons(group: UserGroup): void {
             `.selected-group-buttons[data-group-id='${CSS.escape(group.id.toString())}'] .deactivate`,
         ).hide();
         $(
-            `.selected-group-buttons[data-group-id='${CSS.escape(group.id.toString())}'] #open_group_info_modal`,
+            `.selected-group-buttons[data-group-id='${CSS.escape(group.id.toString())}'] #group_title_open_group_info_modal`,
         ).hide();
         return;
     }
     $(
-        `.selected-group-buttons[data-group-id='${CSS.escape(group.id.toString())}'] #open_group_info_modal`,
+        `.selected-group-buttons[data-group-id='${CSS.escape(group.id.toString())}'] #group_title_open_group_info_modal`,
     ).show();
 
     if (group.deactivated) {
@@ -2072,7 +2072,7 @@ export function initialize(): void {
 
     $("#groups_overlay_container").on(
         "click",
-        "#open_group_info_modal",
+        ".open-group-info-button",
         function (this: HTMLElement, e) {
             e.preventDefault();
             e.stopPropagation();

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -280,9 +280,17 @@ function update_general_panel_ui(group: UserGroup): void {
     const $edit_container = get_edit_container(group.id);
 
     if (settings_data.can_manage_user_group(group.id)) {
-        $edit_container.find(".group-description-field #open_group_info_modal").show();
+        $edit_container.find(".group-setting-label").removeClass("cursor-text");
+        $edit_container
+            .find(".group-description-field #open_group_info_modal")
+            .prop("disabled", false)
+            .show();
     } else {
-        $edit_container.find(".group-description-field #open_group_info_modal").hide();
+        $edit_container.find(".group-setting-label").addClass("cursor-text");
+        $edit_container
+            .find(".group-description-field #open_group_info_modal")
+            .prop("disabled", true)
+            .hide();
     }
     update_user_group_title_buttons(group);
     update_group_permission_settings_elements(group);

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -13,7 +13,8 @@
                 {{> stream_settings_tip .}}
             </div>
             <div class="channel-description-box">
-                <label class="settings-field-label">
+                <label class="settings-field-label {{#unless can_change_name_description}}cursor-text{{/unless}}"
+                  for="{{#if can_change_name_description}}open_stream_info_modal{{/if}}">
                     {{t "Description" }}
                     {{> ../help_link_widget link="/help/change-the-channel-description" }}
                 </label>

--- a/web/templates/user_group_settings/selected_group_title.hbs
+++ b/web/templates/user_group_settings/selected_group_title.hbs
@@ -8,8 +8,8 @@
     {{#unless is_system_group}}
     <div class="button-group selected-group-buttons" data-group-id="{{group_id}}">
         <div class="left-end button-group">
-            {{> ../components/icon_button icon="edit" intent="neutral" custom_classes="tippy-zulip-delayed-tooltip"
-              data-tippy-content=(t 'Change group info') id="open_group_info_modal" }}
+            {{> ../components/icon_button icon="edit" intent="neutral" custom_classes="open-group-info-button tippy-zulip-delayed-tooltip"
+              data-tippy-content=(t 'Change group info') id="group_title_open_group_info_modal" }}
         </div>
         <div class="right-end button-group">
             <div class="join_leave_button_wrapper inline-block">

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -16,7 +16,7 @@
                       rendered_description=group.description }}
                 </div>
                 {{#unless group.is_system_group}}
-                    {{> ../components/icon_button icon="edit" intent="neutral" custom_classes="tippy-zulip-delayed-tooltip"
+                    {{> ../components/icon_button icon="edit" intent="neutral" custom_classes="open-group-info-button tippy-zulip-delayed-tooltip"
                       data-tippy-content=(t 'Change group info') id="open_group_info_modal" }}
                 {{/unless}}
             </div>

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -7,7 +7,7 @@
         <div class="group_general_settings group_setting_section" data-group-section="general">
             <div class="group-reactivation-error-banner"></div>
             <div class="group-banner"></div>
-            <label class="group-setting-label">
+            <label class="group-setting-label" for="open_group_info_modal">
                 {{t "Description" }}
             </label>
             <div class="group-description-field">


### PR DESCRIPTION
Design topic: [#design > uneditable field styling @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/uneditable.20field.20styling/near/2434090)
 
(Last re-test on April 16)
### Channel settings:

- Owner:
  <img width="1438" height="898" alt="20260415-0856-16 1963706" src="https://github.com/user-attachments/assets/c1659cbe-e548-4d88-8ca9-ae5b27b241c5" />

- View-only:
  <img width="1436" height="892" alt="20260415-0858-44 4111774" src="https://github.com/user-attachments/assets/77029a78-022d-4a6a-aa50-ed2db836d34c" />

### User group settings:

- Owner:
  <img width="1438" height="898" alt="20260415-0859-45 7717140" src="https://github.com/user-attachments/assets/d75774fa-8cd0-40be-b850-d35075bf5a1f" />

- View-only:
  <img width="1434" height="892" alt="20260415-0900-33 8193588" src="https://github.com/user-attachments/assets/31932cdc-9dfc-4eee-84b9-beb6d0f53207" />
 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
