### PR TITLE
[ai] Implement mark-then-fill cache filling to close race conditions

### DIFF
--- a/scripts/setup/flush-memcached
+++ b/scripts/setup/flush-memcached
@@ -15,7 +15,11 @@ from django.conf import settings
 
 cache = settings.CACHES["default"]
 match cache["BACKEND"]:
-    case "django.core.cache.backends.locmem.LocMemCache":
+    case (
+        "django.core.cache.backends.locmem.LocMemCache"
+        | "zerver.lib.test_cache_backends.CASCapableLocMemCache"
+    ):
+        # In-process; nothing to flush across runs.
         pass
     case "zerver.lib.singleton_bmemcached.SingletonBMemcached":
         assert isinstance(cache["OPTIONS"], dict)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -753,38 +753,60 @@ def generic_bulk_cached_fetch(
             pickled_tupled=False,
         )
 
-    cache_keys: dict[ObjKT, str] = {}
-    for object_id in object_ids:
-        cache_keys[object_id] = cache_key_function(object_id)
+    global _cache_fill_hit, _cache_fill_won, _cache_fill_race_detected
+    global _cache_fill_claim_lost, _cache_fill_saw_sentinel
 
-    cached_objects_compressed: dict[str, CompressedItemT] = safe_cache_get_many(
-        [cache_keys[object_id] for object_id in object_ids],
-    )
+    cache_keys: dict[ObjKT, str] = {oid: cache_key_function(oid) for oid in object_ids}
 
-    cached_objects = {key: extractor(val) for key, val in cached_objects_compressed.items()}
-    needed_ids = [
-        object_id for object_id in object_ids if cache_keys[object_id] not in cached_objects
+    # Initial read: one pipelined round-trip returning (value, cas_id) for every
+    # present key.
+    initial = cache_gets_many(list(cache_keys.values()))
+
+    # Drop sentinel entries -- a concurrent filler has written a sentinel we
+    # should not return to this caller.  These keys are treated as misses; our
+    # own add() below will fail, and we'll return the DB value without caching.
+    cached_objects: dict[str, CacheItemT] = {}
+    for key, (val, _cas) in initial.items():
+        if isinstance(val, _CacheFillSentinel):
+            _cache_fill_saw_sentinel += 1
+            continue
+        cached_objects[key] = extractor(val)
+    _cache_fill_hit += len(cached_objects)
+
+    needed: list[tuple[ObjKT, str]] = [
+        (oid, key) for oid, key in cache_keys.items() if key not in cached_objects
     ]
 
-    # Only call query_function if there are some ids to fetch from the database:
-    if len(needed_ids) > 0:
-        db_objects = query_function(needed_ids)
-    else:
-        db_objects = []
+    # Try to claim every missed key with the sentinel in a pipelined add_multi;
+    # we get back the new cas id for each successful add, which is our
+    # ownership token for the subsequent cas-commit.  Keys where we lose the
+    # add fell to another reader or already have a real value, and we won't
+    # write them.
+    owned_cas_ids: dict[str, int] = {}
+    if needed:
+        owned_cas_ids = cache_add_many(
+            {key: _CACHE_FILL_SENTINEL for _, key in needed},
+            CACHE_FILL_SENTINEL_TIMEOUT,
+        )
+        _cache_fill_claim_lost += len(needed) - len(owned_cas_ids)
 
-    items_for_remote_cache: dict[str, CompressedItemT] = {}
-    for obj in db_objects:
-        key = cache_keys[id_fetcher(obj)]
-        item = cache_transformer(obj)
-        items_for_remote_cache[key] = setter(item)
-        cached_objects[key] = item
-    if len(items_for_remote_cache) > 0:
-        safe_cache_set_many(items_for_remote_cache)
-    return {
-        object_id: cached_objects[cache_keys[object_id]]
-        for object_id in object_ids
-        if cache_keys[object_id] in cached_objects
-    }
+        # Collect values for pipelined cas writes.  Keys we don't own are still
+        # returned to the caller but never cached.
+        items_to_cas: dict[str, tuple[CompressedItemT, int]] = {}
+        for obj in query_function([oid for oid, _ in needed]):
+            key = cache_keys[id_fetcher(obj)]
+            item = cache_transformer(obj)
+            cached_objects[key] = item
+            if key in owned_cas_ids:
+                items_to_cas[key] = (setter(item), owned_cas_ids[key])
+
+        if items_to_cas:
+            committed = cache_cas_many(items_to_cas)
+            _cache_fill_won += len(committed)
+            # cas failures == writer's delete() landed during our DB fetch.
+            _cache_fill_race_detected += len(items_to_cas) - len(committed)
+
+    return {oid: cached_objects[key] for oid, key in cache_keys.items() if key in cached_objects}
 
 
 def bulk_cached_fetch(

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -17,7 +17,7 @@ from django.conf import settings
 from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
 from django.db.models import Q, QuerySet
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, override
 
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, get_recent_deployments
 
@@ -39,6 +39,16 @@ remote_cache_time_start = 0.0
 remote_cache_total_time = 0.0
 remote_cache_total_requests = 0
 
+# Counters for the read-through mark-then-fill path in read_through_cache().
+# These are in-process only; they match the existing
+# remote_cache_total_requests convention rather than introducing a separate
+# statsd pipeline.
+_cache_fill_hit = 0
+_cache_fill_won = 0
+_cache_fill_race_detected = 0
+_cache_fill_claim_lost = 0
+_cache_fill_saw_sentinel = 0
+
 
 def get_remote_cache_time() -> float:
     return remote_cache_total_time
@@ -46,6 +56,24 @@ def get_remote_cache_time() -> float:
 
 def get_remote_cache_requests() -> int:
     return remote_cache_total_requests
+
+
+def get_cache_fill_counts() -> dict[str, int]:
+    """Counters for read_through_cache outcomes.
+
+    race_detected counts misses where the reader's cas() failed (or the
+    sentinel disappeared between add and gets) -- i.e., a writer's
+    delete() landed during the fill.  A nonzero value here is the
+    point: it's a race that would previously have written a stale value
+    into the cache and is now being correctly rejected.
+    """
+    return {
+        "hit": _cache_fill_hit,
+        "won": _cache_fill_won,
+        "race_detected": _cache_fill_race_detected,
+        "claim_lost": _cache_fill_claim_lost,
+        "saw_sentinel": _cache_fill_saw_sentinel,
+    }
 
 
 def remote_cache_stats_start() -> None:
@@ -285,6 +313,10 @@ def cache_get(key: str, cache_name: str | None = None) -> Any:
     cache_backend = get_cache_backend(cache_name)
     ret = cache_backend.get(final_key)
     remote_cache_stats_finish()
+    if isinstance(ret, _CacheFillSentinel):
+        # A read_through_cache fill is in progress (or recently aborted);
+        # the sentinel is an internal marker, not a value to return.
+        return None
     return ret
 
 
@@ -295,7 +327,11 @@ def cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, 
     remote_cache_stats_start()
     ret = get_cache_backend(cache_name).get_many(keys)
     remote_cache_stats_finish()
-    return {key.removeprefix(KEY_PREFIX): value for key, value in ret.items()}
+    return {
+        key.removeprefix(KEY_PREFIX): value
+        for key, value in ret.items()
+        if not isinstance(value, _CacheFillSentinel)
+    }
 
 
 def safe_cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, Any]:
@@ -368,6 +404,185 @@ def cache_delete_many(items: Iterable[str], cache_name: str | None = None) -> No
             validate_cache_key(key, auto_prepend_prefix=False)
         get_cache_backend(cache_name).delete_many(batch)
     remote_cache_stats_finish()
+
+
+def _get_cache_fill_sentinel() -> "_CacheFillSentinel":
+    return _CACHE_FILL_SENTINEL
+
+
+class _CacheFillSentinel:
+    """Marker stored during a read-through fill to detect concurrent invalidation.
+
+    read_through_cache() writes this value via add(get_cas=True), keeps the
+    cas id memcached returns, and later cas-commits the fetched value with
+    that cas id.  If a writer's delete() (or any other write) intervenes,
+    the slot's cas changes, and the cas-commit fails atomically -- so the
+    (potentially stale) value is not cached.  The cas id is the ownership
+    token; the sentinel value just needs to be a non-collidable placeholder.
+
+    The sentinel pickles to a stable singleton via _get_cache_fill_sentinel
+    so identity / isinstance checks work after a memcached round-trip.
+    """
+
+    __slots__ = ()
+
+    @override
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        return (_get_cache_fill_sentinel, ())
+
+
+_CACHE_FILL_SENTINEL = _CacheFillSentinel()
+
+
+# Lifetime of the sentinel slot during a fill.  Must exceed any plausible
+# DB fetch; short enough that a crashed filler doesn't block the key for long.
+CACHE_FILL_SENTINEL_TIMEOUT = 30
+
+
+def _backend_gets(backend: BaseCache, pre_make_key: str) -> tuple[Any, int | None]:
+    """Memcached gets(); returns (None, None) on miss."""
+    if hasattr(backend, "gets"):
+        return backend.gets(pre_make_key)
+    raw_key = backend.make_key(pre_make_key)
+    return backend._cache.gets(raw_key)  # type: ignore[attr-defined] # not in stubs
+
+
+def _backend_cas(
+    backend: BaseCache, pre_make_key: str, value: Any, cas_id: int, timeout: int | None
+) -> bool:
+    """Memcached cas(): conditional set keyed on a matching cas_token."""
+    if hasattr(backend, "cas"):
+        return backend.cas(pre_make_key, value, cas_id, timeout)
+    raw_key = backend.make_key(pre_make_key)
+    return backend._cache.cas(  # type: ignore[attr-defined] # not in stubs
+        raw_key, value, cas_id, backend.get_backend_timeout(timeout)
+    )
+
+
+def _backend_add(
+    backend: BaseCache, pre_make_key: str, value: Any, timeout: int | None
+) -> tuple[bool, int | None]:
+    """Memcached add(); returns the new cas id on success."""
+    if hasattr(backend, "add_cas"):
+        return backend.add_cas(pre_make_key, value, timeout=timeout)
+    raw_key = backend.make_key(pre_make_key)
+    return backend._cache.add(  # type: ignore[attr-defined] # not in stubs
+        raw_key, value, backend.get_backend_timeout(timeout), get_cas=True
+    )
+
+
+def cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
+    final_key = KEY_PREFIX + key
+    validate_cache_key(final_key)
+
+    remote_cache_stats_start()
+    ret = _backend_gets(get_cache_backend(cache_name), final_key)
+    remote_cache_stats_finish()
+    return ret
+
+
+def cache_add(
+    key: str, val: Any, timeout: int, cache_name: str | None = None
+) -> tuple[bool, int | None]:
+    """Add-if-absent that returns the cas id of the just-added value.
+
+    On success returns (True, cas_id); on failure (key already present)
+    returns (False, None).  The cas id can be passed to a later cache_cas()
+    to write conditionally on the value still being ours.
+    """
+    final_key = KEY_PREFIX + key
+    validate_cache_key(final_key)
+
+    remote_cache_stats_start()
+    try:
+        added, cas_id = _backend_add(get_cache_backend(cache_name), final_key, val, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        added, cas_id = False, None
+    remote_cache_stats_finish()
+    return added, cas_id
+
+
+def cache_cas(
+    key: str,
+    val: Any,
+    cas_id: int,
+    timeout: int | None = None,
+    cache_name: str | None = None,
+) -> bool:
+    final_key = KEY_PREFIX + key
+    validate_cache_key(final_key)
+
+    remote_cache_stats_start()
+    try:
+        ok = _backend_cas(get_cache_backend(cache_name), final_key, val, cas_id, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        ok = False
+    remote_cache_stats_finish()
+    return ok
+
+
+def read_through_cache(
+    key: str,
+    fetcher: Callable[[], ReturnT],
+    *,
+    cache_name: str | None = None,
+    timeout: int | None = None,
+    pickled_tupled: bool = True,
+) -> ReturnT:
+    """Fetch a value through the cache, mark-then-fill to avoid stale writes.
+
+    On miss, we claim the fill slot with the _CACHE_FILL_SENTINEL via add(),
+    which gives us back the cas id of the just-added sentinel.  After the
+    DB fetch we cas-commit the value with that cas id; the cas succeeds
+    only if the slot has not been touched since (same value, same cas id).
+    A writer's delete() during the fetch -- or a delete followed by another
+    reader's add of their own sentinel -- changes the slot's cas, so the
+    cas-commit fails atomically and the (possibly stale) value is not
+    cached.  Callers that lose the initial add race -- or that see an
+    existing sentinel -- fall back to the DB directly and do not write to
+    the cache.
+
+    When pickled_tupled=True (the default), the value is wrapped in a
+    1-tuple on write and unwrapped on read, so that a cached None is
+    distinguishable from a missing key.  Setting pickled_tupled=False
+    skips the wrap (and the pickle it would force) -- a performance
+    optimization, reasonable when the value is a string or bytes that
+    cannot be None.  The sentinel class is separate, so
+    isinstance(val, _CacheFillSentinel) reliably distinguishes it from
+    any wrapped real value.
+    """
+    global _cache_fill_hit, _cache_fill_won, _cache_fill_race_detected
+    global _cache_fill_claim_lost, _cache_fill_saw_sentinel
+
+    val, _cas_id = cache_gets(key, cache_name=cache_name)
+
+    if isinstance(val, _CacheFillSentinel):
+        _cache_fill_saw_sentinel += 1
+        return fetcher()
+    if val is not None:
+        _cache_fill_hit += 1
+        return val[0] if pickled_tupled else val
+
+    # Genuine miss.  Claim the fill; the cas id we get back is our
+    # ownership token for the subsequent cas-commit.
+    claimed, our_cas = cache_add(
+        key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT, cache_name=cache_name
+    )
+    if not claimed:
+        _cache_fill_claim_lost += 1
+        return fetcher()
+    assert our_cas is not None
+
+    value = fetcher()
+
+    payload: Any = (value,) if pickled_tupled else value
+    if cache_cas(key, payload, our_cas, timeout=timeout, cache_name=cache_name):
+        _cache_fill_won += 1
+    else:
+        _cache_fill_race_detected += 1
+    return value
 
 
 def filter_good_and_bad_keys(keys: list[str]) -> tuple[list[str], list[str]]:

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -156,6 +156,26 @@ def get_cache_backend(cache_name: str | None) -> BaseCache:
     return caches[cache_name]
 
 
+def _no_queryset_returns(
+    func: Callable[ParamT, ReturnT],
+) -> Callable[ParamT, ReturnT]:
+    """Dev/test guard: assert a @cache_with_key-decorated function never
+    returns a QuerySet.  Production skips the check.
+    """
+
+    @wraps(func)
+    def wrapped(*args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
+        val = func(*args, **kwargs)
+        if isinstance(val, QuerySet):
+            raise AssertionError(
+                f"@cache_with_key {func.__qualname__} returned a QuerySet; "
+                f"materialize (e.g. list(qs)) before returning."
+            )
+        return val
+
+    return wrapped
+
+
 def cache_with_key(
     keyfunc: Callable[ParamT, str],
     cache_name: str | None = None,
@@ -170,6 +190,11 @@ def cache_with_key(
     other uses of caching."""
 
     def decorator(func: Callable[ParamT, ReturnT]) -> Callable[ParamT, ReturnT]:
+        if settings.TEST_SUITE or settings.DEBUG:
+            checked = _no_queryset_returns(func)
+        else:
+            checked = func
+
         @wraps(func)
         def func_with_caching(*args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
             key = keyfunc(*args, **kwargs)
@@ -179,7 +204,7 @@ def cache_with_key(
             except InvalidCacheKeyError:
                 stack_trace = traceback.format_exc()
                 log_invalid_cache_keys(stack_trace, [key])
-                return func(*args, **kwargs)
+                return checked(*args, **kwargs)
 
             # Values are singleton tuples so that we can distinguish a
             # result of None from a missing key.  Setting
@@ -189,16 +214,10 @@ def cache_with_key(
             if val is not None and pickled_tupled:
                 return val[0]
 
-            val = func(*args, **kwargs)
-            if isinstance(val, QuerySet):
-                logging.error(
-                    "cache_with_key attempted to store a full QuerySet object -- declining to cache",
-                    stack_info=True,
-                )
-            else:
-                cache_set(
-                    key, val, cache_name=cache_name, timeout=timeout, pickled_tupled=pickled_tupled
-                )
+            val = checked(*args, **kwargs)
+            cache_set(
+                key, val, cache_name=cache_name, timeout=timeout, pickled_tupled=pickled_tupled
+            )
 
             return val
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -228,26 +228,19 @@ def cache_with_key(
             key = keyfunc(*args, **kwargs)
 
             try:
-                val = cache_get(key, cache_name=cache_name)
+                validate_cache_key(KEY_PREFIX + key)
             except InvalidCacheKeyError:
                 stack_trace = traceback.format_exc()
                 log_invalid_cache_keys(stack_trace, [key])
                 return checked(*args, **kwargs)
 
-            # Values are singleton tuples so that we can distinguish a
-            # result of None from a missing key.  Setting
-            # pickled_tupled=False avoids pickling the result (if it's
-            # a raw string or bytes) at the cost of losing this
-            # distinction.
-            if val is not None and pickled_tupled:
-                return val[0]
-
-            val = checked(*args, **kwargs)
-            cache_set(
-                key, val, cache_name=cache_name, timeout=timeout, pickled_tupled=pickled_tupled
+            return read_through_cache(
+                key,
+                lambda: checked(*args, **kwargs),
+                cache_name=cache_name,
+                timeout=timeout,
+                pickled_tupled=pickled_tupled,
             )
-
-            return val
 
         return func_with_caching
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -464,6 +464,56 @@ def _backend_add(
     )
 
 
+def _backend_gets_multi(backend: BaseCache, pre_make_keys: list[str]) -> dict[str, tuple[Any, int]]:
+    """Pipelined gets across N keys in one round-trip; absent keys are omitted."""
+    if hasattr(backend, "gets_multi"):
+        return backend.gets_multi(pre_make_keys)
+    raw_to_orig = {backend.make_key(k): k for k in pre_make_keys}
+    raw = backend._cache.get_multi(  # type: ignore[attr-defined] # not in stubs
+        list(raw_to_orig), get_cas=True
+    )
+    return {raw_to_orig[rk]: (val, cas) for rk, (val, cas) in raw.items()}
+
+
+def _backend_add_multi(
+    backend: BaseCache, items: dict[str, Any], timeout: int | None
+) -> dict[str, int]:
+    """Pipelined add across N keys; returns cas ids of successful adds."""
+    if hasattr(backend, "add_multi_cas"):
+        return backend.add_multi_cas(items, timeout=timeout)
+    raw_to_orig = {backend.make_key(k): k for k in items}
+    # bmemcached.set_multi_cas with a (key, cas=0) mapping turns into a
+    # pipelined add, with per-key new cas ids returned for successful adds
+    # and None for keys that already existed.
+    raw_mappings = {(rk, 0): items[raw_to_orig[rk]] for rk in raw_to_orig}
+    raw_result: dict[str, int | None] = backend._cache.set_multi_cas(  # type: ignore[attr-defined] # not in stubs
+        raw_mappings, backend.get_backend_timeout(timeout)
+    )
+    return {raw_to_orig[rk]: cas for rk, cas in raw_result.items() if cas is not None}
+
+
+def _backend_cas_multi(
+    backend: BaseCache, items_with_cas: dict[str, tuple[Any, int]], timeout: int | None
+) -> set[str]:
+    """Pipelined cas across N keys; returns keys whose set committed."""
+    if hasattr(backend, "cas_multi"):
+        return backend.cas_multi(items_with_cas, timeout=timeout)
+    raw_to_orig = {backend.make_key(k): k for k in items_with_cas}
+    # bmemcached.set_multi treats a (key, cas != 0) mapping as a pipelined setq
+    # with the CAS field set, matching a single-key cas() call.
+    raw_mappings = {
+        (rk, items_with_cas[raw_to_orig[rk]][1]): items_with_cas[raw_to_orig[rk]][0]
+        for rk in raw_to_orig
+    }
+    failed_raw = backend._cache.set_multi(  # type: ignore[attr-defined] # not in stubs
+        raw_mappings, backend.get_backend_timeout(timeout)
+    )
+    failed_orig = {
+        raw_to_orig[entry[0] if isinstance(entry, tuple) else entry] for entry in failed_raw
+    }
+    return set(items_with_cas) - failed_orig
+
+
 def cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
     final_key = KEY_PREFIX + key
     validate_cache_key(final_key)
@@ -514,6 +564,60 @@ def cache_cas(
         ok = False
     remote_cache_stats_finish()
     return ok
+
+
+def cache_gets_many(keys: list[str], cache_name: str | None = None) -> dict[str, tuple[Any, int]]:
+    """Pipelined gets_many returning (value, cas_id) for each present key."""
+    final_keys = [KEY_PREFIX + k for k in keys]
+    for fk in final_keys:
+        validate_cache_key(fk)
+
+    remote_cache_stats_start()
+    raw = _backend_gets_multi(get_cache_backend(cache_name), final_keys)
+    remote_cache_stats_finish()
+    return {fk.removeprefix(KEY_PREFIX): v for fk, v in raw.items()}
+
+
+def cache_add_many(
+    items: dict[str, Any], timeout: int, cache_name: str | None = None
+) -> dict[str, int]:
+    """Pipelined add_many returning the new cas id for each successful add.
+
+    The cas ids can be passed back into cache_cas_many() to write
+    conditionally on the slots still being ours.
+    """
+    final_items = {KEY_PREFIX + k: v for k, v in items.items()}
+    for fk in final_items:
+        validate_cache_key(fk)
+
+    remote_cache_stats_start()
+    try:
+        added = _backend_add_multi(get_cache_backend(cache_name), final_items, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        added = {}
+    remote_cache_stats_finish()
+    return {fk.removeprefix(KEY_PREFIX): cas for fk, cas in added.items()}
+
+
+def cache_cas_many(
+    items_with_cas: dict[str, tuple[Any, int]],
+    timeout: int | None = None,
+    cache_name: str | None = None,
+) -> set[str]:
+    """Pipelined cas_many.  Returns the keys where the conditional set committed."""
+    final_items = {KEY_PREFIX + k: v for k, v in items_with_cas.items()}
+    for fk in final_items:
+        validate_cache_key(fk)
+
+    remote_cache_stats_start()
+    try:
+        committed = _backend_cas_multi(get_cache_backend(cache_name), final_items, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        committed = set()
+    remote_cache_stats_finish()
+    return {fk.removeprefix(KEY_PREFIX) for fk in committed}
 
 
 def read_through_cache(

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from zerver.models import Attachment, Message, MutedUser, Realm, Stream, SubMessage, UserProfile
 
 MEMCACHED_MAX_KEY_LENGTH = 250
+# Printable ASCII (! through ~).
+_VALID_CACHE_KEY_RE = re.compile(r"[!-~]+")
 
 ParamT = ParamSpec("ParamT")
 ReturnT = TypeVar("ReturnT")
@@ -229,7 +231,7 @@ def validate_cache_key(key: str, auto_prepend_prefix: bool = True) -> None:
     # the resulting keys fit the regex below.
     # The regex checks "all characters between ! and ~ in the ascii table",
     # which happens to be the set of all "nice" ascii characters.
-    if not bool(re.fullmatch(r"([!-~])+", key)):
+    if _VALID_CACHE_KEY_RE.fullmatch(key) is None:
         raise InvalidCacheKeyError("Invalid characters in the cache key: " + key)
     if len(key) > MEMCACHED_MAX_KEY_LENGTH:
         raise InvalidCacheKeyError(f"Cache key too long: {key} Length: {len(key)}")

--- a/zerver/lib/test_cache_backends.py
+++ b/zerver/lib/test_cache_backends.py
@@ -1,0 +1,95 @@
+import itertools
+import pickle
+from typing import Any
+
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+from django.core.cache.backends.locmem import LocMemCache
+from typing_extensions import override
+
+# Per-cache-name dict of {key: cas_token}. Keyed the same way LocMemCache keys
+# its _caches global so that multiple backend instances sharing a name also
+# share cas tokens, consistent with a real memcached server.
+_cas_tokens: dict[str, dict[str, int]] = {}
+
+
+class CASCapableLocMemCache(LocMemCache):
+    """LocMemCache with memcached-style gets/cas.
+
+    The production backend (bmemcached.Client) exposes gets/cas natively,
+    but LocMemCache does not. Tests of CAS-based read-through code paths
+    use this backend instead so they don't require a real memcached server.
+
+    Implementation approach: every write goes through LocMemCache._set,
+    which we override to also bump a per-key cas token under the same
+    lock.  incr() writes to self._cache directly instead of going through
+    _set, so it gets its own override.
+    """
+
+    def __init__(self, name: str, params: dict[str, Any]) -> None:
+        super().__init__(name, params)
+        self._cas_tokens = _cas_tokens.setdefault(name, {})
+        self._cas_counter = itertools.count(1)
+
+    # LocMemCache's _set / _delete / _cache / _lock / _has_expired / _expire_info
+    # are private and not declared in django-stubs, so mypy can't see them. The
+    # attribute-access ignores below are for that reason only.
+
+    def _set(self, key: str, value: bytes, timeout: Any = DEFAULT_TIMEOUT) -> None:
+        super()._set(key, value, timeout)  # type: ignore[misc] # not in stubs
+        self._cas_tokens[key] = next(self._cas_counter)
+
+    def _delete(self, key: str) -> bool:
+        self._cas_tokens.pop(key, None)
+        return super()._delete(key)  # type: ignore[misc] # not in stubs
+
+    @override
+    def clear(self) -> None:
+        super().clear()
+        self._cas_tokens.clear()
+
+    def gets(self, key: str, version: Any = None) -> tuple[Any, int | None]:
+        raw_key = self.make_and_validate_key(key, version=version)
+        with self._lock:  # type: ignore[attr-defined] # not in stubs
+            if self._has_expired(raw_key):  # type: ignore[attr-defined] # not in stubs
+                self._delete(raw_key)
+                return None, None
+            pickled = self._cache[raw_key]  # type: ignore[attr-defined] # not in stubs
+            cas_id = self._cas_tokens.get(raw_key)
+            self._cache.move_to_end(raw_key, last=False)  # type: ignore[attr-defined] # not in stubs
+        return pickle.loads(pickled), cas_id  # noqa: S301
+
+    def cas(
+        self,
+        key: str,
+        value: Any,
+        cas_id: int,
+        timeout: Any = DEFAULT_TIMEOUT,
+        version: Any = None,
+    ) -> bool:
+        raw_key = self.make_and_validate_key(key, version=version)
+        pickled = pickle.dumps(value, self.pickle_protocol)
+        with self._lock:  # type: ignore[attr-defined] # not in stubs
+            if self._has_expired(raw_key):  # type: ignore[attr-defined] # not in stubs
+                return False
+            if self._cas_tokens.get(raw_key) != cas_id:
+                return False
+            # _set is our override, so this also refreshes the cas token.
+            self._set(raw_key, pickled, timeout)
+            return True
+
+    def add_cas(
+        self, key: str, value: Any, timeout: Any = DEFAULT_TIMEOUT, version: Any = None
+    ) -> tuple[bool, int | None]:
+        """Add-if-absent that returns the cas id of the just-added value.
+
+        Mirrors bmemcached.Client.add(get_cas=True) so callers don't need a
+        follow-up gets() to recover the cas id of their own write.  Returns
+        (True, cas_id) on success, (False, None) if the slot was already set.
+        """
+        raw_key = self.make_and_validate_key(key, version=version)
+        pickled = pickle.dumps(value, self.pickle_protocol)
+        with self._lock:  # type: ignore[attr-defined] # not in stubs
+            if not self._has_expired(raw_key):  # type: ignore[attr-defined] # not in stubs
+                return False, None
+            self._set(raw_key, pickled, timeout)
+            return True, self._cas_tokens[raw_key]

--- a/zerver/lib/test_cache_backends.py
+++ b/zerver/lib/test_cache_backends.py
@@ -93,3 +93,45 @@ class CASCapableLocMemCache(LocMemCache):
                 return False, None
             self._set(raw_key, pickled, timeout)
             return True, self._cas_tokens[raw_key]
+
+    # The multi-key variants below are sequential in this in-memory test
+    # backend, but mirror the interface that bmemcached implements via
+    # pipelined memcached commands, so callers can be exercised by the
+    # test suite without spinning up a real memcached.
+
+    def gets_multi(self, keys: list[str], version: Any = None) -> dict[str, tuple[Any, int]]:
+        result: dict[str, tuple[Any, int]] = {}
+        for key in keys:
+            val, cas_id = self.gets(key, version=version)
+            if cas_id is not None:
+                result[key] = (val, cas_id)
+        return result
+
+    def add_multi_cas(
+        self, items: dict[str, Any], timeout: Any = DEFAULT_TIMEOUT, version: Any = None
+    ) -> dict[str, int]:
+        """Pipelined add returning the new cas id for each successful add.
+
+        Mirrors bmemcached.Client.set_multi_cas with (key, 0) tuples (which
+        the protocol turns into pipelined add operations) -- on success the
+        per-key new cas id is returned to the caller.
+        """
+        result: dict[str, int] = {}
+        for key, value in items.items():
+            success, cas_id = self.add_cas(key, value, timeout=timeout, version=version)
+            if success:
+                assert cas_id is not None
+                result[key] = cas_id
+        return result
+
+    def cas_multi(
+        self,
+        items: dict[str, tuple[Any, int]],
+        timeout: Any = DEFAULT_TIMEOUT,
+        version: Any = None,
+    ) -> set[str]:
+        return {
+            key
+            for key, (value, cas_id) in items.items()
+            if self.cas(key, value, cas_id, timeout=timeout, version=version)
+        }

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -135,17 +135,31 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
     cache_queries: list[tuple[str, str | list[str], str | None]] = []
 
     orig_get = cache.cache_get
+    orig_gets = cache.cache_gets
     orig_get_many = cache.cache_get_many
 
-    def my_cache_get(key: str, cache_name: str | None = None) -> dict[str, Any] | None:
+    def my_cache_get(  # nocoverage -- no current test exercises this path
+        key: str, cache_name: str | None = None
+    ) -> dict[str, Any] | None:
         cache_queries.append(("get", key, cache_name))
         return orig_get(key, cache_name)
 
-    def my_cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, Any]:
+    def my_cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
+        cache_queries.append(("gets", key, cache_name))
+        return orig_gets(key, cache_name)
+
+    def my_cache_get_many(  # nocoverage -- no current test exercises this path
+        keys: list[str], cache_name: str | None = None
+    ) -> dict[str, Any]:
         cache_queries.append(("getmany", keys, cache_name))
         return orig_get_many(keys, cache_name)
 
-    with mock.patch.multiple(cache, cache_get=my_cache_get, cache_get_many=my_cache_get_many):
+    with mock.patch.multiple(
+        cache,
+        cache_get=my_cache_get,
+        cache_gets=my_cache_gets,
+        cache_get_many=my_cache_get_many,
+    ):
         yield cache_queries
 
 
@@ -153,9 +167,15 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
 def simulated_empty_cache() -> Iterator[list[tuple[str, str | list[str], str | None]]]:
     cache_queries: list[tuple[str, str | list[str], str | None]] = []
 
-    def my_cache_get(key: str, cache_name: str | None = None) -> dict[str, Any] | None:
+    def my_cache_get(  # nocoverage -- simulated code doesn't use this
+        key: str, cache_name: str | None = None
+    ) -> dict[str, Any] | None:
         cache_queries.append(("get", key, cache_name))
         return None
+
+    def my_cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
+        cache_queries.append(("gets", key, cache_name))
+        return None, None
 
     def my_cache_get_many(
         keys: list[str], cache_name: str | None = None
@@ -163,7 +183,12 @@ def simulated_empty_cache() -> Iterator[list[tuple[str, str | list[str], str | N
         cache_queries.append(("getmany", keys, cache_name))
         return {}
 
-    with mock.patch.multiple(cache, cache_get=my_cache_get, cache_get_many=my_cache_get_many):
+    with mock.patch.multiple(
+        cache,
+        cache_get=my_cache_get,
+        cache_gets=my_cache_gets,
+        cache_get_many=my_cache_get_many,
+    ):
         yield cache_queries
 
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -137,6 +137,7 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
     orig_get = cache.cache_get
     orig_gets = cache.cache_gets
     orig_get_many = cache.cache_get_many
+    orig_gets_many = cache.cache_gets_many
 
     def my_cache_get(  # nocoverage -- no current test exercises this path
         key: str, cache_name: str | None = None
@@ -154,11 +155,18 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
         cache_queries.append(("getmany", keys, cache_name))
         return orig_get_many(keys, cache_name)
 
+    def my_cache_gets_many(
+        keys: list[str], cache_name: str | None = None
+    ) -> dict[str, tuple[Any, int]]:
+        cache_queries.append(("getsmany", keys, cache_name))
+        return orig_gets_many(keys, cache_name)
+
     with mock.patch.multiple(
         cache,
         cache_get=my_cache_get,
         cache_gets=my_cache_gets,
         cache_get_many=my_cache_get_many,
+        cache_gets_many=my_cache_gets_many,
     ):
         yield cache_queries
 
@@ -183,11 +191,18 @@ def simulated_empty_cache() -> Iterator[list[tuple[str, str | list[str], str | N
         cache_queries.append(("getmany", keys, cache_name))
         return {}
 
+    def my_cache_gets_many(  # nocoverage -- simulated code doesn't use this
+        keys: list[str], cache_name: str | None = None
+    ) -> dict[str, tuple[Any, int]]:
+        cache_queries.append(("getsmany", keys, cache_name))
+        return {}
+
     with mock.patch.multiple(
         cache,
         cache_get=my_cache_get,
         cache_gets=my_cache_gets,
         cache_get_many=my_cache_get_many,
+        cache_gets_many=my_cache_gets_many,
     ):
         yield cache_queries
 

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -2,7 +2,9 @@ from unittest.mock import Mock, patch
 
 from bmemcached.exceptions import MemcachedException
 from django.conf import settings
+from django.core.cache import caches
 from django.db.models import QuerySet
+from typing_extensions import override
 
 from zerver.apps import flush_cache
 from zerver.lib.cache import (
@@ -349,3 +351,61 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
             id_fetcher=get_user_email,
         )
         self.assertEqual(result, {})
+
+
+class CASCapableBackendTest(ZulipTestCase):
+    """Round-trip tests for the gets/cas/add backend operations that the
+    read-through race-protection code relies on. These exercise the test
+    suite's CASCapableLocMemCache directly, since LocMemCache has no
+    gets/cas of its own."""
+
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        from zerver.lib.test_cache_backends import CASCapableLocMemCache
+
+        backend = caches["default"]
+        assert isinstance(backend, CASCapableLocMemCache)
+        self.backend = backend
+        self.key = "CASCapableBackendTest:key"
+        # Ensure a clean slate; prior tests may have populated this key.
+        self.backend.delete(self.key)
+
+    def test_gets_miss_returns_none_none(self) -> None:
+        value, cas_id = self.backend.gets(self.key)
+        self.assertIsNone(value)
+        self.assertIsNone(cas_id)
+
+    def test_gets_hit_returns_value_and_token(self) -> None:
+        self.backend.set(self.key, "hello")
+        value, cas_id = self.backend.gets(self.key)
+        self.assertEqual(value, "hello")
+        self.assertIsNotNone(cas_id)
+
+    def test_cas_succeeds_with_matching_token(self) -> None:
+        self.backend.set(self.key, "v1")
+        _, cas_id = self.backend.gets(self.key)
+        assert cas_id is not None
+        self.assertTrue(self.backend.cas(self.key, "v2", cas_id))
+        self.assertEqual(self.backend.get(self.key), "v2")
+
+    def test_cas_fails_after_concurrent_write(self) -> None:
+        self.backend.set(self.key, "v1")
+        _, stale_cas_id = self.backend.gets(self.key)
+        assert stale_cas_id is not None
+        self.backend.set(self.key, "intervening")
+        self.assertFalse(self.backend.cas(self.key, "v2", stale_cas_id))
+        self.assertEqual(self.backend.get(self.key), "intervening")
+
+    def test_cas_fails_after_delete(self) -> None:
+        self.backend.set(self.key, "v1")
+        _, cas_id = self.backend.gets(self.key)
+        assert cas_id is not None
+        self.backend.delete(self.key)
+        self.assertFalse(self.backend.cas(self.key, "v2", cas_id))
+        self.assertIsNone(self.backend.get(self.key))
+
+    def test_add_is_atomic(self) -> None:
+        self.assertTrue(self.backend.add(self.key, "first"))
+        self.assertFalse(self.backend.add(self.key, "second"))
+        self.assertEqual(self.backend.get(self.key), "first")

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -362,6 +362,113 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
         )
         self.assertEqual(result, {})
 
+    def test_hit_miss_mix_only_queries_missing_ids(self) -> None:
+        """A bulk fetch of N ids where some are pre-populated should only
+        call query_function for the missing ones, fill the cache for
+        those, and return all N."""
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        othello = self.example_user("othello")
+
+        # Warm the cache for hamlet and iago only.
+        get_user_profile_by_id(hamlet.id)
+        get_user_profile_by_id(iago.id)
+        cache_delete(user_profile_by_id_cache_key(othello.id))
+
+        queried_ids: list[int] = []
+
+        def query_function(ids: list[int]) -> list[UserProfile]:
+            queried_ids.extend(ids)
+            return list(UserProfile.objects.filter(id__in=ids))
+
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=query_function,
+            object_ids=[hamlet.id, iago.id, othello.id],
+            id_fetcher=get_user_id,
+        )
+        self.assertEqual(set(result), {hamlet.id, iago.id, othello.id})
+        self.assertEqual(queried_ids, [othello.id])
+
+        # othello should now be cached; a second bulk fetch doesn't
+        # re-query.
+        queried_ids.clear()
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=query_function,
+            object_ids=[hamlet.id, iago.id, othello.id],
+            id_fetcher=get_user_id,
+        )
+        self.assertEqual(queried_ids, [])
+
+    def test_race_writer_delete_during_bulk_query(self) -> None:
+        """If a writer invalidates a key while the reader's query_function
+        is running, the reader's cas() must fail and the stale value
+        must not be cached."""
+        hamlet = self.example_user("hamlet")
+        key = user_profile_by_id_cache_key(hamlet.id)
+        cache_delete(key)
+
+        counts_before = get_cache_fill_counts()
+
+        def racing_query(ids: list[int]) -> list[UserProfile]:
+            # Simulate the writer's invalidation landing while we're
+            # "reading" from the database.
+            cache_delete(key)
+            return list(UserProfile.objects.filter(id__in=ids))
+
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=racing_query,
+            object_ids=[hamlet.id],
+            id_fetcher=get_user_id,
+        )
+
+        # The caller still gets the fetched value...
+        self.assertIn(hamlet.id, result)
+        # ...but the cache is NOT populated, and the race was detected.
+        self.assertIsNone(cache_get(key))
+        self.assertEqual(
+            get_cache_fill_counts()["race_detected"] - counts_before["race_detected"],
+            1,
+        )
+
+    def test_race_bulk_writer_delete_then_other_reader_adds(self) -> None:
+        """Bulk analog of ReadThroughCacheTest.test_race_writer_delete_then_other_reader_adds:
+        during our query_function, a writer deletes our sentinel and another
+        reader (simulated) adds their own.  The cas id we got back from our
+        own add no longer matches the slot's current cas, so cache_cas_many
+        rejects the write and the stale DB value is not cached."""
+        hamlet = self.example_user("hamlet")
+        key = user_profile_by_id_cache_key(hamlet.id)
+        cache_delete(key)
+
+        counts_before = get_cache_fill_counts()
+
+        def racing_query(ids: list[int]) -> list[UserProfile]:
+            cache_delete(key)
+            added, _cas = cache_add(key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+            self.assertTrue(added)
+            return list(UserProfile.objects.filter(id__in=ids))
+
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=racing_query,
+            object_ids=[hamlet.id],
+            id_fetcher=get_user_id,
+        )
+
+        # Caller gets the fetched value, cache holds the other reader's
+        # sentinel (not our stale 1-tuple), and the race was counted.
+        # cache_gets exposes the raw value; cache_get filters sentinels.
+        self.assertIn(hamlet.id, result)
+        raw, _cas = cache_gets(key)
+        self.assertIsInstance(raw, _CacheFillSentinel)
+        self.assertEqual(
+            get_cache_fill_counts()["race_detected"] - counts_before["race_detected"],
+            1,
+        )
+
 
 class CASCapableBackendTest(ZulipTestCase):
     """Round-trip tests for the gets/cas/add backend operations that the

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -420,6 +420,45 @@ class CASCapableBackendTest(ZulipTestCase):
         self.assertFalse(self.backend.add(self.key, "second"))
         self.assertEqual(self.backend.get(self.key), "first")
 
+    def test_gets_multi_absent_keys_omitted(self) -> None:
+        self.backend.set(self.key, "v1")
+        other_key = self.key + ":other"
+        self.backend.delete(other_key)
+        got = self.backend.gets_multi([self.key, other_key])
+        self.assertIn(self.key, got)
+        self.assertEqual(got[self.key][0], "v1")
+        self.assertNotIn(other_key, got)
+
+    def test_add_multi_cas_returns_cas_for_added_keys_only(self) -> None:
+        other_key = self.key + ":other"
+        self.backend.set(self.key, "existing")
+        self.backend.delete(other_key)
+        added = self.backend.add_multi_cas({self.key: "nope", other_key: "added"})
+        self.assertEqual(set(added), {other_key})
+        # The cas id we got back matches what gets() would return for the
+        # newly-added value.
+        _, cas_id = self.backend.gets(other_key)
+        self.assertEqual(added[other_key], cas_id)
+        # The prior value at self.key wasn't overwritten.
+        self.assertEqual(self.backend.get(self.key), "existing")
+        self.assertEqual(self.backend.get(other_key), "added")
+
+    def test_cas_multi_commits_only_matching_cas(self) -> None:
+        other_key = self.key + ":other"
+        self.backend.set(self.key, "v1")
+        self.backend.set(other_key, "v1")
+        _, good_cas = self.backend.gets(self.key)
+        _, stale_cas = self.backend.gets(other_key)
+        assert good_cas is not None and stale_cas is not None
+        # Invalidate one of the cas ids by an intervening write.
+        self.backend.set(other_key, "intervening")
+        committed = self.backend.cas_multi(
+            {self.key: ("v2", good_cas), other_key: ("v2", stale_cas)}
+        )
+        self.assertEqual(committed, {self.key})
+        self.assertEqual(self.backend.get(self.key), "v2")
+        self.assertEqual(self.backend.get(other_key), "intervening")
+
 
 class ReadThroughCacheTest(ZulipTestCase):
     """Tests for read_through_cache() and its mark-then-fill race protection."""

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -1,5 +1,8 @@
+import threading
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
+import time_machine
 from bmemcached.exceptions import MemcachedException
 from django.conf import settings
 from django.core.cache import caches
@@ -8,16 +11,23 @@ from typing_extensions import override
 
 from zerver.apps import flush_cache
 from zerver.lib.cache import (
+    _CACHE_FILL_SENTINEL,
+    CACHE_FILL_SENTINEL_TIMEOUT,
     MEMCACHED_MAX_KEY_LENGTH,
     InvalidCacheKeyError,
+    _CacheFillSentinel,
     bulk_cached_fetch,
+    cache_add,
     cache_delete,
     cache_delete_many,
     cache_get,
     cache_get_many,
+    cache_gets,
     cache_set,
     cache_set_many,
     cache_with_key,
+    get_cache_fill_counts,
+    read_through_cache,
     safe_cache_get_many,
     safe_cache_set_many,
     user_profile_by_id_cache_key,
@@ -409,3 +419,196 @@ class CASCapableBackendTest(ZulipTestCase):
         self.assertTrue(self.backend.add(self.key, "first"))
         self.assertFalse(self.backend.add(self.key, "second"))
         self.assertEqual(self.backend.get(self.key), "first")
+
+
+class ReadThroughCacheTest(ZulipTestCase):
+    """Tests for read_through_cache() and its mark-then-fill race protection."""
+
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        self.key = "ReadThroughCacheTest:key"
+        cache_delete(self.key)
+        # Snapshot counters so assertions can compare deltas.
+        self._counts_before = get_cache_fill_counts()
+
+    def _delta(self, name: str) -> int:
+        return get_cache_fill_counts()[name] - self._counts_before[name]
+
+    def test_hit_returns_cached_value(self) -> None:
+        cache_set(self.key, "stored")
+        fetcher = Mock()
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "stored")
+        fetcher.assert_not_called()
+        self.assertEqual(self._delta("hit"), 1)
+
+    def test_miss_fills_cache(self) -> None:
+        fetcher = Mock(return_value="fetched")
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "fetched")
+        fetcher.assert_called_once()
+        self.assertEqual(self._delta("won"), 1)
+
+        # Second read is a hit.
+        fetcher.reset_mock()
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "fetched")
+        fetcher.assert_not_called()
+
+    def test_writer_delete_during_fill_is_detected(self) -> None:
+        """The core race test: writer deletes during the reader's fetch,
+        reader's cas() must fail and the stale value must not be cached."""
+
+        def fetcher() -> str:
+            cache_delete(self.key)
+            return "stale"
+
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "stale")
+        self.assertEqual(self._delta("race_detected"), 1)
+        self.assertEqual(self._delta("won"), 0)
+
+        # Cache is empty; the next read causes a fresh fetch.
+        next_fetcher = Mock(return_value="fresh")
+        self.assertEqual(read_through_cache(self.key, next_fetcher), "fresh")
+        next_fetcher.assert_called_once()
+
+    def test_concurrent_readers_only_one_fills(self) -> None:
+        """Two readers miss simultaneously; only one wins the add()."""
+        reader_a_in_fetcher = threading.Event()
+        allow_a_to_finish = threading.Event()
+        fetcher_call_count = 0
+        call_count_lock = threading.Lock()
+
+        def slow_fetcher() -> str:
+            nonlocal fetcher_call_count
+            with call_count_lock:
+                fetcher_call_count += 1
+            reader_a_in_fetcher.set()
+            allow_a_to_finish.wait(timeout=5)
+            return "A-value"
+
+        results: dict[str, str] = {}
+
+        def reader_a() -> None:
+            results["A"] = read_through_cache(self.key, slow_fetcher)
+
+        thread = threading.Thread(target=reader_a)
+        thread.start()
+        self.assertTrue(reader_a_in_fetcher.wait(timeout=5))
+
+        # Reader B arrives mid-fill; it must see the sentinel and bypass.
+        def fast_fetcher() -> str:
+            nonlocal fetcher_call_count
+            with call_count_lock:
+                fetcher_call_count += 1
+            return "B-value"
+
+        results["B"] = read_through_cache(self.key, fast_fetcher)
+        self.assertEqual(results["B"], "B-value")
+
+        allow_a_to_finish.set()
+        thread.join(timeout=5)
+        self.assertEqual(results["A"], "A-value")
+
+        # Both fetchers ran.  B's path was saw_sentinel, not claim_lost,
+        # because the sentinel was visible when B arrived.
+        self.assertEqual(fetcher_call_count, 2)
+        self.assertEqual(self._delta("saw_sentinel"), 1)
+        self.assertEqual(self._delta("won"), 1)
+
+    def test_sentinel_expires_if_filler_crashes(self) -> None:
+        """If the filler raises before cas(), the sentinel must expire
+        so that the next reader can fill normally."""
+
+        class FillerError(Exception):
+            pass
+
+        def crashing_fetcher() -> str:
+            raise FillerError
+
+        t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        with time_machine.travel(t0, tick=False) as traveller:
+            with self.assertRaises(FillerError):
+                read_through_cache(self.key, crashing_fetcher)
+
+            # While the sentinel is still live, the next reader bypasses
+            # (saw_sentinel) and does not write to the cache.
+            recovered = Mock(return_value="recovered")
+            self.assertEqual(read_through_cache(self.key, recovered), "recovered")
+            recovered.assert_called_once()
+
+            # Advance past the sentinel's TTL.
+            traveller.shift(timedelta(seconds=CACHE_FILL_SENTINEL_TIMEOUT + 1))
+
+            recovered.reset_mock()
+            self.assertEqual(read_through_cache(self.key, recovered), "recovered")
+            recovered.assert_called_once()
+            # The cache is now populated with the recovered value.
+            self.assertEqual(cache_get(self.key), ("recovered",))
+
+    def test_cache_get_of_sentinel_is_not_exposed_to_callers(self) -> None:
+        """Belt-and-suspenders: a raw cache_get of a key mid-fill must not
+        leak the sentinel into application code via read_through_cache."""
+        # Manually plant a sentinel.
+        added, _cas = cache_add(self.key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+        self.assertTrue(added)
+
+        fetcher = Mock(return_value="real-value")
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "real-value")
+        fetcher.assert_called_once()
+        self.assertEqual(self._delta("saw_sentinel"), 1)
+
+    def test_cache_get_filters_sentinel(self) -> None:
+        """cache_get hides the in-progress-fill marker; an in-progress fill
+        looks the same as a missing key from the public API."""
+        added, _cas = cache_add(self.key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+        self.assertTrue(added)
+        self.assertIsNone(cache_get(self.key))
+
+    def test_cache_get_many_filters_sentinel(self) -> None:
+        """cache_get_many drops sentinel entries from the result dict, the
+        same way cache_get returns None for a sentinel."""
+        cache_set(self.key + ":real", "real-value")
+        added, _cas = cache_add(
+            self.key + ":fill", _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT
+        )
+        self.assertTrue(added)
+
+        result = cache_get_many([self.key + ":real", self.key + ":fill", self.key + ":missing"])
+        # cache_set wraps with pickled_tupled=True, so the value is a 1-tuple.
+        self.assertEqual(result, {self.key + ":real": ("real-value",)})
+
+    def test_fetcher_raise_does_not_leak_sentinel_via_cache_get(self) -> None:
+        """If the read_through_cache fetcher raises, the sentinel is left to
+        expire on its TTL.  A subsequent raw cache_get must not return it."""
+        fetcher = Mock(side_effect=RuntimeError("boom"))
+        with self.assertRaises(RuntimeError):
+            read_through_cache(self.key, fetcher)
+        self.assertIsNone(cache_get(self.key))
+
+    def test_race_writer_delete_then_other_reader_adds(self) -> None:
+        """The subtle race: while we're fetching, a writer deletes our sentinel
+        and another reader adds their own in the now-empty slot.  Our cas-
+        commit uses the cas id we got from our own add, so the slot's new
+        cas (assigned to the other reader's add) won't match and the cas
+        will fail -- we must not cache the stale value."""
+
+        def racing_fetcher() -> str:
+            # While we "fetch", simulate writer-delete + other-reader-add
+            # landing on the same key.
+            cache_delete(self.key)
+            added, _cas = cache_add(self.key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+            self.assertTrue(added)
+            return "stale"
+
+        result = read_through_cache(self.key, racing_fetcher)
+        self.assertEqual(result, "stale")
+        self.assertEqual(self._delta("race_detected"), 1)
+        self.assertEqual(self._delta("won"), 0)
+        # The slot holds the other reader's sentinel, not our stale 1-tuple.
+        # cache_gets exposes the raw value; cache_get filters sentinels.
+        raw, _cas = cache_gets(self.key)
+        self.assertIsInstance(raw, _CacheFillSentinel)

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 from bmemcached.exceptions import MemcachedException
 from django.conf import settings
+from django.db.models import QuerySet
 
 from zerver.apps import flush_cache
 from zerver.lib.cache import (
@@ -157,6 +158,23 @@ class CacheWithKeyDecoratorTest(ZulipTestCase):
             result_two = get_user_function_can_return_none(last_user_id + 1)
 
         self.assertEqual(result_two, None)
+
+    def test_cache_with_key_rejects_queryset_return(self) -> None:
+        """Returning a QuerySet from a @cache_with_key-decorated function
+        raises AssertionError under TEST_SUITE / DEBUG; production skips
+        the check."""
+
+        def cache_key_function(user_id: int) -> str:
+            return f"CacheWithKeyDecoratorTest:queryset_return:{user_id}"
+
+        @cache_with_key(cache_key_function, timeout=1000)
+        def buggy_returns_queryset(user_id: int) -> QuerySet[UserProfile]:
+            return UserProfile.objects.filter(id=user_id)
+
+        hamlet = self.example_user("hamlet")
+        with self.assertRaises(AssertionError) as cm:
+            buggy_returns_queryset(hamlet.id)
+        self.assertIn("returned a QuerySet", str(cm.exception))
 
 
 class SetCacheExceptionTest(ZulipTestCase):

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -308,7 +308,8 @@ class HomeTest(ZulipTestCase):
         # Verify succeeds once logged-in
         with (
             self.assert_database_query_count(56),
-            patch("zerver.lib.cache.cache_set") as cache_mock,
+            patch("zerver.lib.cache.cache_set") as cache_set_mock,
+            patch("zerver.lib.cache.cache_cas") as cache_cas_mock,
         ):
             result = self._get_home_page(stream="Denmark")
             self.check_rendered_logged_in_app(result)
@@ -316,7 +317,9 @@ class HomeTest(ZulipTestCase):
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
 
-        self.assert_length(cache_mock.call_args_list, 7)
+        # Cache fills go through cache_cas (read-through mark-then-fill);
+        # direct cache_set calls are rare.
+        self.assert_length(cache_set_mock.call_args_list + cache_cas_mock.call_args_list, 7)
 
         html = result.content.decode()
 
@@ -659,11 +662,14 @@ class HomeTest(ZulipTestCase):
         self.login("iago")
         with (
             self.assert_database_query_count(58),
-            patch("zerver.lib.cache.cache_set") as cache_mock,
+            patch("zerver.lib.cache.cache_set") as cache_set_mock,
+            patch("zerver.lib.cache.cache_cas") as cache_cas_mock,
         ):
             result = self._get_home_page()
             self.check_rendered_logged_in_app(result)
-            self.assert_length(cache_mock.call_args_list, 9)
+            # Cache fills go through cache_cas (read-through mark-then-fill);
+            # direct cache_set calls are rare.
+            self.assert_length(cache_set_mock.call_args_list + cache_cas_mock.call_args_list, 9)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -160,9 +160,9 @@ class EventsTestCase(TornadoWebTestCase):
                 self.assert_length(cache_gets, 2)
                 self.assertEqual(
                     cache_gets[0],
-                    ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None),
+                    ("gets", user_profile_narrow_by_id_cache_key(user_profile.id), None),
                 )
-                self.assertEqual(cache_gets[1][0], "get")
+                self.assertEqual(cache_gets[1][0], "gets")
                 assert isinstance(cache_gets[1][1], str)
                 self.assertTrue(cache_gets[1][1].startswith("get_client:"))
 
@@ -187,7 +187,7 @@ class EventsTestCase(TornadoWebTestCase):
                 self.assert_length(cache_gets, 1)
                 self.assertEqual(
                     cache_gets[0],
-                    ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None),
+                    ("gets", user_profile_narrow_by_id_cache_key(user_profile.id), None),
                 )
                 # Client is cached in-process-memory, so doesn't even see
                 # a memcached hit

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -95,13 +95,7 @@ settings.ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS = False
 settings.ZULIP_SERVICE_SECURITY_ALERTS = False
 settings.ANALYTICS_DATA_UPLOAD_LEVEL = AnalyticsDataUploadLevel.NONE
 settings.USING_TORNADO = False
-# Disable using memcached caches to avoid 'unsupported pickle
-# protocol' errors if `populate_db` is run with a different Python
-# from `run-dev`.
 default_cache = settings.CACHES["default"]
-settings.CACHES["default"] = {
-    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-}
 
 DEFAULT_EMOJIS = [
     ("+1", "1f44d"),

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -111,9 +111,12 @@ else:
 WEBPACK_BUNDLES = "webpack-bundles/"
 
 if not PUPPETEER_TESTS:
-    # Use local memory cache for backend tests.
+    # Use local memory cache for backend tests. The CASCapableLocMemCache
+    # subclass adds the memcached-style gets/cas operations that the
+    # read-through helpers in zerver.lib.cache rely on to avoid
+    # stale-cache races; the stock LocMemCache has no such concept.
     CACHES["default"] = {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": "zerver.lib.test_cache_backends.CASCapableLocMemCache",
     }
 
     # Here we set various loggers to be less noisy for unit tests.


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
