### PR TITLE
api: Add realm_deactivated_redirect to server_settings

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -22773,6 +22773,11 @@ paths:
                           feature on the login page for an organization.
 
                           **Changes**: New in Zulip 5.0 (feature level 116).
+                      realm_deactivated_redirect:
+                        type: string
+                        description: |
+                          If the organization has migrated to a new server, this contains the URL of the new workspace.
+                          Clients should automatically redirect or prompt the user to update their configuration.
                     example:
                       {
                         "authentication_methods":
@@ -22800,6 +22805,7 @@ paths:
                         "realm_icon": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
                         "realm_description": "<p>The Zulip development environment default organization.  It's great for testing!</p>",
                         "realm_web_public_access_enabled": false,
+                        "realm_deactivated_redirect": "https://chat.zulip.org",
                         "result": "success",
                         "external_authentication_methods":
                           [

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -6575,6 +6575,25 @@ class FetchAuthBackends(ZulipTestCase):
             result = self.client_get("/api/v1/server_settings", subdomain="")
             self.assert_json_error_contains(result, "Subdomain required", 400)
 
+            # Verify realm_deactivated_redirect is correctly serialized
+            realm = get_realm("zulip")
+            realm.deactivated_redirect = "https://chat.zulip.org"
+            realm.save(update_fields=["deactivated_redirect"])
+
+            with self.settings(ROOT_DOMAIN_LANDING_PAGE=False):
+                result = self.client_get("/api/v1/server_settings", subdomain="zulip", HTTP_USER_AGENT="")
+
+            check_result(
+                result,
+                [
+                    ("realm_name", check_string),
+                    ("realm_description", check_string),
+                    ("realm_icon", check_string),
+                    ("realm_deactivated_redirect", check_string),
+                ],
+            )
+            response_dict = self.assert_json_success(result)
+            self.assertEqual(response_dict["realm_deactivated_redirect"], "https://chat.zulip.org")
 
 class TestTwoFactor(ZulipTestCase):
     def test_direct_dev_login_with_2fa(self) -> None:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -6581,7 +6581,9 @@ class FetchAuthBackends(ZulipTestCase):
             realm.save(update_fields=["deactivated_redirect"])
 
             with self.settings(ROOT_DOMAIN_LANDING_PAGE=False):
-                result = self.client_get("/api/v1/server_settings", subdomain="zulip", HTTP_USER_AGENT="")
+                result = self.client_get(
+                    "/api/v1/server_settings", subdomain="zulip", HTTP_USER_AGENT=""
+                )
 
             check_result(
                 result,
@@ -6594,6 +6596,7 @@ class FetchAuthBackends(ZulipTestCase):
             )
             response_dict = self.assert_json_success(result)
             self.assertEqual(response_dict["realm_deactivated_redirect"], "https://chat.zulip.org")
+
 
 class TestTwoFactor(ZulipTestCase):
     def test_direct_dev_login_with_2fa(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -1238,6 +1238,11 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
             result[settings_item] = context[settings_item]
     # TODO/compatibility: Backwards-compatibility name for realm_url.
     result["realm_uri"] = result["realm_url"]
+
+    realm = get_realm_from_request(request)
+    if realm and realm.deactivated_redirect:
+        result["realm_deactivated_redirect"] = realm.deactivated_redirect
+
     return json_success(request, data=result)
 
 


### PR DESCRIPTION
This exposes the `deactivated_redirect` realm property via the `/api/v1/server_settings` endpoint. Allows remote clients to detect when a realm has migrated to a new URL and automatically update their configurations.

Fixes: #5090.

**How changes were tested:**
* Updated the OpenAPI schema in `zulip.yaml` and verified it passes lint via `./tools/lint`.
* Wrote a unit test in `zerver.tests.test_auth_backends` that creates a test realm, sets a dummy `deactivated_redirect` URL, and asserts that the `/api/v1/server_settings` GET request serializes correctly and returns that field. 
* Ran `./tools/test-backend zerver.tests.test_auth_backends` (Passed).

**Screenshots and screen captures:**
**N/A** - This is a backend modification only, no frontend UI changes.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
