### PR TITLE
markdown: Add support for x-devonthink-item:// deeplinks.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -102,8 +102,16 @@ html_safelisted_schemes = (
     "xmpp",
     "zotero",
     "asanadesktop",
+    "x-devonthink-item",
 )
-auto_linked_schemes = ["https?", "hansoft", "obsidian", "zotero", "asanadesktop"]
+auto_linked_schemes = [
+    "https?",
+    "hansoft",
+    "obsidian",
+    "zotero",
+    "asanadesktop",
+    "x-devonthink-item",
+]
 allowed_schemes = ("http", "https", "ftp", "file", "mid", *html_safelisted_schemes)
 
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1095,6 +1095,11 @@
       "name": "explicit_link_asana_desktop",
       "input": "[Asana Task](asanadesktop://task/123456789)",
       "expected_output": "<p><a href=\"asanadesktop://task/123456789\">Asana Task</a></p>"
+    },
+    {
+      "name": "explicit_link_devonthink",
+      "input": "[DEVONthink Document](x-devonthink-item://AF54031A-0F3F-4E44-A5DB-B490E30648B6)",
+      "expected_output": "<p><a href=\"x-devonthink-item://AF54031A-0F3F-4E44-A5DB-B490E30648B6\">DEVONthink Document</a></p>"
     }
   ],
   "linkify_tests": [
@@ -1507,6 +1512,11 @@
       "Приветhttps://google.com",
       "<p>Привет<a href=\"https://google.com\">https://google.com</a></p>",
       "https://google.com"
+    ],
+    [
+      "x-devonthink-item://AF54031A-0F3F-4E44-A5DB-B490E30648B6",
+      "<p>%s</p>",
+      "x-devonthink-item://AF54031A-0F3F-4E44-A5DB-B490E30648B6"
     ]
   ]
 }


### PR DESCRIPTION
Currently, users cannot click on `x-devonthink-item://` links in Zulip messages because the scheme is not recognized by the markdown parser.

Following the approach used for other desktop apps like Obsidian, Asana this PR adds `x-devonthink-item` to both `html_safelisted_schemes` and `auto_linked_schemes` in `zerver/lib/markdown/__init__.py`. This allows DEVONthink URLs to linkify automatically and fully supports explicit Markdown link syntax.

Fixes: #29924.

**How changes were tested:**
* Added test cases to `zerver/tests/fixtures/markdown_test_cases.json` for both explicit linking (`[text](x-devonthink-item://...)`) and auto-linking.
* Ran `./tools/test-backend zerver/tests/test_markdown.py` to ensure all markdown rules pass.
* Manually tested in the local development environment by sending `x-devonthink-item://AF54031A-0F3F-4E44-A5DB-B490E30648B6` and `[DEVONthink](x-devonthink-item://AF54031A-0F3F-4E44-A5DB-B490E30648B6)` in the compose box and verifying they render as valid, clickable links.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
1. Before
<img width="892" height="294" alt="image" src="https://github.com/user-attachments/assets/41b13ade-d7e0-4803-85f2-8f21bf88c104" />


2. After
<img width="902" height="270" alt="Screenshot 2026-04-24 at 9 57 29 AM" src="https://github.com/user-attachments/assets/cad6c1a7-d3e6-42b1-aa04-1b57801a9ed2" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
