### PR TITLE
[ai] copy: Fix missing newlines between messages in plain-text clipboard.

### DIFF
--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -8,7 +8,7 @@ async function copy_messages(
     page: Page,
     start_message: string,
     end_message: string,
-): Promise<string[]> {
+): Promise<{html_lines: string[]; plain_text: string}> {
     return await page.evaluate(
         (start_message: string, end_message: string) => {
             function get_message_node(message: string): Element {
@@ -34,12 +34,16 @@ async function copy_messages(
             document.dispatchEvent(copy_event);
 
             const copied_html = clipboard_data.getData("text/html");
+            const plain_text = clipboard_data.getData("text/plain");
 
             // Convert the copied HTML into separate message strings
             const parser = new DOMParser();
             const doc = parser.parseFromString(copied_html, "text/html");
 
-            return [...doc.body.children].map((el) => el.textContent.trim());
+            return {
+                html_lines: [...doc.body.children].map((el) => el.textContent.trim()),
+                plain_text,
+            };
         },
         start_message,
         end_message,
@@ -47,25 +51,41 @@ async function copy_messages(
 }
 
 async function test_copying_first_message_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test C");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test C",
+        "copy paste test C",
+    );
     const expected_copied_lines: string[] = [];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
 async function test_copying_last_message_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test E", "copy paste test E");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test E",
+        "copy paste test E",
+    );
     const expected_copied_lines: string[] = [];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
 async function test_copying_first_two_messages_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test D");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test C",
+        "copy paste test D",
+    );
     const expected_copied_lines = ["Desdemona: copy paste test C", "Desdemona: copy paste test D"];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
 async function test_copying_all_messages_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test E");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test C",
+        "copy paste test E",
+    );
     const expected_copied_lines = [
         "Desdemona: copy paste test C",
         "Desdemona: copy paste test D",
@@ -75,7 +95,11 @@ async function test_copying_all_messages_from_topic(page: Page): Promise<void> {
 }
 
 async function test_copying_last_from_prev_first_from_next(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test C");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test B",
+        "copy paste test C",
+    );
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
         "Desdemona: copy paste test B",
@@ -86,7 +110,11 @@ async function test_copying_last_from_prev_first_from_next(page: Page): Promise<
 }
 
 async function test_copying_last_from_prev_all_from_next(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test E");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test B",
+        "copy paste test E",
+    );
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
         "Desdemona: copy paste test B",
@@ -99,7 +127,11 @@ async function test_copying_last_from_prev_all_from_next(page: Page): Promise<vo
 }
 
 async function test_copying_all_from_prev_first_from_next(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test A", "copy paste test C");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test A",
+        "copy paste test C",
+    );
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
         "Desdemona: copy paste test A",
@@ -111,7 +143,11 @@ async function test_copying_all_from_prev_first_from_next(page: Page): Promise<v
 }
 
 async function test_copying_messages_from_several_topics(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test F");
+    const {html_lines: actual_copied_lines} = await copy_messages(
+        page,
+        "copy paste test B",
+        "copy paste test F",
+    );
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 Today",
         "Desdemona: copy paste test B",
@@ -123,6 +159,15 @@ async function test_copying_messages_from_several_topics(page: Page): Promise<vo
         "Desdemona: copy paste test F",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
+}
+
+async function test_plain_text_newlines_between_messages(page: Page): Promise<void> {
+    // Verify that plain-text copies of multiple messages are separated by
+    // newlines rather than being squashed onto one line (#39021).
+    const {plain_text} = await copy_messages(page, "copy paste test C", "copy paste test E");
+    const expected =
+        "Desdemona: copy paste test C\nDesdemona: copy paste test D\nDesdemona: copy paste test E";
+    assert.strictEqual(plain_text, expected);
 }
 
 async function copy_paste_test(page: Page): Promise<void> {
@@ -163,6 +208,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_last_from_prev_all_from_next(page);
     await test_copying_all_from_prev_first_from_next(page);
     await test_copying_messages_from_several_topics(page);
+    await test_plain_text_newlines_between_messages(page);
 }
 
 await common.run_test(copy_paste_test);

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -232,6 +232,56 @@ function maybe_update_range_for_code_blocks(range: Range, ev: ClipboardEvent): b
     return false;
 }
 
+function get_plain_text_with_newlines($elem: JQuery): string {
+    // jQuery's .text() concatenates all text nodes without any separator,
+    // causing block-level elements like <p> to produce no newlines in the
+    // plain-text clipboard output.  This function traverses the DOM tree
+    // and appends a newline after each block-level element so that pasting
+    // into a plain-text editor preserves message separation.
+    const block_tags = new Set([
+        "BLOCKQUOTE",
+        "DIV",
+        "H1",
+        "H2",
+        "H3",
+        "H4",
+        "H5",
+        "H6",
+        "LI",
+        "OL",
+        "P",
+        "PRE",
+        "UL",
+    ]);
+
+    function process_node(node: Node): string {
+        if (node.nodeType === Node.TEXT_NODE) {
+            return node.textContent ?? "";
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return "";
+        }
+        assert(node instanceof Element);
+        if (node.tagName === "BR") {
+            return "\n";
+        }
+        let child_text = "";
+        for (const child of node.childNodes) {
+            child_text += process_node(child);
+        }
+        if (block_tags.has(node.tagName)) {
+            return child_text + "\n";
+        }
+        return child_text;
+    }
+
+    let result = "";
+    for (const child of $elem[0]!.childNodes) {
+        result += process_node(child);
+    }
+    return result.replaceAll(/\n{3,}/g, "\n\n").trim();
+}
+
 export function copy_handler(ev: ClipboardEvent): boolean {
     // This is the main handler for copying message content via
     // `Ctrl+C` in Zulip (note that this is totally independent of the
@@ -318,7 +368,7 @@ export function copy_handler(ev: ClipboardEvent): boolean {
     construct_copy_div($div, start_id, end_id);
 
     const html_content = $div.html().trim();
-    const plain_text = $div.text().trim();
+    const plain_text = get_plain_text_with_newlines($div);
     ev.clipboardData?.setData("text/html", html_content);
     ev.clipboardData?.setData("text/plain", plain_text);
 


### PR DESCRIPTION
Fixes: #39021

When copying multiple messages from the feed and pasting into a
plain-text editor (e.g., a terminal, Notepad, or VS Code in plain
mode), all messages were squashed onto a single line with no
separation between them.

**Root cause:** `copy_handler` built the `text/plain` clipboard
entry using jQuery's `.text()`, which concatenates every text node
in the DOM without inserting any separator for block-level elements
like `<p>` or `<div>`. The `text/html` entry was unaffected because
browsers render block elements with their natural spacing.

**Fix:** Replace `.text()` with a new `get_plain_text_with_newlines()`
helper that walks the DOM tree and appends `\n` after each block-level
element (`P`, `DIV`, `LI`, `UL`, `OL`, `H1`–`H6`, `BLOCKQUOTE`,
`PRE`). `<BR>` elements are mapped to `\n` directly. Three or more
consecutive newlines are collapsed to two, so the output is clean
regardless of message content complexity.

**How changes were tested:**

- [x] `./tools/lint web/src/copy_messages.ts web/e2e-tests/copy-messages.test.ts` — no errors.
- [x] `./tools/test-js-with-node` — all tests passed.
- [x] Extended `copy-messages.test.ts`: `copy_messages()` now also
      returns `text/plain` content; added
      `test_plain_text_newlines_between_messages` which asserts that
      copying three messages from the same topic produces the expected
      newline-separated string.
- [ ] Full e2e test (`./tools/test-puppeteer`) requires a running dev
      server; to be verified by CI.

**Screenshots and screen captures:**
<img width="1610" height="1339" alt="image" src="https://github.com/user-attachments/assets/c5cef235-bee4-43d2-a9de-830ad98a55cc" />

_(UI behavior — no visual change to the message feed. The fix only
affects clipboard contents when pasting into a plain-text target.)_

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [ ] Visual appearance of the changes. _(N/A — no UI change)_
- [ ] Responsiveness and internationalization. _(N/A)_
- [ ] Strings and tooltips. _(N/A)_
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
