### PR TITLE
docs: Fix link to only_events and exclude_events documentation.

### DIFF
--- a/templates/zerver/integrations/include/event-filtering-additional-feature.md
+++ b/templates/zerver/integrations/include/event-filtering-additional-feature.md
@@ -7,4 +7,4 @@ The {{ integration_display_name }} integration supports
 
 {% for event_type in all_event_types -%} {{- comma() -}} `{{ event_type }}` {%- endfor %}
 
-[event-filters]: https://zulip.readthedocs.io/en/latest/webhooks/incoming-webhooks-overview.html#only_events-exclude_events
+[event-filters]: https://zulip.readthedocs.io/en/latest/webhooks/incoming-webhooks-overview.html#only-events-exclude-events


### PR DESCRIPTION
When the incoming webhook URL specification was moved to the production docs, the link to the new page in the `event_filtering_additional_feature.md` include file wasn't updated to properly navigate to the section on `only_events` and `exclude_events` URL parameters.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
