### PR TITLE
internal_url: Exclude stream name from encoded slug if it is too long.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -58,7 +58,7 @@ export function encode_stream_id(stream_id: number): string {
     // URI encoding piece
     const slug = stream_data.id_to_slug(stream_id);
 
-    return internal_url.encodeHashComponent(slug);
+    return internal_url.encode_slug(stream_id, slug);
 }
 
 export function decode_operand(

--- a/web/src/internal_url.ts
+++ b/web/src/internal_url.ts
@@ -46,6 +46,26 @@ export function stream_id_to_slug(
     return `${stream_id}-${name}`;
 }
 
+export function encode_slug(stream_id: number, slug: string): string {
+    // When generating slugs for channels in URLs, we like to provide
+    // an encoding of the channel name in the URL along with the
+    // channel ID to have the link hint what channel it is. But we
+    // want to only do this when the hinting is useful and does not
+    // greatly lengthen the string as a whole.
+    const MAX_SLUG_LENGTH_DIFF_FROM_ENCODING = 10;
+    const MAX_SLUG_LENGTH_RATIO_FROM_ENCODING = 1.5;
+
+    const encoded_slug = encodeHashComponent(slug);
+    const length_diff = encoded_slug.length - slug.length;
+    if (
+        length_diff > MAX_SLUG_LENGTH_DIFF_FROM_ENCODING ||
+        encoded_slug.length > slug.length * MAX_SLUG_LENGTH_RATIO_FROM_ENCODING
+    ) {
+        return String(stream_id);
+    }
+    return encoded_slug;
+}
+
 export function encode_stream_id(
     stream_id: number,
     maybe_get_stream_name: MaybeGetStreamName,
@@ -54,7 +74,7 @@ export function encode_stream_id(
     // URI encoding piece.
     const slug = stream_id_to_slug(stream_id, maybe_get_stream_name);
 
-    return encodeHashComponent(slug);
+    return encode_slug(stream_id, slug);
 }
 
 export function by_stream_url(

--- a/web/tests/internal_url.test.cjs
+++ b/web/tests/internal_url.test.cjs
@@ -64,3 +64,50 @@ run_test("test by_stream_topic_url", () => {
     result = internal_url.by_stream_topic_url(123, "test topic", maybe_get_stream_name, 12);
     assert.equal(result, "#narrow/channel/123-a-test-stream/topic/test.20topic/with/12");
 });
+
+run_test("test encode_slug", () => {
+    // The test cases include stream id to mirror how
+    // internal_url.encode_stream_id works.
+    const test_cases = [
+        // diff=0, ratio=1.0 → included (pure ASCII)
+        ["1-test-stream-autocomplete", true],
+        // 1-books.2C-film.2C-tv.2C-and-games;
+        // diff=6, ratio=1.214 → included (ASCII with commas)
+        ["1-books,-film,-tv,-and-games", true],
+        // 1-.E7.B2.BE.E9.80.89.20-.20.E8.AF.91.E6.96.87;
+        // diff=36, ratio=5.0 → excluded (Chinese with spaces)
+        ["1-精选 - 译文", false],
+        // 1-go.C3.BBta.20.C3.A0.20l.27.C5.93uf.20br.C3.BBl.C3.A9;
+        // diff=33, ratio=2.571 → excluded (many accented Latin chars)
+        ["1-goûta à l'œuf brûlé", false],
+        // 1-.E0.B0.AF.E0.B0.B6;
+        // diff=16, ratio=5.0 → excluded (very short non-Latin slug)
+        ["1-యశ", false],
+        // 1-.282.2B3.29.255;
+        // diff=8, ratio=1.889 → excluded (ASCII special chars, short slug)
+        ["1-(2+3)%5", false],
+        // 1-abcdefghijklmnop-.C3.A9.C3.A9;
+        // diff=10, ratio=1.476 → included (at diff limit)
+        ["1-abcdefghijklmnop-éé", true],
+        // 1-abcdefghijklmno-.C3.A9.C3.A9;
+        // diff=10, ratio=1.5 exactly → included (at ratio limit)
+        ["1-abcdefghijklmno-éé", true],
+        // 1-abcdefghijklmnopqrstu-.C3.A9.C3.A9.2E;
+        // diff=12, ratio=1.444 → excluded (over diff limit)
+        ["1-abcdefghijklmnopqrstu-éé.", false],
+        // 1-abcd-.C3.A9;
+        // diff=5, ratio=1.625 → excluded (over ratio limit)
+        ["1-abcd-é", false],
+    ];
+
+    for (const [channel_slug, should_encode_slug] of test_cases) {
+        if (should_encode_slug) {
+            assert.equal(
+                internal_url.encode_slug(1, channel_slug),
+                internal_url.encodeHashComponent(channel_slug),
+            );
+        } else {
+            assert.ok(Number(internal_url.encode_slug(1, channel_slug)) === 1);
+        }
+    }
+});

--- a/web/tests/markdown.test.cjs
+++ b/web/tests/markdown.test.cjs
@@ -664,12 +664,12 @@ test("marked", ({override}) => {
         {
             input: "#**& &amp; &amp;amp;**",
             expected:
-                '<p><a class="stream" data-stream-id="5" href="/#narrow/channel/5-.26-.26-.26amp.3B">#&amp; &amp; &amp;amp;</a></p>',
+                '<p><a class="stream" data-stream-id="5" href="/#narrow/channel/5">#&amp; &amp; &amp;amp;</a></p>',
         },
         {
             input: "#**& &amp; &amp;amp;>& &amp; &amp;amp;**",
             expected:
-                '<p><a class="stream-topic" data-stream-id="5" href="#narrow/channel/5-.26-.26-.26amp.3B/topic/.26.20.26.20.26amp.3B">#&amp; &amp; &amp;amp; &gt; &amp; &amp; &amp;amp;</a></p>',
+                '<p><a class="stream-topic" data-stream-id="5" href="#narrow/channel/5/topic/.26.20.26.20.26amp.3B">#&amp; &amp; &amp;amp; &gt; &amp; &amp; &amp;amp;</a></p>',
         },
     ];
 

--- a/web/tests/topic_link_util.test.cjs
+++ b/web/tests/topic_link_util.test.cjs
@@ -60,7 +60,7 @@ run_test("stream_link_syntax_test", () => {
     assert.equal(topic_link_util.get_stream_link_syntax("Denmark"), "#**Denmark**");
     assert.equal(
         topic_link_util.get_stream_link_syntax("$$MONEY$$"),
-        "[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/6-.24.24MONEY.24.24)",
+        "[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/6)",
     );
     assert.equal(
         topic_link_util.get_stream_link_syntax("Markdown [md]"),
@@ -95,7 +95,7 @@ run_test("stream_topic_link_syntax_test", () => {
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("$$MONEY$$", "dollar"),
-        "[#&#36;&#36;MONEY&#36;&#36; > dollar](#narrow/channel/6-.24.24MONEY.24.24/topic/dollar)",
+        "[#&#36;&#36;MONEY&#36;&#36; > dollar](#narrow/channel/6/topic/dollar)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("Sweden", "swe$$dish"),
@@ -108,7 +108,7 @@ run_test("stream_topic_link_syntax_test", () => {
 
     assert.equal(
         topic_link_util.get_fallback_markdown_link("$$MONEY$$"),
-        "[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/6-.24.24MONEY.24.24)",
+        "[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/6)",
     );
     assert.equal(
         topic_link_util.get_fallback_markdown_link("Markdown [md]"),
@@ -133,7 +133,7 @@ run_test("stream_topic_link_syntax_test", () => {
 
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("$$MONEY$$", ""),
-        "[#&#36;&#36;MONEY&#36;&#36; > translated: general chat](#narrow/channel/6-.24.24MONEY.24.24/topic/)",
+        "[#&#36;&#36;MONEY&#36;&#36; > translated: general chat](#narrow/channel/6/topic/)",
     );
 
     assert.equal(


### PR DESCRIPTION
Supersedes #34938.

Addresses [#user questions > long links to non-ASCII channels/topics](https://chat.zulip.org/#narrow/channel/138-user-questions/topic/long.20links.20to.20non-ASCII.20channels.2Ftopics/with/2305201) 

One logic change we did from that PR is replace `length_diff > Math.max(slug.length, MAX_SLUG_LENGTH_DIFF_FROM_ENCODING)` with `length_diff > MAX_SLUG_LENGTH_DIFF_FROM_ENCODING`. 
The comment by Tim on that PR indicates that we want to allow a 10 character difference, but that particular condition will only fail at greater than 2x ratio, in which case, the ratio check following it will fail.

Rest are test changes you can check at this [diff](https://github.com/zulip/zulip/compare/f85dffc97b759c07910c331f87e75bac3d6131fe..fbf2b49c82098ffcaaa42ebc36d9fc68551cfebe). (The before part of this diff has 1 additional test fix for `web/tests/topic_link_util.test.cjs`, which was part of the first push for this PR). and [diff](https://github.com/zulip/zulip/compare/d916211045a253433b7f350dcc47d993af912c9f..50498a5f7cdcb647fedfbb3efc37d79891880944)


When generating slugs for channels in URLs, we like to provide an encoding of the channel name in the URL along with the channel ID to have the link hint what channel it is. But we want to only do this when the hinting is useful and does not greatly lengthen the string as a whole.

If the difference in characters between the encoded slug and the slug is greater than 10, it is not encoded. We also have a max slug length ratio of 1.5.

Test changes made with the help of Claude.

<!-- Describe your pull request here.-->

**How changes were tested:**

Also tested the changes end to end manually by creating the channels in the test.

<img width="328" height="313" alt="Screenshot 2026-04-15 at 4 21 12 PM" src="https://github.com/user-attachments/assets/1f81903d-bfa3-4e2f-aa24-4de5695e19ba" />


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
