### PR TITLE
[ai] components: Add key() accessor to toggle, and fix misuse of value().

### DIFF
--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -23,6 +23,7 @@ export type Toggle = {
     disable_tab: (name: string) => void;
     enable_tab: (name: string) => void;
     value: () => string | undefined;
+    key: () => string | undefined;
     get: () => JQuery;
     goto: (name: string) => void;
     register_event_handlers: () => void;
@@ -181,6 +182,14 @@ export function toggle(opts: {
         value() {
             if (meta.idx >= 0) {
                 return opts.values[meta.idx]!.label;
+            }
+            /* istanbul ignore next */
+            return undefined;
+        },
+
+        key() {
+            if (meta.idx >= 0) {
+                return opts.values[meta.idx]!.key;
             }
             /* istanbul ignore next */
             return undefined;

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1166,7 +1166,7 @@ export function change_state(
         // Callback to .goto() will update browser_history unless a
         // stream is being edited. We are always editing a stream here
         // so its safe to call
-        if (left_side_tab !== toggler.value()) {
+        if (left_side_tab !== toggler.key()) {
             toggler.goto(left_side_tab);
         }
         switch_to_stream_row(stream_id);

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1657,7 +1657,7 @@ export function change_state(
         // Callback to .goto() will update browser_history unless a
         // group is being edited. We are always editing a group here
         // so its safe to call
-        if (left_side_tab !== group_list_toggler.value()) {
+        if (left_side_tab !== group_list_toggler.key()) {
             user_group_components.set_active_group_id(group.id);
             group_list_toggler.goto(left_side_tab);
         }

--- a/web/tests/components.test.cjs
+++ b/web/tests/components.test.cjs
@@ -231,6 +231,7 @@ run_test("basics", () => {
     assert.equal(env.tabs[2].class, "last");
     assert.deepEqual(callback_args, ["translated: Keyboard shortcuts", "keyboard-shortcuts"]);
     assert.equal(widget.value(), "translated: Keyboard shortcuts");
+    assert.equal(widget.key(), "keyboard-shortcuts");
 
     callback_args = undefined;
 
@@ -241,6 +242,7 @@ run_test("basics", () => {
     assert.equal(env.tabs[2].class, "last");
     assert.deepEqual(callback_args, ["translated: Message formatting", "message-formatting"]);
     assert.equal(widget.value(), "translated: Message formatting");
+    assert.equal(widget.key(), "message-formatting");
 
     // Go to same tab twice and make sure we get callback.
     callback_args = undefined;


### PR DESCRIPTION
The existing value() returns the human-readable (translated) label for the selected tab. Add key() returning the underlying key, so callers that need a stable, locale-independent identifier (e.g., for building URLs) don't have to compare against translated strings.

Two existing call sites were comparing a key (e.g., "subscribed", "all-streams") against value() (the translated label), which is always unequal. The comparison was meant to skip a redundant toggler.goto() when already on the target tab, but in practice the goto fired on every stream-edit and group-edit navigation, rerunning the toggler callback's side effects. Switch them to compare against key() instead.
