### PR TITLE
Use either "Email address" or "Email message" but never "Email"

### DIFF
--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -22,7 +22,7 @@ the registration flow has its own (nearly identical) copy of the fields below in
             <form method="post" id="registration" action="{{ url('accept_terms') }}">
                 {{ csrf_input }}
                 <div id="registration-email">
-                    <label for="id_email">{{ _("Email") }}</label>
+                    <label for="id_email">{{ _("Email address") }}</label>
                     <div class="controls fakecontrol">{{ email }}</div>
                     {% if first_time_login %}
                     {% include 'zerver/create_user/new_user_email_address_visibility.html' %}

--- a/templates/zerver/create_user/accounts_home.html
+++ b/templates/zerver/create_user/accounts_home.html
@@ -60,7 +60,7 @@ page can be easily identified in it's respective JavaScript file -->
 
                                 <div class="input-box no-validate">
                                     <input type="email" id="email" class="email" name="email" value="" autofocus required />
-                                    <label for="email">{{ _('Email') }}</label>
+                                    <label for="email">{{ _('Email address') }}</label>
                                     <div class="alert alert-error email-frontend-error"></div>
                                     {% if form.email.errors %}
                                         {% for error in form.email.errors %}

--- a/templates/zerver/create_user/register.html
+++ b/templates/zerver/create_user/register.html
@@ -85,7 +85,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 <div class="input-box">
                     <input type='hidden' name='key' value='{{ key }}' />
                     <input type='hidden' name='timezone' id='timezone'/>
-                    <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
+                    <label for="id_email" class="inline-block label-title">{{ _('Email address') }}</label>
                     <div id="id_email">{{ email }}</div>
                     {% if not creating_new_realm %}
                     {% include 'zerver/create_user/new_user_email_address_visibility.html' %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -94,11 +94,11 @@ page can be easily identified in it's respective JavaScript file. -->
                                   maxlength="{{ form.username.field.max_length }}" required />
                                 <label for="id_username">
                                     {% if not require_email_format_usernames and email_auth_enabled %}
-                                    {{ _('Email or username') }}
+                                    {{ _('Email address or username') }}
                                     {% elif not require_email_format_usernames %}
                                     {{ _('Username') }}
                                     {% else %}
-                                    {{ _('Email') }}
+                                    {{ _('Email address') }}
                                     {% endif %}
                                 </label>
                             </div>

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -21,7 +21,7 @@
                 <div class="new-style">
                     <div class="input-box horizontal">
                         <div class="inline-block relative">
-                            <label for="id_email" class="">{{ _('Email') }}</label>
+                            <label for="id_email" class="">{{ _('Email address') }}</label>
                             <input id="id_email" class="required" type="text" name="email"
                               value="{% if form.email.value() %}{{ form.email.value() }}{% endif %}"
                               maxlength="100" placeholder="{{ _("Enter your email address") }}" autofocus required />

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -17,7 +17,7 @@
             <form class="form-inline" method="post" id="password_reset" autocomplete="off">
                 {{ csrf_input }}
                 <div class="input-box" id="email-section">
-                    <label for="id_email">{{ _("Email") }}</label>
+                    <label for="id_email">{{ _("Email address") }}</label>
                     <div>
                         <input type="text" name="name" placeholder='{{ form.user.delivery_email }}' disabled />
                     </div>

--- a/web/templates/demo_organization_add_email_modal.hbs
+++ b/web/templates/demo_organization_add_email_modal.hbs
@@ -1,6 +1,6 @@
 <form class="modal-form" id="demo_organization_add_email_form">
     <div class="input-group">
-        <label for="demo_organization_add_email" class="modal-field-label">{{t "Email" }}</label>
+        <label for="demo_organization_add_email" class="modal-field-label">{{t "Email address" }}</label>
         <input id="demo_organization_add_email" type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
     </div>
     <div class="input-group">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -7,7 +7,7 @@
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
-                    <label class="settings-field-label {{#unless user_can_change_email}}cursor-text{{/unless}}" for="change_email_button">{{t "Email" }}</label>
+                    <label class="settings-field-label {{#unless user_can_change_email}}cursor-text{{/unless}}" for="change_email_button">{{t "Email address" }}</label>
                     <div class="change-email">
                         <div id="email_field_container" class="inline-block {{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
                             <input type="email" value="{{current_user.delivery_email}}" class="settings_text_input" disabled="disabled" />

--- a/web/templates/settings/active_user_list_admin.hbs
+++ b/web/templates/settings/active_user_list_admin.hbs
@@ -16,7 +16,7 @@
                     <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    <th class="settings-email-column" data-sort="email">{{t "Email" }}
+                    <th class="settings-email-column" data-sort="email">{{t "Email address" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
                     <th class="user_role" data-sort="role">{{t "Role" }}

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -8,7 +8,7 @@
         </div>
         {{#if email}}
         <div class="input-group email_change_container">
-            <label for="email" class="modal-field-label">{{t "Email" }}</label>
+            <label for="email" class="modal-field-label">{{t "Email address" }}</label>
             <input type="text" autocomplete="off" name="email" class="modal_text_input" value="{{ email }}" readonly/>
         </div>
         {{/if}}

--- a/web/templates/settings/bot_list.hbs
+++ b/web/templates/settings/bot_list.hbs
@@ -14,7 +14,7 @@
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}
                     <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                 </th>
-                <th class="settings-email-column" data-sort="email">{{t "Email" }}
+                <th class="settings-email-column" data-sort="email">{{t "Email address" }}
                     <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                 </th>
                 <th class="user_role" data-sort="role">{{t "Role" }}

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -19,7 +19,7 @@
                     <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    <th class="settings-email-column" {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}}>{{t "Email" }}
+                    <th class="settings-email-column" {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}}>{{t "Email address" }}
                         {{#if allow_sorting_deactivated_users_list_by_email}}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                         {{/if}}

--- a/web/templates/settings/imported_user_list_admin.hbs
+++ b/web/templates/settings/imported_user_list_admin.hbs
@@ -16,7 +16,7 @@
                     <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    <th class="settings-email-column" data-sort="email">{{t "Email" }}
+                    <th class="settings-email-column" data-sort="email">{{t "Email address" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
                     <th class="user_role" data-sort="role">{{t "Role" }}

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -19,7 +19,7 @@
                         </span>
                         {{> ../help_link_widget link="/help/mobile-notifications#enabling-push-notifications-for-self-hosted-servers" }}
                     </th>
-                    <th rowspan="2" width="14%">{{t "Email"}}</th>
+                    <th rowspan="2" width="14%">{{t "Email message" }}</th>
                     <th rowspan="2" width="14%">@all
                         <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
                     </th>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -22,7 +22,7 @@
                     <th class="panel_user_list" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    <th class="settings-email-column" data-sort="email">{{t "Email" }}
+                    <th class="settings-email-column" data-sort="email">{{t "Email address" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
                     <th class="action-column">{{t "Action" }}</th>

--- a/web/templates/stream_settings/stream_members_table.hbs
+++ b/web/templates/stream_settings/stream_members_table.hbs
@@ -6,7 +6,7 @@
                 <th class="panel_user_list" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}
                     <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                 </th>
-                <th class="settings-email-column" data-sort="email">{{t "Email" }}
+                <th class="settings-email-column" data-sort="email">{{t "Email address" }}
                     <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                 </th>
                 {{#if can_remove_subscribers}}

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -19,7 +19,7 @@
                     <th class="panel_user_list" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    <th class="settings-email-column" data-sort="email">{{t "Email" }}
+                    <th class="settings-email-column" data-sort="email">{{t "Email address" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
                     <th class="action-column">{{t "Action" }}</th>

--- a/web/templates/user_group_settings/user_group_members_table.hbs
+++ b/web/templates/user_group_settings/user_group_members_table.hbs
@@ -6,7 +6,7 @@
                 <th class="panel_user_list" data-sort="name">{{t "Name" }}
                     <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                 </th>
-                <th class="settings-email-column" data-sort="email">{{t "Email" }}
+                <th class="settings-email-column" data-sort="email">{{t "Email address" }}
                     <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                 </th>
                 {{#if can_remove_members}}

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -52,7 +52,7 @@
                                 <div id="default-section">
                                     {{#if email}}
                                     <div id="email" class="default-field">
-                                        <div class="name">{{t "Email" }}</div>
+                                        <div class="name">{{t "Email address" }}</div>
                                         <div class="value">{{email}}</div>
                                     </div>
                                     {{/if}}


### PR DESCRIPTION
This supports translations where there's no (good) single word that can refer both to the message and to the address.

**How changes were tested:**

The changes were not tested. The only possible issue is when screen estate is limited. It might be the case in the notification settings screen in particular.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>