### PR TITLE
[ai] settings: Hide click-focus outline on password show/hide toggle.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1244,8 +1244,17 @@ input[type="checkbox"] {
 
                 opacity: 0.6;
 
-                &:hover {
+                &:focus {
+                    outline: none;
+                }
+
+                &:hover,
+                &:focus-visible {
                     opacity: 1;
+                }
+
+                &:focus-visible {
+                    outline: 2px solid var(--color-outline-focus);
                 }
             }
 

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -18,7 +18,7 @@
                             <label for="get_api_key_password" class="modal-field-label">{{t "Your password" }}</label>
                             <div class="password-input-row">
                                 <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
-                                <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
+                                <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
                             </div>
                         </div>
                         <p class="small">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [#issues > extraneous selection box on show/hide button](https://chat.zulip.org/#narrow/channel/9-issues/topic/extraneous.20selection.20box.20on.20show.2Fhide.20button/with/2435431)

The hide unhide button in the API key modal was not keyboard focusable, this PR makes it keyboard focusable.

**How changes were tested:**
No portico files were touched, I checked the login page to not have regressions still.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="398" height="192" alt="show pass in api key" src="https://github.com/user-attachments/assets/517947e5-936c-4692-b01f-05e2e23e6b0f" />
<img width="398" height="192" alt="show pass in change pass" src="https://github.com/user-attachments/assets/dc154165-b342-4ce4-9017-11e69040c9d6" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
