### PR TITLE
[ai] navigate: Bound arrow-key motion when navigating around long messages.

### DIFF
--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -173,6 +173,54 @@ export function set_message_position(
     scrollTop(new_scroll_top);
 }
 
+export function simulated_recenter_scroll_delta(
+    $message: JQuery,
+    viewport_info: MessageViewportInfo,
+): number {
+    // Returns the scroll delta (positive = down, negative = up) that
+    // recenter_view would apply if select_id were called now with
+    // {then_scroll: true, from_scroll: true} and force_center=false.
+    // Returns 0 when recenter_view would short-circuit or when no
+    // scroll is needed. The caller must have already updated
+    // last_movement_direction to match the navigation direction.
+    //
+    // Used by navigate.ts to substitute page_up / page_down when the
+    // simulated select-and-recenter would jump too far in one keypress.
+    const message_top = $message.get_offset_to_window().top;
+    const message_height = $message.outerHeight(true) ?? 0;
+    const message_bottom = message_top + message_height;
+
+    const is_above = message_top < viewport_info.visible_top;
+    const is_below = message_bottom > viewport_info.visible_bottom;
+
+    // Mirror recenter_view's from_scroll short-circuit.
+    if (is_above && last_movement_direction >= 0) {
+        return 0;
+    }
+    if (is_below && last_movement_direction <= 0) {
+        return 0;
+    }
+
+    let how_far_down_in_visible_page;
+    if (is_above) {
+        how_far_down_in_visible_page = viewport_info.visible_height * (1 / 2);
+    } else if (is_below) {
+        how_far_down_in_visible_page = viewport_info.visible_height * (1 / 7);
+    } else {
+        return 0;
+    }
+
+    // Mirror set_message_position's tall-message clamp.
+    if (how_far_down_in_visible_page + message_height > viewport_info.visible_height) {
+        how_far_down_in_visible_page = viewport_info.visible_height - message_height;
+        if (how_far_down_in_visible_page < 0) {
+            how_far_down_in_visible_page = 0;
+        }
+    }
+
+    return message_top - viewport_info.visible_top - how_far_down_in_visible_page;
+}
+
 function in_viewport_or_tall(
     rect: DOMRect,
     top_of_feed: number,

--- a/web/src/navigate.ts
+++ b/web/src/navigate.ts
@@ -45,13 +45,23 @@ export function up(): void {
 
     const $prev_message = message_lists.current.get_row(prev_msg_id);
     assert($prev_message.length > 0);
-    const prev_message_props = $prev_message.get_offset_to_window();
 
-    if (
-        is_long_message(prev_message_props.height) &&
-        prev_message_props.top < viewport_info.visible_top
-    ) {
-        page_up();
+    // Predict what the select-and-recenter scroll would do. If it
+    // would scroll upward by more than page_up's bounded amount
+    // (typically because the prev message is tall and recenter clamps
+    // its top to the viewport top, skipping past content the user
+    // wanted to read), move the selection to the prev message but
+    // skip the recenter scroll. That keeps the top of the previously
+    // selected message in view so the user can confirm they didn't
+    // miss anything, and subsequent up arrows fall into the
+    // "selected long message extends above viewport" branch above
+    // and page up through the prev message one screen at a time.
+    const recenter_delta = message_viewport.simulated_recenter_scroll_delta(
+        $prev_message,
+        viewport_info,
+    );
+    if (recenter_delta < -amount_to_paginate()) {
+        message_lists.current.select_id(prev_msg_id, {then_scroll: false});
         return;
     }
 
@@ -63,8 +73,8 @@ export function down(with_centering = false): void {
     message_viewport.set_last_movement_direction(1);
 
     const $selected_message = message_lists.current.selected_row();
+    const viewport_info = message_viewport.message_viewport_info();
     if ($selected_message.length > 0) {
-        const viewport_info = message_viewport.message_viewport_info();
         const message_props = $selected_message.get_offset_to_window();
         // We scroll down to show the hidden bottom of long messages.
         if (
@@ -95,6 +105,25 @@ export function down(with_centering = false): void {
     if (msg_id === undefined) {
         return;
     }
+
+    const $next_message = message_lists.current.get_row(msg_id);
+    assert($next_message.length > 0);
+
+    // See the corresponding block in up(): if select-and-recenter
+    // would scroll downward by more than page_down's bounded amount,
+    // move the selection without scrolling so the bottom of the
+    // previously selected message stays in view. Subsequent down
+    // arrows then fall into the "selected long message extends
+    // below viewport" branch above and page down one screen at a time.
+    const recenter_delta = message_viewport.simulated_recenter_scroll_delta(
+        $next_message,
+        viewport_info,
+    );
+    if (recenter_delta > amount_to_paginate()) {
+        message_lists.current.select_id(msg_id, {then_scroll: false});
+        return;
+    }
+
     go_to_row(msg_id);
 }
 


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Arrow.20up.20navigation.20on.20long.20messages/with/2327785

## Summary

- Replace the height-based heuristic in `navigate.up` / `navigate.down` for falling back to `page_up` / `page_down` with a simulation of the actual `recenter_view` + `set_message_position` scroll. When the simulated scroll would exceed `amount_to_paginate()` in the navigation direction, page instead of selecting — keeping motion bounded to roughly one screen per arrow press, including for tall previous messages where the recenter clamp would otherwise jump past content the user wanted to read.
- Fill in the previously-missing symmetric next-message check in `down()`, using the same simulation criterion.


## Testing

Arrow up to navigate to the long message.

### Before: 
<img width="800" height="1262" alt="before" src="https://github.com/user-attachments/assets/4da6ebfe-8c43-4268-9b93-81f1be64b4cb" /> 

### After:
<img width="800" height="1287" alt="after" src="https://github.com/user-attachments/assets/b01552f9-5ce3-4064-9b06-2b0b8bc1b42c" />


----

Asked claude to simulate the behaviour of `keep_pointer_in_view` when navigating using `up` or `down` keys where there is risk of `page_up` / `page_down` scrolling the view too much.
