### PR TITLE
user_card: Attach popover to inline_profile_picture element.

### DIFF
--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -604,7 +604,7 @@ export function toggle_sender_info(): void {
     popovers.hide_all();
 
     const $message = $(".selected_message");
-    let $sender = $message.find(".message-avatar");
+    let $sender = $message.find(".message-avatar .inline-profile-picture-wrapper");
     if ($sender.length === 0) {
         // Messages without an avatar have an invisible message_sender
         // element that's roughly in the right place.

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -433,6 +433,13 @@ function show_user_card_popover(
         popover_html = render_user_card_popover(args);
     }
 
+    if ($popover_element.hasClass("inline-profile-picture-wrapper")) {
+        // The .inline-profile-picture-wrapper element has additional
+        // space around it, but we want to place the user card immediately
+        // adjacent the avatar. So we update the element here accordingly.
+        $popover_element = $popover_element.find(".inline_profile_picture");
+    }
+
     popover_menus.toggle_popover_menu(
         the($popover_element),
         {


### PR DESCRIPTION
This PR ensures that all user cards on avatars are attached to the same element inner element that precisely wraps the user-avatar image (including the `U` hotkey, which previously attached the card to a completely different element from the various click events; it's now in concord with the targets of the associated click events).

The visual improvement here is that the arrows on user-card popovers are now immediately adjacent the avatar. Note that the hotkey tooltip still shows when hovering the avatar and username, but I have not included screenshots of that here.

Fixes: [#issues > user card too far from avatar](https://chat.zulip.org/#narrow/channel/9-issues/topic/user.20card.20too.20far.20from.20avatar/with/2433008)

**Screenshots and screen captures:**

| Before (click) | After (click) |
| --- | --- |
| <img width="2360" height="1550" alt="avatar-card-click--before" src="https://github.com/user-attachments/assets/9d5cc6e0-e2ff-4555-b531-ba379f2a9b94" /> | <img width="2360" height="1550" alt="avatar-card-click--after" src="https://github.com/user-attachments/assets/bf1d9702-6405-4e39-a48d-9e952faef09f" /> |

| Before (`U` hotkey) | After (`U` hotkey) |
| --- | --- |
| <img width="2360" height="1550" alt="avatar-card-hotkey--before" src="https://github.com/user-attachments/assets/4ab6445d-3864-446f-9190-dbe7770c8fec" /> | <img width="2360" height="1550" alt="avatar-card-hotkey--after" src="https://github.com/user-attachments/assets/d4f1bf0b-b903-4d3e-9e29-bb1f92fa0427" /> |

| Before (username) | After (username; no change) |
| --- | --- |
| <img width="2360" height="1550" alt="username-card-before" src="https://github.com/user-attachments/assets/60ea890e-1cb6-494a-99dc-4a18fc025373" /> | <img width="2360" height="1550" alt="username-card-after--no-change" src="https://github.com/user-attachments/assets/e933087b-342e-486e-8835-8dfd33eac172" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>