### PR TITLE
webhooks/github: Add include_emoji parameter for notifications.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -673,6 +673,11 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
                 label="Include repository name in the notifications",
                 input_type="checkbox",
             ),
+            WebhookUrlOption(
+                name="include_emoji_indicators",
+                label="Include emoji indicators in the notifications",
+                input_type="checkbox_enabled",
+            ),
         ],
     ),
     IncomingWebhookIntegration(

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -16,9 +16,12 @@ Get GitHub notifications in Zulip!
 
 1. Decide where to send {{ integration_display_name }} notifications, and
    [generate the integration URL](/help/generate-integration-url). You'll be
-   able to configure which branches you'll receive notifications from,
-   whether to exclude notifications from private repositories, and whether
-   to include the repository name in the notifications.
+   able to configure:
+    - Which branches you'll receive notifications from.
+    - Whether to exclude notifications from private repositories.
+    - Whether to include the repository name in the notifications.
+    - Whether to include emoji indicators in the notifications.
+
 
 1. On your repository's web page, go to **Settings**. Select **Webhooks**,
    and click **Add webhook**. GitHub may prompt you for your password.

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -67,12 +67,14 @@ class Helper:
         payload: WildValue,
         include_title: bool,
         include_repository_name: bool,
+        include_emoji_indicators: bool,
         user_profile: UserProfile,
     ) -> None:
         self.request = request
         self.payload = payload
         self.include_title = include_title
         self.include_repository_name = include_repository_name
+        self.include_emoji_indicators = include_emoji_indicators
         self.realm = user_profile.realm
 
     def log_unsupported(self, event: str) -> None:
@@ -1150,6 +1152,7 @@ def api_github_webhook(
     user_specified_topic: OptionalUserSpecifiedTopicStr = None,
     ignore_private_repositories: Json[bool] = False,
     include_repository_name: Json[bool] = False,
+    include_emoji_indicators: Json[bool] = True,
 ) -> HttpResponse:
     """
     GitHub sends the event as an HTTP header.  We have our
@@ -1194,6 +1197,7 @@ def api_github_webhook(
         payload=payload,
         include_title=user_specified_topic is not None,
         include_repository_name=include_repository_name,
+        include_emoji_indicators=include_emoji_indicators,
         user_profile=user_profile,
     )
     body = body_function(helper)


### PR DESCRIPTION
Add support for `include_emoji_indicators` URL parameter in the GitHub webhook integration to control whether emoji indicators are included in notification messages. 

Fixes part of #37250.

<!-- Describe your pull request here.-->
This is preparatory PR for #37757 
As discussed in [#integrations > Github emoji mapping](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Github.20emoji.20mapping/with/2373153) this PR adds `include_emoji_indicators` parameter to make emoji indicators optional and by default its value is true.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="780" height="838" alt="image" src="https://github.com/user-attachments/assets/d7b873c9-57d0-47ad-a598-2b4548ae9a3f" />

<img width="1525" height="788" alt="image" src="https://github.com/user-attachments/assets/520d6a19-1342-4b86-89de-cfaa94930283" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
