### PR TITLE
Fix noreply smtp rejection

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -111,6 +111,20 @@ def is_missed_message_address(address: str) -> bool:
     return is_mm_32_format(msg_string)
 
 
+def is_noreply_address(address: str) -> bool:
+    if address.lower() == settings.NOREPLY_EMAIL_ADDRESS.lower():
+        return True
+
+    if settings.ADD_TOKENS_TO_NOREPLY_ADDRESS:
+        tokenized_noreply_pattern = re.escape(settings.TOKENIZED_NOREPLY_EMAIL_ADDRESS).replace(
+            r"\{token\}", r"[a-z2-7]{24}"
+        )
+        if re.fullmatch(tokenized_noreply_pattern, address, re.IGNORECASE):
+            return True
+
+    return False
+
+
 def is_mm_32_format(msg_string: str | None) -> bool:
     """
     Missed message strings are formatted with a little "mm" prefix

--- a/zerver/lib/email_mirror_server.py
+++ b/zerver/lib/email_mirror_server.py
@@ -22,7 +22,11 @@ from django.core.mail import EmailMultiAlternatives as DjangoEmailMultiAlternati
 from typing_extensions import override
 
 from version import ZULIP_VERSION
-from zerver.lib.email_mirror import decode_stream_email_address, validate_to_address
+from zerver.lib.email_mirror import (
+    decode_stream_email_address,
+    is_noreply_address,
+    validate_to_address,
+)
 from zerver.lib.email_mirror_helpers import (
     ZulipEmailForwardError,
     get_email_gateway_message_string_from_address,
@@ -84,6 +88,10 @@ class ZulipMessageHandler(MessageHandler):
         if address.lower() == "postmaster":
             envelope.rcpt_tos.append("postmaster")
             return "250 Continue"
+
+        # Reject mail to the noreply address.
+        if is_noreply_address(address):
+            return "550 5.1.1 This address is not monitored. Please reply within Zulip."
 
         with suppress(ZulipEmailForwardError):
             if get_email_gateway_message_string_from_address(address).lower() == "postmaster":

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -2146,6 +2146,59 @@ class TestEmailMirrorServer(ZulipTestCase):
             self.assert_length(error_logs.output, 1)
             self.assertTrue("Exception: Some bug" in error_logs.output[0])
 
+    @override_settings(NOREPLY_EMAIL_ADDRESS="noreply@zulip.example.com")
+    async def test_handler_noreply(self) -> None:
+        self.assertEqual(
+            await self.handler_response(
+                [
+                    "HELO localhost",
+                    "MAIL FROM: <test@example.com>",
+                    "RCPT TO: <noreply@zulip.example.com>",
+                    "QUIT",
+                ]
+            ),
+            [
+                "220 testhost Zulip 1.2.3\r\n",
+                "250 testhost\r\n",
+                "250 OK\r\n",
+                "550 5.1.1 This address is not monitored. Please reply within Zulip.\r\n",
+                "221 Bye\r\n",
+            ],
+        )
+
+    @override_settings(
+        NOREPLY_EMAIL_ADDRESS="noreply@zulip.example.com",
+        TOKENIZED_NOREPLY_EMAIL_ADDRESS="noreply-{token}@zulip.example.com",
+        ADD_TOKENS_TO_NOREPLY_ADDRESS=True,
+    )
+    async def test_handler_tokenized_noreply(self) -> None:
+        # A valid 24-character base32 token (a-z, 2-7)
+        token = (
+            "abc234567890def123456789".replace("0", "2")
+            .replace("1", "3")
+            .replace("8", "4")
+            .replace("9", "5")
+        )
+        # Wait, the regex I used was [a-z2-7]{24}.
+        token = "abcdefghijklmnopqrstuvw2"  # 24 chars
+        self.assertEqual(
+            await self.handler_response(
+                [
+                    "HELO localhost",
+                    "MAIL FROM: <test@example.com>",
+                    f"RCPT TO: <noreply-{token}@zulip.example.com>",
+                    "QUIT",
+                ]
+            ),
+            [
+                "220 testhost Zulip 1.2.3\r\n",
+                "250 testhost\r\n",
+                "250 OK\r\n",
+                "550 5.1.1 This address is not monitored. Please reply within Zulip.\r\n",
+                "221 Bye\r\n",
+            ],
+        )
+
     @override_settings(EMAIL_GATEWAY_PATTERN="%s@zulip.example.com")
     async def test_handler_invalid_domain(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
**email mirror**: Reject replies to **noreply** addresses via SMTP.

Previously, replies sent to generated noreply email
addresses were accepted by the email mirror server
without an immediate **SMTP-level rejection**. This caused
invalid replies to fail later without a clear error
response.

This commit adds explicit SMTP 550 5.1.1 rejection
handling for both plain and tokenized noreply
addresses so invalid replies are rejected during SMTP
processing.

Added **backend tests** covering plain noreply addresses,
tokenized noreply addresses, and SMTP rejection
behavior.

Fixes #5577.

<img width="1345" height="172" alt="Screenshot 2026-05-07 043625" src="https://github.com/user-attachments/assets/5b01fe21-8ba1-4cf3-aefa-d320d89b4549" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
