### PR TITLE
run-dev: Add -H short option for --help-center-dev-server.

### DIFF
--- a/tools/run-dev
+++ b/tools/run-dev
@@ -72,6 +72,7 @@ parser.add_argument(
     help="Host existing static build of help center with search",
 )
 parser.add_argument(
+    "-H",
     "--help-center-dev-server",
     action="store_true",
     help="Run dev server for help center alongside the Zulip app. Hot reload will work for this mode, but search will not work in the generated website.",


### PR DESCRIPTION
Added `-H` as a shortcut for --help-center-dev-server.

Fixes CZO: [#documentation > --help-center-dev-server shortcut?](https://chat.zulip.org/#narrow/channel/19-documentation/topic/--help-center-dev-server.20shortcut.3F/with/2441648)

## Screenshot:
<img width="1491" height="630" alt="image" src="https://github.com/user-attachments/assets/e98e4bc0-2c49-4541-acba-3670a38eed31" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x ] Corner cases, error conditions, and easily imagined bugs.
</details>
