### PR TITLE
[ai] help: Repair fallout from "All messages" → "Combined feed" rename.

### DIFF
--- a/docs/translating/polish.md
+++ b/docs/translating/polish.md
@@ -48,13 +48,13 @@ You can set your own alert words for Zulip messages.
 
 > Możesz ustawić powiadomienia dla wybranych fraz w Zulipie.
 
-**Combined feed**: wszystkie wiadomości
+**Combined feed**: strumień mieszany
 
 example:
 
 You can see all messages in unmuted streams and topics with "Combined feed".
 
-> Możesz zobaczyć pełną listę wiadomości poprzez widok "Wszystkie wiadomości".
+> Możesz zobaczyć pełną listę wiadomości poprzez widok "Strumień mieszany".
 
 **bot**: bot
 

--- a/starlight_help/src/content/docs/mute-a-user.mdx
+++ b/starlight_help/src/content/docs/mute-a-user.mdx
@@ -17,10 +17,10 @@ import UserCardThreeDotMenu from "../include/_UserCardThreeDotMenu.mdx";
 You can mute any user you do not wish to interact with. Muting someone will
 have the following effects:
 
-* Combined feed sent by a muted user will automatically be [marked as
+* All messages sent by a muted user will automatically be [marked as
   read](/help/marking-messages-as-read) for you, and will never
   generate any desktop, email, or mobile push notifications.
-* Combined feed sent by muted users, including the name, profile
+* All messages sent by muted users, including the name, profile
   picture, and message content, are hidden behind a **Click here to
   reveal** banner. A revealed message can later be
   [re-hidden](/help/mute-a-user#re-hide-a-message-that-has-been-revealed).

--- a/templates/corporate/case-studies/end-point-case-study.md
+++ b/templates/corporate/case-studies/end-point-case-study.md
@@ -52,7 +52,7 @@ explored all the leading open-source team chat products. They found that while
 Mattermost and Rocket.Chat were similar to Slack (but felt less polished), Zulip
 stood out. “Zulip had all the modern features we were looking for, like
 reliable, flexible notifications. At the same time, the [extensive keyboard
-shortcuts](/help/keyboard-shortcuts) and the ‘Combined feed’
+shortcuts](/help/keyboard-shortcuts) and the ‘All messages’
 view offered a UI that the IRC fans loved.”
 
 When End Point moved to Zulip, it was an immediate improvement over the
@@ -117,7 +117,7 @@ Jensen](https://www.endpointdev.com/team/jon-jensen/) has experienced them all.
 “It is amazing that companies would use Teams in its current state,” Jon says, a
 bit exasperated. “The UI is slow and inconsistent, and you have to do so much
 clicking to get anywhere. Compared to Zulip, it’s missing key features like the
-‘Combined feed’ view and topics.”
+‘All messages’ view and topics.”
 
 > It is amazing that companies would use Teams in its current state. The UI is
 > slow and inconsistent, and compared to Zulip, it’s missing key features.

--- a/templates/corporate/case-studies/gut-contact-case-study.md
+++ b/templates/corporate/case-studies/gut-contact-case-study.md
@@ -79,7 +79,7 @@ customer, where team leaders post daily updates.
 For agents, many of whom are not fully comfortable with modern software, Zulip
 being easy to use is invaluable. "We checked out Microsoft Teams and Mattermost,
 and most of our users didn’t like these programs, because they didn’t know how
-to work with them,” Erik says. “In Zulip, agents love the “Combined feed” view,”
+to work with them,” Erik says. “In Zulip, agents love the “All messages” view,”
 which combines direct messages and channel messages into a single feed. “Unlike
 other chat apps, you don’t have to click on each channel separately to see
 unreads,” Erik explains.


### PR DESCRIPTION
I spotted the issue on the /help/mute-a-user, and had Claude track down the origin, and check for other problems with the commit that introduced it.

#Claude's description

Fixes: three pieces of stale or garbled text introduced by the global "All messages" → "Combined feed" search-and-replace in commit     
  1594011b67 (PR #27841, April 2024). No tracking issue; surfaced while reading the muted-user help article.                              
                                                                                                                                          
  Each commit fixes one place where the rename misfired:                                                                                  
                                                         
  - **`mute-a-user.mdx`:** The original prose said "All messages sent by a muted user will automatically be marked as read..." — using      "all messages" generically to mean *every message*, not the **All messages** view. The rename mangled this into "Combined feed sent by a
   muted user...", which is gibberish. A subsequent "Global Feed" → "Combined feed" pass perpetuated the broken text. Restore the original   wording.                                              
  - **`docs/translating/polish.md`:** The Polish translator glossary entry was rewritten as `**Combined feed**: wszystkie wiadomości`, but   `wszystkie wiadomości` is the literal Polish for "all messages" and no longer matches the actual translation in                         `locale/pl/translations.json`, which is `Strumień mieszany`. Sync the glossary entry and example with the live translation.
  - **Case-study testimonials:** The rename silently rewrote three direct quotes attributed to Jon Jensen (End Point) and Erik (Gut       
  Contact). The interviewees said "All messages"; editing their words inside quotation marks isn't appropriate even when the underlying UI  label changes. Restore the original quotes.
                                                                                                                                          
  I also looked at the rest of commit 1594011b67's churn. The other ~40 swaps (in-app strings, settings, narrow titles, code comments     
  referring to the view, e2e tests, OpenAPI yaml) are legitimate UI references and look correct. Two code comments
  (`web/src/narrow_title.ts:21`, `web/src/narrow.js`) became slightly less precise after the rename, but neither actually misleads a    reader, so I left them alone.                          

  **How changes were tested:**

  - [x] Read each diff in context to confirm the rewrite is grammatical English.                                                          
  - [x] Verified the Polish translation by grepping `locale/pl/translations.json` for "Combined feed" — it maps to "Strumień mieszany".
  - [x] No code changes; nothing to lint or test programmatically.                                                                        
                                                                                                                                          
  <details>                                                                                                                               
  <summary>Self-review checklist</summary>                                                                                                
                                                         
  - [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for       
  clarity and maintainability.
  - [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines). 
                                                                                                                                          
  Communicate decisions, questions, and potential concerns.
                                                                                                                                          
  - [x] Explains differences from previous plans (e.g., issue description).                                                               
  - [x] Highlights technical choices and bugs encountered.
  - [x] Calls out remaining decisions and concerns.                                                                                       
  - [ ] Automated tests verify logic where appropriate. (N/A — prose-only fixes.)
                                                                                                                                          
  Individual commits are ready for review.
                                                                                                                                          
  - [x] Each commit is a coherent idea.                  
  - [x] Commit message(s) explain reasoning and motivation for changes.
                                                                                                                                          
  Completed manual review and testing of the following:
                                                                                                                                          
  - [ ] Visual appearance of the changes. (N/A — no rendered UI changes.)                                                                 
  - [ ] Responsiveness and internationalization. (N/A — but the Polish glossary update *is* an i18n correctness fix.)
  - [x] Strings and tooltips.                                                                                                             
  - [ ] End-to-end functionality of buttons, interactions and flows. (N/A.)                                                               
  - [x] Corner cases, error conditions, and easily imagined bugs.                                                                         
  </details>                                                                