### PR TITLE
recent_view: Remove envolope icon from header row.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1118,6 +1118,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     if (processed_count < row_keys.length && was_all_rendered) {
         topics_widget.render(row_keys.length - processed_count);
     }
+    update_unread_sort_header_state();
     setTimeout(revive_current_focus, 0);
 }
 
@@ -1178,6 +1179,7 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         );
     }
     if (!is_bulk_rerender) {
+        update_unread_sort_header_state();
         setTimeout(revive_current_focus, 0);
     }
     return true;
@@ -1433,6 +1435,54 @@ function unread_sort(a: ConversationData, b: ConversationData): number {
     return a.last_msg_id - b.last_msg_id;
 }
 
+function has_visible_unread_conversation(): boolean {
+    // Fast path: no unreads exist anywhere, so none can be visible.
+    if (unread.get_unread_message_count() === 0) {
+        return false;
+    }
+    assert(topics_widget !== undefined);
+    // When the unread filter is active, every row in the filtered
+    // list is unread by construction, so any non-empty list suffices.
+    if (filters.has("unread")) {
+        return topics_widget.get_current_list().length > 0;
+    }
+    // Iterate the widget's already-filtered list so we avoid
+    // re-evaluating `filters_should_hide_row` per topic.
+    for (const topic_data of topics_widget.get_current_list()) {
+        const msg = message_store.get(topic_data.last_msg_id);
+        assert(msg !== undefined);
+        if (message_to_conversation_unread_count(msg) > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+let last_has_visible_unread_conversation: boolean | undefined;
+
+function update_unread_sort_header_state(): void {
+    if (!topics_widget || !recent_view_util.is_visible()) {
+        return;
+    }
+    const has_visible_unreads = has_visible_unread_conversation();
+    if (has_visible_unreads === last_has_visible_unread_conversation) {
+        return;
+    }
+    last_has_visible_unread_conversation = has_visible_unreads;
+    const $unread_sort_header = $("#recent-view-table-headers .recent-view-unread-sort-header");
+    $unread_sort_header.toggleClass("hidden", !has_visible_unreads);
+    if (!has_visible_unreads && $unread_sort_header.hasClass("active")) {
+        // Fall back to time sort, which is the default, when the
+        // unread sort column is no longer meaningful.
+        $unread_sort_header.removeClass("active descend");
+        $("#recent-view-table-headers .recent-view-last-msg-time-header").addClass(
+            "active descend",
+        );
+        topics_widget.set_reverse_mode(true);
+        topics_widget.sort("numeric", "last_msg_id");
+    }
+}
+
 function topic_offset_to_visible_area($topic_row: JQuery): string | undefined {
     if ($topic_row.length === 0) {
         // TODO: There is a possibility of topic_row being undefined here
@@ -1512,6 +1562,7 @@ function callback_after_render(): void {
     }
 
     update_load_more_banner();
+    update_unread_sort_header_state();
     setTimeout(() => {
         revive_current_focus();
         is_waiting_for_revive_current_focus = false;

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1429,6 +1429,16 @@ function unread_count(conversation_data: ConversationData): number {
 function unread_sort(a: ConversationData, b: ConversationData): number {
     const a_unread_count = unread_count(a);
     const b_unread_count = unread_count(b);
+    const a_has_unread = a_unread_count > 0;
+    const b_has_unread = b_unread_count > 0;
+    if (a_has_unread !== b_has_unread) {
+        // Always float conversations with unreads above those without,
+        // regardless of sort direction. list_widget negates the entire
+        // return value in descend mode, so we compensate here.
+        const is_descend = $(".recent-view-unread-sort-header").hasClass("descend");
+        const unread_first = a_has_unread ? -1 : 1;
+        return is_descend ? -unread_first : unread_first;
+    }
     if (a_unread_count !== b_unread_count) {
         return a_unread_count - b_unread_count;
     }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1156,6 +1156,7 @@
     );
 
     /* Recent view */
+    --recent-view-body-border-width: 1px;
     --recent-view-max-avatars: 4;
     --recent-view-participant-item-width: 1.5em; /* 24px at 16px / 1em */
     --recent-view-participant-item-padding-x: 0.0938em; /* 1.5px at 16px / 1em */
@@ -3195,6 +3196,7 @@
 
     /* Zulip resizer handle svg */
     --svg-resize-handle: url("../images/resize-handle-white.svg");
+    --recent-view-body-border-width: 0.1875em; /* 3px at 16px/1em */
 }
 
 @media screen {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -111,7 +111,6 @@
     }
 
     #recent-view-content-table {
-        border-width: 0.1875em; /* 3px at 16px/1em */
         border-bottom-width: 1px;
 
         .unread_topic a {

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -588,6 +588,12 @@
         }
     }
 
+    #recent-view-table-headers:hover
+        .recent-view-unread-sort-header
+        .table-sortable-arrow {
+        opacity: 0.7;
+    }
+
     .recent-view-topic-header {
         /* Match left padding with row td (.recent_topic_name),
            including the extra space for the unread marker bar. */

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -654,8 +654,11 @@
         }
 
         .recent-view-unread-sort-header {
+            /* Use width that reasonably covers 2-3 magnitudes of count. */
+            width: 1.5em;
             margin-right: -0.1563em; /* 2.5px at 16px/1em */
             justify-self: end;
+            justify-content: center;
         }
     }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -598,12 +598,16 @@
     .recent-view-topic-header {
         /* Match left padding with row td (.recent_topic_name),
            including the extra space for the unread marker bar. */
-        padding: 0.25em 0.5em 0.25em 0.75em; /* 4px 8px 4px 12px at 16px/1em */
+        padding: 0 0.5em 0 0; /* 8px 12px at 16px/1em */
         /* th no longer has data-sort; the individual sort spans handle
            cursor and hover. */
         cursor: default;
 
         .recent-view-header-wrapper {
+            /* 0.75em left padding, 1px header width */
+            --recent-view-channel-row-header-minus-body: calc(
+                0.75em + var(--recent-view-body-border-width) - 1px
+            );
             /* Match the row grid so "Channel" and "Conversation" sort
                spans align with channel and topic text in rows. Sort
                arrows are inside the spans, so 3 columns suffice.
@@ -611,14 +615,26 @@
                at 16px/1em) privacy icon width in data rows. */
             display: grid;
             grid-template-columns:
-                min(
-                    calc(
-                        var(--longest-subscribed-channel-name-width) + 1em + 8px
-                    ),
-                    33.3%
+                calc(
+                    min(
+                            calc(
+                                var(--longest-subscribed-channel-name-width) +
+                                    1em + 8px
+                            ),
+                            calc(
+                                calc(
+                                        100% -
+                                            var(
+                                                --recent-view-channel-row-header-minus-body
+                                            )
+                                    ) /
+                                    3
+                            )
+                        ) +
+                        var(--recent-view-channel-row-header-minus-body)
                 )
                 auto 1fr auto;
-            align-items: center;
+            align-items: stretch;
         }
 
         .recent-view-channel-sort-header,
@@ -630,8 +646,8 @@
             cursor: pointer;
             /* Negative margin compensates the padding so the pill hover
                highlight doesn't push adjacent elements out of alignment. */
-            padding: 0.125em 0.25em; /* 2px 4px at 16px/1em */
-            margin: -0.125em -0.25em;
+            padding: 0.25em; /* 4px at 16px/1em */
+            margin: 0;
             border-radius: 3px;
             transition: background-color 100ms ease-in-out;
 
@@ -652,6 +668,11 @@
             &.descend .table-sortable-arrow {
                 transform: rotate(0deg);
             }
+        }
+
+        .recent-view-channel-sort-header {
+            padding-left: 1em;
+            margin-left: 0;
         }
 
         .recent-view-conversation-sort-header {
@@ -729,7 +750,7 @@
                     calc(
                         var(--longest-subscribed-channel-name-width) + 1em + 8px
                     ),
-                    33.3%
+                    calc(100% / 3)
                 )
                 auto 1fr auto;
             align-items: center;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -28,7 +28,8 @@
 }
 
 #recent-view-content-table {
-    border: 1px solid var(--color-border-recent-view-table);
+    border: var(--recent-view-body-border-width) solid
+        var(--color-border-recent-view-table);
     border-top: none;
     border-radius: 0 0 5px 5px;
     overflow: hidden;

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -23,9 +23,7 @@
                                 <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                             </span>
                             <span class="recent-view-unread-sort-header hidden-for-spectators tippy-zulip-delayed-tooltip" data-sort="unread_sort" data-tippy-content="{{t 'Sort by unread message count' }}">
-                                {{!-- Arrow is intentionally kept before unread icon to better align with unread count --}}
                                 <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
-                                <i class="zulip-icon zulip-icon-unread"></i>
                             </span>
                         </div>
                     </th>


### PR DESCRIPTION
Fixes #38918

discussion: [#design > Recent conversations redesign #38545](https://chat.zulip.org/#narrow/channel/101-design/topic/Recent.20conversations.20redesign.20.2338545/with/2392787)

| before | after |
| --- | --- |
| <img width="1237" height="1627" alt="image" src="https://github.com/user-attachments/assets/04a17d29-626b-429c-902b-8e737de63a7d" /> | <img width="1195" height="1614" alt="image" src="https://github.com/user-attachments/assets/a4721f36-ac50-4b12-97ad-6d9d866a56e1" /> | 


Unread sort icon visible on hover:

<img width="1178" height="250" alt="image" src="https://github.com/user-attachments/assets/adaf280a-f8d4-4a7c-9b40-0b57ca6cb830" />

Channel column = max channel name width
<img width="1173" height="1054" alt="image" src="https://github.com/user-attachments/assets/2b70354d-9161-4eee-9c00-60f0df3cc839" />

Channel column = 33.3% of row width.
<img width="1195" height="977" alt="image" src="https://github.com/user-attachments/assets/3bf9c285-9d2c-4a69-b757-8a97cb8d63d0" />

Time header hover.
<img width="1203" height="565" alt="image" src="https://github.com/user-attachments/assets/8c59d474-5492-4002-977a-e269ccc07cc9" />

Conversation header hover

<img width="1180" height="535" alt="image" src="https://github.com/user-attachments/assets/d4b97517-660f-4d5e-97eb-e1b02e5fef79" />


Unread count header hover
<img width="1178" height="627" alt="image" src="https://github.com/user-attachments/assets/397f87d2-cf71-4b12-92f4-9123934a26bf" />

