### PR TITLE
Separate command from text in Slack-compatible outgoing webhooks

### DIFF
--- a/api_docs/outgoing-webhook-payload.md
+++ b/api_docs/outgoing-webhook-payload.md
@@ -80,6 +80,12 @@ message into the Slack-compatible webhook format.
             <td><code>service_id</code></td>
             <td>ID of the bot user</td>
         </tr>
+        <tr>
+            <td><code>command</code></td>
+            <td>If the message starts with a bot mention, the mention
+            converted to a slash command (e.g., <code>/botname</code>).
+            Only present when the message begins with a mention.</td>
+        </tr>
     </tbody>
 </table>
 
@@ -95,9 +101,10 @@ The above data is posted as list of tuples (not JSON), here's an example:
  ('timestamp', 1532078950),
  ('user_id', 'U21'),
  ('user_name', 'Full Name'),
- ('text', '@**test**'),
+ ('text', 'What is the weather?'),
  ('trigger_word', 'mention'),
- ('service_id', 27)]
+ ('service_id', 27),
+ ('command', '/test')]
 ```
 
 * For successful requests, if data is returned, it returns that data,

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import logging
+import re
 from contextlib import suppress
 from dataclasses import dataclass
 from time import perf_counter
@@ -118,20 +119,20 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             fail_with_message(event, failure_message)
             return None
 
-        # https://api.slack.com/legacy/custom-integrations/outgoing-webhooks#legacy-info__post-data
-        # documents the Slack outgoing webhook format:
+        # https://docs.slack.dev/interactivity/implementing-slash-commands/
         #
-        # token=XXXXXXXXXXXXXXXXXX
-        # team_id=T0001
-        # team_domain=example
-        # channel_id=C2147483705
-        # channel_name=test
-        # thread_ts=1504640714.003543
-        # timestamp=1504640775.000005
-        # user_id=U2147483697
-        # user_name=Steve
-        # text=googlebot: What is the air-speed velocity of an unladen swallow?
-        # trigger_word=googlebot:
+        # If the message starts with a bot mention (@**botname**), parse it
+        # into a slash command (/botname) in a separate "command" field,
+        # with the remainder of the message in "text". This matches the
+        # format Slack uses for slash commands.
+        raw_text = event["command"]
+        mention_match = re.match(r"^@\*\*(.*?)\*\*\s*(.*)", raw_text, flags=re.DOTALL)
+        if mention_match:
+            command = f"/{mention_match.group(1)}"
+            text = mention_match.group(2)
+        else:
+            command = None
+            text = raw_text
 
         request_data = [
             ("token", self.token),
@@ -143,9 +144,10 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
+            ("text", text),
             ("trigger_word", event["trigger"]),
             ("service_id", event["user_profile_id"]),
+            *([("command", command)] if command else []),
         ]
         return self.session.post(base_url, data=request_data)
 

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -161,7 +161,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         super().setUp()
         self.bot_user = get_user("outgoing-webhook@zulip.com", get_realm("zulip"))
         self.stream_message_event = {
-            "command": "@**test**",
+            "command": "@**test** hello world",
             "user_profile_id": 12,
             "service_name": "test-service",
             "trigger": "mention",
@@ -222,9 +222,27 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         self.assertEqual(request_data[6][1], 123456)  # timestamp
         self.assertEqual(request_data[7][1], "U21")  # user_id
         self.assertEqual(request_data[8][1], "Sample User")  # user_name
-        self.assertEqual(request_data[9][1], "@**test**")  # text
+        self.assertEqual(request_data[9][1], "hello world")  # text
         self.assertEqual(request_data[10][1], "mention")  # trigger_word
-        self.assertEqual(request_data[11][1], 12)  # user_profile_id
+        self.assertEqual(request_data[11][1], 12)  # service_id
+        self.assertEqual(request_data[12], ("command", "/test"))  # command
+
+    def test_make_request_stream_message_no_mention(self) -> None:
+        event = {
+            **self.stream_message_event,
+            "command": "plain text with no mention",
+        }
+        test_url = "https://example.com/example"
+        with mock.patch.object(self.handler, "session") as session:
+            self.handler.make_request(
+                test_url,
+                event,
+                self.bot_user.realm,
+            )
+            request_data = session.post.call_args[1]["data"]
+
+        self.assertEqual(request_data[9][1], "plain text with no mention")  # text
+        self.assertEqual(len(request_data), 12)  # no command field
 
     @mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
     def test_make_request_private_message(self, mock_fail_with_message: mock.Mock) -> None:


### PR DESCRIPTION
When Zulip sends Slack-compatible outgoing webhook payloads for messages that begin with a bot mention, the command field currently includes the entire message content instead of just the command portion.

This change updates the Slack-compatible payload so that: command contains only the command token text contains the remaining message content. This matches the expected Slack-style behavior and makes it easier for integrations to parse commands reliably.

Added/updated tests covering Slack-compatible outgoing webhook payloads for bot-command messages.
Verified that existing generic JSON webhook behavior is unchanged.