### PR TITLE
[ai] events: Start migrating call sites to Pydantic event types. 

### DIFF
--- a/zerver/actions/alert_words.py
+++ b/zerver/actions/alert_words.py
@@ -3,12 +3,13 @@ from collections.abc import Iterable, Sequence
 from django.db import transaction
 
 from zerver.lib.alert_words import add_user_alert_words, remove_user_alert_words
+from zerver.lib.event_types import AlertWordsEvent
 from zerver.models import UserProfile
 from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_alert_words(user_profile: UserProfile, words: Sequence[str]) -> None:
-    event = dict(type="alert_words", alert_words=words)
+    event = AlertWordsEvent(alert_words=list(words))
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 

--- a/zerver/actions/bots.py
+++ b/zerver/actions/bots.py
@@ -2,6 +2,14 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.create_user import created_bot_event
+from zerver.lib.event_types import (
+    BotTypeForDelete,
+    BotTypeForUpdate,
+    PersonBotOwnerId,
+    RealmBotDeleteEvent,
+    RealmBotUpdateEvent,
+    RealmUserUpdateEvent,
+)
 from zerver.models import RealmAuditLog, Stream, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.users import active_user_ids, bot_owner_user_ids
@@ -13,25 +21,14 @@ def send_bot_owner_update_events(
 ) -> None:
     # Since `bot_owner_id` is included in the user profile dict we need
     # to update the users dict with the new bot owner id
-    event = dict(
-        type="realm_user",
-        op="update",
-        person=dict(
-            user_id=user_profile.id,
-            bot_owner_id=bot_owner.id,
-        ),
+    event = RealmUserUpdateEvent(
+        person=PersonBotOwnerId(user_id=user_profile.id, bot_owner_id=bot_owner.id),
     )
     send_event_on_commit(user_profile.realm, event, active_user_ids(user_profile.realm_id))
 
     # Delete the bot from previous owner's bot data.
     if previous_owner and not previous_owner.is_realm_admin:
-        delete_event = dict(
-            type="realm_bot",
-            op="delete",
-            bot=dict(
-                user_id=user_profile.id,
-            ),
-        )
+        delete_event = RealmBotDeleteEvent(bot=BotTypeForDelete(user_id=user_profile.id))
         previous_owner_id = previous_owner.id
         send_event_on_commit(
             user_profile.realm,
@@ -94,13 +91,8 @@ def do_change_default_sending_stream(
             stream_name: str | None = stream.name
         else:
             stream_name = None
-        event = dict(
-            type="realm_bot",
-            op="update",
-            bot=dict(
-                user_id=user_profile.id,
-                default_sending_stream=stream_name,
-            ),
+        event = RealmBotUpdateEvent(
+            bot=BotTypeForUpdate(user_id=user_profile.id, default_sending_stream=stream_name),
         )
         send_event_on_commit(
             user_profile.realm,
@@ -136,12 +128,9 @@ def do_change_default_events_register_stream(
         else:
             stream_name = None
 
-        event = dict(
-            type="realm_bot",
-            op="update",
-            bot=dict(
-                user_id=user_profile.id,
-                default_events_register_stream=stream_name,
+        event = RealmBotUpdateEvent(
+            bot=BotTypeForUpdate(
+                user_id=user_profile.id, default_events_register_stream=stream_name
             ),
         )
         send_event_on_commit(
@@ -173,10 +162,8 @@ def do_change_default_all_public_streams(
     )
 
     if user_profile.is_bot:
-        event = dict(
-            type="realm_bot",
-            op="update",
-            bot=dict(
+        event = RealmBotUpdateEvent(
+            bot=BotTypeForUpdate(
                 user_id=user_profile.id,
                 default_all_public_streams=user_profile.default_all_public_streams,
             ),

--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.utils.translation import gettext as _
 
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
+from zerver.lib.event_types import DefaultStreamGroupsEvent, DefaultStreamsEvent, StreamGroup
 from zerver.lib.exceptions import JsonableError
 from zerver.models import DefaultStream, DefaultStreamGroup, Realm, Stream
 from zerver.models.streams import get_default_stream_groups
@@ -50,20 +51,18 @@ def lookup_default_stream_groups(
 
 
 def notify_default_streams(realm: Realm) -> None:
-    event = dict(
-        type="default_streams",
+    event = DefaultStreamsEvent(
         default_streams=list(get_default_stream_ids_for_realm(realm.id)),
     )
     send_event_on_commit(realm, event, active_non_guest_user_ids(realm.id))
 
 
 def notify_default_stream_groups(realm: Realm) -> None:
-    event = dict(
-        type="default_stream_groups",
-        default_stream_groups=default_stream_groups_to_dicts_sorted(
-            get_default_stream_groups(realm)
-        ),
+    default_stream_groups = sorted(
+        (StreamGroup(**group.to_dict()) for group in get_default_stream_groups(realm)),
+        key=lambda group: group.name,
     )
+    event = DefaultStreamGroupsEvent(default_stream_groups=default_stream_groups)
     send_event_on_commit(realm, event, active_non_guest_user_ids(realm.id))
 
 

--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.utils.translation import gettext as _
 
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
+from zerver.lib.event_types import DefaultStreamGroupsEvent, DefaultStreamsEvent, StreamGroup
 from zerver.lib.exceptions import JsonableError
 from zerver.models import DefaultStream, DefaultStreamGroup, Realm, Stream
 from zerver.models.streams import get_default_stream_groups
@@ -50,19 +51,20 @@ def lookup_default_stream_groups(
 
 
 def notify_default_streams(realm: Realm) -> None:
-    event = dict(
-        type="default_streams",
+    event = DefaultStreamsEvent(
         default_streams=list(get_default_stream_ids_for_realm(realm.id)),
     )
     send_event_on_commit(realm, event, active_non_guest_user_ids(realm.id))
 
 
 def notify_default_stream_groups(realm: Realm) -> None:
-    event = dict(
-        type="default_stream_groups",
-        default_stream_groups=default_stream_groups_to_dicts_sorted(
-            get_default_stream_groups(realm)
-        ),
+    event = DefaultStreamGroupsEvent(
+        default_stream_groups=[
+            StreamGroup(**group_dict)
+            for group_dict in default_stream_groups_to_dicts_sorted(
+                get_default_stream_groups(realm)
+            )
+        ],
     )
     send_event_on_commit(realm, event, active_non_guest_user_ids(realm.id))
 

--- a/zerver/actions/devices.py
+++ b/zerver/actions/devices.py
@@ -1,4 +1,5 @@
 from zerver.lib.devices import check_device_id
+from zerver.lib.event_types import DeviceAddEvent, DeviceRemoveEvent
 from zerver.models.devices import Device
 from zerver.models.users import UserProfile
 from zerver.tornado.django_api import send_event_on_commit
@@ -6,11 +7,7 @@ from zerver.tornado.django_api import send_event_on_commit
 
 def do_register_device(user_profile: UserProfile) -> int:
     device = Device.objects.create(user=user_profile)
-    event = dict(
-        type="device",
-        op="add",
-        device_id=device.id,
-    )
+    event = DeviceAddEvent(device_id=device.id)
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
     return device.id
 
@@ -19,9 +16,5 @@ def do_remove_device(user_profile: UserProfile, device_id: int) -> None:
     device = check_device_id(device_id, user_profile.id)
     device.delete()
 
-    event = dict(
-        type="device",
-        op="remove",
-        device_id=device_id,
-    )
+    event = DeviceRemoveEvent(device_id=device_id)
     send_event_on_commit(user_profile.realm, event, [user_profile.id])

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -1,6 +1,5 @@
 import time
 from collections import defaultdict
-from dataclasses import asdict, dataclass, field
 
 from django.db import transaction
 from django.db.models import F
@@ -8,6 +7,12 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from analytics.lib.counts import COUNT_STATS, do_increment_logging_stat
+from zerver.lib.event_types import (
+    BaseEvent,
+    MessageDetails,
+    UpdateMessageFlagsAddEvent,
+    UpdateMessageFlagsRemoveEvent,
+)
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import (
     bulk_access_messages,
@@ -20,16 +25,6 @@ from zerver.lib.topic import filter_by_topic_name_via_message
 from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.models import Device, Message, PushDeviceToken, Recipient, UserMessage, UserProfile
 from zerver.tornado.django_api import send_event_on_commit, send_event_rollback_unsafe
-
-
-@dataclass
-class ReadMessagesEvent:
-    messages: list[int]
-    all: bool
-    type: str = field(default="update_message_flags", init=False)
-    op: str = field(default="add", init=False)
-    operation: str = field(default="add", init=False)
-    flag: str = field(default="read", init=False)
 
 
 def do_mark_all_as_read(user_profile: UserProfile, *, timeout: float | None = None) -> int | None:
@@ -89,11 +84,11 @@ def do_mark_all_as_read(user_profile: UserProfile, *, timeout: float | None = No
             if updated_count < batch_size:
                 break
 
-    event = asdict(
-        ReadMessagesEvent(
-            messages=[],  # we don't send messages, since the client reloads anyway
-            all=True,
-        )
+    event = UpdateMessageFlagsAddEvent(
+        flag="read",
+        # Empty list because the client reloads anyway.
+        messages=[],
+        all=True,
     )
     send_event_rollback_unsafe(user_profile.realm, event, [user_profile.id])
 
@@ -130,12 +125,7 @@ def do_mark_stream_messages_as_read(
         flags=F("flags").bitor(UserMessage.flags.read),
     )
 
-    event = asdict(
-        ReadMessagesEvent(
-            messages=message_ids,
-            all=False,
-        )
-    )
+    event = UpdateMessageFlagsAddEvent(flag="read", messages=message_ids, all=False)
     event_time = timezone_now()
 
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
@@ -173,12 +163,7 @@ def do_mark_muted_user_messages_as_read(
         flags=F("flags").bitor(UserMessage.flags.read),
     )
 
-    event = asdict(
-        ReadMessagesEvent(
-            messages=message_ids,
-            all=False,
-        )
-    )
+    event = UpdateMessageFlagsAddEvent(flag="read", messages=message_ids, all=False)
     event_time = timezone_now()
 
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
@@ -416,24 +401,26 @@ def do_update_message_flags(
         else:
             to_update.update(flags=F("flags").bitand(~flagattr))
 
-        event = {
-            "type": "update_message_flags",
-            "op": operation,
-            "operation": operation,
-            "flag": flag,
-            "messages": messages,
-            "all": False,
-        }
-
-        if flag == "read" and not is_adding:
+        event: BaseEvent
+        if is_adding:
+            event = UpdateMessageFlagsAddEvent(flag=flag, messages=messages, all=False)
+        elif flag == "read":
             # When removing the read flag (i.e. marking messages as
             # unread), extend the event with an additional object with
             # details on the messages required to update the client's
             # `unread_msgs` data structure.
             raw_unread_data = get_raw_unread_data(user_profile, messages)
-            event["message_details"] = format_unread_message_details(
-                user_profile.id, raw_unread_data
+            message_details = {
+                message_id: MessageDetails(**details)
+                for message_id, details in format_unread_message_details(
+                    user_profile.id, raw_unread_data
+                ).items()
+            }
+            event = UpdateMessageFlagsRemoveEvent(
+                flag=flag, messages=messages, all=False, message_details=message_details
             )
+        else:
+            event = UpdateMessageFlagsRemoveEvent(flag=flag, messages=messages, all=False)
 
         send_event_on_commit(user_profile.realm, event, [user_profile.id])
 

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -1,6 +1,5 @@
 import time
 from collections import defaultdict
-from dataclasses import asdict, dataclass, field
 
 from django.db import transaction
 from django.db.models import F
@@ -8,6 +7,11 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from analytics.lib.counts import COUNT_STATS, do_increment_logging_stat
+from zerver.lib.event_types import (
+    BaseEvent,
+    UpdateMessageFlagsAddEvent,
+    UpdateMessageFlagsRemoveEvent,
+)
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import (
     bulk_access_messages,
@@ -20,16 +24,6 @@ from zerver.lib.topic import filter_by_topic_name_via_message
 from zerver.lib.user_message import DEFAULT_HISTORICAL_FLAGS, create_historical_user_messages
 from zerver.models import Device, Message, PushDeviceToken, Recipient, UserMessage, UserProfile
 from zerver.tornado.django_api import send_event_on_commit, send_event_rollback_unsafe
-
-
-@dataclass
-class ReadMessagesEvent:
-    messages: list[int]
-    all: bool
-    type: str = field(default="update_message_flags", init=False)
-    op: str = field(default="add", init=False)
-    operation: str = field(default="add", init=False)
-    flag: str = field(default="read", init=False)
 
 
 def do_mark_all_as_read(user_profile: UserProfile, *, timeout: float | None = None) -> int | None:
@@ -89,11 +83,11 @@ def do_mark_all_as_read(user_profile: UserProfile, *, timeout: float | None = No
             if updated_count < batch_size:
                 break
 
-    event = asdict(
-        ReadMessagesEvent(
-            messages=[],  # we don't send messages, since the client reloads anyway
-            all=True,
-        )
+    event = UpdateMessageFlagsAddEvent(
+        flag="read",
+        # Empty list because the client reloads anyway.
+        messages=[],
+        all=True,
     )
     send_event_rollback_unsafe(user_profile.realm, event, [user_profile.id])
 
@@ -130,12 +124,7 @@ def do_mark_stream_messages_as_read(
         flags=F("flags").bitor(UserMessage.flags.read),
     )
 
-    event = asdict(
-        ReadMessagesEvent(
-            messages=message_ids,
-            all=False,
-        )
-    )
+    event = UpdateMessageFlagsAddEvent(flag="read", messages=message_ids, all=False)
     event_time = timezone_now()
 
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
@@ -179,12 +168,7 @@ def do_mark_muted_user_messages_as_read(
         flags=F("flags").bitor(UserMessage.flags.read),
     )
 
-    event = asdict(
-        ReadMessagesEvent(
-            messages=message_ids,
-            all=False,
-        )
-    )
+    event = UpdateMessageFlagsAddEvent(flag="read", messages=message_ids, all=False)
     event_time = timezone_now()
 
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
@@ -422,24 +406,23 @@ def do_update_message_flags(
         else:
             to_update.update(flags=F("flags").bitand(~flagattr))
 
-        event = {
-            "type": "update_message_flags",
-            "op": operation,
-            "operation": operation,
-            "flag": flag,
-            "messages": messages,
-            "all": False,
-        }
-
-        if flag == "read" and not is_adding:
+        event: BaseEvent
+        if is_adding:
+            event = UpdateMessageFlagsAddEvent(flag=flag, messages=messages, all=False)
+        elif flag == "read":
             # When removing the read flag (i.e. marking messages as
             # unread), extend the event with an additional object with
             # details on the messages required to update the client's
             # `unread_msgs` data structure.
             raw_unread_data = get_raw_unread_data(user_profile, messages)
-            event["message_details"] = format_unread_message_details(
-                user_profile.id, raw_unread_data
+            event = UpdateMessageFlagsRemoveEvent(
+                flag=flag,
+                messages=messages,
+                all=False,
+                message_details=format_unread_message_details(user_profile.id, raw_unread_data),
             )
+        else:
+            event = UpdateMessageFlagsRemoveEvent(flag=flag, messages=messages, all=False)
 
         send_event_on_commit(user_profile.realm, event, [user_profile.id])
 

--- a/zerver/actions/muted_users.py
+++ b/zerver/actions/muted_users.py
@@ -4,6 +4,8 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.message_flags import do_mark_muted_user_messages_as_read
+from zerver.lib.event_types import MutedUser as MutedUserData
+from zerver.lib.event_types import MutedUsersEvent
 from zerver.lib.muted_users import add_user_mute, get_user_mutes
 from zerver.models import MutedUser, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
@@ -20,7 +22,9 @@ def do_mute_user(
         date_muted = timezone_now()
     add_user_mute(user_profile, muted_user, date_muted)
     do_mark_muted_user_messages_as_read(user_profile, muted_user)
-    event = dict(type="muted_users", muted_users=get_user_mutes(user_profile))
+    event = MutedUsersEvent(
+        muted_users=[MutedUserData(**m) for m in get_user_mutes(user_profile)],
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
     RealmAuditLog.objects.create(
@@ -38,7 +42,9 @@ def do_unmute_user(mute_object: MutedUser) -> None:
     user_profile = mute_object.user_profile
     muted_user = mute_object.muted_user
     mute_object.delete()
-    event = dict(type="muted_users", muted_users=get_user_mutes(user_profile))
+    event = MutedUsersEvent(
+        muted_users=[MutedUserData(**m) for m in get_user_mutes(user_profile)],
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
     RealmAuditLog.objects.create(

--- a/zerver/actions/muted_users.py
+++ b/zerver/actions/muted_users.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.message_flags import do_mark_muted_user_messages_as_read
+from zerver.lib.event_types import MutedUsersEvent
 from zerver.lib.muted_users import add_user_mute, get_user_mutes
 from zerver.models import MutedUser, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
@@ -20,7 +21,7 @@ def do_mute_user(
         date_muted = timezone_now()
     add_user_mute(user_profile, muted_user, date_muted)
     do_mark_muted_user_messages_as_read(user_profile, muted_user)
-    event = dict(type="muted_users", muted_users=get_user_mutes(user_profile))
+    event = MutedUsersEvent(muted_users=get_user_mutes(user_profile))
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
     RealmAuditLog.objects.create(
@@ -38,7 +39,7 @@ def do_unmute_user(mute_object: MutedUser) -> None:
     user_profile = mute_object.user_profile
     muted_user = mute_object.muted_user
     mute_object.delete()
-    event = dict(type="muted_users", muted_users=get_user_mutes(user_profile))
+    event = MutedUsersEvent(muted_users=get_user_mutes(user_profile))
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
     RealmAuditLog.objects.create(

--- a/zerver/actions/navigation_views.py
+++ b/zerver/actions/navigation_views.py
@@ -1,6 +1,15 @@
+from typing import Any
+
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import (
+    NavigationViewAddEvent,
+    NavigationViewFields,
+    NavigationViewFieldsForUpdate,
+    NavigationViewRemoveEvent,
+    NavigationViewUpdateEvent,
+)
 from zerver.lib.navigation_views import get_navigation_view_dict
 from zerver.models import NavigationView, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
@@ -30,11 +39,9 @@ def do_add_navigation_view(
         extra_data={"fragment": fragment},
     )
 
-    event = {
-        "type": "navigation_view",
-        "op": "add",
-        "navigation_view": get_navigation_view_dict(navigation_view),
-    }
+    event = NavigationViewAddEvent(
+        navigation_view=NavigationViewFields(**get_navigation_view_dict(navigation_view)),
+    )
     send_event_on_commit(user.realm, event, [user.id])
     return navigation_view
 
@@ -46,12 +53,15 @@ def do_update_navigation_view(
     is_pinned: bool | None,
     name: str | None = None,
 ) -> None:
-    update_dict: dict[str, str | bool] = {}
+    # Only the fields the caller actually updated flow through to the
+    # event's data payload, so the serialized event omits keys for
+    # unchanged values (matching the legacy dict-based behavior).
+    update_kwargs: dict[str, Any] = {}
     audit_logs_extra_data: list[dict[str, str | bool | None]] = []
     if name is not None:
         old_name = navigation_view.name
         navigation_view.name = name
-        update_dict["name"] = name
+        update_kwargs["name"] = name
         audit_logs_extra_data.append(
             {
                 "fragment": navigation_view.fragment,
@@ -64,7 +74,7 @@ def do_update_navigation_view(
     if is_pinned is not None:
         old_is_pinned_value = navigation_view.is_pinned
         navigation_view.is_pinned = is_pinned
-        update_dict["is_pinned"] = is_pinned
+        update_kwargs["is_pinned"] = is_pinned
         audit_logs_extra_data.append(
             {
                 "fragment": navigation_view.fragment,
@@ -87,12 +97,10 @@ def do_update_navigation_view(
             extra_data=audit_log_extra_data,
         )
 
-    event = {
-        "type": "navigation_view",
-        "op": "update",
-        "fragment": navigation_view.fragment,
-        "data": update_dict,
-    }
+    event = NavigationViewUpdateEvent(
+        fragment=navigation_view.fragment,
+        data=NavigationViewFieldsForUpdate(**update_kwargs),
+    )
     send_event_on_commit(user.realm, event, [user.id])
 
 
@@ -113,9 +121,5 @@ def do_remove_navigation_view(
         extra_data={"fragment": fragment},
     )
 
-    event = {
-        "type": "navigation_view",
-        "op": "remove",
-        "fragment": navigation_view.fragment,
-    }
+    event = NavigationViewRemoveEvent(fragment=navigation_view.fragment)
     send_event_on_commit(user.realm, event, [user.id])

--- a/zerver/actions/navigation_views.py
+++ b/zerver/actions/navigation_views.py
@@ -1,10 +1,24 @@
+from typing import TypedDict
+
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import (
+    NavigationViewAddEvent,
+    NavigationViewFields,
+    NavigationViewFieldsForUpdate,
+    NavigationViewRemoveEvent,
+    NavigationViewUpdateEvent,
+)
 from zerver.lib.navigation_views import get_navigation_view_dict
 from zerver.models import NavigationView, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.tornado.django_api import send_event_on_commit
+
+
+class NavigationViewUpdateDict(TypedDict, total=False):
+    name: str
+    is_pinned: bool
 
 
 @transaction.atomic(durable=True)
@@ -30,11 +44,9 @@ def do_add_navigation_view(
         extra_data={"fragment": fragment},
     )
 
-    event = {
-        "type": "navigation_view",
-        "op": "add",
-        "navigation_view": get_navigation_view_dict(navigation_view),
-    }
+    event = NavigationViewAddEvent(
+        navigation_view=NavigationViewFields(**get_navigation_view_dict(navigation_view)),
+    )
     send_event_on_commit(user.realm, event, [user.id])
     return navigation_view
 
@@ -46,7 +58,10 @@ def do_update_navigation_view(
     is_pinned: bool | None,
     name: str | None = None,
 ) -> None:
-    update_dict: dict[str, str | bool] = {}
+    # Only the fields the caller actually updated flow through to the
+    # event's data payload, so the serialized event omits keys for
+    # unchanged values (matching the legacy dict-based behavior).
+    update_dict: NavigationViewUpdateDict = {}
     audit_logs_extra_data: list[dict[str, str | bool | None]] = []
     if name is not None:
         old_name = navigation_view.name
@@ -87,12 +102,10 @@ def do_update_navigation_view(
             extra_data=audit_log_extra_data,
         )
 
-    event = {
-        "type": "navigation_view",
-        "op": "update",
-        "fragment": navigation_view.fragment,
-        "data": update_dict,
-    }
+    event = NavigationViewUpdateEvent(
+        fragment=navigation_view.fragment,
+        data=NavigationViewFieldsForUpdate(**update_dict),
+    )
     send_event_on_commit(user.realm, event, [user.id])
 
 
@@ -113,9 +126,5 @@ def do_remove_navigation_view(
         extra_data={"fragment": fragment},
     )
 
-    event = {
-        "type": "navigation_view",
-        "op": "remove",
-        "fragment": navigation_view.fragment,
-    }
+    event = NavigationViewRemoveEvent(fragment=navigation_view.fragment)
     send_event_on_commit(user.realm, event, [user.id])

--- a/zerver/actions/onboarding_steps.py
+++ b/zerver/actions/onboarding_steps.py
@@ -1,7 +1,6 @@
-from dataclasses import asdict
-
 from django.db import transaction
 
+from zerver.lib.event_types import OnboardingSteps, OnboardingStepsEvent
 from zerver.lib.onboarding_steps import get_next_onboarding_steps
 from zerver.models import OnboardingStep, UserProfile
 from zerver.tornado.django_api import send_event_on_commit
@@ -10,8 +9,10 @@ from zerver.tornado.django_api import send_event_on_commit
 @transaction.atomic(durable=True)
 def do_mark_onboarding_step_as_read(user: UserProfile, onboarding_step: str) -> None:
     OnboardingStep.objects.get_or_create(user=user, onboarding_step=onboarding_step)
-    event = dict(
-        type="onboarding_steps",
-        onboarding_steps=[asdict(step) for step in get_next_onboarding_steps(user)],
+    event = OnboardingStepsEvent(
+        onboarding_steps=[
+            OnboardingSteps(type=step.type, name=step.name)
+            for step in get_next_onboarding_steps(user)
+        ],
     )
     send_event_on_commit(user.realm, event, [user.id])

--- a/zerver/actions/push_notifications.py
+++ b/zerver/actions/push_notifications.py
@@ -1,5 +1,6 @@
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import DeviceUpdateEvent
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import UserProfile
 from zerver.models.devices import Device
@@ -34,9 +35,7 @@ def do_register_push_device(
         ]
     )
 
-    event = dict(
-        type="device",
-        op="update",
+    event = DeviceUpdateEvent(
         device_id=device.id,
         push_key_id=device.push_key_id,
         pending_push_token_id=token_id_base64,
@@ -60,12 +59,7 @@ def do_rotate_push_key(
     device.push_key_id = push_key_id
     device.save(update_fields=["push_key", "push_key_id"])
 
-    event = dict(
-        type="device",
-        op="update",
-        device_id=device.id,
-        push_key_id=device.push_key_id,
-    )
+    event = DeviceUpdateEvent(device_id=device.id, push_key_id=device.push_key_id)
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
@@ -83,9 +77,7 @@ def do_rotate_token(
             "push_registration_error_code",
         ]
     )
-    event = dict(
-        type="device",
-        op="update",
+    event = DeviceUpdateEvent(
         device_id=device.id,
         pending_push_token_id=token_id_base64,
         push_token_last_updated_timestamp=datetime_to_timestamp(token_updated_at),

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -1,9 +1,8 @@
-from typing import Literal
-
-from typing_extensions import TypedDict
+from typing import Literal, cast
 
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.emoji import check_emoji_request, get_emoji_data
+from zerver.lib.event_types import BaseEvent, ReactionAddEvent, ReactionRemoveEvent
 from zerver.lib.exceptions import ReactionExistsError
 from zerver.lib.message import (
     access_message_and_usermessage,
@@ -19,31 +18,34 @@ from zerver.models import Message, Reaction, UserProfile
 from zerver.tornado.django_api import send_event_on_commit
 
 
-class ReactionEvent(TypedDict):
-    type: Literal["reaction"]
-    op: Literal["add", "remove"]
-    user_id: int
-    message_id: int
-    emoji_name: str
-    emoji_code: str
-    reaction_type: str
-
-
 def notify_reaction_update(
     user_profile: UserProfile,
     message: Message,
     reaction: Reaction,
     op: Literal["add", "remove"],
 ) -> None:
-    event: ReactionEvent = {
-        "type": "reaction",
-        "op": op,
-        "user_id": user_profile.id,
-        "message_id": message.id,
-        "emoji_name": reaction.emoji_name,
-        "emoji_code": reaction.emoji_code,
-        "reaction_type": reaction.reaction_type,
-    }
+    # The reaction_type column is a CharField restricted to these
+    # values via choices, so the cast is safe.
+    reaction_type = cast(
+        Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"], reaction.reaction_type
+    )
+    event: BaseEvent
+    if op == "add":
+        event = ReactionAddEvent(
+            user_id=user_profile.id,
+            message_id=message.id,
+            emoji_name=reaction.emoji_name,
+            emoji_code=reaction.emoji_code,
+            reaction_type=reaction_type,
+        )
+    else:
+        event = ReactionRemoveEvent(
+            user_id=user_profile.id,
+            message_id=message.id,
+            emoji_name=reaction.emoji_name,
+            emoji_code=reaction.emoji_code,
+            reaction_type=reaction_type,
+        )
 
     # Update the cached message since new reaction is added.
     update_message_cache([message])

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -1,9 +1,8 @@
-from typing import Literal
-
-from typing_extensions import TypedDict
+from typing import Literal, cast
 
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.emoji import check_emoji_request, get_emoji_data
+from zerver.lib.event_types import BaseEvent, ReactionAddEvent, ReactionRemoveEvent, ReactionType
 from zerver.lib.exceptions import ReactionExistsError
 from zerver.lib.message import (
     access_message_and_usermessage,
@@ -19,31 +18,32 @@ from zerver.models import Message, Reaction, UserProfile
 from zerver.tornado.django_api import send_event_on_commit
 
 
-class ReactionEvent(TypedDict):
-    type: Literal["reaction"]
-    op: Literal["add", "remove"]
-    user_id: int
-    message_id: int
-    emoji_name: str
-    emoji_code: str
-    reaction_type: str
-
-
 def notify_reaction_update(
     user_profile: UserProfile,
     message: Message,
     reaction: Reaction,
     op: Literal["add", "remove"],
 ) -> None:
-    event: ReactionEvent = {
-        "type": "reaction",
-        "op": op,
-        "user_id": user_profile.id,
-        "message_id": message.id,
-        "emoji_name": reaction.emoji_name,
-        "emoji_code": reaction.emoji_code,
-        "reaction_type": reaction.reaction_type,
-    }
+    # The reaction_type column is a CharField restricted to these
+    # values via choices, so the cast is safe.
+    reaction_type = cast(ReactionType, reaction.reaction_type)
+    event: BaseEvent
+    if op == "add":
+        event = ReactionAddEvent(
+            user_id=user_profile.id,
+            message_id=message.id,
+            emoji_name=reaction.emoji_name,
+            emoji_code=reaction.emoji_code,
+            reaction_type=reaction_type,
+        )
+    else:
+        event = ReactionRemoveEvent(
+            user_id=user_profile.id,
+            message_id=message.id,
+            emoji_name=reaction.emoji_name,
+            emoji_code=reaction.emoji_code,
+            reaction_type=reaction_type,
+        )
 
     # Update the cached message since new reaction is added.
     update_message_cache([message])

--- a/zerver/actions/realm_domains.py
+++ b/zerver/actions/realm_domains.py
@@ -2,6 +2,12 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.realm_settings import do_set_realm_property
+from zerver.lib.event_types import RealmDomain as RealmDomainData
+from zerver.lib.event_types import (
+    RealmDomainsAddEvent,
+    RealmDomainsChangeEvent,
+    RealmDomainsRemoveEvent,
+)
 from zerver.models import Realm, RealmAuditLog, RealmDomain, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.realms import RealmDomainDict, get_realm_domains
@@ -29,10 +35,8 @@ def do_add_realm_domain(
         },
     )
 
-    event = dict(
-        type="realm_domains",
-        op="add",
-        realm_domain=RealmDomainDict(
+    event = RealmDomainsAddEvent(
+        realm_domain=RealmDomainData(
             domain=realm_domain.domain, allow_subdomains=realm_domain.allow_subdomains
         ),
     )
@@ -63,10 +67,8 @@ def do_change_realm_domain(
         },
     )
 
-    event = dict(
-        type="realm_domains",
-        op="change",
-        realm_domain=dict(
+    event = RealmDomainsChangeEvent(
+        realm_domain=RealmDomainData(
             domain=realm_domain.domain, allow_subdomains=realm_domain.allow_subdomains
         ),
     )
@@ -100,5 +102,5 @@ def do_remove_realm_domain(realm_domain: RealmDomain, *, acting_user: UserProfil
         # anything if there are no domains, and this is probably less
         # confusing than the alternative.
         do_set_realm_property(realm, "emails_restricted_to_domains", False, acting_user=acting_user)
-    event = dict(type="realm_domains", op="remove", domain=domain)
+    event = RealmDomainsRemoveEvent(domain=domain)
     send_event_on_commit(realm, event, active_user_ids(realm.id))

--- a/zerver/actions/realm_export.py
+++ b/zerver/actions/realm_export.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import Export, RealmExportEvent
 from zerver.lib.export import get_realm_exports_serialized
 from zerver.lib.upload import delete_export_tarball
 from zerver.models import Realm, RealmAuditLog, RealmExport, UserProfile
@@ -9,7 +10,9 @@ from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_realm_export(realm: Realm) -> None:
-    event = dict(type="realm_export", exports=get_realm_exports_serialized(realm))
+    event = RealmExportEvent(
+        exports=[Export(**export) for export in get_realm_exports_serialized(realm)],
+    )
     send_event_on_commit(realm, event, realm.get_human_admin_users().values_list("id", flat=True))
 
 

--- a/zerver/actions/realm_icon.py
+++ b/zerver/actions/realm_icon.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import IconData, RealmUpdateDictEvent
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.models import Realm, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
@@ -25,11 +26,9 @@ def do_change_icon_source(
         acting_user=acting_user,
     )
 
-    event = dict(
-        type="realm",
-        op="update_dict",
+    event = RealmUpdateDictEvent(
         property="icon",
-        data=dict(icon_source=realm.icon_source, icon_url=realm_icon_url(realm)),
+        data=IconData(icon_source=realm.icon_source, icon_url=realm_icon_url(realm)),
     )
     send_event_on_commit(
         realm,

--- a/zerver/actions/realm_linkifiers.py
+++ b/zerver/actions/realm_linkifiers.py
@@ -3,6 +3,7 @@ from django.db.models import Max
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
+from zerver.lib.event_types import RealmLinkifier, RealmLinkifiersEvent
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.types import LinkifierDict
 from zerver.models import Realm, RealmAuditLog, RealmFilter, UserProfile
@@ -13,7 +14,9 @@ from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_linkifiers(realm: Realm, realm_linkifiers: list[LinkifierDict]) -> None:
-    event: dict[str, object] = dict(type="realm_linkifiers", realm_linkifiers=realm_linkifiers)
+    event = RealmLinkifiersEvent(
+        realm_linkifiers=[RealmLinkifier(**linkifier) for linkifier in realm_linkifiers],
+    )
     send_event_on_commit(realm, event, active_user_ids(realm.id))
 
 

--- a/zerver/actions/realm_linkifiers.py
+++ b/zerver/actions/realm_linkifiers.py
@@ -3,6 +3,8 @@ from django.db.models import Max
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
+from zerver.lib.event_types import RealmLinkifier as RealmLinkifierData
+from zerver.lib.event_types import RealmLinkifiersEvent
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.types import LinkifierDict
 from zerver.models import Realm, RealmAuditLog, RealmFilter, UserProfile
@@ -13,7 +15,9 @@ from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_linkifiers(realm: Realm, realm_linkifiers: list[LinkifierDict]) -> None:
-    event: dict[str, object] = dict(type="realm_linkifiers", realm_linkifiers=realm_linkifiers)
+    event = RealmLinkifiersEvent(
+        realm_linkifiers=[RealmLinkifierData(**linkifier) for linkifier in realm_linkifiers],
+    )
     send_event_on_commit(realm, event, active_user_ids(realm.id))
 
 

--- a/zerver/actions/realm_logo.py
+++ b/zerver/actions/realm_logo.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import RealmUpdateDictEvent
 from zerver.lib.realm_logo import get_realm_logo_data
 from zerver.models import Realm, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
@@ -29,9 +30,7 @@ def do_change_logo_source(
         acting_user=acting_user,
     )
 
-    event = dict(
-        type="realm",
-        op="update_dict",
+    event = RealmUpdateDictEvent(
         property="night_logo" if night else "logo",
         data=get_realm_logo_data(realm, night),
     )

--- a/zerver/actions/realm_playgrounds.py
+++ b/zerver/actions/realm_playgrounds.py
@@ -2,6 +2,8 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import RealmPlayground as RealmPlaygroundData
+from zerver.lib.event_types import RealmPlaygroundsEvent
 from zerver.lib.exceptions import ValidationFailureError
 from zerver.lib.types import RealmPlaygroundDict
 from zerver.models import Realm, RealmAuditLog, RealmPlayground, UserProfile
@@ -12,7 +14,9 @@ from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_realm_playgrounds(realm: Realm, realm_playgrounds: list[RealmPlaygroundDict]) -> None:
-    event = dict(type="realm_playgrounds", realm_playgrounds=realm_playgrounds)
+    event = RealmPlaygroundsEvent(
+        realm_playgrounds=[RealmPlaygroundData(**p) for p in realm_playgrounds],
+    )
     send_event_on_commit(realm, event, active_user_ids(realm.id))
 
 

--- a/zerver/actions/saved_snippets.py
+++ b/zerver/actions/saved_snippets.py
@@ -4,6 +4,12 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
+from zerver.lib.event_types import (
+    SavedSnippetFields,
+    SavedSnippetsAddEvent,
+    SavedSnippetsRemoveEvent,
+    SavedSnippetsUpdateEvent,
+)
 from zerver.lib.exceptions import ResourceNotFoundError
 from zerver.models import RealmAuditLog, SavedSnippet, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
@@ -32,11 +38,9 @@ def do_create_saved_snippet(
         extra_data={"saved_snippet_id": saved_snippet.id},
     )
 
-    event = {
-        "type": "saved_snippets",
-        "op": "add",
-        "saved_snippet": saved_snippet.to_api_dict(),
-    }
+    event = SavedSnippetsAddEvent(
+        saved_snippet=SavedSnippetFields(**saved_snippet.to_api_dict()),
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
     return saved_snippet
@@ -61,11 +65,9 @@ def do_edit_saved_snippet(
     with transaction.atomic(durable=True):
         saved_snippet.save()
 
-        event = {
-            "type": "saved_snippets",
-            "op": "update",
-            "saved_snippet": saved_snippet.to_api_dict(),
-        }
+        event = SavedSnippetsUpdateEvent(
+            saved_snippet=SavedSnippetFields(**saved_snippet.to_api_dict()),
+        )
         send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
     return saved_snippet
@@ -87,5 +89,5 @@ def do_delete_saved_snippet(
         raise ResourceNotFoundError(_("Saved snippet does not exist."))
     saved_snippet.delete()
 
-    event = {"type": "saved_snippets", "op": "remove", "saved_snippet_id": saved_snippet_id}
+    event = SavedSnippetsRemoveEvent(saved_snippet_id=saved_snippet_id)
     send_event_on_commit(user_profile.realm, event, [user_profile.id])

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -16,6 +16,14 @@ from zerver.actions.message_send import (
 from zerver.actions.uploads import check_attachment_reference_change, do_claim_attachments
 from zerver.lib.addressee import Addressee
 from zerver.lib.display_recipient import get_recipient_ids
+from zerver.lib.event_types import (
+    ReminderFields,
+    RemindersAddEvent,
+    ScheduledMessageFields,
+    ScheduledMessagesAddEvent,
+    ScheduledMessagesRemoveEvent,
+    ScheduledMessagesUpdateEvent,
+)
 from zerver.lib.exceptions import (
     DeliveryTimeNotInFutureError,
     JsonableError,
@@ -78,22 +86,19 @@ def check_schedule_message(
 def notify_new_scheduled_message(
     user_profile: UserProfile, scheduled_messages: list[ScheduledMessage]
 ) -> None:
-    event = {
-        "type": "scheduled_messages",
-        "op": "add",
-        "scheduled_messages": [
-            scheduled_message.to_dict() for scheduled_message in scheduled_messages
+    event = ScheduledMessagesAddEvent(
+        scheduled_messages=[
+            ScheduledMessageFields(**scheduled_message.to_dict())
+            for scheduled_message in scheduled_messages
         ],
-    }
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
 def notify_new_reminder(user_profile: UserProfile, reminders: list[ScheduledMessage]) -> None:
-    event = {
-        "type": "reminders",
-        "op": "add",
-        "reminders": [reminder.to_reminder_dict() for reminder in reminders],
-    }
+    event = RemindersAddEvent(
+        reminders=[ReminderFields(**reminder.to_reminder_dict()) for reminder in reminders],
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
@@ -152,11 +157,9 @@ def do_schedule_messages(
 def notify_update_scheduled_message(
     user_profile: UserProfile, scheduled_message: ScheduledMessage
 ) -> None:
-    event = {
-        "type": "scheduled_messages",
-        "op": "update",
-        "scheduled_message": scheduled_message.to_dict(),
-    }
+    event = ScheduledMessagesUpdateEvent(
+        scheduled_message=ScheduledMessageFields(**scheduled_message.to_dict()),
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
@@ -280,11 +283,7 @@ def edit_scheduled_message(
 
 
 def notify_remove_scheduled_message(user_profile: UserProfile, scheduled_message_id: int) -> None:
-    event = {
-        "type": "scheduled_messages",
-        "op": "remove",
-        "scheduled_message_id": scheduled_message_id,
-    }
+    event = ScheduledMessagesRemoveEvent(scheduled_message_id=scheduled_message_id)
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -16,6 +16,14 @@ from zerver.actions.message_send import (
 from zerver.actions.uploads import check_attachment_reference_change, do_claim_attachments
 from zerver.lib.addressee import Addressee
 from zerver.lib.display_recipient import get_recipient_ids
+from zerver.lib.event_types import (
+    ReminderFields,
+    RemindersAddEvent,
+    ScheduledMessageFields,
+    ScheduledMessagesAddEvent,
+    ScheduledMessagesRemoveEvent,
+    ScheduledMessagesUpdateEvent,
+)
 from zerver.lib.exceptions import (
     DeliveryTimeNotInFutureError,
     JsonableError,
@@ -78,22 +86,19 @@ def check_schedule_message(
 def notify_new_scheduled_message(
     user_profile: UserProfile, scheduled_messages: list[ScheduledMessage]
 ) -> None:
-    event = {
-        "type": "scheduled_messages",
-        "op": "add",
-        "scheduled_messages": [
-            scheduled_message.to_dict() for scheduled_message in scheduled_messages
+    event = ScheduledMessagesAddEvent(
+        scheduled_messages=[
+            ScheduledMessageFields(**scheduled_message.to_dict())
+            for scheduled_message in scheduled_messages
         ],
-    }
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
 def notify_new_reminder(user_profile: UserProfile, reminders: list[ScheduledMessage]) -> None:
-    event = {
-        "type": "reminders",
-        "op": "add",
-        "reminders": [reminder.to_reminder_dict() for reminder in reminders],
-    }
+    event = RemindersAddEvent(
+        reminders=[ReminderFields(**reminder.to_reminder_dict()) for reminder in reminders],
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
@@ -152,11 +157,9 @@ def do_schedule_messages(
 def notify_update_scheduled_message(
     user_profile: UserProfile, scheduled_message: ScheduledMessage
 ) -> None:
-    event = {
-        "type": "scheduled_messages",
-        "op": "update",
-        "scheduled_message": scheduled_message.to_dict(),
-    }
+    event = ScheduledMessagesUpdateEvent(
+        scheduled_message=ScheduledMessageFields(**scheduled_message.to_dict()),
+    )
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
@@ -283,11 +286,7 @@ def edit_scheduled_message(
 
 
 def notify_remove_scheduled_message(user_profile: UserProfile, scheduled_message_id: int) -> None:
-    event = {
-        "type": "scheduled_messages",
-        "op": "remove",
-        "scheduled_message_id": scheduled_message_id,
-    }
+    event = ScheduledMessagesRemoveEvent(scheduled_message_id=scheduled_message_id)
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 

--- a/zerver/actions/submessage.py
+++ b/zerver/actions/submessage.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext as _
 
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
+from zerver.lib.event_types import SubmessageEvent
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import (
     event_recipient_ids_for_action_on_messages,
@@ -83,8 +84,7 @@ def do_add_submessage(
                     visibility_policy=new_visibility_policy,
                 )
 
-    event = dict(
-        type="submessage",
+    event = SubmessageEvent(
         msg_type=msg_type,
         message_id=message_id,
         submessage_id=submessage.id,

--- a/zerver/actions/typing.py
+++ b/zerver/actions/typing.py
@@ -3,6 +3,16 @@ from typing import Literal
 from django.conf import settings
 from django.utils.translation import gettext as _
 
+from zerver.lib.event_types import (
+    BaseEvent,
+    RecipientFieldForTypingEditChannelMessage,
+    RecipientFieldForTypingEditDirectMessage,
+    TypingEditMessageStartEvent,
+    TypingEditMessageStopEvent,
+    TypingPerson,
+    TypingStartEvent,
+    TypingStopEvent,
+)
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.stream_subscription import get_active_subscriptions_for_stream_id
 from zerver.models import Realm, Stream, UserProfile
@@ -11,21 +21,30 @@ from zerver.tornado.django_api import send_event_rollback_unsafe
 
 
 def do_send_typing_notification(
-    realm: Realm, sender: UserProfile, recipient_user_profiles: list[UserProfile], operator: str
+    realm: Realm,
+    sender: UserProfile,
+    recipient_user_profiles: list[UserProfile],
+    operator: Literal["start", "stop"],
 ) -> None:
-    sender_dict = {"user_id": sender.id, "email": sender.email}
+    sender_typing_person = TypingPerson(user_id=sender.id, email=sender.email)
 
     # Include a list of recipients in the event body to help identify where the typing is happening
-    recipient_dicts = [
-        {"user_id": profile.id, "email": profile.email} for profile in recipient_user_profiles
+    recipient_typing_persons = [
+        TypingPerson(user_id=profile.id, email=profile.email) for profile in recipient_user_profiles
     ]
-    event = dict(
-        type="typing",
-        message_type="direct",
-        op=operator,
-        sender=sender_dict,
-        recipients=recipient_dicts,
-    )
+    event: BaseEvent
+    if operator == "start":
+        event = TypingStartEvent(
+            message_type="direct",
+            sender=sender_typing_person,
+            recipients=recipient_typing_persons,
+        )
+    else:
+        event = TypingStopEvent(
+            message_type="direct",
+            sender=sender_typing_person,
+            recipients=recipient_typing_persons,
+        )
 
     # Only deliver the notification to active user recipients
     user_ids_to_notify = [
@@ -39,7 +58,9 @@ def do_send_typing_notification(
 
 # check_send_typing_notification:
 # Checks the typing notification and sends it
-def check_send_typing_notification(sender: UserProfile, user_ids: list[int], operator: str) -> None:
+def check_send_typing_notification(
+    sender: UserProfile, user_ids: list[int], operator: Literal["start", "stop"]
+) -> None:
     realm = sender.realm
 
     if sender.id not in user_ids:
@@ -70,18 +91,25 @@ def check_send_typing_notification(sender: UserProfile, user_ids: list[int], ope
 
 
 def do_send_stream_typing_notification(
-    sender: UserProfile, operator: str, stream: Stream, topic_name: str
+    sender: UserProfile, operator: Literal["start", "stop"], stream: Stream, topic_name: str
 ) -> None:
-    sender_dict = {"user_id": sender.id, "email": sender.email}
+    sender_typing_person = TypingPerson(user_id=sender.id, email=sender.email)
 
-    event = dict(
-        type="typing",
-        message_type="stream",
-        op=operator,
-        sender=sender_dict,
-        stream_id=stream.id,
-        topic=topic_name,
-    )
+    event: BaseEvent
+    if operator == "start":
+        event = TypingStartEvent(
+            message_type="stream",
+            sender=sender_typing_person,
+            stream_id=stream.id,
+            topic=topic_name,
+        )
+    else:
+        event = TypingStopEvent(
+            message_type="stream",
+            sender=sender_typing_person,
+            stream_id=stream.id,
+            topic=topic_name,
+        )
 
     subscriptions_query = get_active_subscriptions_for_stream_id(
         stream.id, include_deactivated_users=False
@@ -109,17 +137,22 @@ def do_send_stream_message_edit_typing_notification(
     operator: Literal["start", "stop"],
     topic_name: str,
 ) -> None:
-    event = dict(
-        type="typing_edit_message",
-        op=operator,
-        sender_id=sender.id,
-        message_id=message_id,
-        recipient=dict(
-            type="channel",
-            channel_id=channel_id,
-            topic=topic_name,
-        ),
+    recipient = RecipientFieldForTypingEditChannelMessage(
+        type="channel", channel_id=channel_id, topic=topic_name
     )
+    event: BaseEvent
+    if operator == "start":
+        event = TypingEditMessageStartEvent(
+            sender_id=sender.id,
+            message_id=message_id,
+            recipient=recipient,
+        )
+    else:
+        event = TypingEditMessageStopEvent(
+            sender_id=sender.id,
+            message_id=message_id,
+            recipient=recipient,
+        )
 
     subscriptions_query = get_active_subscriptions_for_stream_id(
         channel_id, include_deactivated_users=False
@@ -159,15 +192,19 @@ def do_send_direct_message_edit_typing_notification(
         if user.is_active and user.receives_typing_notifications
     ]
 
-    event = dict(
-        type="typing_edit_message",
-        op=operator,
-        sender_id=sender.id,
-        message_id=message_id,
-        recipient=dict(
-            type="direct",
-            user_ids=user_ids_to_notify,
-        ),
-    )
+    recipient = RecipientFieldForTypingEditDirectMessage(type="direct", user_ids=user_ids_to_notify)
+    event: BaseEvent
+    if operator == "start":
+        event = TypingEditMessageStartEvent(
+            sender_id=sender.id,
+            message_id=message_id,
+            recipient=recipient,
+        )
+    else:
+        event = TypingEditMessageStopEvent(
+            sender_id=sender.id,
+            message_id=message_id,
+            recipient=recipient,
+        )
 
     send_event_rollback_unsafe(sender.realm, event, user_ids_to_notify)

--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -5,6 +5,8 @@ from typing import Any
 from django.db import transaction
 
 from zerver.lib.attachments import get_old_unclaimed_attachments, validate_attachment_request
+from zerver.lib.event_types import Attachment as AttachmentData
+from zerver.lib.event_types import AttachmentUpdateEvent
 from zerver.lib.markdown import MessageRenderingResult
 from zerver.lib.upload import claim_attachment, delete_message_attachments
 from zerver.models import (
@@ -14,7 +16,6 @@ from zerver.models import (
     Message,
     ScheduledMessage,
     Stream,
-    UserProfile,
 )
 from zerver.tornado.django_api import send_event_on_commit
 
@@ -23,18 +24,6 @@ from zerver.tornado.django_api import send_event_on_commit
 class AttachmentChangeResult:
     did_attachment_change: bool
     detached_attachments: list[dict[str, Any]]
-
-
-def notify_attachment_update(
-    user_profile: UserProfile, op: str, attachment_dict: dict[str, Any]
-) -> None:
-    event = {
-        "type": "attachment",
-        "op": op,
-        "attachment": attachment_dict,
-        "upload_space_used": user_profile.realm.currently_used_upload_space_bytes(),
-    }
-    send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
 def do_claim_attachments(
@@ -83,7 +72,11 @@ def do_claim_attachments(
         if not isinstance(message, ScheduledMessage):
             # attachment update events don't say anything about scheduled messages,
             # so sending an event is pointless.
-            notify_attachment_update(user_profile, "update", attachment.to_dict())
+            event = AttachmentUpdateEvent(
+                attachment=AttachmentData(**attachment.to_dict()),
+                upload_space_used=user_profile.realm.currently_used_upload_space_bytes(),
+            )
+            send_event_on_commit(user_profile.realm, event, [user_profile.id])
     return claimed
 
 

--- a/zerver/actions/user_status.py
+++ b/zerver/actions/user_status.py
@@ -1,6 +1,9 @@
+from typing import Any, Literal, cast
+
 from django.db import transaction
 
 from zerver.actions.user_settings import do_change_user_setting
+from zerver.lib.event_types import UserStatusEvent
 from zerver.lib.user_status import update_user_status
 from zerver.lib.users import get_user_ids_who_can_access_user
 from zerver.models import UserProfile
@@ -37,19 +40,20 @@ def do_update_user_status(
         reaction_type=reaction_type,
     )
 
-    event = dict(
-        type="user_status",
-        user_id=user_profile.id,
-    )
-
+    # Only fields the caller explicitly opted into go on the event, so
+    # that the serialized event omits keys that weren't requested.
+    event_kwargs: dict[str, Any] = {"user_id": user_profile.id}
     if away is not None:
-        event["away"] = away
-
+        event_kwargs["away"] = away
     if status_text is not None:
-        event["status_text"] = status_text
-
+        event_kwargs["status_text"] = status_text
     if emoji_name is not None:
-        event["emoji_name"] = emoji_name
-        event["emoji_code"] = emoji_code
-        event["reaction_type"] = reaction_type
+        event_kwargs["emoji_name"] = emoji_name
+        event_kwargs["emoji_code"] = emoji_code
+        # The Reaction.reaction_type column is restricted to these values via
+        # CharField choices, so the cast is safe.
+        event_kwargs["reaction_type"] = cast(
+            Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"] | None, reaction_type
+        )
+    event = UserStatusEvent(**event_kwargs)
     send_event_on_commit(realm, event, get_user_ids_who_can_access_user(user_profile))

--- a/zerver/actions/user_status.py
+++ b/zerver/actions/user_status.py
@@ -1,10 +1,23 @@
+from typing import cast
+
 from django.db import transaction
+from typing_extensions import Required, TypedDict
 
 from zerver.actions.user_settings import do_change_user_setting
+from zerver.lib.event_types import ReactionType, UserStatusEvent
 from zerver.lib.user_status import update_user_status
 from zerver.lib.users import get_user_ids_who_can_access_user
 from zerver.models import UserProfile
 from zerver.tornado.django_api import send_event_on_commit
+
+
+class UserStatusEventDict(TypedDict, total=False):
+    user_id: Required[int]
+    away: bool
+    status_text: str
+    emoji_name: str
+    emoji_code: str | None
+    reaction_type: ReactionType | None
 
 
 @transaction.atomic(durable=True)
@@ -37,10 +50,9 @@ def do_update_user_status(
         reaction_type=reaction_type,
     )
 
-    event = dict(
-        type="user_status",
-        user_id=user_profile.id,
-    )
+    # Only fields the caller explicitly opted into go on the event, so
+    # that the serialized event omits keys that weren't requested.
+    event: UserStatusEventDict = {"user_id": user_profile.id}
 
     if away is not None:
         event["away"] = away
@@ -51,5 +63,9 @@ def do_update_user_status(
     if emoji_name is not None:
         event["emoji_name"] = emoji_name
         event["emoji_code"] = emoji_code
-        event["reaction_type"] = reaction_type
-    send_event_on_commit(realm, event, get_user_ids_who_can_access_user(user_profile))
+        # The Reaction.reaction_type column is restricted to these values via
+        # CharField choices, so the cast is safe.
+        event["reaction_type"] = cast(ReactionType | None, reaction_type)
+    send_event_on_commit(
+        realm, UserStatusEvent(**event), get_user_ids_who_can_access_user(user_profile)
+    )

--- a/zerver/actions/user_topics.py
+++ b/zerver/actions/user_topics.py
@@ -1,9 +1,9 @@
 from datetime import datetime
-from typing import Any
 
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
+from zerver.lib.event_types import MutedTopicsEvent, UserTopicEvent
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import maybe_rename_general_chat_to_empty_topic
 from zerver.lib.user_topics import (
@@ -49,19 +49,15 @@ def bulk_do_set_user_topic_visibility_policy(
         # once clients are migrated to handle the user_topic event type
         # instead.
         if not skip_muted_topics_event:
-            muted_topics_event = dict(
-                type="muted_topics", muted_topics=get_topic_mutes(user_profile)
-            )
+            muted_topics_event = MutedTopicsEvent(muted_topics=get_topic_mutes(user_profile))
             send_event_on_commit(user_profile.realm, muted_topics_event, [user_profile.id])
 
-        user_topic_event: dict[str, Any] = {
-            "type": "user_topic",
-            "stream_id": stream.id,
-            "topic_name": topic_name,
-            "last_updated": datetime_to_timestamp(last_updated),
-            "visibility_policy": visibility_policy,
-        }
-
+        user_topic_event = UserTopicEvent(
+            stream_id=stream.id,
+            topic_name=topic_name,
+            last_updated=datetime_to_timestamp(last_updated),
+            visibility_policy=visibility_policy,
+        )
         send_event_on_commit(user_profile.realm, user_topic_event, [user_profile.id])
 
 

--- a/zerver/actions/video_calls.py
+++ b/zerver/actions/video_calls.py
@@ -1,17 +1,21 @@
+from typing import Literal
+
 from django.db import transaction
 
+from zerver.lib.event_types import BaseEvent, HasWebexTokenEvent, HasZoomTokenEvent
 from zerver.models import UserProfile
 from zerver.tornado.django_api import send_event_on_commit
 
 
 @transaction.atomic(durable=True)
 def do_set_video_call_provider_token(
-    user: UserProfile, token_key: str, /, token: dict[str, object] | None
+    user: UserProfile, token_key: Literal["zoom", "webex"], /, token: dict[str, object] | None
 ) -> None:
     user.third_party_api_state[token_key] = token
     user.save(update_fields=["third_party_api_state"])
-    send_event_on_commit(
-        user.realm,
-        dict(type=f"has_{token_key}_token", value=token is not None),
-        [user.id],
-    )
+    event: BaseEvent
+    if token_key == "zoom":
+        event = HasZoomTokenEvent(value=token is not None)
+    else:
+        event = HasWebexTokenEvent(value=token is not None)
+    send_event_on_commit(user.realm, event, [user.id])

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1055,8 +1055,8 @@ class TypingPerson(BaseModel):
 
 
 class TypingStartCoreEvent(BaseEvent):
-    type: Literal["typing"]
-    op: Literal["start"]
+    type: Literal["typing"] = "typing"
+    op: Literal["start"] = "start"
     message_type: Literal["direct", "stream"]
     sender: TypingPerson
 
@@ -1069,8 +1069,8 @@ class TypingStartEvent(TypingStartCoreEvent):
 
 
 class TypingStopCoreEvent(BaseEvent):
-    type: Literal["typing"]
-    op: Literal["stop"]
+    type: Literal["typing"] = "typing"
+    op: Literal["stop"] = "stop"
     message_type: Literal["direct", "stream"]
     sender: TypingPerson
 
@@ -1094,16 +1094,16 @@ class RecipientFieldForTypingEditDirectMessage(BaseModel):
 
 
 class TypingEditMessageStartEvent(BaseEvent):
-    type: Literal["typing_edit_message"]
-    op: Literal["start"]
+    type: Literal["typing_edit_message"] = "typing_edit_message"
+    op: Literal["start"] = "start"
     sender_id: int
     message_id: int
     recipient: RecipientFieldForTypingEditChannelMessage | RecipientFieldForTypingEditDirectMessage
 
 
 class TypingEditMessageStopEvent(BaseEvent):
-    type: Literal["typing_edit_message"]
-    op: Literal["stop"]
+    type: Literal["typing_edit_message"] = "typing_edit_message"
+    op: Literal["stop"] = "stop"
     sender_id: int
     message_id: int
     recipient: RecipientFieldForTypingEditChannelMessage | RecipientFieldForTypingEditDirectMessage

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -471,20 +471,20 @@ class RealmDomain(BaseModel):
 
 
 class RealmDomainsAddEvent(BaseEvent):
-    type: Literal["realm_domains"]
-    op: Literal["add"]
+    type: Literal["realm_domains"] = "realm_domains"
+    op: Literal["add"] = "add"
     realm_domain: RealmDomain
 
 
 class RealmDomainsChangeEvent(BaseEvent):
-    type: Literal["realm_domains"]
-    op: Literal["change"]
+    type: Literal["realm_domains"] = "realm_domains"
+    op: Literal["change"] = "change"
     realm_domain: RealmDomain
 
 
 class RealmDomainsRemoveEvent(BaseEvent):
-    type: Literal["realm_domains"]
-    op: Literal["remove"]
+    type: Literal["realm_domains"] = "realm_domains"
+    op: Literal["remove"] = "remove"
     domain: str
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -38,7 +38,7 @@ class BaseEvent(BaseModel):
 
 
 class AlertWordsEvent(BaseEvent):
-    type: Literal["alert_words"]
+    type: Literal["alert_words"] = "alert_words"
     alert_words: list[str]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -864,20 +864,20 @@ class ScheduledMessageFields(ScheduledMessageFieldsCore):
 
 
 class ScheduledMessagesAddEvent(BaseEvent):
-    type: Literal["scheduled_messages"]
-    op: Literal["add"]
+    type: Literal["scheduled_messages"] = "scheduled_messages"
+    op: Literal["add"] = "add"
     scheduled_messages: list[ScheduledMessageFields]
 
 
 class ScheduledMessagesRemoveEvent(BaseEvent):
-    type: Literal["scheduled_messages"]
-    op: Literal["remove"]
+    type: Literal["scheduled_messages"] = "scheduled_messages"
+    op: Literal["remove"] = "remove"
     scheduled_message_id: int
 
 
 class ScheduledMessagesUpdateEvent(BaseEvent):
-    type: Literal["scheduled_messages"]
-    op: Literal["update"]
+    type: Literal["scheduled_messages"] = "scheduled_messages"
+    op: Literal["update"] = "update"
     scheduled_message: ScheduledMessageFields
 
 
@@ -893,14 +893,14 @@ class ReminderFields(BaseModel):
 
 
 class RemindersAddEvent(BaseEvent):
-    type: Literal["reminders"]
-    op: Literal["add"]
+    type: Literal["reminders"] = "reminders"
+    op: Literal["add"] = "add"
     reminders: list[ReminderFields]
 
 
 class RemindersRemoveEvent(BaseEvent):
-    type: Literal["reminders"]
-    op: Literal["remove"]
+    type: Literal["reminders"] = "reminders"
+    op: Literal["remove"] = "remove"
     reminder_id: int
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -334,14 +334,14 @@ class NavigationViewFields(BaseModel):
 
 
 class NavigationViewAddEvent(BaseEvent):
-    type: Literal["navigation_view"]
-    op: Literal["add"]
+    type: Literal["navigation_view"] = "navigation_view"
+    op: Literal["add"] = "add"
     navigation_view: NavigationViewFields
 
 
 class NavigationViewRemoveEvent(BaseEvent):
-    type: Literal["navigation_view"]
-    op: Literal["remove"]
+    type: Literal["navigation_view"] = "navigation_view"
+    op: Literal["remove"] = "remove"
     fragment: str
 
 
@@ -351,8 +351,8 @@ class NavigationViewFieldsForUpdate(BaseModel):
 
 
 class NavigationViewUpdateEvent(BaseEvent):
-    type: Literal["navigation_view"]
-    op: Literal["update"]
+    type: Literal["navigation_view"] = "navigation_view"
+    op: Literal["update"] = "update"
     fragment: str
     data: NavigationViewFieldsForUpdate
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -538,7 +538,7 @@ class Export(BaseModel):
 
 
 class RealmExportEvent(BaseEvent):
-    type: Literal["realm_export"]
+    type: Literal["realm_export"] = "realm_export"
     exports: list[Export]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -552,7 +552,7 @@ class RealmLinkifier(BaseModel):
 
 
 class RealmLinkifiersEvent(BaseEvent):
-    type: Literal["realm_linkifiers"]
+    type: Literal["realm_linkifiers"] = "realm_linkifiers"
     realm_linkifiers: list[RealmLinkifier]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -831,20 +831,20 @@ class SavedSnippetFields(BaseModel):
 
 
 class SavedSnippetsAddEvent(BaseEvent):
-    type: Literal["saved_snippets"]
-    op: Literal["add"]
+    type: Literal["saved_snippets"] = "saved_snippets"
+    op: Literal["add"] = "add"
     saved_snippet: SavedSnippetFields
 
 
 class SavedSnippetsUpdateEvent(BaseEvent):
-    type: Literal["saved_snippets"]
-    op: Literal["update"]
+    type: Literal["saved_snippets"] = "saved_snippets"
+    op: Literal["update"] = "update"
     saved_snippet: SavedSnippetFields
 
 
 class SavedSnippetsRemoveEvent(BaseEvent):
-    type: Literal["saved_snippets"]
-    op: Literal["remove"]
+    type: Literal["saved_snippets"] = "saved_snippets"
+    op: Literal["remove"] = "remove"
     saved_snippet_id: int
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -426,8 +426,8 @@ class Bot(BaseModel):
 
 
 class RealmBotAddEvent(BaseEvent):
-    type: Literal["realm_bot"]
-    op: Literal["add"]
+    type: Literal["realm_bot"] = "realm_bot"
+    op: Literal["add"] = "add"
     bot: Bot
 
 
@@ -436,8 +436,8 @@ class BotTypeForDelete(BaseModel):
 
 
 class RealmBotDeleteEvent(BaseEvent):
-    type: Literal["realm_bot"]
-    op: Literal["delete"]
+    type: Literal["realm_bot"] = "realm_bot"
+    op: Literal["delete"] = "delete"
     bot: BotTypeForDelete
 
 
@@ -454,8 +454,8 @@ class BotTypeForUpdate(BotTypeForUpdateCore):
 
 
 class RealmBotUpdateEvent(BaseEvent):
-    type: Literal["realm_bot"]
-    op: Literal["update"]
+    type: Literal["realm_bot"] = "realm_bot"
+    op: Literal["update"] = "update"
     bot: BotTypeForUpdate
 
 
@@ -798,8 +798,8 @@ class PersonDateJoined(BaseModel):
 
 
 class RealmUserUpdateEvent(BaseEvent):
-    type: Literal["realm_user"]
-    op: Literal["update"]
+    type: Literal["realm_user"] = "realm_user"
+    op: Literal["update"] = "update"
     person: (
         PersonAvatarFields
         | PersonBotOwnerId

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -300,7 +300,7 @@ class OnboardingSteps(BaseModel):
 
 
 class OnboardingStepsEvent(BaseEvent):
-    type: Literal["onboarding_steps"]
+    type: Literal["onboarding_steps"] = "onboarding_steps"
     onboarding_steps: list[OnboardingSteps]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1,8 +1,9 @@
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from pydantic import AfterValidator, BaseModel
+from typing_extensions import override
 
 from zerver.lib.types import UserGroupMembersDict
 from zerver.models.realms import RealmExportSlug
@@ -20,7 +21,20 @@ Url = Annotated[str, AfterValidator(check_url)]
 
 
 class BaseEvent(BaseModel):
-    pass
+    @override
+    def model_post_init(self, context: Any) -> None:
+        # We serialize events with model_dump(exclude_unset=True) so an
+        # event constructed with a subset of its kwargs has the same
+        # field-presence shape as the legacy dict construction. To make
+        # discriminator fields (type, op) survive that pruning when they
+        # rely on a class-level default, mark any non-None defaulted
+        # field as "set" so it ends up in the serialized output.
+        for name, field_info in type(self).model_fields.items():
+            if name in self.__pydantic_fields_set__:
+                continue
+            default = field_info.get_default(call_default_factory=True)
+            if default is not None:
+                self.__pydantic_fields_set__.add(name)
 
 
 class AlertWordsEvent(BaseEvent):

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -305,20 +305,20 @@ class OnboardingStepsEvent(BaseEvent):
 
 
 class DeviceAddEvent(BaseEvent):
-    type: Literal["device"]
-    op: Literal["add"]
+    type: Literal["device"] = "device"
+    op: Literal["add"] = "add"
     device_id: int
 
 
 class DeviceRemoveEvent(BaseEvent):
-    type: Literal["device"]
-    op: Literal["remove"]
+    type: Literal["device"] = "device"
+    op: Literal["remove"] = "remove"
     device_id: int
 
 
 class DeviceUpdateEvent(BaseEvent):
-    type: Literal["device"]
-    op: Literal["update"]
+    type: Literal["device"] = "device"
+    op: Literal["update"] = "update"
     device_id: int
     push_key_id: int | None = None
     push_token_id: str | None = None

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -141,12 +141,12 @@ class StreamGroup(BaseModel):
 
 
 class DefaultStreamGroupsEvent(BaseEvent):
-    type: Literal["default_stream_groups"]
+    type: Literal["default_stream_groups"] = "default_stream_groups"
     default_stream_groups: list[StreamGroup]
 
 
 class DefaultStreamsEvent(BaseEvent):
-    type: Literal["default_streams"]
+    type: Literal["default_streams"] = "default_streams"
     default_streams: list[int]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1266,7 +1266,7 @@ class UserSettingsUpdateEvent(UserSettingsUpdateCoreEvent):
 
 
 class UserStatusCoreEvent(BaseEvent):
-    type: Literal["user_status"]
+    type: Literal["user_status"] = "user_status"
     user_id: int
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -387,8 +387,8 @@ class ModernPresenceEvent(BaseEvent):
 
 
 class ReactionAddEvent(BaseEvent):
-    type: Literal["reaction"]
-    op: Literal["add"]
+    type: Literal["reaction"] = "reaction"
+    op: Literal["add"] = "add"
     message_id: int
     emoji_name: str
     emoji_code: str
@@ -397,8 +397,8 @@ class ReactionAddEvent(BaseEvent):
 
 
 class ReactionRemoveEvent(BaseEvent):
-    type: Literal["reaction"]
-    op: Literal["remove"]
+    type: Literal["reaction"] = "reaction"
+    op: Literal["remove"] = "remove"
     message_id: int
     emoji_name: str
     emoji_code: str

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -52,8 +52,8 @@ class Attachment(BaseModel):
 
 
 class AttachmentAddEvent(BaseEvent):
-    type: Literal["attachment"]
-    op: Literal["add"]
+    type: Literal["attachment"] = "attachment"
+    op: Literal["add"] = "add"
     attachment: Attachment
     upload_space_used: int
 
@@ -63,15 +63,15 @@ class AttachmentFieldForAttachmentRemoveEvent(BaseModel):
 
 
 class AttachmentRemoveEvent(BaseEvent):
-    type: Literal["attachment"]
-    op: Literal["remove"]
+    type: Literal["attachment"] = "attachment"
+    op: Literal["remove"] = "remove"
     attachment: AttachmentFieldForAttachmentRemoveEvent
     upload_space_used: int
 
 
 class AttachmentUpdateEvent(BaseEvent):
-    type: Literal["attachment"]
-    op: Literal["update"]
+    type: Literal["attachment"] = "attachment"
+    op: Literal["update"] = "update"
     attachment: Attachment
     upload_space_used: int
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -280,7 +280,7 @@ class MessageEvent(BaseEvent):
 
 
 class MutedTopicsEvent(BaseEvent):
-    type: Literal["muted_topics"]
+    type: Literal["muted_topics"] = "muted_topics"
     muted_topics: list[list[str | int]]
 
 
@@ -1280,7 +1280,7 @@ class UserStatusEvent(UserStatusCoreEvent):
 
 
 class UserTopicEvent(BaseEvent):
-    type: Literal["user_topic"]
+    type: Literal["user_topic"] = "user_topic"
     stream_id: int
     topic_name: str
     last_updated: int

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -234,12 +234,12 @@ class DraftsUpdateEvent(BaseEvent):
 
 
 class HasZoomTokenEvent(BaseEvent):
-    type: Literal["has_zoom_token"]
+    type: Literal["has_zoom_token"] = "has_zoom_token"
     value: bool
 
 
 class HasWebexTokenEvent(BaseEvent):
-    type: Literal["has_webex_token"]
+    type: Literal["has_webex_token"] = "has_webex_token"
     value: bool
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -663,8 +663,8 @@ class PlanTypeData(BaseModel):
 
 
 class RealmUpdateDictEvent(BaseEvent):
-    type: Literal["realm"]
-    op: Literal["update_dict"]
+    type: Literal["realm"] = "realm"
+    op: Literal["update_dict"] = "update_dict"
     property: Literal["default", "icon", "logo", "night_logo"]
     data: (
         AllowMessageEditingData

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -290,7 +290,7 @@ class MutedUser(BaseModel):
 
 
 class MutedUsersEvent(BaseEvent):
-    type: Literal["muted_users"]
+    type: Literal["muted_users"] = "muted_users"
     muted_users: list[MutedUser]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -564,7 +564,7 @@ class RealmPlayground(BaseModel):
 
 
 class RealmPlaygroundsEvent(BaseEvent):
-    type: Literal["realm_playgrounds"]
+    type: Literal["realm_playgrounds"] = "realm_playgrounds"
     realm_playgrounds: list[RealmPlayground]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -964,7 +964,7 @@ class StreamUpdateEvent(StreamUpdateCoreEvent):
 
 
 class SubmessageEvent(BaseEvent):
-    type: Literal["submessage"]
+    type: Literal["submessage"] = "submessage"
     message_id: int
     submessage_id: int
     sender_id: int

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1136,9 +1136,9 @@ class UpdateMessageEvent(UpdateMessageCoreEvent):
 
 
 class UpdateMessageFlagsAddEvent(BaseEvent):
-    type: Literal["update_message_flags"]
-    op: Literal["add"]
-    operation: Literal["add"]
+    type: Literal["update_message_flags"] = "update_message_flags"
+    op: Literal["add"] = "add"
+    operation: Literal["add"] = "add"
     flag: str
     messages: list[int]
     all: bool
@@ -1158,9 +1158,9 @@ class MessageDetails(MessageDetailsCore):
 
 
 class UpdateMessageFlagsRemoveCoreEvent(BaseEvent):
-    type: Literal["update_message_flags"]
-    op: Literal["remove"]
-    operation: Literal["remove"]
+    type: Literal["update_message_flags"] = "update_message_flags"
+    op: Literal["remove"] = "remove"
+    operation: Literal["remove"] = "remove"
     flag: str
     messages: list[int]
     all: bool

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -220,12 +220,12 @@ class DraftsUpdateEvent(BaseEvent):
 
 
 class HasZoomTokenEvent(BaseEvent):
-    type: Literal["has_zoom_token"]
+    type: Literal["has_zoom_token"] = "has_zoom_token"
     value: bool
 
 
 class HasWebexTokenEvent(BaseEvent):
-    type: Literal["has_webex_token"]
+    type: Literal["has_webex_token"] = "has_webex_token"
     value: bool
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -414,8 +414,8 @@ class Bot(BaseModel):
 
 
 class RealmBotAddEvent(BaseEvent):
-    type: Literal["realm_bot"]
-    op: Literal["add"]
+    type: Literal["realm_bot"] = "realm_bot"
+    op: Literal["add"] = "add"
     bot: Bot
 
 
@@ -424,8 +424,8 @@ class BotTypeForDelete(BaseModel):
 
 
 class RealmBotDeleteEvent(BaseEvent):
-    type: Literal["realm_bot"]
-    op: Literal["delete"]
+    type: Literal["realm_bot"] = "realm_bot"
+    op: Literal["delete"] = "delete"
     bot: BotTypeForDelete
 
 
@@ -442,8 +442,8 @@ class BotTypeForUpdate(BotTypeForUpdateCore):
 
 
 class RealmBotUpdateEvent(BaseEvent):
-    type: Literal["realm_bot"]
-    op: Literal["update"]
+    type: Literal["realm_bot"] = "realm_bot"
+    op: Literal["update"] = "update"
     bot: BotTypeForUpdate
 
 
@@ -787,8 +787,8 @@ class PersonDateJoined(BaseModel):
 
 
 class RealmUserUpdateEvent(BaseEvent):
-    type: Literal["realm_user"]
-    op: Literal["update"]
+    type: Literal["realm_user"] = "realm_user"
+    op: Literal["update"] = "update"
     person: (
         PersonAvatarFields
         | PersonBotOwnerId

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1045,8 +1045,8 @@ class TypingPerson(BaseModel):
 
 
 class TypingStartCoreEvent(BaseEvent):
-    type: Literal["typing"]
-    op: Literal["start"]
+    type: Literal["typing"] = "typing"
+    op: Literal["start"] = "start"
     message_type: Literal["direct", "stream"]
     sender: TypingPerson
 
@@ -1059,8 +1059,8 @@ class TypingStartEvent(TypingStartCoreEvent):
 
 
 class TypingStopCoreEvent(BaseEvent):
-    type: Literal["typing"]
-    op: Literal["stop"]
+    type: Literal["typing"] = "typing"
+    op: Literal["stop"] = "stop"
     message_type: Literal["direct", "stream"]
     sender: TypingPerson
 
@@ -1084,16 +1084,16 @@ class RecipientFieldForTypingEditDirectMessage(BaseModel):
 
 
 class TypingEditMessageStartEvent(BaseEvent):
-    type: Literal["typing_edit_message"]
-    op: Literal["start"]
+    type: Literal["typing_edit_message"] = "typing_edit_message"
+    op: Literal["start"] = "start"
     sender_id: int
     message_id: int
     recipient: RecipientFieldForTypingEditChannelMessage | RecipientFieldForTypingEditDirectMessage
 
 
 class TypingEditMessageStopEvent(BaseEvent):
-    type: Literal["typing_edit_message"]
-    op: Literal["stop"]
+    type: Literal["typing_edit_message"] = "typing_edit_message"
+    op: Literal["stop"] = "stop"
     sender_id: int
     message_id: int
     recipient: RecipientFieldForTypingEditChannelMessage | RecipientFieldForTypingEditDirectMessage

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -525,7 +525,7 @@ class Export(BaseModel):
 
 
 class RealmExportEvent(BaseEvent):
-    type: Literal["realm_export"]
+    type: Literal["realm_export"] = "realm_export"
     exports: list[Export]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -278,7 +278,7 @@ class MutedUser(BaseModel):
 
 
 class MutedUsersEvent(BaseEvent):
-    type: Literal["muted_users"]
+    type: Literal["muted_users"] = "muted_users"
     muted_users: list[MutedUser]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -820,20 +820,20 @@ class SavedSnippetFields(BaseModel):
 
 
 class SavedSnippetsAddEvent(BaseEvent):
-    type: Literal["saved_snippets"]
-    op: Literal["add"]
+    type: Literal["saved_snippets"] = "saved_snippets"
+    op: Literal["add"] = "add"
     saved_snippet: SavedSnippetFields
 
 
 class SavedSnippetsUpdateEvent(BaseEvent):
-    type: Literal["saved_snippets"]
-    op: Literal["update"]
+    type: Literal["saved_snippets"] = "saved_snippets"
+    op: Literal["update"] = "update"
     saved_snippet: SavedSnippetFields
 
 
 class SavedSnippetsRemoveEvent(BaseEvent):
-    type: Literal["saved_snippets"]
-    op: Literal["remove"]
+    type: Literal["saved_snippets"] = "saved_snippets"
+    op: Literal["remove"] = "remove"
     saved_snippet_id: int
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -268,7 +268,7 @@ class MessageEvent(BaseEvent):
 
 
 class MutedTopicsEvent(BaseEvent):
-    type: Literal["muted_topics"]
+    type: Literal["muted_topics"] = "muted_topics"
     muted_topics: list[list[str | int]]
 
 
@@ -1270,7 +1270,7 @@ class UserStatusEvent(UserStatusCoreEvent):
 
 
 class UserTopicEvent(BaseEvent):
-    type: Literal["user_topic"]
+    type: Literal["user_topic"] = "user_topic"
     stream_id: int
     topic_name: str
     last_updated: int

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -551,7 +551,7 @@ class RealmPlayground(BaseModel):
 
 
 class RealmPlaygroundsEvent(BaseEvent):
-    type: Literal["realm_playgrounds"]
+    type: Literal["realm_playgrounds"] = "realm_playgrounds"
     realm_playgrounds: list[RealmPlayground]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -459,20 +459,20 @@ class RealmDomain(BaseModel):
 
 
 class RealmDomainsAddEvent(BaseEvent):
-    type: Literal["realm_domains"]
-    op: Literal["add"]
+    type: Literal["realm_domains"] = "realm_domains"
+    op: Literal["add"] = "add"
     realm_domain: RealmDomain
 
 
 class RealmDomainsChangeEvent(BaseEvent):
-    type: Literal["realm_domains"]
-    op: Literal["change"]
+    type: Literal["realm_domains"] = "realm_domains"
+    op: Literal["change"] = "change"
     realm_domain: RealmDomain
 
 
 class RealmDomainsRemoveEvent(BaseEvent):
-    type: Literal["realm_domains"]
-    op: Literal["remove"]
+    type: Literal["realm_domains"] = "realm_domains"
+    op: Literal["remove"] = "remove"
     domain: str
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -293,20 +293,20 @@ class OnboardingStepsEvent(BaseEvent):
 
 
 class DeviceAddEvent(BaseEvent):
-    type: Literal["device"]
-    op: Literal["add"]
+    type: Literal["device"] = "device"
+    op: Literal["add"] = "add"
     device_id: int
 
 
 class DeviceRemoveEvent(BaseEvent):
-    type: Literal["device"]
-    op: Literal["remove"]
+    type: Literal["device"] = "device"
+    op: Literal["remove"] = "remove"
     device_id: int
 
 
 class DeviceUpdateEvent(BaseEvent):
-    type: Literal["device"]
-    op: Literal["update"]
+    type: Literal["device"] = "device"
+    op: Literal["update"] = "update"
     device_id: int
     push_key_id: int | None = None
     push_token_id: str | None = None

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -24,7 +24,7 @@ class BaseEvent(BaseModel):
 
 
 class AlertWordsEvent(BaseEvent):
-    type: Literal["alert_words"]
+    type: Literal["alert_words"] = "alert_words"
     alert_words: list[str]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -40,8 +40,8 @@ class Attachment(BaseModel):
 
 
 class AttachmentAddEvent(BaseEvent):
-    type: Literal["attachment"]
-    op: Literal["add"]
+    type: Literal["attachment"] = "attachment"
+    op: Literal["add"] = "add"
     attachment: Attachment
     upload_space_used: int
 
@@ -51,15 +51,15 @@ class AttachmentFieldForAttachmentRemoveEvent(BaseModel):
 
 
 class AttachmentRemoveEvent(BaseEvent):
-    type: Literal["attachment"]
-    op: Literal["remove"]
+    type: Literal["attachment"] = "attachment"
+    op: Literal["remove"] = "remove"
     attachment: AttachmentFieldForAttachmentRemoveEvent
     upload_space_used: int
 
 
 class AttachmentUpdateEvent(BaseEvent):
-    type: Literal["attachment"]
-    op: Literal["update"]
+    type: Literal["attachment"] = "attachment"
+    op: Literal["update"] = "update"
     attachment: Attachment
     upload_space_used: int
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -953,7 +953,7 @@ class StreamUpdateEvent(StreamUpdateCoreEvent):
 
 
 class SubmessageEvent(BaseEvent):
-    type: Literal["submessage"]
+    type: Literal["submessage"] = "submessage"
     message_id: int
     submessage_id: int
     sender_id: int

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -322,14 +322,14 @@ class NavigationViewFields(BaseModel):
 
 
 class NavigationViewAddEvent(BaseEvent):
-    type: Literal["navigation_view"]
-    op: Literal["add"]
+    type: Literal["navigation_view"] = "navigation_view"
+    op: Literal["add"] = "add"
     navigation_view: NavigationViewFields
 
 
 class NavigationViewRemoveEvent(BaseEvent):
-    type: Literal["navigation_view"]
-    op: Literal["remove"]
+    type: Literal["navigation_view"] = "navigation_view"
+    op: Literal["remove"] = "remove"
     fragment: str
 
 
@@ -339,8 +339,8 @@ class NavigationViewFieldsForUpdate(BaseModel):
 
 
 class NavigationViewUpdateEvent(BaseEvent):
-    type: Literal["navigation_view"]
-    op: Literal["update"]
+    type: Literal["navigation_view"] = "navigation_view"
+    op: Literal["update"] = "update"
     fragment: str
     data: NavigationViewFieldsForUpdate
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -650,8 +650,8 @@ class PlanTypeData(BaseModel):
 
 
 class RealmUpdateDictEvent(BaseEvent):
-    type: Literal["realm"]
-    op: Literal["update_dict"]
+    type: Literal["realm"] = "realm"
+    op: Literal["update_dict"] = "update_dict"
     property: Literal["default", "icon", "logo", "night_logo"]
     data: (
         AllowMessageEditingData

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -286,7 +286,7 @@ class OnboardingSteps(BaseModel):
 
 
 class OnboardingStepsEvent(BaseEvent):
-    type: Literal["onboarding_steps"]
+    type: Literal["onboarding_steps"] = "onboarding_steps"
     onboarding_steps: list[OnboardingSteps]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -18,6 +18,8 @@ def check_url(val: str) -> str:
 
 Url = Annotated[str, AfterValidator(check_url)]
 
+ReactionType = Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"]
+
 
 class BaseEvent(BaseModel):
     pass
@@ -373,22 +375,22 @@ class ModernPresenceEvent(BaseEvent):
 
 
 class ReactionAddEvent(BaseEvent):
-    type: Literal["reaction"]
-    op: Literal["add"]
+    type: Literal["reaction"] = "reaction"
+    op: Literal["add"] = "add"
     message_id: int
     emoji_name: str
     emoji_code: str
-    reaction_type: Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"]
+    reaction_type: ReactionType
     user_id: int
 
 
 class ReactionRemoveEvent(BaseEvent):
-    type: Literal["reaction"]
-    op: Literal["remove"]
+    type: Literal["reaction"] = "reaction"
+    op: Literal["remove"] = "remove"
     message_id: int
     emoji_name: str
     emoji_code: str
-    reaction_type: Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"]
+    reaction_type: ReactionType
     user_id: int
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -129,12 +129,12 @@ class StreamGroup(BaseModel):
 
 
 class DefaultStreamGroupsEvent(BaseEvent):
-    type: Literal["default_stream_groups"]
+    type: Literal["default_stream_groups"] = "default_stream_groups"
     default_stream_groups: list[StreamGroup]
 
 
 class DefaultStreamsEvent(BaseEvent):
-    type: Literal["default_streams"]
+    type: Literal["default_streams"] = "default_streams"
     default_streams: list[int]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -539,7 +539,7 @@ class RealmLinkifier(BaseModel):
 
 
 class RealmLinkifiersEvent(BaseEvent):
-    type: Literal["realm_linkifiers"]
+    type: Literal["realm_linkifiers"] = "realm_linkifiers"
     realm_linkifiers: list[RealmLinkifier]
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1256,7 +1256,7 @@ class UserSettingsUpdateEvent(UserSettingsUpdateCoreEvent):
 
 
 class UserStatusCoreEvent(BaseEvent):
-    type: Literal["user_status"]
+    type: Literal["user_status"] = "user_status"
     user_id: int
 
 
@@ -1266,7 +1266,7 @@ class UserStatusEvent(UserStatusCoreEvent):
     status_text: str | None = None
     emoji_name: str | None = None
     emoji_code: str | None = None
-    reaction_type: Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"] | None = None
+    reaction_type: ReactionType | None = None
 
 
 class UserTopicEvent(BaseEvent):

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -853,20 +853,20 @@ class ScheduledMessageFields(ScheduledMessageFieldsCore):
 
 
 class ScheduledMessagesAddEvent(BaseEvent):
-    type: Literal["scheduled_messages"]
-    op: Literal["add"]
+    type: Literal["scheduled_messages"] = "scheduled_messages"
+    op: Literal["add"] = "add"
     scheduled_messages: list[ScheduledMessageFields]
 
 
 class ScheduledMessagesRemoveEvent(BaseEvent):
-    type: Literal["scheduled_messages"]
-    op: Literal["remove"]
+    type: Literal["scheduled_messages"] = "scheduled_messages"
+    op: Literal["remove"] = "remove"
     scheduled_message_id: int
 
 
 class ScheduledMessagesUpdateEvent(BaseEvent):
-    type: Literal["scheduled_messages"]
-    op: Literal["update"]
+    type: Literal["scheduled_messages"] = "scheduled_messages"
+    op: Literal["update"] = "update"
     scheduled_message: ScheduledMessageFields
 
 
@@ -882,14 +882,14 @@ class ReminderFields(BaseModel):
 
 
 class RemindersAddEvent(BaseEvent):
-    type: Literal["reminders"]
-    op: Literal["add"]
+    type: Literal["reminders"] = "reminders"
+    op: Literal["add"] = "add"
     reminders: list[ReminderFields]
 
 
 class RemindersRemoveEvent(BaseEvent):
-    type: Literal["reminders"]
-    op: Literal["remove"]
+    type: Literal["reminders"] = "reminders"
+    op: Literal["remove"] = "remove"
     reminder_id: int
 
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -1126,9 +1126,9 @@ class UpdateMessageEvent(UpdateMessageCoreEvent):
 
 
 class UpdateMessageFlagsAddEvent(BaseEvent):
-    type: Literal["update_message_flags"]
-    op: Literal["add"]
-    operation: Literal["add"]
+    type: Literal["update_message_flags"] = "update_message_flags"
+    op: Literal["add"] = "add"
+    operation: Literal["add"] = "add"
     flag: str
     messages: list[int]
     all: bool
@@ -1148,9 +1148,9 @@ class MessageDetails(MessageDetailsCore):
 
 
 class UpdateMessageFlagsRemoveCoreEvent(BaseEvent):
-    type: Literal["update_message_flags"]
-    op: Literal["remove"]
-    operation: Literal["remove"]
+    type: Literal["update_message_flags"] = "update_message_flags"
+    op: Literal["remove"] = "remove"
+    operation: Literal["remove"] = "remove"
     flag: str
     messages: list[int]
     all: bool

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -359,7 +359,11 @@ def fetch_initial_state_data(
         state["muted_topics"] = [] if user_profile is None else get_topic_mutes(user_profile)
 
     if want("muted_users"):
-        state["muted_users"] = [] if user_profile is None else get_user_mutes(user_profile)
+        state["muted_users"] = (
+            []
+            if user_profile is None
+            else [muted_user.model_dump() for muted_user in get_user_mutes(user_profile)]
+        )
 
     if want("presence"):
         if presence_last_update_id_fetched_by_client is not None or simplified_presence_events:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -62,7 +62,7 @@ from zerver.models.recipients import DirectMessageGroup
 
 
 class MessageDetailsDict(TypedDict, total=False):
-    type: str
+    type: Literal["private", "stream"]
     mentioned: bool
     user_ids: list[int]
     stream_id: int

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -16,6 +16,7 @@ from analytics.lib.counts import COUNT_STATS
 from analytics.models import RealmCount
 from zerver.lib.cache import generic_bulk_cached_fetch, to_dict_cache_key_id
 from zerver.lib.display_recipient import get_display_recipient_by_id
+from zerver.lib.event_types import MessageDetails
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
 from zerver.lib.markdown import MessageRenderingResult
 from zerver.lib.mention import MentionData, sender_can_mention_group, silent_mention_syntax_for_user
@@ -62,7 +63,7 @@ from zerver.models.recipients import DirectMessageGroup
 
 
 class MessageDetailsDict(TypedDict, total=False):
-    type: str
+    type: Literal["private", "stream"]
     mentioned: bool
     user_ids: list[int]
     stream_id: int
@@ -1287,7 +1288,7 @@ def remove_message_id_from_unread_mgs(state: RawUnreadMessagesResult, message_id
 def format_unread_message_details(
     my_user_id: int,
     raw_unread_data: RawUnreadMessagesResult,
-) -> dict[str, MessageDetailsDict]:
+) -> dict[str, MessageDetails]:
     unread_data = {}
 
     for message_id, private_message_details in raw_unread_data["pm_dict"].items():
@@ -1299,18 +1300,18 @@ def format_unread_message_details(
 
         # Note that user_ids excludes ourself, even for the case we send messages
         # to ourself.
-        message_details = MessageDetailsDict(
+        message_details = MessageDetails(
             type="private",
             user_ids=user_ids,
         )
         if message_id in raw_unread_data["mentions"]:
-            message_details["mentioned"] = True
+            message_details.mentioned = True
         unread_data[str(message_id)] = message_details
 
     for message_id, stream_message_details in raw_unread_data["stream_dict"].items():
         unmuted_stream_msg = message_id in raw_unread_data["unmuted_stream_msgs"]
 
-        message_details = MessageDetailsDict(
+        message_details = MessageDetails(
             type="stream",
             stream_id=stream_message_details["stream_id"],
             topic=stream_message_details["topic"],
@@ -1318,7 +1319,7 @@ def format_unread_message_details(
             unmuted_stream_msg=unmuted_stream_msg,
         )
         if message_id in raw_unread_data["mentions"]:
-            message_details["mentioned"] = True
+            message_details.mentioned = True
         unread_data[str(message_id)] = message_details
 
     for message_id, huddle_message_details in raw_unread_data["huddle_dict"].items():
@@ -1329,12 +1330,12 @@ def format_unread_message_details(
             for s in huddle_message_details["user_ids_string"].split(",")
             if (user_id := int(s)) != my_user_id
         )
-        message_details = MessageDetailsDict(
+        message_details = MessageDetails(
             type="private",
             user_ids=user_ids,
         )
         if message_id in raw_unread_data["mentions"]:
-            message_details["mentioned"] = True
+            message_details.mentioned = True
         unread_data[str(message_id)] = message_details
 
     return unread_data

--- a/zerver/lib/muted_users.py
+++ b/zerver/lib/muted_users.py
@@ -1,21 +1,22 @@
 from datetime import datetime
 
 from zerver.lib.cache import cache_with_key, get_muting_users_cache_key
+from zerver.lib.event_types import MutedUser as MutedUserData
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import MutedUser, UserProfile
 
 
-def get_user_mutes(user_profile: UserProfile) -> list[dict[str, int]]:
+def get_user_mutes(user_profile: UserProfile) -> list[MutedUserData]:
     rows = MutedUser.objects.filter(user_profile=user_profile).values(
         "muted_user_id",
         "date_muted",
     )
     return [
-        {
-            "id": row["muted_user_id"],
-            "timestamp": datetime_to_timestamp(assert_is_not_none(row["date_muted"])),
-        }
+        MutedUserData(
+            id=row["muted_user_id"],
+            timestamp=datetime_to_timestamp(assert_is_not_none(row["date_muted"])),
+        )
         for row in rows
     ]
 

--- a/zerver/lib/realm_logo.py
+++ b/zerver/lib/realm_logo.py
@@ -1,8 +1,7 @@
-from typing import Any
-
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 
+from zerver.lib.event_types import LogoData, NightLogoData
 from zerver.lib.upload import get_uploaded_realm_logo_url
 from zerver.models import Realm
 
@@ -29,10 +28,10 @@ def get_realm_logo_url(realm: Realm, night: bool) -> str:
     return staticfiles_storage.url("images/logo/zulip-org-logo.svg") + "?version=0"
 
 
-def get_realm_logo_data(realm: Realm, night: bool) -> dict[str, Any]:
+def get_realm_logo_data(realm: Realm, night: bool) -> LogoData | NightLogoData:
     if night:
-        return dict(
+        return NightLogoData(
             night_logo_url=get_realm_logo_url(realm, night),
             night_logo_source=realm.night_logo_source,
         )
-    return dict(logo_url=get_realm_logo_url(realm, night), logo_source=realm.logo_source)
+    return LogoData(logo_url=get_realm_logo_url(realm, night), logo_source=realm.logo_source)

--- a/zerver/lib/reminders.py
+++ b/zerver/lib/reminders.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.utils.translation import gettext as _
 
 from zerver.lib.display_recipient import get_display_recipient
+from zerver.lib.event_types import RemindersRemoveEvent
 from zerver.lib.exceptions import JsonableError, ResourceNotFoundError
 from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
@@ -174,9 +175,5 @@ def access_reminder(user_profile: UserProfile, reminder_id: int) -> ScheduledMes
 
 
 def notify_remove_reminder(user_profile: UserProfile, reminder_id: int) -> None:
-    event = {
-        "type": "reminders",
-        "op": "remove",
-        "reminder_id": reminder_id,
-    }
+    event = RemindersRemoveEvent(reminder_id=reminder_id)
     send_event_on_commit(user_profile.realm, event, [user_profile.id])

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -139,9 +139,15 @@ def create_attachment(
         content_type=content_type,
     )
     maybe_thumbnail(file_vips_data, content_type, path_id, realm.id)
-    from zerver.actions.uploads import notify_attachment_update
+    from zerver.lib.event_types import Attachment as AttachmentData
+    from zerver.lib.event_types import AttachmentAddEvent
+    from zerver.tornado.django_api import send_event_on_commit
 
-    notify_attachment_update(user_profile, "add", attachment.to_dict())
+    event = AttachmentAddEvent(
+        attachment=AttachmentData(**attachment.to_dict()),
+        upload_space_used=user_profile.realm.currently_used_upload_space_bytes(),
+    )
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
 def get_file_info(user_file: UploadedFile) -> tuple[str, str]:

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -150,9 +150,15 @@ def create_attachment(
         content_type=content_type,
     )
     maybe_thumbnail(file_vips_data, content_type, path_id, realm.id)
-    from zerver.actions.uploads import notify_attachment_update
+    from zerver.lib.event_types import Attachment as AttachmentData
+    from zerver.lib.event_types import AttachmentAddEvent
+    from zerver.tornado.django_api import send_event_on_commit
 
-    notify_attachment_update(user_profile, "add", attachment.to_dict())
+    event = AttachmentAddEvent(
+        attachment=AttachmentData(**attachment.to_dict()),
+        upload_space_used=user_profile.realm.currently_used_upload_space_bytes(),
+    )
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
 def get_file_info(user_file: UploadedFile[bytes]) -> tuple[str, str]:

--- a/zerver/models/scheduled_jobs.py
+++ b/zerver/models/scheduled_jobs.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from django.conf import settings
 from django.db import models
@@ -141,7 +141,7 @@ class APIScheduledDirectMessageDict(TypedDict):
 class APIReminderDirectMessageDict(TypedDict):
     reminder_id: int
     to: list[int]
-    type: str
+    type: Literal["private"]
     content: str
     rendered_content: str
     scheduled_delivery_timestamp: int
@@ -266,7 +266,7 @@ class ScheduledMessage(models.Model):
         return APIReminderDirectMessageDict(
             reminder_id=self.id,
             to=recipient,
-            type=recipient_type_str,
+            type="private",
             content=self.content,
             rendered_content=self.rendered_content,
             scheduled_delivery_timestamp=datetime_to_timestamp(self.scheduled_timestamp),

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -10,6 +10,7 @@ from zerver.actions.streams import do_change_stream_group_based_setting, do_chan
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
+from zerver.lib.event_types import MessageDetails
 from zerver.lib.fix_unreads import fix, fix_unsubscribed
 from zerver.lib.message import (
     MessageDetailsDict,
@@ -2211,7 +2212,7 @@ class MarkUnreadTest(ZulipTestCase):
         self.assertEqual(
             message_details,
             {
-                str(message_id): dict(type="private", user_ids=[]),
+                str(message_id): MessageDetails(type="private", user_ids=[]),
             },
         )
 

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -506,9 +506,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         users_notified_via_user_topic_event: list[int] = []
         for call_args in mock_send_event_on_commit.call_args_list:
             (_arg_realm, arg_event, arg_notified_users) = call_args[0]
-            if arg_event["type"] == "user_topic":
+            if arg_event.type == "user_topic":
                 users_notified_via_user_topic_event.append(*arg_notified_users)
-            elif arg_event["type"] == "muted_topics":
+            elif arg_event.type == "muted_topics":
                 users_notified_via_muted_topics_event.append(*arg_notified_users)
         self.assertEqual(
             sorted(users_notified_via_muted_topics_event),
@@ -768,9 +768,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         users_notified_via_user_topic_event: list[int] = []
         for call_args in mock_send_event_on_commit.call_args_list:
             (_arg_realm, arg_event, arg_notified_users) = call_args[0]
-            if arg_event["type"] == "user_topic":
+            if arg_event.type == "user_topic":
                 users_notified_via_user_topic_event.append(*arg_notified_users)
-            elif arg_event["type"] == "muted_topics":
+            elif arg_event.type == "muted_topics":
                 users_notified_via_muted_topics_event.append(*arg_notified_users)
         self.assertEqual(
             sorted(users_notified_via_muted_topics_event),

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -464,13 +464,13 @@ class MessageMoveTopicTest(ZulipTestCase):
         for call_args in mock_send_event_on_commit.call_args_list:
             (_arg_realm, arg_event, arg_notified_users) = call_args[0]
             [notified_user_id] = arg_notified_users
-            if arg_event["type"] == "user_topic":
-                self.assertEqual(arg_event["stream_id"], stream.id)
+            if arg_event.type == "user_topic":
+                self.assertEqual(arg_event.stream_id, stream.id)
                 user_topic_events[notified_user_id].append(
-                    (arg_event["topic_name"], arg_event["visibility_policy"])
+                    (arg_event.topic_name, arg_event.visibility_policy)
                 )
-            elif arg_event["type"] == "muted_topics":
-                muted_topics_events[notified_user_id].append(arg_event["muted_topics"])
+            elif arg_event.type == "muted_topics":
+                muted_topics_events[notified_user_id].append(arg_event.muted_topics)
         self.assertEqual(
             user_topic_events[hamlet.id],
             [
@@ -597,9 +597,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         users_notified_via_user_topic_event: list[int] = []
         for call_args in mock_send_event_on_commit.call_args_list:
             (_arg_realm, arg_event, arg_notified_users) = call_args[0]
-            if arg_event["type"] == "user_topic":
+            if arg_event.type == "user_topic":
                 users_notified_via_user_topic_event.append(*arg_notified_users)
-            elif arg_event["type"] == "muted_topics":
+            elif arg_event.type == "muted_topics":
                 users_notified_via_muted_topics_event.append(*arg_notified_users)
         self.assertEqual(
             sorted(users_notified_via_muted_topics_event),
@@ -859,9 +859,9 @@ class MessageMoveTopicTest(ZulipTestCase):
         users_notified_via_user_topic_event: list[int] = []
         for call_args in mock_send_event_on_commit.call_args_list:
             (_arg_realm, arg_event, arg_notified_users) = call_args[0]
-            if arg_event["type"] == "user_topic":
+            if arg_event.type == "user_topic":
                 users_notified_via_user_topic_event.append(*arg_notified_users)
-            elif arg_event["type"] == "muted_topics":
+            elif arg_event.type == "muted_topics":
                 users_notified_via_muted_topics_event.append(*arg_notified_users)
         self.assertEqual(
             sorted(users_notified_via_muted_topics_event),

--- a/zerver/tests/test_muted_users.py
+++ b/zerver/tests/test_muted_users.py
@@ -5,6 +5,7 @@ import time_machine
 
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.cache import cache_get, get_muting_users_cache_key
+from zerver.lib.event_types import MutedUser as MutedUserData
 from zerver.lib.muted_users import get_mute_object, get_muting_users, get_user_mutes
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -30,12 +31,12 @@ class MutedUsersTests(ZulipTestCase):
         muted_users = get_user_mutes(hamlet)
         self.assert_length(muted_users, 1)
 
-        self.assertDictEqual(
+        self.assertEqual(
             muted_users[0],
-            {
-                "id": cordelia.id,
-                "timestamp": datetime_to_timestamp(mute_time),
-            },
+            MutedUserData(
+                id=cordelia.id,
+                timestamp=datetime_to_timestamp(mute_time),
+            ),
         )
 
     def test_add_muted_user_mute_self(self) -> None:
@@ -94,10 +95,10 @@ class MutedUsersTests(ZulipTestCase):
             self.assert_json_success(result)
 
         self.assertIn(
-            {
-                "id": cordelia.id,
-                "timestamp": datetime_to_timestamp(mute_time),
-            },
+            MutedUserData(
+                id=cordelia.id,
+                timestamp=datetime_to_timestamp(mute_time),
+            ),
             get_user_mutes(hamlet),
         )
         self.assertIsNotNone(get_mute_object(hamlet, cordelia))
@@ -154,10 +155,10 @@ class MutedUsersTests(ZulipTestCase):
 
         self.assert_json_success(result)
         self.assertNotIn(
-            {
-                "id": cordelia.id,
-                "timestamp": datetime_to_timestamp(mute_time),
-            },
+            MutedUserData(
+                id=cordelia.id,
+                timestamp=datetime_to_timestamp(mute_time),
+            ),
             get_user_mutes(hamlet),
         )
         self.assertIsNone(get_mute_object(hamlet, cordelia))

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -1238,7 +1238,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
             message=message,
             emoji_name="whatever",
             emoji_code="whatever",
-            reaction_type="whatever",
+            reaction_type="unicode_emoji",
         )
 
         with (

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -2338,8 +2338,8 @@ class UploadSpaceTests(UploadSerializeMixin, ZulipTestCase):
 
         data = b"zulip!"
         upload_message_attachment("dummy.txt", "text/plain", data, self.user_profile)
-        # notify_attachment_update function calls currently_used_upload_space_bytes which
-        # updates the cache.
+        # Sending the attachment event calls currently_used_upload_space_bytes,
+        # which updates the cache.
         self.assert_length(data, cache_get(get_realm_used_upload_space_cache_key(self.realm.id))[0])
         self.assert_length(data, self.realm.currently_used_upload_space_bytes())
 

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -14,6 +14,7 @@ from requests.models import PreparedRequest, Response
 from typing_extensions import override
 from urllib3.util import Retry
 
+from zerver.lib.event_types import BaseEvent
 from zerver.lib.partial import partial
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.models import Client, Realm, UserProfile
@@ -215,11 +216,30 @@ def send_notification_http(port: int, data: Mapping[str, Any]) -> None:
 # with the schema verified in `zerver/lib/event_schema.py`.
 #
 # See https://zulip.readthedocs.io/en/latest/subsystems/events-system.html
+#
+# The event argument accepts either a Pydantic BaseEvent or a legacy
+# dict, while we are migrating call sites. Once the migration is done,
+# this should narrow to BaseEvent so mypy enforces that every event
+# sent to clients has a complete, declared schema.
+def _event_to_dict(event: Mapping[str, Any] | BaseEvent) -> Mapping[str, Any]:
+    if isinstance(event, BaseEvent):
+        # exclude_unset preserves the legacy "absent vs explicit null" shape:
+        # a field passed by the caller appears in the dict (even if its value
+        # is None), while a field not passed (and falling back to the class
+        # default) is omitted. BaseEvent.model_post_init marks non-None
+        # defaults as "set" so discriminator fields like type/op still appear.
+        return event.model_dump(exclude_unset=True)
+    return event
+
+
 def send_event_rollback_unsafe(
-    realm: Realm, event: Mapping[str, Any], users: Iterable[int] | Iterable[Mapping[str, Any]]
+    realm: Realm,
+    event: Mapping[str, Any] | BaseEvent,
+    users: Iterable[int] | Iterable[Mapping[str, Any]],
 ) -> None:
     """`users` is a list of user IDs, or in some special cases like message
     send/update or embeds, dictionaries containing extra data."""
+    event = _event_to_dict(event)
     realm_ports = get_realm_tornado_ports(realm)
     if len(realm_ports) == 1:
         port_user_map = {realm_ports[0]: list(users)}
@@ -238,8 +258,11 @@ def send_event_rollback_unsafe(
 
 
 def send_event_on_commit(
-    realm: Realm, event: Mapping[str, Any], users: Iterable[int] | Iterable[Mapping[str, Any]]
+    realm: Realm,
+    event: Mapping[str, Any] | BaseEvent,
+    users: Iterable[int] | Iterable[Mapping[str, Any]],
 ) -> None:
+    event = _event_to_dict(event)
     if not settings.USING_RABBITMQ:
         # In tests, round-trip the event through JSON, as happens with
         # RabbitMQ.  zerver.lib.queue also enforces this, but the

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -236,11 +236,12 @@ def _event_to_dict(event: Mapping[str, Any] | BaseEvent) -> Mapping[str, Any]:
             if name not in data:
                 default = field_info.get_default(call_default_factory=True)
                 if default is not None:
-                    # Only the constant type/op discriminators are spelled
-                    # as class defaults; a default on any other field would
-                    # silently change which fields are sent by call sites
-                    # that omit it.
-                    assert name in ("type", "op")
+                    # Only the constant type/op discriminators (and the
+                    # legacy "operation" duplicate) are spelled as class
+                    # defaults; a default on any other field would silently
+                    # change which fields are sent by call sites that omit
+                    # it.
+                    assert name in ("type", "op", "operation")
                     data[name] = default
         return data
     return event

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -14,6 +14,7 @@ from requests.models import PreparedRequest, Response
 from typing_extensions import override
 from urllib3.util import Retry
 
+from zerver.lib.event_types import BaseEvent
 from zerver.lib.partial import partial
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.models import Client, Realm, UserProfile
@@ -215,11 +216,44 @@ def send_notification_http(port: int, data: Mapping[str, Any]) -> None:
 # with the schema verified in `zerver/lib/event_schema.py`.
 #
 # See https://zulip.readthedocs.io/en/latest/subsystems/events-system.html
+#
+# The event argument accepts either a Pydantic BaseEvent or a legacy
+# dict, while we are migrating call sites. Once the migration is done,
+# this should narrow to BaseEvent so mypy enforces that every event
+# sent to clients has a complete, declared schema.
+def _event_to_dict(event: Mapping[str, Any] | BaseEvent) -> Mapping[str, Any]:
+    if isinstance(event, BaseEvent):
+        # Plain-dict events only had the keys the caller put in them. A
+        # Pydantic model has every declared field, so a naive model_dump()
+        # would add "field: null" for each optional field the caller
+        # skipped, which the dict version never sent and the OpenAPI
+        # schema rejects. exclude_unset drops those (recursively, so
+        # nested models behave the same way), but it also drops type/op,
+        # which are spelled as class defaults on the event classes; put
+        # those back.
+        data = event.model_dump(exclude_unset=True)
+        for name, field_info in type(event).model_fields.items():
+            if name not in data:
+                default = field_info.get_default(call_default_factory=True)
+                if default is not None:
+                    # Only the constant type/op discriminators are spelled
+                    # as class defaults; a default on any other field would
+                    # silently change which fields are sent by call sites
+                    # that omit it.
+                    assert name in ("type", "op")
+                    data[name] = default
+        return data
+    return event
+
+
 def send_event_rollback_unsafe(
-    realm: Realm, event: Mapping[str, Any], users: Iterable[int] | Iterable[Mapping[str, Any]]
+    realm: Realm,
+    event: Mapping[str, Any] | BaseEvent,
+    users: Iterable[int] | Iterable[Mapping[str, Any]],
 ) -> None:
     """`users` is a list of user IDs, or in some special cases like message
     send/update or embeds, dictionaries containing extra data."""
+    event = _event_to_dict(event)
     realm_ports = get_realm_tornado_ports(realm)
     if len(realm_ports) == 1:
         port_user_map = {realm_ports[0]: list(users)}
@@ -238,8 +272,11 @@ def send_event_rollback_unsafe(
 
 
 def send_event_on_commit(
-    realm: Realm, event: Mapping[str, Any], users: Iterable[int] | Iterable[Mapping[str, Any]]
+    realm: Realm,
+    event: Mapping[str, Any] | BaseEvent,
+    users: Iterable[int] | Iterable[Mapping[str, Any]],
 ) -> None:
+    event = _event_to_dict(event)
     if not settings.USING_RABBITMQ:
         # In tests, round-trip the event through JSON, as happens with
         # RabbitMQ.  zerver.lib.queue also enforces this, but the

--- a/zerver/views/attachments.py
+++ b/zerver/views/attachments.py
@@ -1,10 +1,11 @@
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 
-from zerver.actions.uploads import notify_attachment_update
 from zerver.lib.attachments import access_attachment_by_id, remove_attachment, user_attachments
+from zerver.lib.event_types import AttachmentFieldForAttachmentRemoveEvent, AttachmentRemoveEvent
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def list_by_user(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
@@ -21,5 +22,9 @@ def list_by_user(request: HttpRequest, user_profile: UserProfile) -> HttpRespons
 def remove(request: HttpRequest, user_profile: UserProfile, attachment_id: int) -> HttpResponse:
     attachment = access_attachment_by_id(user_profile, attachment_id, needs_owner=True)
     remove_attachment(user_profile, attachment)
-    notify_attachment_update(user_profile, "remove", {"id": attachment_id})
+    event = AttachmentRemoveEvent(
+        attachment=AttachmentFieldForAttachmentRemoveEvent(id=attachment_id),
+        upload_space_used=user_profile.realm.currently_used_upload_space_bytes(),
+    )
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
     return json_success(request)

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -194,7 +194,7 @@ class OAuthVideoCallProvider(ABC):
     token_url: str = NotImplemented
     auto_refresh_url: str = NotImplemented
     create_meeting_url: str = NotImplemented
-    token_key_name: str = NotImplemented
+    token_key_name: Literal["zoom", "webex"] = NotImplemented
 
     def get_token(self, user: UserProfile) -> object | None:
         return user.third_party_api_state.get(self.token_key_name)


### PR DESCRIPTION
I'm reviewing these commits myself and then will mark it as ready for review.

**Note**: Final PR (once schema gaps are closed) should make sure to add `extra='forbid'` across `event_types.py` so that we can guarantee data isn't lost by coercing to these types.

---

This is the start of migrating event call sites in `zerver/actions/` from untyped dicts to the typed Pydantic `BaseEvent` subclasses already defined in `zerver/lib/event_types.py`. The end goal is to narrow `send_event_on_commit` (and `send_event_rollback_unsafe`) to accept only `BaseEvent`, at which point mypy enforces that every event sent to clients has a complete, declared schema.

Anders flagged that property as a prerequisite for confidently parsing events with Zod on the frontend (see [thread][1]): without mypy proving exhaustiveness, optional fields can be silently dropped during Zod parsing, and we can't see the problem in Sentry. This also unblocks the few remaining JavaScript-to-TypeScript migrations that depend on trustworthy event shapes (notably `server_events_dispatch.js`).

[1]: https://chat.zulip.org/#narrow/channel/6-frontend/topic/integrating.20pydantic.20types.20into.20real.20code/with/2272886

This branch picks up where #33172 (Steve Howell's spike) left off. The prep PR (renaming `EventX` → `XEvent` and dropping the test-only `id` field from `BaseEvent`) already merged, so this PR is the follow-on: one infrastructure commit that widens `send_event_on_commit` / `send_event_rollback_unsafe` to accept `BaseEvent`, and 23 per-file commits that convert action call sites to construct typed events. A final PR will tighten the signature to `BaseEvent` only, at which point mypy enforces the completeness property.

**Foundation commit (worth a careful pass):**

Plain-dict events only had the keys the caller put in them, while a Pydantic model has every declared field. So `_event_to_dict` serializes with `model_dump(exclude_unset=True)` to drop optional fields the caller didn't pass (this recurses into nested models, which matters for e.g. `NavigationViewFieldsForUpdate`), then puts back top-level fields whose class default is non-None — which is how `type`/`op` are spelled on the event classes so call sites don't repeat them. The result has the same field-presence shape the old dicts did, which the OpenAPI schema and several exact-keyset test assertions depend on. `exclude_none` alone would be wrong: `push_registration_error_code=None` is meaningfully sent to clear a value.

Nested non-`BaseEvent` models (e.g. `RecipientFieldForTypingEditChannelMessage`) don't get the default-restoring treatment, so their `type` literals stay required and call sites pass them explicitly.

**Deferred to follow-up PRs — each has a schema gap in `event_types.py` to fix first:**

| File | Gap |
| --- | --- |
| `presence.py` | Event sends `legacy_presence` + `modern_presence` in one payload; neither `LegacyPresenceEvent` nor `ModernPresenceEvent` matches. |
| `realm_emoji.py` | Missing compat `realm_emoji: dict[str, EmojiInfo]` field; `EmojiInfo.author_id` is `int \| None` but `RealmEmoji.author_id` is `int`. |
| `channel_folders.py` | `ChannelFolderData.order` isn't on `ChannelFolderForChannelFolderAddEvent`. |
| `custom_profile_fields.py` | `use_for_user_matching`, conditionally added by `CustomProfileField.as_dict()`, isn't on `DetailedCustomProfile`. |
| `user_groups.py` | Top-level `for_reactivation: bool` isn't on `UserGroupAddEvent`. |
| `create_user.py` | `RealmUser` is missing several `APIUserDict` fields (`bot_type`, `bot_owner_id`, `is_system_bot`, `max_message_id`, `is_deleted`); the `inaccessible_user=True` variant isn't declared. |
| `realm_settings.py`, `user_settings.py`, `users.py`, `streams.py`, `message_send.py`, `message_edit.py`, `message_delete.py` | Not yet audited; expected to surface more gaps. |

These gaps are exactly the property this migration exists to surface — Pydantic's default `extra="ignore"` would have silently dropped those fields on the wire.

Co-authored with @showell on the foundation commits.
