### PR TITLE
stream_pill: Remove unused show_subscriber_count field.

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -476,7 +476,7 @@ function update_stream_list(): void {
         for (const stream_id of guest_invite_stream_ids) {
             const sub = stream_data.get_sub_by_id(stream_id);
             if (sub) {
-                stream_pill.append_stream(sub, stream_pill_widget, false);
+                stream_pill.append_stream(sub, stream_pill_widget);
             }
         }
     } else {

--- a/web/src/invite_stream_picker_pill.ts
+++ b/web/src/invite_stream_picker_pill.ts
@@ -16,13 +16,11 @@ function create_item_from_stream_name(
 ): StreamPill | undefined {
     const stream_prefix_required = false;
     const get_allowed_streams = stream_data.get_invite_stream_data;
-    const show_stream_sub_count = false;
     return stream_pill.create_item_from_stream_name(
         stream_name,
         current_items,
         stream_prefix_required,
         get_allowed_streams,
-        show_stream_sub_count,
     );
 }
 
@@ -40,7 +38,7 @@ export function add_default_stream_pills(pill_widget: stream_pill.StreamPillWidg
     for (const stream_id of default_stream_ids) {
         const sub = stream_data.get_sub_by_id(stream_id);
         if (sub) {
-            stream_pill.append_stream(sub, pill_widget, false);
+            stream_pill.append_stream(sub, pill_widget);
         }
     }
 }

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -130,7 +130,7 @@ export function set_up_stream(
             return typeahead_helper.sort_streams_by_name(stream_matches, query);
         },
         updater(item: StreamPillData, _query: string): undefined {
-            stream_pill.append_stream(item, pills, false);
+            stream_pill.append_stream(item, pills);
             $input.trigger("focus");
             opts.update_func?.();
         },

--- a/web/src/stream_pill.ts
+++ b/web/src/stream_pill.ts
@@ -11,7 +11,6 @@ import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper.ts";
 export type StreamPill = {
     type: "stream";
     stream_id: number;
-    show_subscriber_count: boolean;
 };
 
 export type StreamPillWidget = InputPillContainer<StreamPill>;
@@ -23,7 +22,6 @@ export function create_item_from_stream_name(
     current_items: CombinedPill[],
     stream_prefix_required = true,
     get_allowed_streams: () => StreamSubscription[] = stream_data.get_unsorted_subs,
-    show_subscriber_count = true,
 ): StreamPill | undefined {
     stream_name = stream_name.trim();
     if (stream_prefix_required) {
@@ -49,7 +47,6 @@ export function create_item_from_stream_name(
 
     return {
         type: "stream",
-        show_subscriber_count,
         stream_id: sub.stream_id,
     };
 }
@@ -106,11 +103,9 @@ export function generate_pill_html(item: StreamPill): string {
 export function append_stream(
     stream: StreamSubscription,
     pill_widget: StreamPillWidget | CombinedPillContainer,
-    show_subscriber_count = true,
 ): void {
     pill_widget.appendValidatedData({
         type: "stream",
-        show_subscriber_count,
         stream_id: stream.stream_id,
     });
     pill_widget.clear_text();

--- a/web/tests/stream_pill.test.cjs
+++ b/web/tests/stream_pill.test.cjs
@@ -72,12 +72,10 @@ const germany = make_stream({
 const denmark_pill = {
     type: "stream",
     stream_id: denmark.stream_id,
-    show_subscriber_count: true,
 };
 const sweden_pill = {
     type: "stream",
     stream_id: sweden.stream_id,
-    show_subscriber_count: true,
 };
 
 const subs = [denmark, sweden, germany];
@@ -123,8 +121,6 @@ run_test("create_item", ({override}) => {
 
 run_test("display_value", () => {
     assert.deepEqual(stream_pill.get_display_value_from_item(denmark_pill), "Denmark");
-    assert.deepEqual(stream_pill.get_display_value_from_item(sweden_pill), "Sweden");
-    sweden_pill.show_subscriber_count = false;
     assert.deepEqual(stream_pill.get_display_value_from_item(sweden_pill), "Sweden");
 });
 


### PR DESCRIPTION
Fixes part of #29510.

Remove the `show_subscriber_count` field from `StreamPill`. The subscriber count was moved from channel pills to channel card popovers in c032bd9, but the field was left behind in `StreamPill` and the related functions, still being set at all call sites but never read anywhere.

Prep PR for #38345.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
