### PR TITLE
compose_paste: Focus paste button on compose banner when shown.

### DIFF
--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -823,6 +823,13 @@ export function paste_handler(
                     // and also is required for undo, see above.
                     $banner.remove();
                 });
+                if (avoid_direct_paste) {
+                    // Using focus({focusVisible: true}) here ensures that :focus-visible
+                    // activates in Chrome.
+                    $banner
+                        .find(".main-view-banner-action-button.paste-to-compose")[0]
+                        ?.focus({focusVisible: true});
+                }
             }, 0);
         }
 


### PR DESCRIPTION
When pasting content in the compose box is withheld and a compose banner is shown, we move focus to the paste button in the banner so users can easily paste the text, which is likely the desired motive for the user.

<!-- Describe your pull request here.-->

Fixes: [#issues > keyboard navigation after pasting large text @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20navigation.20after.20pasting.20large.20text/near/2427875)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

[Screencast from 2026-04-25 02-37-15.webm](https://github.com/user-attachments/assets/b2cb0b0c-a777-427d-855c-d02ace350a68)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
