### PR TITLE
css: Fix None row height in channel-folder selector

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2253,6 +2253,13 @@ body:not(.spectator-view) {
                 align-self: start;
             }
         }
+
+        /* Match the row height of items without buttons (e.g. "None")
+           to the 1.75em first row used by items with buttons. */
+        .dropdown-list-item-name:not(:has(.dropdown-list-buttons)) {
+            min-height: 1.75em;
+            align-content: center;
+        }
     }
 
     .no-dropdown-items {


### PR DESCRIPTION
The `None` row in the channel-folder selector dropdown was shorter than the other single-line folder rows, which caused a visual inconsistency.

This fix adds `min-height: 1.75em` and `align-content: center` to items without action buttons, so they match the height of the folder rows without setting a fixed height.

I also checked the left padding imbalance issue, and it seems to already be resolved in main (both sides compute to 6px).

Fixes: #37647

**How changes were tested:**

Opened the channel settings page in the development environment and verified that the "None" row height now matches other folder rows.

**Screenshots and screen captures:**

Before:
<img width="740" height="592" alt="Captura desde 2026-05-02 15-44-13" src="https://github.com/user-attachments/assets/ae733aae-3c95-47dc-888c-c4e33c6494bc" />

After:
<img width="309" height="567" alt="Captura desde 2026-05-02 16-27-41" src="https://github.com/user-attachments/assets/1d68d998-e50f-4f3c-a30a-d97418785cf7" />
<img width="982" height="581" alt="Captura desde 2026-05-02 16-31-54" src="https://github.com/user-attachments/assets/0180cdfb-0c5c-4d05-8563-3d61500c498e" />
<img width="1305" height="593" alt="Captura desde 2026-05-02 16-32-03" src="https://github.com/user-attachments/assets/b58ac646-255c-4491-b681-8019996d8aa9" />


<details>

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
