### PR TITLE
popovers: Exclude clicked date from "Scroll to" suggestions.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -479,7 +479,11 @@ export function initialize(): void {
                 popover_menus.on_show_prep(instance);
                 assert(message_lists.current !== undefined);
                 const messages = message_lists.current.all_messages();
-                const suggested_dates = popover_menus_data.get_scroll_to_date_suggestions(messages);
+                const clicked_message = message_lists.current.get(message_id)!;
+                const suggested_dates = popover_menus_data.get_scroll_to_date_suggestions(
+                    messages,
+                    clicked_message.timestamp,
+                );
                 instance.setContent(parse_html(render_scroll_to_time_popover({suggested_dates})));
             },
             onMount(instance) {

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -579,16 +579,24 @@ function closest_index(cumulative: number[], target: number): number {
 // Algorithm: divide the message volume into equal slices, then
 // for each slice boundary, prefer a nearby date with a long
 // silence before it (the start of a new conversation burst).
-export function get_scroll_to_date_suggestions(messages: Message[]): ScrollToDateSuggestion[] {
+export function get_scroll_to_date_suggestions(
+    messages: Message[],
+    clicked_timestamp?: number,
+): ScrollToDateSuggestion[] {
     if (messages.length === 0) {
         return [];
     }
 
     const date_groups = build_date_groups(messages);
 
-    // Exclude today — the user is likely already there.
+    // Exclude today (the user is likely already there) and the
+    // clicked date if any (the user just signaled it isn't useful).
     const today_key = get_date_key(Date.now() / 1000);
-    const filtered_groups = date_groups.filter((group) => group.date_string !== today_key);
+    const clicked_key =
+        clicked_timestamp === undefined ? undefined : get_date_key(clicked_timestamp);
+    const filtered_groups = date_groups.filter(
+        (group) => group.date_string !== today_key && group.date_string !== clicked_key,
+    );
 
     if (filtered_groups.length === 0) {
         return [];

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -338,6 +338,43 @@ function date_timestamp(date_string) {
     return new Date(date_string + "T12:00:00").getTime() / 1000;
 }
 
+function make_messages_from_date_counts(date_counts) {
+    const messages = [];
+    let id = 1;
+    for (const {date, count} of date_counts) {
+        for (let i = 0; i < count; i += 1) {
+            messages.push(make_message(id, date_timestamp(date)));
+            id += 1;
+        }
+    }
+    return messages;
+}
+
+// Simulate a conversation with bursts separated by gaps.
+// Burst 1: Jan 5-7 (9 messages)
+// Gap: 20 days
+// Burst 2: Jan 27-28 (8 messages)
+// Gap: 15 days
+// Burst 3: Feb 12-14 (10 messages)
+// Gap: 25 days
+// Burst 4: Mar 11-12 (8 messages)
+const FOUR_MESSAGE_BURSTS = [
+    // Burst 1
+    {date: "2025-01-05", count: 3},
+    {date: "2025-01-06", count: 3},
+    {date: "2025-01-07", count: 3},
+    // Burst 2
+    {date: "2025-01-27", count: 4},
+    {date: "2025-01-28", count: 4},
+    // Burst 3
+    {date: "2025-02-12", count: 4},
+    {date: "2025-02-13", count: 3},
+    {date: "2025-02-14", count: 3},
+    // Burst 4
+    {date: "2025-03-11", count: 4},
+    {date: "2025-03-12", count: 4},
+];
+
 run_test("get_scroll_to_date_suggestions - empty messages", () => {
     const result = popover_menus_data.get_scroll_to_date_suggestions([]);
     assert.deepEqual(result, []);
@@ -367,38 +404,7 @@ run_test("get_scroll_to_date_suggestions - few unique dates", () => {
 });
 
 run_test("get_scroll_to_date_suggestions - many dates with gaps", () => {
-    // Simulate a conversation with bursts separated by gaps.
-    // Burst 1: Jan 5-7 (9 messages)
-    // Gap: 20 days
-    // Burst 2: Jan 27-28 (8 messages)
-    // Gap: 15 days
-    // Burst 3: Feb 12-14 (10 messages)
-    // Gap: 25 days
-    // Burst 4: Mar 11-12 (8 messages)
-    const messages = [];
-    let id = 1;
-    // 4 bursts of conversation separated by multi-week gaps.
-    for (const [count, date] of [
-        // Burst 1
-        [3, "2025-01-05"],
-        [3, "2025-01-06"],
-        [3, "2025-01-07"],
-        // Burst 2
-        [4, "2025-01-27"],
-        [4, "2025-01-28"],
-        // Burst 3
-        [4, "2025-02-12"],
-        [3, "2025-02-13"],
-        [3, "2025-02-14"],
-        // Burst 4
-        [4, "2025-03-11"],
-        [4, "2025-03-12"],
-    ]) {
-        for (let i = 0; i < count; i += 1) {
-            messages.push(make_message(id, date_timestamp(date)));
-            id += 1;
-        }
-    }
+    const messages = make_messages_from_date_counts(FOUR_MESSAGE_BURSTS);
 
     const result = popover_menus_data.get_scroll_to_date_suggestions(messages);
     // We have 10 unique dates across 4 bursts; expect 3-4 suggestions.

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -431,3 +431,37 @@ run_test("get_scroll_to_date_suggestions - single date in the past", () => {
     const result = popover_menus_data.get_scroll_to_date_suggestions(messages);
     assert.equal(result.length, 1);
 });
+
+run_test("get_scroll_to_date_suggestions - excludes the clicked date", () => {
+    const messages = [
+        make_message(1, date_timestamp("2025-01-10")),
+        make_message(2, date_timestamp("2025-02-15")),
+        make_message(3, date_timestamp("2025-03-20")),
+    ];
+    const result = popover_menus_data.get_scroll_to_date_suggestions(
+        messages,
+        date_timestamp("2025-02-15"),
+    );
+    assert.equal(result.length, 2);
+    const dates = result.map((date) => date.iso_date_string.slice(0, 10));
+    assert.ok(!dates.includes("2025-02-15"));
+});
+
+run_test("get_scroll_to_date_suggestions - clicked slot is replaced not dropped", () => {
+    const messages = make_messages_from_date_counts(FOUR_MESSAGE_BURSTS);
+    const clicked_date = "2025-02-12";
+
+    const baseline = popover_menus_data.get_scroll_to_date_suggestions(messages);
+    const baseline_dates = baseline.map((s) => s.iso_date_string.slice(0, 10));
+    // The clicked date must be one the slicer would otherwise
+    // pick, or this test proves nothing.
+    assert.ok(baseline_dates.includes(clicked_date));
+
+    const filtered = popover_menus_data.get_scroll_to_date_suggestions(
+        messages,
+        date_timestamp(clicked_date),
+    );
+    const filtered_dates = filtered.map((date) => date.iso_date_string.slice(0, 10));
+    assert.equal(filtered.length, baseline.length);
+    assert.ok(!filtered_dates.includes(clicked_date));
+});


### PR DESCRIPTION
The "Scroll to" popover opens when a user clicks a date label in the message feed. Suggesting that same date back is useless — the user is already at it. Pass the clicked message's timestamp to get_scroll_to_date_suggestions and filter out its calendar day alongside today.

Re-running the slicer on the smaller pool naturally produces a different representative set of dates, so the matching slot is replaced rather than dropped.

<!-- Describe your pull request here.-->

Fixes: [#design > search date @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/search.20date/near/2443086)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="982" height="382" alt="Screenshot 2026-04-27 at 2 34 54 PM" src="https://github.com/user-attachments/assets/579aa38e-282f-4a61-9393-b32591ac7dc3" />

After:
<img width="982" height="382" alt="Screenshot 2026-04-27 at 2 35 09 PM" src="https://github.com/user-attachments/assets/f222638d-63db-44cc-8c9b-5dbdded4c05c" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
