### PR TITLE
settings: Fix spacing between folder name and description inputs.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -130,7 +130,8 @@
     color: hsl(0deg 100% 50%);
 }
 
-.change-stream-name-container {
+.change-stream-name-container,
+.channel-folder-name-container {
     margin-bottom: 20px;
 }
 

--- a/web/templates/stream_settings/create_channel_folder_modal.hbs
+++ b/web/templates/stream_settings/create_channel_folder_modal.hbs
@@ -1,4 +1,4 @@
-<div>
+<div class="channel-folder-name-container">
     <label for="new_channel_folder_name" class="modal-field-label">
         {{t 'Channel folder name' }}
     </label>

--- a/web/templates/stream_settings/edit_channel_folder_modal.hbs
+++ b/web/templates/stream_settings/edit_channel_folder_modal.hbs
@@ -1,5 +1,5 @@
 <div id="channel_folder_banner" class="banner-wrapper"></div>
-<div>
+<div class="channel-folder-name-container">
     <label for="edit_channel_folder_name" class="modal-field-label">
         {{t 'Channel folder name' }}
     </label>


### PR DESCRIPTION
Previously, there was no space between channel folder name and description inputs in channel folder creation and edit modals.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
| ------ | ------ |
|<img width="1442" height="1642" alt="image" src="https://github.com/user-attachments/assets/9bef154a-5f49-4091-be37-7267b9f8e2db" /> | <img width="1442" height="1642" alt="image" src="https://github.com/user-attachments/assets/2029ea50-97c9-47cc-826f-6a76607903b7" /> |
| <img width="1442" height="718" alt="image" src="https://github.com/user-attachments/assets/8adb317f-b08d-4027-978e-df06aac28c9b" /> | <img width="1442" height="718" alt="image" src="https://github.com/user-attachments/assets/d57cd9fb-77f5-424e-974d-657e01d7296e" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
