### PR TITLE
test-api: Reset uploaded realm emoji for realm export tests.

### DIFF
--- a/tools/test-api
+++ b/tools/test-api
@@ -45,6 +45,7 @@ with test_server_running(
     from zerver.models.users import get_user
     from zerver.openapi.javascript_examples import test_js_bindings
     from zerver.openapi.python_examples import (
+        reset_realm_uploaded_emoji,
         test_invalid_api_key,
         test_realm_deactivated,
         test_the_api,
@@ -118,7 +119,9 @@ with test_server_running(
         site=site,
     )
 
+    reset_realm_uploaded_emoji(iago)
     test_the_api(client, nonadmin_client, owner_client, bot_client)
+    reset_realm_uploaded_emoji(iago)
     test_generated_curl_examples_for_success(client)
     test_js_bindings(client)
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -20,11 +20,15 @@ from email.headerregistry import Address
 from functools import wraps
 from typing import Any, TypeVar
 
+from django.core.files.base import File
 from typing_extensions import ParamSpec
 from zulip import Client
 
+from zerver.actions.realm_emoji import check_add_realm_emoji
+from zerver.lib.storage import static_path
+from zerver.models.realm_emoji import RealmEmoji
 from zerver.models.realms import get_realm
-from zerver.models.users import get_user
+from zerver.models.users import UserProfile, get_user
 from zerver.openapi.openapi import validate_against_openapi_schema
 
 ZULIP_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -59,6 +63,18 @@ def openapi_test_function(
         return _record_calls_wrapper
 
     return wrapper
+
+
+def reset_realm_uploaded_emoji(user: UserProfile) -> None:
+    # Due to the way that the test runner varies settings.LOCAL_UPLOADS_DIR
+    # we need to reset the uploaded green_tick emoji in order to generate
+    # successful realm exports for the API python and curl example tests.
+    RealmEmoji.objects.all().delete()
+    IMAGE_FILE_PATH = static_path("images/test-images/checkbox.png")
+    with open(IMAGE_FILE_PATH, "rb") as fp:
+        check_add_realm_emoji(
+            user.realm, "green_tick", user, File(fp, name="checkbox.png"), "image/png"
+        )
 
 
 def ensure_users(ids_list: list[int], user_names: list[str]) -> None:


### PR DESCRIPTION
Because of how the test runner varies `settings.LOCAL_UPLOADS_DIR`, we reset the realm uploaded emoji for the realm export tests for both the python and curl examples. Previously, the realm export was failing after the success response with the export ID was sent.

**Notes**:
- Removing the RealmEmoji is similar to what we do in `zerver/tests/test_import_export.py` ([CODE LINK](https://github.com/zulip/zulip/blob/11bf985d1f38c4e65e1b795de7496ede60e0ba8a/zerver/tests/test_import_export.py#L177-L193)), but here we add back a test image for a custom realm emoji with the name `green_tick` for the API endpoint parameter tests.
- Setting the `green_tick` emoji in `python_examples.py` is identical to the code in the `populate_db` management command where that's set ([CODE LINK](https://github.com/zulip/zulip/blob/11bf985d1f38c4e65e1b795de7496ede60e0ba8a/zilencer/management/commands/populate_db.py#L962-L967)).
  - Having a shared helper for that code would make sense, but I couldn't land on a `zerver/lib/...` file that made sense currently. `test_helpers.py` imports some dependencies that don't work with the `populate_db` command.

---

**console logs from `test-api`**:
<details>
<summary>BEFORE</summary>

```console
2026-04-20 12:50:15.450 WARN [django.server] "DELETE /api/v1/messages/56 HTTP/1.1" 400 97
2026-04-20 12:51:03.902 INFO [] Exporting data from get_realm_config()...
2026-04-20 12:51:03.903 INFO [] Exporting via export_from_config:  zerver_realm
2026-04-20 12:51:03.903 INFO [] Exporting via export_from_config:  zerver_realmauthenticationmethod
2026-04-20 12:51:03.904 INFO [] Exporting via export_from_config:  zerver_presencesequence
2026-04-20 12:51:03.904 INFO [] Exporting via export_from_config:  zerver_scheduledmessage
2026-04-20 12:51:03.904 INFO [] Exporting via export_from_config:  zerver_defaultstream
2026-04-20 12:51:03.904 INFO [] Exporting via export_from_config:  zerver_customprofilefield
2026-04-20 12:51:03.904 INFO [] Exporting via export_from_config:  zerver_realmauditlog
2026-04-20 12:51:03.913 INFO [] Exporting via export_from_config:  zerver_realmemoji
2026-04-20 12:51:03.913 INFO [] Exporting via export_from_config:  zerver_realmdomain
2026-04-20 12:51:03.913 INFO [] Exporting via export_from_config:  zerver_realmexport
2026-04-20 12:51:03.914 INFO [] Exporting via export_from_config:  zerver_realmfilter
2026-04-20 12:51:03.914 INFO [] Exporting via export_from_config:  zerver_realmplayground
2026-04-20 12:51:03.914 INFO [] Exporting via export_from_config:  zerver_realmuserdefault
2026-04-20 12:51:03.914 INFO [] Exporting via export_from_config:  zerver_onboardingusermessage
2026-04-20 12:51:03.915 INFO [] Exporting via export_from_config:  zerver_userprofile
2026-04-20 12:51:03.915 INFO [] Exporting via export_from_config:  zerver_userprofile_mirrordummy
2026-04-20 12:51:03.936 INFO [] Exporting via export_from_config:  zerver_userprofile_crossrealm
2026-04-20 12:51:03.941 INFO [] Exporting via export_from_config:  zerver_service
2026-04-20 12:51:03.941 INFO [] Exporting via export_from_config:  zerver_botstoragedata
2026-04-20 12:51:03.941 INFO [] Exporting via export_from_config:  zerver_botconfigdata
2026-04-20 12:51:03.941 INFO [] Exporting via export_from_config:  _huddle_recipient
2026-04-20 12:51:03.941 INFO [] Exporting via export_from_config:  _huddle_subscription
2026-04-20 12:51:03.941 INFO [] Exporting via export_from_config:  zerver_huddle
2026-04-20 12:51:03.943 INFO [] Exporting via export_from_config:  zerver_alertword
2026-04-20 12:51:03.943 INFO [] Exporting via export_from_config:  zerver_customprofilefieldvalue
2026-04-20 12:51:03.943 INFO [] Exporting via export_from_config:  zerver_muteduser
2026-04-20 12:51:03.943 INFO [] Exporting via export_from_config:  zerver_navigationview
2026-04-20 12:51:03.943 INFO [] Exporting via export_from_config:  zerver_onboardingstep
2026-04-20 12:51:03.943 INFO [] Exporting via export_from_config:  zerver_savedsnippet
2026-04-20 12:51:03.943 INFO [] Exporting via export_from_config:  zerver_useractivity
2026-04-20 12:51:03.944 INFO [] Exporting via export_from_config:  zerver_useractivityinterval
2026-04-20 12:51:03.944 INFO [] Exporting via export_from_config:  zerver_userpresence
2026-04-20 12:51:03.944 INFO [] Exporting via export_from_config:  zerver_userstatus
2026-04-20 12:51:03.944 INFO [] Exporting via export_from_config:  zerver_usertopic
2026-04-20 12:51:03.944 INFO [] Exporting via export_from_config:  zerver_externalauthid
2026-04-20 12:51:03.945 INFO [] Exporting via export_from_config:  zerver_usergroup
2026-04-20 12:51:03.945 INFO [] Exporting via export_from_config:  zerver_usergroupmembership
2026-04-20 12:51:03.946 INFO [] Exporting via export_from_config:  zerver_groupgroupmembership
2026-04-20 12:51:03.946 INFO [] Exporting via export_from_config:  zerver_namedusergroup
2026-04-20 12:51:03.946 INFO [] Exporting via export_from_config:  zerver_stream
2026-04-20 12:51:03.948 INFO [] Exporting via export_from_config:  _stream_recipient
2026-04-20 12:51:03.949 INFO [] Exporting via export_from_config:  _stream_subscription
2026-04-20 12:51:03.949 INFO [] Exporting via export_from_config:  zerver_recipient
2026-04-20 12:51:03.949 INFO [] Deleted temporary _stream_recipient
2026-04-20 12:51:03.949 INFO [] Deleted temporary _huddle_recipient
2026-04-20 12:51:03.949 INFO [] Exporting via export_from_config:  zerver_subscription
2026-04-20 12:51:03.949 INFO [] Deleted temporary _stream_subscription
2026-04-20 12:51:03.950 INFO [] Deleted temporary _huddle_subscription
2026-04-20 12:51:03.950 INFO [] Exporting via export_from_config:  zerver_channelfolder
2026-04-20 12:51:03.950 INFO [] ...DONE with get_realm_config() data
2026-04-20 12:51:03.950 INFO [] Exporting .partial files messages
2026-04-20 12:51:03.970 INFO [] Fetched messages for /tmp/zulip-export-3vb3sl_f/messages-000001.json.partial
2026-04-20 12:51:03.970 INFO [] Finished writing /tmp/zulip-export-3vb3sl_f/messages-000001.json.partial
2026-04-20 12:51:03.970 INFO [] 39 messages were exported
2026-04-20 12:51:03.992 INFO [] Finished writing /tmp/zulip-export-3vb3sl_f/realm.json
2026-04-20 12:51:03.992 INFO [] Fetching analytics table data
2026-04-20 12:51:03.992 INFO [] Exporting via export_from_config:  zerver_realm
2026-04-20 12:51:03.992 INFO [] Exporting via export_from_config:  analytics_realmcount
2026-04-20 12:51:03.992 INFO [] Exporting via export_from_config:  analytics_usercount
2026-04-20 12:51:03.992 INFO [] Exporting via export_from_config:  analytics_streamcount
2026-04-20 12:51:03.995 INFO [] Finished writing /tmp/zulip-export-3vb3sl_f/analytics.json
2026-04-20 12:51:03.998 INFO [] Finished writing /tmp/zulip-export-3vb3sl_f/attachment.json
2026-04-20 12:51:03.998 INFO [] Exporting uploaded files and avatars
2026-04-20 12:51:04.000 INFO [] Finished writing /tmp/zulip-export-3vb3sl_f/uploads/records.json
2026-04-20 12:51:04.002 INFO [] Finished writing /tmp/zulip-export-3vb3sl_f/avatars/records.json
2026-04-20 12:51:04.005 ERR  [] Data export for zulip failed after 0.10619139671325684
Traceback (most recent call last):
  File "/srv/zulip/zerver/worker/deferred_work.py", line 127, in consume
    export_realm_wrapper(
  File "/srv/zulip/zerver/lib/export.py", line 3007, in export_realm_wrapper
    tarball_path, stats = do_export_realm(
  File "/srv/zulip/zerver/lib/export.py", line 2564, in do_export_realm
    export_uploads_and_avatars(
  File "/srv/zulip/zerver/lib/export.py", line 2003, in export_uploads_and_avatars
    export_emoji_from_local(
  File "/srv/zulip/zerver/lib/export.py", line 2419, in export_emoji_from_local
    write_records_json_file(output_dir, iterate_emoji(emoji_path_tuples()))
  File "/srv/zulip/zerver/lib/export.py", line 510, in write_records_json_file
    f.writelines(orjson_stream(records))
  File "/srv/zulip/zerver/lib/export.py", line 420, in orjson_stream
    for batch in batched(it, chunk_size):
  File "/srv/zulip/zerver/lib/export.py", line 2817, in batched
    while batch := tuple(islice(iterator, n)):
  File "/srv/zulip/zerver/lib/export.py", line 2404, in iterate_emoji
    shutil.copy2(local_path, output_path)
  File "/usr/lib/python3.10/shutil.py", line 434, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.10/shutil.py", line 254, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/srv/zulip/var/e79eb5c9-2f4e-4115-95cc-d92a62b367bf/test-backend/test_uploads/avatars/2/emoji/images/bbf52f63.png'
Stack (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.10/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.10/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.10/socketserver.py", line 747, in __init__
    self.handle()
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/servers/basehttp.py", line 230, in handle
    self.handle_one_request()
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/servers/basehttp.py", line 253, in handle_one_request
    handler.run(self.server.get_app())
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/wsgi.py", line 124, in __call__
    response = self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 140, in get_response
    response = self._middleware_chain(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/utils/deprecation.py", line 120, in __call__
    response = response or self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django_otp/middleware.py", line 44, in __call__
    return self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/two_factor/middleware/threadlocals.py", line 19, in __call__
    return self.get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/srv/zulip/zerver/lib/rest.py", line 42, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "/srv/zulip/zerver/lib/rest.py", line 217, in rest_dispatch
    return target_function(request, **kwargs)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "/srv/zulip/zerver/decorator.py", line 809, in _wrapped_func_arguments
    return view_func(request, user_profile, *args, **kwargs)
  File "/usr/lib/python3.10/contextlib.py", line 78, in inner
    with self._recreate_cm():
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/transaction.py", line 307, in __exit__
    connection.set_autocommit(True)
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/backends/base/base.py", line 491, in set_autocommit
    self.run_and_clear_commit_hooks()
  File "/srv/zulip/.venv/lib/python3.10/site-packages/django/db/backends/base/base.py", line 769, in run_and_clear_commit_hooks
    func()
  File "/srv/zulip/zerver/lib/queue.py", line 466, in <lambda>
    transaction.on_commit(lambda: queue_json_publish_rollback_unsafe(queue_name, event))
  File "/srv/zulip/zerver/lib/queue.py", line 460, in queue_json_publish_rollback_unsafe
    get_worker(queue_name, disable_timeout=True).consume_single_event(
  File "/srv/zulip/zerver/worker/base.py", line 246, in consume_single_event
    self.do_consume(consume_func, [event])
  File "/srv/zulip/zerver/worker/base.py", line 210, in do_consume
    consume_func(events)
  File "/srv/zulip/zerver/worker/base.py", line 245, in <lambda>
    consume_func = lambda events: self.consume(events[0])
  File "/srv/zulip/zerver/worker/deferred_work.py", line 134, in consume
    logging.exception(
2026-04-20 12:51:04.173 WARN [django.server] "POST /api/v1/messages/render HTTP/1.1" 400 109
```
</details>

<details>
<summary>AFTER</summary>

```console
2026-04-20 12:45:30.198 WARN [django.server] "DELETE /api/v1/messages/56 HTTP/1.1" 400 97
2026-04-20 12:46:22.695 INFO [] Exporting data from get_realm_config()...
2026-04-20 12:46:22.695 INFO [] Exporting via export_from_config:  zerver_realm
2026-04-20 12:46:22.695 INFO [] Exporting via export_from_config:  zerver_realmauthenticationmethod
2026-04-20 12:46:22.696 INFO [] Exporting via export_from_config:  zerver_presencesequence
2026-04-20 12:46:22.696 INFO [] Exporting via export_from_config:  zerver_scheduledmessage
2026-04-20 12:46:22.696 INFO [] Exporting via export_from_config:  zerver_defaultstream
2026-04-20 12:46:22.696 INFO [] Exporting via export_from_config:  zerver_customprofilefield
2026-04-20 12:46:22.696 INFO [] Exporting via export_from_config:  zerver_realmauditlog
2026-04-20 12:46:22.704 INFO [] Exporting via export_from_config:  zerver_realmemoji
2026-04-20 12:46:22.705 INFO [] Exporting via export_from_config:  zerver_realmdomain
2026-04-20 12:46:22.705 INFO [] Exporting via export_from_config:  zerver_realmexport
2026-04-20 12:46:22.705 INFO [] Exporting via export_from_config:  zerver_realmfilter
2026-04-20 12:46:22.705 INFO [] Exporting via export_from_config:  zerver_realmplayground
2026-04-20 12:46:22.705 INFO [] Exporting via export_from_config:  zerver_realmuserdefault
2026-04-20 12:46:22.705 INFO [] Exporting via export_from_config:  zerver_onboardingusermessage
2026-04-20 12:46:22.706 INFO [] Exporting via export_from_config:  zerver_userprofile
2026-04-20 12:46:22.706 INFO [] Exporting via export_from_config:  zerver_userprofile_mirrordummy
2026-04-20 12:46:22.725 INFO [] Exporting via export_from_config:  zerver_userprofile_crossrealm
2026-04-20 12:46:22.729 INFO [] Exporting via export_from_config:  zerver_service
2026-04-20 12:46:22.729 INFO [] Exporting via export_from_config:  zerver_botstoragedata
2026-04-20 12:46:22.729 INFO [] Exporting via export_from_config:  zerver_botconfigdata
2026-04-20 12:46:22.729 INFO [] Exporting via export_from_config:  _huddle_recipient
2026-04-20 12:46:22.729 INFO [] Exporting via export_from_config:  _huddle_subscription
2026-04-20 12:46:22.729 INFO [] Exporting via export_from_config:  zerver_huddle
2026-04-20 12:46:22.731 INFO [] Exporting via export_from_config:  zerver_alertword
2026-04-20 12:46:22.731 INFO [] Exporting via export_from_config:  zerver_customprofilefieldvalue
2026-04-20 12:46:22.731 INFO [] Exporting via export_from_config:  zerver_muteduser
2026-04-20 12:46:22.731 INFO [] Exporting via export_from_config:  zerver_navigationview
2026-04-20 12:46:22.731 INFO [] Exporting via export_from_config:  zerver_onboardingstep
2026-04-20 12:46:22.731 INFO [] Exporting via export_from_config:  zerver_savedsnippet
2026-04-20 12:46:22.732 INFO [] Exporting via export_from_config:  zerver_useractivity
2026-04-20 12:46:22.732 INFO [] Exporting via export_from_config:  zerver_useractivityinterval
2026-04-20 12:46:22.732 INFO [] Exporting via export_from_config:  zerver_userpresence
2026-04-20 12:46:22.733 INFO [] Exporting via export_from_config:  zerver_userstatus
2026-04-20 12:46:22.733 INFO [] Exporting via export_from_config:  zerver_usertopic
2026-04-20 12:46:22.733 INFO [] Exporting via export_from_config:  zerver_externalauthid
2026-04-20 12:46:22.734 INFO [] Exporting via export_from_config:  zerver_usergroup
2026-04-20 12:46:22.734 INFO [] Exporting via export_from_config:  zerver_usergroupmembership
2026-04-20 12:46:22.735 INFO [] Exporting via export_from_config:  zerver_groupgroupmembership
2026-04-20 12:46:22.735 INFO [] Exporting via export_from_config:  zerver_namedusergroup
2026-04-20 12:46:22.735 INFO [] Exporting via export_from_config:  zerver_stream
2026-04-20 12:46:22.737 INFO [] Exporting via export_from_config:  _stream_recipient
2026-04-20 12:46:22.737 INFO [] Exporting via export_from_config:  _stream_subscription
2026-04-20 12:46:22.738 INFO [] Exporting via export_from_config:  zerver_recipient
2026-04-20 12:46:22.738 INFO [] Deleted temporary _stream_recipient
2026-04-20 12:46:22.738 INFO [] Deleted temporary _huddle_recipient
2026-04-20 12:46:22.738 INFO [] Exporting via export_from_config:  zerver_subscription
2026-04-20 12:46:22.738 INFO [] Deleted temporary _stream_subscription
2026-04-20 12:46:22.738 INFO [] Deleted temporary _huddle_subscription
2026-04-20 12:46:22.738 INFO [] Exporting via export_from_config:  zerver_channelfolder
2026-04-20 12:46:22.738 INFO [] ...DONE with get_realm_config() data
2026-04-20 12:46:22.738 INFO [] Exporting .partial files messages
2026-04-20 12:46:22.758 INFO [] Fetched messages for /tmp/zulip-export-84ysm65_/messages-000001.json.partial
2026-04-20 12:46:22.759 INFO [] Finished writing /tmp/zulip-export-84ysm65_/messages-000001.json.partial
2026-04-20 12:46:22.759 INFO [] 39 messages were exported
2026-04-20 12:46:22.776 INFO [] Finished writing /tmp/zulip-export-84ysm65_/realm.json
2026-04-20 12:46:22.777 INFO [] Fetching analytics table data
2026-04-20 12:46:22.777 INFO [] Exporting via export_from_config:  zerver_realm
2026-04-20 12:46:22.777 INFO [] Exporting via export_from_config:  analytics_realmcount
2026-04-20 12:46:22.777 INFO [] Exporting via export_from_config:  analytics_usercount
2026-04-20 12:46:22.777 INFO [] Exporting via export_from_config:  analytics_streamcount
2026-04-20 12:46:22.779 INFO [] Finished writing /tmp/zulip-export-84ysm65_/analytics.json
2026-04-20 12:46:22.781 INFO [] Finished writing /tmp/zulip-export-84ysm65_/attachment.json
2026-04-20 12:46:22.781 INFO [] Exporting uploaded files and avatars
2026-04-20 12:46:22.783 INFO [] Finished writing /tmp/zulip-export-84ysm65_/uploads/records.json
2026-04-20 12:46:22.785 INFO [] Finished writing /tmp/zulip-export-84ysm65_/avatars/records.json
2026-04-20 12:46:22.786 INFO [] Finished writing /tmp/zulip-export-84ysm65_/emoji/records.json
2026-04-20 12:46:22.786 INFO [] Finished writing /tmp/zulip-export-84ysm65_/realm_icons/records.json
2026-04-20 12:46:22.786 INFO [] Launching 6 PARALLEL subprocesses to export UserMessage rows
2026-04-20 12:46:22.828 INFO [] Fetched UserMessages for /tmp/zulip-export-84ysm65_/messages-000001.json
2026-04-20 12:46:22.829 INFO [] Finished writing /tmp/zulip-export-84ysm65_/messages-000001.json
2026-04-20 12:46:22.835 INFO [] Exporting migration status
2026-04-20 12:46:22.884 INFO [] Finished exporting zulip
2026-04-20 12:46:22.884 INFO [] Writing stats file: /tmp/zulip-export-84ysm65_/stats.json

2026-04-20 12:46:22.885 INFO [] Compressing tarball...
Tarball written to /tmp/zulip-export-84ysm65_.tar.gz
Calculating SHA-256 checksum of tarball...
SHA-256 checksum is d83e22f8be722351ebdcf04201a0e431fe6b411eaa775979b1e581ae0ac420a9
Uploading export tarball...

Uploaded to http://zulip.zulipdev.com:9981/user_avatars/exports/2/dWR_PIYRNUXn7YPpUie47Hq7/zulip-export-84ysm65_.tar.gz
Successfully deleted the tarball at /tmp/zulip-export-84ysm65_.tar.gz
2026-04-20 12:46:22.947 INFO [] Completed data export for zulip in 0.25557756423950195
2026-04-20 12:46:23.123 WARN [django.server] "POST /api/v1/messages/render HTTP/1.1" 400 109
```
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
