### PR TITLE
home_views: Bring borders, backgrounds in Inbox, Recents into concord.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1175,10 +1175,6 @@
             var(--recent-view-table-border-radius) -
                 var(--recent-view-table-border-bottom-width)
         );
-    --color-border-recent-view-row: light-dark(
-        hsl(0deg 0% 87%),
-        hsl(0deg 0% 0% / 20%)
-    );
     --color-border-recent-view-table: light-dark(
         hsl(0deg 0% 0% / 10%),
         hsl(0deg 0% 0% / 10%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1175,9 +1175,8 @@
             var(--recent-view-table-border-radius) -
                 var(--recent-view-table-border-bottom-width)
         );
-    --color-border-recent-view-table: light-dark(
-        hsl(0deg 0% 0% / 10%),
-        hsl(0deg 0% 0% / 10%)
+    --color-border-recent-view-table: var(
+        --color-border-inbox-folder-component
     );
     --color-background-recent-view-row: var(--color-background-inbox-row);
     --color-background-recent-view-row-hover: var(
@@ -2132,6 +2131,7 @@
     );
 
     /* Inbox view constants - Values from Figma design */
+    --inbox-view-folder-component-border-width: 0.5px;
     --width-inbox-search: calc(27.4375em); /* 439px / 16px em */
     --width-inbox-filters-dropdown: 10.7142em; /* 150px / 14px em */
     --color-background-inbox-no-unreads-illustration: light-dark(
@@ -2139,6 +2139,7 @@
         hsl(147deg 40% 55%)
     );
     --color-background-inbox: var(--color-background);
+    --color-border-inbox-folder-component: hsl(0deg 0% 0% / 13%);
     --color-icon-search-inbox: light-dark(hsl(0deg 0% 0%), hsl(0deg 0% 100%));
     --color-inbox-search-text: light-dark(hsl(0deg 0% 0%), hsl(0deg 0% 95%));
     --color-border-inbox-search: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2183,7 +2183,7 @@
     );
     --color-background-inbox-row-hover: light-dark(
         color-mix(in srgb, hsl(0deg 0% 0%) 5%, hsl(0deg 0% 100%)),
-        color-mix(in srgb, hsl(0deg 0% 100%) 5%, hsl(0deg 0% 14.12%))
+        color-mix(in srgb, hsl(0deg 0% 100%) 5%, hsl(0deg 0% 14%))
     );
     --color-background-button-inbox-selected: light-dark(
         hsl(0deg 0% 0% / 5%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1183,13 +1183,9 @@
         hsl(0deg 0% 0% / 10%),
         hsl(0deg 0% 0% / 10%)
     );
-    --color-background-recent-view-row: light-dark(
-        hsl(0deg 0% 100%),
-        hsl(0deg 0% 11%)
-    );
-    --color-background-recent-view-row-hover: light-dark(
-        color-mix(in srgb, hsl(0deg 0% 0%) 5%, hsl(0deg 0% 100%)),
-        color-mix(in srgb, hsl(0deg 0% 100%) 5%, hsl(0deg 0% 11%))
+    --color-background-recent-view-row: var(--color-background-inbox-row);
+    --color-background-recent-view-row-hover: var(
+        --color-background-inbox-row-hover
     );
     --color-recent-view-link-unread: light-dark(
         hsl(0deg 0% 5%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1191,12 +1191,6 @@
         color-mix(in srgb, hsl(0deg 0% 0%) 5%, hsl(0deg 0% 100%)),
         color-mix(in srgb, hsl(0deg 0% 100%) 5%, hsl(0deg 0% 11%))
     );
-    --color-background-recent-view-unread-row: var(
-        --color-background-recent-view-row
-    );
-    --color-background-recent-view-unread-row-hover: var(
-        --color-background-recent-view-row-hover
-    );
     --color-recent-view-link-unread: light-dark(
         hsl(0deg 0% 5%),
         hsl(0deg 0% 100% / 83%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1217,7 +1217,7 @@
     );
     --color-background-recent-view-table-thead-th: light-dark(
         hsl(0deg 0% 97%),
-        hsl(0deg 0% 16%)
+        hsl(0deg 0% 17%)
     );
     --color-background-recent-view-table-thead-sort-header: light-dark(
         hsl(229deg 9% 36% / 7%),

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -666,7 +666,8 @@
 
 .inbox-folder-components {
     border-radius: 5px;
-    border: 0.5px solid hsl(0deg 0% 0% / 13%);
+    border: var(--inbox-view-folder-component-border-width) solid
+        var(--color-border-inbox-folder-component);
     overflow: hidden;
 
     &:has(.inbox-row:not(.hidden_by_filters)),

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -481,24 +481,9 @@
     }
 
     .unread_topic {
-        & td {
-            background-color: var(--color-background-recent-view-unread-row);
-        }
-
         & a {
             color: var(--color-recent-view-link-unread);
             font-weight: 500;
-        }
-
-        /* Avoid annoying, confusing hover-state when scrolling on
-           touch devices like iPad that treat a tap-and-hold/swipe
-           as a hover. */
-        @media (hover: hover) and (pointer: fine) {
-            &:hover td {
-                background-color: var(
-                    --color-background-recent-view-unread-row-hover
-                );
-            }
         }
 
         .recent_topic_name {


### PR DESCRIPTION
This PR attempts to bring greater visual concord between the Inbox and Recents views:

* Borders on Recents now share the color as in Inbox (widths remain the same until we have bandwidth to confirm [the viability of an 0.5px border](https://github.com/zulip/zulip/pull/39056#issuecomment-4300298500))
* Dark-theme recents now shares the same row and hover background colors as Inbox
* Some cleanup to the CSS variables, introducing and adjusting Inbox, Recents variables where needed

[#design > consolidating inbox and recent conversations styles](https://chat.zulip.org/#narrow/channel/101-design/topic/consolidating.20inbox.20and.20recent.20conversations.20styles/with/2428268)


**Screenshots and screen captures:**

| Recents, before | Recents, after |
| --- | --- |
| <img width="1400" height="1600" alt="revised-recents-dark-before" src="https://github.com/user-attachments/assets/16106f10-3443-4074-9745-93fe83fd0556" /> | <img width="1400" height="1600" alt="revised-recents-dark-after" src="https://github.com/user-attachments/assets/ed88b76c-2f31-404f-98fc-03e74498ec17" /> |
| <img width="1400" height="1600" alt="revised-recents-light-before" src="https://github.com/user-attachments/assets/5c762908-8f34-4466-b828-023da5360763" /> | <img width="1400" height="1600" alt="revised-recents-light-after" src="https://github.com/user-attachments/assets/3a67abec-9336-4319-aca0-a7540c36a7b4" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>