### PR TITLE
[ai] popovers: Prevent focus ring from clipping at fractional zoom.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1084,9 +1084,14 @@ ul.popover-group-menu-member-list {
 
             &:focus-visible {
                 border-radius: 4px;
-                /* Override the default focus style */
-                outline: 1px solid var(--color-outline-focus) !important;
-                outline-offset: -1px;
+                /* Use an inset box-shadow rather than
+                   `outline` with a negative `outline-offset`,
+                   which at fractional browser zoom levels can
+                   render at subpixel positions outside the item
+                   and get clipped by the menu's `overflow-x:
+                   hidden`. */
+                outline: none;
+                box-shadow: inset 0 0 0 1px var(--color-outline-focus);
                 background: var(--color-background-hover-popover-menu);
             }
 


### PR DESCRIPTION
Fixes issue found on CZO: [#issues > menu keyboard selection box cut off when zoomed out](https://chat.zulip.org/#narrow/channel/9-issues/topic/menu.20keyboard.20selection.20box.20cut.20off.20when.20zoomed.20out/with/2443998)

Note: I couldn't reproduce, so Alya should test in the environment where the bug was discovered.

---

The keyboard-focus highlight on popover menu items used `outline` with `outline-offset: -1px`, drawing the ring 1px inside the item's edge. At fractional browser zoom levels (reported on an external monitor), subpixel rounding can render the outline at or just past the item's edge, where the menu's `overflow-x: hidden` clips it on the left and right sides.

Switch to an inset `box-shadow`, which paints inside the element's box and is unaffected by outline subpixel positioning, so the ring stays fully visible regardless of zoom or display scaling.
