### PR TITLE
api-docs: Fix having multiple curl auth line notes in examples.

### DIFF
--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -265,6 +265,19 @@ cURL example."""
         return example_value
 
 
+INSECURE_OPERATIONS = [
+    "/dev_fetch_api_key:post",
+    "/fetch_api_key:post",
+    "/jwt/fetch_api_key:post",
+    "/dev_list_users:get",
+]
+
+
+def add_curl_auth_credentials_note(endpoint: str, method: str) -> bool:
+    operation = endpoint + ":" + method.lower()
+    return operation not in INSECURE_OPERATIONS
+
+
 def generate_curl_example(
     endpoint: str,
     method: str,
@@ -276,17 +289,8 @@ def generate_curl_example(
     operation_entry = openapi_spec.openapi()["paths"][endpoint][method.lower()]
     global_security = openapi_spec.openapi()["security"]
 
-    insecure_operations = [
-        "/dev_fetch_api_key:post",
-        "/fetch_api_key:post",
-        "/jwt/fetch_api_key:post",
-        "/dev_list_users:get",
-    ]
     lines = []
-    if operation in insecure_operations:
-        lines.append("```curl")
-    else:
-        lines.append("{!curl-auth-credentials.md!}\n\n```curl")
+    lines.append("```curl")
 
     parameters = get_openapi_parameters(endpoint, method)
     operation_request_body = operation_entry.get("requestBody", None)
@@ -318,7 +322,7 @@ def generate_curl_example(
                 "Unhandled global securityScheme. Please update the code to handle this scheme."
             )
     elif operation_security == []:
-        if operation in insecure_operations:
+        if operation in INSECURE_OPERATIONS:
             authentication_required = False
         else:
             raise AssertionError(
@@ -375,6 +379,8 @@ def render_curl_example(
     kwargs: dict[str, Any] = {}
     kwargs["api_url"] = api_url
     rendered_example = []
+    if add_curl_auth_credentials_note(endpoint, method):
+        rendered_example += ["{!curl-auth-credentials.md!}\n\n"]
     for element in get_curl_include_exclude(endpoint, method):
         kwargs["include"] = None
         kwargs["exclude"] = None

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -753,7 +753,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
     def test_generate_and_render_curl_example(self) -> None:
         generated_curl_example = self.curl_example("/get_stream_id", "GET")
         expected_curl_example = [
-            "{!curl-auth-credentials.md!}\n\n```curl",
+            "```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/get_stream_id \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream=Denmark",
@@ -782,7 +782,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_without_examples
         generated_curl_example = self.curl_example("/mark_stream_as_read", "POST")
         expected_curl_example = [
-            "{!curl-auth-credentials.md!}\n\n```curl",
+            "```curl",
             "curl -sSX POST http://localhost:9991/api/v1/mark_stream_as_read \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream_id=1 \\",
@@ -809,7 +809,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             ],
         )
         expected_curl_example = [
-            "{!curl-auth-credentials.md!}\n\n```curl",
+            "```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/messages \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode anchor=43 \\",
@@ -828,7 +828,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_using_object
         generated_curl_example = self.curl_example("/endpoint", "GET")
         expected_curl_example = [
-            "{!curl-auth-credentials.md!}\n\n```curl",
+            "```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             '    --data-urlencode \'param1={"key": "value"}\'',
@@ -857,7 +857,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_using_param_in_path
         generated_curl_example = self.curl_example("/endpoint/{param1}", "GET")
         expected_curl_example = [
-            "{!curl-auth-credentials.md!}\n\n```curl",
+            "```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint/35 \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             '    --data-urlencode \'param2={"key": "value"}\'',
@@ -870,7 +870,8 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "/get_stream_id:GET", api_url="https://zulip.example.com/api"
         )
         expected_curl_example = [
-            "{!curl-auth-credentials.md!}\n\n```curl",
+            "{!curl-auth-credentials.md!}\n\n",
+            "```curl",
             "curl -sSX GET -G https://zulip.example.com/api/v1/get_stream_id \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream=Denmark",
@@ -892,7 +893,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             ],
         )
         expected_curl_example = [
-            "{!curl-auth-credentials.md!}\n\n```curl",
+            "```curl",
             "curl -sSX GET -G http://localhost:9991/api/v1/messages \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode anchor=43 \\",


### PR DESCRIPTION
For endpoints with multiple curl examples, which highlight passing various parameters, we only need to render the line about the curl authentication line.

**Notes**:
- The curl authentication note was added in #38141, and introduced the issue.

---

**Screenshots and screen captures:**

[CURRENT DOC](https://zulip.com/api/get-subscriptions)
| Current | After |
| --- | --- |
| <img width="1544" height="1252" alt="Screenshot From 2026-04-22 17-11-20" src="https://github.com/user-attachments/assets/ec42cb77-93d5-41a4-9fcb-e4872012449f" /> | <img width="1544" height="1076" alt="Screenshot From 2026-04-22 17-05-43" src="https://github.com/user-attachments/assets/535c9ad3-708b-4cde-acab-ca6a432ddc3e" />

[CURRENT DOC](https://zulip.com/api/get-subscription-status) - NO CHANGE WHEN THERE'S ONLY ONE EXAMPLE
| Current | After |
| --- | --- |
| <img width="1544" height="1030" alt="Screenshot From 2026-04-22 17-13-17" src="https://github.com/user-attachments/assets/e79b5a61-baea-4b4f-a83c-baa831663950" /> | <img width="1544" height="986" alt="Screenshot From 2026-04-22 17-06-23" src="https://github.com/user-attachments/assets/ed59be9f-3000-46d8-b89e-58e7235915bf" />

[CURRENT DOC](https://zulip.com/api/dev-list-users) - NO CHANGE IF AUTH LINE NOT PRESENT
| Current | After |
| --- | --- |
| <img width="1544" height="874" alt="Screenshot From 2026-04-22 17-12-41" src="https://github.com/user-attachments/assets/543c8b0d-9c80-4a54-812e-c790b645f1d0" /> | <img width="1544" height="876" alt="Screenshot From 2026-04-22 17-05-28" src="https://github.com/user-attachments/assets/72f70e33-7bf3-4935-89e4-0faaaa0bc21b" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
