### PR TITLE
stripe: Add BillingSession helpers for plan and ledger entry creation.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -973,6 +973,30 @@ class BillingSession(ABC):
         stripe.Invoice.finalize_invoice(stripe_invoice)
         return stripe_invoice
 
+    # Customer plan offers are always for negotiated, annual, fixed-price plans.
+    def create_customer_plan_offer(
+        self, *, customer: Customer, fixed_price: int, tier: int, sent_invoice_id: str | None = None
+    ) -> None:
+        status = CustomerPlanOffer.CONFIGURED
+        CustomerPlanOffer.objects.create(
+            customer=customer,
+            status=status,
+            sent_invoice_id=sent_invoice_id,
+            fixed_price=fixed_price,
+            tier=tier,
+        )
+        self.write_to_audit_log(
+            event_type=BillingSessionEventType.CUSTOMER_PLAN_CREATED,
+            event_time=timezone_now(),
+            extra_data={
+                "customer_id": customer.id,
+                "status": status,
+                "sent_invoice_id": sent_invoice_id,
+                "fixed_price": fixed_price,
+                "tier": tier,
+            },
+        )
+
     @abstractmethod
     def update_or_create_customer(
         self, stripe_customer_id: str | None = None, *, defaults: dict[str, Any] | None = None
@@ -1579,22 +1603,17 @@ class BillingSession(ABC):
                 # linked to the customer in stripe.
                 self.link_stripe_customer_id(str(invoice_customer_id))
 
-            fixed_price_plan_params["sent_invoice_id"] = sent_invoice_id
             Invoice.objects.create(
                 customer=customer,
                 stripe_invoice_id=sent_invoice_id,
                 status=Invoice.SENT,
             )
 
-        fixed_price_plan_params["status"] = CustomerPlanOffer.CONFIGURED
-        CustomerPlanOffer.objects.create(
+        self.create_customer_plan_offer(
             customer=customer,
-            **fixed_price_plan_params,
-        )
-        self.write_to_audit_log(
-            event_type=BillingSessionEventType.CUSTOMER_PLAN_CREATED,
-            event_time=timezone_now(),
-            extra_data=fixed_price_plan_params,
+            fixed_price=fixed_price_cents,
+            tier=customer.required_plan_tier,
+            sent_invoice_id=sent_invoice_id,
         )
         return f"Customer can now buy a fixed price {required_plan_tier_name} plan."
 

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1014,6 +1014,85 @@ class BillingSession(ABC):
             },
         )
 
+    def create_customer_plan(
+        self,
+        *,
+        customer: Customer,
+        tier: int,
+        anchor_date: datetime,
+        billing_schedule: int,
+        charge_automatically: bool,
+        automanage_licenses: bool,
+        next_invoice_date: datetime | None,
+        status: int = CustomerPlan.ACTIVE,
+        invoicing_status: int = CustomerPlan.INVOICING_STATUS_DONE,
+        fixed_price: int | None = None,
+        price_per_license: int | None = None,
+        discount: str | None = None,
+        end_date: datetime | None = None,
+        create_audit_log: bool = True,
+    ) -> CustomerPlan:
+        # Only self-hosted community plans are never invoiced.
+        if next_invoice_date is None:
+            assert tier == CustomerPlan.TIER_SELF_HOSTED_COMMUNITY
+
+        if fixed_price is not None:
+            assert price_per_license is None
+            assert discount is None
+            # Fixed-price plans must have an end date.
+            assert end_date is not None
+            plan = CustomerPlan.objects.create(
+                customer=customer,
+                tier=tier,
+                billing_cycle_anchor=anchor_date,
+                status=status,
+                next_invoice_date=next_invoice_date,
+                invoicing_status=invoicing_status,
+                billing_schedule=billing_schedule,
+                charge_automatically=charge_automatically,
+                automanage_licenses=automanage_licenses,
+                fixed_price=fixed_price,
+                end_date=end_date,
+            )
+        else:
+            assert price_per_license is not None
+            plan = CustomerPlan.objects.create(
+                customer=customer,
+                tier=tier,
+                billing_cycle_anchor=anchor_date,
+                status=status,
+                next_invoice_date=next_invoice_date,
+                invoicing_status=invoicing_status,
+                billing_schedule=billing_schedule,
+                charge_automatically=charge_automatically,
+                automanage_licenses=automanage_licenses,
+                price_per_license=price_per_license,
+                discount=discount,
+                end_date=end_date,
+            )
+
+        if create_audit_log:
+            self.write_to_audit_log(
+                event_type=BillingSessionEventType.CUSTOMER_PLAN_CREATED,
+                event_time=timezone_now(),
+                extra_data={
+                    "customer_id": customer.id,
+                    "status": status,
+                    "tier": tier,
+                    "billing_cycle_anchor": anchor_date,
+                    "invoicing_status": invoicing_status,
+                    "next_invoice_date": next_invoice_date,
+                    "billing_schedule": billing_schedule,
+                    "charge_automatically": charge_automatically,
+                    "automanage_licenses": automanage_licenses,
+                    "fixed_price": fixed_price,
+                    "price_per_license": price_per_license,
+                    "discount": discount,
+                    "end_date": end_date,
+                },
+            )
+        return plan
+
     @abstractmethod
     def update_or_create_customer(
         self, stripe_customer_id: str | None = None, *, defaults: dict[str, Any] | None = None
@@ -1538,10 +1617,6 @@ class BillingSession(ABC):
         required_plan_tier_name = CustomerPlan.name_from_tier(customer.required_plan_tier)
 
         fixed_price_cents = fixed_price * 100
-        fixed_price_plan_params: dict[str, Any] = {
-            "fixed_price": fixed_price_cents,
-            "tier": customer.required_plan_tier,
-        }
 
         current_plan = get_current_plan_by_customer(customer)
         if current_plan is not None and self.check_plan_tier_is_billable(current_plan.tier):
@@ -1556,28 +1631,23 @@ class BillingSession(ABC):
                 raise SupportRequestError(
                     f"New plan for {self.billing_entity_display_name} cannot be scheduled until all the invoices of the current plan are processed."
                 )
-            fixed_price_plan_params["billing_cycle_anchor"] = current_plan.end_date
-            fixed_price_plan_params["end_date"] = add_months(
-                current_plan.end_date, CustomerPlan.FIXED_PRICE_PLAN_DURATION_MONTHS
-            )
-            fixed_price_plan_params["status"] = CustomerPlan.NEVER_STARTED
-            fixed_price_plan_params["next_invoice_date"] = current_plan.end_date
-            fixed_price_plan_params["invoicing_status"] = (
-                CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT
-            )
-            fixed_price_plan_params["billing_schedule"] = current_plan.billing_schedule
-            fixed_price_plan_params["charge_automatically"] = current_plan.charge_automatically
-            # Manual license management is not available for fixed price plan.
-            fixed_price_plan_params["automanage_licenses"] = True
 
-            CustomerPlan.objects.create(
+            self.create_customer_plan(
                 customer=customer,
-                **fixed_price_plan_params,
-            )
-            self.write_to_audit_log(
-                event_type=BillingSessionEventType.CUSTOMER_PLAN_CREATED,
-                event_time=timezone_now(),
-                extra_data=fixed_price_plan_params,
+                tier=customer.required_plan_tier,
+                anchor_date=current_plan.end_date,
+                billing_schedule=current_plan.billing_schedule,
+                charge_automatically=current_plan.charge_automatically,
+                # Manual license management is not available for fixed-price plans.
+                automanage_licenses=True,
+                next_invoice_date=current_plan.end_date,
+                status=CustomerPlan.NEVER_STARTED,
+                invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
+                fixed_price=fixed_price_cents,
+                price_per_license=None,
+                end_date=add_months(
+                    current_plan.end_date, CustomerPlan.FIXED_PRICE_PLAN_DURATION_MONTHS
+                ),
             )
 
             current_plan.status = CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END
@@ -1956,16 +2026,12 @@ class BillingSession(ABC):
             else:
                 billable_licenses = current_licenses_count
 
-            plan_params = {
-                "automanage_licenses": automanage_licenses,
-                "charge_automatically": charge_automatically,
-                "billing_cycle_anchor": billing_cycle_anchor,
-                "billing_schedule": billing_schedule,
-                "tier": plan_tier,
-            }
+            # Defaults for new CustomerPlan objects.
+            status = CustomerPlan.ACTIVE
+            invoicing_status = CustomerPlan.INVOICING_STATUS_DONE
 
             if free_trial:
-                plan_params["status"] = CustomerPlan.FREE_TRIAL
+                status = CustomerPlan.FREE_TRIAL
                 if charge_automatically:
                     # Ensure free trial customers not paying via invoice have a default payment method set
                     assert customer.stripe_customer_id is not None  # for mypy
@@ -2003,10 +2069,8 @@ class BillingSession(ABC):
                 # Setting status > CustomerPlan.LIVE_STATUS_THRESHOLD makes sure we
                 # don't have to worry about this plan being used for any other purpose.
                 # NOTE: This is the 2nd plan for the customer.
-                plan_params["status"] = CustomerPlan.NEVER_STARTED
-                plan_params["invoicing_status"] = (
-                    CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT
-                )
+                status = CustomerPlan.NEVER_STARTED
+                invoicing_status = CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT
 
                 # Schedule switching to the new paid plan for the complimentary
                 # access plan's end date.
@@ -2029,33 +2093,47 @@ class BillingSession(ABC):
                 complimentary_access_plan.status = CustomerPlan.ENDED
                 complimentary_access_plan.save(update_fields=["status"])
 
+            # Create plan and audit log entry.
             if fixed_price_plan_offer is None:
-                plan_params["price_per_license"] = price_per_license
                 _price_per_license, percent_off = get_price_per_license_and_discount(
                     plan_tier, billing_schedule, customer
                 )
-                plan_params["discount"] = percent_off
                 assert price_per_license == _price_per_license
+                plan = self.create_customer_plan(
+                    customer=customer,
+                    tier=plan_tier,
+                    anchor_date=billing_cycle_anchor,
+                    billing_schedule=billing_schedule,
+                    charge_automatically=charge_automatically,
+                    automanage_licenses=automanage_licenses,
+                    next_invoice_date=next_invoice_date,
+                    status=status,
+                    invoicing_status=invoicing_status,
+                    price_per_license=price_per_license,
+                    discount=percent_off,
+                )
             else:
-                # Manual license management is not available for fixed price plan.
+                # Manual license management is not available for fixed-price plans.
                 assert automanage_licenses is True
-                plan_params["fixed_price"] = fixed_price_plan_offer.fixed_price
-                period_end = add_months(
+                # Fixed-price plans always have an end date.
+                end_date = add_months(
                     billing_cycle_anchor, CustomerPlan.FIXED_PRICE_PLAN_DURATION_MONTHS
                 )
-                plan_params["end_date"] = period_end
                 fixed_price_plan_offer.status = CustomerPlanOffer.PROCESSED
                 fixed_price_plan_offer.save(update_fields=["status"])
-
-            # Create plan and audit log entry.
-            plan = CustomerPlan.objects.create(
-                customer=customer, next_invoice_date=next_invoice_date, **plan_params
-            )
-            self.write_to_audit_log(
-                event_type=BillingSessionEventType.CUSTOMER_PLAN_CREATED,
-                event_time=standardize_datetime_for_stripe(),
-                extra_data=plan_params,
-            )
+                plan = self.create_customer_plan(
+                    customer=customer,
+                    tier=plan_tier,
+                    anchor_date=billing_cycle_anchor,
+                    billing_schedule=billing_schedule,
+                    charge_automatically=charge_automatically,
+                    automanage_licenses=automanage_licenses,
+                    next_invoice_date=next_invoice_date,
+                    status=status,
+                    invoicing_status=invoicing_status,
+                    fixed_price=fixed_price_plan_offer.fixed_price,
+                    end_date=end_date,
+                )
 
             if upgrade_when_complimentary_access_plan_ends:
                 # The complimentary access plan and new upgrade plan have
@@ -2280,29 +2358,30 @@ class BillingSession(ABC):
             plan.tier, schedule, plan.customer
         )
 
-        new_plan = CustomerPlan.objects.create(
+        new_free_trial_plan = self.create_customer_plan(
             customer=plan.customer,
+            tier=plan.tier,
+            anchor_date=plan.billing_cycle_anchor,
             billing_schedule=schedule,
-            automanage_licenses=plan.automanage_licenses,
             charge_automatically=plan.charge_automatically,
+            automanage_licenses=plan.automanage_licenses,
+            next_invoice_date=next_billing_cycle,
+            status=CustomerPlan.FREE_TRIAL,
             price_per_license=price_per_license,
             discount=discount_for_current_plan,
-            billing_cycle_anchor=plan.billing_cycle_anchor,
-            tier=plan.tier,
-            status=CustomerPlan.FREE_TRIAL,
-            next_invoice_date=next_billing_cycle,
+            create_audit_log=False,
         )
 
         ledger_entry = self.create_license_ledger_entry(
-            plan=new_plan,
+            plan=new_free_trial_plan,
             is_renewal=True,
             event_time=plan.billing_cycle_anchor,
             licenses=licenses_at_next_renewal,
             licenses_at_next_renewal=licenses_at_next_renewal,
         )
 
-        new_plan.invoiced_through = ledger_entry
-        new_plan.save(update_fields=["invoiced_through"])
+        new_free_trial_plan.invoiced_through = ledger_entry
+        new_free_trial_plan.save(update_fields=["invoiced_through"])
 
         if schedule == CustomerPlan.BILLING_SCHEDULE_ANNUAL:
             self.write_to_audit_log(
@@ -2310,7 +2389,7 @@ class BillingSession(ABC):
                 event_time=timezone_now(),
                 extra_data={
                     "monthly_plan_id": plan.id,
-                    "annual_plan_id": new_plan.id,
+                    "annual_plan_id": new_free_trial_plan.id,
                 },
             )
         else:
@@ -2319,7 +2398,7 @@ class BillingSession(ABC):
                 event_time=timezone_now(),
                 extra_data={
                     "annual_plan_id": plan.id,
-                    "monthly_plan_id": new_plan.id,
+                    "monthly_plan_id": new_free_trial_plan.id,
                 },
             )
 
@@ -2470,23 +2549,22 @@ class BillingSession(ABC):
                     plan.tier, CustomerPlan.BILLING_SCHEDULE_ANNUAL, plan.customer
                 )
 
-                new_plan = CustomerPlan.objects.create(
+                new_annual_plan = self.create_customer_plan(
                     customer=plan.customer,
+                    tier=plan.tier,
+                    anchor_date=next_billing_cycle,
                     billing_schedule=CustomerPlan.BILLING_SCHEDULE_ANNUAL,
-                    automanage_licenses=plan.automanage_licenses,
                     charge_automatically=plan.charge_automatically,
+                    automanage_licenses=plan.automanage_licenses,
+                    next_invoice_date=next_billing_cycle,
+                    invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
                     price_per_license=price_per_license,
                     discount=discount_for_current_plan,
-                    billing_cycle_anchor=next_billing_cycle,
-                    tier=plan.tier,
-                    status=CustomerPlan.ACTIVE,
-                    next_invoice_date=next_billing_cycle,
-                    invoiced_through=None,
-                    invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
+                    create_audit_log=False,
                 )
 
                 new_plan_ledger_entry = self.create_license_ledger_entry(
-                    plan=new_plan,
+                    plan=new_annual_plan,
                     is_renewal=True,
                     event_time=next_billing_cycle,
                     licenses=licenses_at_next_renewal,
@@ -2498,11 +2576,11 @@ class BillingSession(ABC):
                     event_time=event_time,
                     extra_data={
                         "monthly_plan_id": plan.id,
-                        "annual_plan_id": new_plan.id,
+                        "annual_plan_id": new_annual_plan.id,
                     },
                     background_update=True,
                 )
-                return new_plan, new_plan_ledger_entry
+                return new_annual_plan, new_plan_ledger_entry
 
             if plan.status == CustomerPlan.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE:
                 self.validate_plan_license_management(plan, licenses_at_next_renewal)
@@ -2516,23 +2594,22 @@ class BillingSession(ABC):
                     plan.tier, CustomerPlan.BILLING_SCHEDULE_MONTHLY, plan.customer
                 )
 
-                new_plan = CustomerPlan.objects.create(
+                new_monthly_plan = self.create_customer_plan(
                     customer=plan.customer,
+                    tier=plan.tier,
+                    anchor_date=next_billing_cycle,
                     billing_schedule=CustomerPlan.BILLING_SCHEDULE_MONTHLY,
-                    automanage_licenses=plan.automanage_licenses,
                     charge_automatically=plan.charge_automatically,
+                    automanage_licenses=plan.automanage_licenses,
+                    next_invoice_date=next_billing_cycle,
+                    invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
                     price_per_license=price_per_license,
                     discount=discount_for_current_plan,
-                    billing_cycle_anchor=next_billing_cycle,
-                    tier=plan.tier,
-                    status=CustomerPlan.ACTIVE,
-                    next_invoice_date=next_billing_cycle,
-                    invoiced_through=None,
-                    invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
+                    create_audit_log=False,
                 )
 
                 new_plan_ledger_entry = self.create_license_ledger_entry(
-                    plan=new_plan,
+                    plan=new_monthly_plan,
                     is_renewal=True,
                     event_time=next_billing_cycle,
                     licenses=licenses_at_next_renewal,
@@ -2544,11 +2621,11 @@ class BillingSession(ABC):
                     event_time=event_time,
                     extra_data={
                         "annual_plan_id": plan.id,
-                        "monthly_plan_id": new_plan.id,
+                        "monthly_plan_id": new_monthly_plan.id,
                     },
                     background_update=True,
                 )
-                return new_plan, new_plan_ledger_entry
+                return new_monthly_plan, new_plan_ledger_entry
 
             if plan.status == CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL:
                 self.downgrade_now_without_creating_additional_invoices(
@@ -3257,18 +3334,17 @@ class BillingSession(ABC):
 
         new_plan_billing_cycle_anchor = standardize_datetime_for_stripe(current_plan.end_date)
 
-        new_plan = CustomerPlan.objects.create(
+        new_tier_plan = self.create_customer_plan(
             customer=current_plan.customer,
-            status=CustomerPlan.ACTIVE,
-            automanage_licenses=current_plan.automanage_licenses,
+            tier=new_plan_tier,
+            anchor_date=new_plan_billing_cycle_anchor,
+            billing_schedule=current_plan.billing_schedule,
             charge_automatically=current_plan.charge_automatically,
+            automanage_licenses=current_plan.automanage_licenses,
+            next_invoice_date=new_plan_billing_cycle_anchor,
+            invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
             price_per_license=new_price_per_license,
             discount=discount_for_new_plan_tier,
-            billing_schedule=current_plan.billing_schedule,
-            tier=new_plan_tier,
-            billing_cycle_anchor=new_plan_billing_cycle_anchor,
-            invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
-            next_invoice_date=new_plan_billing_cycle_anchor,
         )
 
         current_plan_last_ledger = (
@@ -3283,12 +3359,12 @@ class BillingSession(ABC):
             new_plan_tier,
             old_plan_licenses_at_next_renewal,
         )
-        if not new_plan.automanage_licenses:  # nocoverage
+        if not new_tier_plan.automanage_licenses:  # nocoverage
             licenses_for_new_plan = max(old_plan_licenses_at_next_renewal, licenses_for_new_plan)
 
         assert licenses_for_new_plan is not None
         self.create_license_ledger_entry(
-            plan=new_plan,
+            plan=new_tier_plan,
             is_renewal=True,
             event_time=new_plan_billing_cycle_anchor,
             licenses=licenses_for_new_plan,
@@ -4030,24 +4106,20 @@ class BillingSession(ABC):
             return None
         customer = self.update_or_create_customer()
 
-        complimentary_access_plan_anchor = renewal_date
-        complimentary_access_plan_params = {
-            "billing_cycle_anchor": complimentary_access_plan_anchor,
-            "status": CustomerPlan.ACTIVE,
-            "tier": plan_tier,
+        complimentary_access_plan = self.create_customer_plan(
+            customer=customer,
+            tier=plan_tier,
+            anchor_date=renewal_date,
             # end_date and next_invoice_date should always be the same for these plans.
-            "end_date": end_date,
-            "next_invoice_date": end_date,
+            next_invoice_date=end_date,
+            end_date=end_date,
+            billing_schedule=CustomerPlan.BILLING_SCHEDULE_ANNUAL,
+            charge_automatically=False,
+            automanage_licenses=True,
             # The primary mechanism for preventing charges under this
             # plan is setting 'invoiced_through' to the ledger_entry below,
             # but setting a 0 price is useful defense in depth here.
-            "price_per_license": 0,
-            "billing_schedule": CustomerPlan.BILLING_SCHEDULE_ANNUAL,
-            "automanage_licenses": True,
-        }
-        complimentary_access_plan = CustomerPlan.objects.create(
-            customer=customer,
-            **complimentary_access_plan_params,
+            price_per_license=0,
         )
 
         try:
@@ -4061,18 +4133,12 @@ class BillingSession(ABC):
         ledger_entry = self.create_license_ledger_entry(
             plan=complimentary_access_plan,
             is_renewal=True,
-            event_time=complimentary_access_plan_anchor,
+            event_time=renewal_date,
             licenses=billed_licenses,
             licenses_at_next_renewal=billed_licenses,
         )
         complimentary_access_plan.invoiced_through = ledger_entry
         complimentary_access_plan.save(update_fields=["invoiced_through"])
-        self.write_to_audit_log(
-            event_type=BillingSessionEventType.CUSTOMER_PLAN_CREATED,
-            event_time=complimentary_access_plan_anchor,
-            extra_data=complimentary_access_plan_params,
-        )
-
         self.do_change_plan_type(tier=CustomerPlan.TIER_SELF_HOSTED_LEGACY, is_sponsored=False)
 
     def add_customer_to_community_plan(self) -> None:
@@ -4089,21 +4155,18 @@ class BillingSession(ABC):
         # was already ended by the support path from which is this function is called.
         assert plan is None
         now = timezone_now()
-        community_plan_params = {
-            "billing_cycle_anchor": now,
-            "status": CustomerPlan.ACTIVE,
-            "tier": CustomerPlan.TIER_SELF_HOSTED_COMMUNITY,
+        community_plan = self.create_customer_plan(
+            customer=customer,
+            tier=CustomerPlan.TIER_SELF_HOSTED_COMMUNITY,
+            anchor_date=now,
+            billing_schedule=CustomerPlan.BILLING_SCHEDULE_ANNUAL,
+            charge_automatically=False,
+            automanage_licenses=True,
             # The primary mechanism for preventing charges under this
             # plan is setting a null `next_invoice_date`, but setting
             # a 0 price is useful defense in depth here.
-            "next_invoice_date": None,
-            "price_per_license": 0,
-            "billing_schedule": CustomerPlan.BILLING_SCHEDULE_ANNUAL,
-            "automanage_licenses": True,
-        }
-        community_plan = CustomerPlan.objects.create(
-            customer=customer,
-            **community_plan_params,
+            next_invoice_date=None,
+            price_per_license=0,
         )
 
         try:
@@ -4122,11 +4185,6 @@ class BillingSession(ABC):
         )
         community_plan.invoiced_through = ledger_entry
         community_plan.save(update_fields=["invoiced_through"])
-        self.write_to_audit_log(
-            event_type=BillingSessionEventType.CUSTOMER_PLAN_CREATED,
-            event_time=now,
-            extra_data=community_plan_params,
-        )
 
     def get_last_ledger_for_automanaged_plan_if_exists(
         self,

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -973,6 +973,23 @@ class BillingSession(ABC):
         stripe.Invoice.finalize_invoice(stripe_invoice)
         return stripe_invoice
 
+    def create_license_ledger_entry(
+        self,
+        *,
+        plan: CustomerPlan,
+        is_renewal: bool,
+        event_time: datetime,
+        licenses: int,
+        licenses_at_next_renewal: int,
+    ) -> LicenseLedger:
+        return LicenseLedger.objects.create(
+            plan=plan,
+            is_renewal=is_renewal,
+            event_time=event_time,
+            licenses=licenses,
+            licenses_at_next_renewal=licenses_at_next_renewal,
+        )
+
     # Customer plan offers are always for negotiated, annual, fixed-price plans.
     def create_customer_plan_offer(
         self, *, customer: Customer, fixed_price: int, tier: int, sent_invoice_id: str | None = None
@@ -2053,7 +2070,7 @@ class BillingSession(ABC):
 
             # LicenseLedger entries are way for us to charge customer and track their license usage.
             # So, we should only create these entries for live plans.
-            ledger_entry = LicenseLedger.objects.create(
+            ledger_entry = self.create_license_ledger_entry(
                 plan=plan,
                 is_renewal=True,
                 event_time=billing_cycle_anchor,
@@ -2074,7 +2091,7 @@ class BillingSession(ABC):
                 if billable_licenses > licenses:
                     # Customer paid for less licenses than they have in use.
                     # We need to create a new ledger entry to track the additional licenses.
-                    LicenseLedger.objects.create(
+                    self.create_license_ledger_entry(
                         plan=plan,
                         is_renewal=False,
                         event_time=billing_cycle_anchor,
@@ -2086,7 +2103,7 @@ class BillingSession(ABC):
                 else:
                     # Customer paid for more licenses than they have in use.
                     # We need to create a new ledger entry to track the reduced renewal licenses.
-                    LicenseLedger.objects.create(
+                    self.create_license_ledger_entry(
                         plan=plan,
                         is_renewal=False,
                         event_time=billing_cycle_anchor,
@@ -2276,7 +2293,7 @@ class BillingSession(ABC):
             next_invoice_date=next_billing_cycle,
         )
 
-        ledger_entry = LicenseLedger.objects.create(
+        ledger_entry = self.create_license_ledger_entry(
             plan=new_plan,
             is_renewal=True,
             event_time=plan.billing_cycle_anchor,
@@ -2356,7 +2373,7 @@ class BillingSession(ABC):
 
             if plan.status == CustomerPlan.ACTIVE:
                 self.validate_plan_license_management(plan, licenses_at_next_renewal)
-                return None, LicenseLedger.objects.create(
+                return None, self.create_license_ledger_entry(
                     plan=plan,
                     is_renewal=True,
                     event_time=next_billing_cycle,
@@ -2411,7 +2428,7 @@ class BillingSession(ABC):
                 plan.billing_cycle_anchor = standardize_datetime_for_stripe(next_billing_cycle)
                 plan.status = CustomerPlan.ACTIVE
                 plan.save(update_fields=["invoiced_through", "billing_cycle_anchor", "status"])
-                return None, LicenseLedger.objects.create(
+                return None, self.create_license_ledger_entry(
                     plan=plan,
                     is_renewal=is_renewal,
                     event_time=next_billing_cycle,
@@ -2433,7 +2450,7 @@ class BillingSession(ABC):
                 new_plan.status = CustomerPlan.ACTIVE
                 new_plan.save(update_fields=["status"])
                 self.do_change_plan_type(tier=new_plan.tier, background_update=True)
-                return None, LicenseLedger.objects.create(
+                return None, self.create_license_ledger_entry(
                     plan=new_plan,
                     is_renewal=True,
                     event_time=next_billing_cycle,
@@ -2468,7 +2485,7 @@ class BillingSession(ABC):
                     invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
                 )
 
-                new_plan_ledger_entry = LicenseLedger.objects.create(
+                new_plan_ledger_entry = self.create_license_ledger_entry(
                     plan=new_plan,
                     is_renewal=True,
                     event_time=next_billing_cycle,
@@ -2514,7 +2531,7 @@ class BillingSession(ABC):
                     invoicing_status=CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT,
                 )
 
-                new_plan_ledger_entry = LicenseLedger.objects.create(
+                new_plan_ledger_entry = self.create_license_ledger_entry(
                     plan=new_plan,
                     is_renewal=True,
                     event_time=next_billing_cycle,
@@ -3270,7 +3287,7 @@ class BillingSession(ABC):
             licenses_for_new_plan = max(old_plan_licenses_at_next_renewal, licenses_for_new_plan)
 
         assert licenses_for_new_plan is not None
-        LicenseLedger.objects.create(
+        self.create_license_ledger_entry(
             plan=new_plan,
             is_renewal=True,
             event_time=new_plan_billing_cycle_anchor,
@@ -3837,7 +3854,7 @@ class BillingSession(ABC):
 
         # Create a new renewal invoice with updated licenses so that this becomes the last
         # renewal invoice for customer which will be used for any future comparisons.
-        LicenseLedger.objects.create(
+        self.create_license_ledger_entry(
             plan=plan,
             is_renewal=True,
             event_time=event_time,
@@ -3915,8 +3932,9 @@ class BillingSession(ABC):
             if not plan.customer.exempt_from_license_number_check:
                 assert self.get_current_billed_license_count() <= licenses
             assert licenses > plan.licenses()
-            LicenseLedger.objects.create(
+            self.create_license_ledger_entry(
                 plan=plan,
+                is_renewal=False,
                 event_time=event_time,
                 licenses=licenses,
                 licenses_at_next_renewal=licenses,
@@ -3928,8 +3946,9 @@ class BillingSession(ABC):
                 )
                 <= licenses_at_next_renewal
             )
-            LicenseLedger.objects.create(
+            self.create_license_ledger_entry(
                 plan=plan,
+                is_renewal=False,
                 event_time=event_time,
                 licenses=plan.licenses(),
                 licenses_at_next_renewal=licenses_at_next_renewal,
@@ -3987,8 +4006,9 @@ class BillingSession(ABC):
             )
             licenses = max(licenses_at_next_renewal, last_ledger_entry.licenses)
 
-        LicenseLedger.objects.create(
+        self.create_license_ledger_entry(
             plan=plan,
+            is_renewal=False,
             event_time=event_time,
             licenses=licenses,
             licenses_at_next_renewal=licenses_at_next_renewal,
@@ -4038,7 +4058,7 @@ class BillingSession(ABC):
             billed_licenses = 0
 
         # Create a ledger entry for the complimentary access plan for tracking purposes.
-        ledger_entry = LicenseLedger.objects.create(
+        ledger_entry = self.create_license_ledger_entry(
             plan=complimentary_access_plan,
             is_renewal=True,
             event_time=complimentary_access_plan_anchor,
@@ -4093,7 +4113,7 @@ class BillingSession(ABC):
 
         # Create a ledger entry for the community plan for tracking purposes.
         # Also, since it is an active plan we need to it have at least one license ledger entry.
-        ledger_entry = LicenseLedger.objects.create(
+        ledger_entry = self.create_license_ledger_entry(
             plan=community_plan,
             is_renewal=True,
             event_time=now,


### PR DESCRIPTION
Refactors the billing code to have three new `BillingSession` helpers:
- `create_customer_plan_offer` for creating new `CustomerPlanOffer` objects.
- `create_license_ledger_entry` for creating new `LicenseLedger` objects.
- `create_customer_plan` for creating new `CustomerPlan` objects.

**Notes**:
- This is prep for adding new fields to the ledger and plan models for workplace user group billing, as it will be important for plans with user group billing enabled to have the correct type of ledger entries.
- Fixes a few issues with the audit logs tracking plan creation:
  - Adds a customer_id field to the extra data dict.
  - Makes the audit log extra data more consistent for different plan tiers.
  - The support action that upgrades a Zulip Cloud customer from Standard to Plus now creates an audit log for the new Plus plan creation.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
