### PR TITLE
navbar: Highlight active menu when popover is open.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2453,7 +2453,8 @@ body:not(.spectator-view) {
         text-decoration: none;
     }
 
-    &:hover {
+    &:hover,
+    .navbar-item.active-navbar-menu & {
         background-color: var(--color-header-button-hover);
     }
 


### PR DESCRIPTION
When a navbar menu popover is open, the menu items now show the hover background color by applying the same CSS to elements with the `.navbar-item.active-navbar-menu` class.

Fixes: [#design > Navbar menus highlighting when selected](https://chat.zulip.org/#narrow/channel/101-design/topic/Navbar.20menus.20highlighting.20when.20selected/with/2434814)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="763" height="316" alt="image" src="https://github.com/user-attachments/assets/60fffd0c-52bb-4dba-ab59-942401b96554" />|<img width="763" height="316" alt="image" src="https://github.com/user-attachments/assets/bdc0ff24-a67f-4266-a84a-68bf4500d973" />|

| Before | After |
|--------|-------|
|<img width="763" height="316" alt="image" src="https://github.com/user-attachments/assets/70ae1128-f284-41b5-a2be-f5234e1c4dce" />|<img width="763" height="316" alt="image" src="https://github.com/user-attachments/assets/e9697b04-9c1e-49e9-850d-cd9af04ac183" />|

| Before | After |
|--------|-------|
|<img width="763" height="316" alt="image" src="https://github.com/user-attachments/assets/36e7671e-de0e-40d6-a806-a932c8bb4fab" />|<img width="763" height="316" alt="image" src="https://github.com/user-attachments/assets/a681a5bd-c400-4342-b588-79958130f0e1" />|

| Before | After |
|--------|-------|
|<img width="751" height="312" alt="image" src="https://github.com/user-attachments/assets/b6450c5b-d25c-48d7-97fd-8afdfc2fdc77" />|<img width="751" height="312" alt="image" src="https://github.com/user-attachments/assets/41924790-15c4-4e54-87ef-9773d90dcc33" />|

| Before | After |
|--------|-------|
|<img width="751" height="312" alt="image" src="https://github.com/user-attachments/assets/ed11ca93-046c-4dbf-a44a-7a471502dc26" />|<img width="751" height="312" alt="image" src="https://github.com/user-attachments/assets/09c4f477-cbad-481f-961a-606595c9103f" />|

| Before | After |
|--------|-------|
|<img width="751" height="312" alt="image" src="https://github.com/user-attachments/assets/e44759b7-f486-458c-a2a2-41f767701ed8" />|<img width="751" height="312" alt="image" src="https://github.com/user-attachments/assets/16ffd881-f5e9-43e1-89e3-fb4e83d6b620" />|




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
