### PR TITLE
[ai] email_notifications: Use canonical topic name in threading header.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -591,8 +591,11 @@ def do_send_missedmessage_events_reply_in_zulip(
             topic_name=display_topic_name,
             topic_resolved=topic_resolved,
         )
+        # Use the canonical (untranslated) topic name in the threading
+        # header so that recipients with different default_language
+        # settings receive a stable Message-Id for the same conversation.
         synthetic_root_message_id = prepare_synthetic_root_message_id(
-            Recipient.STREAM, message.recipient_id, topic_name=display_topic_name
+            Recipient.STREAM, message.recipient_id, topic_name=bare_topic_name
         )
     else:
         raise AssertionError("Invalid messages!")

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1970,6 +1970,61 @@ class TestMessageNotificationEmails(ZulipTestCase):
         self.assertEqual(mail.outbox[0].subject, expected_email_subject)
         self.assertIn(expected_email_body_includes, self.normalize_string(mail.outbox[0].body))
 
+    def test_empty_string_topic_threading_header_is_locale_invariant(self) -> None:
+        # The In-Reply-To/References header on an empty-topic stream
+        # missedmessage email is currently derived from the per-user
+        # locale-translated fallback name (e.g. "general chat" /
+        # "allgemeiner Chat"), so recipients with different
+        # default_language settings get divergent Message-Ids for the
+        # same conversation, which breaks cross-user threading in email
+        # clients.
+        #
+        # This test documents the buggy behavior; the next commit fixes
+        # it and flips the assertions to assertEqual.
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+        self.subscribe(cordelia, "Denmark")
+        do_change_user_setting(hamlet, "default_language", "en", acting_user=None)
+        do_change_user_setting(cordelia, "default_language", "de", acting_user=None)
+
+        message_id = self.send_stream_message(
+            othello,
+            "Denmark",
+            content="Hello channel",
+            topic_name="",
+        )
+
+        # Stub get_topic_display_name to simulate deployed translations
+        # (the test runner's Django catalogs do not include a standalone
+        # "general chat" translation, so without this stub the header
+        # divergence the bug causes in production cannot be observed).
+        def fake_display(topic_name: str, language: str) -> str:
+            assert topic_name == ""
+            return {"en": "general chat", "de": "allgemeiner Chat"}[language]
+
+        with patch(
+            "zerver.lib.email_notifications.get_topic_display_name", side_effect=fake_display
+        ):
+            self.handle_missedmessage_emails(
+                hamlet.id,
+                {message_id: MissedMessageData(trigger=NotificationTriggers.FOLLOWED_TOPIC_EMAIL)},
+            )
+            self.handle_missedmessage_emails(
+                cordelia.id,
+                {message_id: MissedMessageData(trigger=NotificationTriggers.FOLLOWED_TOPIC_EMAIL)},
+            )
+
+        self.assert_length(mail.outbox, 2)
+        self.assertNotEqual(
+            mail.outbox[0].extra_headers["In-Reply-To"],
+            mail.outbox[1].extra_headers["In-Reply-To"],
+        )
+        self.assertNotEqual(
+            mail.outbox[0].extra_headers["References"],
+            mail.outbox[1].extra_headers["References"],
+        )
+
     def test_prepare_synthetic_root_message_id(self) -> None:
         hamlet = self.example_user("hamlet")
         aaron = self.example_user("aaron")

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1972,15 +1972,10 @@ class TestMessageNotificationEmails(ZulipTestCase):
 
     def test_empty_string_topic_threading_header_is_locale_invariant(self) -> None:
         # The In-Reply-To/References header on an empty-topic stream
-        # missedmessage email is currently derived from the per-user
-        # locale-translated fallback name (e.g. "general chat" /
-        # "allgemeiner Chat"), so recipients with different
-        # default_language settings get divergent Message-Ids for the
-        # same conversation, which breaks cross-user threading in email
-        # clients.
-        #
-        # This test documents the buggy behavior; the next commit fixes
-        # it and flips the assertions to assertEqual.
+        # missedmessage email must be derived from the canonical empty
+        # string, not the per-user locale-translated fallback name, so
+        # that recipients with different default_language settings
+        # share a stable Message-Id for the same conversation.
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
         othello = self.example_user("othello")
@@ -2016,14 +2011,12 @@ class TestMessageNotificationEmails(ZulipTestCase):
             )
 
         self.assert_length(mail.outbox, 2)
-        self.assertNotEqual(
-            mail.outbox[0].extra_headers["In-Reply-To"],
-            mail.outbox[1].extra_headers["In-Reply-To"],
-        )
-        self.assertNotEqual(
-            mail.outbox[0].extra_headers["References"],
-            mail.outbox[1].extra_headers["References"],
-        )
+        recipient_id = Message.objects.get(id=message_id).recipient_id
+        expected_message_id = f"<{recipient_id}.@testserver>"
+        self.assertEqual(mail.outbox[0].extra_headers["In-Reply-To"], expected_message_id)
+        self.assertEqual(mail.outbox[0].extra_headers["References"], expected_message_id)
+        self.assertEqual(mail.outbox[1].extra_headers["In-Reply-To"], expected_message_id)
+        self.assertEqual(mail.outbox[1].extra_headers["References"], expected_message_id)
 
     def test_prepare_synthetic_root_message_id(self) -> None:
         hamlet = self.example_user("hamlet")


### PR DESCRIPTION
## Summary

The `In-Reply-To` and `References` headers on missedmessage emails for empty-topic stream messages are derived from the per-recipient locale-translated fallback name returned by `get_topic_display_name` (`zerver/lib/topic.py:391-395`). Recipients with different `default_language` settings therefore get divergent `Message-Id`s for the same conversation — e.g. one user gets a header derived from `base64("general chat")` and another from `base64("allgemeiner Chat")` — which breaks cross-user threading in email clients.

The synthetic-root-message-id contract is that messages in the same conversation share a stable identifier; that contract is currently violated for every empty-topic stream email.

## Approach

Pass `bare_topic_name` (the canonical empty string for empty topics, or the unmodified topic name otherwise) into `prepare_synthetic_root_message_id`. The email subject and body continue to use `display_topic_name`, which is the correct user-facing form — only the threading header needs a stable identifier across recipients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Asked claude the fix this bug in ` event-audience-correctness.md`.