### PR TITLE
docs: Remove unnecessary release checklist items.

### DIFF
--- a/docs/subsystems/release-checklist.md
+++ b/docs/subsystems/release-checklist.md
@@ -30,10 +30,6 @@ preparing a new release.
 - Update the Paper blog post draft with any new commits.
 - Merge updated translations from Weblate (using the appropriate
   branch for the release).
-- Use `build-release-tarball` to generate a pre-release tarball.
-- Test the new tarball extensively, both new install and upgrade from last
-  release, on Ubuntu 22.04.
-- Repeat until release is ready.
 - Send around the Paper blog post draft for review.
 - Move the blog post draft to Astro:
   - Use "··· > Export > Markdown" to get a pretty good Markdown


### PR DESCRIPTION
The production suite CI job covers the risks that manual testing of this form might catch well, and as far as I know, we last did this class of additional extensive manual testing for a release years ago.

(We do such manual testing when authoring/merging a change to the installer experience, but not at release time).
