### PR TITLE
nginx: Make Tornado /events locations exact matches.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -59,7 +59,7 @@ location /help {
 }
 
 # Send longpoll requests to Tornado
-location /json/events {
+location = /json/events {
     if ($request_method = 'OPTIONS') {
         # add_header does not propagate into/out of blocks, so this
         # include cannot be factored out
@@ -81,7 +81,7 @@ location /json/events {
 }
 
 # Send longpoll requests to Tornado
-location /api/v1/events {
+location = /api/v1/events {
 
     if ($request_method = 'OPTIONS') {
         include /etc/nginx/zulip-include/tornado_cors_headers;


### PR DESCRIPTION
`location /api/v1/events` is a *prefix-match*, and as such passes any URI starting with `/api/v1/events` through to Tornado -- including encoded oddities like `/api/v1/events%3fdont%255fblock=false` (whose decoded $uri still has the prefix) and `/api/v1/events/internal`, which is meant to be reachable only via the loopback interface but was being proxied to Tornado from the public socket.  Tornado's internal_api_view rejects external callers both via its REMOTE_ADDR check and its `SHARED_SECRET` check, so this was not exploitable, but a Tornado worker still had to handle each such request just to 403 it.

Switch to exact matches, as was likely intended all along, which lets those requests fall through to Django/uWSGI and 404 without ever waking Tornado.  The legitimate internal callers in zerver/tornado/django_api.py talk to http://127.0.0.1:<tornado-port> directly, so they are unaffected, as is the X-Accel-Redirect path served by the /internal/tornado/ regex location.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
