### PR TITLE
[ai] left_sidebar: Round DM and folder section header highlight outlines.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -342,9 +342,13 @@
             max-content
         );
 
+    &:hover,
+    &.highlighted_row {
+        border-radius: 4px;
+    }
+
     &:hover {
         background-color: var(--color-background-hover-narrow-filter);
-        border-radius: 4px;
         box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
 
         .left-sidebar-title,
@@ -487,13 +491,18 @@
         visibility: visible;
     }
 
+    /* We only set the border radius on the hover/popover/highlighted states,
+       so as to prevent the background on highlighted channels
+       from bleeding through. */
+    &:hover,
+    &:has(.left_sidebar_menu_icon_visible),
+    &.highlighted_row {
+        border-radius: 4px;
+    }
+
     &:hover {
         background-color: var(--color-background-hover-narrow-filter);
         box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
-        /* We only set the border radius on the hover/popover states,
-           so as to prevent the background on highlighted channels
-           from bleeding through. */
-        border-radius: 4px;
 
         .left-sidebar-title,
         .stream-list-section-toggle {
@@ -508,7 +517,6 @@
     &:has(.left_sidebar_menu_icon_visible) {
         box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
         background-color: var(--color-background-hover-narrow-filter);
-        border-radius: 4px;
 
         .left-sidebar-title,
         .stream-list-section-toggle {


### PR DESCRIPTION
The keyboard-highlighted_row outline on #direct-messages-section-header and .stream-list-subsection-header had square corners because those rows only set border-radius on :hover and :has(.left_sidebar_menu_icon_visible), while .top_left_row/.bottom_left_row set it unconditionally. Extend the border-radius rule to also cover .highlighted_row so the keyboard focus outline matches the rounded style used elsewhere in the sidebar.

Before

<img width="340" height="271" alt="image" src="https://github.com/user-attachments/assets/59d8c5d3-bf86-4a6b-b396-93c6ccbc8c39" />

<img width="331" height="81" alt="image" src="https://github.com/user-attachments/assets/69f61eb7-8cbf-4149-9feb-8d2ce28c0bc6" />


After

<img width="349" height="98" alt="image" src="https://github.com/user-attachments/assets/95008e0a-8300-48ef-8820-3362895deb78" />
<img width="330" height="114" alt="image" src="https://github.com/user-attachments/assets/c5717a1f-c40d-44d7-bec9-9ff173d5167b" />
