### PR TITLE
[ai] user_groups: Allow bots to access all user_groups API endpoints.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,19 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 12.0
 
+**Feature level 496**
+
+* [`GET /user_groups`](/api/get-user-groups),
+  [`POST /user_groups/create`](/api/create-user-group),
+  [`PATCH /user_groups/{user_group_id}`](/api/update-user-group),
+  [`POST /user_groups/{user_group_id}/members`](/api/update-user-group-members),
+  [`GET /user_groups/{user_group_id}/members`](/api/get-user-group-members),
+  [`GET /user_groups/{user_group_id}/members/{user_id}`](/api/get-is-user-group-member),
+  [`POST /user_groups/{user_group_id}/subgroups`](/api/update-user-group-subgroups),
+  [`GET /user_groups/{user_group_id}/subgroups`](/api/get-user-group-subgroups):
+  Bot users are now permitted to call these endpoints. Previously, they
+  were restricted to human users; guest users remain blocked.
+
 **Feature level 495**
 
 * [Message formatting](/api/message-formatting): Uploaded videos with

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 495
+API_FEATURE_LEVEL = 496
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -710,7 +710,7 @@ def require_human_non_guest_user(
 def require_user_group_create_permission(
     view_func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse],
 ) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
-    @require_human_non_guest_user
+    @require_non_guest_user
     @wraps(view_func)
     def _wrapped_view_func(
         request: HttpRequest,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25308,6 +25308,9 @@ paths:
       tags: ["users"]
       description: |
         Create a new [user group](/help/user-groups).
+
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
       requestBody:
         required: true
         content:
@@ -25506,7 +25509,10 @@ paths:
         Update the members of a [user group](/help/user-groups). The
         user IDs must correspond to non-deactivated users.
 
-        **Changes**: Prior to Zulip 11.0 (feature level 391), members
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
+
+        Prior to Zulip 11.0 (feature level 391), members
         could not be added or removed from a deactivated group.
 
         **Changes**: Prior to Zulip 10.0 (feature level 303), group memberships of
@@ -25577,7 +25583,10 @@ paths:
       description: |
         Get the members of a [user group](/help/user-groups).
 
-        **Changes**: New in Zulip 6.0 (feature level 127).
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
+
+        New in Zulip 6.0 (feature level 127).
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
         - $ref: "#/components/parameters/DirectMemberOnly"
@@ -25619,7 +25628,10 @@ paths:
         membership, the deactivated group itself cannot be mentioned
         or used in the value of any permission without first being reactivated.
 
-        **Changes**: Starting with Zulip 11.0 (feature level 386), this
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
+
+        Starting with Zulip 11.0 (feature level 386), this
         endpoint can be used to reactivate a user group.
 
         Prior to Zulip 10.0 (feature level 340), only the name field
@@ -25830,9 +25842,11 @@ paths:
 
         !!! warn ""
 
-            **Note**: This endpoint is only available to [members and
-            administrators](/help/user-roles); bots and guests
-            cannot use this endpoint.
+            **Note**: This endpoint is not available to
+            [guest users](/help/user-roles).
+
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
       requestBody:
         required: false
         content:
@@ -26102,10 +26116,13 @@ paths:
       description: |
         Update the subgroups of a [user group](/help/user-groups).
 
-        **Changes**: Prior to Zulip 11.0 (feature level 391), subgroups
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
+
+        Prior to Zulip 11.0 (feature level 391), subgroups
         could not be added or removed from a deactivated group.
 
-        **Changes**: New in Zulip 6.0 (feature level 127).
+        New in Zulip 6.0 (feature level 127).
       x-curl-examples-parameters:
         oneOf:
           - type: exclude
@@ -26150,7 +26167,10 @@ paths:
       description: |
         Get the subgroups of a [user group](/help/user-groups).
 
-        **Changes**: New in Zulip 6.0 (feature level 127).
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
+
+        New in Zulip 6.0 (feature level 127).
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
         - name: direct_subgroup_only
@@ -26192,7 +26212,10 @@ paths:
       description: |
         Check whether a user is member of user group.
 
-        **Changes**: Prior to Zulip 12.0 (feature level 458), this endpoint
+        **Changes**: Prior to Zulip 12.0 (feature level 496), bot
+        users were not permitted to call this endpoint.
+
+        Prior to Zulip 12.0 (feature level 458), this endpoint
         did not support querying group membership of bot users.
 
         Prior to Zulip 10.0 (feature level 303),

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -4097,6 +4097,17 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
         self.assertFalse(result_dict["is_user_group_member"])
 
+        # Bot users can read group membership.
+        bot = self.example_user("default_bot")
+        result_dict = orjson.loads(
+            self.api_get(bot, f"/api/v1/user_groups/{admins_group.id}/members/{iago.id}").content
+        )
+        self.assertTrue(result_dict["is_user_group_member"])
+        result_dict = orjson.loads(
+            self.api_get(bot, f"/api/v1/user_groups/{admins_group.id}/members/{othello.id}").content
+        )
+        self.assertFalse(result_dict["is_user_group_member"])
+
         # Check membership of deactivated user.
         do_deactivate_user(iago, acting_user=None)
         result = self.client_get(f"/json/user_groups/{admins_group.id}/members/{iago.id}")
@@ -4147,6 +4158,13 @@ class UserGroupAPITestCase(UserGroupTestCase):
             self.client_get(f"/json/user_groups/{moderators_group.id}/members", info=params).content
         )
         self.assertCountEqual(result_dict["members"], [shiva.id])
+
+        # Bot users can read group members.
+        bot = self.example_user("default_bot")
+        result_dict = orjson.loads(
+            self.api_get(bot, f"/api/v1/user_groups/{moderators_group.id}/members").content
+        )
+        self.assertCountEqual(result_dict["members"], [desdemona.id, iago.id, shiva.id])
 
         # Check deactivated users are not returned in members list.
         do_deactivate_user(shiva, acting_user=None)
@@ -4213,6 +4231,122 @@ class UserGroupAPITestCase(UserGroupTestCase):
             ).content
         )
         self.assertCountEqual(result_dict["subgroups"], [admins_group.id])
+
+        # Bot users can read group subgroups.
+        bot = self.example_user("default_bot")
+        result_dict = orjson.loads(
+            self.api_get(bot, f"/api/v1/user_groups/{moderators_group.id}/subgroups").content
+        )
+        self.assertEqual(set(result_dict["subgroups"]), {admins_group.id, owners_group.id})
+
+    def test_bot_can_use_user_group_write_endpoints(self) -> None:
+        realm = get_realm("zulip")
+        bot = self.example_user("default_bot")
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+
+        # Bot creates a group; it becomes the owner via the default
+        # can_manage_group setting.
+        result = self.api_post(
+            bot,
+            "/api/v1/user_groups/create",
+            info={
+                "name": "bot-created",
+                "members": orjson.dumps([hamlet.id]).decode(),
+                "description": "Group created by a bot",
+            },
+        )
+        self.assert_json_success(result)
+        bot_group = NamedUserGroup.objects.get(name="bot-created", realm_for_sharding=realm)
+
+        # Bot edits the group's name and description.
+        result = self.api_patch(
+            bot,
+            f"/api/v1/user_groups/{bot_group.id}",
+            info={"name": "bot-renamed", "description": "Renamed by bot"},
+        )
+        self.assert_json_success(result)
+        bot_group.refresh_from_db()
+        self.assertEqual(bot_group.name, "bot-renamed")
+        self.assertEqual(bot_group.description, "Renamed by bot")
+
+        # Bot adds and removes a member.
+        result = self.api_post(
+            bot,
+            f"/api/v1/user_groups/{bot_group.id}/members",
+            info={"add": orjson.dumps([othello.id]).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertTrue(
+            UserGroupMembership.objects.filter(
+                user_group=bot_group.usergroup_ptr, user_profile=othello
+            ).exists()
+        )
+
+        result = self.api_post(
+            bot,
+            f"/api/v1/user_groups/{bot_group.id}/members",
+            info={"delete": orjson.dumps([othello.id]).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertFalse(
+            UserGroupMembership.objects.filter(
+                user_group=bot_group.usergroup_ptr, user_profile=othello
+            ).exists()
+        )
+
+        # Bot adds and removes a subgroup.
+        child_group = check_add_user_group(realm, "bot-child", [hamlet], acting_user=bot)
+        result = self.api_post(
+            bot,
+            f"/api/v1/user_groups/{bot_group.id}/subgroups",
+            info={"add": orjson.dumps([child_group.id]).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertTrue(
+            GroupGroupMembership.objects.filter(supergroup=bot_group, subgroup=child_group).exists()
+        )
+
+        result = self.api_post(
+            bot,
+            f"/api/v1/user_groups/{bot_group.id}/subgroups",
+            info={"delete": orjson.dumps([child_group.id]).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertFalse(
+            GroupGroupMembership.objects.filter(supergroup=bot_group, subgroup=child_group).exists()
+        )
+
+    def test_guest_users_cannot_access_user_group_endpoints(self) -> None:
+        realm = get_realm("zulip")
+        polonius = self.example_user("polonius")
+        self.assertTrue(polonius.is_guest)
+        iago = self.example_user("iago")
+        test_group = check_add_user_group(realm, "guest_test", [iago], acting_user=iago)
+
+        # Read endpoint.
+        result = self.api_get(polonius, "/api/v1/user_groups")
+        self.assert_json_error(result, "Not allowed for guest users")
+
+        # Write endpoint: create.
+        result = self.api_post(
+            polonius,
+            "/api/v1/user_groups/create",
+            info={
+                "name": "guest-attempt",
+                "members": orjson.dumps([polonius.id]).decode(),
+                "description": "Guest should not be able to create this",
+            },
+        )
+        self.assert_json_error(result, "Not allowed for guest users")
+
+        # Write endpoint: edit existing.
+        result = self.api_patch(
+            polonius,
+            f"/api/v1/user_groups/{test_group.id}",
+            info={"description": "Guest edit attempt"},
+        )
+        self.assert_json_error(result, "Not allowed for guest users")
 
     def test_add_subgroup_from_wrong_realm(self) -> None:
         iago = self.example_user("iago")

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -18,7 +18,7 @@ from zerver.actions.user_groups import (
     do_update_user_group_name,
     remove_subgroups_from_user_group,
 )
-from zerver.decorator import require_human_non_guest_user, require_user_group_create_permission
+from zerver.decorator import require_non_guest_user, require_user_group_create_permission
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
 from zerver.lib.response import json_success
@@ -115,7 +115,7 @@ def add_user_group(
     return json_success(request, data={"group_id": user_group.id})
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_user_groups(
     request: HttpRequest,
@@ -130,7 +130,7 @@ def get_user_groups(
 
 
 @transaction.atomic(durable=True)
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def edit_user_group(
     request: HttpRequest,
@@ -239,7 +239,7 @@ def deactivate_user_group(
     return json_success(request)
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 @transaction.atomic(durable=True)
 def update_user_group_backend(
@@ -536,7 +536,7 @@ def remove_subgroups_from_group_backend(
     return json_success(request)
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 @transaction.atomic(durable=True)
 def update_subgroups_of_user_group(
@@ -569,7 +569,7 @@ def update_subgroups_of_user_group(
     return json_success(request, data)
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_is_user_group_member(
     request: HttpRequest,
@@ -592,7 +592,7 @@ def get_is_user_group_member(
     )
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_user_group_members(
     request: HttpRequest,
@@ -611,7 +611,7 @@ def get_user_group_members(
     )
 
 
-@require_human_non_guest_user
+@require_non_guest_user
 @typed_endpoint
 def get_subgroups_of_user_group(
     request: HttpRequest,


### PR DESCRIPTION
The user_groups read and write endpoints were unintentionally blocked to bot users by the @require_member_or_admin decorator (renamed to @require_human_non_guest_user in #37927).  This prevented bot integrations from using groups as an ACL mechanism, and from managing groups they had created.

Switch the seven @require_human_non_guest_user-decorated endpoints in zerver/views/user_groups.py and the inner decorator in require_user_group_create_permission (which gates POST /user_groups/create) to @require_non_guest_user.  Guest users remain blocked.

This also permits a leaked bot API key to create groups and manage the ones the bot owns.  Per discussion on chat.zulip.org, that does not escalate to any security-sensitive operation; a follow-up may revisit the default value of can_create_user_groups for new organizations, which is orthogonal.

Discussed on chat.zulip.org:
https://chat.zulip.org/#narrow/channel/378-api-design/topic/GET.20.2Fuser_groups.2F.3Cid.3E.2Fmembers.2F.3Cuser_id.3E.20not.20accessible.20to.20bo
