### PR TITLE
topic_list: Add "unresolved" pill by default in topic filter.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -588,6 +588,28 @@ export function left_sidebar_scroll_zoomed_in_topic_into_view(): void {
     }
 }
 
+function maybe_add_unresolved_pill_by_default(): void {
+    // Add the "Unresolved topics" pill by default when
+    // there are resolved topics and rebuild the topic list.
+    const stream_id = active_stream_id();
+    assert(stream_id !== undefined);
+
+    if (!stream_topic_history.stream_has_locally_available_resolved_topics(stream_id)) {
+        return;
+    }
+
+    const current_items = topic_filter_pill_widget?.items() ?? [];
+    const unresolved_pill = topic_filter_pill.create_item_from_syntax(
+        "-is:resolved",
+        current_items,
+    );
+
+    if (unresolved_pill) {
+        topic_filter_pill_widget?.appendValidatedData(unresolved_pill);
+        update_widget_for_stream(stream_id);
+    }
+}
+
 // For zooming, we only do topic-list stuff here...let stream_list
 // handle hiding/showing the non-narrowed streams
 export function zoom_in($stream_li: JQuery): void {
@@ -627,6 +649,7 @@ export function zoom_in($stream_li: JQuery): void {
         // position since we just added some topics to the list which moved user
         // to a different position anyway.
         left_sidebar_scroll_zoomed_in_topic_into_view();
+        maybe_add_unresolved_pill_by_default();
         topic_state_typeahead?.lookup(true);
         topic_list_cursor.reset();
     }


### PR DESCRIPTION
Pre-populate the topic filter with an "unresolved" pill (-is:resolved) by default when zooming into a channel's topic list, but only when resolved topics are locally available.

Fixes #35099

**How changes were tested:**

- [x] Manual UI testing.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| With resolved topics |
|--|
|<img width="1898" height="960" alt="image" src="https://github.com/user-attachments/assets/71e912ac-b19c-4df5-91bc-1a6829805c6c" />|
|<img width="1898" height="960" alt="image" src="https://github.com/user-attachments/assets/83bedb36-a139-4546-9ebc-9bb2d79b9397" />|

| Without resolved topics |
|--|
|<img width="1898" height="960" alt="image" src="https://github.com/user-attachments/assets/410bcdd5-dd96-4c79-9595-4c151ad497f7" />|
|<img width="1898" height="960" alt="image" src="https://github.com/user-attachments/assets/6cc42f98-a1b0-4436-b0b6-bebee55b96d8" />|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
