### PR TITLE
[ai] portico: Show action button outline only on keyboard focus.

### DIFF
--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -446,8 +446,11 @@ html {
             clip-path: inset(1px round 4px);
         }
 
-        &:focus {
+        &:focus-visible {
             outline: 3px solid hsl(213deg 81% 79%);
+            /* Override the base clip-path so the focus outline isn't
+               trimmed to a 1px square around the rounded button. */
+            clip-path: none;
         }
 
         &:disabled {


### PR DESCRIPTION
Fixes: a persistent focus outline on portico action buttons after mouse clicks, and a separate bug where the outline on `button.login-social-button` (and other `.new-style button` instances) was clipped to 1px per side with squared-off corners.


| before | after |
| --- | --- |
| <img width="652" height="202" alt="image" src="https://github.com/user-attachments/assets/65ec7796-1df2-47d7-9299-0a8eb768e247" /> | <img width="616" height="155" alt="image" src="https://github.com/user-attachments/assets/c3c925d8-dcdb-4d3d-aafc-90949df00238" /> |

---

Asked claude to make the changes that I wanted and open a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)