### PR TITLE
Fixed the issue of right sidebar

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -562,6 +562,11 @@
         );
         align-items: center;
         color: var(--color-text-sidebar-action-heading);
+        text-decoration: none;
+
+        &:focus {
+            text-decoration: none;
+        }
 
         .right-sidebar-wrappable-text-inner {
             margin: var(--spacing-top-bottom-sidebar-topic-inner) 0;


### PR DESCRIPTION
## Summary

Fixed inconsistent keyboard focus styling for the **"Invite to organization"** link in the right sidebar.

Previously, when navigating with the keyboard, the focus state of this link did not visually match similar interactive links in the left sidebar (such as **"Browse 1 more channel"**). This created an inconsistent user experience and reduced UI accessibility consistency.

## Changes Made

* Updated the right sidebar invite link focus styles.
* Matched the keyboard focus appearance with existing left sidebar interactive links.
* Improved visual consistency for keyboard navigation users.

## Testing

* Opened the app in browser.
* Navigated using the `Tab` key.
* Verified that **"Invite to organization"** now receives the same visible focus styling as comparable sidebar links.
* Confirmed no layout regressions.

## Recording
https://github.com/user-attachments/assets/85722ebb-9d6e-4ddd-9fc7-f6022ed9f7f7

## Issue

Fixes #39172 
