### PR TITLE
[ai] channel_settings: Fix clipped, off-color focus outlines in title row. 

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -588,6 +588,25 @@ h4.stream_setting_subsection_title {
                     white-space: nowrap;
                 }
 
+                /* Focus outlines in this header are inset and forced
+                   to the regular focus blue. The ancestor
+                   .stream-info-title and .display-type both set
+                   `overflow: hidden`, which would otherwise clip an
+                   outside-drawn focus outline. */
+                .selected-stream:focus-visible {
+                    outline: 2px solid var(--color-outline-focus);
+                    outline-offset: -2px;
+                }
+
+                /* `!important` is required to win against the
+                   `.icon-button:focus-visible` and
+                   `.action-button:focus-visible` rules in
+                   buttons.css, which use `!important` themselves. */
+                .button-group :is(.icon-button, .action-button):focus-visible {
+                    outline: 2px solid var(--color-outline-focus) !important;
+                    outline-offset: -2px;
+                }
+
                 /* These contain two button groups, the left group should stick to the
                    right side of the group/channel title name, and the right group that
                    should stick to the rightmost side of the right pane header. */

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -586,6 +586,11 @@ h4.stream_setting_subsection_title {
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
+                    /* Leave space between the channel/group name
+                       and its inset focus ring, and between that
+                       focus ring and the adjacent edit button's
+                       focus ring. */
+                    padding-right: 4px;
                 }
 
                 /* Focus outlines in this header are inset and forced
@@ -596,6 +601,7 @@ h4.stream_setting_subsection_title {
                 .selected-stream:focus-visible {
                     outline: 2px solid var(--color-outline-focus);
                     outline-offset: -2px;
+                    text-decoration: none;
                 }
 
                 /* `!important` is required to win against the


### PR DESCRIPTION
CZO discussion here: https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20focus.20boxes.20cut.20off.20in.20channel.2Fgroup.20title.20area/with/2447564


| before | after  |
| -- | -- |
| <img alt="Kapture 2026-04-30 at 19 04 40" src="https://github.com/user-attachments/assets/307ef505-68cf-4d30-a8e2-eff7bf03782c" /> | <img  alt="Kapture 2026-04-30 at 19 02 56" src="https://github.com/user-attachments/assets/72ea3022-b518-4c84-8423-6209fa433170" />  |
| <img  alt="Kapture 2026-04-30 at 19 05 09" src="https://github.com/user-attachments/assets/a716ef1f-c4dc-44dc-b70d-8abe26a94dfc" /> | <img alt="Kapture 2026-04-30 at 19 02 14" src="https://github.com/user-attachments/assets/4e99e4a3-0338-4de3-b1fb-c7eafd45ae3e" />  |




