### PR TITLE
[ai] sidebars: Add drop shadow to sticky section headers when scrolled.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -24,6 +24,7 @@ import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as settings_config from "./settings_config.ts";
+import * as sidebar_header_sticky_shadow from "./sidebar_header_sticky_shadow.ts";
 import {disconnect_toggle_class, observe_toggle_class} from "./sidebar_tooltip_helpers.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
@@ -1208,6 +1209,8 @@ export class BuddyList extends BuddyListConf {
         $scroll_container.on("scroll", () => {
             this.fill_screen_with_content();
         });
+
+        sidebar_header_sticky_shadow.initialize($scroll_container, ".buddy-list-subsection-header");
     }
 
     update_padding(): void {

--- a/web/src/sidebar_header_sticky_shadow.ts
+++ b/web/src/sidebar_header_sticky_shadow.ts
@@ -1,0 +1,24 @@
+import * as util from "./util.ts";
+
+// Toggles `sidebar-header-drop-shadow` on sticky headers inside a scroll
+// container while the container is scrolled and the header is pinned at
+// its sticky top. The shadow is suppressed once the header's top has been
+// pushed above the pin line by the next section arriving from below, to
+// avoid a visible border at their junction.
+
+export function initialize($scroll_container: JQuery, header_selector: string): void {
+    const scroll_container = util.the($scroll_container);
+    function update(): void {
+        const has_scrolled = scroll_container.scrollTop > 0;
+        const container_top = scroll_container.getBoundingClientRect().top;
+        for (const header of scroll_container.querySelectorAll<HTMLElement>(header_selector)) {
+            const sticky_top = Number.parseFloat(getComputedStyle(header).top) || 0;
+            const pushed_past_pin_line =
+                container_top + sticky_top - header.getBoundingClientRect().top;
+            const is_stuck = has_scrolled && pushed_past_pin_line > -1 && pushed_past_pin_line <= 2;
+            header.classList.toggle("sidebar-header-drop-shadow", is_stuck);
+        }
+    }
+    scroll_container.addEventListener("scroll", update, {passive: true});
+    update();
+}

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -31,6 +31,7 @@ import * as popovers from "./popovers.ts";
 import * as scroll_util from "./scroll_util.ts";
 import {web_channel_default_view_values} from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
+import * as sidebar_header_sticky_shadow from "./sidebar_header_sticky_shadow.ts";
 import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_list_sort from "./stream_list_sort.ts";
@@ -1628,6 +1629,11 @@ export function set_event_handlers({
             pm_list.set_temporarily_collapsed(false);
         }
     }
+
+    sidebar_header_sticky_shadow.initialize(
+        scroll_util.get_left_sidebar_scroll_container(),
+        "#direct-messages-section-header, .stream-list-subsection-header",
+    );
 
     let mark_scroll_inactive_timeout: ReturnType<typeof setTimeout> | undefined;
     // check for user scrolls on streams list for first time

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -896,6 +896,15 @@
         hsl(0deg 0% 0% / 30%),
         hsl(0deg 0% 100% / 30%)
     );
+    /* Layered drop shadow for sticky sidebar headers when scrolled content
+       passes beneath them. Dark mode overrides to full-opacity black in the
+       dark-theme block below, since shadows over a dark background need more
+       contrast to read as "something is floating above." */
+    --box-shadow-sidebar-sticky-header-drop:
+        0 1px 1px -1px hsl(0deg 0% 0% / 25%),
+        0 3px 4px -5px hsl(0deg 0% 0% / 40%),
+        0 4px 9px -10px hsl(0deg 0% 0% / 45%),
+        0 12px 12px -13px hsl(0deg 0% 0% / 30%);
     --color-sidebar-action: light-dark(
         hsl(240deg 30% 40%),
         hsl(240deg 35% 68%)
@@ -3201,6 +3210,12 @@
 
     /* Box shadow for overlays across the web app */
     --box-shadow-overlay: 0 0 30px hsl(212deg 32% 7%);
+
+    /* Shadow layers use full-opacity black on dark backgrounds so the drop
+       shadow still reads as a crisp separation. */
+    --box-shadow-sidebar-sticky-header-drop:
+        0 1px 1px -1px hsl(0deg 0% 0%), 0 3px 4px -5px hsl(0deg 0% 0%),
+        0 4px 9px -10px hsl(0deg 0% 0%), 0 12px 12px -13px hsl(0deg 0% 0%);
 
     /* Colors used across the app */
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -316,10 +316,22 @@
     position: sticky;
     top: 0;
     z-index: 3;
+    transition: box-shadow 150ms ease-out;
 
     /* The active direct messages section has a different background color */
     &:not(.active-direct-messages-section) {
         background-color: var(--color-background);
+    }
+
+    &.sidebar-header-drop-shadow {
+        box-shadow: var(--box-shadow-sidebar-sticky-header-drop);
+    }
+
+    /* Combine hover border with drop shadow since CSS box-shadow doesn't stack. */
+    &:not(.zoom-in):hover.sidebar-header-drop-shadow {
+        box-shadow:
+            inset 0 0 0 1px var(--color-shadow-sidebar-row-hover),
+            var(--box-shadow-sidebar-sticky-header-drop);
     }
 
     #toggle-direct-messages-section-icon {
@@ -502,6 +514,11 @@
        being sticky, it's 0.5px below its actual position and thus overlaps the channel
        below. This extra margin prevents that overlap. */
     margin-bottom: 1px;
+    transition: box-shadow 150ms ease-out;
+
+    &.sidebar-header-drop-shadow {
+        box-shadow: var(--box-shadow-sidebar-sticky-header-drop);
+    }
 
     .markers-and-unreads {
         display: flex;
@@ -552,6 +569,13 @@
 
         .add_stream_icon {
             visibility: visible;
+        }
+
+        /* Combine hover border with drop shadow since CSS box-shadow doesn't stack. */
+        &.sidebar-header-drop-shadow {
+            box-shadow:
+                inset 0 0 0 1px var(--color-shadow-sidebar-row-hover),
+                var(--box-shadow-sidebar-sticky-header-drop);
         }
     }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -280,6 +280,7 @@
     color: var(--color-text-default);
     border-radius: 4px;
     margin-right: var(--width-simplebar-scroll-hover);
+    transition: box-shadow 150ms ease-out;
 
     &:hover {
         background-color: var(--color-buddy-list-highlighted-user);
@@ -289,6 +290,17 @@
         .buddy-list-heading {
             opacity: var(--opacity-sidebar-heading-hover);
         }
+
+        /* Combine hover border with drop shadow since CSS box-shadow doesn't stack. */
+        &.sidebar-header-drop-shadow {
+            box-shadow:
+                inset 0 0 0 1px var(--color-shadow-sidebar-row-hover),
+                var(--box-shadow-sidebar-sticky-header-drop);
+        }
+    }
+
+    &.sidebar-header-drop-shadow {
+        box-shadow: var(--box-shadow-sidebar-sticky-header-drop);
     }
 }
 

--- a/web/tests/activity_ui.test.cjs
+++ b/web/tests/activity_ui.test.cjs
@@ -11,6 +11,7 @@ const buddy_list_presence = mock_esm("../src/buddy_list_presence");
 const scroll_util = mock_esm("../src/scroll_util");
 const pm_list = mock_esm("../src/pm_list");
 const util = mock_esm("../src/util");
+mock_esm("../src/sidebar_header_sticky_shadow", {initialize() {}});
 
 const state_data = zrequire("state_data");
 const activity_ui = zrequire("activity_ui");

--- a/web/tests/buddy_list.test.cjs
+++ b/web/tests/buddy_list.test.cjs
@@ -21,6 +21,7 @@ const $ = require("./lib/zjquery.cjs");
 const padded_widget = mock_esm("../src/padded_widget");
 const message_viewport = mock_esm("../src/message_viewport");
 const background_task = mock_esm("../src/background_task");
+mock_esm("../src/sidebar_header_sticky_shadow", {initialize() {}});
 
 const buddy_data = zrequire("buddy_data");
 const {BuddyList} = zrequire("buddy_list");

--- a/web/tests/sidebar_header_sticky_shadow.test.cjs
+++ b/web/tests/sidebar_header_sticky_shadow.test.cjs
@@ -1,0 +1,111 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const sidebar_header_sticky_shadow = zrequire("sidebar_header_sticky_shadow");
+
+function make_header(top) {
+    const classes = new Set();
+    return {
+        getBoundingClientRect: () => ({top}),
+        classList: {
+            toggle(name, on) {
+                if (on) {
+                    classes.add(name);
+                } else {
+                    classes.delete(name);
+                }
+            },
+            has: (name) => classes.has(name),
+        },
+    };
+}
+
+function make_scroll_container({scrollTop, container_top, headers}) {
+    let scroll_listener;
+    const container = {
+        scrollTop,
+        getBoundingClientRect: () => ({top: container_top}),
+        querySelectorAll: () => headers,
+        addEventListener(event, callback, options) {
+            assert.equal(event, "scroll");
+            assert.deepEqual(options, {passive: true});
+            scroll_listener = callback;
+        },
+    };
+    return {
+        $wrapper: {length: 1, 0: container},
+        get scroll_listener() {
+            return scroll_listener;
+        },
+        container,
+    };
+}
+
+run_test("install toggles shadow based on stickiness", ({override}) => {
+    override(globalThis, "getComputedStyle", () => ({top: "40px"}));
+
+    // Container has been scrolled; pin line is at container_top + sticky_top = 50.
+    // Header sitting exactly at the pin line: stuck, shadow on.
+    const stuck_header = make_header(50);
+    // Header that has been pushed above the pin line by the next section
+    // arriving from below; shadow suppressed to avoid a visible seam at
+    // the junction.
+    const pushed_out_header = make_header(45);
+    // Header still below the pin line, not yet stuck.
+    const below_pin_line_header = make_header(500);
+
+    const scroll = make_scroll_container({
+        scrollTop: 120,
+        container_top: 10,
+        headers: [stuck_header, pushed_out_header, below_pin_line_header],
+    });
+
+    sidebar_header_sticky_shadow.initialize(scroll.$wrapper, ".header");
+
+    assert.ok(stuck_header.classList.has("sidebar-header-drop-shadow"));
+    assert.ok(!pushed_out_header.classList.has("sidebar-header-drop-shadow"));
+    assert.ok(!below_pin_line_header.classList.has("sidebar-header-drop-shadow"));
+
+    // The scroll listener re-runs the update logic.
+    assert.ok(typeof scroll.scroll_listener === "function");
+    scroll.scroll_listener();
+    assert.ok(stuck_header.classList.has("sidebar-header-drop-shadow"));
+});
+
+run_test("install leaves shadow off before any scroll", ({override}) => {
+    override(globalThis, "getComputedStyle", () => ({top: "40px"}));
+
+    // Same geometry as the stuck case above (header top=50, pin line=50),
+    // but scrollTop=0. Pre-set the shadow class so we can see install()
+    // actively removes it, proving the has_scrolled guard is doing its job.
+    const header = make_header(50);
+    header.classList.toggle("sidebar-header-drop-shadow", true);
+    const scroll = make_scroll_container({
+        scrollTop: 0,
+        container_top: 10,
+        headers: [header],
+    });
+
+    sidebar_header_sticky_shadow.initialize(scroll.$wrapper, ".header");
+    assert.ok(!header.classList.has("sidebar-header-drop-shadow"));
+});
+
+run_test("install handles missing computed top", ({override}) => {
+    override(globalThis, "getComputedStyle", () => ({top: "auto"}));
+
+    // With sticky_top defaulting to 0, a header at container_top is stuck.
+    const container_top = 10;
+    const header = make_header(container_top);
+    const scroll = make_scroll_container({
+        scrollTop: 50,
+        container_top,
+        headers: [header],
+    });
+
+    sidebar_header_sticky_shadow.initialize(scroll.$wrapper, ".header");
+    assert.ok(header.classList.has("sidebar-header-drop-shadow"));
+});


### PR DESCRIPTION
When a section header in the left or right sidebar is pinned by sticky positioning with content scrolling beneath it, draw a layered drop shadow under it to reinforce that it's floating above the content. The shadow fades in/out via a 150ms box-shadow transition, and is suppressed while the next sticky header is pushing this one out from below so no visible border appears at their junction.

The `--box-shadow-sidebar-sticky-header-drop` token stacks four shadows with varying offsets and spreads for a soft, natural- looking drop; dark mode overrides to full-opacity black for adequate contrast on dark backgrounds.

Fixes #34467.

<img width="483" height="1156" alt="Kapture 2026-04-21 at 17 25 37" src="https://github.com/user-attachments/assets/1841b73f-650b-497d-9294-fbb58235dc51" />

& similar for right sidebar