### PR TITLE
Add icons to show more/less buttons (fix #38844)

### DIFF
--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -5,6 +5,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{else if (eq toggle_type "condenser")}}
@@ -14,6 +15,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{/if}}


### PR DESCRIPTION
## Summary

Fixes #38844 by adding the appropriate icons before the text label on the "Show more"/"Show less" buttons on long or collapsed messages.

- `zulip-icon-expand` on "Show more" (expander)
- `zulip-icon-collapse` on "Show less" (condenser)

This improves visual affordance so users can easily see what clicking will do.

## Screenshots

See the issue for the expected design: the buttons should show the expand/collapse icon before the text label.

## Testing

- [x] Code change only (template update)
- [x] Icons `zulip-icon-expand` and `zulip-icon-collapse` already exist and are used elsewhere in the codebase (e.g., `popovers/message_actions_popover.hbs`)