### PR TITLE
hotkey: Fix Enter hotkey not toggling buttons in drafts overlay.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -652,6 +652,10 @@ function process_enter_key(e: JQuery.KeyDownEvent): boolean {
     // This handles when pressing Enter while looking at drafts.
     // It restores draft that is focused.
     if (overlays.drafts_open()) {
+        const $draft_overlay = $("#draft_overlay");
+        if ($draft_overlay.find("a:focus, button:focus, input:focus").length > 0) {
+            return false;
+        }
         drafts_overlay_ui.handle_keyboard_events("enter");
         return true;
     }


### PR DESCRIPTION
Currently when we navigate to interactive elements like checkbox and delete button in draft overlay and use hotkey `Enter` it does not toggle and instead the first draft opens.
<!-- Describe your pull request here.-->
Changes:
Ensure Enter hotkey works correctly for focused elements like checkbox and button in drafts overlay.

Fixes: [#issues > Tabbing is not working in Drafts overlay](https://chat.zulip.org/#narrow/channel/9-issues/topic/Tabbing.20.20is.20not.20working.20in.20Drafts.20overlay/with/2416149)


**How changes were tested:**
Manually verified the behaviour.Created a draft and navigated to checkbox and delete button using `Shift+ Tab` .Then using `Enter` deleted the draft.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/cc4771cd-be3c-40a0-a32d-dcfbea1533d2



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
