### PR TITLE
icons: Replace fa fa-ban-deactivated-user-icon with zulip-icon-deactivated-circle.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -178,11 +178,11 @@
     .slashed-circle-icon {
         position: absolute;
         background-color: var(--color-background-deactivated-user-pill);
-        padding: 0.2em;
-        font-size: 0.7em;
-        border-radius: 0.625em;
+        padding: 0.3em 0.22em 0.22em;
+        font-size: 0.6em;
+        border-radius: 0.925em;
         bottom: -0.0625em;
-        left: 1.1em;
+        left: 1.3em;
         opacity: 1;
     }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -310,7 +310,7 @@
 
     .deactivated-user-icon {
         vertical-align: middle;
-        font-size: 0.7em;
+        font-size: 0.6em;
     }
 
     #default-section {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -872,9 +872,9 @@ ul.popover-group-menu-member-list {
         border-radius: 50%;
 
         &.deactivated-user-icon {
-            font-size: 0.8em;
+            font-size: 0.69em;
             background-color: var(--color-background-popover-menu);
-            padding: 1px;
+            padding: 1.5px;
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -903,8 +903,7 @@ h4.stream_setting_subsection_title {
     width: 100%;
 }
 
-.left .group-name-wrapper .fa-ban,
-.right .group-name .fa-ban {
+.left .group-name-wrapper .deactivated-user-icon {
     font-size: 0.8em;
     opacity: 0.6;
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1487,7 +1487,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .deactivated_user .deactivated-user-icon {
     color: inherit;
     margin-left: 2px;
-    font-size: 0.9em;
+    font-size: 0.78em;
 }
 
 .no-drag {
@@ -2553,11 +2553,11 @@ body:not(.spectator-view) {
     .deactivated-user-icon {
         background-color: var(--color-background);
         color: var(--color-user-circle-deactivated);
-        padding: 2px;
-        font-size: 0.8em;
+        padding: 2.4px;
+        font-size: 0.69em;
         position: absolute;
         border-radius: 10px;
-        bottom: -2px;
+        bottom: -1px;
         right: -2px;
     }
 }

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -7,7 +7,7 @@
     <img class="pill-image" src="{{img_src}}" />
     <div class="pill-image-border"></div>
     {{#if deactivated}}
-        <span class="fa fa-ban slashed-circle-icon"></span>
+        <span class="zulip-icon zulip-icon-deactivated-circle slashed-circle-icon"></span>
     {{/if}}
     {{/if}}
     <span class="pill-label">

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -3,7 +3,7 @@
         <div class="inline_profile_picture {{#if sender_is_guest}} guest-avatar{{/if}} {{#if sender_is_deactivated}} deactivated {{/if}} {{#if is_hidden}} muted-sender-avatar {{/if}}">
             <img loading="lazy" src="{{small_avatar_url}}" alt="" class="no-drag"/>
             {{#if sender_is_deactivated}}
-                <i class="fa fa-ban deactivated-user-icon"></i>
+                <i class="zulip-icon zulip-icon-deactivated-circle deactivated-user-icon"></i>
             {{/if}}
         </div>
     </div>

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -6,7 +6,7 @@
                 <div class="popover-menu-user-presence user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} hidden-for-spectators" data-presence-indicator-user-id="{{user_id}}"></div>
             {{/if}}
             {{#if (not is_active)}}
-                <span class="popover-menu-user-presence conversation-partners-icon fa fa-ban fa-lg deactivated-user-icon user_circle"></span>
+                <span class="popover-menu-user-presence conversation-partners-icon zulip-icon zulip-icon-deactivated-circle deactivated-user-icon user_circle"></span>
             {{/if}}
         </div>
         <div class="popover-menu-user-info">

--- a/web/templates/search_user_pill.hbs
+++ b/web/templates/search_user_pill.hbs
@@ -8,7 +8,7 @@
             <img class="pill-image" src="{{this.img_src}}" />
             <div class="pill-image-border"></div>
             {{#if deactivated}}
-            <span class="fa fa-ban slashed-circle-icon"></span>
+            <span class="zulip-icon zulip-icon-deactivated-circle slashed-circle-icon"></span>
             {{/if}}
             <span class="pill-label">
                 <span class="pill-value">{{ this.full_name }}</span>

--- a/web/templates/user_display_only_pill.hbs
+++ b/web/templates/user_display_only_pill.hbs
@@ -16,7 +16,7 @@
                 <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
             {{/if}}
             {{#unless is_active}}
-                <i class="fa fa-ban pill-deactivated deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{#if is_bot}}{{t 'Bot is deactivated' }}{{else}}{{t 'User is deactivated' }}{{/if}}"></i>
+                <i class="zulip-icon zulip-icon-deactivated-circle pill-deactivated deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{#if is_bot}}{{t 'Bot is deactivated' }}{{else}}{{t 'User is deactivated' }}{{/if}}"></i>
             {{/unless}}
         </span>
     </a>

--- a/web/templates/user_group_settings/browse_user_groups_list_item.hbs
+++ b/web/templates/user_group_settings/browse_user_groups_list_item.hbs
@@ -78,7 +78,7 @@
             <div class="group-name-wrapper">
                 <div class="group-name">{{name}}</div>
                 {{#if deactivated}}
-                    <i class="fa fa-ban deactivated-user-icon"></i>
+                    <i class="zulip-icon zulip-icon-deactivated-circle deactivated-user-icon"></i>
                 {{/if}}
             </div>
         </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -12,9 +12,9 @@
                             {{else}}
                                 <span>
                                     {{#if is_deleted}}
-                                        <i class="fa fa-ban deactivated-user-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Deleted user'}}"></i>
+                                        <i class="zulip-icon zulip-icon-deactivated-circle deactivated-user-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Deleted user'}}"></i>
                                     {{else}}
-                                        <i class="fa fa-ban deactivated-user-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Deactivated user'}}"></i>
+                                        <i class="zulip-icon zulip-icon-deactivated-circle deactivated-user-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Deactivated user'}}"></i>
                                     {{/if}}
                                 </span>
                             {{/if}}


### PR DESCRIPTION
Replace all the FontAwesome `fa fa-ban` icon used as a deactivated user indicator with `zulip-icon-deactivated-circle`, consistent with the pattern already used in `dropdown_list.hbs` and `user_group_settings/selected_group_title.hbs`.

- Change `fa fa-ban` &rarr; `zulip-icon-deactivated-circle` in:
   - `input_pill.hbs` 
  - `message_avatar.hbs` 
  - `search_user_pill.hbs` 
  - `user_display_only_pill.hbs` 
  - `user_card_popover.hbs` 
  - `user_group_settings/browse_user_groups_list_item.hbs` 
  - `user_profile_modal.hbs` 

Also updates `.fa-ban` CSS selectors in `subscriptions.css` to use `.deactivated-user-icon` instead.

Fixes: Part of #36224.
<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

**Dark Theme Screenshots**

| Before| After |
|--------|-------|
|<img width="121" height="121" alt="2026-05-06_23-38-38" src="https://github.com/user-attachments/assets/3a4d340d-0d9a-4fe6-b0cc-22f8b133e7e4" />|<img width="121" height="121" alt="2026-06-08_00-41-24" src="https://github.com/user-attachments/assets/7ec99e9f-7d48-487b-a534-965c90af04aa" />|

| Before | After |
|--------|-------|
|<img width="184" height="256" alt="2026-05-06_23-44-23" src="https://github.com/user-attachments/assets/a08c8a39-611a-44f6-800f-cf7867a26de2" />|<img width="184" height="256" alt="image" src="https://github.com/user-attachments/assets/f3bea6d8-4bd6-4c04-ac50-ed19a6b03187" />|

| Before | After |
|--------|-------|
|<img width="447" height="331" alt="2026-05-06_23-45-40" src="https://github.com/user-attachments/assets/738def78-2a2c-4c22-9089-4e295f851233" />|<img width="447" height="331" alt="image" src="https://github.com/user-attachments/assets/a49ad14b-854f-45a8-b6ed-c08952ff512f" />|

| Before | After |
|--------|-------|
|<img width="526" height="75" alt="2026-05-06_23-49-35" src="https://github.com/user-attachments/assets/c2899c06-c7fc-4288-8a41-3e83668b1671" />|<img width="526" height="75" alt="image" src="https://github.com/user-attachments/assets/e59f2c74-00ca-465a-9aaf-1300e26670ed" />|

| Before | After |
|--------|-------|
|<img width="631" height="57" alt="2026-05-06_23-57-29" src="https://github.com/user-attachments/assets/3b7458be-eb7c-4a9c-a664-53d419b527ea" />|<img width="631" height="57" alt="image" src="https://github.com/user-attachments/assets/ffde4383-74f8-4b58-8bd7-171d2a2b7a96" />|

| Before | After |
|--------|-------|
|<img width="175" height="40" alt="image" src="https://github.com/user-attachments/assets/78bd7b0a-4a0f-4ead-83ca-b23c1d0e8c04" />|<img width="175" height="40" alt="image" src="https://github.com/user-attachments/assets/0ac1bccd-5a9f-45ed-bdca-f6217c4d8c0f" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
