### PR TITLE
[ai] provision: Add Fedora 44 support.

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -22,7 +22,7 @@ are:
 - Ubuntu 22.04, 24.04, 26.04
 - Debian 12, 13
 - CentOS 7 (beta)
-- Fedora 43 (beta)
+- Fedora 43, 44 (beta)
 - RHEL 7 (beta)
 
 **Note**: You should not use the `root` user to run the installation.

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -84,7 +84,7 @@ elif vendor == "ubuntu" and os_version == "24.04":  # noble
     POSTGRESQL_VERSION = "16"
 elif vendor == "ubuntu" and os_version == "26.04":  # resolute
     POSTGRESQL_VERSION = "18"
-elif vendor == "fedora" and os_version == "43":
+elif vendor == "fedora" and os_version in ("43", "44"):
     POSTGRESQL_VERSION = "17"
 elif vendor == "rhel" and os_version.startswith("7."):
     POSTGRESQL_VERSION = "10"


### PR DESCRIPTION
Fedora 44 ships Postgres 17 in PGDG and shares Fedora 43's package list, so support is just a matter of accepting the new version in the provision check.
