### PR TITLE
left_sidebar: Gate display options on show_channel_display_options.

### DIFF
--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -144,6 +144,7 @@ export function initialize(): void {
             onShow(instance) {
                 const show_channel_folders = user_settings.web_left_sidebar_show_channel_folders;
                 const show_collapse_expand_all_options = true;
+                const show_channel_display_options = true;
                 // Assuming that the instance can be shown, track and
                 // prep the instance for showing
                 popover_menus.popover_instances.show_folders_sidebar = instance;
@@ -153,6 +154,7 @@ export function initialize(): void {
                             show_channel_folders,
                             channel_folders_id: "left_sidebar_channel_folders",
                             show_collapse_expand_all_options,
+                            show_channel_display_options,
                             web_stream_unreads_count_display_policy_values:
                                 settings_config.web_stream_unreads_count_display_policy_values,
                             web_stream_unreads_count_display_policy:
@@ -192,6 +194,7 @@ export function initialize(): void {
         onShow(instance) {
             const show_channel_folders = user_settings.web_inbox_show_channel_folders;
             const show_collapse_expand_all_options = false;
+            const show_channel_display_options = false;
             // Assuming that the instance can be shown, track and
             // prep the instance for showing
             popover_menus.popover_instances.show_folders_inbox = instance;
@@ -201,6 +204,7 @@ export function initialize(): void {
                         show_channel_folders,
                         channel_folders_id: "inbox_channel_folders",
                         show_collapse_expand_all_options,
+                        show_channel_display_options,
                     }),
                 ),
             );

--- a/web/templates/popovers/left_sidebar_menu_popover.hbs
+++ b/web/templates/popovers/left_sidebar_menu_popover.hbs
@@ -24,6 +24,7 @@
                 {{/if}}
             </a>
         </li>
+        {{#if show_channel_display_options}}
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item">
             <label class="display-style-selector-header popover-menu-link" role="menuitem">
@@ -57,5 +58,6 @@
                 </label>
             </li>
         {{/each}}
+        {{/if}}
     </ul>
 </div>


### PR DESCRIPTION
fd5d37b440 added "Show unread counts for" and "Clicking on a channel navigates to" radio sections to the shared left_sidebar_menu_popover template, but only wired up the data in the left-sidebar onShow handler. The inbox-view onShow uses the same template and does not pass those values, causing a blueslip error ("Cannot loop over a value of type [object Undefined]") whenever the inbox channel-folders popover is opened.

Follow the precedent of show_collapse_expand_all_options (introduced in a6586e62b8) by wrapping the new sections in {{#if show_channel_display_options}} and passing true/false from the respective onShow handlers.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
