### PR TITLE
thumbnail_galleries: Placehold with aspect-ratio.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -310,14 +310,14 @@ export function postprocess_content(html: string): string {
 
             // Despite setting `width` and `height` values above, the
             // flexbox gallery collapses until images have loaded. We
-            // therefore have to avoid the layout shift that would
-            // otherwise cause by setting the only the width attribute
-            // here. And by setting this value in ems, we ensure that
+            // therefore have to prevent a layout shift that would
+            // otherwise happen by setting the width attribute here.
+            // And by setting this value in ems, we ensure that
             // images scale as users adjust the information-density
             // settings.
             message_media_image.style.setProperty(
                 "width",
-                `${(image_box_em * font_size_in_use * original_width) / original_height / font_size_in_use}em`,
+                `${(image_box_em * original_width) / original_height}em`,
             );
 
             if (is_dinky_image) {

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -320,6 +320,18 @@ export function postprocess_content(html: string): string {
                 `${(image_box_em * original_width) / original_height}em`,
             );
 
+            // To avoid a layout shift especially on portrait images, we
+            // set the `aspect-ratio`, which flexbox respects and will
+            // therefore preserve exactly the correct amount of space
+            // prior to the image loading.
+            // TODO: Correct our unit tests to not discard `aspect-ratio`;
+            // should that property be recognized, there will be test
+            // failures all over the place in `postprocess_content.test.cjs`
+            message_media_image.style.setProperty(
+                "aspect-ratio",
+                `${original_width / original_height}`,
+            );
+
             if (is_dinky_image) {
                 message_media_image.classList.add("dinky-thumbnail");
                 // For dinky images, we just set the original width

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1830,7 +1830,7 @@
     );
     --color-background-image-thumbnail-hover: light-dark(
         hsl(0deg 0% 0% / 30%),
-        hsl(0deg 0% 100% / 45%)
+        hsl(0deg 0% 100% / 35%)
     );
 
     /* Icon colors */


### PR DESCRIPTION
This PR sets the CSS `aspect-ratio` property on all images to ensure that they are properly placeheld in the thumbnail gallery's flexbox context. See [#issues > 🎯 Scroll position with Image loading @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Scroll.20position.20with.20Image.20loading/near/2383267)

Additionally, the hover state in dark mode has been adjusted to be less apparently bright than its light-mode counterpart. See [#design > Dark theme image hover behavior](https://chat.zulip.org/#narrow/channel/101-design/topic/Dark.20theme.20image.20hover.20behavior/with/2427198)

There are two follow-up issues I am tracking for after the 12.0 release:

1. Getting our unit tests to recognize the `aspect-ratio` property, which it currently discards. That is why there are no new tests with the changes to `postprocess_content.ts` in this PR. Issue: #39039
2. Improving the presentation of missing images. Issue: #39040

**Screenshots**

_Images are properly placeheld; this is actually easier to see in action with deleted images:_

| Before | After |
| --- | --- |
| <img alt="shifting-images-before" src="https://github.com/user-attachments/assets/f03c2857-c6ff-40b4-b1f5-ab2e2b03e3bd" /> | <img alt="shifting-images-after" src="https://github.com/user-attachments/assets/c7d6ba3c-e3e0-4ea4-b0c5-22d4e03da333" /> |

_Backgrounds and hover states; top row is the static state; bottom row is the hover state:_

| Light mode (reference) | Dark mode, before | Dark mode, after |
| --- | --- | --- |
| <img width="1400" height="1550" alt="light-mode-image-outlines" src="https://github.com/user-attachments/assets/bfbd4ca2-22eb-4e6b-b8af-da8174092d53" /> | <img width="1400" height="1550" alt="dark-mode-image-outlines" src="https://github.com/user-attachments/assets/bb729ab6-9c49-43ee-a9c5-ea7eae611c1f" /> | <img width="1400" height="1550" alt="dark-mode-image-outlines" src="https://github.com/user-attachments/assets/bb729ab6-9c49-43ee-a9c5-ea7eae611c1f" /> |
| <img width="1400" height="1550" alt="light-mode-image-outlines-hover" src="https://github.com/user-attachments/assets/3985b3a6-67ff-4e9a-b5f6-356e2a8ec7f3" /> | <img width="1400" height="1550" alt="dark-mode-image-outlines-hover--before" src="https://github.com/user-attachments/assets/4dce12cf-68cf-449d-8f3a-bbffbf92d870" /> | <img width="1400" height="1550" alt="dark-mode-image-outlines-hover--after" src="https://github.com/user-attachments/assets/594b03f9-6fb6-44a3-b086-a8244b444b27" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>







