### PR TITLE
tooltips: Anchor preview tooltips to scroll container.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -394,10 +394,20 @@ export function initialize(): void {
     // large image caused the tooltip to go out of its container and made it look
     // like it was floating in the app. Since the tooltip was not that useful for
     // this case, we chose to remove it instead.
-    message_list_tooltip(".media-image-element:not(.preview_content *)", {
+    message_list_tooltip(".media-image-element", {
         // Add a short delay so the user can mouseover several inline images without
         // tooltips showing and hiding rapidly
         delay: [300, 20],
+        appendTo(reference) {
+            // This is the "Magic Fix":
+            // If the image is inside the preview, attach the tooltip to the preview.
+            // This ensures it scrolls WITH the preview.
+            const preview_content = reference.closest(".preview_content");
+            if (preview_content) {
+                return preview_content;
+            }
+            return document.body;
+        },
         onShow(instance) {
             // Some message images do not include a title, such as YouTube
             // video previews, so we fall back to displaying the href value


### PR DESCRIPTION

Fixes #38843

Description
This PR fixes the issue where tooltips in the compose/edit preview remained static and "floating" on the screen when the preview area was scrolled. Previously, tooltips for media images in the preview were explicitly disabled to avoid this visual bug.

The root cause was that tooltips were appended to document.body (Global Stacking Context). Since the #compose-container is a scrollable layer, the content moved while the tooltips stayed fixed to the viewport.

By using appendTo to anchor tooltips to the .preview_content container, they are now part of the local stacking context and move in sync with the scrolled content.

How changes were tested
I verified this change locally using the Vagrant development environment on an Apple Silicon (M4) Mac.

Opened the compose box and pasted an image link.

Toggled the Preview mode.

Hovered over the image to trigger the tooltip.

Scrolled the compose area and confirmed the tooltip stayed correctly anchored to the image.


https://github.com/user-attachments/assets/5f971c29-5458-4fa7-9f4e-dc0e81749d8e

<img width="1467" height="884" alt="img" src="https://github.com/user-attachments/assets/6f2f3148-ff53-4ade-9831-13b5fa687086" />
