### PR TITLE
dropdown_widget: Improve empty state UI and add context-specific messages.

### DIFF
--- a/web/src/channel_folders_ui.ts
+++ b/web/src/channel_folders_ui.ts
@@ -336,6 +336,7 @@ function render_add_channel_folder_widget(): void {
         item_click_callback: channel_dropdown_item_click_callback,
         $events_container: $("#edit_channel_folder"),
         unique_id_type: "number",
+        no_items_text: $t({defaultMessage: "No channels to add"}),
     };
     add_channel_folder_widget = new dropdown_widget.DropdownWidget(opts);
     add_channel_folder_widget.setup();

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -10,6 +10,7 @@ import render_dropdown_list from "../templates/dropdown_list.hbs";
 import render_dropdown_list_container from "../templates/dropdown_list_container.hbs";
 
 import * as blueslip from "./blueslip.ts";
+import {$t} from "./i18n.ts";
 import * as ListWidget from "./list_widget.ts";
 import type {ListWidget as ListWidgetType} from "./list_widget.ts";
 import {page_params} from "./page_params.ts";
@@ -96,6 +97,8 @@ export type DropdownWidgetOptions = {
     // When this is set, pressing tab will move focus to the target element.
     tab_moves_focus_to_target?: (event: JQuery.KeyDownEvent) => string | undefined;
     search_placeholder_text?: string;
+    // Text to show when there are no options at all, not due to search filtering.
+    no_items_text?: string;
     sort_list_by_filter_value?: (items: Option[], filter_value: string) => Option[];
 };
 
@@ -147,6 +150,7 @@ export class DropdownWidget {
     // here, so should be generalized or reworked.
     item_clicked = false;
     search_placeholder_text: string;
+    no_items_text: string;
     sort_list_by_filter_value: ((items: Option[], filter_value: string) => Option[]) | undefined;
 
     constructor(options: DropdownWidgetOptions) {
@@ -192,6 +196,7 @@ export class DropdownWidget {
         this.tab_moves_focus_to_target = options.tab_moves_focus_to_target;
         this.current_hover_index = 0;
         this.search_placeholder_text = options.search_placeholder_text ?? "";
+        this.no_items_text = options.no_items_text ?? $t({defaultMessage: "Nothing to show"});
         this.sort_list_by_filter_value = options.sort_list_by_filter_value;
     }
 
@@ -285,6 +290,16 @@ export class DropdownWidget {
         const list_items = this.list_widget.get_current_list();
         const $no_search_results = $popper.find(".no-dropdown-items");
         if (list_items.length === 0) {
+            const $search_input = $popper.find<HTMLInputElement>(
+                "input.dropdown-list-search-input",
+            );
+            const value = $search_input.val()!;
+            const has_search_value = $search_input.length > 0 && value.trim().length > 0;
+            if (!has_search_value) {
+                $no_search_results.text(this.no_items_text);
+            } else {
+                $no_search_results.text($t({defaultMessage: "No matching results"}));
+            }
             $no_search_results.show();
         } else {
             $no_search_results.hide();

--- a/web/src/saved_snippets_ui.ts
+++ b/web/src/saved_snippets_ui.ts
@@ -223,6 +223,7 @@ export function setup_saved_snippets_dropdown_widget(widget_selector: string): v
         sticky_bottom_option: $t({
             defaultMessage: "Create a new saved snippet",
         }),
+        no_items_text: $t({defaultMessage: "No saved snippets"}),
         on_show_callback(dropdown: tippy.Instance) {
             saved_snippets_dropdown = dropdown;
         },

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -288,6 +288,7 @@ function render_customize_stream_notifications_widget(): void {
         item_click_callback: change_state_of_customize_stream_notifications_widget,
         $events_container: $("#user-notification-settings .notification-settings-form"),
         unique_id_type: "number",
+        no_items_text: $t({defaultMessage: "No channels to customize"}),
     });
     customize_stream_notifications_widget.setup();
 }

--- a/web/templates/dropdown_list_container.hbs
+++ b/web/templates/dropdown_list_container.hbs
@@ -8,10 +8,10 @@ events for keyboard navigation. }}
     <div class="dropdown-list-viewport-padding">
         <div class="dropdown-list-wrapper" data-simplebar data-simplebar-tab-index="-1">
             <ul class="dropdown-list"></ul>
+            <div class="no-dropdown-items">
+                {{t 'No matching results'}}
+            </div>
         </div>
-    </div>
-    <div class="no-dropdown-items dropdown-list-item-common-styles">
-        {{t 'No matching results'}}
     </div>
     {{#if sticky_bottom_option}}
     <button class="sticky-bottom-option-button">


### PR DESCRIPTION
This PR improves the empty state UI for dropdown widgets when no items exist in it (not due to search filtering). And also fixes the "No matching results" text vertical alignment, which was not centered before. 

As mentioned in the issue 
> Please check if there are any other places where this situation can arise.

I searched for other dropdown patterns using `grep` and found that a similar `empty-state` issue also occurs
in `Notification triggers`, which is in the Personal settings / Notifications. So, I include a fix for that case as well, by providing an appropriate context-specific empty message "No channels to customize".

I also find and analyze other usages of `DropdownWidget`, but did not make changes because in most cases, the dropdown either already has items to display when nothing is in it (like - default: none) or does not present an empty-state UI where a custom message would be meaningful.

Fixes: [#design > add a "no matching results" string in snippets search](https://chat.zulip.org/#narrow/channel/101-design/topic/add.20a.20.22no.20matching.20results.22.20string.20in.20snippets.20search/with/2414649)

Fixes: #38927


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
<hr>

### **Screenshots and screen captures:**

- **Saved snippet changes screenshots**

| Before | After |
|--------|-------|
|<img width="1561" height="392" alt="Screenshot 2026-04-17 234222" src="https://github.com/user-attachments/assets/7c4f740a-68e7-4dd6-8da2-346fa663a7fa" />|<img width="1703" height="427" alt="Screenshot 2026-04-25 114532" src="https://github.com/user-attachments/assets/50ad6e11-f542-47d5-8f4f-0615fac2287f" />|

| Before | After |
|--------|-------|
|<img width="1732" height="671" alt="Screenshot 2026-04-17 234615" src="https://github.com/user-attachments/assets/b1553067-183f-4703-8c64-1a5905fb92f0" />|<img width="1698" height="649" alt="Screenshot 2026-04-25 114643" src="https://github.com/user-attachments/assets/9d9d6339-12da-49dd-ae29-43968445c18f" />|

- **Manage channel folder / Add a channel screenshots**

| Before | After |
|--------|-------|
|<img width="1186" height="238" alt="Screenshot 2026-04-17 235017" src="https://github.com/user-attachments/assets/0a163bed-5d18-4585-85fb-c1587f0a6d61" />|<img width="1425" height="265" alt="Screenshot 2026-04-25 114918" src="https://github.com/user-attachments/assets/6c61063c-0769-4e25-8399-257208c3d0ec" />|

| Before | After |
|--------|-------|
|<img width="1149" height="331" alt="Screenshot 2026-04-17 235351" src="https://github.com/user-attachments/assets/adcdfed3-c277-4c77-8301-425b99facbad" />|<img width="1105" height="318" alt="Screenshot 2026-04-25 115051" src="https://github.com/user-attachments/assets/0c63b5c5-44ea-45d5-9fc8-2bd3e81e1223" />|

- **Personal settings / Notifications screenshots**

| Before | After |
|--------|-------|
|<img width="1517" height="427" alt="Screenshot 2026-04-17 235557" src="https://github.com/user-attachments/assets/35fc6e0a-93ad-43ab-be49-4103136b0abe" />|<img width="1514" height="442" alt="Screenshot 2026-04-17 235645" src="https://github.com/user-attachments/assets/e0ab4963-f636-434d-921d-7c3683b122b8" />|

| Before | After |
|--------|-------|
|<img width="1511" height="651" alt="Screenshot 2026-04-17 235905" src="https://github.com/user-attachments/assets/81d6cd0c-10c4-458a-9b31-bfb6da549872" />|<img width="1513" height="665" alt="Screenshot 2026-04-17 235813" src="https://github.com/user-attachments/assets/cf6aecbc-7bc1-471d-916a-93555b5be4c4" />|

- **`Nothing to show` example**

<img width="1131" height="352" alt="Screenshot 2026-04-27 113813" src="https://github.com/user-attachments/assets/de6abc7b-6999-40e2-8310-92e1c8eac89a" />




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
