### PR TITLE
auth: Ensure stable group order in process_social_auth_group_sync_info.

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -2107,7 +2107,7 @@ def process_social_auth_group_sync_info(
             # should be passed in zulip_groups.
             all_realm_groups = NamedUserGroup.objects.filter(
                 realm=realm, deactivated=False, is_system_group=False
-            )
+            ).order_by("name")
             external_group_name_to_zulip_group_name = (
                 {g.name: g.name for g in all_realm_groups}
                 # If a group name is included in the user's zulip_groups, in sync-all-groups mode


### PR DESCRIPTION
Otherwise, tests asserting log content can be flaky due to unpredictable group ordering.

Found through the flakiness of `test_social_auth_group_sync_sync_all_groups_mode` (inconsistent ordering in the `external_group_name_to_zulip_group_name` part of the logstring) when working on #31863:
```
    backend.logger.info(
        "social_auth_sync_user_attributes:%s: received group names: %s|intended Zulip groups: %s. group mapping used: %s",
        user_string,
        sorted(all_received_group_names),
        sorted(intended_group_names),
        external_group_name_to_zulip_group_name,
    )
```