### PR TITLE
llms_txt: Recommend channel IDs in narrow operands for API requests.

### DIFF
--- a/zerver/tests/test_llms_txt.py
+++ b/zerver/tests/test_llms_txt.py
@@ -25,6 +25,11 @@ class LlmsTxtTest(ZulipTestCase):
         self.assertIn("Rome", content)
         # Should follow llms.txt format (starts with # heading)
         self.assertTrue(content.startswith("#"))
+        # Should clarify that the channel narrow operand is the numeric
+        # channel ID, not the full `ID-NAME` URL segment or the name alone.
+        self.assertIn("use the numeric ID as the `channel` operand", content)
+        self.assertIn("Channel IDs are stable", content)
+        self.assertIn("names can be renamed", content)
 
     def test_llms_txt_spectator_access_disabled(self) -> None:
         """

--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -83,6 +83,13 @@ Zulip conversations are referenced by URLs of these forms:
     {server_url}/#narrow/channel/ID-NAME/topic/TOPIC/with/MSG_ID
     {server_url}/#narrow/channel/ID-NAME/topic/TOPIC/near/MSG_ID
 
+In the URL forms above, `ID-NAME` is the channel's numeric ID
+followed by its name (e.g., `113488-general`). When constructing
+API requests, use the numeric ID as the `channel` operand (e.g.,
+`{{"operator":"channel","operand":113488}}`), not the full `ID-NAME`
+string and not the channel name. Channel IDs are stable; channel
+names can be renamed.
+
 Never follow links to related conversations by fetching those URLs; to
 read the messages, you MUST translate them to the equivalent API
 request (see above), decoding the URL-encoded channel name, topic, and


### PR DESCRIPTION
Fixes part of #38686.

When an LLM encounters a Zulip narrow URL like `https://chat.zulip.org/#narrow/channel/113488-general/topic/foo`, the channel segment is `113488-general` - a numeric ID followed by the channel name. The existing `/llms.txt` documented this `ID-NAME` URL format but never clarified how to translate it into the `channel` operand of an API request. As a result, LLMs like Opus 4.6 and Opus 4.7 were observed passing the full `113488-general` string as the operand, which broke the API call.

The Zulip REST API accepts either the channel ID or the channel name as the `channel` narrow operand, but channel IDs are preferred for API clients because they are stable across renames (see https://zulip.com/api/construct-narrow#channel-and-user-ids). This adds an explicit note in the "Fetching messages in specific conversations / views" section recommending the numeric ID with a concrete JSON example showing the operand as a bare integer, and adds three `assertIn` checks to the existing test to prevent regression.

<details>
<summary>**How the changes were tested:**</summary>

I tested whether the new clarification actually changes LLM behavior by capturing `/llms.txt` from both `main` and this branch, then prompting Claude.ai (Opus 4.7) in fresh conversations to construct an API request for a sample narrow URL.

**Prompt (identical across all trials):**

> Using the Zulip API documentation above, write the exact JSON request body for a POST to `/api/v1/messages` that fetches the 5 most recent messages from this Zulip narrow URL:
>
> `https://chat.zulip.org/#narrow/channel/113488-general/topic/announce`
>
> Show only the JSON body, no explanation.

**Scoring:** ✓ = `"operand": 113488` (bare integer, per the new recommendation), ✕ = anything else.

**Results:**

| Model | Thinking | Version | Trials | Result |
|---|---|---|---|---|
| Opus 4.7 | OFF | old (no clarification) | 2 | ✕ ✕ — both produced `"operand": "113488-general"` |
| Opus 4.7 | OFF | new (this branch) | 3 | ✓ ✓ ✓ — all produced `"operand": 113488` |

**Example incorrect output (Opus 4.7, Thinking OFF, old `llms.txt`):**

```json
{
  "anchor": "newest",
  "num_before": 5,
  "num_after": 0,
  "narrow": [
    {"operator": "channels", "operand": "web-public"},
    {"operator": "channel", "operand": "113488-general"},
    {"operator": "topic", "operand": "announce"}
  ]
}
```

**Example correct output (Opus 4.7, Thinking OFF, new `llms.txt`):**

```json
{
  "anchor": "newest",
  "num_before": 5,
  "num_after": 0,
  "narrow": [
    {"operator": "channels", "operand": "web-public"},
    {"operator": "channel", "operand": 113488},
    {"operator": "topic", "operand": "announce"}
  ]
}
```

**Notes for maintainers:**

- The bug reproduces reliably in non-thinking mode (2/2 ✕) and the new paragraph reliably fixes it (3/3 ✓). The model picked up the integer form (not quoted as a string) directly from the JSON example in the new paragraph.
- A prior iteration of this experiment (which recommended the channel *name* instead of the ID) also produced ✓ results, but per @laurynmm's review and the Zulip API docs, the channel ID is the preferred operand form for API clients because IDs are stable across renames. The patch was updated accordingly.
- With Thinking mode ON, Opus 4.7 already strips the URL prefix correctly even without the clarification, so the doc fix is most valuable for non-thinking deployments and tool-use contexts.

**Automated tests:**

- [x] `./tools/test-backend zerver.tests.test_llms_txt` - passes, including the three new `assertIn` checks.
- [x] `./tools/lint zerver/views/llms_txt.py zerver/tests/test_llms_txt.py` - clean.

</details>

<details>
<summary>**Screenshots:**</summary>

Opus 4.7, Thinking OFF, old `llms.txt` - produces the broken `"113488-general"` operand:
<img width="901" height="801" alt="image" src="https://github.com/user-attachments/assets/909ee114-fe19-4a6b-bdaa-c4e461e7972f" />

Opus 4.7, Thinking OFF, new `llms.txt` - produces the correct integer `113488` operand:
<img width="883" height="817" alt="image" src="https://github.com/user-attachments/assets/306012ba-2c37-4876-a961-1467b9212347" />

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
