### PR TITLE
lightbox: Fix missing download button for inline videos.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -287,10 +287,7 @@ export function render_lightbox_media_list(): void {
 }
 
 function display_image(payload: Media): void {
-    render_lightbox_media_list();
-
-    $(".player-container, .video-player").hide();
-    $(".image-preview, .media-actions, .media-description, .download, .lightbox-zoom-reset").show();
+    $(".image-preview, .media-actions, .lightbox-zoom-reset").show();
 
     const $img_container = $("#lightbox_overlay .image-preview > .zoom-element");
     const $img = $("<img>");
@@ -307,62 +304,20 @@ function display_image(payload: Media): void {
     }
     $img_container.empty();
     $img_container.append($img).show();
-
-    const filename = payload.url?.split("/").pop();
-    $(".media-description .title")
-        .text(payload.title ?? "N/A")
-        .attr("aria-label", payload.title ?? "N/A")
-        .attr("data-filename", filename ?? "N/A");
-    if (payload.user !== undefined) {
-        $(".media-description .user").text(payload.user).prop("title", payload.user);
-    }
-
-    $(".media-actions .open").attr("href", payload.url);
-
-    const url = new URL(payload.url, window.location.href);
-    const same_origin = url.origin === window.location.origin;
-    if (same_origin && url.pathname.startsWith("/user_uploads/")) {
-        // Switch to the "download" handler, so S3 URLs set their Content-Disposition
-        url.pathname = "/user_uploads/download/" + url.pathname.slice("/user_uploads/".length);
-        $(".media-actions .download").attr("href", url.href);
-    } else if (same_origin) {
-        $(".media-actions .download").attr("href", payload.url);
-    } else {
-        // If it's not same-origin, and we don't know how to tell the remote service to put a
-        // content-disposition on it, the download can't possibly download, just show -- so hide the
-        // element.
-        $(".media-actions .download").hide();
-    }
 }
 
 function display_video(payload: Media): void {
-    render_lightbox_media_list();
-
-    $(
-        "#lightbox_overlay .image-preview, .media-description, .download, .lightbox-zoom-reset, .video-player",
-    ).hide();
-    $(".player-container").show();
-
     if (payload.type === "inline-video") {
-        $(".player-container").hide();
-        $(".video-player, .media-description").show();
+        $(".video-player").show();
         const $video = $("<video>");
         $video.attr("src", payload.source);
         $video.attr("controls", "true");
         $(".video-player").empty();
         $(".video-player").append($video);
-        $(".media-actions .open").attr("href", payload.url);
-
-        const filename = payload.url?.split("/").pop();
-        $(".media-description .title")
-            .text(payload.title ?? "N/A")
-            .attr("aria-label", payload.title ?? "N/A")
-            .attr("data-filename", filename ?? "N/A");
-        if (payload.user !== undefined) {
-            $(".media-description .user").text(payload.user).prop("title", payload.user);
-        }
         return;
     }
+
+    $(".player-container").show();
 
     const $iframe = $("<iframe>");
     $iframe.attr(
@@ -376,7 +331,6 @@ function display_video(payload: Media): void {
 
     $("#lightbox_overlay .player-container").empty();
     $("#lightbox_overlay .player-container").append($iframe);
-    $(".media-actions .open").attr("href", payload.url);
 }
 
 function invoke_overlay_restore_callback(): void {
@@ -402,10 +356,49 @@ export function build_open_media_function(
         const payload = parse_media_data(util.the($media));
 
         assert(payload !== undefined);
+        render_lightbox_media_list();
+
+        $(
+            "#lightbox_overlay .image-preview, .lightbox-zoom-reset, .player-container, .video-player",
+        ).hide();
+
         if (payload.type === "image") {
             display_image(payload);
         } else {
             display_video(payload);
+        }
+        $(".media-actions .open").attr("href", payload.url);
+        if (payload.type === "image" || payload.type === "inline-video") {
+            $(".media-description").show();
+
+            const filename = payload.url?.split("/").pop();
+            $(".media-description .title")
+                .text(payload.title ?? "N/A")
+                .attr("aria-label", payload.title ?? "N/A")
+                .attr("data-filename", filename ?? "N/A");
+
+            if (payload.user !== undefined) {
+                $(".media-description .user").text(payload.user).prop("title", payload.user);
+            }
+
+            const url = new URL(payload.url, window.location.href);
+            const same_origin = url.origin === window.location.origin;
+            if (same_origin && url.pathname.startsWith("/user_uploads/")) {
+                // Switch to the "download" handler, so S3 URLs set their Content-Disposition
+                url.pathname =
+                    "/user_uploads/download/" + url.pathname.slice("/user_uploads/".length);
+                $(".media-actions .download").attr("href", url.href).show();
+            } else if (same_origin) {
+                $(".media-actions .download").attr("href", payload.url).show();
+            } else {
+                // If it's not same-origin, and we don't know how to tell the remote service to put a
+                // content-disposition on it, the download can't possibly download, just show -- so hide the
+                // element.
+                $(".media-actions .download").hide();
+            }
+        } else {
+            // It's an external embed (YouTube/Vimeo) - hide the metadata and download button
+            $(".media-description, .media-actions .download").hide();
         }
         if (is_open) {
             return;


### PR DESCRIPTION
Previously, the display_video function hid the download action. This commit extracts the download link configuration into the shared build_open_media_function, ensuring the download button is properly displayed and routed for both uploaded images and inline videos.

<!-- Describe your pull request here.-->

Fixes: [#issues > no "download" button on video](https://chat.zulip.org/#narrow/channel/9-issues/topic/no.20.22download.22.20button.20on.20video/with/2432923)<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Uploaded video
<img width="1915" height="1079" alt="image" src="https://github.com/user-attachments/assets/11840061-9607-4245-82e3-76c4c750cd06" />
Image
<img width="1912" height="1079" alt="image" src="https://github.com/user-attachments/assets/b3a1850d-1916-4b87-9244-4444668978d8" />
Youtube link
<img width="1919" height="1077" alt="image" src="https://github.com/user-attachments/assets/88b4c683-fd14-4377-9397-51ef5becfed1" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
