### PR TITLE
templates: Add expand/collapse icons to show more/less buttons

### DIFF
--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -5,6 +5,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{else if (eq toggle_type "condenser")}}
@@ -14,6 +15,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{/if}}


### PR DESCRIPTION
## Summary

Add `zulip-icon-expand` icon before "Show more" text and `zulip-icon-collapse` before "Show less" text on message length toggle buttons.

This makes it easy to see what clicking will do at a glance.

Fixes #38844.