### PR TITLE
export: Accept 4-part S3 keys from transfer_uploads_to_s3.

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -2128,7 +2128,6 @@ def _get_exported_s3_record(
 @dataclass
 class S3DownloadsProcessState:
     output_dir: str
-    processing_uploads: bool
     bucket: "Bucket"
 
 
@@ -2142,23 +2141,15 @@ class S3DownloadsProcessState:
 s3_downloads_context: ContextVar[S3DownloadsProcessState] = ContextVar("s3_downloads_context")
 
 
-def s3_downloads_process_initializer(
-    output_dir: str, processing_uploads: bool, bucket_name: str
-) -> None:
+def s3_downloads_process_initializer(output_dir: str, bucket_name: str) -> None:
     bucket = get_bucket(bucket_name)
-    s3_downloads_context.set(S3DownloadsProcessState(output_dir, processing_uploads, bucket))
+    s3_downloads_context.set(S3DownloadsProcessState(output_dir, bucket))
 
 
 def _save_s3_key_to_file(key_name: str) -> None:
-    context = s3_downloads_context.get()
     # Helper function for export_files_from_s3
-    if not context.processing_uploads:
-        filename = os.path.join(context.output_dir, key_name)
-    else:
-        fields = key_name.split("/")
-        if len(fields) != 3:
-            raise AssertionError(f"Suspicious key with invalid format {key_name}")
-        filename = os.path.join(context.output_dir, key_name)
+    context = s3_downloads_context.get()
+    filename = os.path.join(context.output_dir, key_name)
 
     if "../" in filename:
         raise AssertionError(f"Suspicious file with invalid format {filename}")
@@ -2183,7 +2174,6 @@ def export_files_from_s3(
     valid_hashes: set[str] | None,
     processes: int = 1,
 ) -> None:
-    processing_uploads = flavor == "upload"
     processing_emoji = flavor == "emoji"
 
     bucket = get_bucket(bucket_name)
@@ -2246,7 +2236,6 @@ def export_files_from_s3(
         initializer=s3_downloads_process_initializer,
         initargs=(
             output_dir,
-            processing_uploads,
             bucket_name,
         ),
         report_every=100,


### PR DESCRIPTION
_save_s3_key_to_file asserted that upload S3 keys split into exactly three "/"-separated fields, matching the native S3 path layout `<realm_id>/<token>/<filename>`.  Realms that had their uploads migrated from local storage via transfer_uploads_to_s3 keep the local path layout as the S3 key --
`<realm_id>/<hex-shard>/<token>/<filename>`, four fields -- so every download in such a realm's export tripped this assertion and the upload phase of the export raised.

The assertion was never load-bearing for safety.  The "../" check a few lines below prevents directory traversal, and the iteration in export_files_from_s3 already scopes the listing to Prefix=f"{realm.id}/", so keys can't escape the realm's prefix. The branch it guarded also produced an identical filename to the non-uploads branch, so dropping it flattens the conditional and lets the now-unused processing_uploads flag go with it.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
