### PR TITLE
[ai] left sidebar: Show heading icons on keyboard focus and arrow-key nav.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -497,7 +497,8 @@
     }
 
     .add-stream-icon-container:focus-visible .add_stream_icon,
-    &:focus-within .add_stream_icon {
+    &:focus-within .add_stream_icon,
+    &.highlighted_row .add_stream_icon {
         visibility: visible;
     }
 
@@ -658,17 +659,23 @@
     }
 }
 
-/* Only show section header unread counts when the section is collapsed
-   or when the header is being hovered over. */
+/* Only show section header unread counts when the section is collapsed,
+   when the header is being hovered over, when keyboard focus is inside
+   the header, or when the header is the current arrow-key target. */
 #streams_list .stream-list-section-container:not(.collapsed) {
-    .stream-list-subsection-header:not(:hover) {
+    .stream-list-subsection-header:not(
+            :hover,
+            :focus-within,
+            .highlighted_row
+        ) {
         .unread_count,
         .masked_unread_count {
             visibility: hidden;
         }
     }
 
-    .stream-list-subsection-header:not(:hover) .unread_mention_info {
+    .stream-list-subsection-header:not(:hover, :focus-within, .highlighted_row)
+        .unread_mention_info {
         display: none;
     }
 }


### PR DESCRIPTION
The plus icon and unread markers on channel folder section headings were only visible on hover, so keyboard users tabbing through the sidebar or moving up/down with arrow keys couldn't see them. Extend the visibility rules to cover :focus-within and the .highlighted_row class set during arrow-key navigation, matching the three-dot menu's existing behavior.

<img width="329" height="129" alt="image" src="https://github.com/user-attachments/assets/cd9b916e-fd43-454e-93b1-380995c5f267" />
