### PR TITLE
compose: Fix multiline inline formatting.

### DIFF
--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -2,12 +2,22 @@ export const get_last_line = (text: string): string => text.slice(text.lastIndex
 
 export const get_indent = (line: string): string => /^(\s*)/.exec(line)![1] ?? "";
 
+const numbered_pattern = /^\d+\. /;
+
 export const is_bulleted = (line: string): boolean =>
     line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
 
-// testing against regex for string with numbered syntax, that is,
-// any string starting with digit/s followed by a period and space
-export const is_numbered = (line: string): boolean => /^\d+\. /.test(line);
+export const is_numbered = (line: string): boolean => numbered_pattern.test(line);
+
+// Returns the bulleted or numbered list prefix at the start of `line`
+// (e.g., "- ", "1. "), or "" if the line is not part of a list.
+export const get_prefix = (line: string): string => {
+    if (is_bulleted(line)) {
+        return line.slice(0, 2);
+    }
+    const numbered_match = numbered_pattern.exec(line);
+    return numbered_match === null ? "" : numbered_match[0];
+};
 
 export const strip_bullet = (line: string): string => line.slice(2);
 

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -812,6 +812,7 @@ export let format_text = (
     const italic_syntax = "*";
     const bold_syntax = "**";
     const bold_and_italic_syntax = "***";
+    const strikethrough_syntax = "~~";
     let is_selected_text_italic = false;
     let is_inner_text_italic = false;
     const field = $textarea.get(0)!;
@@ -822,6 +823,10 @@ export let format_text = (
     // before the selected text, as it is conventionally depicted with a highlight
     // at the end of the previous line, which we would like to format.
     const TRIM_ONLY_END_TYPES = ["bulleted", "numbered"];
+
+    // Inline formatting syntax markers that should be applied
+    // independently to each line in a multiline selection.
+    const inline_syntax_markers = new Set([italic_syntax, bold_syntax, strikethrough_syntax]);
 
     let start_trim_length;
     if (TRIM_ONLY_END_TYPES.includes(type)) {
@@ -967,6 +972,45 @@ export let format_text = (
         }
     };
 
+    // Splits a line into its leading list prefix, its trailing
+    // whitespace, and the content in between. Inline syntax markers
+    // wrap the content; the prefix and trailing whitespace are
+    // re-attached unchanged. Trailing whitespace must stay outside the
+    // wrapping markers because Markdown won't recognize a closing `**`
+    // (or `*`, `~~`) preceded by whitespace.
+    const split_inline_line = (
+        line: string,
+    ): {prefix: string; content: string; trailing: string} => {
+        const prefix = bulleted_numbered_list_util.get_prefix(line);
+        const after_prefix = line.slice(prefix.length);
+        const content = after_prefix.trimEnd();
+        const trailing = after_prefix.slice(content.length);
+        return {prefix, content, trailing};
+    };
+
+    // Whether `content` is already wrapped by `syntax`. For italic we
+    // intentionally do NOT count `**X**` (bold-only) as wrapped, so
+    // that applying italic to a bold line promotes it to `***X***`
+    // rather than stripping the bold markers.
+    const is_content_wrapped = (content: string, syntax: string): boolean => {
+        if (
+            content.length <= syntax.length * 2 ||
+            !content.startsWith(syntax) ||
+            !content.endsWith(syntax)
+        ) {
+            return false;
+        }
+        if (
+            syntax === italic_syntax &&
+            content.startsWith(bold_syntax) &&
+            content.endsWith(bold_syntax) &&
+            !content.startsWith(bold_and_italic_syntax)
+        ) {
+            return false;
+        }
+        return true;
+    };
+
     const format = (syntax_start: string, syntax_end = syntax_start): boolean => {
         let linebreak_start = "";
         let linebreak_end = "";
@@ -976,6 +1020,77 @@ export let format_text = (
         if (syntax_end.endsWith("\n")) {
             linebreak_end = "\n";
         }
+
+        // For multiline selections with inline syntax (bold, italic,
+        // strikethrough), apply formatting per line rather than
+        // wrapping the entire block (which Zulip's Markdown won't
+        // render across paragraphs; see #23138). We mirror format_list:
+        // if any non-blank line is unmarked, mark every non-blank line;
+        // otherwise strip the syntax from every non-blank line. This
+        // matches the toggle behavior users expect from text editors
+        // (per CZO discussion on #37614).
+        if (
+            selected_text.includes("\n") &&
+            syntax_start === syntax_end &&
+            inline_syntax_markers.has(syntax_start)
+        ) {
+            const syntax = syntax_start;
+            const parsed_lines = selected_text.split("\n").map((line) => {
+                if (line.trim() === "") {
+                    return {prefix: "", content: "", trailing: line, is_blank: true};
+                }
+                const parts = split_inline_line(line);
+                return {...parts, is_blank: parts.content === ""};
+            });
+            const formattable = parsed_lines.filter((line) => !line.is_blank);
+            const should_format = formattable.some(
+                (line) => !is_content_wrapped(line.content, syntax),
+            );
+
+            const formatted_lines = parsed_lines.map(({prefix, content, trailing, is_blank}) => {
+                if (is_blank) {
+                    return prefix + content + trailing;
+                }
+                if (should_format) {
+                    // Promote a bold-only line to bold+italic when
+                    // adding italic, instead of double-wrapping.
+                    if (
+                        syntax === italic_syntax &&
+                        content.startsWith(bold_syntax) &&
+                        content.endsWith(bold_syntax) &&
+                        !content.startsWith(bold_and_italic_syntax) &&
+                        content.length > bold_syntax.length * 2
+                    ) {
+                        const inner = content.slice(
+                            bold_syntax.length,
+                            content.length - bold_syntax.length,
+                        );
+                        return (
+                            prefix +
+                            bold_and_italic_syntax +
+                            inner +
+                            bold_and_italic_syntax +
+                            trailing
+                        );
+                    }
+                    if (is_content_wrapped(content, syntax)) {
+                        return prefix + content + trailing;
+                    }
+                    return prefix + syntax + content + syntax + trailing;
+                }
+                // Strip pass: every formattable line is wrapped.
+                return (
+                    prefix + content.slice(syntax.length, content.length - syntax.length) + trailing
+                );
+            });
+
+            const new_selected = formatted_lines.join("\n");
+            text = text.slice(0, range.start) + new_selected + text.slice(range.end);
+            insert_and_scroll_into_view(text, $textarea, true);
+            field.setSelectionRange(range.start, range.start + new_selected.length);
+            return true;
+        }
+
         if (is_selection_formatted(syntax_start, syntax_end)) {
             text =
                 text.slice(0, range.start - syntax_start.length) +
@@ -1289,6 +1404,17 @@ export let format_text = (
             // fact it's just bold syntax, even though with *foo* and
             // ***foo*** should remove italics.
 
+            // For multiline selections, the elaborate single-line
+            // logic below is meaningless: it inspects characters at
+            // range.start / range.end of the whole selection, but
+            // those boundaries lie on unrelated lines. Delegate to
+            // format(), which applies italic per line with the same
+            // bold-vs-italic-vs-both toggling semantics.
+            if (selected_text.includes("\n")) {
+                format(italic_syntax);
+                break;
+            }
+
             // If the text is already italic, we remove the italic_syntax from text.
             if (range.start >= 1 && text.length - range.end >= italic_syntax.length) {
                 // If text has italic_syntax around it.
@@ -1372,7 +1498,6 @@ export let format_text = (
             format_list(type);
             break;
         case "strikethrough": {
-            const strikethrough_syntax = "~~";
             format(strikethrough_syntax);
             break;
         }

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -763,6 +763,36 @@ run_test("format_text - bold and italic", ({override, override_rewire}) => {
     compose_ui.format_text($textarea, "bold");
     assert.equal(get_textarea_state(), "before <abc> after");
 
+    // Bold multiline numbered list
+    init_textarea_state("<1. abc\n2. def\n3. ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<1. **abc**\n2. **def**\n3. **ghi**>");
+
+    // Undo bold multiline numbered list
+    init_textarea_state("<1. **abc**\n2. **def**\n3. **ghi**>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<1. abc\n2. def\n3. ghi>");
+
+    // Bold multiline bulleted list (- style)
+    init_textarea_state("<- abc\n- def\n- ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<- **abc**\n- **def**\n- **ghi**>");
+
+    // Undo bold multiline bulleted list (- style)
+    init_textarea_state("<- **abc**\n- **def**\n- **ghi**>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<- abc\n- def\n- ghi>");
+
+    // Bold multiline bulleted list (* style)
+    init_textarea_state("<* abc\n* def\n* ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<* **abc**\n* **def**\n* **ghi**>");
+
+    // Bold multiline bulleted list (+ style)
+    init_textarea_state("<+ abc\n+ def\n+ ghi>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<+ **abc**\n+ **def**\n+ **ghi**>");
+
     // Italic selected text
     init_textarea_state("before <abc> after");
     compose_ui.format_text($textarea, "italic");
@@ -781,6 +811,70 @@ run_test("format_text - bold and italic", ({override, override_rewire}) => {
     init_textarea_state("before <*abc*> after");
     compose_ui.format_text($textarea, "italic");
     assert.equal(get_textarea_state(), "before <abc> after");
+
+    // Italic multiline selected text
+    init_textarea_state("before <abc\ndef\nghi> after");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "before <*abc*\n*def*\n*ghi*> after");
+
+    // Undo italic multiline selected text
+    init_textarea_state("before <*abc*\n*def*\n*ghi*> after");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "before <abc\ndef\nghi> after");
+
+    // Mixed-state multiline bold: any unmarked line means we mark all.
+    init_textarea_state("<**abc**\ndef\n**ghi**>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<**abc**\n**def**\n**ghi**>");
+
+    // Italic on multiline bold lines promotes each to bold+italic.
+    init_textarea_state("<**abc**\n**def**>");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "<***abc***\n***def***>");
+
+    // Italic on multiline bold+italic strips italic from each line.
+    init_textarea_state("<***abc***\n***def***>");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "<**abc**\n**def**>");
+
+    // Italic on a mix of bold-only and italic lines: bold-only counts
+    // as unmarked (italic gets added via promotion), already-italic
+    // lines are left alone.
+    init_textarea_state("<**abc**\n*def*>");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "<***abc***\n*def*>");
+
+    // Italic on a bulleted list.
+    init_textarea_state("<- abc\n- def>");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "<- *abc*\n- *def*>");
+
+    // Italic on a numbered list.
+    init_textarea_state("<1. abc\n2. def>");
+    compose_ui.format_text($textarea, "italic");
+    assert.equal(get_textarea_state(), "<1. *abc*\n2. *def*>");
+
+    // Blank lines inside the selection are preserved as-is.
+    init_textarea_state("<abc\n\ndef>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<**abc**\n\n**def**>");
+
+    // Empty list items (no content after the marker) are skipped.
+    init_textarea_state("<- abc\n- \n- def>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<- **abc**\n- \n- **def**>");
+
+    // Trailing whitespace on a line stays outside the wrapping
+    // markers, so the closing marker still renders.
+    init_textarea_state("<abc   \ndef>");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "<**abc**   \n**def**>");
+
+    // Partial-line selection across a newline formats only what was
+    // selected on each side, per the design discussion on #37614.
+    init_textarea_state("ab<c\nab>c");
+    compose_ui.format_text($textarea, "bold");
+    assert.equal(get_textarea_state(), "ab<**c**\n**ab**>c");
 
     // Undo bold selected text, text is both italic and bold, syntax not selected.
     init_textarea_state("before ***<abc>*** after");
@@ -916,6 +1010,21 @@ run_test("format_text - strikethrough", ({override, override_rewire}) => {
     init_textarea_state("before <~~abc~~> after");
     compose_ui.format_text($textarea, "strikethrough");
     assert.equal(get_textarea_state(), "before <abc> after");
+
+    // Strikethrough multiline bulleted list
+    init_textarea_state("<- abc\n- def>");
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(get_textarea_state(), "<- ~~abc~~\n- ~~def~~>");
+
+    // Undo strikethrough multiline bulleted list
+    init_textarea_state("<- ~~abc~~\n- ~~def~~>");
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(get_textarea_state(), "<- abc\n- def>");
+
+    // Strikethrough multiline numbered list
+    init_textarea_state("<1. abc\n2. def>");
+    compose_ui.format_text($textarea, "strikethrough");
+    assert.equal(get_textarea_state(), "<1. ~~abc~~\n2. ~~def~~>");
 });
 
 run_test("format_text - latex", ({override, override_rewire}) => {


### PR DESCRIPTION
Previously inline formatting wrapped the entire selected block, which caused incorrect behavior when formatting multiple lines.
formatting is now applied independently to each non-empty line, preserving existing structure and producing more consistent results when applying styles across multiline selections.

Fixes #37614

**How changes were tested:**

- [x] Added JS test.
- [x] UI testing.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**


https://github.com/user-attachments/assets/67b546c2-77a7-41da-8229-418e206265bd



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
