### PR TITLE
[ai] recent_view: Revert PR #38891 (broken focus outline on unread rows).

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1202,13 +1202,11 @@
     );
 
     /* Recent view */
-    --recent-view-table-border-side-width: 1px;
+    --recent-view-body-border-width: 1px;
     --recent-view-max-avatars: 4;
     --recent-view-participant-item-width: 1.5em; /* 24px at 16px / 1em */
     --recent-view-participant-item-padding-x: 0.0938em; /* 1.5px at 16px / 1em */
     --recent-view-participants-padding-x-start: 0.25em; /* 4px at 16px / 1em */
-    --recent-view-table-border-radius: 5px;
-    --recent-view-table-border-bottom-width: 1px;
     --color-border-recent-view-table: var(
         --color-border-inbox-folder-component
     );
@@ -3223,7 +3221,7 @@
 
     /* Zulip resizer handle svg */
     --svg-resize-handle: url("../images/resize-handle-white.svg");
-    --recent-view-table-border-side-width: 0.1875em; /* 3px at 16px/1em */
+    --recent-view-body-border-width: 0.1875em; /* 3px at 16px/1em */
 }
 
 @media screen {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1209,18 +1209,6 @@
     --recent-view-participants-padding-x-start: 0.25em; /* 4px at 16px / 1em */
     --recent-view-table-border-radius: 5px;
     --recent-view-table-border-bottom-width: 1px;
-    /* Inner radius used on the last row's corner cells, so they
-       hug the container's rounded bottom corners. Derived from
-       the outer radius minus the border widths, which lets it
-       track dark mode's wider side border. */
-    --recent-view-table-inner-radius: calc(
-            var(--recent-view-table-border-radius) -
-                var(--recent-view-table-border-side-width)
-        )
-        calc(
-            var(--recent-view-table-border-radius) -
-                var(--recent-view-table-border-bottom-width)
-        );
     --color-border-recent-view-table: var(
         --color-border-inbox-folder-component
     );

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -111,6 +111,8 @@
     }
 
     #recent-view-content-table {
+        border-bottom-width: 1px;
+
         .unread_topic a {
             font-weight: 400;
         }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -34,6 +34,7 @@
     border-bottom-width: var(--recent-view-table-border-bottom-width);
     border-radius: 0 0 var(--recent-view-table-border-radius)
         var(--recent-view-table-border-radius);
+    overflow: hidden;
 }
 
 #recent_view {
@@ -443,22 +444,6 @@
             background-color: var(--color-background-recent-view-row);
         }
 
-        /* Round the last row's bottom corners to hug the
-           container's rounded bottom corners. */
-        &:last-child {
-            & td:first-child {
-                border-bottom-left-radius: var(
-                    --recent-view-table-inner-radius
-                );
-            }
-
-            & td:last-child {
-                border-bottom-right-radius: var(
-                    --recent-view-table-inner-radius
-                );
-            }
-        }
-
         /* Avoid annoying, confusing hover-state when scrolling on
            touch devices like iPad that treat a tap-and-hold/swipe
            as a hover. */
@@ -821,15 +806,6 @@
             .recent_topic_timestamp,
             thead .last_msg_time_header {
                 display: none;
-            }
-
-            /* With the timestamp cell hidden, the topic name cell
-               is the last visible one in the row, so round its
-               bottom-right corner too. */
-            tr:last-child .recent_topic_name {
-                border-bottom-right-radius: var(
-                    --recent-view-table-inner-radius
-                );
             }
         }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -28,12 +28,10 @@
 }
 
 #recent-view-content-table {
-    border: var(--recent-view-table-border-side-width) solid
+    border: var(--recent-view-body-border-width) solid
         var(--color-border-recent-view-table);
     border-top: none;
-    border-bottom-width: var(--recent-view-table-border-bottom-width);
-    border-radius: 0 0 var(--recent-view-table-border-radius)
-        var(--recent-view-table-border-radius);
+    border-radius: 0 0 5px 5px;
     overflow: hidden;
 }
 
@@ -595,7 +593,7 @@
         .recent-view-header-wrapper {
             /* 0.75em left padding, 1px header width */
             --recent-view-channel-row-header-minus-body: calc(
-                0.75em + var(--recent-view-table-border-side-width) - 1px
+                0.75em + var(--recent-view-body-border-width) - 1px
             );
             /* Match the row grid so "Channel" and "Conversation" sort
                spans align with channel and topic text in rows. Sort

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -435,25 +435,18 @@
     }
 
     & tr {
-        /* Put background on the cells, not tr. Border radius does not work
-           on tr, it works only on td. We want to set the border radius of
-           the last row in accordance to the border radius of the table so
-           that we don't need to use overflow hidden to keep the background
-           from spilling out. */
-        & td {
-            background-color: var(--color-background-recent-view-row);
-        }
+        background-color: var(--color-background-recent-view-row);
 
         /* Avoid annoying, confusing hover-state when scrolling on
            touch devices like iPad that treat a tap-and-hold/swipe
            as a hover. */
         @media (hover: hover) and (pointer: fine) {
-            &:hover td {
+            &:hover {
                 background-color: var(--color-background-recent-view-row-hover);
-            }
 
-            &:hover .change_visibility_policy .recent-view-row-topic-menu {
-                opacity: 0.4;
+                .change_visibility_policy .recent-view-row-topic-menu {
+                    opacity: 0.4;
+                }
             }
         }
     }


### PR DESCRIPTION
discussion: [#design > Recent conversations redesign #38545](https://chat.zulip.org/#narrow/channel/101-design/topic/Recent.20conversations.20redesign.20.2338545/with/2393185)

Reverts #38891.

The three commits from #38891 moved recent view row backgrounds and border-radius from `tr` onto individual `td` cells so the last row's corners could be rounded without `overflow: hidden` (which was clipping the "Mark as read" tooltip when only one unread topic remained). That refactor bugs the `:focus-visible` outline on unread rows — because the background and rounding now live on cells rather than the row, the keyboard focus outline no longer wraps the row cleanly.

Reverting all three commits of #38891 restores a correct focus outline on unread rows. The original clipped-tooltip issue the PR was fixing will need to be addressed separately with an approach that doesn't regress the focus outline.

Each commit is reverted individually so history stays bisectable. Conflicts from later commits on master (`260eea85d3`, `01eeb04324`, `f4527e79ca`) were resolved by keeping the post-#38891 refactors (unified inbox colors, renamed border-table variable) while fully backing out the PR.
ed separately).


--- 

Asked claude to revert #38891 and take care of merge conflicts.