### PR TITLE
hotkey: Route recent-view navigation hotkeys by event target.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -412,6 +412,45 @@ export function rewire_processing_text(value: typeof processing_text): void {
     processing_text = value;
 }
 
+function should_route_hotkey_to_recent_view($target: JQuery<object>): boolean {
+    return $target.is("body") || $target.closest("#recent_view").length > 0;
+}
+
+type RecentViewTargetLike = {
+    to_$: () => JQuery;
+};
+
+function is_recent_view_target_like(target: unknown): target is RecentViewTargetLike {
+    return (
+        typeof target === "object" &&
+        target !== null &&
+        "to_$" in target &&
+        typeof target.to_$ === "function"
+    );
+}
+
+function get_recent_view_hotkey_target(target: unknown): JQuery | undefined {
+    if (target === undefined || target === null) {
+        return undefined;
+    }
+
+    let $target: JQuery;
+
+    if (typeof HTMLElement !== "undefined" && target instanceof HTMLElement) {
+        $target = $(target);
+    } else if (is_recent_view_target_like(target)) {
+        $target = target.to_$();
+    } else {
+        return undefined;
+    }
+
+    if (!should_route_hotkey_to_recent_view($target)) {
+        return undefined;
+    }
+
+    return $target;
+}
+
 // Returns true if we handled it, false if the browser should.
 function process_escape_key(e: JQuery.KeyDownEvent): boolean {
     assert(e.target instanceof HTMLElement);
@@ -840,11 +879,12 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         case "vim_right":
         case "tab":
         case "shift_tab":
-        case "open_recent_view":
-            if (recent_view_ui.is_in_focus()) {
-                assert(e.target instanceof HTMLElement);
-                return recent_view_ui.change_focused_element($(e.target), event_name);
+        case "open_recent_view": {
+            const $target = get_recent_view_hotkey_target(e.target);
+            if (recent_view_ui.is_in_focus() && $target) {
+                return recent_view_ui.change_focused_element($target, event_name);
             }
+        }
     }
 
     switch (event_name) {

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -92,8 +92,9 @@ const stream_popover = mock_esm("../src/stream_popover");
 const stream_settings_ui = mock_esm("../src/stream_settings_ui");
 const user_status_ui = mock_esm("../src/user_status_ui");
 
-mock_esm("../src/recent_view_ui", {
+const recent_view_ui = mock_esm("../src/recent_view_ui", {
     is_in_focus: () => false,
+    change_focused_element: () => false,
 });
 
 const spectators = zrequire("../src/spectators");
@@ -604,6 +605,53 @@ test_while_not_editing_text("n/p keys", () => {
 test_while_not_editing_text("narrow next unread followed topic", () => {
     assert_mapping("N", message_view, "narrow_to_next_topic", true);
 });
+
+run_test("recent view mock defaults", () => {
+    assert.equal(recent_view_ui.change_focused_element(), false);
+});
+
+run_test(
+    "recent view navigation hotkeys only route for recent targets",
+    ({override, override_rewire}) => {
+        override_rewire(hotkey, "processing_text", () => false);
+        override(recent_view_ui, "is_in_focus", () => true);
+        override(list_util, "inside_list", () => false);
+        override(message_lists.current, "visibly_empty", () => true);
+
+        const change_focused_element_calls = make_stub();
+        override(recent_view_ui, "change_focused_element", change_focused_element_calls.f);
+
+        const $recent_target = $.create("recent-target");
+        $recent_target.set_matches("body", false);
+        $recent_target.set_closest_results("#recent_view", $.create("recent-view-root"));
+
+        hotkey.process_keydown({
+            key: "ArrowDown",
+            target: $recent_target[0],
+        });
+        assert.equal(change_focused_element_calls.num_calls, 1);
+
+        const $outside_target = $.create("outside-target");
+        $outside_target.set_matches("body", false);
+        $outside_target.set_closest_results("#recent_view", []);
+
+        const handled_outside_target = hotkey.process_keydown({
+            key: "ArrowDown",
+            target: $outside_target[0],
+        });
+        assert.equal(handled_outside_target, false);
+        assert.equal(change_focused_element_calls.num_calls, 1);
+
+        const $body_target = $.create("body-target");
+        $body_target.set_matches("body", true);
+
+        hotkey.process_keydown({
+            key: "ArrowDown",
+            target: $body_target[0],
+        });
+        assert.equal(change_focused_element_calls.num_calls, 2);
+    },
+);
 
 test_while_not_editing_text("motion_keys", () => {
     $.set_results(".navbar-item:focus", []);


### PR DESCRIPTION

<!-- Describe your pull request here.-->

Fixes: #21858.

This PR improves how hotkeys are routed to Recent View.

Before this change, navigation hotkeys could be sent to Recent View whenever Recent View was considered focused, even when the keyboard event came from unrelated UI elements. The new behavior routes those hotkeys only when the event target is relevant to Recent View (inside Recent View or body), which avoids brittle exception lists and prevents unrelated inputs from being intercepted.

**How changes were tested:**

- Ran targeted frontend hotkey tests, including the new scenario for Recent View target validation.
- Ran frontend lint and formatting checks for the updated files.
- Manual validation in the app:
- In Recent View, navigation hotkeys still work as expected.
- With focus on body, fallback behavior still works.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

No visual UI changes.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
