### PR TITLE
[ai] recent_view: Pin mark-as-read tooltip placement per row.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -1030,6 +1030,35 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: "#recent-view-content-tbody .on_hover_topic_read",
+        popperOptions: {
+            modifiers: [
+                {
+                    // We pick the placement explicitly per row in
+                    // onShow below, so disable Popper's automatic
+                    // flipping by providing no fallback placements.
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: [],
+                    },
+                },
+            ],
+        },
+        onShow(instance) {
+            // The first row's tooltip would overflow the top of the
+            // recent view, so we place it to the left instead. All
+            // other rows' tooltips are placed on top.
+            const is_first_row =
+                $(instance.reference).closest("#recent-view-content-tbody tr:first-child").length >
+                0;
+            instance.setProps({placement: is_first_row ? "left" : "top"});
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".recent-view-conversation-link",
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -36,13 +36,13 @@
                 <span class="unread_mention_info tippy-zulip-tooltip {{#unless has_unread_mention}}unread_hidden{{/unless}}"
                   data-tippy-content="{{t 'You have unread mentions' }}">@</span>
                 <div class="recent_topic_actions recent-view-unread-count-wrapper">
-                    <span class="unread_count unread_count_pm recent-view-table-unread-count recent_view_focusable {{#if (eq unread_count 0)}}unread_hidden{{/if}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" aria-label="{{t 'Mark as read' }}" data-col-index="{{ column_indexes.read }}" tabindex="0">{{unread_count}}</span>
+                    <span class="unread_count unread_count_pm recent-view-table-unread-count recent_view_focusable {{#if (eq unread_count 0)}}unread_hidden{{/if}} on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" aria-label="{{t 'Mark as read' }}" data-col-index="{{ column_indexes.read }}" tabindex="0">{{unread_count}}</span>
                 </div>
                 {{else}}
                 <span class="unread_mention_info tippy-zulip-tooltip {{#unless mention_in_unread}}unread_hidden{{/unless}}"
                   data-tippy-content="{{t 'You have unread mentions'}}">@</span>
                 <div class="recent_topic_actions recent-view-unread-count-wrapper">
-                    <span class="unread_count recent-view-table-unread-count hidden-for-spectators recent_view_focusable {{#if (eq unread_count 0)}}unread_hidden{{/if}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" aria-label="{{t 'Mark as read' }}" data-col-index="{{ column_indexes.read }}" tabindex="0">{{unread_count}}</span>
+                    <span class="unread_count recent-view-table-unread-count hidden-for-spectators recent_view_focusable {{#if (eq unread_count 0)}}unread_hidden{{/if}} on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" aria-label="{{t 'Mark as read' }}" data-col-index="{{ column_indexes.read }}" tabindex="0">{{unread_count}}</span>
                 </div>
                 {{/if}}
             </div>


### PR DESCRIPTION
The "Mark as read" tooltip on the unread-count button in the recent
conversations view used the default `tippy-zulip-tooltip` delegate,
which let Popper flip placement to whatever fit. On the first row
this often overflowed the top of the view, and on other rows the
tooltip occasionally flipped to the side, drifting over adjacent
columns.

This change replaces the default delegate for these buttons with a
recent-view-scoped one that pins the first row's tooltip to `left`
(to avoid the top overflow) and all other rows to `top`, with flip
fallbacks disabled so Popper does not relocate them.

| before | after |
| --- | --- |
| <img width="230" height="212" alt="image" src="https://github.com/user-attachments/assets/84e91d17-529f-4635-9e6c-1970d6a4f401" /> | <img width="433" height="267" alt="image" src="https://github.com/user-attachments/assets/67269de7-8202-46e6-90eb-b1258a323bd5" /> | 

---

Asked claude to point the first row unread count tooltip to left and the rest to top.

