### PR TITLE
user_groups: allow bots to access read endpoints and update tests

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -4651,9 +4651,16 @@ class RealmPropertyActionTest(BaseAction):
         )
 
         othello = self.example_user("othello")
+        bot = self.example_user("default_bot")
         admins_group = system_user_groups_dict[SystemGroups.ADMINISTRATORS]
 
-        setting_group = self.create_or_update_anonymous_group_for_setting([othello], [admins_group])
+        setting_group = self.create_or_update_anonymous_group_for_setting(
+            [othello, bot], [admins_group]
+        )
+
+        setting_group = self.create_or_update_anonymous_group_for_setting(
+            [othello, bot], [admins_group]
+        )
         now = timezone_now()
 
         with self.verify_action(state_change_expected=True, num_events=1) as events:
@@ -4673,7 +4680,7 @@ class RealmPropertyActionTest(BaseAction):
                 extra_data={
                     RealmAuditLog.OLD_VALUE: default_group.id,
                     RealmAuditLog.NEW_VALUE: {
-                        "direct_members": [othello.id],
+                        "direct_members": [othello.id, bot.id],
                         "direct_subgroups": [admins_group.id],
                     },
                     "property": setting_name,
@@ -4684,13 +4691,18 @@ class RealmPropertyActionTest(BaseAction):
         check_realm_update_dict("events[0]", events[0])
         self.assertEqual(
             events[0]["data"][setting_name],
-            UserGroupMembersDict(direct_members=[othello.id], direct_subgroups=[admins_group.id]),
+            UserGroupMembersDict(
+                direct_members=[othello.id, bot.id], direct_subgroups=[admins_group.id]
+            ),
+            UserGroupMembersDict(
+                direct_members=[othello.id, bot.id], direct_subgroups=[admins_group.id]
+            ),
         )
 
         old_setting_api_value = get_group_setting_value_for_api(setting_group)
         moderators_group = system_user_groups_dict[SystemGroups.MODERATORS]
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            [self.user_profile], [moderators_group], existing_setting_group=setting_group
+            [self.user_profile, bot], [moderators_group], existing_setting_group=setting_group
         )
 
         # state_change_expected is False here because the initial state will
@@ -4713,11 +4725,11 @@ class RealmPropertyActionTest(BaseAction):
                 acting_user=self.user_profile,
                 extra_data={
                     RealmAuditLog.OLD_VALUE: {
-                        "direct_members": [othello.id],
+                        "direct_members": [othello.id, bot.id],
                         "direct_subgroups": [admins_group.id],
                     },
                     RealmAuditLog.NEW_VALUE: {
-                        "direct_members": [self.user_profile.id],
+                        "direct_members": [self.user_profile.id, bot.id],
                         "direct_subgroups": [moderators_group.id],
                     },
                     "property": setting_name,
@@ -4729,7 +4741,8 @@ class RealmPropertyActionTest(BaseAction):
         self.assertEqual(
             events[0]["data"][setting_name],
             UserGroupMembersDict(
-                direct_members=[self.user_profile.id], direct_subgroups=[moderators_group.id]
+                direct_members=[self.user_profile.id, bot.id],
+                direct_subgroups=[moderators_group.id],
             ),
         )
 
@@ -4749,7 +4762,7 @@ class RealmPropertyActionTest(BaseAction):
                 acting_user=self.user_profile,
                 extra_data={
                     RealmAuditLog.OLD_VALUE: {
-                        "direct_members": [self.user_profile.id],
+                        "direct_members": [self.user_profile.id, bot.id],
                         "direct_subgroups": [moderators_group.id],
                     },
                     RealmAuditLog.NEW_VALUE: default_group.id,

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -292,6 +292,43 @@ class UserGroupTestCase(ZulipTestCase):
             {"support", SystemGroups.MEMBERS, SystemGroups.FULL_MEMBERS},
         )
 
+    def test_get_is_user_group_member_status_openapi_coverage(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+
+        self.login_user(iago)
+
+        user_group = self.create_user_group_for_test("test_group", acting_user=iago)
+
+        result = self.api_get(
+            iago,
+            f"/api/v1/user_groups/{user_group.id}/members/{hamlet.id}",
+        )
+
+        self.assert_json_success(result)
+        result_dict = orjson.loads(result.content)
+
+        self.assertIn("is_user_group_member", result_dict)
+        self.assertIsInstance(result_dict["is_user_group_member"], bool)
+
+    def test_get_is_user_group_member_status_as_bot_openapi_coverage(self) -> None:
+        iago = self.example_user("iago")
+        bot = self.example_user("default_bot")
+        hamlet = self.example_user("hamlet")
+
+        user_group = self.create_user_group_for_test("test_group", acting_user=iago)
+        UserGroupMembership.objects.create(user_profile=hamlet, user_group=user_group)
+
+        result = self.api_get(
+            bot,
+            f"/api/v1/user_groups/{user_group.id}/members/{hamlet.id}",
+        )
+        self.assert_json_success(result)
+
+        result_dict = orjson.loads(result.content)
+        self.assertIn("is_user_group_member", result_dict)
+        self.assertEqual(result_dict["is_user_group_member"], True)
+
     def test_recursive_queries_for_user_groups(self) -> None:
         realm = get_realm("zulip")
         iago = self.example_user("iago")
@@ -4161,8 +4198,24 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
         self.assertCountEqual(result_dict["members"], [desdemona.id, iago.id])
 
+        bot = self.example_user("default_bot")
+
+        result = self.api_get(
+            bot,
+            f"/api/v1/user_groups/{moderators_group.id}/members",
+        )
+
+        self.assert_json_success(result)
+
     def test_get_subgroups_of_user_group(self) -> None:
         realm = get_realm("zulip")
+
+        # Define users used later in the test
+        iago = self.example_user("iago")
+        desdemona = self.example_user("desdemona")
+        othello = self.example_user("othello")
+        bot = self.example_user("default_bot")
+
         owners_group = NamedUserGroup.objects.get(
             name=SystemGroups.OWNERS, realm_for_sharding=realm, is_system_group=True
         )
@@ -4172,6 +4225,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
         moderators_group = NamedUserGroup.objects.get(
             name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
         )
+
         self.login("iago")
 
         # Test invalid user group id
@@ -4213,6 +4267,62 @@ class UserGroupAPITestCase(UserGroupTestCase):
             ).content
         )
         self.assertCountEqual(result_dict["subgroups"], [admins_group.id])
+
+        # Bot should be able to access membership check endpoint
+        result = self.api_get(bot, f"/api/v1/user_groups/{admins_group.id}/members/{iago.id}")
+        self.assert_json_success(result)
+
+        # Checking membership of not a direct member but member of a subgroup.
+        result_dict = orjson.loads(
+            self.client_get(f"/json/user_groups/{admins_group.id}/members/{desdemona.id}").content
+        )
+        self.assertTrue(result_dict["is_user_group_member"])
+
+        # Checking membership of not a direct member but member of a subgroup
+        # when passing recursive parameter as False.
+        params = {"direct_member_only": orjson.dumps(True).decode()}
+        result_dict = orjson.loads(
+            self.client_get(
+                f"/json/user_groups/{admins_group.id}/members/{desdemona.id}",
+                info=params,
+            ).content
+        )
+        self.assertFalse(result_dict["is_user_group_member"])
+
+        # Bot should be able to access membership check endpoint with direct_member_only
+        result = self.api_get(
+            bot,
+            f"/api/v1/user_groups/{admins_group.id}/members/{desdemona.id}",
+            {"direct_member_only": orjson.dumps(True).decode()},
+        )
+        self.assert_json_success(result)
+
+        # Logging in with a user not part of the group.
+        self.login("hamlet")
+
+        result_dict = orjson.loads(
+            self.client_get(f"/json/user_groups/{admins_group.id}/members/{iago.id}").content
+        )
+        self.assertTrue(result_dict["is_user_group_member"])
+
+        result_dict = orjson.loads(
+            self.client_get(f"/json/user_groups/{admins_group.id}/members/{othello.id}").content
+        )
+        self.assertFalse(result_dict["is_user_group_member"])
+
+        # Check membership of deactivated user.
+        do_deactivate_user(iago, acting_user=None)
+        result = self.client_get(f"/json/user_groups/{admins_group.id}/members/{iago.id}")
+        self.assert_json_error(result, "User is deactivated")
+
+        bot = self.example_user("default_bot")
+
+        result = self.api_get(
+            bot,
+            f"/api/v1/user_groups/{moderators_group.id}/subgroups",
+        )
+
+        self.assert_json_success(result)
 
     def test_add_subgroup_from_wrong_realm(self) -> None:
         iago = self.example_user("iago")

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -18,7 +18,11 @@ from zerver.actions.user_groups import (
     do_update_user_group_name,
     remove_subgroups_from_user_group,
 )
-from zerver.decorator import require_human_non_guest_user, require_user_group_create_permission
+from zerver.decorator import (
+    require_human_non_guest_user,
+    require_non_guest_user,
+    require_user_group_create_permission,
+)
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
 from zerver.lib.response import json_success
@@ -115,7 +119,7 @@ def add_user_group(
     return json_success(request, data={"group_id": user_group.id})
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_user_groups(
     request: HttpRequest,
@@ -569,7 +573,7 @@ def update_subgroups_of_user_group(
     return json_success(request, data)
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_is_user_group_member(
     request: HttpRequest,
@@ -592,7 +596,7 @@ def get_is_user_group_member(
     )
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_user_group_members(
     request: HttpRequest,
@@ -611,7 +615,7 @@ def get_user_group_members(
     )
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_subgroups_of_user_group(
     request: HttpRequest,

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -507,7 +507,8 @@ v1_api_and_json_patterns = [
         GET=get_subgroups_of_user_group,
     ),
     rest_path(
-        "user_groups/<int:user_group_id>/members/<int:user_id>", GET=get_is_user_group_member
+        "user_groups/<int:user_group_id>/members/<int:user_id>",
+        GET=get_is_user_group_member,
     ),
     rest_path("user_groups/<int:user_group_id>/deactivate", POST=deactivate_user_group),
     # users/me -> zerver.views.user_settings


### PR DESCRIPTION
This PR allows bot users to access read-only user group API endpoints by
replacing @require_human_non_guest_user with @require_non_guest_user
on the relevant read endpoints.

Write endpoints (create/edit/update user groups) remain restricted to
human users.

This follows the updated direction from the discussion in #37927,
where the change is scoped only to read endpoints.

---

Supersedes #38128 (closed due to branch/history issues while fixing CI and workflow permission errors during development).

---

How changes were tested:

- [x] Updated backend tests to include bot users in relevant scenarios.
- [x] Ensured anonymous group settings correctly include bots where applicable.
- [x] Verified guest users remain restricted.
- [x] Ran full backend test suite (`./tools/test-backend`) successfully.
- [x] Ran lint checks.
- [x] No API feature level bump required.
- [x] No UI changes.

---

Self-review checklist:

- [x] Self-reviewed code for clarity and maintainability.
- [x] Followed AI use policy.
- [x] Aligned implementation with updated discussion (read endpoints only).
- [x] Avoided modifying write endpoints to prevent unintended permission changes.
- [x] Updated tests to reflect new bot access behavior.
- [x] Ensured event system behavior remains correct.

---

Commit discipline:

- [x] Changes are contained in a single coherent commit.
- [x] Commit message explains reasoning and scope of change.

---

Manual review and testing:

- [x] Verified backend API behavior for user group read endpoints.
- [x] Checked permission handling for bots vs guests.
- [x] Tested edge cases in group membership and anonymous group settings.