### PR TITLE
export: Sync Subscription.is_user_active with exported UserProfile.

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1166,6 +1166,8 @@ def custom_process_subscription_in_realm_config(
         assert exportable_user_ids_from_context is None
         consented_user_ids = set()
 
+    exported_inactive_user_ids = context["exported_inactive_user_ids"]
+
     for subscription in subscriptions:
         if subscription["user_profile"] in consented_user_ids:
             yield subscription
@@ -1173,12 +1175,21 @@ def custom_process_subscription_in_realm_config(
         # We create a replacement Subscription, setting only the essential fields,
         # while allowing all the other ones to fall back to the defaults
         # defined in the model.
+        #
+        # is_user_active must match the is_active we're emitting on the
+        # user's UserProfile row; otherwise the Subscription's
+        # denormalized copy of UserProfile.is_active would contradict
+        # the exported UserProfile (e.g., when a non-consenting user is
+        # mirror-dummied to is_active=False).
         scrubbed_subscription = Subscription(
             id=subscription["id"],
             user_profile_id=subscription["user_profile"],
             recipient_id=subscription["recipient"],
             active=subscription["active"],
-            is_user_active=subscription["is_user_active"],
+            is_user_active=(
+                subscription["is_user_active"]
+                and subscription["user_profile"] not in exported_inactive_user_ids
+            ),
             # Letting the color be the default color for every stream would create a visually
             # jarring experience. Instead, we can pick colors randomly for a normal-feeling
             # experience, without leaking any information about the user's preferences.
@@ -1398,6 +1409,17 @@ def custom_fetch_user_profile(response: TableData, context: Context) -> None:
 
     response["zerver_userprofile"] = normal_rows
     response["zerver_userprofile_mirrordummy"] = dummy_rows
+
+    # Subscription.is_user_active is a denormalized copy of
+    # UserProfile.is_active.  The export can force is_active=False on a
+    # UserProfile row (mirror-dummying a non-consenting user, or
+    # replacing the delivery_email of a NOBODY-visibility user in a
+    # public export); custom_process_subscription_in_realm_config
+    # consults this set so that scrubbed Subscription rows stay in
+    # sync with the UserProfile rows we're emitting.
+    context["exported_inactive_user_ids"] = {
+        row["id"] for row in normal_rows + dummy_rows if not row["is_active"]
+    }
 
 
 def custom_fetch_user_profile_cross_realm(response: TableData, context: Context) -> None:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1430,6 +1430,12 @@ class RealmImportExportTest(ExportFile):
             # "user setting"-type attributes with default values, so the #foo color
             # will be overwritten in the process.
             self.assertNotEqual(exported_sub["color"], "#foo")
+            # is_user_active on the exported Subscription must match
+            # is_active on the exported UserProfile; hamlet (the
+            # non-consenting user) is currently active but gets
+            # mirror-dummied in a consent export, so his exported
+            # Subscription rows must report is_user_active=False.
+            self.assertFalse(exported_sub["is_user_active"])
 
         # Verify the export/scrubbing of user settings for consenting/non-consenting users.
         realm_user_default = RealmUserDefault.objects.get(realm=realm)


### PR DESCRIPTION
Subscription.is_user_active is a denormalized copy of UserProfile.is_active.  custom_fetch_user_profile can force an exported UserProfile row to is_active=False (mirror-dummying a non-consenting user in EXPORT_FULL_WITH_CONSENT, or replacing a NOBODY-visibility user's delivery_email in EXPORT_PUBLIC), but the scrubbed Subscription rows kept carrying the pre-export is_user_active value.  The result was an inconsistent pair on import: a UserProfile marked inactive with Subscription rows claiming the user is still active.

Record the set of user ids that end up exported with is_active=False and have the subscription scrubber respect it.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
