### PR TITLE
markdown: Add support for notes:// deeplinks.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -102,8 +102,9 @@ html_safelisted_schemes = (
     "xmpp",
     "zotero",
     "asanadesktop",
+    "notes",
 )
-auto_linked_schemes = ["https?", "hansoft", "obsidian", "zotero", "asanadesktop"]
+auto_linked_schemes = ["https?", "hansoft", "obsidian", "zotero", "asanadesktop", "notes"]
 allowed_schemes = ("http", "https", "ftp", "file", "mid", *html_safelisted_schemes)
 
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1095,6 +1095,11 @@
       "name": "explicit_link_asana_desktop",
       "input": "[Asana Task](asanadesktop://task/123456789)",
       "expected_output": "<p><a href=\"asanadesktop://task/123456789\">Asana Task</a></p>"
+    },
+    {
+      "name": "explicit_link_notes_app",
+      "input": "[Meeting Notes](notes://my-workspace/note/123)",
+      "expected_output": "<p><a href=\"notes://my-workspace/note/123\">Meeting Notes</a></p>"
     }
   ],
   "linkify_tests": [
@@ -1507,6 +1512,11 @@
       "Приветhttps://google.com",
       "<p>Привет<a href=\"https://google.com\">https://google.com</a></p>",
       "https://google.com"
+    ],
+    [
+      "notes://my-workspace/note/123",
+      "<p>%s</p>",
+      "notes://my-workspace/note/123"
     ]
   ]
 }


### PR DESCRIPTION
Currently, users cannot click on `notes://` links in Zulip messages because the scheme is not recognized by the markdown parser.

Following the approach used for other desktop apps like Obsidian and Asana, this PR adds `notes` to both `html_safelisted_schemes` and `auto_linked_schemes` in `zerver/lib/markdown/__init__.py`. This allows Notes URLs to linkify automatically and fully supports explicit Markdown link syntax.

Fixes: #38877.

**How changes were tested:**
* Added test cases to `zerver/tests/fixtures/markdown_test_cases.json` for both explicit linking (`[text](notes://...)`) and auto-linking.
* Ran `./tools/test-backend zerver/tests/test_markdown.py` and the full backend test suite to ensure all markdown rules pass.
* Manually tested in the local development environment by sending `notes://workspace/123` and `[Notes](notes://workspace/123)` in the compose box and verifying they render as valid, clickable links.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
1. Before
<img width="888" height="254" alt="image" src="https://github.com/user-attachments/assets/b0053107-7337-4f54-809b-b6e29d438012" />

2. After
<img width="879" height="272" alt="image" src="https://github.com/user-attachments/assets/b7bb837c-0ef8-45e6-a09b-648daef24bcb" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
