### PR TITLE
[ai] push_registration: Match APNs tokens case-insensitively on cleanup.

### DIFF
--- a/zerver/lib/push_registration.py
+++ b/zerver/lib/push_registration.py
@@ -70,16 +70,34 @@ def handle_registration_to_bouncer_failure(
         logging.error("Push registration request for device_id=%s expired.", device_id)
 
 
+def compute_token_id_int(token: str) -> int:
+    hash_bytes = hashlib.sha256(token.encode()).digest()
+    return b64decode_token_id_base64(base64.b64encode(hash_bytes[0:8]).decode())
+
+
 def cleanup_legacy_push_device_token(user_profile: UserProfile, token_id_int: int) -> None:
     MAX_REQUEST_RETRIES = 3
     legacy_tokens = PushDeviceToken.objects.filter(user=user_profile)
 
     for legacy_token in legacy_tokens:
-        hash_bytes = hashlib.sha256(legacy_token.token.encode()).digest()
-        computed_token_id_base64 = base64.b64encode(hash_bytes[0:8]).decode()
-        computed_token_id_int = b64decode_token_id_base64(computed_token_id_base64)
+        # APNs treats its tokens (hex strings) as case-insensitive, and
+        # different client versions have sent them in different cases; the
+        # rest of the legacy code path accordingly normalizes to lowercase
+        # (see `remove_push_device_token`).  Match on the stored casing
+        # as well as its lower- and upper-case forms so that E2EE
+        # registration reliably cleans up the matching legacy token
+        # regardless of which case the client used.
+        token = legacy_token.token
+        if legacy_token.kind == PushDeviceToken.APNS:
+            candidate_token_ids = {
+                compute_token_id_int(token),
+                compute_token_id_int(token.lower()),
+                compute_token_id_int(token.upper()),
+            }
+        else:
+            candidate_token_ids = {compute_token_id_int(token)}
 
-        if computed_token_id_int != token_id_int:
+        if token_id_int not in candidate_token_ids:
             continue
 
         for attempt in range(MAX_REQUEST_RETRIES):

--- a/zerver/tests/test_push_registration.py
+++ b/zerver/tests/test_push_registration.py
@@ -979,13 +979,18 @@ class RegisterPushDeviceToServer(BouncerTestCase):
 
         token = "c0ffee"
 
-        # Create a legacy token with a different value
-        # to verify it is NOT removed.
+        # Create legacy tokens with a different value
+        # to verify they are NOT removed.
         PushDeviceToken.objects.create(
             user=hamlet,
             token="different_token",
             kind=PushDeviceToken.APNS,
             ios_app_id="example.app",
+        )
+        PushDeviceToken.objects.create(
+            user=hamlet,
+            token="different_fcm_token",
+            kind=PushDeviceToken.FCM,
         )
 
         # Create legacy PushDeviceToken and RemotePushDeviceToken
@@ -1004,7 +1009,7 @@ class RegisterPushDeviceToServer(BouncerTestCase):
             ios_app_id="example.app",
         )
 
-        self.assertEqual(PushDeviceToken.objects.count(), 2)
+        self.assertEqual(PushDeviceToken.objects.count(), 3)
         self.assertEqual(RemotePushDeviceToken.objects.count(), 1)
 
         payload = self.get_register_push_device_payload(token=token)
@@ -1014,10 +1019,100 @@ class RegisterPushDeviceToServer(BouncerTestCase):
 
         # The matching legacy tokens should be removed
         # on both server and bouncer.
-        remaining_tokens = PushDeviceToken.objects.filter(user=hamlet)
-        self.assert_length(remaining_tokens, 1)
-        self.assertEqual(remaining_tokens[0].token, "different_token")
+        remaining_tokens = PushDeviceToken.objects.filter(user=hamlet).order_by("token")
+        self.assert_length(remaining_tokens, 2)
+        self.assertEqual(remaining_tokens[0].token, "different_fcm_token")
+        self.assertEqual(remaining_tokens[1].token, "different_token")
 
+        self.assertEqual(RemotePushDeviceToken.objects.count(), 0)
+
+    @activate_push_notification_service()
+    @override_settings(ZILENCER_ENABLED=False)
+    @responses.activate
+    def test_legacy_apns_token_cleanup_is_case_insensitive(self) -> None:
+        # APNs treats its tokens as case-insensitive, and different
+        # client versions have sent the same token in different cases.
+        # When an E2EE registration comes in using one case, we still
+        # need to clean up a legacy registration using the other case;
+        # otherwise the device gets two copies of each notification.
+        self.add_mock_response()
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+
+        legacy_token = "abcdef0123456789"
+        e2ee_token = legacy_token.upper()
+
+        PushDeviceToken.objects.create(
+            user=hamlet,
+            token=legacy_token,
+            kind=PushDeviceToken.APNS,
+            ios_app_id="example.app",
+        )
+        RemotePushDeviceToken.objects.create(
+            server=self.server,
+            user_uuid=str(hamlet.uuid),
+            token=legacy_token,
+            kind=RemotePushDeviceToken.APNS,
+            ios_app_id="example.app",
+        )
+
+        payload = self.get_register_push_device_payload(token=e2ee_token)
+        with self.capture_send_event_calls(expected_num_events=2):
+            result = self.client_post("/json/mobile_push/register", payload)
+        self.assert_json_success(result)
+
+        self.assertEqual(PushDeviceToken.objects.filter(user=hamlet).count(), 0)
+        self.assertEqual(RemotePushDeviceToken.objects.count(), 0)
+
+        # Same scenario with the cases reversed: legacy token in
+        # uppercase and E2EE registration in lowercase.
+        PushDeviceToken.objects.create(
+            user=hamlet,
+            token=e2ee_token,
+            kind=PushDeviceToken.APNS,
+            ios_app_id="example.app",
+        )
+        RemotePushDeviceToken.objects.create(
+            server=self.server,
+            user_uuid=str(hamlet.uuid),
+            token=e2ee_token,
+            kind=RemotePushDeviceToken.APNS,
+            ios_app_id="example.app",
+        )
+
+        payload = self.get_register_push_device_payload(token=legacy_token)
+        with self.capture_send_event_calls(expected_num_events=2):
+            result = self.client_post("/json/mobile_push/register", payload)
+        self.assert_json_success(result)
+
+        self.assertEqual(PushDeviceToken.objects.filter(user=hamlet).count(), 0)
+        self.assertEqual(RemotePushDeviceToken.objects.count(), 0)
+
+        # Mixed-case legacy token matched by the E2EE client in the
+        # same mixed case: migration 0740 made the database constraint
+        # case-insensitive but didn't normalize the stored casing, so
+        # rows like this can still exist from before that migration.
+        mixed_case_token = "AbCdEf0123456789"
+        PushDeviceToken.objects.create(
+            user=hamlet,
+            token=mixed_case_token,
+            kind=PushDeviceToken.APNS,
+            ios_app_id="example.app",
+        )
+        RemotePushDeviceToken.objects.create(
+            server=self.server,
+            user_uuid=str(hamlet.uuid),
+            token=mixed_case_token,
+            kind=RemotePushDeviceToken.APNS,
+            ios_app_id="example.app",
+        )
+
+        payload = self.get_register_push_device_payload(token=mixed_case_token)
+        with self.capture_send_event_calls(expected_num_events=2):
+            result = self.client_post("/json/mobile_push/register", payload)
+        self.assert_json_success(result)
+
+        self.assertEqual(PushDeviceToken.objects.filter(user=hamlet).count(), 0)
         self.assertEqual(RemotePushDeviceToken.objects.count(), 0)
 
     @activate_push_notification_service()


### PR DESCRIPTION
When a client registers for E2EE push, cleanup_legacy_push_device_token compares a SHA-256 hash of the new token_id against a hash of each legacy PushDeviceToken for the same user.  APNs, however, treats its tokens (hex strings) as case-insensitive, and different client versions have sent the same device's token in different cases.  If the cases disagreed between the legacy and E2EE registrations, the hashes didn't match, cleanup silently skipped the legacy row, and the device ended up registered in both code paths -- receiving two copies of each notification.  This regressed the exact symptom we already saw and fixed last year (#mobile > received notification twice, and the earlier #mobile > Issue - iOS Notification Badge) for users who upgraded from a legacy-era app to the E2EE app with a differing token case.

For APNs legacy tokens, match the new token_id_int against the stored casing plus both token.lower() and token.upper().  The upper and lower variants cover the two forms that real clients have been observed to send (and mirror the case-insensitive database constraint from migration 0740 and the case-normalization already in remove_push_device_token); keeping the stored casing in the match covers any mixed-case rows that predated that constraint, since migration 0740 didn't normalize existing data.  FCM tokens are case-sensitive by design, so they keep exact-match behavior.

Reported at #mobile > iOS duplicate notifications.
