### PR TITLE
css: Move dark theme input styles to light-dark.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2965,6 +2965,14 @@
         hsl(0deg 0% 90%),
         hsl(0deg 0% 0% / 20%)
     );
+    --color-background-select-option: light-dark(
+        hsl(0deg 0% 100%),
+        var(--color-background)
+    );
+    --color-text-select-option: light-dark(
+        hsl(0deg 0% 14%),
+        hsl(236deg 33% 90%)
+    );
     --color-text-input: light-dark(hsl(0deg 0% 14%), hsl(0deg 0% 95%));
     /* TODO: Light mode uses browser-default white
        backgrounds; we should extend the use of this

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -63,17 +63,6 @@
         opacity: 0.4;
     }
 
-    .popover-filter-input-wrapper .popover-filter-input:focus {
-        background-color: hsl(225deg 6% 7%);
-        border: 1px solid hsl(0deg 0% 100% / 50%);
-        box-shadow: 0 0 5px hsl(0deg 0% 100% / 40%);
-    }
-
-    & select option {
-        background-color: var(--color-background);
-        color: hsl(236deg 33% 90%);
-    }
-
     .pill-container.not-editable-by-user {
         opacity: 0.5;
     }
@@ -87,10 +76,6 @@
             .search_icon {
             opacity: 0.75;
         }
-    }
-
-    textarea.schedule-reminder-note:focus {
-        border-color: hsl(0deg 0% 0% / 90%);
     }
 
     .popover hr,

--- a/web/styles/scheduled_messages.css
+++ b/web/styles/scheduled_messages.css
@@ -39,4 +39,8 @@
     font-size: 1em;
     line-height: var(--base-line-height-unitless);
     font-family: inherit;
+
+    &:focus {
+        border-color: var(--focus-border-color-textarea);
+    }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2194,11 +2194,16 @@ body:not(.spectator-view) {
         margin: 4px 4px 2px;
 
         &:focus {
-            background: hsl(0deg 0% 100%);
-            border: 1px solid hsl(229.09deg 21.57% 10% / 80%);
-            box-shadow: 0 0 6px hsl(228deg 9.8% 20% / 30%);
+            background: var(--color-background-input-focus);
+            border: 1px solid var(--color-outline-input-focus);
+            box-shadow: 0 0 6px var(--color-box-shadow-input-focus);
         }
     }
+}
+
+select option {
+    background-color: var(--color-background-select-option);
+    color: var(--color-text-select-option);
 }
 
 .dropdown-list-container {


### PR DESCRIPTION
PR #34656 introduced shared input styling using `light-dark()`, but a few input-related dark-mode overrides remained in `dark_theme.css`.

This covers three remaining dark-theme overrides:
- `select option` colors now use light/dark CSS variables.
- Popover filter input focus styling now uses the shared input focus variables.
- Scheduled message textarea focus styling now lives with the scheduled message styles.

The dark-theme filter input focus ring changes slightly as a result of using the shared input focus variables rather than the previous hardcoded values. The screenshots below show the difference.

Fixes: part of #35135.

**How changes were tested:**

- Ran `./tools/lint -m`.
- Manually checked popover filter input focus styling in light and dark themes.
- Manually checked scheduled reminder note textarea focus styling in light and dark themes.
- Manually checked select dropdown option styling.

**Screenshots and screen captures:**

<details>
<summary>Popover filter input</summary>

<img width="616" height="939" alt="popover_filter_input_before_after" src="https://github.com/user-attachments/assets/24e06531-d607-4b1b-a6cc-e98f9be7a7a7" />

</details>

<details>
<summary>Scheduled reminder note textarea</summary>

<img width="748" height="747" alt="scheduled_note_textarea_before_after" src="https://github.com/user-attachments/assets/6858dee6-2f87-461e-826a-449cf107dc28" />

</details>

<details>
<summary>Select dropdown</summary>

<img width="616" height="337" alt="select_dropdown_before_after" src="https://github.com/user-attachments/assets/a8742a72-9b4c-4d54-863a-854a7b5c9337" />

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
