### PR TITLE
stripe: Move get_next_billing_cycle out of BillingSession class.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -286,6 +286,31 @@ def start_of_next_billing_cycle(plan: CustomerPlan, event_time: datetime) -> dat
     return dt
 
 
+def get_next_billing_cycle_for_plan(plan: CustomerPlan) -> datetime:
+    if plan.status in (
+        CustomerPlan.FREE_TRIAL,
+        CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL,
+        CustomerPlan.NEVER_STARTED,
+    ):
+        assert plan.next_invoice_date is not None
+        next_billing_cycle = plan.next_invoice_date
+    elif plan.status == CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END:
+        assert plan.end_date is not None
+        next_billing_cycle = plan.end_date
+    else:
+        last_ledger_renewal = (
+            LicenseLedger.objects.filter(plan=plan, is_renewal=True).order_by("-id").first()
+        )
+        assert last_ledger_renewal is not None
+        last_renewal = last_ledger_renewal.event_time
+        next_billing_cycle = start_of_next_billing_cycle(plan, last_renewal)
+
+    if plan.end_date is not None:
+        next_billing_cycle = min(next_billing_cycle, plan.end_date)
+
+    return next_billing_cycle
+
+
 def next_invoice_date(plan: CustomerPlan) -> datetime | None:
     if plan.status == CustomerPlan.ENDED:
         return None
@@ -1486,7 +1511,7 @@ class BillingSession(ABC):
             # Handles the case when the current_plan is a fixed-price plan with
             # a monthly billing schedule. We can't schedule a new plan until the
             # invoice for the 12th month is processed.
-            if current_plan.end_date != self.get_next_billing_cycle(current_plan):
+            if current_plan.end_date != get_next_billing_cycle_for_plan(current_plan):
                 raise SupportRequestError(
                     f"New plan for {self.billing_entity_display_name} cannot be scheduled until all the invoices of the current plan are processed."
                 )
@@ -2262,30 +2287,6 @@ class BillingSession(ABC):
                 },
             )
 
-    def get_next_billing_cycle(self, plan: CustomerPlan) -> datetime:
-        if plan.status in (
-            CustomerPlan.FREE_TRIAL,
-            CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL,
-            CustomerPlan.NEVER_STARTED,
-        ):
-            assert plan.next_invoice_date is not None
-            next_billing_cycle = plan.next_invoice_date
-        elif plan.status == CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END:
-            assert plan.end_date is not None
-            next_billing_cycle = plan.end_date
-        else:
-            last_ledger_renewal = (
-                LicenseLedger.objects.filter(plan=plan, is_renewal=True).order_by("-id").first()
-            )
-            assert last_ledger_renewal is not None
-            last_renewal = last_ledger_renewal.event_time
-            next_billing_cycle = start_of_next_billing_cycle(plan, last_renewal)
-
-        if plan.end_date is not None:
-            next_billing_cycle = min(next_billing_cycle, plan.end_date)
-
-        return next_billing_cycle
-
     def validate_plan_license_management(
         self, plan: CustomerPlan, renewal_license_count: int
     ) -> None:
@@ -2323,7 +2324,7 @@ class BillingSession(ABC):
             .order_by("-id")
             .first()
         )
-        next_billing_cycle = self.get_next_billing_cycle(plan)
+        next_billing_cycle = get_next_billing_cycle_for_plan(plan)
         event_in_next_billing_cycle = next_billing_cycle <= event_time
 
         if event_in_next_billing_cycle and last_ledger_entry is not None:
@@ -2553,7 +2554,7 @@ class BillingSession(ABC):
         last_ledger_entry: LicenseLedger,
     ) -> int:
         if plan.fixed_price is not None:
-            if plan.end_date == self.get_next_billing_cycle(plan):
+            if plan.end_date == get_next_billing_cycle_for_plan(plan):
                 return 0
             return get_amount_due_fixed_price_plan(plan.fixed_price, plan.billing_schedule)
         if last_ledger_entry.licenses_at_next_renewal is None:
@@ -6058,11 +6059,7 @@ def get_push_status_for_remote_request(
             message="Expiring plan few users",
         )
 
-    # TODO: Move get_next_billing_cycle to be plan.get_next_billing_cycle
-    # to avoid this somewhat evil use of a possibly non-matching billing session.
-    expected_end_timestamp = datetime_to_timestamp(
-        user_count_billing_session.get_next_billing_cycle(current_plan)
-    )
+    expected_end_timestamp = datetime_to_timestamp(get_next_billing_cycle_for_plan(current_plan))
     return PushNotificationsEnabledStatus(
         can_push=True,
         expected_end_timestamp=expected_end_timestamp,

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -55,6 +55,7 @@ from corporate.lib.stripe import (
     customer_has_last_n_invoices_open,
     downgrade_small_realms_behind_on_payments_as_needed,
     get_latest_seat_count,
+    get_next_billing_cycle_for_plan,
     get_plan_renewal_or_end_date,
     get_price_per_license,
     invoice_plans_as_needed,
@@ -6670,8 +6671,7 @@ class InvoiceTest(StripeTestCase):
         realm.refresh_from_db()
         self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
 
-        billing_session = RealmBillingSession(user=hamlet, realm=realm)
-        next_billing_cycle = billing_session.get_next_billing_cycle(plan)
+        next_billing_cycle = get_next_billing_cycle_for_plan(plan)
         plan_end_date_string = next_billing_cycle.date().isoformat()
         plan_end_date = datetime.combine(
             date.fromisoformat(plan_end_date_string), time(0, 0, 0), tzinfo=timezone.utc

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -14,6 +14,7 @@ from corporate.lib.stripe import (
     RemoteServerBillingSession,
     add_months,
     get_configured_fixed_price_plan_offer,
+    get_next_billing_cycle_for_plan,
     start_of_next_billing_cycle,
 )
 from corporate.models.customers import Customer, get_customer_by_realm
@@ -1771,7 +1772,7 @@ class TestSupportEndpoint(ZulipTestCase):
         )
 
         billing_session = RealmBillingSession(user=iago, realm=lear_realm, support_session=True)
-        next_billing_cycle = billing_session.get_next_billing_cycle(plan).date().isoformat()
+        next_billing_cycle = get_next_billing_cycle_for_plan(plan).date().isoformat()
         with time_machine.travel(datetime(2016, 1, 3, tzinfo=timezone.utc), tick=False):
             result = self.client_post(
                 "/activity/support",

--- a/zerver/tests/test_zilencer_analytics.py
+++ b/zerver/tests/test_zilencer_analytics.py
@@ -1159,7 +1159,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 return_value=BillingUserCounts(11, 0),
             ),
             mock.patch(
-                "corporate.lib.stripe.RemoteRealmBillingSession.get_next_billing_cycle",
+                "corporate.lib.stripe.get_next_billing_cycle_for_plan",
                 return_value=dummy_date,
             ) as m,
             self.assertLogs("zulip.analytics", level="INFO") as info_log,
@@ -1192,7 +1192,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
                 side_effect=MissingDataError,
             ),
             mock.patch(
-                "corporate.lib.stripe.RemoteRealmBillingSession.get_next_billing_cycle",
+                "corporate.lib.stripe.get_next_billing_cycle_for_plan",
                 return_value=dummy_date,
             ) as m,
             self.assertLogs("zulip.analytics", level="INFO") as info_log,


### PR DESCRIPTION
Moves `get_next_billing_cycle` out of the `BillingSession` class and renames it to `get_next_billing_cycle_for_plan`.

**Notes**:
- This addresses an outstanding `TODO` comment in `get_push_status_for_remote_request`.
- Because `get_next_billing_cycle` uses the `add_months` helper for getting the start of the next billing cycle for some plans, it didn't make sense to add the function to the `CustomerPlan` model. So, instead it's just a function in the billing code that takes a plan object as a parameter.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
