### PR TITLE
settings: Add disabled styling for text and URL inputs.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -74,7 +74,8 @@
         color: hsl(236deg 33% 90%);
     }
 
-    .pill-container.not-editable-by-user {
+    .pill-container.not-editable-by-user,
+    .group_setting_disabled .pill-container {
         opacity: 0.5;
     }
 

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -231,6 +231,7 @@
 
     &.not-editable-by-user {
         cursor: not-allowed;
+        background-color: var(--color-background-pill-container-input-disabled);
 
         .pill {
             cursor: not-allowed;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2429,6 +2429,14 @@ label.preferences-radio-choice-label {
     }
 }
 
+/* Use `input.settings_*:disabled` to match the specificity of the
+   `input[type=...]` rule in zulip.css and override its background. */
+input.settings_url_input:disabled,
+input.settings_text_input:disabled {
+    background-color: var(--color-background-disabled-settings-select);
+    opacity: 0.7;
+}
+
 .empty-required-field {
     border: 1px solid hsl(3deg 57% 33%);
     border-radius: 5px;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1179,7 +1179,9 @@ h4.stream_setting_subsection_title {
         }
 
         .pill-container {
-            opacity: 0.7;
+            background-color: var(
+                --color-background-pill-container-input-disabled
+            );
 
             .pill {
                 .exit {


### PR DESCRIPTION
In light mode, the `Name input field`(text input field) and `custom profile URL fields` showed no visible difference between enabled and disabled states. When the organization disabled the name change permission. In dark mode, the difference was clear, but not in light mode. 

Disabled text inputs, URL inputs, and pill containers in settings previously blended in with their enabled state in light mode. This gives them the same gray background already used for disabled settings selects, so the disabled state reads consistently across input types.

Dark mode keeps its existing opacity-based dimming, so no visual change there.

**This PR addresses the unfinished work in PR #38142.**

Also addressing the reviewer feedback given in PR #38142.
> I think you can keep the disabled selector `input:disabled` and move this CSS above inside the `.settings_text_input, .settings_url_input` block.

> Less faded looks better to me. Let's make sure we're meeting accessibility guidelines.


Fixes: [#issues > light mode disabled input background appears same @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/light.20mode.20disabled.20input.20background.20appears.20same/near/2387465)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="307" height="126" alt="2026-05-05_20-33-03" src="https://github.com/user-attachments/assets/e1e10c18-5116-4f51-880d-7a6d309a98f0" />|<img width="307" height="126" alt="2026-05-05_20-34-54" src="https://github.com/user-attachments/assets/2e99ed1f-f576-4106-9b0f-902b1508ca4f" />|

| Before | After |
|--------|-------|
|<img width="629" height="265" alt="image" src="https://github.com/user-attachments/assets/982796f1-31d6-4829-ae33-65f09f946d2f" />|<img width="629" height="265" alt="image" src="https://github.com/user-attachments/assets/e800a091-2293-4f8f-bdba-922f2ae7004c" />|

| Before | After |
|--------|-------|
|<img width="629" height="265" alt="image" src="https://github.com/user-attachments/assets/5178f6b4-f954-465c-88be-e5dcdfec1508" />|<img width="629" height="265" alt="image" src="https://github.com/user-attachments/assets/8d121b7b-1ff6-4950-bf79-ac874a4ee9e4" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="317" height="95" alt="2026-05-05_20-37-48" src="https://github.com/user-attachments/assets/e92c5dc5-6a8b-4063-ad2e-2ca63b779f06" />|<img width="316" height="138" alt="2026-05-05_20-39-43" src="https://github.com/user-attachments/assets/f3fd498b-62ed-4fd3-9c4a-4b3c76bc8a49" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="316" height="95" alt="2026-05-05_20-50-42" src="https://github.com/user-attachments/assets/94c87454-c758-4f82-b051-893073fa944e" />|<img width="318" height="138" alt="2026-05-05_20-51-24" src="https://github.com/user-attachments/assets/4b4a0f4a-9524-4974-b3d2-7cbf7baa6928" />|

| Before | After |
|--------|-------|
|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/ed76cba4-0f81-4376-99a1-9a87e32b1a0f" />|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/59e5b073-87fd-47ee-af4d-c67fdc2900b7" />|

| Before | After |
|--------|-------|
|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/3036cd2e-2e4f-4e3e-bb3b-db762c21b3e6" />|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/1db399ad-fba8-452a-b3cc-6ae09fd7df8f" />|

| Before | After |
|--------|-------|
|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/e208c974-e425-450d-90d4-e5fa512dcc99" />|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/6bae2a03-40dc-4a07-a6ab-7da665077a2e" />|

| Before | After |
|--------|-------|
|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/1cd979a1-7c06-4f36-854c-4f41965202c4" />|<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/42444618-ae7a-41f8-a7c5-05534e6873b8" />|

| Before | After |
|--------|-------|
|<img width="621" height="147" alt="image" src="https://github.com/user-attachments/assets/b298299f-efb4-4e6e-99f7-e7803a4af9f8" />|<img width="621" height="147" alt="image" src="https://github.com/user-attachments/assets/ae25eb13-b917-482f-9268-bc1dc0897e6c" />|

| Before | After |
|--------|-------|
|<img width="618" height="144" alt="image" src="https://github.com/user-attachments/assets/9c274b64-48d0-4450-a4fc-b52a674ea958" />|<img width="618" height="144" alt="image" src="https://github.com/user-attachments/assets/a3944b59-4cb3-4a2a-8f9a-410dacb7e77c" />|


| Before | After |
|--------|-------|
|<img width="643" height="209" alt="image" src="https://github.com/user-attachments/assets/c86ff0ca-cb84-4cc3-9e36-97dc7a3a9f63" />|<img width="643" height="209" alt="image" src="https://github.com/user-attachments/assets/dbe855d5-553b-41c2-bac7-b3e82b19f78a" />|

| Before | After |
|--------|-------|
|<img width="661" height="236" alt="image" src="https://github.com/user-attachments/assets/60a95242-300a-44b3-9f06-aaee9c19b2f4" />|<img width="661" height="236" alt="image" src="https://github.com/user-attachments/assets/2d705af6-c37c-44a0-9a46-d4c553377991" />|


| Dark theme Before | Dark theme After |
|--------|-------|
|<img width="645" height="230" alt="image" src="https://github.com/user-attachments/assets/0ba0881f-3878-4be3-9a94-0cda64dbdc54" />|<img width="645" height="230" alt="image" src="https://github.com/user-attachments/assets/4ca07ba4-a796-4546-89ea-75339aa46077" />|




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
