### PR TITLE
[ai] topic_list: Don't hijack Enter/arrows while filter typeahead is open.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -728,6 +728,15 @@ export function setup_topic_search_typeahead(): void {
     });
 
     $input.on("keydown", (e: JQuery.KeyDownEvent) => {
+        // While the filter typeahead is open, Enter / ArrowUp /
+        // ArrowDown belong to it; don't also drive the sidebar
+        // topic-row cursor.
+        if (
+            topic_state_typeahead?.shown &&
+            (e.key === "Enter" || e.key === "ArrowDown" || e.key === "ArrowUp")
+        ) {
+            return;
+        }
         switch (e.key) {
             case "Enter": {
                 const $current_row = topic_list_cursor.get_key();


### PR DESCRIPTION
The zoomed topic list's filter input handles Enter / ArrowUp / ArrowDown to drive the sidebar topic-row cursor. When the filter typeahead (e.g. opened by typing "is:") is also showing, those keys should belong to the typeahead menu, but the keydown handler ran unconditionally: Enter clicked the highlighted sidebar row (including "+ New topic") instead of selecting the highlighted typeahead option, and the arrow keys moved the sidebar cursor instead of the menu.

Skip the sidebar-cursor logic for these keys when
topic_state_typeahead.shown is true, letting the typeahead's own keydown handler take them. This matches how search.ts and message_edit.ts gate on the same .shown property.

Fixes bug reported here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20UI.3A.20selection.20while.20typeahead.20is.20open/with/2441549
