### PR TITLE
popover_menus: Don't close popover when soft keyboard hides reference. 

### DIFF
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -922,10 +922,12 @@ function get_default_emoji_popover_options(
                 }
             });
 
-            // Don't focus filter box on mobile since it leads to window resize due
-            // to keyboard being open and scrolls the emoji popover out of view while
-            // still open in Chrome Android and can hide it based on device height in Firefox Android.
-            if (!util.is_mobile()) {
+            // Don't auto-focus the filter on touch devices, since the soft
+            // keyboard opening can resize the viewport and cause the popover
+            // to be hidden or destroyed.
+            // We use a media query rather than util.is_mobile() because some
+            // touch devices (iPadOS 13+) report a desktop User-Agent string.
+            if (!util.is_touch_screen()) {
                 change_focus_to_filter();
             }
         },

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -268,8 +268,35 @@ export const default_popover_props: Partial<tippy.Props> = {
                     }
 
                     if (is_reference_outside_window) {
+                        // On touch devices, focusing a text input inside the
+                        // popover opens the soft keyboard, which can resize
+                        // the viewport and push the reference element out of
+                        // view. Don't destroy the popover if the user is
+                        // actively interacting with an input inside it.
+                        // We add `show-when-reference-hidden` so that the
+                        // CSS rule hiding `[data-reference-hidden]` elements
+                        // is also bypassed, preventing a visual flicker.
+                        const active_element = document.activeElement;
+                        if (
+                            util.is_touch_screen() &&
+                            active_element instanceof HTMLElement &&
+                            popper.contains(active_element) &&
+                            $(active_element).is("input[type=text], input[type=number], textarea")
+                        ) {
+                            $tippy_box.addClass("show-when-reference-hidden");
+                            $tippy_box.attr("data-soft-keyboard-hidden", "");
+                            return;
+                        }
                         hide_current_popover_if_visible(instance);
                         return;
+                    }
+
+                    // Remove the class if it was added by the soft keyboard
+                    // workaround above, now that the reference is visible again
+                    // (e.g. when the keyboard is dismissed).
+                    if ($tippy_box.attr("data-soft-keyboard-hidden") !== undefined) {
+                        $tippy_box.removeClass("show-when-reference-hidden");
+                        $tippy_box.removeAttr("data-soft-keyboard-hidden");
                     }
 
                     const $reference = $(state.elements.reference);

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -221,6 +221,10 @@ export function is_mobile(): boolean {
     );
 }
 
+export function is_touch_screen(): boolean {
+    return !window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+}
+
 export function is_client_safari(): boolean {
     // Since GestureEvent is only supported on Safari, we can use it
     // to detect if the browser is Safari including Safari on iOS.

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -139,6 +139,15 @@ run_test("is_mobile", () => {
     assert.ok(!util.is_mobile());
 });
 
+run_test("is_touch_screen", ({override}) => {
+    // Desktop: hover and fine pointer available
+    override(window, "matchMedia", (query) => {
+        assert.equal(query, "(hover: hover) and (pointer: fine)");
+        return {matches: true};
+    });
+    assert.ok(!util.is_touch_screen());
+});
+
 run_test("array_compare", () => {
     assert.ok(util.array_compare([], []));
     assert.ok(util.array_compare([1, 2, 3], [1, 2, 3]));


### PR DESCRIPTION
Fix https://github.com/zulip/zulip/issues/28703

supercede and close https://github.com/zulip/zulip/pull/38565

On touch devices with large screens (iPads), tapping a text
input inside a popover opens the soft keyboard, resizing the
viewport sometimes pushing the reference element out of view. The
destroy-popover-if-reference-hidden Popper modifier then closes the
popover, making it impossible to use the search input.

This is particularly egregious for the emoji picker because its button
is placed at the very bottom of the screen.

Fixed this by detecting on touch screen if what's focused is inside the popover
and the reference is outside the window.
In that case, bypass `data-reference-hidden`, because the reference could be hidden by the virtual keyboard.

It does feel a bit hacky but I haven't found a better way.

**tested on an real iPad this fixes the issue**


https://github.com/user-attachments/assets/e0e76270-202c-4727-a351-f34df60e3b71


CZO thread https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Emoji.20picker.20self-closing.20on.20touchscreen.20.2328703/with/1727171
