### PR TITLE
[ai] home: Stop overriding max_message_id for narrow_stream mini-window.

### DIFF
--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -22,7 +22,7 @@ from zerver.lib.workplace_users import (
     realm_eligible_for_non_workplace_pricing,
     realm_on_discounted_cloud_plan,
 )
-from zerver.models import Message, Realm, Stream, UserProfile
+from zerver.models import Realm, Stream, UserProfile
 from zerver.views.message_flags import get_latest_update_message_flag_activity
 
 
@@ -202,18 +202,6 @@ def build_page_params_for_home_page_load(
     page_params["state_data"] = state_data
 
     if narrow_stream is not None and state_data is not None:
-        # In narrow_stream context, initial pointer is just latest message
-        recipient = narrow_stream.recipient
-        state_data["max_message_id"] = -1
-        max_message = (
-            # Uses index: zerver_message_realm_recipient_id
-            Message.objects.filter(realm_id=realm.id, recipient=recipient)
-            .order_by("-id")
-            .only("id")
-            .first()
-        )
-        if max_message:
-            state_data["max_message_id"] = max_message.id
         page_params["narrow_stream"] = narrow_stream.name
         if narrow_topic_name is not None:
             page_params["narrow_topic"] = narrow_topic_name

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -28,6 +28,7 @@ from zerver.lib.test_helpers import (
     queries_captured,
 )
 from zerver.lib.timestamp import datetime_to_timestamp
+from zerver.lib.users import max_message_id_for_user
 from zerver.models import DefaultStream, Draft, Realm, UserActivity, UserProfile
 from zerver.models.realms import get_realm
 from zerver.models.streams import get_stream
@@ -306,7 +307,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(58),
+            self.assert_database_query_count(56),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -1103,7 +1104,12 @@ class HomeTest(ZulipTestCase):
         page_params = self._get_page_params(result)
         self.assertEqual(page_params["narrow_stream"], stream_name)
         self.assertEqual(page_params["narrow"], [dict(operator="stream", operand=stream_name)])
-        self.assertEqual(page_params["state_data"]["max_message_id"], -1)
+        # max_message_id is the user's global latest message id, not
+        # the narrow's; see local_message.ts for how it's consumed.
+        self.assertEqual(
+            page_params["state_data"]["max_message_id"],
+            max_message_id_for_user(user_profile),
+        )
 
     @activate_push_notification_service()
     def test_has_pending_sponsorship_request(self) -> None:


### PR DESCRIPTION
In the `/?stream=X` embedded mini-window flow, we were overriding `state_data["max_message_id"]` with the latest message in the narrowed channel. This was a legacy from before the `/register` API defaulted to `anchor="latest"`; since then, `max_message_id` is only used client-side (in `local_message.ts`) as the starting point for generating `local_id` values for echoed messages, and the user's global max (the `do_events_register` default) works equally well — `local_id`s just need to exceed any real message id that could appear in the feed, which the global max does by definition.

Removing this override is a prerequisite for a planned follow-up to have the web app unconditionally fetch `state_data` via `POST /json/register` (building on #38521); with it gone, `state_data` no longer depends on URL query parameters, so the server-side rendering path doesn't need narrow-specific processing of `state_data`.


---

Claude recommended to open this pull request as said in the previous paragraph. Makes sense to me.