### PR TITLE
stream_settings: Make stream_description's view-only-styling optional.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -264,6 +264,7 @@ export function update_stream_description(sub: StreamSubscription): void {
     $edit_container.find("input.description").val(sub.description);
     const html = render_stream_description({
         rendered_description: postprocess_content(sub.rendered_description),
+        use_view_only_styling: true,
     });
     $edit_container.find(".stream-description").html(html);
 }

--- a/web/templates/popovers/stream_card_popover.hbs
+++ b/web/templates/popovers/stream_card_popover.hbs
@@ -11,7 +11,9 @@
         </li>
         <li role="none" class="popover-stream-info-menu-description text-item popover-menu-list-item">
             {{> ../stream_settings/stream_description
-              rendered_description=stream.rendered_description}}
+              rendered_description=stream.rendered_description
+              use_view_only_styling=false
+              }}
         </li>
         <li role="none" class="popover-menu-list-item text-item italic">
             {{#tr}}

--- a/web/templates/stream_settings/stream_description.hbs
+++ b/web/templates/stream_settings/stream_description.hbs
@@ -1,5 +1,5 @@
 {{#if rendered_description}}
-<div class="sub-stream-description settings-view-only-textarea rendered_markdown">
+<div class="sub-stream-description {{#if use_view_only_styling}}settings-view-only-textarea{{/if}} rendered_markdown">
     {{rendered_markdown rendered_description}}
 </div>
 {{else}}

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -21,6 +21,7 @@
                     <div class="stream-description">
                         {{> stream_description
                           rendered_description=rendered_description
+                          use_view_only_styling=true
                           }}
                     </div>
                     {{> ../components/icon_button


### PR DESCRIPTION
The previous changes to add the view-only-textarea to stream_description module didn't account for the fact that the module has two call sites -- the channel setting menu and the channel card.

Now the default state for the stream_description module is to not use the view-only styling, one can pass `use_view_only_styling=True` to use the speical styling.

Fixes: [#issues > outline/background change on channel cards @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/outline.2Fbackground.20change.20on.20channel.20cards/near/2434146)

**Screenshots and screen captures:**

- Channel card:

  | Before | After |
  |--------|--------|
  | <img width="338" height="176" alt="image" src="https://github.com/user-attachments/assets/9206a3da-ae6c-4fc4-bd66-f0f513f6ce6b" /> | <img width="338" height="160" alt="image" src="https://github.com/user-attachments/assets/ed13998f-303f-4ce1-b247-3cbe7e617d26" /> |

- Dark mode:
  <img width="338" height="160" alt="image" src="https://github.com/user-attachments/assets/58bc2be7-dce5-4a9c-94ab-c777f8c53626" />

- Channel setting's description field (unchanged):
  <img width="508" height="259" alt="image" src="https://github.com/user-attachments/assets/ae59d49b-1a08-4b2b-a32f-d6ce0b7981d4" />

- There are no similar bugs in the user group card (unchanged):
  <img width="338" height="228" alt="image" src="https://github.com/user-attachments/assets/829835fd-7166-457f-aa3d-1072c78dc093" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
