### PR TITLE
[ai] CSS fixes in settings and personal menu popover.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -939,6 +939,7 @@ ul.popover-group-menu-member-list {
         position: relative;
         width: 64px;
         height: 64px;
+        flex-shrink: 0;
     }
 
     .avatar-image {
@@ -978,7 +979,6 @@ ul.popover-group-menu-member-list {
         /* 20px at 18px/1em */
         line-height: 1.1111em;
         color: var(--color-text-full-name) !important;
-        max-width: 150px;
         overflow-wrap: anywhere;
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2289,7 +2289,6 @@ label.preferences-radio-choice-label {
 
         & .dropdown-widget-button {
             height: 1.4em;
-            max-width: 160px;
             box-sizing: content-box;
         }
 
@@ -2298,6 +2297,14 @@ label.preferences-radio-choice-label {
             filters to keep them aligned in .settings_panel_list_header */
             margin: 0;
         }
+    }
+
+    .user_filters .dropdown-widget-button {
+        max-width: 11em; /* 176px at 16px */
+    }
+
+    .bot-filters .dropdown-widget-button {
+        max-width: 160px;
     }
 
     .add_default_streams_button_container {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2507,7 +2507,8 @@ label.preferences-radio-choice-label {
 }
 
 #admin-user-list .tab-switcher .ind-tab {
-    width: 110px;
+    width: auto;
+    min-width: 110px;
 }
 
 #admin-user-list .tab-switcher {
@@ -2515,7 +2516,14 @@ label.preferences-radio-choice-label {
 }
 
 #data-exports .tab-switcher .ind-tab {
-    width: 160px;
+    width: auto;
+    min-width: 160px;
+}
+
+#admin-bot-list .tab-switcher .ind-tab,
+#personal-bot-list .tab-switcher .ind-tab {
+    width: auto;
+    min-width: 90px;
 }
 
 #admin_invites_table {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fix role filter dropdown width in `Users` panel.
- Second commit is to let name use full available width in personal menu popover.
- Third commit is to let tabs take available width to fit content.
<!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| | Before | After |
| ------ | ------ | ------ |
| Users role filter dropdown | <img width="1974" height="812" alt="image" src="https://github.com/user-attachments/assets/dfe0fecf-0583-4772-8330-d9f3dd451a13" /> | <img width="1974" height="812" alt="image" src="https://github.com/user-attachments/assets/2497300f-d8bc-457e-a018-446c580490e9" /> |
| Personal navbar popover | <img width="764" height="974" alt="image" src="https://github.com/user-attachments/assets/570e81c4-6137-4079-ad1b-856b9913da8c" /> | <img width="764" height="974" alt="image" src="https://github.com/user-attachments/assets/7e730639-c862-4ff3-b253-fcbe0c9d64e1" /> |
| Users tabs | <img width="2174" height="658" alt="image" src="https://github.com/user-attachments/assets/e263fee9-3a7d-455a-97f3-9af4bdb0c96a" /> | <img width="2174" height="658" alt="image" src="https://github.com/user-attachments/assets/44eb3ec5-305a-4959-af9c-b720c397fe88" /> |
| Bots tabs | <img width="2174" height="658" alt="image" src="https://github.com/user-attachments/assets/294bc9b0-e305-42bb-a8b1-5ce3b2cea884" /> | <img width="2174" height="658" alt="image" src="https://github.com/user-attachments/assets/0ec1c29a-82de-4d14-aacc-585325d2c777" /> |
| Data exports tabs | <img width="2174" height="658" alt="image" src="https://github.com/user-attachments/assets/c0718ba5-d097-41e7-987a-2ec8625fc06a" /> | <img width="2174" height="658" alt="image" src="https://github.com/user-attachments/assets/3cd59448-2f27-482c-868a-87a0c9054f7d" /> |







<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
