### PR TITLE
llms_txt: Fix three issues from post-merge review.

### DIFF
--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -134,11 +134,12 @@ export function decodeHashComponent(str: string): string {{
 ```
 
 Zulip topics can be renamed, moved, deleted, or most frequently,
-marked as resolved (represented via adding `RESOLVED_TOPIC_PREFIX = "✔
-"` to the start of the topic name). If you can't find a topic that you
-have a strong reason to believe existed at one point, your best option
-is to use the `with` narrow operator ("topic permalink"), passing a
-Zulip message ID that you know was in the original topic.
+marked as resolved (represented via adding the prefix
+`RESOLVED_TOPIC_PREFIX = "✔ "` to the start of the topic name). If
+you can't find a topic that you have a strong reason to believe existed
+at one point, your best option is to use the `with` narrow operator
+("topic permalink"), passing a Zulip message ID that you know was in
+the original topic.
 
 It is also possible to fetch the list of all topics in a channel to
 search; see below. That operation can be expensive, so use it

--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -35,7 +35,7 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
     content = f"""\
 # {realm.name}
 
-> {realm.url} is a Zulip team chat server.
+> {server_url} is a Zulip team chat server.
 > Zulip organizes messages into channels containing threads ("topics").
 >
 > Web-public channels can be read without logging in.

--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -76,9 +76,12 @@ Fetch the 100 oldest messages from a topic:
 
 ## Fetching messages in specific conversations / views
 
-Zulip conversations are referenced by a URL of this form:
+Zulip conversations are referenced by URLs of these forms:
 
-    https://HOST.DOMAIN/#narrow/channel/ID-NAME/topic/TOPIC[/with|near/MSG_ID]
+    {server_url}/#narrow/channel/ID-NAME
+    {server_url}/#narrow/channel/ID-NAME/topic/TOPIC
+    {server_url}/#narrow/channel/ID-NAME/topic/TOPIC/with/MSG_ID
+    {server_url}/#narrow/channel/ID-NAME/topic/TOPIC/near/MSG_ID
 
 Never follow links to related conversations by fetching those URLs; to
 read the messages, you MUST translate them to the equivalent API


### PR DESCRIPTION
Follow-up to #38736, addressing post-merge review feedback from @alexmv.

Three fixes to `zerver/views/llms_txt.py`:

- Use `{server_url}` consistently throughout the f-string. The introductory blockquote was using `{realm.url}` directly while every other URL reference used `{server_url}`.
- Replace the ambiguous `[/with|near/MSG_ID]` URL pattern (where it was unclear that `|` bound more tightly than the path components) with four separate concrete examples, one per URL form.
- Fix a literal newline that crept into the `RESOLVED_TOPIC_PREFIX` string inside the f-string. The prefix is `"✔ "` (with a trailing space), not `"✔\n"`.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>