### PR TITLE
[ai] outgoing_webhook: Serialize widget_content to JSON string.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -101,7 +101,10 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
 
         if "content" in response_json:
             content = str(response_json["content"])
-            widget_content = response_json.get("widget_content")
+            widget_content_raw = response_json.get("widget_content")
+            widget_content = (
+                json.dumps(widget_content_raw) if widget_content_raw is not None else None
+            )
             return OutgoingWebhookResult(content=content, widget_content=widget_content)
 
         return None

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -139,13 +139,15 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
 
         response = dict(
             content="test_content",
-            widget_content="test_widget_content",
+            widget_content={"widget_type": "zform", "extra_data": {}},
             red_herring="whatever",
         )
         success_response = self.handler.process_success(response)
         self.assertEqual(
             success_response,
-            OutgoingWebhookResult(content="test_content", widget_content="test_widget_content"),
+            OutgoingWebhookResult(
+                content="test_content", widget_content='{"widget_type": "zform", "extra_data": {}}'
+            ),
         )
 
         response = {}

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -19,7 +19,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.topic import TOPIC_NAME
 from zerver.lib.url_encoding import message_link_url
 from zerver.lib.users import add_service
-from zerver.models import Recipient, Service, UserProfile
+from zerver.models import Recipient, Service, SubMessage, UserProfile
 from zerver.models.realms import get_realm
 from zerver.models.recipients import get_or_create_direct_message_group
 from zerver.models.streams import get_stream
@@ -319,9 +319,8 @@ I'm a generic exception :(
         mock_event = self.mock_event(bot_user)
         service_handler = GenericOutgoingWebhookService("token", bot_user, "service")
 
-        # The "widget_content" key is required to be a string which is
-        # itself JSON-encoded; passing arbitrary text data in it will
-        # cause the hook to fail.
+        # The "widget_content" value must be a valid widget_content
+        # dict; passing a plain string will cause validation to fail.
         response = {"content": "whatever", "widget_content": "test"}
         expect_logging_info = self.assertLogs(level="INFO")
         expect_fail = mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
@@ -338,7 +337,7 @@ I'm a generic exception :(
                 bot_owner_notification.content,
                 """[A message](http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
-> Widgets: API programmer sent invalid JSON content\nThe response contains the following payload:\n```\n'{"content": "whatever", "widget_content": "test"}'\n```""",
+> Widgets: widget_content is not a dict\nThe response contains the following payload:\n```\n'{"content": "whatever", "widget_content": "test"}'\n```""",
             )
         assert bot_user.bot_owner is not None
         self.assertEqual(
@@ -584,6 +583,44 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
         self.assertEqual(last_message.sender_id, bot.id)
         self.assertEqual(last_message.topic_name(), "bar")
         self.assert_message_stream_name(last_message, "Denmark")
+
+    @responses.activate
+    def test_stream_message_to_outgoing_webhook_bot_with_widget(self) -> None:
+        bot_owner = self.example_user("othello")
+        bot = self.create_outgoing_bot(bot_owner)
+
+        widget_content = {
+            "widget_type": "zform",
+            "extra_data": {
+                "type": "choices",
+                "heading": "Pick a color",
+                "choices": [
+                    {"type": "choice", "short_name": "r", "long_name": "Red", "reply": "red"},
+                    {"type": "choice", "short_name": "b", "long_name": "Blue", "reply": "blue"},
+                ],
+            },
+        }
+        responses.add(
+            responses.POST,
+            "https://bot.example.com/",
+            json={"content": "Choose a color", "widget_content": widget_content},
+        )
+
+        with self.assertLogs(level="INFO") as logs:
+            self.send_stream_message(
+                bot_owner, "Denmark", content=f"@**{bot.full_name}** foo", topic_name="bar"
+            )
+
+        self.assert_length(responses.calls, 1)
+        self.assert_length(logs.output, 1)
+
+        last_message = self.get_last_message()
+        self.assertEqual(last_message.content, "Choose a color")
+        self.assertEqual(last_message.sender_id, bot.id)
+
+        submessage = SubMessage.objects.get(message_id=last_message.id)
+        self.assertEqual(submessage.msg_type, "widget")
+        self.assertEqual(orjson.loads(submessage.content), widget_content)
 
     @responses.activate
     def test_stream_message_failure_to_outgoing_webhook_bot(self) -> None:


### PR DESCRIPTION
When an outgoing webhook returns widget_content in its JSON response, the parsed response_json already contains a Python dict. However, check_message() expects widget_content to be a JSON-encoded string and calls orjson.loads() on it. Passing a dict raised JSONDecodeError, so widget_content from outgoing webhook responses was silently broken.

Fix by calling json.dumps() on widget_content in process_success() before passing it downstream.

Continuing #38474

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
