### PR TITLE
left_sidebar: Show all topics when viewing topic in collapsed folder.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -564,9 +564,6 @@ function all_rows(): JQuery {
     const $collapsed_channels = $(
         ".stream-list-section-container.collapsed .narrow-filter:not(.stream-expanded) .bottom_left_row",
     );
-    const $hidden_topic_rows = $(
-        ".stream-list-section-container.collapsed .topic-list-item:not(.active-sub-filter).bottom_left_row",
-    );
 
     // Exclude toggle inactive / muted channels row from the list of rows if user is searching.
     const $toggle_inactive_or_muted_channels_row = $(
@@ -583,7 +580,6 @@ function all_rows(): JQuery {
         .not($inactive_or_muted_rows)
         .not($collapsed_views)
         .not($collapsed_channels)
-        .not($hidden_topic_rows)
         .not($toggle_inactive_or_muted_channels_row)
         .not($hidden_topic_search_hint_row);
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -594,16 +594,14 @@ export function rewire_update_stream_section_mention_indicators(
 }
 
 /* When viewing a channel in a collapsed folder, we show that active
-   highlighted channel in the left sidebar even though the folder is
-   collapsed. If there's an active highlighted topic within the
-   channel, we show it too. If there's no highlighted topic within the
-   channel, then we should treat this like an empty topic list and remove
-   the left bracket. */
+   highlighted channel in left sidebar even though the folder is collapsed.
+   If it has topics, keep the bracket visible. If the topic list is empty,
+   hide the bracket. */
 export let maybe_hide_topic_bracket = function (section_id: string): void {
     const $container = $(`#stream-list-${section_id}-container`);
     const is_collapsed = collapsed_sections.has(section_id);
-    const $highlighted_topic = $container.find(".topic-list-item.active-sub-filter");
-    $container.toggleClass("hide-topic-bracket", is_collapsed && $highlighted_topic.length === 0);
+    const $topic_items = $container.find(".topic-list-item");
+    $container.toggleClass("hide-topic-bracket", is_collapsed && $topic_items.length === 0);
 };
 
 export function rewire_maybe_hide_topic_bracket(value: typeof maybe_hide_topic_bracket): void {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -706,7 +706,6 @@
 #streams_list .stream-list-section-container.collapsed {
     .narrow-filter:not(.stream-expanded),
     .stream-list-toggle-inactive-or-muted-channels,
-    .topic-list-item:not(.active-sub-filter),
     &.hide-topic-bracket ul.topic-list.topic-list-has-topics::before,
     &.hide-topic-bracket ul.topic-list.topic-list-has-topics::after {
         display: none;


### PR DESCRIPTION
When navigating to a topic inside a channel that belongs to a collapsed folder (e.g., via Recent conversations), the left sidebar currently shows only the active topic.

This PR updates the behavior to display the full topic list for the channel in this case, even if the folder is collapsed. This improves navigation and provides better context when viewing topics.

Fixes: #38965.
CZO thread: [#design > only one topic shown in left sidebar](https://chat.zulip.org/#narrow/channel/101-design/topic/only.20one.20topic.20shown.20in.20left.20sidebar/with/2419491)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/33ddc045-2b5a-4836-bebf-bcc049909194) | ![image-after](https://github.com/user-attachments/assets/9d835f53-756a-4ef1-8fc7-5897e9ca61fa)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
