### PR TITLE
[ai] channel_settings: Split right-panel state from left tab in change_state.

### DIFF
--- a/web/e2e-tests/subscribe_toggle.test.ts
+++ b/web/e2e-tests/subscribe_toggle.test.ts
@@ -3,7 +3,7 @@ import type {ElementHandle, Page} from "puppeteer";
 import * as common from "./lib/common.ts";
 
 async function test_subscription_button(page: Page): Promise<void> {
-    const all_stream_selector = "[data-tab-key='all-streams']";
+    const all_stream_selector = "[data-tab-key='all']";
     await page.waitForSelector(all_stream_selector, {visible: true});
     await page.click(all_stream_selector);
     const stream_selector = "[data-stream-name='Venice']";

--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -238,11 +238,11 @@ export function initialize(): void {
                     assert(instance.reference instanceof HTMLElement);
                     ui_util.show_left_sidebar_menu_icon(instance.reference);
                     $popper.one("click", "#folder_popover_view_channels", () => {
-                        let section = "all";
+                        let left_side_tab = "all";
                         if (current_user.is_guest) {
-                            section = "subscribed";
+                            left_side_tab = "subscribed";
                         }
-                        stream_settings_ui.launch(section, undefined, undefined, folder_id);
+                        stream_settings_ui.launch(undefined, left_side_tab, undefined, folder_id);
                     });
                     $popper.one("click", "#folder_popover_manage_folder", () => {
                         channel_folders_ui.handle_editing_channel_folder(folder_id);

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -435,7 +435,7 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
         const right_side_tab = hash_parser.get_current_nth_hash_section(3);
 
         if (is_somebody_else_profile_open()) {
-            stream_settings_ui.launch(section, "all-streams", right_side_tab);
+            stream_settings_ui.launch(section, "all", right_side_tab);
             return;
         }
 

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -331,7 +331,7 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
                 stream_settings_ui.change_state(
                     "new",
                     undefined,
-                    "",
+                    undefined,
                     Number.parseInt(folder_id, 10),
                 );
                 return;
@@ -427,7 +427,7 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
     if (base === "channels") {
         if (hash_parser.get_current_nth_hash_section(1) === "folders") {
             const folder_id = hash_parser.get_current_nth_hash_section(2);
-            stream_settings_ui.launch("new", undefined, "", Number.parseInt(folder_id, 10));
+            stream_settings_ui.launch("new", undefined, undefined, Number.parseInt(folder_id, 10));
             return;
         }
 

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
 import * as about_zulip from "./about_zulip.ts";
@@ -70,6 +71,29 @@ function is_somebody_else_profile_open(): boolean {
         user_profile.get_user_id_if_user_profile_modal_open() !== undefined &&
         user_profile.get_user_id_if_user_profile_modal_open() !== people.my_current_user_id()
     );
+}
+
+// The first slot of a channels-settings hash is overloaded:
+//   - "subscribed" / "available" / "all" → left-panel tab
+//   - "new"                              → create-channel form
+//   - a stream-id string                 → that channel's settings
+// Disentangle it into the right-panel state and the left-side tab key
+// that stream_settings_ui expects.
+function channels_overlay_state_from_hash(): {
+    right_panel: "new" | number | undefined;
+    left_side_tab: string | undefined;
+} {
+    const hash_section = hash_parser.get_current_hash_section();
+    if (hash_section === "new") {
+        return {right_panel: "new", left_side_tab: undefined};
+    }
+    if (/^\d+$/.test(hash_section)) {
+        return {right_panel: Number.parseInt(hash_section, 10), left_side_tab: undefined};
+    }
+    // validate_channels_settings_hash has already constrained
+    // hash_section, so anything else is one of "subscribed" /
+    // "available" / "all".
+    return {right_panel: undefined, left_side_tab: hash_section};
 }
 
 function get_settings_tab(section: string): string | undefined {
@@ -328,6 +352,7 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
         if (base === "channels") {
             if (hash_parser.get_current_nth_hash_section(1) === "folders") {
                 const folder_id = hash_parser.get_current_nth_hash_section(2);
+                // Folder-create: show create form; left tab unchanged.
                 stream_settings_ui.change_state(
                     "new",
                     undefined,
@@ -338,8 +363,9 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
             }
 
             // e.g. #channels/29/social/subscribers
+            const {right_panel, left_side_tab} = channels_overlay_state_from_hash();
             const right_side_tab = hash_parser.get_current_nth_hash_section(3);
-            stream_settings_ui.change_state(section, undefined, right_side_tab);
+            stream_settings_ui.change_state(right_panel, left_side_tab, right_side_tab);
             return;
         }
 
@@ -432,18 +458,20 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
         }
 
         // e.g. #channels/29/social/subscribers
+        const {right_panel, left_side_tab} = channels_overlay_state_from_hash();
         const right_side_tab = hash_parser.get_current_nth_hash_section(3);
 
-        if (is_somebody_else_profile_open()) {
-            stream_settings_ui.launch(section, "all", right_side_tab);
+        // When somebody else's profile is open and we're navigating to
+        // a specific channel, default the left tab to "All" instead of
+        // inferring from subscription. URLs with a channel ID never
+        // carry an explicit left tab, so this overrides nothing.
+        if (is_somebody_else_profile_open() && typeof right_panel === "number") {
+            assert(left_side_tab === undefined);
+            stream_settings_ui.launch(right_panel, "all", right_side_tab);
             return;
         }
 
-        // We pass left_side_tab as undefined in change_state to
-        // select the tab based on user's subscriptions. "Subscribed" is
-        // selected if user is subscribed to the stream being edited.
-        // Otherwise "All streams" is selected.
-        stream_settings_ui.launch(section, undefined, right_side_tab);
+        stream_settings_ui.launch(right_panel, left_side_tab, right_side_tab);
         return;
     }
 

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -83,7 +83,7 @@ export function setup_subscriptions_tab_hash(tab_key_value: string): void {
         return;
     }
     switch (tab_key_value) {
-        case "all-streams": {
+        case "all": {
             browser_history.update("#channels/all");
             break;
         }

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1152,10 +1152,10 @@ export function change_state(
     // Right panel: empty.
     if (right_panel === undefined) {
         assert(left_side_tab !== undefined);
-        // For viewing all streams in a particular folder. Must run
-        // before toggler.goto so the left-panel redraw it triggers
-        // picks up the new folder filter.
-        if (left_side_tab === "all" && folder_id !== undefined) {
+        // Filter the left list to a particular folder. Must run before
+        // toggler.goto so the left-panel redraw it triggers picks up
+        // the new folder filter.
+        if (folder_id !== undefined) {
             stream_settings_components.set_folder_filter_dropdown_value(folder_id);
         }
         toggler.goto(left_side_tab);

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -809,7 +809,7 @@ export function switch_stream_tab(tab_name: string): void {
     */
 
     switch (tab_name) {
-        case "all-streams": {
+        case "all": {
             stream_ui_updates.set_show_subscribed(false);
             stream_ui_updates.set_show_available(false);
             break;
@@ -986,7 +986,7 @@ function setup_page(callback: () => void): void {
             values: [
                 {label: $t({defaultMessage: "Subscribed"}), key: "subscribed"},
                 {label: $t({defaultMessage: "Available"}), key: "available"},
-                {label: $t({defaultMessage: "All"}), key: "all-streams"},
+                {label: $t({defaultMessage: "All"}), key: "all"},
             ],
             callback(_value, key) {
                 switch_stream_tab(key);
@@ -996,7 +996,7 @@ function setup_page(callback: () => void): void {
         const $toggler_elem = toggler.get();
         $("#channels_overlay_container .list-toggler-container").prepend($toggler_elem);
         if (current_user.is_guest) {
-            toggler.disable_tab("all-streams");
+            toggler.disable_tab("all");
             toggler.disable_tab("available");
         }
     }
@@ -1138,7 +1138,7 @@ export function change_state(
         if (folder_id !== undefined) {
             stream_settings_components.set_folder_filter_dropdown_value(folder_id);
         }
-        toggler.goto("all-streams");
+        toggler.goto("all");
         stream_edit.empty_right_panel();
         return;
     }
@@ -1157,7 +1157,7 @@ export function change_state(
         stream_edit_toggler.set_select_tab(right_side_tab);
 
         if (left_side_tab === undefined) {
-            left_side_tab = "all-streams";
+            left_side_tab = "all";
             if (stream_data.is_subscribed(stream_id)) {
                 left_side_tab = "subscribed";
             }
@@ -1289,7 +1289,7 @@ export function toggle_view(event: string): void {
                     toggler.goto("available");
                     break;
                 case "available":
-                    toggler.goto("all-streams");
+                    toggler.goto("all");
                     break;
             }
             break;
@@ -1298,7 +1298,7 @@ export function toggle_view(event: string): void {
                 case "available":
                     toggler.goto("subscribed");
                     break;
-                case "all-streams":
+                case "all":
                     toggler.goto("available");
                     break;
             }

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1120,87 +1120,91 @@ function show_right_section(): void {
     $("#subscription_overlay .two-pane-settings-header").addClass("slide-left");
 }
 
+// `right_panel` controls the right panel:
+//   - "new"               → show the create-channel form
+//   - a channel-ID number → show that channel's settings
+//   - undefined           → empty right panel
+// `left_side_tab` controls the left panel ("subscribed" / "available" /
+//   "all"). URLs that target the right panel instead (e.g.
+//   #channels/new) don't carry a left tab, so this is undefined in
+//   those cases.
+// `right_side_tab` is the in-channel tab (general / personal /
+//   subscribers / permissions); meaningful only when right_panel is a
+//   channel ID.
 export function change_state(
-    section: string,
+    right_panel: "new" | number | undefined,
     left_side_tab: string | undefined,
     right_side_tab: string | undefined,
     folder_id?: number,
 ): void {
     assert(toggler !== undefined);
-    // if in #channels/new form.
-    if (section === "new") {
+
+    // Right panel: create form.
+    if (right_panel === "new") {
         do_open_create_stream(folder_id);
         show_right_section();
+        // We don't change the left side tab when opening the
+        // channel creation flow.
+        assert(left_side_tab === undefined);
         return;
     }
 
-    if (section === "all") {
-        if (folder_id !== undefined) {
+    // Right panel: empty.
+    if (right_panel === undefined) {
+        assert(left_side_tab !== undefined);
+        // For viewing all streams in a particular folder. Must run
+        // before toggler.goto so the left-panel redraw it triggers
+        // picks up the new folder filter.
+        if (left_side_tab === "all" && folder_id !== undefined) {
             stream_settings_components.set_folder_filter_dropdown_value(folder_id);
         }
-        toggler.goto("all");
+        toggler.goto(left_side_tab);
         stream_edit.empty_right_panel();
         return;
     }
 
-    if (section === "available") {
-        toggler.goto("available");
-        stream_edit.empty_right_panel();
-        return;
+    // Right panel: stream-edit.
+    const stream_id = right_panel;
+    show_right_section();
+    assert(right_side_tab !== undefined);
+    stream_edit_toggler.set_select_tab(right_side_tab);
+
+    // If undefined, infer the left side tab depending on subscription status.
+    left_side_tab ??= stream_data.is_subscribed(stream_id) ? "subscribed" : "all";
+
+    // Callback to .goto() will update browser_history unless a
+    // stream is being edited. We are always editing a stream here
+    // so its safe to call
+    if (left_side_tab !== toggler.key()) {
+        toggler.goto(left_side_tab);
     }
+    switch_to_stream_row(stream_id);
 
-    // if the section is a valid number.
-    if (/\d+/.test(section)) {
-        const stream_id = Number.parseInt(section, 10);
-        show_right_section();
-        assert(right_side_tab !== undefined);
-        stream_edit_toggler.set_select_tab(right_side_tab);
-
-        if (left_side_tab === undefined) {
-            left_side_tab = "all";
-            if (stream_data.is_subscribed(stream_id)) {
-                left_side_tab = "subscribed";
-            }
+    const sub = stream_data.get_sub_by_id(stream_id);
+    if (sub && !stream_settings_components.archived_status_filter_includes_channel(sub)) {
+        const FILTERS = stream_settings_data.ARCHIVED_STATUS_FILTERS;
+        let selected_filter;
+        if (sub.is_archived) {
+            selected_filter = FILTERS.ARCHIVED_CHANNELS;
+        } else {
+            selected_filter = FILTERS.NON_ARCHIVED_CHANNELS;
         }
-
-        // Callback to .goto() will update browser_history unless a
-        // stream is being edited. We are always editing a stream here
-        // so its safe to call
-        if (left_side_tab !== toggler.key()) {
-            toggler.goto(left_side_tab);
-        }
-        switch_to_stream_row(stream_id);
-
-        const sub = stream_data.get_sub_by_id(stream_id);
-        if (sub && !stream_settings_components.archived_status_filter_includes_channel(sub)) {
-            const FILTERS = stream_settings_data.ARCHIVED_STATUS_FILTERS;
-            let selected_filter;
-            if (sub.is_archived) {
-                selected_filter = FILTERS.ARCHIVED_CHANNELS;
-            } else {
-                selected_filter = FILTERS.NON_ARCHIVED_CHANNELS;
-            }
-            stream_settings_components.set_archived_status_filter_dropdown_value(selected_filter);
-        }
-        if (sub && !stream_settings_components.folder_filter_includes_channel(sub)) {
-            const folder_filters = folder_filter_dropdown_widget.FOLDER_FILTERS;
-            let selected_filter;
-            if (sub.folder_id === null) {
-                selected_filter = folder_filters.UNCATEGORIZED_DROPDOWN_OPTION;
-            } else {
-                selected_filter = sub.folder_id;
-            }
-            stream_settings_components.set_folder_filter_dropdown_value(selected_filter);
-        }
-        return;
+        stream_settings_components.set_archived_status_filter_dropdown_value(selected_filter);
     }
-
-    toggler.goto("subscribed");
-    stream_edit.empty_right_panel();
+    if (sub && !stream_settings_components.folder_filter_includes_channel(sub)) {
+        const folder_filters = folder_filter_dropdown_widget.FOLDER_FILTERS;
+        let selected_filter;
+        if (sub.folder_id === null) {
+            selected_filter = folder_filters.UNCATEGORIZED_DROPDOWN_OPTION;
+        } else {
+            selected_filter = sub.folder_id;
+        }
+        stream_settings_components.set_folder_filter_dropdown_value(selected_filter);
+    }
 }
 
 export function launch(
-    section: string,
+    right_panel: "new" | number | undefined,
     left_side_tab: string | undefined,
     right_side_tab: string | undefined,
     folder_id?: number,
@@ -1213,10 +1217,10 @@ export function launch(
                 browser_history.exit_overlay();
             },
         });
-        change_state(section, left_side_tab, right_side_tab, folder_id);
+        change_state(right_panel, left_side_tab, right_side_tab, folder_id);
         setTimeout(() => {
             if (!stream_settings_components.get_active_data().id) {
-                if (section === "new") {
+                if (right_panel === "new") {
                     $("#create_stream_name").trigger("focus");
                 } else {
                     $("#search_stream_name").trigger("focus");

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -426,10 +426,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: [
-            "[data-tab-key='available'].disabled",
-            "[data-tab-key='all-streams'].disabled",
-        ].join(","),
+        target: ["[data-tab-key='available'].disabled", "[data-tab-key='all'].disabled"].join(","),
         content: $t({
             defaultMessage: "You can only view channels that you are subscribed to.",
         }),


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/27730.