### PR TITLE
compose: Continue nested bullet lists on Shift+Enter; Fixes #37737

### DIFF
--- a/web/src/bulleted_numbered_list_util.ts
+++ b/web/src/bulleted_numbered_list_util.ts
@@ -1,12 +1,21 @@
 export const get_last_line = (text: string): string => text.slice(text.lastIndexOf("\n") + 1);
 
-export const is_bulleted = (line: string): boolean =>
-    line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
+const bullet_pattern = /^(\s*[-*+] )/;
+
+export const is_bulleted = (line: string): boolean => bullet_pattern.test(line);
+
+export const get_bullet_prefix = (line: string): string => {
+    const match = bullet_pattern.exec(line);
+    return match?.[1] ?? "";
+};
+
+export const strip_bullet = (line: string): string => {
+    const bullet_prefix = get_bullet_prefix(line);
+    return line.slice(bullet_prefix.length);
+};
 
 // testing against regex for string with numbered syntax, that is,
 // any string starting with digit/s followed by a period and space
 export const is_numbered = (line: string): boolean => /^\d+\. /.test(line);
-
-export const strip_bullet = (line: string): string => line.slice(2);
 
 export const strip_numbering = (line: string): string => line.slice(line.indexOf(" ") + 1);

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -279,17 +279,21 @@ function handle_bulleting_or_numbering(
     let to_append = "";
     // if previous line was bulleted, automatically add a bullet to the new line
     if (bulleted_numbered_list_util.is_bulleted(previous_line)) {
+        const bullet_prefix = bulleted_numbered_list_util.get_bullet_prefix(previous_line);
         // if previous line had only bullet, remove it and stay on the same line
         if (bulleted_numbered_list_util.strip_bullet(previous_line) === "") {
-            // below we select and replace the last 2 characters in the textarea before
-            // the cursor - the bullet syntax - with an empty string
-            util.the($textarea).setSelectionRange($textarea.caret() - 2, $textarea.caret());
+            // below we select and replace the bullet syntax in the textarea before
+            // the cursor with an empty string
+            util.the($textarea).setSelectionRange(
+                $textarea.caret() - bullet_prefix.length,
+                $textarea.caret(),
+            );
             compose_ui.insert_and_scroll_into_view("", $textarea);
             e.preventDefault();
             return;
         }
         // use same bullet syntax as the previous line
-        to_append = previous_line.slice(0, 2);
+        to_append = bullet_prefix;
     } else if (bulleted_numbered_list_util.is_numbered(previous_line)) {
         // if previous line was numbered, continue numbering with the new line
         const previous_number_string = previous_line.slice(0, previous_line.indexOf("."));


### PR DESCRIPTION
Fixes nested bullet lists continuation in the compose box.

Previously, the Shift+Enter logic used the "previous_line.slice(0,2)" for bulleted lists. This worked for level 1 lists, but failed once these lists became nested because it only accounted for the first two characters, and the first two characters could be indentation, meaning it didn't recognize the bullet.

This updates the bullet-list utility recognize these indented bullet points and updates the composebox logic to reuse the full bullet prefix when inserting the next list item.
Tested locally using  '-', '*', '+' as the bullet points. 
After pressing Shift + Enter, at the end of the second list, the compose box now inserts another nested bullet at the same indentatoin level.