### PR TITLE
settings: allow non-admins to clear default channels filter

### DIFF
--- a/web/src/settings_streams.ts
+++ b/web/src/settings_streams.ts
@@ -88,16 +88,6 @@ export function reset(): void {
     meta.loaded = false;
 }
 
-export function maybe_disable_widgets(): void {
-    if (current_user.is_admin) {
-        return;
-    }
-
-    $(".organization-box [data-name='default-channels-list']")
-        .find("input:not(.search), button, select")
-        .prop("disabled", true);
-}
-
 export function build_default_stream_table(): void {
     const $table = $("#admin_default_streams_table").expectOne();
 
@@ -235,7 +225,6 @@ function show_add_default_streams_modal(): void {
 
 export function set_up(): void {
     build_page();
-    maybe_disable_widgets();
 }
 
 export function build_page(): void {

--- a/web/src/settings_streams.ts
+++ b/web/src/settings_streams.ts
@@ -94,7 +94,7 @@ export function maybe_disable_widgets(): void {
     }
 
     $(".organization-box [data-name='default-channels-list']")
-        .find("input:not(.search), button, select")
+        .find("input:not(.search), button:not(.clear-filter), select")
         .prop("disabled", true);
 }
 

--- a/web/src/settings_streams.ts
+++ b/web/src/settings_streams.ts
@@ -249,3 +249,13 @@ export function build_page(): void {
         },
     );
 }
+
+export function rerender_default_streams_for_role_change(): void {
+    if (!meta.loaded) {
+        return;
+    }
+
+    $("#show-add-default-streams-modal").toggleClass("hide", !current_user.is_admin);
+    $("#admin-default-channels-list th.actions").toggleClass("hide", !current_user.is_admin);
+    update_default_streams_table();
+}

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -29,7 +29,6 @@ import * as settings_panel_menu from "./settings_panel_menu.ts";
 import * as settings_preferences from "./settings_preferences.ts";
 import * as settings_profile_fields from "./settings_profile_fields.ts";
 import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults.ts";
-import * as settings_streams from "./settings_streams.ts";
 import * as settings_users from "./settings_users.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as stream_events from "./stream_events.ts";
@@ -159,7 +158,6 @@ export const update_person = function update(event: UserUpdate): void {
             settings_org.maybe_disable_widgets();
             settings_org.enable_or_disable_group_permission_settings();
             settings_profile_fields.maybe_disable_widgets();
-            settings_streams.maybe_disable_widgets();
             settings_realm_user_settings_defaults.maybe_disable_widgets();
             settings_account.update_account_settings_display();
             settings.update_lock_icon_in_sidebar();

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -29,6 +29,7 @@ import * as settings_panel_menu from "./settings_panel_menu.ts";
 import * as settings_preferences from "./settings_preferences.ts";
 import * as settings_profile_fields from "./settings_profile_fields.ts";
 import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults.ts";
+import * as settings_streams from "./settings_streams.ts";
 import * as settings_users from "./settings_users.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as stream_events from "./stream_events.ts";
@@ -159,6 +160,7 @@ export const update_person = function update(event: UserUpdate): void {
             settings_org.enable_or_disable_group_permission_settings();
             settings_profile_fields.maybe_disable_widgets();
             settings_realm_user_settings_defaults.maybe_disable_widgets();
+            settings_streams.rerender_default_streams_for_role_change();
             settings_account.update_account_settings_display();
             settings.update_lock_icon_in_sidebar();
             settings_account.update_user_own_role_dropdown_state();

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -4,15 +4,14 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Default channels"}}</h3>
         <div class="add_default_streams_button_container">
-            {{#if is_admin}}
-                {{> ../components/action_button
-                  id="show-add-default-streams-modal"
-                  label=(t "Add channel")
-                  variant="subtle"
-                  intent="brand"
-                  type="submit"
-                  }}
-            {{/if}}
+            {{> ../components/action_button
+              id="show-add-default-streams-modal"
+              label=(t "Add channel")
+              variant="subtle"
+              intent="brand"
+              type="submit"
+              hidden=(not is_admin)
+              }}
             {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter default channels')}}
         </div>
     </div>
@@ -24,9 +23,7 @@
                     <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}
                         <i class="table-sortable-arrow zulip-icon zulip-icon-sort-arrow-down"></i>
                     </th>
-                    {{#if is_admin}}
-                    <th class="actions"></th>
-                    {{/if}}
+                    <th class="actions{{#unless is_admin}} hide{{/unless}}"></th>
                 </tr>
             </thead>
             <tbody data-empty="{{t 'There are no default channels.' }}" data-search-results-empty="{{t 'No default channels match your current filter.' }}"

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -82,6 +82,9 @@ mock_esm("../src/settings_profile_fields", {
 mock_esm("../src/settings_realm_user_settings_defaults", {
     maybe_disable_widgets() {},
 });
+mock_esm("../src/settings_streams", {
+    rerender_default_streams_for_role_change() {},
+});
 
 const bot_data = zrequire("bot_data");
 const message_lists = zrequire("message_lists");

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -82,9 +82,6 @@ mock_esm("../src/settings_profile_fields", {
 mock_esm("../src/settings_realm_user_settings_defaults", {
     maybe_disable_widgets() {},
 });
-mock_esm("../src/settings_streams", {
-    maybe_disable_widgets() {},
-});
 
 const bot_data = zrequire("bot_data");
 const message_lists = zrequire("message_lists");


### PR DESCRIPTION
The `maybe_disable_widgets` function was disabling the search clear button for non-admin users because it used a generic `button` selector. This updates the selector to explicitly exclude `.clear-filter`, allowing all users to clear their search queries.

<!-- Describe your pull request here.-->

Fixes: [#issues > Default channels Filter cross(X) icon not working](https://chat.zulip.org/#narrow/channel/9-issues/topic/Default.20channels.20Filter.20cross.28X.29.20icon.20not.20working/with/2438052)<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:


https://github.com/user-attachments/assets/559daca5-5c9d-4388-8df7-a8178e96d5fd


After:

https://github.com/user-attachments/assets/d8f5799f-4d9b-4eb7-92bb-1c54f4af1558



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
