### PR TITLE
thumbnails: Correct hover behavior on animated preview hovers.

### DIFF
--- a/web/src/message_list_hover.ts
+++ b/web/src/message_list_hover.ts
@@ -126,8 +126,8 @@ export function initialize(): void {
                 return;
             }
             const $img = $(this);
-            $img.closest(".message-media-preview-image, .message-media-inline-image").removeClass(
-                "message_inline_animated_image_still",
+            $img.closest(".message-media-preview-image, .message-media-inline-image").addClass(
+                "animated-preview-hover",
             );
             $img.attr(
                 "src",
@@ -144,8 +144,8 @@ export function initialize(): void {
                 return;
             }
             const $img = $(this);
-            $img.closest(".message-media-preview-image, .message-media-inline-image").addClass(
-                "message_inline_animated_image_still",
+            $img.closest(".message-media-preview-image, .message-media-inline-image").removeClass(
+                "animated-preview-hover",
             );
             $img.attr(
                 "src",

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -730,6 +730,25 @@
         }
     }
 
+    /* For the sake of ultra-narrow or ultra-wide
+       animated stills, we want to keep the image
+       area at least as wide and tall as the play
+       button. */
+    .message_inline_animated_image_still {
+        min-width: var(--play-button-length);
+        min-height: var(--play-button-length);
+    }
+
+    /* We add an .animated-preview-hover class to hide
+       the play button and zero its width so the button
+       itself cannot be hovered. Users can still
+       click anywhere on the image to open it in the
+       lightbox. */
+    .message_inline_animated_image_still.animated-preview-hover::after {
+        background-image: none;
+        width: 0;
+    }
+
     .message_inline_video.video-format-unsupported {
         display: none;
     }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -679,6 +679,8 @@
     .message_inline_video,
     .message_inline_animated_image_still,
     .youtube-video .media-anchor-element {
+        /* 32px at 14px/1em */
+        --play-button-length: 2.2857em;
         /* Once collections of thumbnails are set to render as
            flex items, this can be updated to use `display: grid`
            instead of `display: inline-grid`. */
@@ -706,12 +708,11 @@
             background-image: url("../images/play_button.svg");
             background-position: center center;
             background-repeat: no-repeat;
-            /* 32px at 14px/1em */
-            background-size: 2.2857em;
+            background-size: var(--play-button-length);
             /* Match the box to the play button's
                background-size value. */
-            width: 2.2857em;
-            height: 2.2857em;
+            width: var(--play-button-length);
+            height: var(--play-button-length);
             border-radius: 100%;
             transform: scale(0.8);
             transition: transform 0.2s;


### PR DESCRIPTION
This PR corrects an edge-case with animated preview hovers on images that are not part of a gallery (a previously overlooked phenomenon related to our support for true inline images).

Previously, in an effort to hide the play button, we removed the entire `.message_inline_animated_image_still` class while hovering on a preview. That doesn't matter in a gallery setting, where the external layout is managed differently.

But in a non-image-gallery setting, we very much need to preserve the `inline-grid` formatting for placing the button. Otherwise, users will see a layout shift as originally reported in the issue topic linked below.

Additionally, this PR corrects an edge case on very tall/wide images to make sure they're always at least as tall/wide as the play button, which can create other shifts and weird jangy behavior where the shift causes the hover-state to change, and the class to be added and removed infinitely.

<!-- Describe your pull request here.-->

Fixes: [#issues > gif mouseover changes size](https://chat.zulip.org/#narrow/channel/9-issues/topic/gif.20mouseover.20changes.20size/with/2449801)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img alt="preview-hovers-before" src="https://github.com/user-attachments/assets/8cb10f5f-c4b9-4bb6-92ea-36ba60f91055" /> | <img alt="preview-hovers-after" src="https://github.com/user-attachments/assets/092cd2f6-c7dc-4a9b-a96b-5c3df9af0935" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>