### PR TITLE
[ai] right_sidebar: Stop overflowing .column-right into the scrollbar gutter.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -612,6 +612,7 @@ body.has-overlay-scrollbar {
     }
 
     .column-right .right-sidebar {
+        box-sizing: border-box;
         padding-left: var(--right-sidebar-left-spacing);
         width: var(--right-sidebar-width);
     }


### PR DESCRIPTION
discussion: [#issues > Scrollbar track always visible](https://chat.zulip.org/#narrow/channel/9-issues/topic/Scrollbar.20track.20always.20visible/with/2437968)

## Summary

`.right-sidebar` inside `.column-right` sets both `width: var(--right-sidebar-width)` and `padding-left: var(--right-sidebar-left-spacing)` (5px). With the default `box-sizing: content-box`, the padding is added outside the declared width, so the rendered box is 5px wider than its containing `.column-right` (same width, no padding) and extends past `documentElement.clientWidth` into the browser's scrollbar gutter.

This only surfaces visually when the browser scrollbar is non-overlay and always visible, e.g. Firefox with **Always show scrollbars** enabled: the simplebar track inside `.right-sidebar` inherits the 5px overflow and partially overlaps the Firefox scrollbar. The existing overlay-scrollbar shift in `handle_overlay_scrollbars` does not trigger for this case because `window.innerWidth - documentElement.clientWidth > 0`.

Switching `.right-sidebar` to `box-sizing: border-box` absorbs the padding into the declared width so the element stays within `.column-right`, and the simplebar track ends at body's right edge — aligned with the start of the scrollbar gutter rather than inside it.

| before | after |
| --- | --- |
| <img width="467" height="614" alt="image" src="https://github.com/user-attachments/assets/09457540-2541-40d3-9b46-2060b891c650" /> | <img width="494" height="629" alt="image" src="https://github.com/user-attachments/assets/fa5d69cd-5987-4561-981d-f8c7ee10cf72" /> |


---

Debugged it myself and asked Claude to open a PR after providing it a fix.
