### PR TITLE
help: Explain how viewing muted channels works.

### DIFF
--- a/starlight_help/src/content/docs/mute-a-channel.mdx
+++ b/starlight_help/src/content/docs/mute-a-channel.mdx
@@ -13,54 +13,25 @@ import SelectChannelViewPersonal from "../include/_SelectChannelViewPersonal.mdx
 
 <MuteUnmuteIntro />
 
-## Mute a channel
+## Viewing muted channels
+
+When you view the [channel feed](/help/channel-feed) or [list of
+topics](/help/list-of-topics) for a muted channel, messages and topics are
+displayed just as they would be in an unmuted channel. [Muted
+topics](/help/mute-a-topic) are hidden by default, just as in unmuted channels.
+
+## Mute or unmute a channel
 
 <Tabs>
-  <TabItem label="Desktop/Web">
+  <TabItem label="Via left sidebar">
     <FlattenedSteps>
       <ChannelActions />
 
-      1. Click **Mute channel**.
+      1. Click **Mute channel** or **Unmute channel**.
     </FlattenedSteps>
   </TabItem>
 
-  <TabItem label="Mobile">
-    Access this feature by following the web app instructions in your
-    mobile device browser.
-
-    Implementation of this feature in the mobile app is tracked [on
-    GitHub](https://github.com/zulip/zulip-flutter/issues/347). If
-    you're interested in this feature, please react to the issue's
-    description with 👍.
-  </TabItem>
-</Tabs>
-
-## Unmute a channel
-
-<Tabs>
-  <TabItem label="Desktop/Web">
-    <FlattenedSteps>
-      <ChannelActions />
-
-      1. Click **Unmute channel**.
-    </FlattenedSteps>
-  </TabItem>
-
-  <TabItem label="Mobile">
-    Access this feature by following the web app instructions in your
-    mobile device browser.
-
-    Implementation of this feature in the mobile app is tracked [on
-    GitHub](https://github.com/zulip/zulip-flutter/issues/347). If
-    you're interested in this feature, please react to the issue's
-    description with 👍.
-  </TabItem>
-</Tabs>
-
-## Alternate method to mute or unmute a channel
-
-<Tabs>
-  <TabItem label="Desktop/Web">
+  <TabItem label="Via channel settings">
     <FlattenedSteps>
       <NavigationSteps target="relative/gear/channel-settings" />
 
@@ -72,6 +43,16 @@ import SelectChannelViewPersonal from "../include/_SelectChannelViewPersonal.mdx
     </FlattenedSteps>
 
     <ChannelSettingsNavbarTip />
+  </TabItem>
+
+  <TabItem label="Mobile">
+    Access this feature by following the web app instructions in your
+    mobile device browser.
+
+    Implementation of this feature in the mobile app is tracked [on
+    GitHub](https://github.com/zulip/zulip-flutter/issues/347). If
+    you're interested in this feature, please react to the issue's
+    description with 👍.
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Fixes [#api documentation > is:muted narrow filter @ 💬](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/is.3Amuted.20narrow.20filter/near/2353377).

<details><summary>Screenshots</summary>
Current page: https://zulip.com/help/mute-a-channel

<p>
<img width="697" height="528" alt="Screenshot 2026-04-23 at 15 54 47" src="https://github.com/user-attachments/assets/9659179e-83e5-4ce9-918a-6e5dbe8def29" />
<img width="709" height="362" alt="Screenshot 2026-04-23 at 15 54 36" src="https://github.com/user-attachments/assets/5859b3e4-fb5a-4521-9bc5-07794a898431" />
</p>
</details> 