### PR TITLE
compose: Fix keyboard navigation focus for send later popover.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1498,12 +1498,6 @@ textarea.new_message_textarea {
             align-self: center;
             font-size: inherit;
 
-            &:focus {
-                outline: 1px dotted hsl(0deg 0% 20%);
-                outline: 5px auto -webkit-focus-ring-color;
-                outline-offset: -2px;
-            }
-
             &:checked
                 + .enter_sends_choice_text_container
                 .popover-menu-hotkey-hint {

--- a/web/templates/popovers/send_later_popover.hbs
+++ b/web/templates/popovers/send_later_popover.hbs
@@ -3,7 +3,7 @@
         <li role="none" class="popover-menu-list-item">
             <div role="group" class="enter_sends_choices" aria-label="{{t 'Enter to send choices' }}">
                 <label role="menuitemradio" class="enter_sends_choice" tabindex="0">
-                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="true"{{#if enter_sends_true }} checked{{/if}} />
+                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="true"{{#if enter_sends_true }} checked{{/if}} tabindex="-1" />
                     <span class="enter_sends_choice_text_container">
                         <span class="enter_sends_major enter_sends_choice_text">
                             {{#tr}}
@@ -20,7 +20,7 @@
                     </span>
                 </label>
                 <label role="menuitemradio" class="enter_sends_choice" tabindex="0">
-                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="false"{{#unless enter_sends_true }} checked{{/unless}} />
+                    <input type="radio" class="enter_sends_choice_radio" name="enter_sends_choice" value="false"{{#unless enter_sends_true }} checked{{/unless}} tabindex="-1" />
                     <span class="enter_sends_choice_text_container">
                         <span class="enter_sends_major enter_sends_choice_text">
                             {{#tr}}


### PR DESCRIPTION
Tab navigation in the send-later popover would focus the inner radio input elements rather than the menu item elements. This caused the radio input to get focus on keyboard navigation via Tab and the menu item selection box would disappear when radio is focused.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/8b03c825-fc9a-4e42-ad7d-3703671cc867">|<video src="https://github.com/user-attachments/assets/881fef6e-8a57-4ca9-b33d-c7a306fd3c86">|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
