### PR TITLE
message_list_view: Reapply message collapse formatting after rerendering.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1666,7 +1666,7 @@ export class MessageListView {
     _rerender_message(
         message_container: MessageContainer,
         opts: {message_content_edited: boolean; is_revealed: boolean},
-    ): void {
+    ): JQuery {
         const {message_content_edited, is_revealed} = opts;
         const $row = this.get_row(message_container.msg.id);
         const was_selected = this.list.selected_message() === message_container.msg;
@@ -1695,6 +1695,8 @@ export class MessageListView {
         if (was_selected && this.list === message_lists.current) {
             this.list.reselect_selected_id();
         }
+
+        return $rendered_msg;
     }
 
     reveal_hidden_message(message_id: number): void {
@@ -1759,6 +1761,7 @@ export class MessageListView {
 
         const message_groups = [];
         let current_group = [];
+        let $rerendered_rows = $();
 
         for (const message_container of message_containers) {
             if (
@@ -1770,11 +1773,23 @@ export class MessageListView {
                 message_groups.push(current_group);
                 current_group = [];
             }
-            this._rerender_message(message_container, {message_content_edited, is_revealed: false});
+            const $rendered = this._rerender_message(message_container, {
+                message_content_edited,
+                is_revealed: false,
+            });
+            $rerendered_rows = $rerendered_rows.add($rendered);
         }
 
         if (current_group.length > 0) {
             message_groups.push(current_group);
+        }
+
+        // Only the current message list needs its condense/collapse
+        // state refreshed here; non-current lists get
+        // `condense_and_collapse` reapplied via `restore_rendered_list`
+        // in `message_view` when they're brought back into view.
+        if (this.list === message_lists.current && $rerendered_rows.length > 0) {
+            condense.condense_and_collapse($rerendered_rows);
         }
 
         for (const messages_in_group of message_groups) {


### PR DESCRIPTION
When a message is rerendered after server ack, which happens in `echo.ts` in function `process_from_server`, the newly rendered DOM must have condense/collapse state applied, just as it would when initially rendered.

CZO: [#issues > bugs with editing collapsed messages](https://chat.zulip.org/#narrow/channel/9-issues/topic/bugs.20with.20editing.20collapsed.20messages/with/2434019)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
