### PR TITLE
group_settings: Use CSS flex layout for member list height.

### DIFF
--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -80,6 +80,10 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .user-group-settings-header-actions").hide();
         resize.resize_settings_overlay($("#groups_overlay_container"));
         resize.resize_settings_creation_overlay($("#groups_overlay_container"));
+        $("#user_group_creation_form .two-pane-settings-creation-simplebar-container").toggleClass(
+            "members-visible",
+            container_name === "user_group_members_container",
+        );
     },
 };
 

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1241,6 +1241,7 @@ export function setup_group_settings(group: UserGroup): void {
             select_tab = key;
             const hash = hash_util.group_edit_url(group, select_tab);
             browser_history.update(hash);
+            $("#user_group_settings").toggleClass("members-tab-active", key === "members");
         },
     });
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -284,8 +284,22 @@ h4.user_group_setting_subsection_title {
     padding-right: 8px;
 }
 
+.add_members_container,
 .add_subscribers_container {
+    display: inline-flex;
     width: 100%;
+    align-items: center;
+
+    /* We need on click events to fire on this input for our typeahead.
+       This ensures that the input occupies space in the parent
+       container. */
+    .input {
+        flex-grow: 1;
+    }
+
+    & button[disabled] {
+        pointer-events: none;
+    }
 
     /* Set minimum height so that at least one row of pills is visible. */
     min-height: calc(
@@ -293,6 +307,7 @@ h4.user_group_setting_subsection_title {
             var(--outer-spacing-input-pill-container) + 2px
     );
 
+    .members-input-scrollable-container,
     .subscriber-input-scrollable-container {
         max-height: 30vh;
         height: 100%;
@@ -343,24 +358,6 @@ h4.user_group_setting_subsection_title {
         justify-content: flex-start;
         align-items: center;
         margin: 0 0 5px;
-    }
-}
-
-.add_subscribers_container,
-.add_members_container {
-    display: inline-flex;
-    width: 100%;
-    align-items: center;
-
-    /* We need on click events to fire on this input for our typeahead.
-       This ensures that the input occupies space in the parent
-       container. */
-    .input {
-        flex-grow: 1;
-    }
-
-    & button[disabled] {
-        pointer-events: none;
     }
 }
 
@@ -1360,24 +1357,29 @@ h4.user_group_setting_subsection_title {
         }
     }
 
-    #stream_settings.subscribers-tab-active {
-        /* When the subscribers tab is active, disable simplebar on
-           #stream_settings so the panel itself is not scrollable —
-           only the subscriber list table scrolls via its own simplebar.
-           Simplebar reads the host element's computed overflow-y and
-           disables its scrollbar when it sees 'hidden'. */
+    #stream_settings.subscribers-tab-active,
+    #user_group_settings.members-tab-active {
+        /* When the subscribers/members tab is active, disable simplebar
+           on #stream_settings/#user_group_settings so the panel itself
+           is not scrollable — only the subscriber/member list table
+           scrolls via its own simplebar. Simplebar reads the host
+           element's computed overflow-y and disables its scrollbar
+           when it sees 'hidden'. */
         overflow-y: hidden;
 
         /* Propagate the container height through simplebar's wrapper
            DOM to the actual content. :has() targets only the outer
-           simplebar-content (the one containing .subscription_settings),
-           not the nested one inside .subscriber_list_container. */
-        .simplebar-content:has(> .subscription_settings) {
+           simplebar-content (the one containing .subscription_settings/
+           user_group_settings_wrapper), not the nested one inside
+           .subscriber_list_container/.member_list_container. */
+        .simplebar-content:has(> .subscription_settings),
+        .simplebar-content:has(> .user_group_settings_wrapper) {
             height: 100%;
             display: flex;
             flex-direction: column;
 
             .subscription_settings,
+            .user_group_settings_wrapper,
             .inner-box {
                 flex: 1;
                 overflow: hidden;
@@ -1385,40 +1387,50 @@ h4.user_group_setting_subsection_title {
                 flex-direction: column;
             }
 
-            .stream_section[data-stream-section="subscribers"] {
+            .stream_section[data-stream-section="subscribers"],
+            .group_setting_section[data-group-section="members"] {
                 flex: 1;
                 overflow: hidden;
 
                 .edit_subscribers_for_stream,
-                .subscriber_list_settings_container {
+                .edit_members_for_user_group,
+                .subscriber_list_settings_container,
+                .member_list_settings_container {
                     height: 100%;
                 }
             }
         }
     }
 
-    .two-pane-settings-creation-simplebar-container.subscribers-visible {
-        /* When the subscribers step is visible in the stream creation form,
-        disable simplebar on the outer container and use flex layout so
-        only the subscriber list table scrolls via its own simplebar. */
+    .two-pane-settings-creation-simplebar-container.subscribers-visible,
+    .two-pane-settings-creation-simplebar-container.members-visible {
+        /* When the subscribers/members step is visible in the stream/group
+        creation form, disable simplebar on the outer container and use
+        flex layout so only the subscriber/member list table scrolls
+        via its own simplebar. */
         overflow-y: hidden;
 
-        .simplebar-content:has(> .stream-creation-body) {
+        .simplebar-content:has(> .stream-creation-body),
+        .simplebar-content:has(> .user-group-creation-body) {
             height: 100%;
             display: flex;
             flex-direction: column;
 
-            .stream-creation-body {
+            .stream-creation-body,
+            .user-group-creation-body {
                 flex: 1;
                 overflow: hidden;
 
-                .subscribers_container {
+                .subscribers_container,
+                .user_group_members_container {
                     height: 100%;
                     display: flex;
                     flex-direction: column;
 
                     .stream_create_add_subscriber_container,
-                    #people_to_add {
+                    #choose_member_section,
+                    #people_to_add,
+                    #people_to_add_in_group {
                         flex: 1;
                         overflow: hidden;
                         display: flex;
@@ -1430,23 +1442,27 @@ h4.user_group_setting_subsection_title {
     }
 
     #stream_settings.subscribers-tab-active .subscriber-list-box,
+    #user_group_settings.members-tab-active .member-list-box,
     .two-pane-settings-creation-simplebar-container.subscribers-visible
-        .subscriber-list-box {
+        .subscriber-list-box,
+    .two-pane-settings-creation-simplebar-container.members-visible
+        .member-list-box {
         /* flex: 1 takes remaining space after the auto-sized siblings. */
         flex: 1;
         overflow: hidden;
         /* Hide borders here since they would extend to the
            full flex item height; they are redeclared on
-           .subscriber_list_container instead. */
+           .subscriber_list_container/.member_list_container instead. */
         border-left: none;
         border-right: none;
         /* This is slightly larger than the height required to show at least one
-           subscriber row is shown along with the table header. It is not easy
+           subscriber/member row is shown along with the table header. It is not easy
            to calculate exact height since it depends whether the user has
-           permission to remove subscribers or not. */
+           permission to remove subscribers/members or not. */
         min-height: 4.7em;
 
-        .subscriber_list_container {
+        .subscriber_list_container,
+        .member_list_container {
             box-sizing: border-box;
             max-height: 100%;
             /* overflow: clip prevents the native scrollbar that would otherwise

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1119,7 +1119,7 @@ h4.user_group_setting_subsection_title {
 }
 
 .add_subscribers_container.add_subscribers_disabled,
-.member_list_settings .add_members_disabled {
+.member_list_add .add_members_disabled {
     cursor: not-allowed;
 
     .pill-container {
@@ -1129,7 +1129,7 @@ h4.user_group_setting_subsection_title {
 }
 
 .add_subscribers_container,
-.member_list_settings {
+.member_list_add {
     & button[disabled] {
         pointer-events: none;
     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -321,10 +321,6 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-.member_list_add {
-    width: 100%;
-}
-
 .user_group_subscription_request_result,
 .stream_subscription_request_result {
     & a {
@@ -361,6 +357,10 @@ h4.user_group_setting_subsection_title {
        container. */
     .input {
         flex-grow: 1;
+    }
+
+    & button[disabled] {
+        pointer-events: none;
     }
 }
 
@@ -1119,18 +1119,11 @@ h4.user_group_setting_subsection_title {
 }
 
 .add_subscribers_container.add_subscribers_disabled,
-.member_list_add .add_members_disabled {
+.add_members_container.add_members_disabled {
     cursor: not-allowed;
 
     .pill-container {
         cursor: not-allowed;
-        pointer-events: none;
-    }
-}
-
-.add_subscribers_container,
-.member_list_add {
-    & button[disabled] {
         pointer-events: none;
     }
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -323,7 +323,6 @@ h4.user_group_setting_subsection_title {
 
 .member_list_add {
     width: 100%;
-    margin: 0 0 10px;
 }
 
 .user_group_subscription_request_result,
@@ -411,7 +410,8 @@ h4.user_group_setting_subsection_title {
     padding-left: 2px;
 }
 
-#stream_settings .add-subscribers-subtitle {
+#stream_settings .add-subscribers-subtitle,
+#user_group_settings .add-members-subtitle {
     margin-bottom: 10px;
 }
 

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -1,8 +1,10 @@
 <div class="add_members_container add-button-container">
-    <div class="pill-container person_picker">
-        <div class="input" contenteditable="true"
-          data-placeholder="{{t 'Add users or groups. Use #channelname to add all subscribers.' }}">
-            {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
+    <div class="members-input-scrollable-container" data-simplebar>
+        <div class="pill-container person_picker">
+            <div class="input" contenteditable="true"
+              data-placeholder="{{t 'Add users or groups. Use #channelname to add all subscribers.' }}">
+                {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
+            </div>
         </div>
     </div>
     {{#if (not hide_add_button)}}

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -24,14 +24,3 @@
         </div>
     {{/if}}
 </div>
-<div class="add-members-subtitle">
-    {{#tr}}
-        You can add members by name or email address.
-        Enter a <z-user-roles-link>user role</z-user-roles-link>,
-        <z-user-groups-link>user group</z-user-groups-link>,
-        or <z-channel-link>#channel</z-channel-link> to add multiple users at once.
-        {{#*inline "z-user-roles-link"}}<a href="/help/user-roles" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-        {{#*inline "z-user-groups-link"}}<a href="/help/user-groups" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-        {{#*inline "z-channel-link"}}<a href="/help/introduction-to-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-    {{/tr}}
-</div>

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -1,6 +1,4 @@
-<div class="member_list_add">
-    {{> add_members_form hide_add_button=true}}
-</div>
+{{> add_members_form hide_add_button=true}}
 
 <div class="add-members-subtitle">
     {{#tr}}

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -2,7 +2,19 @@
     {{> add_members_form hide_add_button=true}}
 </div>
 
-<div class="create_member_list_header">
+<div class="add-members-subtitle">
+    {{#tr}}
+        You can add members by name or email address.
+        Enter a <z-user-roles-link>user role</z-user-roles-link>,
+        <z-user-groups-link>user group</z-user-groups-link>,
+        or <z-channel-link>#channel</z-channel-link> to add multiple users at once.
+        {{#*inline "z-user-roles-link"}}<a href="/help/user-roles" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-user-groups-link"}}<a href="/help/user-groups" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-channel-link"}}<a href="/help/introduction-to-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+    {{/tr}}
+</div>
+
+<div class="create_user_group_member_list_header">
     <h4 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h4>
     <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter' }}" />

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -12,6 +12,17 @@
                 {{> add_members_form .}}
             </div>
         </div>
+        <div class="add-members-subtitle">
+            {{#tr}}
+                You can add members by name or email address.
+                Enter a <z-user-roles-link>user role</z-user-roles-link>,
+                <z-user-groups-link>user group</z-user-groups-link>,
+                or <z-channel-link>#channel</z-channel-link> to add multiple users at once.
+                {{#*inline "z-user-roles-link"}}<a href="/help/user-roles" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-user-groups-link"}}<a href="/help/user-groups" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-channel-link"}}<a href="/help/introduction-to-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </div>
     {{/unless}}
     <div>
         <h4 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h4>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -7,9 +7,7 @@
             {{t "Add members" }}
         </h4>
         <div class="user_group_subscription_request_result banner-wrapper"></div>
-        <div class="member_list_add">
-            {{> add_members_form .}}
-        </div>
+        {{> add_members_form .}}
         <div class="add-members-subtitle">
             {{#tr}}
                 You can add members by name or email address.

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -7,10 +7,8 @@
             {{t "Add members" }}
         </h4>
         <div class="user_group_subscription_request_result banner-wrapper"></div>
-        <div class="member_list_settings">
-            <div class="member_list_add">
-                {{> add_members_form .}}
-            </div>
+        <div class="member_list_add">
+            {{> add_members_form .}}
         </div>
         <div class="add-members-subtitle">
             {{#tr}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR improves the layout and usability of the user group settings and creation forms by transitioning to a CSS flexbox-based layout for the member list. These changes ensure that the member list height adjusts dynamically and remains contained within the viewport. Key UI refinements include making the group member pill input scrollable to prevent overflow and reorganizing template structures (like moving subtitles and removing redundant divs) to create a cleaner, more maintainable codebase.

Fixes: #39082

**How changes were tested:**

- [x] UI testing

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--|--|
|<img width="1920" height="965" alt="before_user_group_settings" src="https://github.com/user-attachments/assets/36645565-d0bf-420d-ae48-8138209039b5" />|<img width="1917" height="963" alt="user_group_settings" src="https://github.com/user-attachments/assets/33c8d013-e57c-4479-8cca-b62083ae572b" />|
|<img width="1920" height="967" alt="before_user_group_settings_role_tab" src="https://github.com/user-attachments/assets/49655011-967a-4b6c-b11d-d14d15e9c255" />|<img width="1920" height="968" alt="user_group_settings_role_tab" src="https://github.com/user-attachments/assets/4ba1f52e-4461-45e5-8c0d-966cee72c704" />|

| Group creation form |
|--|
|<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/cbeef4a4-f1a5-4b0a-abb5-e32846b49e20" />|

https://github.com/user-attachments/assets/6097791e-62b8-4ee1-b229-81a667aadbbf


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
