### PR TITLE
[ai] dms: Live update header + compose box when a user's name changes. 

### DIFF
--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -127,6 +127,13 @@ export function update_user_pill_active_status(user: User, is_active: boolean): 
     widget.updatePill(pill.$element[0]!, updated_pill);
 }
 
+export function update_user_pill_full_name(user_id: number, full_name: string): void {
+    if (!widget) {
+        return;
+    }
+    user_pill.update_pill_full_name(widget, user_id, full_name);
+}
+
 export function rewire_widget(value: UserPillWidget): void {
     widget = value;
 }

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -307,6 +307,19 @@ export function possibly_update_stream_name_in_compose(stream_id: number): void 
     }
 }
 
+export function update_user_name_in_compose(user_id: number, full_name: string): void {
+    // Only a current DM recipient's rename affects this compose box, so
+    // ignore renames of anyone else.
+    if (!compose_pm_pill.get_user_ids().includes(user_id)) {
+        return;
+    }
+    // DM pills carry their own captured full_name and aren't rebuilt by
+    // on_compose_select_recipient_update, so we update the pill in place
+    // and refresh the textarea placeholder text.
+    compose_pm_pill.update_user_pill_full_name(user_id, full_name);
+    update_compose_area_placeholder_text();
+}
+
 function item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance): void {
     const recipient_id_str = $(event.currentTarget).attr("data-unique-id");
     assert(recipient_id_str !== undefined);

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -6,6 +6,7 @@ import {FetchStatus} from "./fetch_status.ts";
 import type {Filter} from "./filter.ts";
 import type {Message} from "./message_store.ts";
 import * as muted_users from "./muted_users.ts";
+import * as people from "./people.ts";
 import {current_user} from "./state_data.ts";
 import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
@@ -638,6 +639,14 @@ export class MessageListData {
             return [];
         }
         return msgs;
+    }
+
+    get_messages_involving_user(user_id: number): Message[] {
+        return this._items.filter(
+            (msg) =>
+                msg.sender_id === user_id ||
+                people.pm_with_user_ids(msg)?.includes(user_id) === true,
+        );
     }
 
     get_last_message_sent_by_me(): Message | undefined {

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1605,36 +1605,19 @@ export class MessageListView {
         );
     }
 
-    _rerender_header(message_containers: MessageContainer[]): void {
-        // Given a list of messages that are in the **same** message group,
-        // rerender the header / recipient bar of the messages. This method
-        // should only be called with rerender_messages as the rerendered
-        // header may need to be updated for the "sticky_header" class.
-        if (message_containers.length === 0) {
-            return;
-        }
-
-        const $first_row = this.get_row(message_containers[0]!.msg.id);
-
-        // We may not have the row if the stream or topic was muted
-        if ($first_row.length === 0) {
-            return;
-        }
-
-        const $recipient_row = rows.get_message_recipient_row($first_row);
-        const $header = $recipient_row.find(".message_header");
-        const message_group_id = $recipient_row.attr("id")!;
-
-        // Since there might be multiple dates within the message
-        // group, it's important to look up the original/full message
-        // group rather than doing an artificial rerendering of the
-        // message header from the set of message containers passed in
-        // here.
+    _rerender_header(message_group_id: string): void {
+        // Rerender the header / recipient bar of the given message group,
+        // rebuilding it from the authoritative group looked up below. This
+        // method should only be called with rerender_messages as the
+        // rerendered header may need to be updated for the "sticky_header"
+        // class.
         const group = this._find_message_group(message_group_id);
         if (group === undefined) {
             blueslip.error("Could not find message group for rerendering headers");
             return;
         }
+
+        const $header = $(`#${CSS.escape(message_group_id)}`).find(".message_header");
 
         // TODO: It's possible that we no longer need this populate
         // call; it was introduced in an earlier version of this code
@@ -1759,29 +1742,28 @@ export class MessageListView {
             }
         }
 
-        const message_groups = [];
-        let current_group = [];
+        // Rerender each message row, collecting the distinct recipient
+        // bars they belong to by their row's rendered group id. The
+        // messages can span several bars -- even bars that share a
+        // recipient -- so the group id is what distinguishes the bars.
         const rerendered_elements: HTMLElement[] = [];
-
+        const rerendered_group_ids = new Set<string>();
         for (const message_container of message_containers) {
-            if (
-                current_group.length === 0 ||
-                same_recipient(current_group.at(-1), message_container)
-            ) {
-                current_group.push(message_container);
-            } else {
-                message_groups.push(current_group);
-                current_group = [];
-            }
             const $rendered = this._rerender_message(message_container, {
                 message_content_edited,
                 is_revealed: false,
             });
             rerendered_elements.push(...$rendered);
-        }
-
-        if (current_group.length > 0) {
-            message_groups.push(current_group);
+            const $row = this.get_row(message_container.msg.id);
+            // The row may be absent, e.g. for a muted stream or topic, in
+            // which case there is no recipient bar to rerender.
+            if ($row.length === 0) {
+                continue;
+            }
+            const message_group_id = rows.get_message_recipient_row($row).attr("id");
+            if (message_group_id !== undefined) {
+                rerendered_group_ids.add(message_group_id);
+            }
         }
 
         // Only the current message list needs its condense/collapse
@@ -1792,8 +1774,10 @@ export class MessageListView {
             condense.condense_and_collapse($(rerendered_elements));
         }
 
-        for (const messages_in_group of message_groups) {
-            this._rerender_header(messages_in_group);
+        // Now that every row is rerendered, rerender each affected bar's
+        // header once.
+        for (const message_group_id of rerendered_group_ids) {
+            this._rerender_header(message_group_id);
         }
 
         if (message_lists.current === this.list && narrow_state.is_message_feed_visible()) {

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1761,7 +1761,7 @@ export class MessageListView {
 
         const message_groups = [];
         let current_group = [];
-        let $rerendered_rows = $();
+        const rerendered_elements: HTMLElement[] = [];
 
         for (const message_container of message_containers) {
             if (
@@ -1777,7 +1777,7 @@ export class MessageListView {
                 message_content_edited,
                 is_revealed: false,
             });
-            $rerendered_rows = $rerendered_rows.add($rendered);
+            rerendered_elements.push(...$rendered);
         }
 
         if (current_group.length > 0) {
@@ -1788,8 +1788,8 @@ export class MessageListView {
         // state refreshed here; non-current lists get
         // `condense_and_collapse` reapplied via `restore_rendered_list`
         // in `message_view` when they're brought back into view.
-        if (this.list === message_lists.current && $rerendered_rows.length > 0) {
-            condense.condense_and_collapse($rerendered_rows);
+        if (this.list === message_lists.current && rerendered_elements.length > 0) {
+            condense.condense_and_collapse($(rerendered_elements));
         }
 
         for (const messages_in_group of message_groups) {

--- a/web/src/message_live_update.ts
+++ b/web/src/message_live_update.ts
@@ -22,9 +22,19 @@ export function rerender_messages_view_by_message_ids(message_ids: number[]): vo
     }
 }
 
-function rerender_messages_view_for_user(user_id: number): void {
+function rerender_messages_sent_by_user(user_id: number): void {
     for (const list of message_lists.all_rendered_message_lists()) {
         const messages = list.data.get_messages_sent_by_user(user_id);
+        if (messages.length === 0) {
+            continue;
+        }
+        list.view.rerender_messages(messages);
+    }
+}
+
+function rerender_messages_involving_user(user_id: number): void {
+    for (const list of message_lists.all_rendered_message_lists()) {
+        const messages = list.data.get_messages_involving_user(user_id);
         if (messages.length === 0) {
             continue;
         }
@@ -76,12 +86,12 @@ export function update_stream_name(stream_id: number, new_name: string): void {
 
 export function update_user_full_name(user_id: number, full_name: string): void {
     message_store.update_sender_full_name(user_id, full_name);
-    rerender_messages_view_for_user(user_id);
+    rerender_messages_involving_user(user_id);
 }
 
 export function update_avatar(user_id: number, avatar_url: string | null): void {
     message_store.update_small_avatar_url(user_id, avatar_url);
-    rerender_messages_view_for_user(user_id);
+    rerender_messages_sent_by_user(user_id);
 }
 
 export function update_user_status_emoji(
@@ -89,7 +99,7 @@ export function update_user_status_emoji(
     status_emoji_info: UserStatusEmojiInfo | undefined,
 ): void {
     message_store.update_status_emoji_info(user_id, status_emoji_info);
-    rerender_messages_view_for_user(user_id);
+    rerender_messages_sent_by_user(user_id);
 }
 
 export function update_thumbnails(): void {

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -234,3 +234,32 @@ export function maybe_rerender_title_area_for_stream(modified_stream_id: number)
         render_title_area();
     }
 }
+
+// The navbar title shows a user's name when narrowed to a DM that
+// includes them or to messages sent by them, so we refresh it for a
+// rename of such a user.
+export function maybe_update_navbar_title_for_user(modified_user_id: number): void {
+    const filter = narrow_state.filter();
+    if (filter === undefined) {
+        return;
+    }
+    // Only common narrows show a name in the title; others show a search
+    // bar and have no title to update.
+    if (!filter.is_common_narrow()) {
+        return;
+    }
+    const narrowed_to_dm_with_user = narrow_state.pm_ids_set(filter).has(modified_user_id);
+    const sender_id = filter.terms_with_operator("sender")[0]?.operand;
+    const narrowed_to_messages_sent_by_user = sender_id === modified_user_id;
+
+    if (narrowed_to_dm_with_user || narrowed_to_messages_sent_by_user) {
+        // Update just the title text rather than rebuilding the whole
+        // header with render_title_area(), which would close or reset a
+        // search bar the user has open to refine the narrow. For these
+        // narrows the title is plain text and the icon doesn't depend on
+        // the renamed user.
+        const title = filter.get_title();
+        assert(title !== undefined);
+        $("#message_view_header .message-header-navbar-title").text(title);
+    }
+}

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -11,6 +11,7 @@ import * as blueslip from "./blueslip.ts";
 import * as bot_data from "./bot_data.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
+import * as compose_recipient from "./compose_recipient.ts";
 import * as message_live_update from "./message_live_update.ts";
 import * as message_view_header from "./message_view_header.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
@@ -107,6 +108,7 @@ export const update_person = function update(event: UserUpdate): void {
         reactions.update_user_full_name(event.user_id);
         pm_list.update_private_messages();
         message_view_header.maybe_update_navbar_title_for_user(event.user_id);
+        compose_recipient.update_user_name_in_compose(event.user_id, event.full_name);
         user_profile.update_profile_modal_ui(user, event);
         if (people.is_my_user_id(event.user_id)) {
             current_user.full_name = event.full_name;

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -12,6 +12,7 @@ import * as bot_data from "./bot_data.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as message_live_update from "./message_live_update.ts";
+import * as message_view_header from "./message_view_header.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
@@ -105,6 +106,7 @@ export const update_person = function update(event: UserUpdate): void {
         message_live_update.update_user_full_name(event.user_id, event.full_name);
         reactions.update_user_full_name(event.user_id);
         pm_list.update_private_messages();
+        message_view_header.maybe_update_navbar_title_for_user(event.user_id);
         user_profile.update_profile_modal_ui(user, event);
         if (people.is_my_user_id(event.user_id)) {
             current_user.full_name = event.full_name;

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -186,6 +186,18 @@ export function get_display_value_from_item(item: UserPill): string {
     return item.full_name ?? item.email;
 }
 
+export function update_pill_full_name(
+    pill_widget: UserPillWidget,
+    user_id: number,
+    full_name: string,
+): void {
+    const pill = pill_widget.getPillByPredicate((item) => item.user_id === user_id);
+    if (!pill) {
+        return;
+    }
+    pill_widget.updatePill(pill.$element[0]!, {...pill.item, full_name});
+}
+
 export function generate_pill_html(item: UserPill, show_user_status_emoji = false): string {
     let status_emoji_info;
     let has_status;

--- a/web/tests/compose_pm_pill.test.cjs
+++ b/web/tests/compose_pm_pill.test.cjs
@@ -276,3 +276,25 @@ run_test("update_user_pill_active_status", ({override_rewire}) => {
 
     assert.ok(!pill_updated);
 });
+
+run_test("update_user_pill_full_name", ({override_rewire}) => {
+    // The pill-update logic lives in user_pill.update_pill_full_name and
+    // is tested there; here we just verify the wrapper delegates when
+    // the widget is set, and is a no-op otherwise.
+    let user_pill_function_called = false;
+    const widget = {
+        getPillByPredicate() {
+            user_pill_function_called = true;
+            return undefined;
+        },
+        updatePill() {},
+    };
+
+    override_rewire(compose_pm_pill, "widget", undefined);
+    compose_pm_pill.update_user_pill_full_name(1, "Othello the Moor");
+    assert.ok(!user_pill_function_called);
+
+    override_rewire(compose_pm_pill, "widget", widget);
+    compose_pm_pill.update_user_pill_full_name(1, "Othello the Moor");
+    assert.ok(user_pill_function_called);
+});

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -134,6 +134,7 @@ message_lists.current = {
     rerender_view: noop,
     data: {
         get_messages_sent_by_user: () => [],
+        get_messages_involving_user: () => [],
         filter: new Filter([]),
     },
 };
@@ -142,6 +143,7 @@ const cached_message_list = {
     rerender_view: noop,
     data: {
         get_messages_sent_by_user: () => [],
+        get_messages_involving_user: () => [],
     },
 };
 message_lists.all_rendered_message_lists = () => [cached_message_list, message_lists.current];

--- a/web/tests/example4.test.cjs
+++ b/web/tests/example4.test.cjs
@@ -63,6 +63,9 @@ const pm_list = mock_esm("../src/pm_list");
 const settings_bots = mock_esm("../src/settings_bots");
 const settings_users = mock_esm("../src/settings_users");
 const user_profile = mock_esm("../src/user_profile");
+mock_esm("../src/message_view_header", {
+    maybe_update_navbar_title_for_user() {},
+});
 
 // Use real versions of these modules.
 const bot_data = zrequire("bot_data");

--- a/web/tests/example4.test.cjs
+++ b/web/tests/example4.test.cjs
@@ -63,6 +63,9 @@ const pm_list = mock_esm("../src/pm_list");
 const settings_bots = mock_esm("../src/settings_bots");
 const settings_users = mock_esm("../src/settings_users");
 const user_profile = mock_esm("../src/user_profile");
+mock_esm("../src/compose_recipient", {
+    update_user_name_in_compose() {},
+});
 mock_esm("../src/message_view_header", {
     maybe_update_navbar_title_for_user() {},
 });

--- a/web/tests/message_list_data.test.cjs
+++ b/web/tests/message_list_data.test.cjs
@@ -38,6 +38,12 @@ function assert_msg_ids(messages, msg_ids) {
 
 mock_esm("../src/people.ts", {
     maybe_get_user_by_id: noop,
+    pm_with_user_ids(msg) {
+        if (msg.type !== "private") {
+            return undefined;
+        }
+        return msg.to_user_ids.split(",").map(Number);
+    },
 });
 
 run_test("basics", () => {
@@ -95,16 +101,21 @@ run_test("basics", () => {
         {id: 4, sender_id: 6, type: "private", to_user_ids: "6,9,10"},
         {id: 6, sender_id: 6, type: "private", to_user_ids: "6, 11"},
     ];
+    // A DM 6 received but did not send -- in get_messages_involving_user
+    // but not get_messages_sent_by_user.
+    const dm_received_by_6 = {id: 7, sender_id: 11, type: "private", to_user_ids: "11,6"};
+    const msgs_involving_6 = [...msgs_sent_by_6, dm_received_by_6];
     const msgs_with_sender_ids = [
         {id: 1, sender_id: 1, type: "stream", stream_id: 1, topic: "random1"},
         {id: 3, sender_id: 4, type: "stream", stream_id: 1, topic: "random2"},
         {id: 5, sender_id: 2, type: "private", to_user_ids: "2,10,11"},
         {id: 8, sender_id: 11, type: "private", to_user_ids: "10"},
         {id: 9, sender_id: 11, type: "private", to_user_ids: "9"},
-        ...msgs_sent_by_6,
+        ...msgs_involving_6,
     ];
     mld.add_messages(msgs_with_sender_ids, true);
     assert.deepEqual(mld.get_messages_sent_by_user(6), msgs_sent_by_6);
+    assert.deepEqual(mld.get_messages_involving_user(6), msgs_involving_6);
 
     mld.clear();
     assert_contents(mld, []);

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -303,6 +303,52 @@ test("message_edited_vars", () => {
     })();
 });
 
+test("rerender_messages rebuilds every distinct recipient bar", () => {
+    // A user can show up in several recipient bars at once -- e.g. DMs
+    // with the same user spread through Combined feed or search views.
+    // When that user is renamed, rerender_messages gets all their
+    // messages together and must rebuild every one of those bars, not
+    // just the first. The bars share a recipient, so we identify each bar
+    // by its rendered group id rather than by recipient.
+    const view = new MessageListView({id: 1}, true, true);
+
+    const dm1 = {msg: {id: 1, type: "private", to_user_ids: "5"}};
+    const dm2 = {msg: {id: 2, type: "private", to_user_ids: "5"}};
+    // dm3 has a container but no rendered row (e.g. a muted stream or
+    // topic), so there is no recipient bar to rebuild for it.
+    const dm3 = {msg: {id: 3, type: "private", to_user_ids: "5"}};
+    view.message_containers = new Map([
+        [1, dm1],
+        [2, dm2],
+        [3, dm3],
+    ]);
+
+    // dm1 and dm2 share a recipient but render in different bars; dm3 has
+    // no row. The stub row mirrors how rows.get_message_recipient_row
+    // reads the bar id from the DOM, and returns an empty set (length 0)
+    // for the unrendered message -- which must be skipped before any DOM
+    // lookup.
+    const group_id_by_msg_id = {1: "group-A", 2: "group-B"};
+    view.get_row = (id) => {
+        const group_id = group_id_by_msg_id[id];
+        if (group_id === undefined) {
+            return {length: 0};
+        }
+        return {length: 1, parent: () => ({expectOne: () => ({attr: () => group_id})})};
+    };
+
+    view._rerender_message = () => [];
+    const rerendered_group_ids = [];
+    view._rerender_header = (message_group_id) => {
+        rerendered_group_ids.push(message_group_id);
+    };
+
+    view.rerender_messages([dm1.msg, dm2.msg, dm3.msg]);
+
+    // One header rerender per distinct bar; the rowless message is skipped.
+    assert.deepEqual(rerendered_group_ids, ["group-A", "group-B"]);
+});
+
 test("muted_message_vars", () => {
     // This verifies that the variables for muted/hidden messages are set
     // correctly.

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -49,6 +49,9 @@ const buddy_list = mock_esm("../src/buddy_list", {
 const compose_pm_pill = mock_esm("../src/compose_pm_pill", {
     update_user_pill_active_status() {},
 });
+mock_esm("../src/compose_recipient", {
+    update_user_name_in_compose() {},
+});
 const pm_list = mock_esm("../src/pm_list", {
     update_private_messages() {},
 });

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -4,9 +4,11 @@ const assert = require("node:assert/strict");
 
 const {make_realm} = require("./lib/example_realm.cjs");
 const {make_bot, make_user} = require("./lib/example_user.cjs");
+const {make_message_list} = require("./lib/message_list.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
+const $ = require("./lib/zjquery.cjs");
 
 const message_live_update = mock_esm("../src/message_live_update");
 const navbar_alerts = mock_esm("../src/navbar_alerts");
@@ -78,14 +80,17 @@ mock_esm("../src/settings_streams", {
 });
 
 const bot_data = zrequire("bot_data");
+const message_lists = zrequire("message_lists");
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");
 const {set_current_user, set_realm} = zrequire("state_data");
+const {initialize_user_settings} = zrequire("user_settings");
 const user_events = zrequire("user_events");
 
 const current_user = {};
 set_current_user(current_user);
 set_realm(make_realm());
+initialize_user_settings({user_settings: {default_language: "en"}});
 
 const me = make_user({
     email: "me@example.com",
@@ -173,12 +178,27 @@ run_test("updates", ({override}) => {
         full_name = full_name_arg;
     };
 
+    const $navbar_title = $("#message_view_header .message-header-navbar-title");
+
+    // The navbar title lists the participants of the current DM narrow,
+    // so renaming one of them refreshes its text in place.
+    people.add_valid_user_id(isaac.user_id);
+    message_lists.set_current(make_message_list([{operator: "dm", operand: [isaac.user_id]}]));
+    $navbar_title.text("Isaac Newton");
+
     user_events.update_person({user_id: isaac.user_id, full_name: "Sir Isaac"});
     person = people.get_by_email(isaac.email);
     assert.equal(person.full_name, "Sir Isaac");
     assert.equal(person.is_admin, true);
     assert.equal(user_id, isaac.user_id);
     assert.equal(full_name, "Sir Isaac");
+    assert.equal($navbar_title.text(), "Sir Isaac");
+
+    // Renaming someone the title does not mention leaves it untouched.
+    user_events.update_person({user_id: me.user_id, full_name: "Me Interim"});
+    assert.equal($navbar_title.text(), "Sir Isaac");
+
+    message_lists.set_current(undefined);
 
     user_events.update_person({
         user_id: me.user_id,
@@ -375,4 +395,17 @@ run_test("updates", ({override}) => {
     };
     people.add_active_user(imported_user);
     user_events.update_person({user_id: imported_user.user_id, is_imported_stub: false});
+
+    // A non-common narrow (here sender: combined with is:) shows a search
+    // bar, not a name, so renaming the user must leave the title alone.
+    message_lists.set_current(
+        make_message_list([
+            {operator: "is", operand: "starred"},
+            {operator: "sender", operand: isaac.user_id},
+        ]),
+    );
+    $navbar_title.text("placeholder");
+    user_events.update_person({user_id: isaac.user_id, full_name: "Sir Isaac Newton"});
+    assert.equal($navbar_title.text(), "placeholder");
+    message_lists.set_current(undefined);
 });

--- a/web/tests/user_pill.test.cjs
+++ b/web/tests/user_pill.test.cjs
@@ -212,3 +212,23 @@ test("typeahead", () => {
     const result = user_pill.typeahead_source(pill_widget);
     assert.deepEqual(result, [{type: "user", user: alice}]);
 });
+
+test("update_pill_full_name", () => {
+    const pill = {item: {...isaac_item}, $element: {0: {}}};
+    let pill_updated = false;
+    pill_widget.getPillByPredicate = (predicate) => (predicate(pill.item) ? pill : undefined);
+    pill_widget.updatePill = (_element, item) => {
+        pill.item = item;
+        pill_updated = true;
+    };
+
+    assert.equal(pill.item.full_name, "Isaac Newton");
+    user_pill.update_pill_full_name(pill_widget, isaac.user_id, "Sir Isaac Newton");
+    assert.equal(pill.item.full_name, "Sir Isaac Newton");
+    assert.ok(pill_updated);
+
+    // No-op when no matching pill.
+    pill_updated = false;
+    user_pill.update_pill_full_name(pill_widget, 999, "Nobody");
+    assert.ok(!pill_updated);
+});


### PR DESCRIPTION
This PR was created when making changes for #39033. Since this is a pre-existing bug, it is better reviewed separately and merged before that PR.

This PR fixes name change live update not working in the following places:
- Message header.
- Recipient header.
- Compose pill name
- Compose placeholder

This PR has not done a full scan of missing live update code for name change at other places, only the DM view.

The first commit was needed to live update the shimmer for PR 39033 but then I noticed the other issues on the same page and fixed it.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="1722" height="930" alt="DM live update not working" src="https://github.com/user-attachments/assets/865918f3-41b9-464d-8a51-9c151f2ff619" />

After:
<img width="1722" height="930" alt="DM working live update" src="https://github.com/user-attachments/assets/ca9835fd-2cd4-4367-b5b8-1d6a636965fd" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
