### PR TITLE
[ai] modal: Redesign footer buttons.

### DIFF
--- a/web/e2e-tests/custom-profile.test.ts
+++ b/web/e2e-tests/custom-profile.test.ts
@@ -70,7 +70,7 @@ async function test_delete_custom_profile_field(page: Page): Promise<void> {
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, ".micromodal .dialog_submit_button"),
-        "Confirm",
+        "Delete",
     );
     await page.click(".micromodal .dialog_submit_button");
     await common.wait_for_micromodal_to_close(page);

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -88,6 +88,7 @@ export type DialogWidgetConfig = {
     always_visible_scrollbar?: boolean;
     footer_minor_text?: string;
     close_on_overlay_click?: boolean;
+    dangerous_action?: boolean;
 };
 
 type RequestOpts = {
@@ -203,6 +204,8 @@ export function launch(conf: DialogWidgetConfig): string {
     //   has scrollable content. Default behaviour is to hide the scrollbar when it is
     //   not in use.
     // * close_on_overlay_click: Whether to close modal on clicking overlay.
+    // * dangerous_action: If true, styles the submit button as a danger
+    //   button (e.g., for delete or deactivate actions).
 
     widget_id_counter += 1;
     const modal_unique_id = current_dialog_widget_id();
@@ -229,6 +232,7 @@ export function launch(conf: DialogWidgetConfig): string {
         footer_minor_text: conf.footer_minor_text,
         close_on_overlay_click: conf.close_on_overlay_click ?? true,
         hide_footer: conf.hide_footer,
+        dangerous_action: conf.dangerous_action,
     });
     const $dialog = $(html);
     $("body").append($dialog);

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -301,8 +301,10 @@ export function confirm_delete_all_drafts(): void {
     confirm_dialog.launch({
         modal_title_html: $t_html({defaultMessage: "Delete all drafts"}),
         modal_content_html: render_confirm_delete_all_drafts(),
+        modal_submit_button_text: $t({defaultMessage: "Delete"}),
         is_compact: true,
         on_click: delete_all_drafts,
+        dangerous_action: true,
     });
 }
 

--- a/web/src/message_delete.ts
+++ b/web/src/message_delete.ts
@@ -5,7 +5,7 @@ import * as z from "zod/mini";
 import * as channel from "./channel.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
 import * as dialog_widget from "./dialog_widget.ts";
-import {$t_html} from "./i18n.ts";
+import {$t, $t_html} from "./i18n.ts";
 import type {Message} from "./message_store.ts";
 import * as people from "./people.ts";
 import * as settings_data from "./settings_data.ts";
@@ -120,10 +120,12 @@ export function delete_message(msg_id: number): void {
         modal_content_html: $t_html({
             defaultMessage: "Deleting a message permanently removes it for everyone.",
         }),
+        modal_submit_button_text: $t({defaultMessage: "Delete"}),
         is_compact: true,
         help_link: "/help/delete-a-message#delete-a-message-completely",
         on_click: do_delete_message,
         loading_spinner: true,
+        dangerous_action: true,
     });
 }
 

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -186,8 +186,10 @@ function delete_profile_field(this: HTMLElement, e: JQuery.ClickEvent): void {
     confirm_dialog.launch({
         modal_title_html: $t_html({defaultMessage: "Delete custom profile field?"}),
         modal_content_html,
+        modal_submit_button_text: $t({defaultMessage: "Delete"}),
         is_compact: true,
         on_click: request_delete,
+        dangerous_action: true,
     });
 }
 
@@ -477,7 +479,9 @@ function show_modal_for_deleting_options(
             {N: deleted_options_count},
         ),
         modal_content_html,
+        modal_submit_button_text: $t({defaultMessage: "Delete"}),
         on_click: update_profile_field,
+        dangerous_action: true,
     });
 }
 

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -186,8 +186,10 @@ function delete_profile_field(this: HTMLElement, e: JQuery.ClickEvent): void {
     confirm_dialog.launch({
         modal_title_html: $t_html({defaultMessage: "Delete custom profile field?"}),
         modal_content_html,
+        modal_submit_button_text: $t({defaultMessage: "Delete"}),
         is_compact: true,
         on_click: request_delete,
+        dangerous_action: true,
     });
 }
 
@@ -476,7 +478,9 @@ function show_modal_for_deleting_options(
             {N: deleted_options_count},
         ),
         modal_content_html,
+        modal_submit_button_text: $t({defaultMessage: "Delete"}),
         on_click: update_profile_field,
+        dangerous_action: true,
     });
 }
 

--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -7,7 +7,7 @@ import render_left_sidebar_topic_actions_popover from "../templates/popovers/lef
 
 import * as clipboard_handler from "./clipboard_handler.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
-import {$t_html} from "./i18n.ts";
+import {$t, $t_html} from "./i18n.ts";
 import * as message_delete from "./message_delete.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_summary from "./message_summary.ts";
@@ -205,9 +205,11 @@ export function initialize(): void {
                         modal_title_html: $t_html({defaultMessage: "Delete topic"}),
                         help_link: "/help/delete-a-topic",
                         modal_content_html,
+                        modal_submit_button_text: $t({defaultMessage: "Delete"}),
                         on_click() {
                             message_delete.delete_topic(stream_id, topic_name);
                         },
+                        dangerous_action: true,
                     });
 
                     popover_menus.hide_current_popover_if_visible(instance);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2694,7 +2694,7 @@
         color-mix(in oklch, hsl(0deg 0% 100%) 85%, transparent)
     );
     --color-background-danger-solid-action-button: light-dark(
-        hsl(4deg 75% 53%),
+        hsl(4deg 75% 51%),
         hsl(2deg 74% 47%)
     );
     --color-background-danger-solid-action-button-hover: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1322,8 +1322,12 @@
         hsl(0deg 0% 0% / 40%)
     );
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
-    --color-compose-send-button-background: hsl(240deg 96% 68%);
-    --color-compose-send-button-background-interactive: hsl(240deg 41% 50%);
+    --color-compose-send-button-background: var(
+        --color-background-modal-confirm-button
+    );
+    --color-compose-send-button-background-interactive: var(
+        --color-background-modal-confirm-button-hover
+    );
     --color-compose-send-button-focus-border: hsl(232deg 20% 10%);
     --color-compose-send-button-focus-shadow: light-dark(
         hsl(230deg 100% 20%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2703,7 +2703,7 @@
     );
     --color-background-danger-solid-action-button-active: light-dark(
         hsl(359deg 93% 39%),
-        hsl(2deg 74% 47%)
+        hsl(2deg 92% 33%)
     );
     --color-text-danger-subtle-action-button: light-dark(
         hsl(359deg 94% 35%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2728,7 +2728,7 @@
     );
     --color-background-danger-solid-action-button-active: light-dark(
         hsl(359deg 93% 39%),
-        hsl(2deg 74% 47%)
+        hsl(2deg 92% 33%)
     );
     --color-text-danger-subtle-action-button: light-dark(
         hsl(359deg 94% 35%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1325,8 +1325,12 @@
         hsl(0deg 0% 0% / 40%)
     );
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
-    --color-compose-send-button-background: hsl(240deg 96% 68%);
-    --color-compose-send-button-background-interactive: hsl(240deg 41% 50%);
+    --color-compose-send-button-background: var(
+        --color-background-modal-confirm-button
+    );
+    --color-compose-send-button-background-interactive: var(
+        --color-background-modal-confirm-button-hover
+    );
     --color-compose-send-button-focus-border: hsl(232deg 20% 10%);
     --color-compose-send-button-focus-shadow: light-dark(
         hsl(230deg 100% 20%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2719,7 +2719,7 @@
         color-mix(in oklch, hsl(0deg 0% 100%) 85%, transparent)
     );
     --color-background-danger-solid-action-button: light-dark(
-        hsl(4deg 75% 53%),
+        hsl(4deg 75% 51%),
         hsl(2deg 74% 47%)
     );
     --color-background-danger-solid-action-button-hover: light-dark(

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -3,9 +3,32 @@
     /* Exit buttons are sometimes Cancel, but sometimes
        other "Nah, forget it" actions. */
     --color-exit-button-text: hsl(0deg 0% 0%);
-    --color-exit-button-border: hsl(300deg 2% 11% / 30%);
     --color-exit-button-background: hsl(226deg 1% 42% / 20%);
     --color-exit-button-background-interactive: hsl(226deg 1% 42% / 27%);
+    --color-background-modal-confirm-button: light-dark(
+        hsl(240deg 80% 66%),
+        hsl(245deg 55% 50%)
+    );
+    --color-background-modal-confirm-button-hover: light-dark(
+        hsl(240deg 63% 59%),
+        hsl(245deg 60% 58%)
+    );
+    --color-background-modal-confirm-button-active: light-dark(
+        hsl(240deg 55% 51%),
+        hsl(245deg 65% 42%)
+    );
+    --color-text-modal-cancel-button: light-dark(
+        hsl(229deg 9% 36%),
+        hsl(229deg 10% 70%)
+    );
+    --color-background-modal-cancel-button-hover: light-dark(
+        hsl(229deg 9% 36% / 7%),
+        hsl(230deg 9% 60% / 14%)
+    );
+    --color-background-modal-cancel-button-active: light-dark(
+        hsl(229deg 9% 36% / 11%),
+        hsl(230deg 9% 60% / 18%)
+    );
 
     /* Since modals are also present in portico and billing pages, we define
        the modal related variables directly here in the modal.css — which is
@@ -206,8 +229,8 @@
     }
 }
 
-.modal__button:focus,
-.modal__button:hover {
+.modal__button:focus:not(.dialog_submit_button, .dialog_exit_button),
+.modal__button:hover:not(.dialog_submit_button, .dialog_exit_button) {
     transform: scale(1.05);
     /* The extremely subtle 1.05 scale can cause
        a gap to appear between the outline and
@@ -218,19 +241,46 @@
 }
 
 .dialog_exit_button {
-    color: var(--color-exit-button-text);
-    background: var(--color-exit-button-background);
-    border: 1px solid var(--color-exit-button-border);
+    color: var(--color-text-modal-cancel-button);
+    background: transparent;
 
     &:hover {
-        background: var(--color-exit-button-background-interactive);
+        background: var(--color-background-modal-cancel-button-hover);
+    }
+
+    &:active {
+        background: var(--color-background-modal-cancel-button-active);
     }
 }
 
 .dialog_submit_button {
     margin-left: 12px;
-    background-color: hsl(240deg 96% 68%);
+    background-color: var(--color-background-modal-confirm-button);
     color: hsl(0deg 0% 100%) !important;
+
+    &:hover {
+        background-color: var(--color-background-modal-confirm-button-hover);
+    }
+
+    &:active {
+        background-color: var(--color-background-modal-confirm-button-active);
+    }
+
+    &.dangerous_action_button {
+        background-color: var(--color-background-danger-solid-action-button);
+
+        &:hover {
+            background-color: var(
+                --color-background-danger-solid-action-button-hover
+            );
+        }
+
+        &:active {
+            background-color: var(
+                --color-background-danger-solid-action-button-active
+            );
+        }
+    }
 }
 
 .modal__tab-switcher-container {

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -42,7 +42,7 @@
                 <button class="modal__button dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{ modal_exit_button_text }}</button>
                 {{/unless}}
                 <div class="dialog_submit_button_container">
-                    <button class="modal__button dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                    <button class="modal__button dialog_submit_button{{#if dangerous_action}} dangerous_action_button{{/if}}"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
                         <span class="submit-button-text">{{ modal_submit_button_text }}</span>
                         <span class="modal__spinner"></span>
                     </button>


### PR DESCRIPTION
Fixes #34364.

Updates modal footer buttons per the new design:

* High-emphasis brand color for confirm buttons.
* High-emphasis danger color for dangerous confirm buttons, applied via a new `dangerous_action` option on `dialog_widget.launch()`.
* Low-emphasis neutral style for the cancel button.

The redesigned buttons no longer grow slightly on hover, since the new design conveys interactivity through color changes. Other modal buttons keep their existing hover behavior.

Screen captures showing button colors can be see here on CZO: [#design > redesign modal footer buttons @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/redesign.20modal.20footer.20buttons/near/2453043)

Changed modals: delete message, delete topic, delete all drafts, delete custom profile field, delete custom profile field option
