### PR TITLE
webhooks/harbor: Fix user lookup and improve push event message template.

### DIFF
--- a/zerver/webhooks/harbor/tests.py
+++ b/zerver/webhooks/harbor/tests.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import WebhookTestCase
 class HarborHookTests(WebhookTestCase):
     def test_push_image(self) -> None:
         expected_topic_name = "example/test"
-        expected_message = """**admin** pushed image `example/test:latest`"""
+        expected_message = """**admin** pushed image `example/test:latest`."""
         self.check_webhook("push_image", expected_topic_name, expected_message)
 
     @patch("zerver.lib.webhooks.common.check_send_webhook_message")

--- a/zerver/webhooks/harbor/view.py
+++ b/zerver/webhooks/harbor/view.py
@@ -45,10 +45,17 @@ def image_id(payload: WildValue) -> str:
         return image_name + "@" + resource["digest"].tame(check_string)
 
 
-def handle_push_image_event(
-    payload: WildValue, user_profile: UserProfile, operator_username: str
-) -> str:
-    return f"{operator_username} pushed image `{image_id(payload)}`"
+IMAGE_PUSHED_TEMPLATE_WITH_OPERATOR = "{operator} pushed image `{image_id}`."
+IMAGE_PUSHED_TEMPLATE = "Image `{image_id}` was pushed."
+
+
+def handle_push_image_event(payload: WildValue, operator_username: str | None = None) -> str:
+    if operator_username:
+        return IMAGE_PUSHED_TEMPLATE_WITH_OPERATOR.format(
+            operator=operator_username,
+            image_id=image_id(payload),
+        )
+    return IMAGE_PUSHED_TEMPLATE.format(image_id=image_id(payload))  # nocoverage
 
 
 SCANNING_COMPLETED_TEMPLATE = """
@@ -59,7 +66,7 @@ Image scan completed for `{image_id}`. Vulnerabilities by severity:
 
 
 def handle_scanning_completed_event(
-    payload: WildValue, user_profile: UserProfile, operator_username: str
+    payload: WildValue, operator_username: str | None = None
 ) -> str:
     scan_results = ""
     scan_overview = payload["event_data"]["resources"][0]["scan_overview"]
@@ -115,9 +122,9 @@ def api_harbor_webhook(
         else:
             operator_username = f"**{operator}**"
     else:
-        operator_username = operator
+        operator_username = None
 
-    content: str = content_func(payload, user_profile, operator_username)
+    content: str = content_func(payload, operator_username)
 
     check_send_webhook_message(
         request, user_profile, topic_name, content, event, unquote_url_parameters=True

--- a/zerver/webhooks/harbor/view.py
+++ b/zerver/webhooks/harbor/view.py
@@ -96,14 +96,6 @@ def api_harbor_webhook(
     *,
     payload: JsonBodyPayload[WildValue],
 ) -> HttpResponse:
-    operator_username = "**{}**".format(payload["operator"].tame(check_string))
-
-    if operator_username != "auto":
-        operator_profile = guess_zulip_user_from_harbor(operator_username, user_profile.realm)
-
-    if operator_profile:
-        operator_username = f"@**{operator_profile.full_name}**"  # nocoverage
-
     event = payload["type"].tame(check_string)
     topic_name = payload["event_data"]["repository"]["repo_full_name"].tame(check_string)
 
@@ -114,6 +106,16 @@ def api_harbor_webhook(
 
     if content_func is None:
         raise UnsupportedWebhookEventTypeError(event)
+
+    operator = payload["operator"].tame(check_string)
+    if operator != "auto":
+        operator_profile = guess_zulip_user_from_harbor(operator, user_profile.realm)
+        if operator_profile:
+            operator_username = f"@**{operator_profile.full_name}**"  # nocoverage
+        else:
+            operator_username = f"**{operator}**"
+    else:
+        operator_username = operator
 
     content: str = content_func(payload, user_profile, operator_username)
 


### PR DESCRIPTION
Fixes: part of https://github.com/zulip/zulip/pull/38452 (https://github.com/zulip/zulip/pull/38452/changes/d49400ed846feb420d7d288de77947e91a638e9d)
Caught by Claude.

This PR does not aim to fully clean up or update the Harbor integration.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
