### PR TITLE
rendered_markdown: Render stream privacy icons in message links.

### DIFF
--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -257,7 +257,7 @@ export const update_elements = ($content: JQuery): void => {
                 });
                 $(this).replaceWith($(topic_link_html));
             } else {
-                const message_link_html = render_channel_message_link(context);
+                const message_link_html = render_channel_message_link({stream: sub, ...context});
                 $(this).replaceWith($(message_link_html));
             }
         }

--- a/web/templates/channel_message_link.hbs
+++ b/web/templates/channel_message_link.hbs
@@ -1,13 +1,21 @@
 {{#if is_empty_string_topic}}
 <a class="message-link" href="{{href}}">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; <span class="empty-topic-display">{{topic_display_name}}</span> @ 💬
+    {{#if stream~}}
+    {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+    {{~else~}}
+    #{{channel_name}}
+    {{~/if}} &gt; <span class="empty-topic-display">{{topic_display_name}}</span> @ 💬
     {{~!-- squash whitespace --~}}
 </a>
 {{~else}}
 <a class="message-link" href="{{href}}">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; {{topic_display_name}} @ 💬
+    {{#if stream~}}
+    {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+    {{~else~}}
+    #{{channel_name}}
+    {{~/if}} &gt; {{topic_display_name}} @ 💬
     {{~!-- squash whitespace --~}}
 </a>
 {{~/if}}

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -527,6 +527,7 @@ run_test("message-links", ({mock_template}) => {
         topic_display_name: `translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`,
         is_empty_string_topic: true,
         href: `/#narrow/channel/${stream.stream_id}-test/topic//near/123`,
+        stream,
     });
     assert.ok(channel_message_link_rendered_html.includes("empty-topic-display"));
 });
@@ -844,8 +845,16 @@ run_test("stream-private", ({mock_template}) => {
     $topic.addClass("stream-topic");
     $topic[0].replaceWith = noop;
 
+    const $message_link = $.create("a.message-link");
+    $message_link.attr(
+        "href",
+        `/#narrow/channel/${private_stream.stream_id}-secret-stream/topic/test/near/123`,
+    );
+    $message_link.set_find_results(".highlight", []);
+    $message_link[0].replaceWith = noop;
+
     $content.set_find_results("a.stream", $stream);
-    $content.set_find_results("a.stream-topic, a.message-link", $topic);
+    $content.set_find_results("a.stream-topic, a.message-link", [...$topic, ...$message_link]);
 
     let stream_name_context;
     mock_template("decorated_channel_name.hbs", true, (data, html) => {
@@ -859,6 +868,12 @@ run_test("stream-private", ({mock_template}) => {
         return html;
     });
 
+    let message_link_context;
+    mock_template("channel_message_link.hbs", true, (data, html) => {
+        message_link_context = data;
+        return html;
+    });
+
     rm.update_elements($content);
 
     // Verify decorated_channel_name was called with the private stream.
@@ -868,6 +883,10 @@ run_test("stream-private", ({mock_template}) => {
     // Verify topic_link was called with the private stream.
     assert.ok(topic_link_context, "topic_link should be called");
     assert.ok(topic_link_context.stream.invite_only, "Topic stream should be private");
+
+    // Verify channel_message_link was called with the private stream.
+    assert.ok(message_link_context, "channel_message_link should be called");
+    assert.ok(message_link_context.stream.invite_only, "Message link stream should be private");
 });
 
 run_test("stream-web-public", ({mock_template}) => {
@@ -895,8 +914,16 @@ run_test("stream-web-public", ({mock_template}) => {
     $topic.addClass("stream-topic");
     $topic[0].replaceWith = noop;
 
+    const $message_link = $.create("a.message-link");
+    $message_link.attr(
+        "href",
+        `/#narrow/channel/${web_public_stream.stream_id}-web-public-stream/topic/test/near/123`,
+    );
+    $message_link.set_find_results(".highlight", []);
+    $message_link[0].replaceWith = noop;
+
     $content.set_find_results("a.stream", $stream);
-    $content.set_find_results("a.stream-topic, a.message-link", $topic);
+    $content.set_find_results("a.stream-topic, a.message-link", [...$topic, ...$message_link]);
 
     let stream_name_context;
     mock_template("decorated_channel_name.hbs", true, (data, html) => {
@@ -910,6 +937,12 @@ run_test("stream-web-public", ({mock_template}) => {
         return html;
     });
 
+    let message_link_context;
+    mock_template("channel_message_link.hbs", true, (data, html) => {
+        message_link_context = data;
+        return html;
+    });
+
     rm.update_elements($content);
 
     // Verify decorated_channel_name was called with the web-public stream.
@@ -919,6 +952,13 @@ run_test("stream-web-public", ({mock_template}) => {
     // Verify topic_link was called with the web-public stream.
     assert.ok(topic_link_context, "topic_link should be called");
     assert.ok(topic_link_context.stream.is_web_public, "Topic stream should be web-public");
+
+    // Verify channel_message_link was called with the web-public stream.
+    assert.ok(message_link_context, "channel_message_link should be called");
+    assert.ok(
+        message_link_context.stream.is_web_public,
+        "Message link stream should be web-public",
+    );
 });
 
 run_test("stream-archived", ({mock_template}) => {
@@ -943,8 +983,16 @@ run_test("stream-archived", ({mock_template}) => {
     $topic.addClass("stream-topic");
     $topic[0].replaceWith = noop;
 
+    const $message_link = $.create("a.message-link");
+    $message_link.attr(
+        "href",
+        `/#narrow/channel/${archived_stream.stream_id}-old-stream/topic/test/near/123`,
+    );
+    $message_link.set_find_results(".highlight", []);
+    $message_link[0].replaceWith = noop;
+
     $content.set_find_results("a.stream", $stream);
-    $content.set_find_results("a.stream-topic, a.message-link", $topic);
+    $content.set_find_results("a.stream-topic, a.message-link", [...$topic, ...$message_link]);
 
     let stream_name_context;
     mock_template("decorated_channel_name.hbs", true, (data, html) => {
@@ -958,6 +1006,12 @@ run_test("stream-archived", ({mock_template}) => {
         return html;
     });
 
+    let message_link_context;
+    mock_template("channel_message_link.hbs", true, (data, html) => {
+        message_link_context = data;
+        return html;
+    });
+
     rm.update_elements($content);
 
     // Verify decorated_channel_name was called with the archived stream.
@@ -967,6 +1021,10 @@ run_test("stream-archived", ({mock_template}) => {
     // Verify topic_link was called with the archived stream.
     assert.ok(topic_link_context, "topic_link should be called");
     assert.ok(topic_link_context.stream.is_archived, "Topic stream should be archived");
+
+    // Verify channel_message_link was called with the archived stream.
+    assert.ok(message_link_context, "channel_message_link should be called");
+    assert.ok(message_link_context.stream.is_archived, "Message link stream should be archived");
 });
 
 run_test("rtl", () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #37847.

Stream and topic links were updated in #37847 to show privacy icons, but message links (`a.message-link`) were still rendering a plain `#` before the channel name. This PR applies the exact same icon logic to message links so all stream references in rendered messages are visually consistent.

The `decorated_channel_name` partial is now used in `channel_message_link.hbs`, with a `#{{channel_name}}` fallback for when the stream is not in `sub_store`. Tests are extended to cover all four stream types for message links.

## Screenshots

**Public stream**
| Before | After |
|--------|-------|
|<img width="1294" height="83" alt="Screen Shot 2026-04-15 at 16 32 00" src="https://github.com/user-attachments/assets/35534795-5edf-4b2b-96fc-b253a7257230" />| <img width="1294" height="83" alt="Screen Shot 2026-04-15 at 14 55 34" src="https://github.com/user-attachments/assets/09768f34-8c9b-4923-bdf6-1f591c31756b" />|

**Private stream**
| Before | After |
|--------|-------|
|<img width="1294" height="83" alt="Screen Shot 2026-04-15 at 16 33 32" src="https://github.com/user-attachments/assets/795f9423-1767-4f7f-82ae-680b105023cc" />| <img width="1294" height="83" alt="Screen Shot 2026-04-15 at 14 58 45" src="https://github.com/user-attachments/assets/9396b616-cc00-4fed-91a0-afded3fc22cf" />|

**Web-public stream**
| Before | After |
|--------|-------|
|<img width="1294" height="83" alt="Screen Shot 2026-04-15 at 16 36 52" src="https://github.com/user-attachments/assets/ccd990a1-4da5-44c5-a230-604b92f805d7" />| <img width="1294" height="83" alt="Screen Shot 2026-04-15 at 15 01 17" src="https://github.com/user-attachments/assets/c904bc0c-5497-4449-8bd7-56238e4826e0" />|

**Archived stream**
| Before | After |
|--------|-------|
|<img width="1294" height="83" alt="Screen Shot 2026-04-15 at 16 39 23" src="https://github.com/user-attachments/assets/2c118c13-140c-4e78-8eec-63b2fd06884c" />| <img width="1294" height="83" alt="Screen Shot 2026-04-15 at 15 02 17" src="https://github.com/user-attachments/assets/5a875260-0fd3-4697-aadf-1b16619d9a1e" />|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
