### PR TITLE
[ai] home: Apply narrow_stream desktop-notification override on the client.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -459,6 +459,14 @@ export async function initialize_everything(state_data) {
     set_realm(state_data.realm);
     set_realm_billing(state_data.realm_billing);
 
+    if (page_params.narrow_stream !== undefined) {
+        // In the /?stream=X mini-window flow, the user's main Zulip
+        // window is the primary recipient of desktop notifications;
+        // suppress them here so the embedded window doesn't fire
+        // duplicate alerts.
+        state_data.user_settings.user_settings.enable_desktop_notifications = false;
+    }
+
     /* To store theme data for spectators, we need to initialize
        user_settings before setting the theme. Because information
        density is so fundamental, we initialize that first, however. */

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -201,15 +201,13 @@ def build_page_params_for_home_page_load(
 
     page_params["state_data"] = state_data
 
-    if narrow_stream is not None and state_data is not None:
+    if narrow_stream is not None:
         page_params["narrow_stream"] = narrow_stream.name
         if narrow_topic_name is not None:
             page_params["narrow_topic"] = narrow_topic_name
         page_params["narrow"] = [
             dict(operator=term.operator, operand=term.operand) for term in narrow
         ]
-        assert isinstance(state_data["user_settings"], dict)
-        state_data["user_settings"]["enable_desktop_notifications"] = False
 
     page_params["translation_data"] = get_language_translation_data(request_language)
 

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -1110,6 +1110,13 @@ class HomeTest(ZulipTestCase):
             page_params["state_data"]["max_message_id"],
             max_message_id_for_user(user_profile),
         )
+        # The mini-window's desktop-notification suppression is now
+        # applied client-side; the server returns the user's actual
+        # setting unchanged.
+        self.assertEqual(
+            page_params["state_data"]["user_settings"]["enable_desktop_notifications"],
+            user_profile.enable_desktop_notifications,
+        )
 
     @activate_push_notification_service()
     def test_has_pending_sponsorship_request(self) -> None:


### PR DESCRIPTION
This is a prep commit for unconditionally fetching `state_data` via
`POST /json/register` (the planned follow-up after #39080).

The `/?stream=X` mini-window flow suppresses desktop notifications so
the user's main Zulip window in another tab/window remains the sole
notification source. Until now, the server implemented that by mutating
`state_data["user_settings"]["enable_desktop_notifications"] = False`
before embedding `state_data` in the HTML. That mutation is the last
piece of narrow-specific `state_data` processing in
`build_page_params_for_home_page_load`, and it is what currently
prevents the deferred-fetch path from being used for mini-window
loads.

This PR moves the override to `web/src/ui_init.js`, applied to
`state_data.user_settings.user_settings.enable_desktop_notifications`
just before `initialize_user_settings`. The server now passes
`page_params["narrow_stream"]` whenever the URL specifies one (not only
when `state_data` is embedded), so the client has the signal it needs
in both the embedded and deferred-fetch paths.

User-visible behavior is unchanged.

---

Claude noted that this needs to be addressed before we allow unconditionally fetching `state_data`. 