### PR TITLE
[ai] puppeteer: Wait for navigation after clicking logout.

### DIFF
--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -286,7 +286,7 @@ export async function log_out(page: Page): Promise<void> {
     await page.waitForSelector(menu_selector, {visible: true});
     await page.click(menu_selector);
     await page.waitForSelector(logout_selector);
-    await page.click(logout_selector);
+    await Promise.all([page.waitForNavigation(), page.click(logout_selector)]);
 
     // Wait for a email input in login page so we know login
     // page is loaded. Then check that we are at the login url.


### PR DESCRIPTION
`page.click()` returns when the click event dispatches, not when the form submission's navigation completes.  The subsequent `waitForSelector('input[name="username"]')` can poll a destroyed execution context before the new login page is wired up, causing intermittent 30-second timeouts in CI.

Wrap the click in `Promise.all([waitForNavigation, click])` so the selector wait runs against the loaded login page, matching the pattern already used in realm-creation.test.ts.

---

Asked Claude to fix https://github.com/zulip/zulip/actions/runs/25412563066/job/74537283919#step:17:7541