### PR TITLE
users: Test that deleted users cannot be reactivated.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -708,13 +708,13 @@ def do_activate_mirror_dummy_user(
 @transaction.atomic(savepoint=False)
 def do_reactivate_user(user_profile: UserProfile, *, acting_user: UserProfile | None) -> None:
     """Reactivate a user that had previously been deactivated"""
+    if user_profile.is_deleted:
+        raise JsonableError(_("Cannot reactivate a deleted user"))
+
     if user_profile.is_mirror_dummy:
         raise JsonableError(
             _("Cannot activate a placeholder account; ask the user to sign up, instead.")
         )
-
-    if user_profile.is_deleted:  # nocoverage
-        raise JsonableError(_("Cannot reactivate a deleted user"))
 
     change_user_is_active(user_profile, True)
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -2216,7 +2216,7 @@ class ActivateTest(ZulipTestCase):
         desdemona.is_mirror_dummy = True
         desdemona.save(update_fields=["is_mirror_dummy"])
 
-        # Cannot deactivate a user which is marked as "mirror dummy" from importing
+        # Cannot reactivate a user which is marked as "mirror dummy" from importing
         result = self.client_post(f"/json/users/{desdemona.id}/reactivate")
         self.assert_json_error(
             result, "Cannot activate a placeholder account; ask the user to sign up, instead."

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -3996,6 +3996,16 @@ class DeleteUserTest(ZulipTestCase):
         result = orjson.loads(self.client_get(f"/json/users/{hamlet_user_id}").content)
         self.assertEqual(result["user"]["is_deleted"], True)
 
+    def test_reactivate_deleted_user(self) -> None:
+        hamlet = self.example_user("hamlet")
+        do_delete_user(hamlet, acting_user=None)
+        hamlet.refresh_from_db()
+        self.assertTrue(hamlet.is_deleted)
+
+        self.login("iago")
+        result = self.client_post(f"/json/users/{hamlet.id}/reactivate")
+        self.assert_json_error(result, "Cannot reactivate a deleted user")
+
     def test_do_delete_user_preserving_messages(self) -> None:
         """
         Since do_delete_user and do_delete_user_preserving_messages share the same


### PR DESCRIPTION
When `do_reactivate_user` was added in #38374, its `is_deleted` guard was marked `# nocoverage` because it was unreachable in practice - deleted users also have `is_mirror_dummy=True`, so the mirror-dummy check always fires first. This commit fixes the check ordering so `is_deleted` is tested before `is_mirror_dummy`, and adds a test to confirm that trying to reactivate a deleted user via the API returns the right error.

Fixes: Follow-up to #38374.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>