### PR TITLE
Set "sound": "default" in APNs notification payloads (E2EE)

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -6,7 +6,7 @@ import logging
 import re
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from email.headerregistry import Address
 from functools import cache
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, TypeAlias, Union, cast
@@ -1452,9 +1452,7 @@ class APNsHTTPHeaders:
 
 @dataclass
 class APNsPayload(PushRequestBasePayload):
-    aps: dict[str, int | dict[str, str]] = field(
-        default_factory=lambda: {"mutable-content": 1, "alert": {"title": "New notification"}}
-    )
+    aps: dict[str, int | dict[str, str]]
 
 
 @dataclass
@@ -1520,9 +1518,13 @@ def send_push_notifications(
                 apns_priority=apns_priority,
                 apns_push_type=apns_push_type,
             )
+            aps: dict[str, int | dict[str, str]] = {"mutable-content": 1}
+            if not is_removal:
+                aps["alert"] = {"title": "New notification"}
             apns_payload = APNsPayload(
                 push_key_id=push_device.push_key_id,
                 encrypted_data=encrypted_data,
+                aps=aps,
             )
             apns_push_request = APNsPushRequest(
                 token_id=b64encode_token_id_int(push_device.push_token_id),

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1452,7 +1452,7 @@ class APNsHTTPHeaders:
 
 @dataclass
 class APNsPayload(PushRequestBasePayload):
-    aps: dict[str, int | dict[str, str]]
+    aps: dict[str, int | str | dict[str, str]]
 
 
 @dataclass
@@ -1518,9 +1518,10 @@ def send_push_notifications(
                 apns_priority=apns_priority,
                 apns_push_type=apns_push_type,
             )
-            aps: dict[str, int | dict[str, str]] = {"mutable-content": 1}
+            aps: dict[str, int | str | dict[str, str]] = {"mutable-content": 1}
             if not is_removal:
                 aps["alert"] = {"title": "New notification"}
+                aps["sound"] = "default"
             apns_payload = APNsPayload(
                 push_key_id=push_device.push_key_id,
                 encrypted_data=encrypted_data,

--- a/zerver/tests/test_e2ee_push_notifications.py
+++ b/zerver/tests/test_e2ee_push_notifications.py
@@ -67,6 +67,12 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 mock_fcm_messaging.send_each.assert_called_once()
                 send_notification.assert_called_once()
 
+                apns_message = send_notification.call_args.args[0].message
+                self.assertEqual(
+                    apns_message["aps"],
+                    {"mutable-content": 1, "alert": {"title": "New notification"}},
+                )
+
                 self.assertEqual(
                     "INFO:zerver.lib.push_notifications:"
                     f"Sending push notifications to mobile clients for user {hamlet.id}",
@@ -871,6 +877,9 @@ class RemovePushNotificationTest(E2EEPushNotificationTestCase):
 
             mock_fcm_messaging.send_each.assert_called_once()
             send_notification.assert_called_once()
+
+            apns_message = send_notification.call_args.args[0].message
+            self.assertEqual(apns_message["aps"], {"mutable-content": 1})
 
             user_message.refresh_from_db()
             self.assertFalse(user_message.flags.active_mobile_push_notification)

--- a/zerver/tests/test_e2ee_push_notifications.py
+++ b/zerver/tests/test_e2ee_push_notifications.py
@@ -70,7 +70,11 @@ class SendPushNotificationTest(E2EEPushNotificationTestCase):
                 apns_message = send_notification.call_args.args[0].message
                 self.assertEqual(
                     apns_message["aps"],
-                    {"mutable-content": 1, "alert": {"title": "New notification"}},
+                    {
+                        "mutable-content": 1,
+                        "alert": {"title": "New notification"},
+                        "sound": "default",
+                    },
                 )
 
                 self.assertEqual(


### PR DESCRIPTION
The client should be responsible for setting this (and zulip/zulip-flutter#2300 is open to start doing that), but might as well have the server set it too, as kind of a backup. Discussion: [#mobile > iOS notifications silent @ 💬](https://chat.zulip.org/#narrow/channel/48-mobile/topic/iOS.20notifications.20silent/near/2445055)

Also, it doesn't seem right to be including "title": "New notification" in the remove-notification payload, which we were doing in `main`, so this includes a commit to stop doing that. (And the "sound": "default" is also only done in the non-"remove" case.)