### PR TITLE
css: Fix slow-send spinner rotating around wrong axis

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -848,7 +848,7 @@ strong {
 .messagebox-content .slow-send-spinner {
     display: block;
     font-size: 0.8571em; /* 12px at 14px/em */
-    text-align: right;
+    margin-left: auto;
     opacity: 0.8;
     color: var(--color-text-default);
     animation: rotate 1s infinite linear;


### PR DESCRIPTION
The .slow-send-spinner is display:block inside a CSS Grid column, which
stretches it to the full column width (~700px). The icon is right-aligned
via text-align:right, so the default transform-origin of 50% 50% resolves
to the center of that wide box, far to the left of the icon. The result
is the spinner visibly orbiting a distant point instead of spinning in
place.

As a fix, I replace text-align:right with margin-left:auto. In CSS Grid, auto margins
absorb all free space, collapsing the element box to the icon's width
(14px). The default transform-origin 50% 50% then resolves to the icon's
visual center, giving a sub-pixel orbit radius.

**How changes were tested:**
1. Verified with a Puppeteer test against the real Zulip test server: measured orbit radius = 0.15px (was ~350px before).
2. Side-by-side screenshots at 0/90/180/270 degrees confirm the icon stays in place in the fixed state and visibly orbits in the broken state.
3. ./tools/lint web/styles/zulip.css passes.

**Screenshots and screen captures:**
Here are images gathered by the local puppeteer test I wrote, comparing the spinner before to the spinner after.
Before:
<img width="794" height="72" alt="Image" src="https://github.com/user-attachments/assets/a87983e8-7989-4031-87ec-2d5818f24125" />
<img width="794" height="72" alt="Image" src="https://github.com/user-attachments/assets/5c166831-797c-4156-af02-0e146b179e3d" />
<img width="794" height="72" alt="Image" src="https://github.com/user-attachments/assets/178c8513-90a7-4cf7-add7-c23677828f63" />
After:
<img width="794" height="72" alt="Image" src="https://github.com/user-attachments/assets/9763c61d-d967-4a70-922c-aed341e48956" />
<img width="794" height="72" alt="Image" src="https://github.com/user-attachments/assets/0788e5eb-e0a6-4ab0-824d-7626677e8f87" />
<img width="794" height="72" alt="Image" src="https://github.com/user-attachments/assets/1b521356-7d3d-48fc-816f-2c753fdea2c8" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [Check] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [Check] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [Check] Explains differences from previous plans (e.g., issue description).
- [Check] Highlights technical choices and bugs encountered.
- [Check] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [Check] Each commit is a coherent idea.
- [Check] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [Check] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
