### PR TITLE
message_formatting: Use decorated channel name in message formatting overlay

### DIFF
--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import render_keyboard_shortcut from "../templates/keyboard_shortcuts.hbs";
 import render_markdown_help from "../templates/markdown_help.hbs";
@@ -25,6 +26,9 @@ import {user_settings} from "./user_settings.ts";
 // Make it explicit that our toggler is undefined until
 // set_up_toggler is called.
 export let toggler: Toggle | undefined;
+
+const mock_sub = {stream_id: 0, name: $t({defaultMessage: "channel name"})};
+const mock_topic = $t({defaultMessage: "topic name"});
 
 function format_usage_html(...keys: string[]): string {
     return $t_html(
@@ -57,11 +61,11 @@ const markdown_help_rows = [
         usage_html: format_usage_html("Ctrl", "Shift", "L"),
     },
     {
-        markdown: `#**${$t({defaultMessage: "channel name"})}**`,
+        markdown: `#**${mock_sub.name}**`,
         effect_html: $t({defaultMessage: "(links to a channel)"}),
     },
     {
-        markdown: `#**${$t({defaultMessage: "channel name"})}>${$t({defaultMessage: "topic name"})}**`,
+        markdown: `#**${mock_sub.name}>${mock_topic}**`,
         effect_html: $t({defaultMessage: "(links to topic)"}),
     },
     {
@@ -217,7 +221,7 @@ export function set_up_toggler(): void {
             return "";
         },
         get_stream_by_name(stream_name) {
-            return {stream_id: 0, name: stream_name};
+            return {stream_id: mock_sub.stream_id, name: stream_name};
         },
     };
     for (const row of markdown_help_rows) {
@@ -227,6 +231,21 @@ export function set_up_toggler(): void {
                 ...markdown.render(row.markdown, helper_config),
             };
             const rendered_content = new DOMParser().parseFromString(message.content, "text/html");
+            for (const elt of rendered_content.querySelectorAll<HTMLElement>("a[data-stream-id]")) {
+                const $elt = $(elt);
+                if ($elt.is("a.stream")) {
+                    rendered_markdown.update_stream_link_element($elt, mock_sub);
+                } else {
+                    const href = $elt.attr("href");
+                    assert(href !== undefined);
+                    rendered_markdown.update_topic_or_message_link_element(
+                        $elt,
+                        mock_sub,
+                        mock_topic,
+                        href,
+                    );
+                }
+            }
             // We remove all attributes from stream links in the markdown content since
             // we just want to display a mock template.
             for (const elt of rendered_content.querySelectorAll("a[data-stream-id]")) {

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -65,6 +65,44 @@ function get_user_group_id_for_mention_button(elem: HTMLElement): number {
     return Number.parseInt(user_group_id, 10);
 }
 
+// We pass a minimal mock stream object in info_overlay for rendering stream links.
+type StreamInfo = {stream_id: number; name: string} | sub_store.StreamSubscription;
+
+export function update_stream_link_element($elem: JQuery, stream_info: StreamInfo): void {
+    $elem.html(render_decorated_channel_name({stream: stream_info, inline_with_text: true}));
+}
+
+export function update_topic_or_message_link_element(
+    $elem: JQuery,
+    stream_info: StreamInfo,
+    topic_name: string,
+    narrow_url: string,
+): void {
+    const topic_display_name = util.get_final_topic_display_name(topic_name);
+
+    const context = {
+        channel_name: stream_info.name,
+        topic_display_name,
+        is_empty_string_topic: topic_name === "",
+        href: narrow_url,
+    };
+
+    if ($elem.hasClass("stream-topic")) {
+        const topic_link_html = render_topic_link({
+            channel_id: stream_info.stream_id,
+            stream: stream_info,
+            ...context,
+        });
+        $elem.replaceWith($(topic_link_html));
+    } else {
+        const message_link_html = render_channel_message_link({
+            stream: stream_info,
+            ...context,
+        });
+        $elem.replaceWith($(message_link_html));
+    }
+}
+
 function get_message_for_message_content($content: JQuery): Message | undefined {
     // TODO: This selector is designed to exclude drafts/scheduled
     // messages. Arguably those settings should be unconditionally
@@ -232,7 +270,7 @@ export const update_elements = ($content: JQuery): void => {
                 // If the stream has been deleted, sub_store.get
                 // might return undefined.  Otherwise, display the
                 // current stream name.
-                $(this).html(render_decorated_channel_name({stream: sub, inline_with_text: true}));
+                update_stream_link_element($(this), sub);
             }
         }
     });
@@ -248,26 +286,13 @@ export const update_elements = ($content: JQuery): void => {
             // and not being displayed in search highlight.
             // TODO: Ideally, we should NOT skip this if only topic is highlighted,
             // but we are doing so currently.
-            const topic_name = channel_topic.topic_name;
-            assert(topic_name !== undefined);
-            const topic_display_name = util.get_final_topic_display_name(topic_name);
-            const context = {
-                channel_name: sub.name,
-                topic_display_name,
-                is_empty_string_topic: topic_name === "",
-                href: narrow_url,
-            };
-            if ($(this).hasClass("stream-topic")) {
-                const topic_link_html = render_topic_link({
-                    channel_id: channel_topic.stream_id,
-                    stream: sub,
-                    ...context,
-                });
-                $(this).replaceWith($(topic_link_html));
-            } else {
-                const message_link_html = render_channel_message_link({stream: sub, ...context});
-                $(this).replaceWith($(message_link_html));
-            }
+            assert(channel_topic.topic_name !== undefined);
+            update_topic_or_message_link_element(
+                $(this),
+                sub,
+                channel_topic.topic_name,
+                narrow_url,
+            );
         }
     });
 


### PR DESCRIPTION
The message formatting Tab was showing channel and topic links as plain `#channel name`(a generic `#`) text, which did not match the new decorated channel name format introduced in #37847, where channel links now render with an appropriate stream type icon before the channel name.

Updated the channel name and topic in the message formatting help overlay to use `output_html` with `render_decorated_channel_name` template directly, so the overlay now shows the correct stream type icon (default `#`), consistent with how channel links appear in actual messages.


Fixes: [#user questions > Message formatting still uses old channel&gt;topic format](https://chat.zulip.org/#narrow/channel/138-user-questions/topic/Message.20formatting.20still.20uses.20old.20channel.3Etopic.20format/with/2444095)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="1918" height="881" alt="Screenshot 2026-04-27 001710" src="https://github.com/user-attachments/assets/36dc9f9e-8fc1-4b00-9ed2-a7e81fa69c62" />|<img width="1919" height="885" alt="Screenshot 2026-04-26 225941" src="https://github.com/user-attachments/assets/fde55ccc-787f-4ee8-93ad-26b4385c61fc" />|


| Before | After |
|--------|-------|
|<img width="1054" height="675" alt="Screenshot 2026-04-27 001718" src="https://github.com/user-attachments/assets/ac8c8164-f753-426a-8f54-7523dad73219" />|<img width="1055" height="676" alt="Screenshot 2026-04-26 230014" src="https://github.com/user-attachments/assets/8d42da19-dd67-47e7-a259-2471f095afff" />|

| Before | After |
|--------|-------|
|<img width="1008" height="109" alt="Screenshot 2026-04-27 111627" src="https://github.com/user-attachments/assets/1f808dab-9bcf-426c-92a7-b30b5351fee3" />|<img width="1012" height="104" alt="Screenshot 2026-04-27 001647" src="https://github.com/user-attachments/assets/5685bf6b-78f8-4569-b009-a1a9bd3a0ae5" />|

| Before | After |
|--------|-------|
|<img width="1013" height="109" alt="Screenshot 2026-04-27 111713" src="https://github.com/user-attachments/assets/b2c3541e-d256-499d-ac1c-c269a1bbb5d8" />|<img width="1014" height="110" alt="Screenshot 2026-04-27 001637" src="https://github.com/user-attachments/assets/b1d127a2-3f6f-4bb3-8b13-3c899bf6615b" />|


<img width="1054" height="675" alt="ezgif com-animated-gif-maker (1)" src="https://github.com/user-attachments/assets/77f8b89b-12f0-42ca-9df2-ac7cb4064a01" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
