### PR TITLE
presence: Fix web client parsing of single-user presence API response.

### DIFF
--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -31,12 +31,8 @@ export const user_last_seen_response_schema = z.object({
     msg: z.optional(z.string()),
     presence: z.optional(
         z.object({
-            /* We ignore the keys other than aggregated, since they just contain
-               duplicate data. */
-            aggregated: z.object({
-                status: z.enum(["active", "idle", "offline"]),
-                timestamp: z.number(),
-            }),
+            active_timestamp: z.optional(z.number()),
+            idle_timestamp: z.optional(z.number()),
         }),
     ),
 });

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -267,11 +267,13 @@ export let fetch_presence_for_popover = (user_id: number): void => {
             const response = parsed_data.data;
 
             if (response.result === "success" && response.presence) {
-                const {aggregated} = response.presence;
-                presence.presence_info.set(user_id, {
-                    status: aggregated.status,
-                    last_active: aggregated.timestamp,
-                });
+                const raw = {
+                    ...response.presence,
+                    server_timestamp: Date.now() / 1000,
+                };
+                const user = people.get_by_user_id(user_id);
+                const status = presence.status_from_raw(raw, user);
+                presence.presence_info.set(user_id, status);
 
                 // Update the user's last seen time in the user card
                 // popover once we have their presence information, if

--- a/web/tests/presence.test.cjs
+++ b/web/tests/presence.test.cjs
@@ -370,3 +370,36 @@ test("update_info_from_event", () => {
         last_active: 1000,
     });
 });
+
+test("user_last_seen_response_schema", () => {
+    // Modern format with both timestamps — should parse successfully
+    const valid_modern = {
+        result: "success",
+        msg: "",
+        presence: {
+            active_timestamp: 1656958520,
+            idle_timestamp: 1656958530,
+        },
+    };
+    const result_modern = presence.user_last_seen_response_schema.safeParse(valid_modern);
+    assert.ok(result_modern.success);
+    assert.equal(result_modern.data.presence?.active_timestamp, 1656958520);
+    assert.equal(result_modern.data.presence?.idle_timestamp, 1656958530);
+
+    // Only active_timestamp present — should also parse successfully
+    const active_only = {
+        result: "success",
+        msg: "",
+        presence: {active_timestamp: 1656958520},
+    };
+    const result_active = presence.user_last_seen_response_schema.safeParse(active_only);
+    assert.ok(result_active.success);
+    assert.equal(result_active.data.presence?.active_timestamp, 1656958520);
+    assert.equal(result_active.data.presence?.idle_timestamp, undefined);
+
+    // Presence absent entirely (user with no presence data) — should parse successfully
+    const no_presence = {result: "success", msg: ""};
+    const result_no_presence = presence.user_last_seen_response_schema.safeParse(no_presence);
+    assert.ok(result_no_presence.success);
+    assert.equal(result_no_presence.data.presence, undefined);
+});


### PR DESCRIPTION
The `GET /users/{user_id_or_email}/presence` endpoint was updated in 4c3aa4c007ef0caa6c15f8bb9af515eda01521ec to always return the modern presence format, with `active_timestamp` and `idle_timestamp` at the top level of the `presence` object. However, the web client's `user_last_seen_response_schema` was never updated to match, itt still expected the legacy format with `aggregated.status` and `aggregated.timestamp`.

This caused a "Failed to parse presence API response" error in the user card popover for any currently active/online user. Only active users trigger a fresh presence request when their card is opened (all others are served from the client-side cache), which is why the bug was only reproducible for online users.

Fixes: Regression introduced by 4c3aa4c007ef0caa6c15f8bb9af515eda01521ec (presence: Always return modern format from single-user presence API.) The CZO Thread discussing this issue can be found [here](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Failed.20to.20parse.20presence.20API.20response/with/2441099).

**How changes were tested**:
- Updated `user_last_seen_response_schema` in `presence.ts` to validate `active_timestamp` and `idle_timestamp` in the modern format.
- Updated the success callback in `fetch_presence_for_popover` in `user_card_popover.ts` to derive presence status using `status_from_raw()`, consistent with how presence data is processed.
- Added unit tests for `user_last_seen_response_schema` in `presence.test.cjs` covering: both timestamps present, only `active_timestamp` present, and no presence data.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
