### PR TITLE
[ai] recent_view: Strengthen unread row contrast in dark theme.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1216,7 +1216,7 @@
     );
     --color-recent-view-link-unread: light-dark(
         hsl(0deg 0% 5%),
-        hsl(0deg 0% 100% / 83%)
+        hsl(0deg 0% 100% / 90%)
     );
     --color-recent-view-link: light-dark(
         hsl(0deg 0% 20%),

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -112,10 +112,6 @@
 
     #recent-view-content-table {
         border-bottom-width: 1px;
-
-        .unread_topic a {
-            font-weight: 400;
-        }
     }
 
     .drafts-container .header-body .delete-drafts-group > *:focus {


### PR DESCRIPTION
<details><summary>Before/after screenshots</summary>
<p>
<img width="2800" height="2048" alt="full-dark-baseline-opacity83-weight400" src="https://github.com/user-attachments/assets/e09918fb-2513-4892-8bf9-e29493e0a359" />


<img width="2800" height="2048" alt="full-dark-opacity90-weight500" src="https://github.com/user-attachments/assets/5fb712f6-28bb-449f-b0e5-e3e202a37f99" />


</p>
</details> 


# Claude's commit message
In dark theme, unread rows in recent conversations didn't have enough
contrast against read rows: the dark_theme.css override knocked the
unread font-weight back to 400 (matching read rows), leaving only an
83%-vs-75% alpha difference on the link color to convey state.

Drop the dark-theme-specific font-weight override so unread rows pick
up the 500 weight from the base style (matching light theme), and
bump the unread alpha from 83% to 90%.
