### PR TITLE
screenshots: Remove `document.querySelector` by using `page.$eval`.

### DIFF
--- a/tools/screenshots/message-screenshot.ts
+++ b/tools/screenshots/message-screenshot.ts
@@ -73,14 +73,14 @@ async function run(): Promise<void> {
         await page.waitForSelector(messageSelector);
         // remove unread marker and don't select message
         const marker = `#message-row-${message_list_id}-${CSS.escape(messageId)} .unread_marker`;
-        await page.evaluate((sel) => {
-            globalThis.document.querySelector(sel)?.remove();
-        }, marker);
+        await page.$eval(marker, (element) => {
+            element.remove();
+        });
         const messageBox = await page.$(messageSelector);
         assert.ok(messageBox !== null);
-        await page.evaluate((msg) => {
-            globalThis.document.querySelector(msg)?.classList.remove("selected_message");
-        }, messageSelector);
+        await page.$eval(messageSelector, (element) => {
+            element.classList.remove("selected_message");
+        });
         const messageGroup = await messageBox.$("xpath/..");
         assert.ok(messageGroup !== null);
         // Compute screenshot area, with some padding around the message group

--- a/tools/screenshots/thread-screenshot.ts
+++ b/tools/screenshots/thread-screenshot.ts
@@ -84,28 +84,28 @@ async function run(): Promise<void> {
         const marker = `.message-list[data-message-list-id="${CSS.escape(
             `${message_list_id}`,
         )}"] .unread_marker`;
-        await page.evaluate((sel) => {
-            globalThis.document.querySelector(sel)?.remove();
-        }, marker);
+        await page.$eval(marker, (element) => {
+            element.remove();
+        });
 
         const messageSelector = `#message-row-${message_list_id}-${CSS.escape(messageId)}`;
         await page.waitForSelector(messageSelector);
 
         const messageListBox = await page.$(messageListSelector);
         assert.ok(messageListBox !== null);
-        await page.evaluate((msg) => {
-            globalThis.document.querySelector(msg)?.classList.remove("selected_message");
-        }, messageSelector);
+        await page.$eval(messageSelector, (element) => {
+            element.classList.remove("selected_message");
+        });
 
         // This is done so as to get white background while capturing screenshots.
         const background_selectors = [".app-main", ".message-feed", ".message_header"];
-        await page.evaluate((selectors) => {
-            for (const selector of selectors) {
-                for (const element of globalThis.document.querySelectorAll<HTMLElement>(selector)) {
+        await page.$$eval(background_selectors.join(","), (elements) => {
+            for (const element of elements) {
+                if (element instanceof HTMLElement) {
                     element.style.backgroundColor = "white";
                 }
             }
-        }, background_selectors);
+        });
 
         // This is done so that the message control buttons are not visible.
         await page.hover(".compose_new_conversation_button");


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/38598#discussion_r3103555514

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
