### PR TITLE
stream_color: Handle missing stream in privacy icon update.

### DIFF
--- a/web/src/stream_color.ts
+++ b/web/src/stream_color.ts
@@ -76,7 +76,11 @@ export function adjust_stream_privacy_icon_colors(
     icon_selector: string,
 ): void {
     if (stream_id !== undefined) {
-        const privacy_icon_color = stream_data.get_sub_by_id(stream_id)?.color;
+        const stream = stream_data.get_sub_by_id(stream_id);
+        if (!stream) {
+            return;
+        }
+        const privacy_icon_color = stream.color;
 
         assert(privacy_icon_color);
         const privacy_icon_colors_modified = get_stream_privacy_icon_color(


### PR DESCRIPTION
<!-- Describe your pull request here.-->
While restoring drafts, they may reference streams that the user no longer has access to.In such cases, stream_data.get_sub_by_id(stream_id) returns undefined, leading to an assertion failure in adjust_stream_privacy_icon_colors.
I have added a check to return if stream doesnt exist.


**How changes were tested:**
Created a private stream and draft in it. After that removed the user from that stream and tried to restore the draft.Now there is no error.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
`Before`

https://github.com/user-attachments/assets/f7012445-2363-4091-a174-bd4e1a4e4c86


`After`


https://github.com/user-attachments/assets/39b7f92d-0f38-4bae-bc7c-2c576c169acb



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
