### PR TITLE
push_notifications: Delete E2EE device records on API key regeneration.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 492**
+
+* [`POST /users/me/api_key/regenerate`](/api/regenerate-api-key): When
+  a user's API key is regenerated, the server now also removes all of
+  the user's E2EE push device registrations, stopping E2EE push
+  notifications to those devices.
+
 **Feature level 491**
 
 * [`GET /events`](/api/get-events): A new `individual_emoji_changes`

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 491
+API_FEATURE_LEVEL = 492
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -35,6 +35,7 @@ from zerver.lib.users import (
 )
 from zerver.lib.utils import generate_api_key
 from zerver.models import (
+    Device,
     Draft,
     EmailChangeStatus,
     Realm,
@@ -338,6 +339,9 @@ def do_regenerate_api_key(user_profile: UserProfile, acting_user: UserProfile) -
 
     event = {"type": "clear_push_device_tokens", "user_profile_id": user_profile.id}
     queue_event_on_commit("deferred_work", event)
+
+    # Delete all of the user's Device records to stop sending E2EE push notifications.
+    Device.objects.filter(user_id=user_profile.id).delete()
 
     return new_api_key
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -801,6 +801,8 @@ def regenerate_api_key(client: Client) -> None:
 
     # Update the client with the new API key so subsequent tests don't fail.
     client.api_key = result["api_key"]
+    # Reset the session so it is re-created with the new API key.
+    client.session = None
 
 
 @openapi_test_function("/bots/{bot_id}/api_key:get")
@@ -2265,6 +2267,10 @@ def test_api_key_endpoints(client: Client) -> None:
 
 def test_the_api(client: Client, nonadmin_client: Client, owner_client: Client) -> None:
     get_user_agent(client)
+    # Run `test_api_key_endpoints` before `test_users` so Device records created by
+    # `register_push_device` & `register_device` are not bulk-deleted by
+    # `regenerate_api_key`, since they are needed for curl tests.
+    test_api_key_endpoints(client)
     test_users(client, owner_client)
     test_streams(client, nonadmin_client)
     test_messages(client, nonadmin_client)
@@ -2273,7 +2279,6 @@ def test_the_api(client: Client, nonadmin_client: Client, owner_client: Client) 
     test_errors(client)
     test_invitations(client)
     test_welcome_bot_custom_message(client)
-    test_api_key_endpoints(client)
 
     sys.stdout.flush()
     if REGISTERED_TEST_FUNCTIONS != CALLED_TEST_FUNCTIONS:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11741,6 +11741,11 @@ paths:
         Changing a user's API key will immediately log them out of Zulip
         on devices registered for [mobile push notifications][mobile-push].
 
+        **Changes**: Before Zulip 12.0 (feature level 492),
+        regenerating a user's API key didn't remove all of the user's
+        [E2EE push device registrations](/api/register-push-device),
+        so E2EE push notifications could still be sent.
+
         [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
       responses:
         "200":

--- a/zerver/tests/test_devices.py
+++ b/zerver/tests/test_devices.py
@@ -28,3 +28,18 @@ class TestDeviceRegistration(ZulipTestCase):
         self.assert_json_success(result)
 
         self.assertEqual(Device.objects.count(), 0)
+
+    def test_remove_device_on_api_key_regeneration(self) -> None:
+        user = self.example_user("hamlet")
+
+        for _ in range(3):
+            result = self.api_post(user, "/api/v1/register_client_device")
+            self.assert_json_success(result)
+
+        self.assertEqual(Device.objects.filter(user=user).count(), 3)
+
+        # Verify all of the user's Device records deleted on API key
+        # regeneration, to stop sending E2EE push notifications.
+        result = self.api_post(user, "/api/v1/users/me/api_key/regenerate")
+        self.assert_json_success(result)
+        self.assertEqual(Device.objects.filter(user=user).count(), 0)


### PR DESCRIPTION
PR to Delete E2EE device records on API key regeneration, to stop sending push notifications.

Took help of Opus to fix things in `zerver/openapi/python_examples.py‎`.

**Screenshots and screen captures:**

<img width="754" height="321" alt="Screenshot 2026-04-16 at 2 34 15 PM" src="https://github.com/user-attachments/assets/e1255ba6-02fe-451a-9cae-aaf8967afad0" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
