### PR TITLE
sidebar: Show full topic list for active stream in collapsed folders.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -641,7 +641,7 @@
 #streams_list .stream-list-section-container.collapsed {
     .narrow-filter:not(.stream-expanded),
     .stream-list-toggle-inactive-or-muted-channels,
-    .topic-list-item:not(.active-sub-filter),
+    .narrow-filter:not(.stream-expanded) .topic-list-item,
     &.hide-topic-bracket ul.topic-list.topic-list-has-topics::before,
     &.hide-topic-bracket ul.topic-list.topic-list-has-topics::after {
         display: none;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes the "tunnel vision" UX issue where navigating to a topic within a collapsed folder would only display that single topic in the left sidebar.

The sidebar now renders the full active topic list for the current channel even if the parent folder remains collapsed. This provides necessary context and navigation options for the user.

Fixes: #38965 
CZO thread: [#design > only one topic shown in left sidebar](https://chat.zulip.org/#narrow/channel/101-design/topic/only.20one.20topic.20shown.20in.20left.20sidebar/with/2419491)



<!-- If the PR makes UI changes, you must include screenshots.

Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html

-->



**Screenshots and screen captures:**
| Before | After |
| :--- | :--- |
| [Before](https://github.com/user-attachments/assets/876defbf-9f61-42cd-b1cb-d8a9a08e6dd9) | [After](https://github.com/user-attachments/assets/8dad9a64-7f18-46fa-8c4c-3c5c0b7a8da5) |




<details>

<summary>Self-review checklist</summary>



<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:

https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->



<!-- Once you create the PR, check off all the steps below that you have completed.

If any of these steps are not relevant or not completed, leave them unchecked.-->



- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

      (variable names, code reuse, readability, etc.).

- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).



Communicate decisions, questions, and potential concerns.



- [x] Explains differences from previous plans (e.g., issue description).

- [x] Highlights technical choices and bugs encountered.

- [x] Calls out remaining decisions and concerns.

- [x] Automated tests verify logic where appropriate.



Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).



- [x] Each commit is a coherent idea.

- [x] Commit message(s) explain reasoning and motivation for changes.



Completed manual review and testing of the following:



- [x] Visual appearance of the changes.

- [x] Responsiveness and internationalization.

- [x] Strings and tooltips.

- [x] End-to-end functionality of buttons, interactions and flows.

- [x] Corner cases, error conditions, and easily imagined bugs.

</details>