### PR TITLE
Revert "run-dev: Abbreviate error message when receiving an https request."

### DIFF
--- a/tools/run-dev
+++ b/tools/run-dev
@@ -24,7 +24,6 @@ from urllib.parse import urlsplit
 import aiohttp
 import aiohttp.web_fileresponse
 from aiohttp import hdrs, web
-from aiohttp.http_exceptions import BadStatusLine
 
 from scripts.lib.zulip_tools import CYAN, ENDC
 from tools.lib.test_script import add_provision_check_override_param, assert_provisioning_status_ok
@@ -438,27 +437,6 @@ def print_listeners(external_host_url: str) -> None:
         print(f"   {port}: {label}")
     print()
 
-
-def https_log_filter(record: logging.LogRecord) -> bool:
-    # aiohttp emits an exception with a traceback when receiving an
-    # https request (https://github.com/aio-libs/aiohttp/issues/8065).
-    # Abbreviate it to a one-line message.
-    if (
-        record.exc_info is not None
-        and isinstance(error := record.exc_info[1], BadStatusLine)
-        and error.message.startswith(
-            (
-                "Invalid method encountered:\n\n  b'\\x16",
-                'Invalid method encountered:\n\n  b"\\x16',
-            )
-        )
-    ):
-        record.msg = "Rejected https request (this development server only supports http)"
-        record.exc_info = None
-    return True
-
-
-logging.getLogger("aiohttp.server").addFilter(https_log_filter)
 
 runner: web.AppRunner
 children: list["subprocess.Popen[bytes]"] = []


### PR DESCRIPTION
This reverts commit bf4933942ca844e87cdc84495db2012cce5c8db0 (#29034).

The logging issue was fixed upstream in aiohttp 3.11.8.