### PR TITLE
webhooks/github: Add status emoji to check_run, deployment_status, page_build

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -145,7 +145,7 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("deployment", TOPIC_DEPLOYMENT, expected_message)
 
     def test_deployment_status_msg(self) -> None:
-        expected_message = "Deployment changed status to success."
+        expected_message = ":green_circle: Deployment changed status to success."
         self.check_webhook("deployment_status", TOPIC_DEPLOYMENT, expected_message)
 
     def test_fork_msg(self) -> None:
@@ -380,12 +380,12 @@ class GitHubWebhookTest(WebhookTestCase):
 
     def test_page_build_msg(self) -> None:
         expected_message = (
-            "GitHub Pages build, triggered by baxterthehacker, has finished building."
+            ":green_circle: GitHub Pages build, triggered by baxterthehacker, has finished building."
         )
         self.check_webhook("page_build", TOPIC_REPO, expected_message)
 
     def test_page_build_errored_msg(self) -> None:
-        expected_message = "GitHub Pages build, triggered by baxterthehacker, has failed: \n``` quote\nSomething went wrong.\n```."
+        expected_message = ":cross_mark: GitHub Pages build, triggered by baxterthehacker, has failed: \n``` quote\nSomething went wrong.\n```."
         self.check_webhook("page_build__errored", TOPIC_REPO, expected_message)
 
     def test_status_msg(self) -> None:
@@ -563,7 +563,7 @@ class GitHubWebhookTest(WebhookTestCase):
     def test_check_run(self) -> None:
         expected_topic_name = "hello-world / checks"
         expected_message = """
-Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92930d](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))
+:green_circle: Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92930d](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))
 """.strip()
         self.check_webhook("check_run__completed", expected_topic_name, expected_message)
 

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -257,11 +257,19 @@ def get_deployment_body(helper: Helper) -> str:
     return f"{get_sender_name(helper)} created new deployment."
 
 
+def get_deployment_status_emoji(state: str) -> str:
+    if state == "success":
+        return ":green_circle:"
+    if state in ("failure", "error"):
+        return ":cross_mark:"
+    return ":yellow_circle:"
+
+
 def get_change_deployment_status_body(helper: Helper) -> str:
     payload = helper.payload
-    return "Deployment changed status to {}.".format(
-        payload["deployment_status"]["state"].tame(check_string),
-    )
+    state = payload["deployment_status"]["state"].tame(check_string)
+    emoji = get_deployment_status_emoji(state)
+    return "{} Deployment changed status to {}.".format(emoji, state)
 
 
 def get_create_or_delete_body(action: str, helper: Helper) -> str:
@@ -561,6 +569,14 @@ def get_release_body(helper: Helper) -> str:
     return get_release_event_message(**data)
 
 
+def get_page_build_emoji(status: str) -> str:
+    if status == "built":
+        return ":green_circle:"
+    if status == "errored":
+        return ":cross_mark:"
+    return ":yellow_circle:"
+
+
 def get_page_build_body(helper: Helper) -> str:
     payload = helper.payload
     build = payload["build"]
@@ -582,7 +598,9 @@ def get_page_build_body(helper: Helper) -> str:
             ),
         )
 
-    return "GitHub Pages build, triggered by {}, {}.".format(
+    emoji = get_page_build_emoji(status)
+    return "{} GitHub Pages build, triggered by {}, {}.".format(
+        emoji,
         payload["build"]["pusher"]["login"].tame(check_string),
         action,
     )
@@ -795,13 +813,23 @@ def get_pull_request_review_requested_body(helper: Helper) -> str:
     )
 
 
+def get_check_run_conclusion_emoji(conclusion: str) -> str:
+    if conclusion == "success":
+        return ":green_circle:"
+    if conclusion in ("failure", "cancelled", "timed_out", "action_required"):
+        return ":cross_mark:"
+    return ":yellow_circle:"
+
+
 def get_check_run_body(helper: Helper) -> str:
     payload = helper.payload
     template = """
-Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}))
+{emoji} Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}))
 """.strip()
 
+    conclusion = payload["check_run"]["conclusion"].tame(check_string)
     kwargs = {
+        "emoji": get_check_run_conclusion_emoji(conclusion),
         "name": payload["check_run"]["name"].tame(check_string),
         "html_url": payload["check_run"]["html_url"].tame(check_string),
         "status": payload["check_run"]["status"].tame(check_string),
@@ -810,7 +838,7 @@ Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}
             payload["repository"]["html_url"].tame(check_string),
             payload["check_run"]["head_sha"].tame(check_string),
         ),
-        "conclusion": payload["check_run"]["conclusion"].tame(check_string),
+        "conclusion": conclusion,
     }
 
     return template.format(**kwargs)


### PR DESCRIPTION
Fixes #37250.

Add colored circle and cross-mark emoji to the notification messages for `check_run`, `deployment_status`, and `page_build` webhook events to give users an at-a-glance visual indicator of pass/fail status:

- `:green_circle:` for success/built
- `:cross_mark:` for failure/error/cancelled/timed_out/action_required/errored
- `:yellow_circle:` for all other states (pending, in_progress, neutral, building, etc.)

The three updated functions are:
- `get_check_run_body`
- `get_change_deployment_status_body`
- `get_page_build_body`

Tests updated to match new expected messages.