### PR TITLE
Refactor error handling and unread mention tracking

### DIFF
--- a/web/src/server_event_types.ts
+++ b/web/src/server_event_types.ts
@@ -99,7 +99,10 @@ export type UpdateMessageEvent = z.output<typeof update_message_event_schema>;
 export const message_details_schema = z.record(
     z.coerce.number<string>(),
     z.intersection(
-        z.object({mentioned: z.optional(z.boolean())}),
+        z.object({
+            mentioned: z.optional(z.boolean()),
+            mentioned_me_directly: z.optional(z.boolean()),
+        }),
         z.discriminatedUnion("type", [
             z.object({type: z.literal("private"), user_ids: z.array(z.number())}),
             z.object({

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -407,16 +407,15 @@ function create_stream(): void {
             // The rest of the work is done via the subscribe event we will get
         },
         error(xhr): void {
-            const error_message = z.object({msg: z.optional(z.string())}).parse(xhr.responseJSON);
-            if (error_message?.msg?.includes("access")) {
+            const response_data = z
+                .object({
+                    msg: z.string(),
+                    code: z.optional(z.string()),
+                })
+                .safeParse(xhr.responseJSON);
+            if (response_data.success && response_data.data.code === "CHANNEL_ACCESS_DENIED") {
                 // If we can't access the stream, we can safely
                 // assume it's a duplicate stream that we are not invited to.
-                //
-                // BUG: This check should be using error codes, not
-                // parsing the error string, so it works correctly
-                // with i18n.  And likely we should be reporting the
-                // error text directly rather than turning it into
-                // "Error creating channel"?
                 const rendered_error = render_channel_name_conflict_error({
                     stream_id: undefined,
                     is_archived: false,

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -655,25 +655,7 @@ export function process_unread_messages_event({
             message.unread = true;
             mentioned_me_directly = message.mentioned_me_directly;
         } else {
-            // BUG: If we don't have a copy of the message locally, we
-            // have no way to correctly compute whether the mentions
-            // are personal mentions or wildcard mentions, because
-            // message_info doesn't contain that information... so we
-            // guess that it's a personal mention.
-            //
-            // This is a correctness bug, but is likely very rare: We
-            // will have a copy of all unread messages locally once
-            // the app has finished the message_fetch backfill
-            // sequence (and also will certainly have this message if
-            // this is the client where the "Mark as unread" action
-            // was taken). Further, the distinction is only important
-            // for mentions in muted streams, where we count direct
-            // mentions as important enough to promote, and wildcard
-            // mentions as not.
-            //
-            // A possible fix would be to just fetch the fully message
-            // from the API here, but the right fix likely requires API changes.
-            mentioned_me_directly = message_info.mentioned;
+            mentioned_me_directly = message_info.mentioned_me_directly ?? false;
         }
 
         if (message_info.type === "private") {

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1137,6 +1137,7 @@ class MessageDetailsCore(BaseModel):
 class MessageDetails(MessageDetailsCore):
     # TODO: fix types to avoid optional fields
     mentioned: bool | None = None
+    mentioned_me_directly: bool | None = None
     user_ids: list[int] | None = None
     stream_id: int | None = None
     topic: str | None = None

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -197,15 +197,15 @@ class ChannelExistsError(JsonableError):
 
 class ChannelAccessError(JsonableError):
     code = ErrorCode.CHANNEL_ACCESS_DENIED
-    data_fields = ["channel_name"]
+    data_fields = ["stream"]
 
-    def __init__(self, channel_name: str) -> None:
-        self.channel_name: str = channel_name
+    def __init__(self, stream: str) -> None:
+        self.stream = stream
 
     @staticmethod
     @override
     def msg_format() -> str:
-        return _("Unable to access channel ({channel_name}).")
+        return _("You do not have permission to access channel '{stream}'.")
 
 
 class StreamDoesNotExistError(JsonableError):
@@ -750,13 +750,14 @@ class MissingRemoteRealmError(JsonableError):  # nocoverage
 class StreamWildcardMentionNotAllowedError(JsonableError):
     code: ErrorCode = ErrorCode.STREAM_WILDCARD_MENTION_NOT_ALLOWED
 
-    def __init__(self) -> None:
-        pass
+    def __init__(self, stream: str) -> None:
+        self.stream = stream
 
-    @staticmethod
     @override
-    def msg_format() -> str:
-        return _("You do not have permission to use channel wildcard mentions in this channel.")
+    def to_json_error_msg(self) -> str:
+        return _("You do not have permission to access channel '{channel_name}'.").format(
+            channel_name=self.stream,
+        )
 
 
 class TopicWildcardMentionNotAllowedError(JsonableError):

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -68,6 +68,7 @@ class ErrorCode(Enum):
     INTERNAL_SERVER_ERROR_ON_BOUNCER = auto()
     ADMIN_ACTION_REQUIRED = auto()
     PERMISSION_DENIED = auto()
+    CHANNEL_ACCESS_DENIED = auto()
 
 
 class JsonableError(Exception):
@@ -192,6 +193,19 @@ class ChannelExistsError(JsonableError):
     @override
     def msg_format() -> str:
         return _("Channel '{channel_name}' already exists")
+
+
+class ChannelAccessError(JsonableError):
+    code = ErrorCode.CHANNEL_ACCESS_DENIED
+    data_fields = ["channel_name"]
+
+    def __init__(self, channel_name: str) -> None:
+        self.channel_name: str = channel_name
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Unable to access channel ({channel_name}).")
 
 
 class StreamDoesNotExistError(JsonableError):

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -64,6 +64,7 @@ from zerver.models.recipients import DirectMessageGroup
 class MessageDetailsDict(TypedDict, total=False):
     type: str
     mentioned: bool
+    mentioned_me_directly: bool
     user_ids: list[int]
     stream_id: int
     topic: str
@@ -88,6 +89,7 @@ class RawUnreadMessagesResult(TypedDict):
     stream_dict: dict[int, RawUnreadStreamDict]
     huddle_dict: dict[int, RawUnreadDirectMessageGroupDict]
     mentions: set[int]
+    personal_mentions: set[int]
     muted_stream_ids: set[int]
     unmuted_stream_msgs: set[int]
     old_unreads_missing: bool
@@ -980,6 +982,7 @@ def extract_unread_data_from_um_rows(
         unmuted_stream_msgs=unmuted_stream_msgs,
         huddle_dict=direct_message_group_dict,
         mentions=mentions,
+        personal_mentions=set(),
         old_unreads_missing=False,
     )
 
@@ -1072,6 +1075,7 @@ def extract_unread_data_from_um_rows(
         ) != 0
         if is_mentioned:
             mentions.add(message_id)
+            raw_unread_messages["personal_mentions"].add(message_id)
         if is_stream_wildcard_mentioned or is_topic_wildcard_mentioned:
             if msg_type == Recipient.STREAM:
                 stream_id = row["recipient__type_id"]
@@ -1261,6 +1265,7 @@ def apply_unread_message_event(
 
     if "mentioned" in flags:
         state["mentions"].add(message_id)
+        state["personal_mentions"].add(message_id)
     if (
         "stream_wildcard_mentioned" in flags or "topic_wildcard_mentioned" in flags
     ) and message_id in state["unmuted_stream_msgs"]:
@@ -1275,6 +1280,7 @@ def remove_message_id_from_unread_mgs(state: RawUnreadMessagesResult, message_id
     state["huddle_dict"].pop(message_id, None)
     state["unmuted_stream_msgs"].discard(message_id)
     state["mentions"].discard(message_id)
+    state["personal_mentions"].discard(message_id)
 
 
 def format_unread_message_details(
@@ -1298,6 +1304,8 @@ def format_unread_message_details(
         )
         if message_id in raw_unread_data["mentions"]:
             message_details["mentioned"] = True
+        if message_id in raw_unread_data["personal_mentions"]:
+            message_details["mentioned_me_directly"] = True
         unread_data[str(message_id)] = message_details
 
     for message_id, stream_message_details in raw_unread_data["stream_dict"].items():
@@ -1312,6 +1320,8 @@ def format_unread_message_details(
         )
         if message_id in raw_unread_data["mentions"]:
             message_details["mentioned"] = True
+        if message_id in raw_unread_data["personal_mentions"]:
+            message_details["mentioned_me_directly"] = True
         unread_data[str(message_id)] = message_details
 
     for message_id, huddle_message_details in raw_unread_data["huddle_dict"].items():
@@ -1328,6 +1338,8 @@ def format_unread_message_details(
         )
         if message_id in raw_unread_data["mentions"]:
             message_details["mentioned"] = True
+        if message_id in raw_unread_data["personal_mentions"]:
+            message_details["mentioned_me_directly"] = True
         unread_data[str(message_id)] = message_details
 
     return unread_data
@@ -1341,6 +1353,8 @@ def add_message_to_unread_msgs(
 ) -> None:
     if message_details.get("mentioned"):
         state["mentions"].add(message_id)
+    if message_details.get("mentioned_me_directly"):
+        state["personal_mentions"].add(message_id)
 
     if message_details["type"] == "private":
         user_ids: list[int] = message_details["user_ids"]

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -210,7 +210,7 @@ def test_authorization_errors_fatal(client: Client, nonadmin_client: Client) -> 
         ],
         authorization_errors_fatal=True,
     )
-    assert_error_response(result)
+    assert_error_response(result, code="CHANNEL_ACCESS_DENIED")
     validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "400")
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3704,6 +3704,15 @@ paths:
                                           of the user.
 
                                           Present only if the message mentions the current user.
+                                      mentioned_me_directly:
+                                        type: boolean
+                                        description: |
+                                          A flag which indicates whether the message contains a personal
+                                          mention of the user.
+
+                                          Present only if the message mentions the current user personally.
+
+                                          **Changes**: New in Zulip 12.0 (feature level 475).
                                       user_ids:
                                         type: array
                                         items:
@@ -19227,6 +19236,15 @@ paths:
                               topic features were not handled correctly in calculating this field.
                             items:
                               type: integer
+                          personal_mentions:
+                            type: array
+                            description: |
+                              Array containing the IDs of all unread messages in which the user was
+                              mentioned personally.
+
+                              **Changes**: New in Zulip 12.0 (feature level 475).
+                            items:
+                              type: integer
                           old_unreads_missing:
                             type: boolean
                             description: |
@@ -30139,6 +30157,27 @@ components:
               "msg": "Channel 'nonexistent' does not exist",
               "result": "error",
               "stream": "nonexistent",
+            }
+    ChannelAccessDeniedError:
+      allOf:
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+            stream:
+              type: string
+              description: |
+                The name of the channel for which access was denied.
+
+                **Changes**: New in Zulip 12.0 (feature level 475).
+          example:
+            {
+              "code": "CHANNEL_ACCESS_DENIED",
+              "msg": "You do not have permission to access channel 'private-channel'.",
+              "result": "error",
+              "stream": "private-channel",
             }
     NonExistingChannelIdError:
       allOf:

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -2202,6 +2202,7 @@ class MarkUnreadTest(ZulipTestCase):
             stream_dict={},
             huddle_dict={},
             mentions=set(),
+            personal_mentions=set(),
             muted_stream_ids=set(),
             unmuted_stream_msgs=set(),
             old_unreads_missing=False,
@@ -2224,6 +2225,7 @@ class MarkUnreadTest(ZulipTestCase):
             stream_dict={},
             huddle_dict={},
             mentions=set(),
+            personal_mentions=set(),
             muted_stream_ids=set(),
             unmuted_stream_msgs=set(),
             old_unreads_missing=False,
@@ -2428,6 +2430,7 @@ class MarkUnreadTest(ZulipTestCase):
                 dict(
                     type="stream",
                     mentioned=True,
+                    mentioned_me_directly=True,
                     topic="test",
                     unmuted_stream_msg=True,
                     stream_id=stream.id,
@@ -2754,6 +2757,7 @@ class MarkUnreadTest(ZulipTestCase):
                     type="private",
                     user_ids=[sender.id],
                     mentioned=True,
+                    mentioned_me_directly=True,
                 ),
             )
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -57,6 +57,7 @@ from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
 from zerver.lib.exceptions import (
     CannotManageDefaultChannelError,
+    ChannelAccessError,
     JsonableError,
     OrganizationOwnerRequiredError,
 )
@@ -898,11 +899,7 @@ def add_subscriptions_backend(
     )
 
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
-        raise JsonableError(
-            _("Unable to access channel ({channel_name}).").format(
-                channel_name=unauthorized_streams[0].name,
-            )
-        )
+        raise ChannelAccessError(unauthorized_streams[0].name)
     if len(streams_to_which_user_cannot_add_subscribers) > 0:
         raise JsonableError(_("Insufficient permission"))
 


### PR DESCRIPTION
This PR addresses technical debt in Zulip by implementing structured error handling for channel access and explicit server-side metadata for unread mentions.

It replaces fragile string-parsing in the frontend and fixes a correctness bug in unread mention tracking for messages not yet loaded locally.