### PR TITLE
[ai] e2e: Pair the log_out click with waitForNavigation.

### DIFF
--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -286,7 +286,14 @@ export async function log_out(page: Page): Promise<void> {
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
     await page.waitForSelector(logout_selector);
-    await page.click(logout_selector);
+    // The logout button submits #logout_form via JS, which navigates
+    // through /accounts/logout/ → 302 → /accounts/login/. Pair the
+    // click with waitForNavigation so the next selector wait runs
+    // against the loaded login page rather than racing with the
+    // in-flight navigation; without this, the polling occasionally
+    // gets stuck on the transitional document and times out even
+    // though the login page renders correctly.
+    await Promise.all([page.waitForNavigation(), page.click(logout_selector)]);
 
     // Wait for a email input in login page so we know login
     // page is loaded. Then check that we are at the login url.


### PR DESCRIPTION
The puppeteer `log_out` helper has been seen to time out on
`waitForSelector('input[name="username"]')` after a clean logout —
e.g., on a recent rerun of CI for #39176, where the failure-time
screenshot clearly showed the login page rendered correctly. The
race is between the click on the logout button (which JS-submits
`#logout_form`, taking the browser through
`POST /accounts/logout/` → 302 → `GET /accounts/login/`) and the
selector wait that follows: puppeteer's polling occasionally latches
onto the transitional document instead of the loaded login page.

Wrap the click with the standard `Promise.all` +
`waitForNavigation` pattern already used in
`realm-creation.test.ts:24-29` for form submissions, so the next
`waitForSelector` runs against the new document instead of a
navigation in flight.