### PR TITLE
typeahead: Show email only when it's not null.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -120,12 +120,13 @@ export let render_person = (
 
     // Show the email or a matched custom profile field in the secondary text.
     // If both the email and a custom profile field match the query, show both.
-    let secondary_text = person.user.delivery_email;
+    const user_email = person.user.delivery_email;
+    let secondary_text = user_email;
 
     if (opts) {
         const email_matches = typeahead.query_matches_string_in_order(
             opts.query,
-            secondary_text ?? "",
+            user_email ?? "",
             "",
             opts.should_remove_diacritics,
         );
@@ -152,10 +153,12 @@ export let render_person = (
         }
 
         // if both email and custom field matches, show both.
-        if (email_matches && matched_custom_field) {
-            secondary_text = `${secondary_text}, ${matched_custom_field}`;
-        } else if (matched_custom_field) {
-            secondary_text = matched_custom_field;
+        if (matched_custom_field) {
+            if (user_email !== null && email_matches) {
+                secondary_text = `${user_email}, ${matched_custom_field}`;
+            } else {
+                secondary_text = matched_custom_field;
+            }
         }
     }
     const typeahead_arguments = {

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -1802,6 +1802,47 @@ test("render_person skips custom profile fields not used for user matching", ({
     assert.ok(rendered);
 });
 
+test("render_person with matching custom profile field but email hidden", ({
+    mock_template,
+    override,
+}) => {
+    override(realm, "custom_profile_field_types", {
+        SHORT_TEXT: {id: 1, name: "Short text"},
+        PRONOUNS: {id: 3, name: "Pronouns"},
+    });
+
+    override(realm, "custom_profile_fields", [
+        {
+            id: 1,
+            name: "Alpha field",
+            type: realm.custom_profile_field_types.SHORT_TEXT.id,
+            use_for_user_matching: true,
+        },
+    ]);
+
+    b_user_1.delivery_email = null;
+
+    people.set_custom_profile_field_data(b_user_1.user_id, {
+        id: 1,
+        value: "Alpha",
+    });
+
+    let rendered = false;
+    mock_template("typeahead_list_item.hbs", false, (args) => {
+        // When email is null and custom field matches,
+        // secondary should only show the custom field value, not "null, value"
+        assert.equal(args.secondary, "Alpha");
+        rendered = true;
+        return "typeahead-item-stub";
+    });
+
+    assert.equal(
+        th.render_person(b_user_1_item, {query: "", should_remove_diacritics: true}),
+        "typeahead-item-stub",
+    );
+    assert.ok(rendered);
+});
+
 test("query_matches_person matches custom profile fields when they are enabled for user matching ", ({
     override,
 }) => {


### PR DESCRIPTION
This PR adds a separate `user_email` variable instead of using `secondary_text` directly, so the `secondary_text` builds upon to get final value.

This also ensures that we only show the `user_email` in `secondary_text` in typeahead when its value is not null.


Fixes: [#issues > null values in typeahead](https://chat.zulip.org/#narrow/channel/9-issues/topic/null.20values.20in.20typeahead/with/2452533)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/7b5e666e-53ad-4eca-b895-09ef912071e2) | ![image-after](https://github.com/user-attachments/assets/3c22c36e-a203-497d-b24a-52d19b383c58)





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
