### PR TITLE
[ai] user_card: Fix focus-return crash for non-sidebar popovers.

### DIFF
--- a/web/src/channel_folders_popover.ts
+++ b/web/src/channel_folders_popover.ts
@@ -176,8 +176,6 @@ export function initialize(): void {
         },
         {
             also_trigger_on_enter: true,
-            get_focus_return_element: (reference) =>
-                util.the($(reference).siblings(".stream-list-section-toggle")),
         },
     );
 

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -339,6 +339,7 @@ export function initialize(): void {
         {
             ...popover_menus.left_sidebar_tippy_options,
             onMount(instance) {
+                popover_menus.popover_instances.top_left_sidebar = instance;
                 const $popper = $(instance.popper);
 
                 $popper.one(

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -385,8 +385,6 @@ export function initialize(): void {
         },
         {
             also_trigger_on_enter: true,
-            get_focus_return_element: (reference) =>
-                util.the($(reference).siblings(".left-sidebar-navigation-label-container")),
         },
     );
 

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -492,8 +492,13 @@ function show_user_card_popover(
         {
             show_as_overlay_on_mobile: true,
             show_as_overlay_always: show_as_overlay,
-            get_focus_return_element: (reference) =>
-                the($(reference).closest(".user_sidebar_entry").find(".user-presence-link")),
+            get_focus_return_element(reference) {
+                const $entry = $(reference).closest(".user_sidebar_entry");
+                if ($entry.length === 0) {
+                    return undefined;
+                }
+                return the($entry.find(".user-presence-link"));
+            },
         },
     );
 }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -28,8 +28,8 @@
                     <span class="unread_count normal-count"></span>
                 </li>
             </ul>
-            <div class="left-sidebar-navigation-menu-icon">
-                <i class="zulip-icon zulip-icon-more-vertical" aria-label="{{t 'Other views'}}"></i>
+            <div class="left-sidebar-navigation-menu-icon" tabindex="0" role="button" aria-label="{{t 'Other views'}}">
+                <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
             </div>
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">


### PR DESCRIPTION
show_user_card_popover is called from several contexts — the buddy list, message sender headers, @-mentions, and the compose box recipient pills — but only the buddy-list case has a .user_sidebar_entry ancestor. For the others (e.g., clicking a sender's avatar in the message feed), the .closest().find() chain returned an empty jQuery set, and util.the threw "expected only 1 item, got none" when the popover closed.

Return undefined when there's no .user_sidebar_entry, so popover_menus falls back to focusing the reference element itself.
