### PR TITLE
[ai] events: Add apply_event handler for reminders events.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1156,6 +1156,21 @@ def apply_event(
                 if scheduled_message["scheduled_message_id"] == event["scheduled_message_id"]:
                     del state["scheduled_messages"][idx]
 
+    elif event["type"] == "reminders":
+        if event["op"] == "add":
+            # Bulk addition of reminders is not used in normal flow.
+            assert len(event["reminders"]) == 1
+
+            state["reminders"].append(event["reminders"][0])
+            # Sort in ascending order of scheduled_delivery_timestamp.
+            state["reminders"].sort(key=lambda reminder: reminder["scheduled_delivery_timestamp"])
+
+        if event["op"] == "remove":
+            for idx, reminder in enumerate(state["reminders"]):
+                if reminder["reminder_id"] == event["reminder_id"]:
+                    del state["reminders"][idx]
+                    break
+
     elif event["type"] == "onboarding_steps":
         state["onboarding_steps"] = event["onboarding_steps"]
     elif event["type"] == "custom_profile_fields":

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -105,6 +105,7 @@ from zerver.actions.realm_settings import (
     do_set_realm_user_default_setting,
     do_set_realm_zulip_update_announcements_stream,
 )
+from zerver.actions.reminders import do_delete_reminder, schedule_reminder_for_message
 from zerver.actions.saved_snippets import (
     do_create_saved_snippet,
     do_delete_saved_snippet,
@@ -219,6 +220,8 @@ from zerver.lib.event_schema import (
     check_realm_user_add,
     check_realm_user_remove,
     check_realm_user_update,
+    check_reminder_add,
+    check_reminder_remove,
     check_saved_snippets_add,
     check_saved_snippets_remove,
     check_saved_snippets_update,
@@ -297,6 +300,7 @@ from zerver.models import (
     RealmPlayground,
     RealmUserDefault,
     SavedSnippet,
+    ScheduledMessage,
     Service,
     Stream,
     UserMessage,
@@ -5699,6 +5703,31 @@ class ScheduledMessagesEventsTest(BaseAction):
         with self.verify_action() as events:
             delete_scheduled_message(self.user_profile, scheduled_message_id)
         check_scheduled_message_remove("events[0]", events[0])
+
+
+class RemindersEventsTest(BaseAction):
+    def schedule_reminder(self, message_id: int) -> int:
+        return schedule_reminder_for_message(
+            self.user_profile,
+            get_client("website"),
+            message_id,
+            convert_to_UTC(dateparser("2023-04-19 18:24:56")),
+            note="",
+        )
+
+    def test_reminder_add_event(self) -> None:
+        message_id = self.send_stream_message(self.user_profile, "Verona", "Test message")
+        with self.verify_action() as events:
+            self.schedule_reminder(message_id)
+        check_reminder_add("events[0]", events[0])
+
+    def test_reminder_remove_event(self) -> None:
+        message_id = self.send_stream_message(self.user_profile, "Verona", "Test message")
+        reminder_id = self.schedule_reminder(message_id)
+        reminder = ScheduledMessage.objects.get(id=reminder_id)
+        with self.verify_action() as events:
+            do_delete_reminder(self.user_profile, reminder)
+        check_reminder_remove("events[0]", events[0])
 
 
 class ChannelFolderActionTest(BaseAction):


### PR DESCRIPTION
## Summary

Web clients call `/register` with `fetch_event_types=None`, so no events are filtered out by the early-continue in `apply_events`. Without a `reminders` branch in the `apply_event` cascade, a `reminders` event that lands in the queue between queue allocation and the initial-state snapshot falls through to the bare `AssertionError` at the end of `apply_event` (`zerver/lib/events.py:2060`), crashing the register response with a 500.

The race window is narrow but reproducible for a user who schedules or completes a reminder while a tab is reconnecting.

The frontend dispatch in `web/src/server_events_dispatch.js:709-725` and the initial-state hydration at `zerver/lib/events.py:348-349` were both already in place — only the server-side replay branch was missing.

## Approach

Mirror the adjacent `scheduled_messages` handler:

- `op="add"`: append the new entry and re-sort `state[\"reminders\"]` by `scheduled_delivery_timestamp`.
- `op="remove"`: delete the entry whose `reminder_id` matches `event[\"reminder_id\"]`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Asked claude to address this issue from `event-audience-correctness.md`