### PR TITLE
Upgrade altcha widget; send altcha v2 challenges

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@zxcvbn-ts/core": "^3.0.1",
     "@zxcvbn-ts/language-common": "^3.0.2",
     "@zxcvbn-ts/language-en": "^3.0.1",
-    "altcha": "^2.0.3",
+    "altcha": "^3.0.4",
     "autosize": "^5.0.2",
     "babel-loader": "^10.0.0",
     "babel-plugin-formatjs": "^11.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.2
       altcha:
-        specifier: ^2.0.3
-        version: 2.3.0
+        specifier: ^3.0.4
+        version: 3.0.4
       autosize:
         specifier: ^5.0.2
         version: 5.0.2(patch_hash=f08807ede2459b743c2cbdf5c266a685abe39d73930ccc4e469a9cb67cd2560b)
@@ -664,9 +664,6 @@ importers:
         version: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
 
 packages:
-
-  '@altcha/crypto@0.0.1':
-    resolution: {integrity: sha512-qZMdnoD3lAyvfSUMNtC2adRi666Pxdcw9zqfMU5qBOaJWqpN9K+eqQGWqeiKDMqL0SF+EytNG4kR/Pr/99GJ6g==}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -2640,12 +2637,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.18.0':
-    resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
@@ -3369,8 +3360,8 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
-  altcha@2.3.0:
-    resolution: {integrity: sha512-vl8I0dQvSQB7/Mx09XuWZ1+LdSP7vEda6OLbg9kUQ2ZO2LT7MzgUyLK7Iips+GAV6c0ntVcS1XWOqhEPpwbDhQ==}
+  altcha@3.0.4:
+    resolution: {integrity: sha512-TA1N0vnKR7aI/usDN2y3dPDcg9DdsDQKvRuCwApMtw3kJHjxH7NRtt+hSV8NZ01tkfHqXEJOtCYRFr8sxw8Fbg==}
 
   amator@1.1.0:
     resolution: {integrity: sha512-V5+aH8pe+Z3u/UG3L3pG3BaFQGXAyXHVQDroRwjPHdh08bcUEchAVsU1MCuJSCaU5o60wTK6KaE6te5memzgYw==}
@@ -5554,6 +5545,9 @@ packages:
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  hash-wasm@4.12.0:
+    resolution: {integrity: sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==}
 
   hasha@5.2.2:
     resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
@@ -10059,8 +10053,6 @@ packages:
 
 snapshots:
 
-  '@altcha/crypto@0.0.1': {}
-
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
@@ -12275,9 +12267,6 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.18.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     optional: true
 
@@ -13163,11 +13152,9 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  altcha@2.3.0:
+  altcha@3.0.4:
     dependencies:
-      '@altcha/crypto': 0.0.1
-    optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.18.0
+      hash-wasm: 4.12.0
 
   amator@1.1.0:
     dependencies:
@@ -15794,6 +15781,8 @@ snapshots:
       has-symbols: 1.1.0
 
   has-unicode@2.0.1: {}
+
+  hash-wasm@4.12.0: {}
 
   hasha@5.2.2:
     dependencies:

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 493
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (376, 0)  # bumped 2026-04-06 to upgrade JavaScript dependencies
+PROVISION_VERSION = (377, 0)  # bumped 2026-04-20 to upgrade altcha

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -1,3 +1,5 @@
+import "altcha";
+import type {AltchaWidgetElement} from "altcha";
 import $ from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
@@ -11,9 +13,6 @@ import {password_quality, password_warning} from "../password_quality.ts";
 import * as settings_config from "../settings_config.ts";
 
 import * as portico_modals from "./portico_modals.ts";
-
-/* global AltchaWidgetMethods, AltchaStateChangeEvent */
-import "altcha";
 
 $(() => {
     // Initialize emoji rendering for login/signup pages
@@ -383,18 +382,24 @@ $(() => {
     });
 
     // Configure altcha
-    const altcha = document.querySelector<AltchaWidgetMethods & HTMLElement>("altcha-widget");
+    const altcha = document.querySelector<AltchaWidgetElement>("altcha-widget");
     if (altcha) {
-        altcha.configure({
+        void altcha.configure({
             auto: "onload",
-            async customfetch(url: string, init?: RequestInit) {
+            async fetch(url: string | Request | URL, init?: RequestInit) {
                 return fetch(url, {...init, credentials: "include"});
             },
         });
         const $submit = $(altcha).closest("form").find("button[type=submit]");
         $submit.prop("disabled", true);
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        altcha.addEventListener("statechange", ((ev: AltchaStateChangeEvent) => {
+        altcha.addEventListener("statechange", ((ev) => {
+            assert(
+                "detail" in ev &&
+                    typeof ev.detail === "object" &&
+                    ev.detail !== null &&
+                    "state" in ev.detail,
+            );
             if (ev.detail.state === "verified") {
                 $submit.prop("disabled", false);
                 // Hide checkbox on successful verification.

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -4,7 +4,7 @@ import re
 from typing import Any
 
 import orjson
-from altcha.v1 import verify_solution
+from altcha.v2 import verify_solution
 from django import forms
 from django.conf import settings
 from django.contrib.auth import authenticate, password_validation
@@ -398,9 +398,11 @@ def validate_captcha_payload(request: HttpRequest, captcha_payload: str) -> None
         raise forms.ValidationError(_("Challenges are not enabled."))
 
     try:
-        ok, err = verify_solution(captcha_payload, settings.ALTCHA_HMAC_KEY, check_expires=True)
-        if not ok:
-            logging.warning("Invalid altcha solution: %s", err)
+        result = verify_solution(
+            captcha_payload, settings.ALTCHA_HMAC_KEY, hmac_key_secret=settings.ALTCHA_HMAC_KEY
+        )
+        if not result.verified:
+            logging.warning("Invalid altcha solution: %s", result.error)
             raise forms.ValidationError(_("Validation failed, please try again."))
     except forms.ValidationError:
         raise
@@ -409,15 +411,15 @@ def validate_captcha_payload(request: HttpRequest, captcha_payload: str) -> None
         raise forms.ValidationError(_("Validation failed, please try again."))
 
     captcha_data = orjson.loads(base64.b64decode(captcha_payload))
-    challenge = captcha_data["challenge"]
+    parameters = captcha_data["challenge"]["parameters"]
     session_challenges = [e[0] for e in request.session.get("altcha_challenges", [])]
-    if challenge not in session_challenges:
+    if parameters not in session_challenges:
         logging.warning("Expired or replayed altcha solution")
         raise forms.ValidationError(_("Validation failed, please try again."))
 
     # Remove the successful solve from the session, to prevent replay
     request.session["altcha_challenges"] = [
-        e for e in request.session.get("altcha_challenges", []) if e[0] != challenge
+        e for e in request.session.get("altcha_challenges", []) if e[0] != parameters
     ]
 
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -375,7 +375,7 @@ class AltchaWidget(forms.TextInput):
             (
                 "<altcha-widget"
                 '  name="captcha"'
-                '  challengeurl="/json/antispam_challenge"'
+                '  challenge="/json/antispam_challenge"'
                 "  hidelogo"
                 "  hidefooter"
                 "  refetchonexpire"

--- a/zerver/tests/test_realm_creation.py
+++ b/zerver/tests/test_realm_creation.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from urllib.parse import quote, quote_plus
 
 import orjson
+from altcha.v2 import VerifySolutionResult
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import override_settings
@@ -161,46 +162,80 @@ class DemoCreationTest(ZulipTestCase):
         with self.assertLogs(level="WARNING") as logs:
             result = self.submit_demo_creation_form(
                 captcha=base64.b64encode(
-                    orjson.dumps(["algorithm", "challenge", "number", "salt", "signature"])
+                    orjson.dumps(
+                        {
+                            "challenge": {
+                                "parameters": {
+                                    "algorithm": 0,
+                                    "cost": 0,
+                                    "nonce": 0,
+                                    "salt": 0,
+                                    "expiresAt": " ",
+                                }
+                            },
+                            "solution": {"counter": 0, "derivedKey": 0},
+                        }
+                    )
                 ).decode(),
             )
             self.assert_in_success_response(["Validation failed, please try again."], result)
             self.assert_length(logs.output, 1)
             self.assertIn(
-                "TypeError: list indices must be integers or slices, not str", logs.output[0]
+                "TypeError: '<' not supported between instances of 'str' and 'float'",
+                logs.output[0],
             )
 
         # If we override the validation, we get an error because it's not in the session
-        payload = base64.b64encode(orjson.dumps({"challenge": "moose"})).decode()
+        payload = base64.b64encode(orjson.dumps({"challenge": {"parameters": "moose"}})).decode()
         with (
-            patch("zerver.forms.verify_solution", return_value=(True, None)) as verify,
+            patch(
+                "zerver.forms.verify_solution",
+                return_value=VerifySolutionResult(
+                    expired=False,
+                    invalid_signature=False,
+                    invalid_solution=False,
+                    time=0.0,
+                    verified=True,
+                ),
+            ) as verify,
             self.assertLogs(level="WARNING") as logs,
         ):
             result = self.submit_demo_creation_form(captcha=payload)
             self.assert_in_success_response(["Validation failed, please try again."], result)
-            verify.assert_called_once_with(payload, "secret", check_expires=True)
+            verify.assert_called_once_with(payload, "secret", hmac_key_secret="secret")
             self.assert_length(logs.output, 1)
             self.assertIn("Expired or replayed altcha solution", logs.output[0])
 
         self.assertEqual(self.client.session.get("altcha_challenges"), None)
         result = self.client_get("/json/antispam_challenge")
         data = self.assert_json_success(result)
-        self.assertEqual(data["algorithm"], "SHA-256")
-        self.assertEqual(data["max_number"], 500000)
+        self.assertEqual(data["parameters"]["algorithm"], "PBKDF2/SHA-256")
+        self.assertEqual(data["parameters"]["cost"], 5000)
         self.assertIn("signature", data)
-        self.assertIn("challenge", data)
-        self.assertIn("salt", data)
+        self.assertIn("nonce", data["parameters"])
+        self.assertIn("salt", data["parameters"])
 
         self.assert_length(self.client.session["altcha_challenges"], 1)
-        self.assertEqual(self.client.session["altcha_challenges"][0][0], data["challenge"])
+        self.assertEqual(self.client.session["altcha_challenges"][0][0], data["parameters"])
 
         # Update the payload so the challenge matches what is in the
         # session.  The real payload would have other keys.
-        payload = base64.b64encode(orjson.dumps({"challenge": data["challenge"]})).decode()
-        with patch("zerver.forms.verify_solution", return_value=(True, None)) as verify:
+        payload = base64.b64encode(
+            orjson.dumps({"challenge": {"parameters": data["parameters"]}})
+        ).decode()
+        with patch(
+            "zerver.forms.verify_solution",
+            return_value=VerifySolutionResult(
+                expired=False,
+                invalid_signature=False,
+                invalid_solution=False,
+                time=0.0,
+                verified=True,
+            ),
+        ) as verify:
             result = self.submit_demo_creation_form(captcha=payload)
             self.assertEqual(result.status_code, 302)
-            verify.assert_called_once_with(payload, "secret", check_expires=True)
+            verify.assert_called_once_with(payload, "secret", hmac_key_secret="secret")
 
         # And the challenge has been stripped out of the session
         self.assertEqual(self.client.session["altcha_challenges"], [])
@@ -1171,50 +1206,84 @@ class RealmCreationTest(ZulipTestCase):
                 realm_subdomain=string_id,
                 realm_name=realm_name,
                 captcha=base64.b64encode(
-                    orjson.dumps(["algorithm", "challenge", "number", "salt", "signature"])
+                    orjson.dumps(
+                        {
+                            "challenge": {
+                                "parameters": {
+                                    "algorithm": 0,
+                                    "cost": 0,
+                                    "nonce": 0,
+                                    "salt": 0,
+                                    "expiresAt": " ",
+                                }
+                            },
+                            "solution": {"counter": 0, "derivedKey": 0},
+                        }
+                    )
                 ).decode(),
             )
             self.assert_in_success_response(["Validation failed, please try again."], result)
             self.assert_length(logs.output, 1)
             self.assertIn(
-                "TypeError: list indices must be integers or slices, not str", logs.output[0]
+                "TypeError: '<' not supported between instances of 'str' and 'float'",
+                logs.output[0],
             )
 
         # If we override the validation, we get an error because it's not in the session
-        payload = base64.b64encode(orjson.dumps({"challenge": "moose"})).decode()
+        payload = base64.b64encode(orjson.dumps({"challenge": {"parameters": "moose"}})).decode()
         with (
-            patch("zerver.forms.verify_solution", return_value=(True, None)) as verify,
+            patch(
+                "zerver.forms.verify_solution",
+                return_value=VerifySolutionResult(
+                    expired=False,
+                    invalid_signature=False,
+                    invalid_solution=False,
+                    time=0.0,
+                    verified=True,
+                ),
+            ) as verify,
             self.assertLogs(level="WARNING") as logs,
         ):
             result = self.submit_realm_creation_form(
                 email, realm_subdomain=string_id, realm_name=realm_name, captcha=payload
             )
             self.assert_in_success_response(["Validation failed, please try again."], result)
-            verify.assert_called_once_with(payload, "secret", check_expires=True)
+            verify.assert_called_once_with(payload, "secret", hmac_key_secret="secret")
             self.assert_length(logs.output, 1)
             self.assertIn("Expired or replayed altcha solution", logs.output[0])
 
         self.assertEqual(self.client.session.get("altcha_challenges"), None)
         result = self.client_get("/json/antispam_challenge")
         data = self.assert_json_success(result)
-        self.assertEqual(data["algorithm"], "SHA-256")
-        self.assertEqual(data["max_number"], 500000)
+        self.assertEqual(data["parameters"]["algorithm"], "PBKDF2/SHA-256")
+        self.assertEqual(data["parameters"]["cost"], 5000)
         self.assertIn("signature", data)
-        self.assertIn("challenge", data)
-        self.assertIn("salt", data)
+        self.assertIn("nonce", data["parameters"])
+        self.assertIn("salt", data["parameters"])
 
         self.assert_length(self.client.session["altcha_challenges"], 1)
-        self.assertEqual(self.client.session["altcha_challenges"][0][0], data["challenge"])
+        self.assertEqual(self.client.session["altcha_challenges"][0][0], data["parameters"])
 
         # Update the payload so the challenge matches what is in the
         # session.  The real payload would have other keys.
-        payload = base64.b64encode(orjson.dumps({"challenge": data["challenge"]})).decode()
-        with patch("zerver.forms.verify_solution", return_value=(True, None)) as verify:
+        payload = base64.b64encode(
+            orjson.dumps({"challenge": {"parameters": data["parameters"]}})
+        ).decode()
+        with patch(
+            "zerver.forms.verify_solution",
+            return_value=VerifySolutionResult(
+                expired=False,
+                invalid_signature=False,
+                invalid_solution=False,
+                time=0.0,
+                verified=True,
+            ),
+        ) as verify:
             result = self.submit_realm_creation_form(
                 email, realm_subdomain=string_id, realm_name=realm_name, captcha=payload
             )
             self.assertEqual(result.status_code, 302)
-            verify.assert_called_once_with(payload, "secret", check_expires=True)
+            verify.assert_called_once_with(payload, "secret", hmac_key_secret="secret")
 
         # And the challenge has been stripped out of the session
         self.assertEqual(self.client.session["altcha_challenges"], [])

--- a/zerver/views/antispam.py
+++ b/zerver/views/antispam.py
@@ -1,7 +1,8 @@
 import logging
+import secrets
 from datetime import timedelta
 
-from altcha.v1 import ChallengeOptions, create_challenge
+from altcha.v2 import create_challenge
 from django.conf import settings
 from django.http import HttpRequest, HttpResponseBase
 from django.utils.timezone import now as timezone_now
@@ -32,11 +33,12 @@ def get_challenge(
     expires = now + timedelta(minutes=1)
     try:
         challenge = create_challenge(
-            ChallengeOptions(
-                hmac_key=settings.ALTCHA_HMAC_KEY,
-                max_number=500000,
-                expires=expires,
-            )
+            algorithm="PBKDF2/SHA-256",
+            cost=5000,
+            counter=secrets.randbelow(20000),
+            hmac_secret=settings.ALTCHA_HMAC_KEY,
+            hmac_key_secret=settings.ALTCHA_HMAC_KEY,
+            expires_at=expires,
         )
         session_challenges = request.session.get("altcha_challenges", [])
         # We prune out expired challenges not for correctness (the
@@ -45,9 +47,9 @@ def get_challenge(
         session_challenges = [(c, e) for (c, e) in session_challenges if e > now.timestamp()]
         request.session["altcha_challenges"] = [
             *session_challenges,
-            (challenge.challenge, expires.timestamp()),
+            (challenge.parameters.to_dict(), expires.timestamp()),
         ]
-        return json_success(request, data=challenge.__dict__)
+        return json_success(request, data=challenge.to_dict())
     except Exception as e:  # nocoverage
         logging.exception(e)
         raise JsonableError(_("Failed to generate challenge"))


### PR DESCRIPTION
This is functional but ugly, as all our CSS customizations and cancellations of conflicting Bootstrap and portico CSS rules have been invalidated. We need to express these in a maintainable way.