### PR TITLE
[ai] portico: Hide button focus outline on mouse click.

### DIFF
--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -446,7 +446,7 @@ html {
             clip-path: inset(1px round 4px);
         }
 
-        &:focus {
+        &:focus-visible {
             outline: 3px solid hsl(213deg 81% 79%);
         }
 


### PR DESCRIPTION
Works for me in manual testing to resolve [#design > button styles on logged out pages @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/button.20styles.20on.20logged.20out.20pages/near/2439521).

---
Using :focus leaves the blue focus outline visible after a button click, since clicked buttons retain focus until the user clicks elsewhere. This appeared as an extraneous blue box around the button after clicking, newly noticeable once the 0.3s outline transition was replaced with snappier clip-path effects.

Switch to :focus-visible so the outline shows only for keyboard focus, matching the pattern already used elsewhere in this file.

