### PR TITLE
docs: Testing with the third-party service

### DIFF
--- a/docs/development/using.md
+++ b/docs/development/using.md
@@ -92,9 +92,79 @@ the development environment][authentication-dev-server].
 See the mobile project's documentation on [getting set up to develop
 and contribute to the mobile app][mobile-development-guide].
 
+## Accessing development environment from other systems
+
+:::{warning}
+The development environment is not hardened against hostile
+traffic. Only expose it to networks you trust, and only while
+testing.
+:::
+
+By default, the development environment is reachable only from the
+machine it runs on. The most common reason to change that is running
+the mobile app on a phone or emulator against it (the [mobile
+dev-server guide][mobile-dev-server-guide] covers the client-side
+setup).
+
+First, find your host's IP address on your network:
+
+::::{tab-set}
+
+:::{tab-item} Windows
+:sync: os-windows
+
+Run `ipconfig` and look for the IPv4 address.
+:::
+
+:::{tab-item} macOS
+:sync: os-mac
+
+Run `ipconfig getifaddr en0`, or open the Network settings pane.
+:::
+
+:::{tab-item} Linux
+:sync: os-linux
+
+Run `ip addr` and look for your network interface's address.
+:::
+
+::::
+
+The development server listens on port 9991. The steps below use
+`192.168.1.10` as an example IP address, so the server ends up
+reachable at `192.168.1.10:9991`.
+
+1. If you're using Vagrant, [set `HOST_IP_ADDR 0.0.0.0` in
+   `~/.zulip-vagrant-config`][vagrant-host-ip] and run
+   `vagrant reload`, so that the VM accepts connections from other
+   machines.
+
+2. Start the development server with `EXTERNAL_HOST` set to the
+   address other systems will use to reach it, so that the Zulip
+   server knows what base URL it's being accessed at:
+
+   ```bash
+   env EXTERNAL_HOST=192.168.1.10:9991 ./tools/run-dev --interface=''
+   ```
+
+   `--interface=''` makes `run-dev` listen on all network
+   interfaces; it's needed only outside Vagrant, since inside the
+   VM `run-dev` already does this and Vagrant controls which ports
+   are exposed to the network.
+
+The development environment is now reachable from other devices on
+your network at `http://192.168.1.10:9991`.
+
+To instead let a service hosted outside your network (such as a
+cloud-hosted SaaS product) reach your development environment, you
+can use a tunneling tool to get a temporary public URL, and set
+`EXTERNAL_HOST` to the hostname the tunnel gives you.
+
 [rest-api]: https://zulip.com/api/rest
 [authentication-dev-server]: authentication.md
 [django-runserver]: https://docs.djangoproject.com/en/5.0/ref/django-admin/#runserver
 [new-feature-tutorial]: ../tutorials/new-feature-tutorial.md
 [testing-docs]: ../testing/testing.md
 [mobile-development-guide]: https://github.com/zulip/zulip-flutter/blob/main/docs/setup.md
+[mobile-dev-server-guide]: https://github.com/zulip/zulip-flutter/blob/main/docs/howto/dev-server.md
+[vagrant-host-ip]: setup-recommended.md#using-a-different-port-for-vagrant

--- a/docs/development/using.md
+++ b/docs/development/using.md
@@ -90,7 +90,9 @@ the development environment][authentication-dev-server].
 ## Mobile
 
 See the mobile project's documentation on [getting set up to develop
-and contribute to the mobile app][mobile-development-guide].
+and contribute to the mobile app][mobile-development-guide], including
+how to [run the app against your development
+server][mobile-dev-server-guide].
 
 [rest-api]: https://zulip.com/api/rest
 [authentication-dev-server]: authentication.md
@@ -98,3 +100,4 @@ and contribute to the mobile app][mobile-development-guide].
 [new-feature-tutorial]: ../tutorials/new-feature-tutorial.md
 [testing-docs]: ../testing/testing.md
 [mobile-development-guide]: https://github.com/zulip/zulip-flutter/blob/main/docs/setup.md
+[mobile-dev-server-guide]: https://github.com/zulip/zulip-flutter/blob/main/docs/howto/dev-server.md

--- a/docs/webhooks/incoming-webhooks-overview.md
+++ b/docs/webhooks/incoming-webhooks-overview.md
@@ -135,12 +135,6 @@ configured! 🎉"
 - Sometimes it can be helpful to contact the third-party service if it
   appears they don't have an API or outgoing webhook you can use.
   Sometimes the API you're looking for is just not properly documented.
-- A helpful tool for testing your integration is [UltraHook](http://www.ultrahook.com/),
-  which allows you to receive webhook calls via your local Zulip
-  development environment. This enables you to do end-to-end testing with
-  live data from the third-party service you're integrating, and can help
-  you spot why something isn't working or if the service is using [custom
-  HTTP headers](incoming-webhooks-reference.md#custom-http-headers).
 
 ## URL specification
 

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -261,17 +261,18 @@ for [generating an integration URL](https://zulip.com/help/generate-integration-
 ## Step 4: Manually test the webhook
 
 You'll want to manually test your webhook implementation in the Zulip
-development environment. There are two command line tools you can use,
-as well as a GUI tool.
+development environment.
 
-For either one of the command line tools, you'll need to [get an API
-key](https://zulip.com/api/api-keys) for an [incoming webhook
-bot](https://zulip.com/help/add-a-bot-or-integration) in your Zulip
-development environment. Replace `<api_key>` with the bot's API key in
-the examples below. This is how the server knows that the request was
-made by an authorized user.
+### Command line tools
 
-### curl
+There are two command line tools you can use. For either one of them,
+you'll need to [get an API key](https://zulip.com/api/api-keys) for
+an [incoming webhook bot](https://zulip.com/help/add-a-bot-or-integration)
+in your Zulip development environment. Replace `<api_key>` with the
+bot's API key in the examples below. This is how the server knows that
+the request was made by an authorized user.
+
+#### curl
 
 Using curl, with the Zulip development server running in a separate
 console window:
@@ -289,7 +290,7 @@ After running the above command, you should see something similar to:
 And if you log-in to the web app as the bot's owner, you should see a new
 direct message from the bot.
 
-### `send_webhook_fixture_message` management command
+#### `send_webhook_fixture_message` management command
 
 Using `manage.py` from within the Zulip development environment:
 

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -339,6 +339,35 @@ test fixtures.
 Custom HTTP headers must be entered as a JSON dictionary, if you want to
 use any. Feel free to use 4-spaces as tabs for indentation if you'd like.
 
+### Testing with the third-party service
+
+:::{warning}
+The development environment is not hardened against hostile traffic. Only
+expose it while you are actively testing.
+:::
+
+To have the third-party service deliver the webhooks itself, it needs to
+be able to reach your development server over the internet.
+
+You don't need to reconfigure the development server for this. You can
+use a tunneling tool, such as [UltraHook](https://www.ultrahook.com/) or
+[localtunnel](https://github.com/localtunnel/localtunnel), to expose
+`http://localhost:9991` at a temporary public URL. When you configure the
+webhook in the third-party service, use that temporary public URL with the
+path for your incoming webhook integration, e.g.,
+`<temporary-public-url>/api/v1/external/helloworld?api_key=<api_key>`.
+
+End-to-end testing with live data can help you spot why something isn't
+working, or whether the service is using [custom HTTP
+headers](incoming-webhooks-reference.md#custom-http-headers) that your
+integration needs to handle.
+
+If you instead need the development server to be reachable from another
+device on your own network, the mobile project's guide to [running the app
+against a development
+server](https://github.com/zulip/zulip-flutter/blob/main/docs/howto/dev-server.md)
+covers configuring the server to listen on all network interfaces.
+
 ## Step 5: Create automated tests
 
 Every incoming webhook integration should have a corresponding `tests.py`


### PR DESCRIPTION
Fixes: #12386.

This adds an "Testing with Third party services"
section to `ncoming-webhook-walkthrough.md`, documenting how to expose the
dev server so a third-party service can deliver webhooks directly, also links the [mobile dev server guide](https://github.com/zulip/zulip-flutter/blob/main/docs/howto/dev-server.md) so the mobile  


**Screenshots and screen captures:**
<img width="901" height="655" alt="2026-08-05-180053_hyprshot" src="https://github.com/user-attachments/assets/b8f41898-44a3-481a-83c0-9a0ec13e8fa2" />
General Advice section:(links with the new section added)
<img width="902" height="106" alt="2026-08-05-180113_hyprshot" src="https://github.com/user-attachments/assets/c272c237-e591-4cdc-b795-3700ce400b6b" />
Mobile: (Links with the guide)
<img width="902" height="128" alt="2026-08-05-180219_hyprshot" src="https://github.com/user-attachments/assets/9a34eb67-61ec-4797-bc76-46599ed361ec" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

