### PR TITLE
push_registration: Clean up case-mismatched legacy tokens on bouncer.

### DIFF
--- a/zilencer/migrations/0071_cleanup_case_mismatched_legacy_apns_tokens.py
+++ b/zilencer/migrations/0071_cleanup_case_mismatched_legacy_apns_tokens.py
@@ -1,0 +1,67 @@
+from collections import defaultdict
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+APNS_KIND = 1
+
+
+def cleanup_case_mismatched_legacy_apns_tokens_bouncer(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    """Bouncer counterpart to zerver migration
+    0800_cleanup_case_mismatched_legacy_apns_tokens.
+    See that migration for context.
+    """
+    RemotePushDevice = apps.get_model("zilencer", "RemotePushDevice")
+    RemotePushDeviceToken = apps.get_model("zilencer", "RemotePushDeviceToken")
+
+    # Find tokens registered for E2EE through remote servers.
+    # (Those registered through this server (with `remote_realm` null)
+    # also appear in `Device` and are covered by zerver migration 0800.)
+    e2ee_tokens_by_remote_realm: dict[int, set[str]] = defaultdict(set)
+    for remote_realm_id, token in (
+        RemotePushDevice.objects.filter(
+            token_kind="apns",
+            remote_realm__isnull=False,
+        )
+        .values_list("remote_realm_id", "token")
+        .iterator()
+    ):
+        e2ee_tokens_by_remote_realm[remote_realm_id].add(token.lower())
+
+    if not e2ee_tokens_by_remote_realm:
+        return
+
+    legacy_ids_to_delete: list[int] = []
+    for legacy_id, remote_realm_id, token in (
+        RemotePushDeviceToken.objects.filter(
+            kind=APNS_KIND,
+            remote_realm_id__in=e2ee_tokens_by_remote_realm,
+        )
+        .values_list("id", "remote_realm_id", "token")
+        .iterator()
+    ):
+        if token.lower() in e2ee_tokens_by_remote_realm[remote_realm_id]:
+            legacy_ids_to_delete.append(legacy_id)
+
+    if legacy_ids_to_delete:
+        RemotePushDeviceToken.objects.filter(id__in=legacy_ids_to_delete).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "zilencer",
+            "0070_remove_remoterealmauditlog_zilencer_remoterealmauditlog_synced_billing_events_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            cleanup_case_mismatched_legacy_apns_tokens_bouncer,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]


### PR DESCRIPTION
PR to address: [#mobile > iOS duplicate notifications @ 💬](https://chat.zulip.org/#narrow/channel/48-mobile/topic/iOS.20duplicate.20notifications/near/2445332)

Follow-up #39092 


**How changes were tested:**

Asked claude to add a temporary test to verify the migration. It added a nice test with 8 different possible cases.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
