### PR TITLE
peer_data: Ignore webhook bots in subscriber subset checks.

### DIFF
--- a/web/src/bot_type_values.ts
+++ b/web/src/bot_type_values.ts
@@ -1,0 +1,8 @@
+// Bot type integer values from the API.
+export const GENERIC_BOT_TYPE = 1;
+export const INCOMING_WEBHOOK_BOT_TYPE_INT = 2;
+export const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
+
+// String forms used as HTML form values.
+export const OUTGOING_WEBHOOK_BOT_TYPE = "3";
+export const EMBEDDED_BOT_TYPE = "4";

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -2,6 +2,7 @@ import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
 import * as blueslip from "./blueslip.ts";
+import {INCOMING_WEBHOOK_BOT_TYPE_INT} from "./bot_type_values.ts";
 import * as channel from "./channel.ts";
 import {LazySet} from "./lazy_set.ts";
 import {page_params} from "./page_params.ts";
@@ -222,7 +223,26 @@ export async function is_subscriber_subset(
         return null;
     }
 
-    return [...sub1_set.keys()].every((key) => sub2_set.has(key));
+    return [...sub1_set.keys()].every((key) => {
+        // If the user is in the linked stream, the check passes.
+        if (sub2_set.has(key)) {
+            return true;
+        }
+
+        // Use ignore_missing=true because subscribers may include users
+        // inaccessible to the current viewer (e.g., guest-visibility limits);
+        // those will return undefined and fall through to the non-subset case.
+        const user = people.maybe_get_user_by_id(key, true);
+
+        // Incoming webhook bots are write-only and can't read messages, so a
+        // private channel containing them as the only "extra" subscriber
+        // doesn't expose anything.
+        if (user?.bot_type === INCOMING_WEBHOOK_BOT_TYPE_INT) {
+            return true;
+        }
+
+        return false;
+    });
 }
 
 export function potential_subscribers(stream_id: number): User[] {

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -217,7 +217,7 @@ export async function is_subscriber_subset(
     const sub2_promise = get_full_subscriber_set(stream_id2, false);
     const sub1_set = await sub1_promise;
     const sub2_set = await sub2_promise;
-    // This happens if we encountered an error feteching subscribers.
+    // This happens if we encountered an error fetching subscribers.
     if (sub1_set === null || sub2_set === null) {
         return null;
     }

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -10,6 +10,13 @@ import * as avatar from "./avatar.ts";
 import * as bot_data from "./bot_data.ts";
 import type {Bot} from "./bot_data.ts";
 import * as bot_helper from "./bot_helper.ts";
+import {
+    EMBEDDED_BOT_TYPE,
+    GENERIC_BOT_TYPE,
+    INCOMING_WEBHOOK_BOT_TYPE_INT,
+    OUTGOING_WEBHOOK_BOT_TYPE,
+    OUTGOING_WEBHOOK_BOT_TYPE_INT,
+} from "./bot_type_values.ts";
 import * as buttons from "./buttons.ts";
 import * as channel from "./channel.ts";
 import {csrf_token} from "./csrf.ts";
@@ -34,12 +41,6 @@ import type {UploadWidget} from "./upload_widget.ts";
 import * as user_deactivation_ui from "./user_deactivation_ui.ts";
 import * as user_sort from "./user_sort.ts";
 import * as util from "./util.ts";
-
-const GENERIC_BOT_TYPE = 1;
-const INCOMING_WEBHOOK_BOT_TYPE_INT = 2;
-const OUTGOING_WEBHOOK_BOT_TYPE = "3";
-const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
-const EMBEDDED_BOT_TYPE = "4";
 
 export const org_all_bots_list_dropdown_widget_name = "org_all_bots_list_select_bot_status";
 export const org_your_bots_list_dropdown_widget_name = "org_your_bots_list_select_bot_status";

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -21,6 +21,11 @@ import * as avatar from "./avatar.ts";
 import * as banners from "./banners.ts";
 import * as bot_data from "./bot_data.ts";
 import * as bot_helper from "./bot_helper.ts";
+import {
+    EMBEDDED_BOT_TYPE,
+    INCOMING_WEBHOOK_BOT_TYPE_INT,
+    OUTGOING_WEBHOOK_BOT_TYPE,
+} from "./bot_type_values.ts";
 import * as browser_history from "./browser_history.ts";
 import * as buddy_data from "./buddy_data.ts";
 import * as buttons from "./buttons.ts";
@@ -92,10 +97,6 @@ let user_group_pill_widget: user_group_pill.UserGroupPillWidget;
 let toggler: components.Toggle;
 let bot_owner_dropdown_widget: DropdownWidget | undefined;
 let original_values: (Record<string, unknown> & {user_id?: string | undefined}) | undefined;
-
-const INCOMING_WEBHOOK_BOT_TYPE_INT = 2;
-const OUTGOING_WEBHOOK_BOT_TYPE = "3";
-const EMBEDDED_BOT_TYPE = "4";
 
 export function show_button_spinner($button: JQuery): void {
     const $spinner = $button.find(".modal__spinner");

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -93,7 +93,7 @@ let toggler: components.Toggle;
 let bot_owner_dropdown_widget: DropdownWidget | undefined;
 let original_values: (Record<string, unknown> & {user_id?: string | undefined}) | undefined;
 
-const INCOMING_WEBHOOK_BOT_TYPE = 2;
+const INCOMING_WEBHOOK_BOT_TYPE_INT = 2;
 const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 const EMBEDDED_BOT_TYPE = "4";
 
@@ -861,7 +861,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
         disable_role_dropdown: !current_user.is_admin || (bot.is_owner && !current_user.is_owner),
         bot_avatar_url: bot.avatar_url,
         bot_type: settings_data.bot_type_id_to_string(bot.bot_type),
-        is_incoming_webhook_bot: bot.bot_type === INCOMING_WEBHOOK_BOT_TYPE,
+        is_incoming_webhook_bot: bot.bot_type === INCOMING_WEBHOOK_BOT_TYPE_INT,
         max_bot_name_length: people.MAX_USER_NAME_LENGTH,
         realm_bot_domain: realm.realm_bot_domain,
     });

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -21,6 +21,7 @@ const {page_params} = require("./lib/zpage_params.cjs");
 
 const channel = mock_esm("../src/channel");
 
+const {GENERIC_BOT_TYPE, INCOMING_WEBHOOK_BOT_TYPE_INT} = zrequire("bot_type_values");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const {set_current_user, set_realm} = zrequire("state_data");
@@ -528,6 +529,46 @@ test("is_subscriber_subset", async () => {
             row[2],
         );
     }
+
+    // Create a mock Incoming Webhook bot
+    const webhook_bot = make_bot({
+        email: "webhook@zulip.com",
+        full_name: "Webhook Bot",
+        user_id: 105,
+        bot_type: INCOMING_WEBHOOK_BOT_TYPE_INT,
+    });
+    people.add_active_user(webhook_bot);
+
+    // Create a mock Generic Bot
+    const generic_bot = make_bot({
+        email: "generic@zulip.com",
+        full_name: "Generic Bot",
+        user_id: 106,
+        bot_type: GENERIC_BOT_TYPE,
+    });
+    people.add_active_user(generic_bot);
+
+    const sub_with_webhook = make_sub(304, [1, 2, webhook_bot.user_id]);
+    const sub_with_generic = make_sub(305, [1, 2, generic_bot.user_id]);
+    const sub_with_unknown_user = make_sub(306, [1, 2, 9999]);
+
+    // Webhooks should be ignored.
+    assert.equal(
+        await peer_data.is_subscriber_subset(sub_with_webhook.stream_id, sub_a.stream_id),
+        true,
+    );
+
+    // Generic bots can read, so they are NOT ignored.
+    assert.equal(
+        await peer_data.is_subscriber_subset(sub_with_generic.stream_id, sub_a.stream_id),
+        false,
+    );
+
+    // Unknown users are treated conservatively (not ignored).
+    assert.equal(
+        await peer_data.is_subscriber_subset(sub_with_unknown_user.stream_id, sub_a.stream_id),
+        false,
+    );
 
     // Two untracked streams should never be passed into us.
     blueslip.expect(


### PR DESCRIPTION
Incoming webhook bots are write-only and cannot read messages. This updates `is_subscriber_subset` to ignore them, preventing unnecessary "private channel" warnings when linking to a private stream in a channel where a webhook bot is subscribed.

<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/issues/38976<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### Screenshots and screen captures:

| Before (main) | After (this PR) |
| :--- | :--- |
| **Incoming Webhook Bot**<br>![Before Webhook](https://github.com/user-attachments/assets/dbad2689-43ed-479d-801c-a1672fbc7058) | <br>![After Webhook](https://github.com/user-attachments/assets/7407a04f-df66-490a-a48a-ab46bcbdba0a) |
| **Zulip Default Bot**<br>![Before Generic](https://github.com/user-attachments/assets/dbad2689-43ed-479d-801c-a1672fbc7058) | <br>![After Generic](https://github.com/user-attachments/assets/3384c5e8-fecf-4142-ad8c-be023ea3a024) |
| **Iago**<br>![Before Human](https://github.com/user-attachments/assets/dbad2689-43ed-479d-801c-a1672fbc7058) | <br>![After Human](https://github.com/user-attachments/assets/dbad2689-43ed-479d-801c-a1672fbc7058) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
