### PR TITLE
webhooks/github: Fix typo in discussion URL of the message template.

### DIFF
--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -48,7 +48,7 @@ DISCUSSION_TEMPLATES = {
     "generic_action": "{sender} {action} [discussion #{discussion_number}{configured_title}]({url}).",
     "deleted": "{sender} {action} discussion #{discussion_number}{configured_title}.",
     "closed": "{sender} {action} [discussion #{discussion_number}{configured_title}]({url}) as {closed_reason}.",
-    "locked": "{sender} {action} [discussion #{discussion_number}{configured_title}]({url}{configured_title}){locked_reason}.",
+    "locked": "{sender} {action} [discussion #{discussion_number}{configured_title}]({url}){locked_reason}.",
     "labeled": "{sender} added the {label} label to [discussion #{discussion_number}{configured_title}]({url}).",
     "unlabeled": "{sender} removed the {label} label from [discussion #{discussion_number}{configured_title}]({url}).",
     "category_changed": "{sender} changed the category of [discussion #{discussion_number}{configured_title}]({url}) from {old_category} to {category}.",


### PR DESCRIPTION
Fixes: part of #38452 (https://github.com/zulip/zulip/pull/38452/changes/8ed698bbdc2e6959c1ede3cfec234a856b47228e)
Caught by Claude.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
