### PR TITLE
integrations: Use category name in search placeholder.

### DIFF
--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -34,7 +34,7 @@
                     <div class="searchbar">
                         <div class="searchbar-reset">
                             <i class="zulip-icon zulip-icon-search" aria-hidden="true"></i>
-                            <input type="text" class="search_input" placeholder="Search integrations"/>
+                            <input type="text" class="search_input" placeholder="{{ search_placeholder }}"/>
                         </div>
                     </div>
                 </div>

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -28,7 +28,8 @@ list. For example, to add a new incoming webhook integration, declare a
 IncomingWebhookIntegration in the INCOMING_WEBHOOK_INTEGRATIONS list. All
 *_INTEGRATIONS lists are automatically aggregated into the INTEGRATIONS dict.
 
-To add a new integration category, add it to the CATEGORIES dict below.
+To add a new integration category, add it to the CATEGORIES and
+CATEGORY_SEARCH_PLACEHOLDERS dicts below.
 
 Over time, we expect this registry to grow additional convenience
 features for writing and configuring integrations efficiently.
@@ -51,6 +52,25 @@ CATEGORIES: dict[str, str] = {
     "project-management": "Project management",
     "productivity": "Productivity",
     "version-control": "Version control",
+}
+
+CATEGORY_SEARCH_PLACEHOLDERS: dict[str, str] = {
+    "meta-integration": "Search integration frameworks",
+    "bots": "Search interactive bot integrations",
+    "video-calling": "Search video calling integrations",
+    "continuous-integration": "Search continuous integration tools",
+    "customer-support": "Search customer support integrations",
+    "deployment": "Search deployment integrations",
+    "entertainment": "Search entertainment integrations",
+    "communication": "Search communication integrations",
+    "financial": "Search financial integrations",
+    "hr": "Search human resources integrations",
+    "marketing": "Search marketing integrations",
+    "misc": "Search miscellaneous integrations",
+    "monitoring": "Search monitoring integrations",
+    "project-management": "Search project management integrations",
+    "productivity": "Search productivity integrations",
+    "version-control": "Search version control integrations",
 }
 
 # Can also be computed from INTEGRATIONS by removing entries from

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -15,7 +15,12 @@ from corporate.models.customers import Customer
 from corporate.models.plans import CustomerPlan
 from zerver.actions.realm_settings import do_set_realm_property
 from zerver.context_processors import get_apps_page_url
-from zerver.lib.integrations import BOT_INTEGRATIONS, CATEGORIES, INTEGRATIONS
+from zerver.lib.integrations import (
+    BOT_INTEGRATIONS,
+    CATEGORIES,
+    CATEGORY_SEARCH_PLACEHOLDERS,
+    INTEGRATIONS,
+)
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import HostRequestMock
 from zerver.lib.url_redirects import INTEGRATION_CATEGORY_SLUGS
@@ -550,6 +555,19 @@ class DocPageTest(ZulipTestCase):
         url = "/integrations/"
         og_title = '<meta property="og:title" content="Zulip integrations" />'
         self._test(url, [og_title, og_description, get_canonical_url(url)])
+
+    def test_integration_search_placeholder(self) -> None:
+        # A category missing from CATEGORY_SEARCH_PLACEHOLDERS would
+        # silently fall back to the unfiltered catalog's placeholder.
+        self.assertEqual(set(CATEGORY_SEARCH_PLACEHOLDERS), set(CATEGORIES))
+
+        url = "/integrations/"
+        self._test(url, ['class="search_input" placeholder="Search integrations"'])
+
+        for category in CATEGORIES:
+            url = f"/integrations/category/{category}"
+            placeholder = CATEGORY_SEARCH_PLACEHOLDERS[category]
+            self._test(url, [f'class="search_input" placeholder="{placeholder}"'])
 
     def test_integration_404s(self) -> None:
         # We don't need to test all the pages for 404

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -22,6 +22,7 @@ from zerver.decorator import add_google_analytics_context
 from zerver.lib.html_to_text import get_content_description
 from zerver.lib.integrations import (
     CATEGORIES,
+    CATEGORY_SEARCH_PLACEHOLDERS,
     INTEGRATIONS,
     HubotIntegration,
     IncomingWebhookIntegration,
@@ -409,11 +410,14 @@ def add_catalog_integrations_context(request: HttpRequest, category_slug: str) -
     # round down to the nearest multiple of 10.
     integrations_count_display = ((enabled_integrations_count - 1) // 10) * 10
 
+    search_placeholder = CATEGORY_SEARCH_PLACEHOLDERS.get(category_slug, "Search integrations")
+
     context = add_base_integrations_context(request)
     context.update(
         {
             "categories_dict": OrderedDict(sorted(CATEGORIES.items())),
             "integrations_count_display": integrations_count_display,
+            "search_placeholder": search_placeholder,
             "selected_category_slug": category_slug,
             "visible_integrations": get_visible_integrations_for_category(category_slug),
         }


### PR DESCRIPTION
On /integrations catalog pages, the search box filters now reflects the selected category's display name in the place holder instead of  "Search integrations" 

Meta categories `Interactive bots`, `Integration frameworks` drop the trailing **integrations**.
Fixes #39019.
[CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/.2Fintegrations.20and.20.2Fcommunities.20design.20update.20.2338913/with/2440201)[#design > /integrations and /communities design update #38913](https://chat.zulip.org/#narrow/channel/101-design/topic/.2Fintegrations.20and.20.2Fcommunities.20design.20update.20.2338913/with/2440201)
**How changes were tested:**
Added a test in test_doc and also manually tested from the /integration page

**Screenshots and screen captures:**


https://github.com/user-attachments/assets/2966115e-9002-4135-af82-0018e54c9a28




<details>
<summary>Screenshot</summary>

English:

<img width="500" height="46" alt="image" src="https://github.com/user-attachments/assets/4ff6b08b-9041-4596-b45a-c68132f5877f" />

<img width="500" height="46" alt="Screenshot From 2026-07-30 16-35-19" src="https://github.com/user-attachments/assets/fe7be43e-eb9d-4558-812d-7198e327c439" />

Russian:

<img width="500" height="46" alt="Screenshot From 2026-07-30 16-35-01" src="https://github.com/user-attachments/assets/0e513cf6-a5d9-4da8-b587-bdbb45883c25" />

Spanish:

<img width="500" height="46" alt="Screenshot From 2026-07-30 16-51-58" src="https://github.com/user-attachments/assets/3f469a57-6db5-4570-8776-4aac817c154a" />

German:

<img width="500" height="46" alt="Screenshot From 2026-07-30 16-34-37" src="https://github.com/user-attachments/assets/0154dc3c-13dc-4d33-b7e1-cd0cefa88fd8" />

Japanese:

<img width="500" height="46" alt="Screenshot From 2026-07-30 16-48-06" src="https://github.com/user-attachments/assets/54078437-95d4-4ade-833f-1da6b963d457" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
