### PR TITLE
templates: Fix formatting of unsubscribed channels alert

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -774,6 +774,7 @@ input.settings_text_input {
 }
 
 .inline-decorated-channel-name {
+    white-space: nowrap;
     display: inline;
     padding-left: var(--inline-decorated-channel-name-padding-left);
 

--- a/web/templates/decorated_channel_name.hbs
+++ b/web/templates/decorated_channel_name.hbs
@@ -7,3 +7,4 @@
     <span class="decorated-channel-name">{{stream.name}}</span>
     {{~!-- squash whitespace --~}}
 </span>
+{{~!-- squash whitespace --~}}

--- a/web/templates/skipped_marking_unread.hbs
+++ b/web/templates/skipped_marking_unread.hbs
@@ -1,10 +1,8 @@
 {{#tr}}
-    Because you are not subscribed to <z-streams></z-streams>, messages in this channel were not marked as unread.
-    {{#*inline "z-streams" ~}}
-    <strong>
-        {{~#list_each streams as |stream| ~}}
-        {{> decorated_channel_name inline_with_text=true stream=stream}}
-        {{~/list_each ~}}
-    </strong>
+    Messages in unsubscribed channels (<z-streams></z-streams>) were not marked as unread.
+    {{#*inline "z-streams"~}}
+    {{~#list_each streams as |stream|~}}
+        <strong>{{~> decorated_channel_name inline_with_text=true stream=stream~}}</strong>
+    {{~/list_each~}}
     {{~/inline}}
 {{/tr}}

--- a/web/tests/stream_pill.test.cjs
+++ b/web/tests/stream_pill.test.cjs
@@ -154,8 +154,7 @@ run_test("generate_pill_html", () => {
         "<div class='pill 'data-stream-id=\"101\" tabindex=0>\n" +
             '    <span class="pill-label">\n' +
             '        <span class="pill-value">\n' +
-            '                <span class="decorated-channel-name-wrapper"><span class="channel-privacy-type-icon"><i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i></span><span class="decorated-channel-name">Denmark</span></span>\n' +
-            "        </span></span>\n" +
+            '                <span class="decorated-channel-name-wrapper"><span class="channel-privacy-type-icon"><i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i></span><span class="decorated-channel-name">Denmark</span></span>        </span></span>\n' +
             '    <div class="exit">\n' +
             '        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n' +
             "    </div>\n" +


### PR DESCRIPTION
This updates the alert string to a single, translation-friendly sentence: "Messages in unsubscribed channels (...) were not marked as unread."

This also wraps the channel name and icon in a `nowrap` span so the icon sticks with the channel name, and fixes the stray space before commas using strict Handlebars whitespace control.

<!-- Describe your pull request here.-->

Fixes: [#issues > channel icon separated from channel name in alert](https://chat.zulip.org/#narrow/channel/9-issues/topic/channel.20icon.20separated.20from.20channel.20name.20in.20alert/with/2434862)<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="412" height="158" alt="image" src="https://github.com/user-attachments/assets/5a68ebdb-604d-4ea8-9710-68b2f887cdaf" />
After:
<img width="545" height="201" alt="image" src="https://github.com/user-attachments/assets/ee310e92-e737-4321-b741-084c4fc5a3f7" />
<img width="534" height="162" alt="image" src="https://github.com/user-attachments/assets/aa5cacd6-4904-4057-8dc9-4f648a218c33" />
<img width="533" height="163" alt="image" src="https://github.com/user-attachments/assets/1367eff8-77df-48b4-b42a-bf8f2df9a3b1" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
