### PR TITLE
[ai] channel_folders: Auto-select new folder created from channel settings.

### DIFF
--- a/web/src/channel_folders_ui.ts
+++ b/web/src/channel_folders_ui.ts
@@ -37,7 +37,7 @@ function compare_by_name(a: dropdown_widget.Option, b: dropdown_widget.Option): 
     return util.strcmp(a.name, b.name);
 }
 
-export function add_channel_folder(): void {
+export function add_channel_folder(on_create?: (folder_id: number) => void): void {
     const modal_content_html = render_create_channel_folder_modal({
         max_channel_folder_name_length: realm.max_channel_folder_name_length,
         max_channel_folder_description_length: realm.max_channel_folder_description_length,
@@ -76,6 +76,7 @@ export function add_channel_folder(): void {
                         order: id,
                     };
                     channel_folders.add(channel_folder);
+                    on_create?.(id);
                 },
             },
             close_on_success,

--- a/web/src/settings_folders.ts
+++ b/web/src/settings_folders.ts
@@ -96,11 +96,9 @@ export function set_up(): void {
     do_populate_channel_folders();
     meta.loaded = true;
 
-    $("#channel-folder-settings").on(
-        "click",
-        ".add-channel-folder-button",
-        channel_folders_ui.add_channel_folder,
-    );
+    $("#channel-folder-settings").on("click", ".add-channel-folder-button", () => {
+        channel_folders_ui.add_channel_folder();
+    });
     $("#channel-folder-settings").on("click", ".edit-channel-folder-button", (e) => {
         const folder_id = Number.parseInt(
             $(e.target).closest(".channel-folder-row").attr("data-channel-folder-id")!,

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -6,6 +6,7 @@ import render_subscription_invites_warning_modal from "../templates/confirm_dial
 import render_channel_name_conflict_error from "../templates/stream_settings/channel_name_conflict_error.hbs";
 
 import * as channel from "./channel.ts";
+import * as channel_folders_ui from "./channel_folders_ui.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
 import type {DropdownWidget} from "./dropdown_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
@@ -657,6 +658,11 @@ export function set_up_handlers(): void {
 
     $container.on("input", "#id_new_history_public_to_subscribers", () => {
         stream_ui_updates.update_can_create_topic_group_setting_state($("#stream-creation"));
+    });
+
+    $container.on("click", ".create-channel-folder-button", (e) => {
+        e.preventDefault();
+        channel_folders_ui.add_channel_folder(set_channel_folder_dropdown_value);
     });
 
     set_up_group_setting_widgets();

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -1114,7 +1114,14 @@ export function initialize(): void {
         },
     );
 
-    $("#channels_overlay_container").on("click", ".create-channel-folder-button", () => {
-        channel_folders_ui.add_channel_folder();
-    });
+    // Scope to #stream_settings (the editing pane) so this handler does not
+    // fire for the sibling creation pane (#stream-creation), which has its
+    // own handler.
+    $("#channels_overlay_container").on(
+        "click",
+        "#stream_settings .create-channel-folder-button",
+        () => {
+            channel_folders_ui.add_channel_folder();
+        },
+    );
 }

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -1121,7 +1121,17 @@ export function initialize(): void {
         "click",
         "#stream_settings .create-channel-folder-button",
         () => {
-            channel_folders_ui.add_channel_folder();
+            const active_stream_id = stream_settings_components.get_active_data().id;
+            const sub = sub_store.get(active_stream_id);
+            assert(sub !== undefined);
+            channel_folders_ui.add_channel_folder((folder_id) => {
+                settings_components.set_dropdown_list_widget_setting_value("folder_id", folder_id);
+                const $edit_container = stream_settings_containers.get_edit_container(sub);
+                settings_components.save_discard_stream_settings_widget_status_handler(
+                    $edit_container.find(".stream-settings-subsection"),
+                    sub,
+                );
+            });
         },
     );
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [#design > channel folders UI @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20folders.20UI/near/2434600)

We could have had a single function in `add_channel_folder` that selected the newly created folder for edit and create modals both. The `on_create` way was chosen since that way we don't need to rely on the DOM to find out whether we are editing or creating. 

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
New stream:
<img width="846" height="510" alt="new folder new stream" src="https://github.com/user-attachments/assets/daab51ca-f336-4bc8-967f-89a1fbf19dfa" />

Edit stream:
<img width="838" height="508" alt="new folder edit stream" src="https://github.com/user-attachments/assets/09ebcff0-63a9-4593-afa0-b85b27a18546" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
