### PR TITLE
Use dynamic viewport units in key overlays

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -164,16 +164,30 @@
 
     color-scheme: light;
 
-    /* Variable for setting the viewport to full height.
+    /* Variables for setting viewport-sized layouts.
        As of late 2025, we still support browsers (e.g.,
        Chrome 105) that do not support dynamic viewport
-       units. 100% is the legacy full-height value. */
+       units. Use percentage/vw/vh fallbacks where needed
+       until dynamic viewport units are available. */
     --full-height-dynamic-viewport: 100%;
+    --full-width-dynamic-viewport: 100vw;
     --gif-scroll-container-height: 80vh;
+    --overlay-container-height: 95vh;
+    --settings-overlay-width: 97vw;
+    --settings-overlay-vertical-margin: 2.5vh;
+    --popover-menu-max-height: 85vh;
 
     @supports (height: 100dvh) {
         --full-height-dynamic-viewport: 100dvh;
         --gif-scroll-container-height: 80dvh;
+        --overlay-container-height: 95dvh;
+        --settings-overlay-vertical-margin: 2.5dvh;
+        --popover-menu-max-height: 85dvh;
+    }
+
+    @supports (width: 100dvw) {
+        --full-width-dynamic-viewport: 100dvw;
+        --settings-overlay-width: 97dvw;
     }
 
     /*
@@ -639,8 +653,7 @@
     --length-user-status-circle-popover-menu: 8px;
     --length-user-popover-menu-avatar: 64px;
 
-    /* Overlay heights for streams modal */
-    --overlay-container-height: 95vh;
+    /* Streams modal overlay max height. */
     --overlay-container-max-height: 1000px;
     /* The width of the settings sidebar. */
     --settings-sidebar-width: 18.2142em; /* 255px at 14px/em */

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -422,8 +422,8 @@ ul.popover-group-menu-member-list {
         top: 0 !important;
         left: 0 !important;
 
-        width: 100vw;
-        height: 100vh;
+        width: var(--full-width-dynamic-viewport);
+        height: var(--full-height-dynamic-viewport);
 
         display: flex !important;
         justify-content: center;
@@ -912,7 +912,7 @@ ul.popover-group-menu-member-list {
 
 .popover-menu {
     margin: 0;
-    max-height: 85vh;
+    max-height: var(--popover-menu-max-height);
     overflow-x: hidden;
     user-select: none;
     border-radius: 6px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1087,13 +1087,13 @@ input[type="checkbox"] {
 
 .progressive-table-wrapper {
     position: relative;
-    max-height: calc(95vh - 220px);
+    max-height: calc(var(--overlay-container-height) - 220px);
     overflow: auto;
     width: 100%;
 }
 
 #admin-default-channels-list .progressive-table-wrapper {
-    max-height: calc(95vh - 280px);
+    max-height: calc(var(--overlay-container-height) - 280px);
 }
 
 .edit_bot_form {
@@ -1428,10 +1428,10 @@ label.preferences-radio-choice-label {
 
 /* -- new settings overlay -- */
 #settings_page {
-    height: 95vh;
-    width: 97vw;
+    height: var(--overlay-container-height);
+    width: var(--settings-overlay-width);
     max-width: 73.1429em; /* 1024px at 14px em */
-    margin: 2.5vh auto;
+    margin: var(--settings-overlay-vertical-margin) auto;
     overflow: hidden;
     border-radius: 4px;
 


### PR DESCRIPTION
## Summary
- add shared dynamic viewport width/height variables with legacy fallbacks
- apply them to the settings modal dimensions and related table max-heights
- use the shared viewport variables for mobile popover overlays and popover max-height

## Testing
- not run (CSS-only change; browser verification not completed locally)

Closes #37366.