### PR TITLE
presence: Restore backwards compat for single-user presence API endpoint

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 496**
+
+* [`GET /users/{user_id_or_email}/presence`](/api/get-user-presence):
+  Re-added the legacy `website` and `aggregated` fields to the response
+  alongside the modern `active_timestamp` and `idle_timestamp` fields
+  introduced in feature level 487. This restores backwards compatibility
+  for existing API clients while preserving the new format for clients
+  that have already migrated.
+
 **Feature level 495**
 
 * [Message formatting](/api/message-formatting): Uploaded videos with
@@ -72,6 +81,7 @@ format used by the Zulip server that they are interacting with.
   Clients that do not set the `individual_emoji_changes` client
   capability will continue to receive the legacy `realm_emoji/update`
   event containing all emoji.
+
 
 **Feature level 490**
 

--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -204,13 +204,12 @@ _Released 2026-03-12_
   such groups will be created automatically when syncing the groups
   for a user who should be a member of that group.
 - The [`GET /api/v1/users/{user_id_or_email}/presence`](https://zulip.com/api/get-user-presence)
-  API endpoint was migrated to the modern presence API format that is
-  incompatible with the previous format. Custom API integrations that
-  fetch presence data for a user using this endpoint will need to be
-  updated after upgrading. (See the [API changelog][api-changelog] for
-  the dozens of other API changes in this release; this specific
-  change is notable only because backwards-compatibility was not
-  implemented, because the endpoint is rarely used).
+  API endpoint now returns presence data in both the modern format
+  (`active_timestamp` and `idle_timestamp` fields, added in feature level 487) and the legacy format (`website` and `aggregated` fields). Custom
+  API integrations using this endpoint will continue to work without any
+  changes, regardless of which format they expect. New integrations should
+  prefer the modern format. (See the [API changelog][api-changelog] for
+  details.)
 
 [api-changelog]: https://zulip.com/api/changelog
 [docker-upgrade-to-12]: https://zulip.readthedocs.io/projects/docker/en/latest/how-to/compose-upgrading.html#upgrading-from-zulip-docker-zulip-11-x-and-earlier

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11696,16 +11696,89 @@ paths:
                       msg: {}
                       ignored_parameters_unsupported: {}
                       presence:
-                        allOf:
-                          - $ref: "#/components/schemas/ModernPresenceFormat"
                         description: |
-                          An object containing the presence details for the user.
+                          An object containing the presence details for the user,
+                          in both the legacy and modern formats.
 
-                          **Changes**: In Zulip 12.0 (feature level 487), the
-                          `active_timestamp` and `idle_timestamp` fields were added to
-                          this object, deprecating and removing the `website` and
-                          `aggregated` dictionaries, which contained a timestamp and
-                          a status string.
+                          The `website` and `aggregated` fields provide the legacy
+                          format. Each has `status` (`active`, `idle`, or `offline`)
+                          and `timestamp` (Unix timestamp of the last presence update).
+
+                          The `active_timestamp` and `idle_timestamp` fields provide
+                          the modern format. See `ModernPresenceFormat` for
+                          their semantics.
+
+                          **Changes**: In Zulip 12.0 (feature level 496), the legacy
+                          `website` and `aggregated` fields were re-added alongside
+                          the modern `active_timestamp` and `idle_timestamp` fields
+                          to restore backwards compatibility after they were removed
+                          in feature level 487.
+                        type: object
+                        additionalProperties: false
+                        properties:
+                          active_timestamp:
+                            type: integer
+                            description: |
+                              The UNIX timestamp of the last time a client connected
+                              to Zulip reported that the user was actually present
+                              (e.g. via focusing a browser window or interacting
+                              with a computer running the desktop app).
+                          idle_timestamp:
+                            type: integer
+                            description: |
+                              The UNIX timestamp of the last time the user had a
+                              client connected to Zulip, including idle clients
+                              where the user hasn't interacted with the system
+                              recently.
+                          website:
+                            type: object
+                            description: |
+                              Legacy presence data for the `website` client.
+                            additionalProperties: false
+                            properties:
+                              status:
+                                type: string
+                                description: |
+                                  The status of the user on this client. Will be either `"idle"`
+                                  or `"active"`.
+                                enum:
+                                  - active
+                                  - idle
+                                  - offline
+                              timestamp:
+                                type: integer
+                                description: |
+                                  The UNIX timestamp of when this client sent the user's presence
+                                  to the server with the precision of a second.
+                            required:
+                              - status
+                              - timestamp
+                          aggregated:
+                            type: object
+                            description: |
+                              Aggregated presence data across all of the user's clients.
+                            additionalProperties: false
+                            properties:
+                              status:
+                                type: string
+                                description: |
+                                  The aggregated status of the user. Will be either `"idle"`
+                                  or `"active"`.
+                                enum:
+                                  - active
+                                  - idle
+                                  - offline
+                              timestamp:
+                                type: integer
+                                description: |
+                                  The UNIX timestamp of when the user's presence was most recently
+                                  updated across all clients with the precision of a second.
+                            required:
+                              - status
+                              - timestamp
+                        required:
+                          - website
+                          - aggregated
                 example:
                   {
                     "msg": "",
@@ -11713,6 +11786,10 @@ paths:
                       {
                         "active_timestamp": 1656958520,
                         "idle_timestamp": 1656958530,
+                        "website":
+                          {"status": "active", "timestamp": 1656958520},
+                        "aggregated":
+                          {"status": "active", "timestamp": 1656958520},
                       },
                     "result": "success",
                   }

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -613,7 +613,11 @@ class UserPresenceTests(ZulipTestCase):
         result = self.client_get(f"/json/users/{othello.id}/presence")
         result_dict = self.assert_json_success(result)
 
-        # Ensure date_joined was used as the fallback.
+        # Ensure date_joined was used as the fallback in both formats.
+        self.assertEqual(
+            result_dict["presence"]["website"]["timestamp"],
+            datetime_to_timestamp(othello.date_joined),
+        )
         self.assertEqual(
             result_dict["presence"]["active_timestamp"],
             datetime_to_timestamp(othello.date_joined),
@@ -737,29 +741,28 @@ class SingleUserPresenceTests(ZulipTestCase):
 
         result = self.client_get(f"/json/users/{othello.id}/presence")
         result_dict = self.assert_json_success(result)
-        self.assertEqual(
-            set(result_dict["presence"].keys()), {"active_timestamp", "idle_timestamp"}
-        )
-        self.assertIsInstance(result_dict["presence"]["active_timestamp"], int)
-        self.assertIsInstance(result_dict["presence"]["idle_timestamp"], int)
+        # Both legacy and modern format fields should be present.
+        self.assertIn("website", result_dict["presence"])
+        self.assertIn("aggregated", result_dict["presence"])
+        self.assertIn("active_timestamp", result_dict["presence"])
+        self.assertIn("idle_timestamp", result_dict["presence"])
+        self.assertEqual(set(result_dict["presence"]["website"].keys()), {"status", "timestamp"})
 
         # Then, we check everything works
         self.login("hamlet")
         result = self.client_get("/json/users/othello@zulip.com/presence")
         result_dict = self.assert_json_success(result)
-        self.assertEqual(
-            set(result_dict["presence"].keys()), {"active_timestamp", "idle_timestamp"}
-        )
-        self.assertIsInstance(result_dict["presence"]["active_timestamp"], int)
-        self.assertIsInstance(result_dict["presence"]["idle_timestamp"], int)
+        self.assertIn("website", result_dict["presence"])
+        self.assertIn("aggregated", result_dict["presence"])
+        self.assertIn("active_timestamp", result_dict["presence"])
+        self.assertIn("idle_timestamp", result_dict["presence"])
 
         result = self.client_get(f"/json/users/{othello.id}/presence")
         result_dict = self.assert_json_success(result)
-        self.assertEqual(
-            set(result_dict["presence"].keys()), {"active_timestamp", "idle_timestamp"}
-        )
-        self.assertIsInstance(result_dict["presence"]["active_timestamp"], int)
-        self.assertIsInstance(result_dict["presence"]["idle_timestamp"], int)
+        self.assertIn("website", result_dict["presence"])
+        self.assertIn("aggregated", result_dict["presence"])
+        self.assertIn("active_timestamp", result_dict["presence"])
+        self.assertIn("idle_timestamp", result_dict["presence"])
 
     def test_ping_only(self) -> None:
         self.login("othello")
@@ -845,6 +848,29 @@ class UserPresenceAggregationTests(ZulipTestCase):
                 "status": "idle",
                 "timestamp": datetime_to_timestamp(validate_time - timedelta(seconds=5)),
                 "client": "website",
+            },
+        )
+
+    def test_aggregated_presence_offline(self) -> None:
+        user = self.example_user("othello")
+        self.login_user(user)
+        validate_time = timezone_now()
+        self._send_presence_for_aggregated_tests(user, "idle", validate_time)
+
+        with time_machine.travel(
+            (validate_time + timedelta(seconds=settings.OFFLINE_THRESHOLD_SECS + 1)),
+            tick=False,
+        ):
+            # After settings.OFFLINE_THRESHOLD_SECS + 1 this generated, recent presence data
+            # will count as offline.
+            result = self.client_get(f"/json/users/{user.email}/presence")
+        result_dict = self.assert_json_success(result)
+
+        self.assertDictEqual(
+            result_dict["presence"]["aggregated"],
+            {
+                "status": "offline",
+                "timestamp": datetime_to_timestamp(validate_time - timedelta(seconds=5)),
             },
         )
 

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -13,26 +13,20 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.presence import get_presence_for_user, get_presence_response
 from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
-from zerver.lib.typed_endpoint import (
-    ApiParamConfig,
-    PathOnly,
-    typed_endpoint,
-    typed_endpoint_without_parameters,
-)
+from zerver.lib.timestamp import datetime_to_timestamp
+from zerver.lib.typed_endpoint import ApiParamConfig, PathOnly, typed_endpoint
 from zerver.lib.user_status import check_update_user_status, get_user_status
 from zerver.lib.users import access_user_by_id, check_can_access_user
 from zerver.models import UserPresence, UserProfile
 from zerver.models.users import get_active_user, get_active_user_profile_by_id_in_realm
 
 
-@typed_endpoint_without_parameters
 def get_presence_backend(
-    request: HttpRequest,
-    user_profile: UserProfile,
-    user_id_or_email: PathOnly[str],
+    request: HttpRequest, user_profile: UserProfile, user_id_or_email: str
 ) -> HttpResponse:
     # This isn't used by the web app; it's available for API use by
-    # bots and other clients.
+    # bots and other clients.  We may want to add slim_presence
+    # support for it (or just migrate its API wholesale) later.
 
     try:
         try:
@@ -56,13 +50,27 @@ def get_presence_backend(
     ):
         raise JsonableError(_("Insufficient permission"))
 
-    presence_dict = get_presence_for_user(target.id, slim_presence=True)
+    presence_dict = get_presence_for_user(target.id)
     if len(presence_dict) == 0:
         raise JsonableError(
             _("No presence data for {user_id_or_email}").format(user_id_or_email=user_id_or_email)
         )
 
-    result = dict(presence=presence_dict[str(target.id)])
+    # For initial version, we just include the status and timestamp keys
+    result = dict(presence=presence_dict[target.email])
+    aggregated_info = result["presence"]["aggregated"]
+    aggr_status_duration = datetime_to_timestamp(timezone_now()) - aggregated_info["timestamp"]
+    if aggr_status_duration > settings.OFFLINE_THRESHOLD_SECS:
+        aggregated_info["status"] = "offline"
+    for val in result["presence"].values():
+        val.pop("client", None)
+        val.pop("pushable", None)
+
+    # Also include the modern format fields (active_timestamp/idle_timestamp)
+    # alongside the legacy fields for forwards compatibility with newer clients.
+    modern_presence_dict = get_presence_for_user(target.id, slim_presence=True)
+    result["presence"].update(modern_presence_dict[str(target.id)])
+
     return json_success(request, data=result)
 
 


### PR DESCRIPTION
Commit [4c3aa4c](https://github.com/zulip/zulip/commit/4c3aa4c007ef0caa6c15f8bb9af515eda01521ec) changed `GET /users/{user_id_or_email}/presence` to always return only the modern format (`active_timestamp`/`idle_timestamp`), removing the legacy format (`aggregated`/`website`) with no backwards-compatibility period. This broke existing API clients including the Zulip web client user card popover and the python-zulip-api library.

Re-add the legacy `aggregated` and `website` fields to the response alongside the modern `active_timestamp` and `idle_timestamp` fields. This allows all existing clients to continue working without modification, while still providing the modern format for clients that have already migrated to it.

Also restore `test_aggregated_presence_offline` (deleted in [4c3aa4c](https://github.com/zulip/zulip/commit/4c3aa4c007ef0caa6c15f8bb9af515eda01521ec)), update test assertions to verify both formats are present, and update the OpenAPI spec, API changelog, and server upgrade notes accordingly.

Fixes: #38597

**Note to maintainers**:
- Two `get_presence_for_user` calls: The view now calls `get_presence_for_user` twice, once without `slim_presence` for the legacy dict, and once with `slim_presence=True` for the modern fields.
- Server upgrade note corrected: `docs/overview/changelog.md` previously contained an upgrade note telling admins their integrations would break and need updating. That was written when [4c3aa4c](https://github.com/zulip/zulip/commit/4c3aa4c007ef0caa6c15f8bb9af515eda01521ec) landed. This PR corrects it to reflect that no changes are required.

<details> 
<summary>Screenshots:</summary>
The rendered documentation page, Heading and Parameters:
<img width="735" height="820" alt="image" src="https://github.com/user-attachments/assets/7e55f6a7-1729-49a4-8c4b-4371ec5fbb05" />


The redenered documentation page, Response and Example:
<img width="591" height="1165" alt="image" src="https://github.com/user-attachments/assets/1bd42675-72f9-4fae-984c-ec7c25be7c0b" />



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
