### PR TITLE
import: Make import fix messages' has_link and has_image.

### DIFF
--- a/zerver/data_import/microsoft_teams.py
+++ b/zerver/data_import/microsoft_teams.py
@@ -644,17 +644,6 @@ def process_messages(
         content = attachment_result.updated_content
         accumulated_batch_upload_records += attachment_result.upload_records
 
-        if attachment_result.upload_records != []:
-            # Currently process_hosted_content_attachments only supports processeing
-            # images so has_image is always true in this case.
-            has_image = True
-            has_link = True
-            has_attachments = True
-        else:
-            has_image = False
-            has_link = False
-            has_attachments = False
-
         zulip_message = build_message(
             topic_name=topic_name,
             date_sent=get_timestamp_from_message(message),
@@ -665,9 +654,10 @@ def process_messages(
             recipient_id=recipient_id,
             realm_id=realm_id,
             is_channel_message=not is_direct_message_type,
-            has_image=has_image,
-            has_link=has_link,
-            has_attachment=has_attachments,
+            # Import will correct the message's has_image and has_link attributes.
+            has_image=False,
+            has_link=False,
+            has_attachment=attachment_result.upload_records != [],
             is_direct_message_type=is_direct_message_type,
         )
         zerver_messages.append(zulip_message)

--- a/zerver/data_import/microsoft_teams.py
+++ b/zerver/data_import/microsoft_teams.py
@@ -210,8 +210,8 @@ MICROSOFT_GRAPH_API_URL = "https://graph.microsoft.com/v1.0{endpoint}"
 
 # https://learn.microsoft.com/en-us/graph/api/chatmessagehostedcontent-get
 HOSTED_CONTENT_GRAPH_API_URL_REGEX = r"https://graph\.microsoft\.com/v1\.0/teams/[^/]+/channels/[^/]+/messages/[^/]+/hostedContents/[^/]+/\$value"
-HOSTED_CONTENT_FILE_REGEX = rf"""
-            \[
+HOSTED_CONTENT_MARKDOWN_IMAGE_SYNTAX_REGEX = rf"""
+            !\[
                (?P<file_name>[^\]]+)
             \]\(
                (?P<api_url>{HOSTED_CONTENT_GRAPH_API_URL_REGEX})
@@ -554,7 +554,7 @@ def process_hosted_content_attachments(
         return AttachmentConversionResult(updated_content=content, upload_records=upload_records)
     else:
         updated_content = regex.sub(
-            HOSTED_CONTENT_FILE_REGEX,
+            HOSTED_CONTENT_MARKDOWN_IMAGE_SYNTAX_REGEX,
             export_file_and_get_zulip_url,
             content,
             flags=re.VERBOSE,

--- a/zerver/data_import/microsoft_teams.py
+++ b/zerver/data_import/microsoft_teams.py
@@ -38,7 +38,7 @@ from zerver.data_import.import_util import (
 )
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE, do_common_export_processes
-from zerver.lib.markdown import get_markdown_link_for_url
+from zerver.lib.markdown import get_markdown_image_for_url
 from zerver.lib.mime_types import bare_content_type
 from zerver.lib.parallel import run_parallel_queue
 from zerver.lib.partial import partial
@@ -546,7 +546,7 @@ def process_hosted_content_attachments(
         )
         # Use inline thumbnail here since MS Teams only supports customizing the hosted
         # content image's alt tag.
-        return get_markdown_link_for_url(file_name, attachment_data.url, inline_thumbnail=True)
+        return get_markdown_image_for_url(file_name, attachment_data.url)
 
     if is_direct_message_type:
         # TODO: hosted content URL for private chats have a different format, we

--- a/zerver/data_import/microsoft_teams.py
+++ b/zerver/data_import/microsoft_teams.py
@@ -7,6 +7,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from email.headerregistry import Address
+from multiprocessing import Manager
+from multiprocessing.managers import ListProxy
 from typing import Any, Literal, TypeAlias
 from urllib.parse import SplitResult
 
@@ -438,7 +440,7 @@ def is_microsoft_teams_event_message(message: MicrosoftTeamsFieldsT) -> bool:
 
 
 def download_and_export_microsoft_teams_upload_file(
-    attachment_records: list[AttachmentRecordData],
+    attachment_records: ListProxy | list[AttachmentRecordData],  # type: ignore[type-arg] # ListProxy is not subscriptable
     output_dir: str,
     args: ExportMessageAttachmentParameter,
 ) -> None:
@@ -472,7 +474,8 @@ def download_and_export_microsoft_teams_upload_file(
             content_type=bare_content_type(raw_content_type),
             create_time=os.path.getmtime(file_output_path),
             file_name=os.path.basename(file_output_path),
-            id=NEXT_ID("attachment"),
+            # IDs will be assigned later after all uploads have been downloaded.
+            id=0,
             is_realm_public=True,
             messages=[args.message_id],
             owner=args.sender_id,
@@ -743,7 +746,21 @@ def convert_messages(
                 membership_type=team_channel["MembershipType"],
                 team_id=team_id,
             )
-    total_attachment_records: list[AttachmentRecordData] = []
+
+    # Attachment record data is only fully known after the file is
+    # downloaded, so records must be built inside the download
+    # workers. When processes > 1, workers run in separate processes
+    # and can't share memory with the parent, so we use a
+    # multiprocessing-shared list to gather their results.
+    #
+    # A nicer approach worth considering in the future would be to
+    # have run_parallel_queue return futures that the parent can
+    # wait on and collect results from, avoiding this shared-state
+    # coordination entirely.
+    total_attachment_records: list[AttachmentRecordData] | ListProxy = (  # type: ignore[type-arg] # ListProxy is not subscriptable
+        Manager().list() if processes > 1 else []
+    )
+
     total_accumulated_upload_records: list[UploadRecordData] = []
     with run_parallel_queue(
         partial(
@@ -778,7 +795,15 @@ def convert_messages(
                 f"/messages-{dump_file_id:06}.json",
             )
             dump_file_id += 1
-    return (total_accumulated_upload_records, total_attachment_records)
+
+    def fix_attachment_id(attachment: AttachmentRecordData) -> AttachmentRecordData:
+        attachment.id = NEXT_ID("attachment")
+        return attachment
+
+    return (
+        total_accumulated_upload_records,
+        list(map(fix_attachment_id, total_attachment_records)),
+    )
 
 
 def do_convert_directory(

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -484,7 +484,7 @@ def fix_customprofilefield(data: ImportedTableData) -> None:
             item["value"] = orjson.dumps(new_id_list).decode()
 
 
-def fix_message_rendered_content(
+def fix_message_content_attributes(
     realm: Realm,
     sender_map: dict[int, Record],
     messages: list[Record],
@@ -493,6 +493,8 @@ def fix_message_rendered_content(
 ) -> None:
     """
     This function sets the rendered_content of the messages we're importing.
+    For messages imported from a third-party export, it also corrects the
+    has_link and has_image attributes.
     """
     for message in messages:
         if content_key not in message:
@@ -573,13 +575,16 @@ def fix_message_rendered_content(
             realm_alert_words_automaton = None
 
             # This also enqueues thumbnailing for images that are referenced
-            rendered_content = markdown_convert(
+            rendering_result = markdown_convert(
                 content=content,
                 realm_alert_words_automaton=realm_alert_words_automaton,
                 message_realm=realm,
                 sent_by_bot=sent_by_bot,
                 translate_emoticons=translate_emoticons,
-            ).rendered_content
+            )
+            rendered_content = rendering_result.rendered_content
+            message["has_image"] = rendering_result.has_image
+            message["has_link"] = rendering_result.has_link
 
             message[rendered_content_key] = rendered_content
             if "scheduled_timestamp" not in message:
@@ -610,7 +615,7 @@ def fix_message_edit_history(
         for edit_history_message_dict in edit_history:
             edit_history_message_dict["user_id"] = user_id_map[edit_history_message_dict["user_id"]]
 
-        fix_message_rendered_content(
+        fix_message_content_attributes(
             realm,
             sender_map,
             messages=edit_history,
@@ -1982,7 +1987,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
 
         fix_upload_links(data, "zerver_scheduledmessage")
 
-        fix_message_rendered_content(
+        fix_message_content_attributes(
             realm=realm,
             sender_map=sender_map,
             messages=data["zerver_scheduledmessage"],
@@ -2321,7 +2326,7 @@ def _process_message_file(
     for row in data["zerver_usermessage"]:
         assert row["message"] in message_id_map
 
-    fix_message_rendered_content(
+    fix_message_content_attributes(
         realm=realm,
         sender_map=sender_map,
         messages=data["zerver_message"],

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2836,12 +2836,13 @@ def render_message_markdown(
     return rendering_result
 
 
-def get_markdown_link_for_url(filename: str, url: str, inline_thumbnail: bool = False) -> str:
+def get_markdown_link_for_url(filename: str, url: str) -> str:
     # Our markdown has no escaping, so we cannot link any
     # text containing brackets; strip them from the
     # filename we're linking.
     filename = re.sub(r"\[|\]", "", filename)
-    markdown_link = f"[{filename}]({url})"
-    if inline_thumbnail:
-        markdown_link = "!" + markdown_link
-    return markdown_link
+    return f"[{filename}]({url})"
+
+
+def get_markdown_image_for_url(filename: str, url: str) -> str:
+    return f"!{get_markdown_link_for_url(filename, url)}"

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -126,6 +126,8 @@ class MessageRenderingResult:
     user_ids_with_alert_words: set[int]
     potential_attachment_path_ids: list[str]
     thumbnail_spinners: set[str]
+    has_image: bool
+    has_link: bool
 
 
 @dataclass
@@ -638,8 +640,8 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         desc = desc if desc is not None else ""
 
         # Update message.has_image attribute.
-        if "message_inline_image" in class_attr and self.zmd.zulip_message:
-            self.zmd.zulip_message.has_image = True
+        if "message_inline_image" in class_attr:
+            self.zmd.zulip_rendering_result.has_image = True
 
         if insertion_index is not None:
             div = Element("div")
@@ -1099,8 +1101,8 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         }
 
         # Update message.has_link attribute.
-        if len(found_urls) > 0 and self.zmd.zulip_message:
-            self.zmd.zulip_message.has_link = True
+        if len(found_urls) > 0:
+            self.zmd.zulip_rendering_result.has_link = True
 
         if self.zmd.zulip_message:
             for url in unique_urls:
@@ -2190,8 +2192,7 @@ class ImageInlineProcessor(markdown.inlinepatterns.ImageInlineProcessor):
             )
 
         # Update message.has_image attribute.
-        if self.zmd.zulip_message:
-            self.zmd.zulip_message.has_image = True
+        self.zmd.zulip_rendering_result.has_image = True
 
         return img
 
@@ -2639,15 +2640,9 @@ def do_convert(
         user_ids_with_alert_words=set(),
         potential_attachment_path_ids=[],
         thumbnail_spinners=set(),
+        has_image=False,
+        has_link=False,
     )
-
-    # Set has_image and has_link attributes on message to False before
-    # converting to Markdown each time a message's content is processed.
-    # This way if a message's content is edited these attributes are
-    # checked and set to True when the updated content is processed.
-    if message is not None:
-        message.has_image = False
-        message.has_link = False
 
     md_engine.zulip_message = message
     md_engine.zulip_rendering_result = rendering_result
@@ -2721,6 +2716,12 @@ def do_convert(
             rendering_result.thumbnail_spinners = thumbnail_spinners
             if content_with_thumbnails is not None:
                 rendering_result.rendered_content = content_with_thumbnails
+
+        # Update the has_link and has_image on message based on the rendering result.
+        # This way if a message's content is edited these attributes are still accurate.
+        if message is not None:
+            message.has_image = rendering_result.has_image
+            message.has_link = rendering_result.has_link
 
         # Throw an exception if the content is huge; this protects the
         # rest of the codebase from any bugs where we end up rendering

--- a/zerver/tests/test_microsoft_teams_importer.py
+++ b/zerver/tests/test_microsoft_teams_importer.py
@@ -755,16 +755,16 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
             ),
             # Unprocessed converted html
             MessageFixture(
-                content="Normal text and an [image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/aWQ9eF8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZC92aWV3cy9pbWdv/$value)",
+                content="Normal text and an ![image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/aWQ9eF8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZC92aWV3cy9pbWdv/$value)",
                 hosted_content_count=1,
                 is_direct_message_type=False,
                 test_name="text and an image 2",
             ),
             MessageFixture(
                 content=(
-                    "First [image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/aWQ9eF8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZC92aWV3cy9pbWdv/$value)"
-                    "Second [image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/ABC/$value)"
-                    "Third [image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/DEF/$value)"
+                    "First ![image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/aWQ9eF8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZCx0eXBlPTEsdXJsPWh0dHBzOi8vdXMtYXBpLmFzbS5za3lwZS5jb20vdjEvb2JqZWN0cy8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZC92aWV3cy9pbWdv/$value)"
+                    "Second ![image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/ABC/$value)"
+                    "Third ![image](https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/DEF/$value)"
                 ),
                 hosted_content_count=3,
                 is_direct_message_type=False,
@@ -806,15 +806,15 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                 test_name="text only",
             ),
             MessageFixture(
-                content="MS Sharepoint attachment URL [image](https://zulipchat.sharepoint.com/sites/Community/Shared Documents/General/wp12245700.jpg)",
+                content="MS Sharepoint attachment URL ![image](https://zulipchat.sharepoint.com/sites/Community/Shared Documents/General/wp12245700.jpg)",
                 hosted_content_count=0,
                 is_direct_message_type=False,
                 test_name="text and other URL",
             ),
             MessageFixture(
                 content=(
-                    "List all hosted content [invalid](https://graph.microsoft.com/v1.0/teams/FOO/channels/BAZ/hostedContents)"
-                    "Get a hosted content [valid](https://graph.microsoft.com/v1.0/teams/FOO/channels/BAZ/messages/BAR/hostedContents/QUX/$value)"
+                    "List all hosted content ![invalid](https://graph.microsoft.com/v1.0/teams/FOO/channels/BAZ/hostedContents)"
+                    "Get a hosted content ![valid](https://graph.microsoft.com/v1.0/teams/FOO/channels/BAZ/messages/BAR/hostedContents/QUX/$value)"
                 ),
                 hosted_content_count=1,
                 is_direct_message_type=False,
@@ -822,7 +822,7 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
             ),
             MessageFixture(
                 content=(
-                    "DM [image](https://graph.microsoft.com/v1.0/chats/{chat-id}/messages/{message-id}/hostedContents/{hosted-content-id}/$value)"
+                    "DM ![image](https://graph.microsoft.com/v1.0/chats/{chat-id}/messages/{message-id}/hostedContents/{hosted-content-id}/$value)"
                 ),
                 hosted_content_count=0,
                 is_direct_message_type=True,

--- a/zerver/tests/test_microsoft_teams_importer.py
+++ b/zerver/tests/test_microsoft_teams_importer.py
@@ -477,20 +477,19 @@ class MicrosoftTeamsImporterIntegrationTest(MicrosoftTeamsImportTestCase):
                     message_with_attachment.has_image,
                     attachment.content_type in THUMBNAIL_ACCEPT_IMAGE_TYPES,
                 )
-                self.assertTrue(message_with_attachment.has_link)
                 assert isinstance(message_with_attachment.rendered_content, str)
                 self.assertIn(
                     f"/user_uploads/{attachment.path_id}", message_with_attachment.rendered_content
                 )
                 message_ids_with_attachment.add(message_with_attachment.id)
 
-        # Make sure no weird message conversion with wrong has_attachment, has_link
+        # Make sure no weird message conversion with wrong has_attachment
         # and has_image property.
         self.assertSetEqual(
             message_ids_with_attachment,
             set(
                 Message.objects.filter(
-                    realm=test_realm, has_link=True, has_attachment=True, has_image=True
+                    realm=test_realm, has_attachment=True, has_image=True
                 ).values_list("id", flat=True)
             ),
         )


### PR DESCRIPTION
Now import fixes third-party messages' `has_link` and `has_image` when rendering their content. This also includes an assortment of follow-ups from #37264.

Fixes: https://github.com/zulip/zulip/pull/37264#discussion_r3111979463

