### PR TITLE
[ai] CLAUDE.md: Describe the actual create-api-changelog filename pattern.

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -117,11 +117,17 @@ Structure changes as clean commits:
 - Backend and API changes (with tests and API doc changes documented
   fully using our double-entry changelog system). When starting an API
   change, reread `docs/documentation/api.md` to review the process for
-  documenting an API change. You'll run `tools/create-api-changelog`
-  to create an `api_docs/unmerged.d/ZF-RANDOM.md` file. Never update
-  `API_FEATURE_LEVEL` manually. **Changes** entries should use the
-  "New in Zulip 12.0 (Feature level RANDOM)" pattern, which will be
-  replaced with the final feature level when the changes are merged.
+  documenting an API change. Run `tools/create-api-changelog`; it
+  generates an empty `api_docs/unmerged.d/ZF-XXXXXX.md` file (where
+  `XXXXXX` is a random hex string the tool picks for you) and stages
+  it for you. Document the changes in that file with the header
+  `**Feature level ZF-XXXXXX**` and an unordered list (`*` bullets)
+  of the additions or changes, formatted to match `api_docs/changelog.md`.
+  In the OpenAPI yaml (`zerver/openapi/zulip.yaml`), reference the same
+  filename stem in **Changes** notes, e.g.,
+  `**Changes**: New in Zulip 12.0 (feature level ZF-XXXXXX).` The merge
+  process replaces the placeholder with the final feature level.
+  Never update `API_FEATURE_LEVEL` manually.
 - Frontend UI changes (with tests and user-facing documentation
   updates). Remember to plan to use your visual test skill to check
   your work whenever you change web app code (HTML, CSS, JS).


### PR DESCRIPTION
## Why

The previous wording told AI contributors that `tools/create-api-changelog`
produces `api_docs/unmerged.d/ZF-RANDOM.md` and that **Changes** entries
should literally read `Feature level RANDOM`. That's not what the tool
does — it generates a `ZF-XXXXXX.md` file with a random hex stem, and
the OpenAPI **Changes** note is expected to reference that same stem.
Following the old instructions would produce changelog entries that
don't match `docs/documentation/api.md` and would be flagged in review.

This commit rewrites that bullet to describe the actual filename
pattern, the header format inside the unmerged changelog file, and how
the OpenAPI **Changes** note should reference the same stem.

## Test plan

- [x] Cross-checked the new wording against `docs/documentation/api.md`
      and `tools/create-api-changelog`.
- [x] Documentation-only change; no code, tests, or runtime behavior
      affected.

## Self-review

- [x] Each commit is a minimal coherent idea.
- [x] Commit message explains the why.
- [x] No debugging code or stray comments.
- [x] No user-facing strings changed (internal contributor doc only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)