### PR TITLE
integrations: Use category for page title.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -30,21 +30,16 @@ list. For example, to add a new incoming webhook integration, declare a
 IncomingWebhookIntegration in the INCOMING_WEBHOOK_INTEGRATIONS list. All
 *_INTEGRATIONS lists are automatically aggregated into the INTEGRATIONS dict.
 
-To add a new integration category, add to either the CATEGORIES or
-META_CATEGORY dicts below. The META_CATEGORY dict is for categories
-that do not describe types of tools (e.g., bots or frameworks).
+To add a new integration category, add it to the CATEGORIES dict below.
 
 Over time, we expect this registry to grow additional convenience
 features for writing and configuring integrations efficiently.
 """
 
-META_CATEGORY: dict[str, StrPromise] = {
-    "meta-integration": gettext_lazy("Integration frameworks"),
-    "bots": gettext_lazy("Interactive bots"),
-}
 
 CATEGORIES: dict[str, StrPromise] = {
-    **META_CATEGORY,
+    "meta-integration": gettext_lazy("Integration frameworks"),
+    "bots": gettext_lazy("Interactive bots"),
     "video-calling": gettext_lazy("Video calling"),
     "continuous-integration": gettext_lazy("Continuous integration"),
     "customer-support": gettext_lazy("Customer support"),

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -15,7 +15,7 @@ from corporate.models.customers import Customer
 from corporate.models.plans import CustomerPlan
 from zerver.actions.realm_settings import do_set_realm_property
 from zerver.context_processors import get_apps_page_url
-from zerver.lib.integrations import BOT_INTEGRATIONS, CATEGORIES, INTEGRATIONS, META_CATEGORY
+from zerver.lib.integrations import BOT_INTEGRATIONS, CATEGORIES, INTEGRATIONS
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import HostRequestMock
 from zerver.lib.url_redirects import INTEGRATION_CATEGORY_SLUGS
@@ -542,12 +542,8 @@ class DocPageTest(ZulipTestCase):
         # Test category pages
         for category in CATEGORIES:
             url = f"/integrations/category/{category}"
-            if category in META_CATEGORY:
-                title = f"<title>{CATEGORIES[category]} | Zulip integrations</title>"
-                og_title = f'<meta property="og:title" content="{CATEGORIES[category]} | Zulip integrations" />'
-            else:
-                title = f"<title>{CATEGORIES[category]} tools | Zulip integrations</title>"
-                og_title = f'<meta property="og:title" content="{CATEGORIES[category]} tools | Zulip integrations" />'
+            title = f"<title>{CATEGORIES[category]} | Zulip integrations</title>"
+            og_title = f'<meta property="og:title" content="{CATEGORIES[category]} | Zulip integrations" />'
             self._test(url, [title, og_title, og_description, get_canonical_url(url)])
 
         # Test integrations index page

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -23,7 +23,6 @@ from zerver.lib.html_to_text import get_content_description
 from zerver.lib.integrations import (
     CATEGORIES,
     INTEGRATIONS,
-    META_CATEGORY,
     HubotIntegration,
     IncomingWebhookIntegration,
     Integration,
@@ -347,10 +346,7 @@ def add_integrations_open_graph_context(context: dict[str, Any], request: HttpRe
 
     elif path_name in CATEGORIES:
         category = CATEGORIES[path_name]
-        if path_name in META_CATEGORY:
-            context["PAGE_TITLE"] = f"{category} | Zulip integrations"
-        else:
-            context["PAGE_TITLE"] = f"{category} tools | Zulip integrations"
+        context["PAGE_TITLE"] = f"{category} | Zulip integrations"
         context["PAGE_DESCRIPTION"] = description
 
     elif path_name == "integrations":


### PR DESCRIPTION
Removes "tools" from the page title for the non-meta integration categories as it was resulting in half translated strings.

**Notes**:
- Removes the `META_CATEGORY` dict as it is no longer used for anything, and I don't expect it to be useful to keep. For example, #39166 doesn't use that dict for the category search placeholder strings.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="562" height="238" alt="Screenshot From 2026-04-28 13-15-44" src="https://github.com/user-attachments/assets/d72aeb8a-5fb5-4469-b9ea-9e4564675d44" /> | <img width="562" height="238" alt="Screenshot From 2026-04-28 13-15-32" src="https://github.com/user-attachments/assets/1ca58faf-ac74-48cb-83b2-b8c5464e9bbd" />
| <img width="562" height="238" alt="Screenshot From 2026-04-28 13-18-10" src="https://github.com/user-attachments/assets/32d3b313-3c5b-419f-87ae-9049226f158f" /> | <img width="562" height="238" alt="Screenshot From 2026-04-28 13-18-22" src="https://github.com/user-attachments/assets/56fba1ef-d849-4e39-86b2-e917c161745d" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
