### PR TITLE
push_registration: Clean up legacy rows missed during E2EE registration.

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -88,6 +88,7 @@ from zilencer.views import DevicesToCleanUpDict, get_deleted_devices
 
 if settings.ZILENCER_ENABLED:
     from zilencer.models import (
+        RemotePushDevice,
         RemotePushDeviceToken,
         RemoteRealm,
         RemoteRealmAuditLog,
@@ -1272,6 +1273,241 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
         remote_realm.refresh_from_db()
         self.assertEqual(remote_realm.last_request_datetime, time_sent)
+
+    def test_delete_registrations_missed_by_e2ee_cleanup(self) -> None:
+        hamlet = self.example_user("hamlet")
+        server = self.server
+        remote_realm = RemoteRealm.objects.get(server=server, uuid=hamlet.realm.uuid)
+
+        apns_token = "ABCDEF0123456789"
+        fcm_token = "fcm-token-aaaa"
+
+        def cleanup_log(count: int, kind_str: str) -> str:
+            return (
+                f"INFO:zilencer.views:Cleaning up {count} stale legacy {kind_str} "
+                f"registration(s) on remote_realm id:{remote_realm.id} "
+                "(device already has an E2EE registration)"
+            )
+
+        def sending_log(fcm: int, apns: int) -> str:
+            return (
+                f"INFO:zilencer.views:Sending mobile push notifications for remote user "
+                f"{self.server_uuid}:<id:{hamlet.id}><uuid:{hamlet.uuid}>: "
+                f"{fcm} via FCM devices, {apns} via APNs devices"
+            )
+
+        def call_notify_endpoint(expected_logs: list[str]) -> None:
+            payload = {
+                "user_id": hamlet.id,
+                "user_uuid": str(hamlet.uuid),
+                "realm_uuid": str(hamlet.realm.uuid),
+                "gcm_payload": {"event": "test"},
+                "apns_payload": {"badge": 0, "custom": {"zulip": {"event": "test"}}},
+                "gcm_options": {},
+            }
+            with (
+                mock.patch("zilencer.views.send_android_push_notification", return_value=0),
+                mock.patch("zilencer.views.send_apple_push_notification", return_value=0),
+                mock.patch(
+                    "corporate.lib.stripe.RemoteRealmBillingSession.current_counts_for_billed_users",
+                    return_value=BillingUserCounts(10, 0),
+                ),
+                self.assertLogs("zilencer.views", level="INFO") as logger,
+            ):
+                result = self.uuid_post(
+                    self.server_uuid,
+                    "/api/v1/remotes/push/notify",
+                    payload,
+                    content_type="application/json",
+                )
+            self.assert_json_success(result)
+            self.assertEqual(logger.output, expected_logs)
+
+        def reset() -> None:
+            RemotePushDevice.objects.all().delete()
+            RemotePushDeviceToken.objects.all().delete()
+
+        # APNs legacy with the same casing as an
+        # E2EE registration on the same remote_realm is cleaned up.
+        RemotePushDevice.objects.create(
+            remote_realm=remote_realm,
+            token=apns_token,
+            token_id=1,
+            token_kind=RemotePushDevice.TokenKind.APNS,
+            ios_app_id="org.zulip.Zulip",
+        )
+        legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token=apns_token,
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+            ios_app_id="org.zulip.Zulip",
+        )
+        call_notify_endpoint([cleanup_log(1, "APNs"), sending_log(0, 0)])
+        self.assertFalse(RemotePushDeviceToken.objects.filter(id=legacy.id).exists())
+        reset()
+
+        # APNs legacy with mismatched casing
+        # (lowercase legacy vs. uppercase E2EE) is cleaned up.
+        RemotePushDevice.objects.create(
+            remote_realm=remote_realm,
+            token=apns_token,
+            token_id=2,
+            token_kind=RemotePushDevice.TokenKind.APNS,
+            ios_app_id="org.zulip.Zulip",
+        )
+        legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token=apns_token.lower(),
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+            ios_app_id="org.zulip.Zulip",
+        )
+        call_notify_endpoint([cleanup_log(1, "APNs"), sending_log(0, 0)])
+        self.assertFalse(RemotePushDeviceToken.objects.filter(id=legacy.id).exists())
+        reset()
+
+        # FCM legacy whose token matches an E2EE FCM
+        # registration on the same realm is cleaned up (FCM match is
+        # exact, not case-insensitive).
+        RemotePushDevice.objects.create(
+            remote_realm=remote_realm,
+            token=fcm_token,
+            token_id=3,
+            token_kind=RemotePushDevice.TokenKind.FCM,
+        )
+        legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.FCM,
+            token=fcm_token,
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+        )
+        call_notify_endpoint([cleanup_log(1, "FCM"), sending_log(0, 0)])
+        self.assertFalse(RemotePushDeviceToken.objects.filter(id=legacy.id).exists())
+        reset()
+
+        # FCM legacy that matches an E2EE FCM token
+        # only after lowercasing is preserved (FCM is case-sensitive,
+        # so the tokens are considered different).
+        RemotePushDevice.objects.create(
+            remote_realm=remote_realm,
+            token=fcm_token.upper(),
+            token_id=4,
+            token_kind=RemotePushDevice.TokenKind.FCM,
+        )
+        legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.FCM,
+            token=fcm_token,
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+        )
+        call_notify_endpoint([sending_log(1, 0)])
+        self.assertTrue(RemotePushDeviceToken.objects.filter(id=legacy.id).exists())
+        reset()
+
+        # legacy whose token doesn't match any E2EE
+        # registration in the realm is preserved.
+        RemotePushDevice.objects.create(
+            remote_realm=remote_realm,
+            token=apns_token,
+            token_id=5,
+            token_kind=RemotePushDevice.TokenKind.APNS,
+            ios_app_id="org.zulip.Zulip",
+        )
+        legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token="some-other-apns-token",
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+            ios_app_id="org.zulip.Zulip",
+        )
+        call_notify_endpoint([sending_log(0, 1)])
+        self.assertTrue(RemotePushDeviceToken.objects.filter(id=legacy.id).exists())
+        reset()
+
+        # legacy on a different remote_realm of the same server is
+        # preserved -- per-realm scoping protects unrelated accounts
+        # on shared self-hosted servers.
+        other_realm = RemoteRealm.objects.create(
+            server=server,
+            uuid=uuid.uuid4(),
+            uuid_owner_secret="secret",
+            host="other.example.com",
+            realm_date_created=now(),
+        )
+        RemotePushDevice.objects.create(
+            remote_realm=other_realm,
+            token=apns_token,
+            token_id=6,
+            token_kind=RemotePushDevice.TokenKind.APNS,
+            ios_app_id="org.zulip.Zulip",
+        )
+        legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token=apns_token,
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+            ios_app_id="org.zulip.Zulip",
+        )
+        call_notify_endpoint([sending_log(0, 1)])
+        self.assertTrue(RemotePushDeviceToken.objects.filter(id=legacy.id).exists())
+        reset()
+
+        # an E2EE FCM registration in the same realm does not affect
+        # an APNs legacy row with the same token text (and vice versa).
+        RemotePushDevice.objects.create(
+            remote_realm=remote_realm,
+            token=apns_token,
+            token_id=7,
+            token_kind=RemotePushDevice.TokenKind.FCM,
+        )
+        legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token=apns_token,
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+            ios_app_id="org.zulip.Zulip",
+        )
+        call_notify_endpoint([sending_log(0, 1)])
+        self.assertTrue(RemotePushDeviceToken.objects.filter(id=legacy.id).exists())
+        reset()
+
+        # When the user has multiple legacy APNs rows on the same
+        # remote_realm and only one of them matches an E2EE
+        # registration, only the matching row is cleaned up.
+        RemotePushDevice.objects.create(
+            remote_realm=remote_realm,
+            token=apns_token,
+            token_id=8,
+            token_kind=RemotePushDevice.TokenKind.APNS,
+            ios_app_id="org.zulip.Zulip",
+        )
+        matching_legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token=apns_token,
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+            ios_app_id="org.zulip.Zulip",
+        )
+        non_matching_legacy = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.APNS,
+            token="some-other-apns-token",
+            user_uuid=str(hamlet.uuid),
+            server=server,
+            remote_realm=remote_realm,
+            ios_app_id="org.zulip.Zulip",
+        )
+        call_notify_endpoint([cleanup_log(1, "APNs"), sending_log(0, 1)])
+        self.assertFalse(RemotePushDeviceToken.objects.filter(id=matching_legacy.id).exists())
+        self.assertTrue(RemotePushDeviceToken.objects.filter(id=non_matching_legacy.id).exists())
 
 
 class TestAPNs(PushNotificationTestCase):

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -738,6 +738,84 @@ def update_remote_realm_last_request_datetime_helper(
             remote_realm.save(update_fields=["last_request_datetime"])
 
 
+def delete_registrations_missed_by_e2ee_cleanup(
+    devices: list[RemotePushDeviceToken], remote_realm: RemoteRealm
+) -> list[RemotePushDeviceToken]:
+    """Filter out (and delete) stale legacy `RemotePushDeviceToken`
+    rows for devices that already have an E2EE `RemotePushDevice`
+    registration in the same remote_realm.
+
+    When a device upgrades to E2EE, the server is expected to delete
+    its legacy bouncer row, but that network call can fail; without
+    this fallback, the device receives both the legacy and the E2EE
+    notifications until the user re-registers, or upgrades the mobile
+    app on every other device they have registered to this realm.
+    """
+    if not devices:
+        return devices
+
+    # All devices passed here should be of the same kind (apple vs android).
+    assert len({device.kind for device in devices}) == 1
+    kind = devices[0].kind
+
+    # APNs tokens are case-insensitive, so a device's legacy
+    # RemotePushDeviceToken and its E2EE RemotePushDevice registration
+    # may store the same token in different cases. We match the two
+    # case-insensitively, so that a case mismatch doesn't leave the
+    # legacy row behind and cause the double-notification bug
+    # this cleanup exists to prevent. FCM tokens are case-sensitive,
+    # so they're matched verbatim.
+    if kind == RemotePushDeviceToken.APNS:
+        legacy_tokens = {device.token.lower() for device in devices}
+        e2ee_tokens = set(
+            RemotePushDevice.objects.annotate(lower_token=Lower("token"))
+            .filter(
+                remote_realm=remote_realm,
+                token_kind=RemotePushDevice.TokenKind.APNS,
+                lower_token__in=legacy_tokens,
+            )
+            .values_list("lower_token", flat=True)
+        )
+
+        def device_token(device: RemotePushDeviceToken) -> str:
+            return device.token.lower()
+    else:
+        legacy_tokens = {device.token for device in devices}
+        e2ee_tokens = set(
+            RemotePushDevice.objects.filter(
+                remote_realm=remote_realm,
+                token_kind=RemotePushDevice.TokenKind.FCM,
+                token__in=legacy_tokens,
+            ).values_list("token", flat=True)
+        )
+
+        def device_token(device: RemotePushDeviceToken) -> str:
+            return device.token
+
+    if not e2ee_tokens:
+        return devices
+
+    stale_ids: list[int] = []
+    retained: list[RemotePushDeviceToken] = []
+    for device in devices:
+        if device_token(device) in e2ee_tokens:
+            stale_ids.append(device.id)
+        else:
+            retained.append(device)
+
+    if stale_ids:
+        logger.info(
+            "Cleaning up %d stale legacy %s registration(s) on remote_realm id:%s "
+            "(device already has an E2EE registration)",
+            len(stale_ids),
+            "APNs" if kind == RemotePushDeviceToken.APNS else "FCM",
+            remote_realm.id,
+        )
+        RemotePushDeviceToken.objects.filter(id__in=stale_ids).delete()
+
+    return retained
+
+
 def delete_duplicate_user_id_registrations(
     registrations: list[RemotePushDeviceToken], server_id: int, user_id: int, user_uuid: str
 ) -> list[RemotePushDeviceToken]:
@@ -973,6 +1051,23 @@ def remote_server_notify_push(
             apple_devices, server.id, user_id, user_uuid
         )
 
+    if remote_realm is not None:
+        ensure_devices_set_remote_realm(
+            android_devices=android_devices, apple_devices=apple_devices, remote_realm=remote_realm
+        )
+        android_devices = delete_registrations_missed_by_e2ee_cleanup(android_devices, remote_realm)
+        apple_devices = delete_registrations_missed_by_e2ee_cleanup(apple_devices, remote_realm)
+        do_increment_logging_stat(
+            remote_realm,
+            COUNT_STATS["mobile_pushes_received::day"],
+            None,
+            timezone_now(),
+            increment=len(android_devices) + len(apple_devices),
+        )
+
+        remote_realm.last_request_datetime = timezone_now()
+        remote_realm.save(update_fields=["last_request_datetime"])
+
     logger.info(
         "Sending mobile push notifications for remote user %s:%s: %s via FCM devices, %s via APNs devices",
         server.uuid,
@@ -987,20 +1082,6 @@ def remote_server_notify_push(
         timezone_now(),
         increment=len(android_devices) + len(apple_devices),
     )
-    if remote_realm is not None:
-        ensure_devices_set_remote_realm(
-            android_devices=android_devices, apple_devices=apple_devices, remote_realm=remote_realm
-        )
-        do_increment_logging_stat(
-            remote_realm,
-            COUNT_STATS["mobile_pushes_received::day"],
-            None,
-            timezone_now(),
-            increment=len(android_devices) + len(apple_devices),
-        )
-
-        remote_realm.last_request_datetime = timezone_now()
-        remote_realm.save(update_fields=["last_request_datetime"])
 
     # Truncate incoming pushes to 200, due to APNs maximum message
     # sizes; see handle_remove_push_notification for the version of

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -738,7 +738,7 @@ def update_remote_realm_last_request_datetime_helper(
             remote_realm.save(update_fields=["last_request_datetime"])
 
 
-def delete_duplicate_registrations(
+def delete_duplicate_user_id_registrations(
     registrations: list[RemotePushDeviceToken], server_id: int, user_id: int, user_uuid: str
 ) -> list[RemotePushDeviceToken]:
     """
@@ -957,7 +957,7 @@ def remote_server_notify_push(
         ).order_by("id")
     )
     if android_devices and user_id is not None and user_uuid is not None:
-        android_devices = delete_duplicate_registrations(
+        android_devices = delete_duplicate_user_id_registrations(
             android_devices, server.id, user_id, user_uuid
         )
 
@@ -969,7 +969,9 @@ def remote_server_notify_push(
         ).order_by("id")
     )
     if apple_devices and user_id is not None and user_uuid is not None:
-        apple_devices = delete_duplicate_registrations(apple_devices, server.id, user_id, user_uuid)
+        apple_devices = delete_duplicate_user_id_registrations(
+            apple_devices, server.id, user_id, user_uuid
+        )
 
     logger.info(
         "Sending mobile push notifications for remote user %s:%s: %s via FCM devices, %s via APNs devices",


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/channel/48-mobile/topic/iOS.20duplicate.20notifications/near/2446325) to fix double push notification issue:
> I guess one thing we could do is: on the bouncer, when we're sending a legacy notification and go and find tokens for the user, we could first check if any of them have a matching E2EE registration. Then if it does, ignore that token (and perhaps go ahead and delete the record).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
