### PR TITLE
stream/group-settings: Focus on an edit modal field when opened.

### DIFF
--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -668,13 +668,17 @@ export function set_up_handlers(): void {
 }
 
 export function initialize(): void {
-    $("#channels_overlay_container").on("click", "#archived_stream_rename", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const stream_id = Number.parseInt($(e.currentTarget).attr("data-stream-id")!, 10);
+    $("#channels_overlay_container").on(
+        "click",
+        "#archived_stream_rename",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            e.stopPropagation();
+            const stream_id = Number.parseInt($(e.currentTarget).attr("data-stream-id")!, 10);
 
-        stream_edit.open_stream_edit_modal(stream_id);
-    });
+            stream_edit.open_stream_edit_modal(stream_id, $(this).attr("id")!);
+        },
+    );
 }
 
 export function set_channel_folder_dropdown_value(folder_id: number): void {

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -56,6 +56,7 @@ import * as stream_ui_updates from "./stream_ui_updates.ts";
 import * as sub_store from "./sub_store.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import * as ui_report from "./ui_report.ts";
+import {place_caret_at_end} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
@@ -101,7 +102,7 @@ export function setup_subscriptions_tab_hash(tab_key_value: string): void {
     }
 }
 
-export function open_stream_edit_modal(stream_id: number): void {
+export function open_stream_edit_modal(stream_id: number, open_modal_button_id: string): void {
     const stream = sub_store.get(stream_id);
     assert(stream !== undefined);
 
@@ -140,6 +141,21 @@ export function open_stream_edit_modal(stream_id: number): void {
             $("#change_stream_info_modal .dialog_submit_button")
                 .addClass("save-button")
                 .attr("data-stream-id", stream_id);
+        },
+        on_shown() {
+            let $input: JQuery<HTMLInputElement | HTMLTextAreaElement> | undefined;
+            switch (open_modal_button_id) {
+                case "archived_stream_rename":
+                case "channel_title_open_channel_info_modal":
+                    $input = $("#change_stream_name");
+                    break;
+                case "open_stream_info_modal":
+                    $input = $("#change_stream_description");
+                    break;
+            }
+            if ($input) {
+                place_caret_at_end(util.the($input));
+            }
         },
         update_submit_disabled_state_on_change: true,
     });
@@ -745,29 +761,37 @@ export function initialize(): void {
             e.preventDefault();
             e.stopPropagation();
             const stream_id = get_stream_id(this);
-            open_stream_edit_modal(stream_id);
+            open_stream_edit_modal(stream_id, $(this).attr("id")!);
         },
     );
 
-    $("body").on("click", "#channel_title_open_channel_info_modal", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const $target = $(e.currentTarget).parents(".stream-title-buttons");
-        const stream_id = Number.parseInt($target.attr("data-stream-id")!, 10);
+    $("body").on(
+        "click",
+        "#channel_title_open_channel_info_modal",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            e.stopPropagation();
+            const $target = $(e.currentTarget).parents(".stream-title-buttons");
+            const stream_id = Number.parseInt($target.attr("data-stream-id")!, 10);
 
-        dialog_widget.close();
-        open_stream_edit_modal(stream_id);
-    });
+            dialog_widget.close();
+            open_stream_edit_modal(stream_id, $(this).attr("id")!);
+        },
+    );
 
-    $("body").on("click", "#change_stream_info_modal #archived_stream_rename", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
+    $("body").on(
+        "click",
+        "#change_stream_info_modal #archived_stream_rename",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            e.stopPropagation();
 
-        const stream_id = Number.parseInt($(e.currentTarget).attr("data-stream-id")!, 10);
+            const stream_id = Number.parseInt($(e.currentTarget).attr("data-stream-id")!, 10);
 
-        dialog_widget.close();
-        open_stream_edit_modal(stream_id);
-    });
+            dialog_widget.close();
+            open_stream_edit_modal(stream_id, $(this).attr("id")!);
+        },
+    );
 
     $("#channels_overlay_container").on("keydown", "#change_stream_description", (e) => {
         // Stream descriptions cannot be multiline, so disable enter key

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -12,7 +12,7 @@ import * as keydown_util from "./keydown_util.ts";
 // https://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser
 export function place_caret_at_end(el: HTMLElement): void {
     el.focus();
-    if (el instanceof HTMLInputElement) {
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
         el.setSelectionRange(el.value.length, el.value.length);
     } else {
         const range = document.createRange();

--- a/web/src/user_group_create.ts
+++ b/web/src/user_group_create.ts
@@ -14,10 +14,12 @@ import * as settings_data from "./settings_data.ts";
 import {realm} from "./state_data.ts";
 import type {GroupSettingPillContainer} from "./typeahead_helper.ts";
 import * as ui_report from "./ui_report.ts";
+import {place_caret_at_end} from "./ui_util.ts";
 import * as user_group_components from "./user_group_components.ts";
 import * as user_group_create_members from "./user_group_create_members.ts";
 import * as user_group_create_members_data from "./user_group_create_members_data.ts";
 import * as user_groups from "./user_groups.ts";
+import {the} from "./util.ts";
 
 let created_group_name: string | undefined;
 
@@ -343,6 +345,9 @@ export function set_up_handlers(): void {
                 $("#change_group_info_modal .dialog_submit_button")
                     .addClass("save-button")
                     .attr("data-group-id", group_id);
+            },
+            on_shown() {
+                place_caret_at_end(the($("#change_user_group_name")));
             },
             update_submit_disabled_state_on_change: true,
         });

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -57,6 +57,7 @@ import type {StreamSubscription} from "./sub_store.ts";
 import * as timerender from "./timerender.ts";
 import {anonymous_group_schema, group_setting_value_schema} from "./types.ts";
 import * as ui_report from "./ui_report.ts";
+import {place_caret_at_end} from "./ui_util.ts";
 import * as user_group_components from "./user_group_components.ts";
 import * as user_group_create from "./user_group_create.ts";
 import * as user_group_edit_members from "./user_group_edit_members.ts";
@@ -2085,6 +2086,7 @@ export function initialize(): void {
         function (this: HTMLElement, e) {
             e.preventDefault();
             e.stopPropagation();
+            const open_modal_button_id = $(this).attr("id");
             const user_group_id = get_user_group_id(this);
             const user_group = user_groups.get_user_group_from_id(user_group_id);
             const template_data = {
@@ -2107,6 +2109,20 @@ export function initialize(): void {
                     $("#change_group_info_modal .dialog_submit_button")
                         .addClass("save-button")
                         .attr("data-group-id", user_group_id);
+                },
+                on_shown() {
+                    let $input;
+                    switch (open_modal_button_id) {
+                        case "group_title_open_group_info_modal":
+                            $input = $("#change_user_group_name");
+                            break;
+                        case "open_group_info_modal":
+                            $input = $("#change_user_group_description");
+                            break;
+                    }
+                    if ($input) {
+                        place_caret_at_end(util.the($input));
+                    }
                 },
                 update_submit_disabled_state_on_change: true,
             });


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [#issues > missing focus on edit channel/group name/description modal](https://chat.zulip.org/#narrow/channel/9-issues/topic/missing.20focus.20on.20edit.20channel.2Fgroup.20name.2Fdescription.20modal/with/2447561)

**Screenshots and screen captures:** (Last updated on 27/05/2026)
These modals now focus on the appropriate field when opened.

- User group settings:
  <img width="1426" height="886" alt="20260526-1529-07 4719935" src="https://github.com/user-attachments/assets/c674c9de-2091-4a01-9247-569a5c5b7321" />

- Rename deactivated group modal:
  <img width="1438" height="892" alt="20260526-1529-59 6071726" src="https://github.com/user-attachments/assets/25dfdacd-bf36-4656-a172-385e898a6878" />

- Channel settings:
  <img width="1436" height="896" alt="20260526-1526-37 7400306" src="https://github.com/user-attachments/assets/00d2b1bc-11c9-4939-8abf-61a750c04405" />


- Edit archived channel modal in channel creation menu:
  <img width="1430" height="894" alt="20260526-1527-42 3865145" src="https://github.com/user-attachments/assets/fe79c1e5-9dd3-4f81-893d-0d87c9396440" />


- Edit archived channel modal opened from another edit channel modal:
  <img width="1438" height="894" alt="20260526-1528-25 6803885" src="https://github.com/user-attachments/assets/280a45c2-df85-4038-9c51-624c67cc8419" />






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
