### PR TITLE
[ai] left_sidebar: Fix focus styling on the channel-section "+" button.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -61,6 +61,16 @@
     border-radius: 3px;
     color: var(--color-sidebar-action);
 
+    /* The section-header variant is an <a>, so without this rule the
+       generic `a:focus` rule in zulip.css would shift the icon to the
+       interactive link color when focused. Re-state the default color
+       here so it stays consistent with the <span>/<div> sibling
+       buttons. */
+    &:focus,
+    &:focus-visible {
+        color: var(--color-sidebar-action);
+    }
+
     &:hover {
         color: var(--color-sidebar-action-hover);
         background-color: var(--color-background-sidebar-action-hover);
@@ -70,6 +80,10 @@
     &:focus-visible {
         outline: 2px solid var(--color-outline-focus);
         outline-offset: -2px;
+        /* `!important` overrides the `.dark-theme:root
+           a:not(:active):focus` rule in dark_theme.css, which would
+           otherwise set this anchor's focus outline to grey. */
+        outline-color: var(--color-outline-focus) !important;
     }
 
     .add_stream_icon {


### PR DESCRIPTION
The "create a channel" button in the channel-list section header is
an <a>, so its keyboard focus state was inheriting the generic
`a:focus` rule from zulip.css (which sets color to the interactive
link color) and the dark-theme override that sets anchor focus
outlines to grey. The result was a blue icon and a grey outline,
inconsistent with the <span> "create a channel" button at the top of
the sidebar and the <div> "start a new topic" button on each channel
row, both of which render with the sidebar-action color and the
focus-blue outline.

Restate the color on `:focus`/`:focus-visible` so it matches the
default sidebar-action color, and add a higher-specificity
dark-theme rule to set the outline color back to
`--color-outline-focus`.

[#issues > keyboard focus styling on "Create a channel"](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20focus.20styling.20on.20.22Create.20a.20channel.22/with/2446666)

| before | after |
| -- | -- |
| <img width="334" height="225" alt="image" src="https://github.com/user-attachments/assets/cf584756-6c9e-4c20-a7f8-766f0621d4f4" /> | <img width="359" height="237" alt="image" src="https://github.com/user-attachments/assets/23c91844-6939-43c3-9fc0-768c63696f8a" /> |
| <img width="384" height="269" alt="image" src="https://github.com/user-attachments/assets/70384a9b-a35e-4a85-b4fa-2ae8ba1aa4c2" /> | <img width="314" height="283" alt="image" src="https://github.com/user-attachments/assets/ddd6bf12-be6a-4bd2-80fb-4d7b214af06c" /> |