### PR TITLE
copy_messages: Preserve newlines for text/plain.

### DIFF
--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -16,6 +16,7 @@ type CopyMessagesOptions = {
     start_message: string;
     end_message: string;
     partial_selection_config?: PartialSelectionConfig;
+    send_copied_plain_text?: boolean;
 };
 
 async function copy_messages({
@@ -23,12 +24,14 @@ async function copy_messages({
     start_message,
     end_message,
     partial_selection_config,
+    send_copied_plain_text,
 }: CopyMessagesOptions): Promise<string[]> {
     return await page.evaluate(
         (
             start_message: string,
             end_message: string,
             partial_selection_config?: PartialSelectionConfig,
+            send_copied_plain_text?: boolean,
         ) => {
             function get_message_node(message: string): Element {
                 return [...document.querySelectorAll(".message-list .message_content")].find(
@@ -74,6 +77,11 @@ async function copy_messages({
             });
             document.dispatchEvent(copy_event);
 
+            if (send_copied_plain_text) {
+                const copied_plain_text = clipboard_data.getData("text/plain");
+                return copied_plain_text.split("\n");
+            }
+
             const copied_html = clipboard_data.getData("text/html");
 
             // Convert the copied HTML into separate message strings
@@ -89,6 +97,7 @@ async function copy_messages({
         start_message,
         end_message,
         partial_selection_config,
+        send_copied_plain_text,
     );
 }
 
@@ -197,6 +206,23 @@ async function test_copying_all_from_prev_first_from_next(page: Page): Promise<v
         "Verona > copy-paste-topic #2 | Today",
         "Desdemona:",
         "copy paste test C",
+    ];
+    assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
+}
+
+async function test_copying_plain_text(page: Page): Promise<void> {
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test A",
+        end_message: "copy paste test B",
+        send_copied_plain_text: true,
+    });
+    const expected_copied_lines = [
+        "**Desdemona:**",
+        "copy paste test A",
+        "",
+        "**Desdemona:**",
+        "copy paste test B",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
@@ -348,6 +374,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_messages_from_several_topics(page);
     await test_timestamp_clipboard_has_datetime(page);
     await test_multiple_message_selection_with_partially_selected_bookend_messages(page);
+    await test_copying_plain_text(page);
 }
 
 await common.run_test(copy_paste_test);

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -10,12 +10,20 @@ type PartialSelectionConfig = {
     start_text_node_offset?: number;
     end_text_node_offset?: number;
 };
-async function copy_messages(
-    page: Page,
-    start_message: string,
-    end_message: string,
-    partial_selection_config?: PartialSelectionConfig,
-): Promise<string[]> {
+
+type CopyMessagesOptions = {
+    page: Page;
+    start_message: string;
+    end_message: string;
+    partial_selection_config?: PartialSelectionConfig;
+};
+
+async function copy_messages({
+    page,
+    start_message,
+    end_message,
+    partial_selection_config,
+}: CopyMessagesOptions): Promise<string[]> {
     return await page.evaluate(
         (
             start_message: string,
@@ -85,19 +93,31 @@ async function copy_messages(
 }
 
 async function test_copying_first_message_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test C");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test C",
+        end_message: "copy paste test C",
+    });
     const expected_copied_lines: string[] = [];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
 async function test_copying_last_message_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test E", "copy paste test E");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test E",
+        end_message: "copy paste test E",
+    });
     const expected_copied_lines: string[] = [];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
 async function test_copying_first_two_messages_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test D");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test C",
+        end_message: "copy paste test D",
+    });
     const expected_copied_lines = [
         "Desdemona:",
         "copy paste test C",
@@ -108,7 +128,11 @@ async function test_copying_first_two_messages_from_topic(page: Page): Promise<v
 }
 
 async function test_copying_all_messages_from_topic(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test C", "copy paste test E");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test C",
+        end_message: "copy paste test E",
+    });
     const expected_copied_lines = [
         "Desdemona:",
         "copy paste test C",
@@ -121,7 +145,11 @@ async function test_copying_all_messages_from_topic(page: Page): Promise<void> {
 }
 
 async function test_copying_last_from_prev_first_from_next(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test C");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test B",
+        end_message: "copy paste test C",
+    });
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
@@ -134,7 +162,11 @@ async function test_copying_last_from_prev_first_from_next(page: Page): Promise<
 }
 
 async function test_copying_last_from_prev_all_from_next(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test E");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test B",
+        end_message: "copy paste test E",
+    });
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
@@ -151,7 +183,11 @@ async function test_copying_last_from_prev_all_from_next(page: Page): Promise<vo
 }
 
 async function test_copying_all_from_prev_first_from_next(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test A", "copy paste test C");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test A",
+        end_message: "copy paste test C",
+    });
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
@@ -166,7 +202,11 @@ async function test_copying_all_from_prev_first_from_next(page: Page): Promise<v
 }
 
 async function test_copying_messages_from_several_topics(page: Page): Promise<void> {
-    const actual_copied_lines = await copy_messages(page, "copy paste test B", "copy paste test F");
+    const actual_copied_lines = await copy_messages({
+        page,
+        start_message: "copy paste test B",
+        end_message: "copy paste test F",
+    });
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
@@ -230,17 +270,17 @@ async function test_timestamp_clipboard_has_datetime(page: Page): Promise<void> 
 async function test_multiple_message_selection_with_partially_selected_bookend_messages(
     page: Page,
 ): Promise<void> {
-    const actual_copied_lines = await copy_messages(
+    const actual_copied_lines = await copy_messages({
         page,
-        "copy paste test B",
-        "copy paste test F",
-        {
+        start_message: "copy paste test B",
+        end_message: "copy paste test F",
+        partial_selection_config: {
             select_start_message_partially: true,
             select_end_message_partially: true,
             start_text_node_offset: 5,
             end_text_node_offset: 7,
         },
-    );
+    });
     const expected_copied_lines = [
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -7,6 +7,7 @@ import assert from "minimalistic-assert";
 import render_copied_recipient_header from "../templates/copied_recipient_header.hbs";
 
 import * as blueslip from "./blueslip.ts";
+import * as compose_paste from "./compose_paste.ts";
 import * as message_lists from "./message_lists.ts";
 import * as rows from "./rows.ts";
 import {the} from "./util.ts";
@@ -576,7 +577,7 @@ export function copy_handler(ev: ClipboardEvent): boolean {
     construct_copy_div($div, start_id, end_id);
 
     const html_content = $div.html().trim();
-    const plain_text = $div.text().trim();
+    const plain_text = compose_paste.paste_handler_converter(html_content);
     ev.clipboardData?.setData("text/html", html_content);
     ev.clipboardData?.setData("text/plain", plain_text);
 

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -7,7 +7,7 @@ import assert from "minimalistic-assert";
 import render_copied_recipient_header from "../templates/copied_recipient_header.hbs";
 
 import * as blueslip from "./blueslip.ts";
-import {MENTION_SELECTOR} from "./compose_paste.ts";
+import * as compose_paste from "./compose_paste.ts";
 import * as message_lists from "./message_lists.ts";
 import * as rows from "./rows.ts";
 import {the} from "./util.ts";
@@ -429,8 +429,8 @@ export function improve_mention_selection_range(range: Range): void {
         return;
     }
 
-    const start_mention = start_element.closest(MENTION_SELECTOR);
-    const end_mention = end_element.closest(MENTION_SELECTOR);
+    const start_mention = start_element.closest(compose_paste.MENTION_SELECTOR);
+    const end_mention = end_element.closest(compose_paste.MENTION_SELECTOR);
 
     if (!start_mention && !end_mention) {
         return;
@@ -606,7 +606,7 @@ export function copy_handler(ev: ClipboardEvent): boolean {
     construct_copy_div($div, start_id, end_id);
 
     const html_content = $div.html().trim();
-    const plain_text = $div.text().trim();
+    const plain_text = compose_paste.paste_handler_converter(html_content);
     ev.clipboardData?.setData("text/html", html_content);
     ev.clipboardData?.setData("text/plain", plain_text);
 


### PR DESCRIPTION
Fixes: #39021.

(The window on the right is a text editor)
Before:

https://github.com/user-attachments/assets/797313cb-9df3-430c-926b-f972e6b343f7


After:

https://github.com/user-attachments/assets/7ac55a41-282c-4b1e-bb0b-3e4efcd3d8ae

