### PR TITLE
video_calls: Fix an error name and a typo in the docs.

### DIFF
--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -172,7 +172,7 @@ Server as follows:
    to be your BigBlueButton Server's shared secret.
 
 2. In `/etc/zulip/settings.py`, set `BIG_BLUE_BUTTON_URL` to your
-   to be your BigBlueButton Server's API URL.
+   BigBlueButton Server's API URL.
 
 3. Restart the Zulip server with
    `/home/zulip/deployments/current/scripts/restart-server`.

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -735,7 +735,9 @@ class ConstructorGroupsVideoCallTest(ZulipTestCase):
         ]:
             with self.settings(**{setting_name: None}):
                 response = self.client_post("/json/calls/constructorgroups/create")
-                self.assert_json_error(response, "Failed to create Constructor Groups call")
+                self.assert_json_error(
+                    response, "Constructor Groups credentials have not been configured"
+                )
 
     @responses.activate
     def test_get_existing_room(self) -> None:

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -133,7 +133,7 @@ class ConstructorGroupsService:
             or (access_key := settings.CONSTRUCTOR_GROUPS_ACCESS_KEY) is None
             or (secret_key := settings.CONSTRUCTOR_GROUPS_SECRET_KEY) is None
         ):
-            raise CreateVideoCallFailedError("Constructor Groups")
+            raise VideoCallProviderNotConfiguredError("Constructor Groups")
 
         self.access_key = access_key
         self.secret_key = secret_key


### PR DESCRIPTION

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
