### PR TITLE
Fix group deactivation error banner.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -587,6 +587,10 @@
     margin-bottom: 10px;
 }
 
+.modal__header #dialog_error {
+    margin-top: 10px;
+}
+
 #read_receipts_modal {
     .modal__container {
         width: 25.7142em; /* 360px at 14px em */

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1553,6 +1553,7 @@ h4.user_group_setting_subsection_title {
 #deactivation-confirm-modal {
     .alert {
         padding-right: 14px;
+        background-color: var(--color-background-error-main-view-banner);
     }
 
     .cannot-deactivate-group-banner {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1570,6 +1570,10 @@ h4.user_group_setting_subsection_title {
             &:focus {
                 outline: 0;
             }
+
+            &:focus-visible {
+                outline: 2px solid var(--color-outline-focus);
+            }
         }
     }
 }

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -13,6 +13,9 @@
                         {{> help_link_widget . }}
                         {{/if}}
                     </h1>
+                    {{#if is_compact}}
+                        <div class="alert" id="dialog_error"></div>
+                    {{/if}}
                     {{#if modal_subtitle_html}}
                     <div class="modal__subtitle">
                         {{{ modal_subtitle_html }}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to show outline on "View permissions" when focussed using keyboard navigation.
- Second commit is to show error message for compact modals.
- Third commit is to fix background color for group deactivation error banner in night mode.

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/channel/9-issues/topic/User.20group.20used.20in.20permissions.20no.20UI.20error.20message.20on.20deact/with/2442650


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1330" height="564" alt="image" src="https://github.com/user-attachments/assets/282a260d-a6ed-4c53-ac78-4c4e3ae65c32" />

<img width="1330" height="564" alt="image" src="https://github.com/user-attachments/assets/5088d5b6-e1a2-4632-93af-98c8098505d8" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
