### PR TITLE
bootstrap_typeahead: Respect helpOnEmptyStrings in select()

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -354,7 +354,7 @@ export class Typeahead<ItemType extends string | object> {
         if (this.hideAfterSelect()) {
             return this.hide();
         }
-        return this.lookup(true);
+        return this.lookup(false);
     }
 
     set_value(): void {


### PR DESCRIPTION
When hideAfterSelect() returns false, select() reopens the typeahead
via lookup() instead of hiding it, so that we can immediately offer
the next set of suggestions. It passes lookup(true), which forces the
typeahead to hide whenever the query is empty, regardless of the
element's helpOnEmptyStrings setting.

The hideOnEmpty parameter to lookup() was introduced in
https://github.com/zulip/zulip/commit/897bfb8b9501b82d3ba5ba86f02b34592bdbcae3 only for the backspace keyup
path, where backspacing on an empty search input should remove pills
rather than re-opening the typeahead. select() has nothing to do with
backspace, so forcing hideOnEmpty here unintentionally suppresses
empty query suggestions after a selection.

Currently, only the search and compose typeaheads are configured to
have hideAfterSelect() return false, causing them to reach the
lookup(true) call (when selecting an operator suggestion in the
search typeahead or a stream link suggestion in the compose
typeahead). In both cases, the query remains non-empty, so this is
not currently user-visible.

This change is a code correctness fix in bootstrap_typeahead rather
than a behavioral change for any existing typeahead instances.

**How changes were tested:**

Manually tested all typeahead instances.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|After (typeahead instances that reach lookup() call below hideAfterSelect)|
|-|
|<video src="https://github.com/user-attachments/assets/7ddf2d94-c132-4fe3-bcc8-5b19391baedf" />|
|<video src="https://github.com/user-attachments/assets/5ee95295-eb76-4b35-9899-4d66fcd65675" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
