### PR TITLE
left-sidebar: avoid baseline-aligning clamped DM names

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1462,6 +1462,9 @@ li.active-sub-filter {
     grid-area: row-content;
     overflow: hidden;
     text-overflow: ellipsis;
+    /* Baseline alignment works for single-line rows, but for clamped
+       multi-line DM names it can let text sit slightly below the row. */
+    align-self: start;
 }
 
 .conversation-partners .status-emoji {
@@ -1946,8 +1949,7 @@ li.active-sub-filter {
     }
 }
 
-.dm-markers-and-unreads,
-.conversation-partners {
+.dm-markers-and-unreads {
     align-self: baseline;
 }
 


### PR DESCRIPTION
## Summary
- keep unread markers baseline-aligned in DM rows
- stop baseline-aligning the clamped multi-line DM name block
- add a comment explaining why multi-line DM names need different alignment

Fixes #38928

## Testing
- not run locally
- frontend dependencies were not installed in this environment, so I could not run stylelint or do browser-based verification
- the change is limited to a small DM-specific CSS adjustment in `web/styles/left_sidebar.css`