### PR TITLE
external_auth: Reject syncing delivery_email onto a system-bot address.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4184,6 +4184,53 @@ class SAMLAuthBackendTest(SocialAuthBase):
             any("Can't sync email" in output for output in m.output),
         )
 
+    def test_external_auth_id_saml_cross_realm_bot_email(self) -> None:
+        """Test that email is NOT synced when the target email is reserved
+        for a cross-realm system bot."""
+        hamlet = self.example_user("hamlet")
+
+        idps_config_dict = copy.deepcopy(settings.SOCIAL_AUTH_SAML_ENABLED_IDPS)
+        idps_config_dict["test_idp"]["attr_user_permanent_id"] = "uid"
+        uid_value = "testuid"
+
+        # Create ExternalAuthID for hamlet.
+        account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
+        with (
+            self.settings(SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_config_dict),
+            self.assertLogs(self.logger_string, level="INFO"),
+        ):
+            result = self.social_auth_test(
+                account_data_dict,
+                subdomain="zulip",
+                extra_attributes={"uid": [uid_value]},
+            )
+        self.assertEqual(result.status_code, 302)
+
+        # Try to login with a cross-realm bot email - should find hamlet by
+        # ExternalAuthID but refuse to sync the email onto a reserved address.
+        bot_email = "notification-bot@zulip.com"
+        assert bot_email in settings.CROSS_REALM_BOT_EMAILS
+        bot_data = self.get_account_data_dict(email=bot_email, name=self.name)
+        with (
+            self.settings(SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_config_dict),
+            self.assertLogs(self.logger_string, level="INFO") as m,
+        ):
+            result = self.social_auth_test(
+                bot_data,
+                subdomain="zulip",
+                extra_attributes={"uid": [uid_value]},
+            )
+        self.assertEqual(result.status_code, 302)
+        data = load_subdomain_token(result)
+        self.assertEqual(data["email"], hamlet.delivery_email)
+
+        hamlet.refresh_from_db()
+        # Email should NOT have changed.
+        self.assertEqual(hamlet.delivery_email, self.email)
+        self.assertTrue(
+            any("reserved for system bots" in output for output in m.output),
+        )
+
     def test_external_auth_id_saml_deactivated_user(self) -> None:
         """Test that a deactivated user can't log in even with ExternalAuthID."""
         hamlet = self.example_user("hamlet")

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -121,6 +121,7 @@ from zerver.models.users import (
     PasswordTooWeakError,
     get_user_by_delivery_email,
     get_user_profile_by_id,
+    is_cross_realm_bot_email,
     remote_user_to_email,
 )
 from zproject.settings_types import OIDCIdPConfigDict
@@ -816,7 +817,17 @@ def get_and_sync_user_profile_by_external_auth_id(
             user_profile.delivery_email,
             email,
         )
-        if (
+        if is_cross_realm_bot_email(email):
+            # Cross-realm bot emails are reserved for system bots; we
+            # must never let an external auth directory sync a regular
+            # user's delivery_email onto one, since is_cross_realm_bot_email
+            # is used as an authorization shortcut in several places.
+            logger.warning(
+                "Can't sync email for user %s: %s is reserved for system bots",
+                user_profile.id,
+                email,
+            )
+        elif (
             UserProfile.objects.filter(realm=realm, delivery_email__iexact=email)
             # The EXISTS query has a somewhat strange shape because we need
             # to again consider the edge case where we might be simply


### PR DESCRIPTION
get_and_sync_user_profile_by_external_auth_id updates a user's delivery_email from the IdP when the ExternalAuthID-keyed account's email has drifted, but only guarded against another user in the realm already holding the target email.  Every other path that changes delivery_email additionally refuses values in CROSS_REALM_BOT_EMAILS via validate_email_not_already_in_realm.

Enforce that here as well.  We cannot use validate_email_not_already_in_realm here, as it may the case that the user is only updating the case of their email address.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
