### PR TITLE
[ai] Add in-thread memcached buffer that aligns with PostgreSQL transaction semantics

### DIFF
--- a/scripts/setup/flush-memcached
+++ b/scripts/setup/flush-memcached
@@ -15,7 +15,11 @@ from django.conf import settings
 
 cache = settings.CACHES["default"]
 match cache["BACKEND"]:
-    case "django.core.cache.backends.locmem.LocMemCache":
+    case (
+        "django.core.cache.backends.locmem.LocMemCache"
+        | "zerver.lib.test_cache_backends.CASCapableLocMemCache"
+    ):
+        # In-process; nothing to flush across runs.
         pass
     case "zerver.lib.singleton_bmemcached.SingletonBMemcached":
         assert isinstance(cache["OPTIONS"], dict)

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -491,6 +491,14 @@ python_rules = RuleList(
                     "with transaction.atomic(savepoint=True):",
                 ),
                 (
+                    "zerver/tests/test_cache.py",
+                    "with transaction.atomic(savepoint=True):",
+                ),
+                (
+                    "zerver/tests/test_cache.py",
+                    "with self.assertRaises(RuntimeError), transaction.atomic(savepoint=True):",
+                ),
+                (
                     "zerver/tests/test_subs.py",
                     "with transaction.atomic(savepoint=True), self.assertRaises(JsonableError):",
                 ),

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1139,12 +1139,12 @@ def do_update_message(
     save_changes_for_propagation_mode()
 
     # Invalidate the message cache for all changed messages.  They'll
-    # be lazily rebuilt from the database on next access.  We defer
-    # this to after the transaction commits so that concurrent readers
-    # don't repopulate the cache with stale pre-commit data.
-    transaction.on_commit(
-        lambda: cache_delete_many(to_dict_cache_key_id(msg_id) for msg_id in changed_message_ids)
-    )
+    # be lazily rebuilt from the database on next access.  cache_delete
+    # is buffered for the duration of the atomic block and only flushed
+    # to memcached at commit, so concurrent readers don't see the
+    # invalidation (and our own re-reads see the fresh DB row) until
+    # the transaction commits.
+    cache_delete_many(to_dict_cache_key_id(msg_id) for msg_id in changed_message_ids)
     event["message_ids"] = sorted(changed_message_ids)
 
     # The following blocks arranges that users who are subscribed to a

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -267,9 +267,7 @@ def do_unarchive_stream(stream: Stream, new_name: str, *, acting_user: UserProfi
         realm_id=realm.id,
         recipient_id=stream.recipient_id,
     ).only("id")
-    transaction.on_commit(
-        lambda: cache_delete_many(to_dict_cache_key_id(message.id) for message in messages)
-    )
+    cache_delete_many(to_dict_cache_key_id(message.id) for message in messages)
 
     # Unset the is_web_public and is_realm_public cache on attachments,
     # since the stream is now private.
@@ -1524,9 +1522,7 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
     # Delete cache entries for everything else, which is cheaper and
     # clearer than trying to set them. display_recipient is the out of
     # date field in all cases.
-    transaction.on_commit(
-        lambda: cache_delete_many(to_dict_cache_key_id(message.id) for message in messages)
-    )
+    cache_delete_many(to_dict_cache_key_id(message.id) for message in messages)
 
     # We want to key these updates by id, not name, since id is
     # the immutable primary key, and obviously name is not.

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -529,7 +529,7 @@ def bulk_change_user_setting(
         assert isinstance(db_setting_value, str)
         event["language_name"] = get_language_name(db_setting_value)
 
-    transaction.on_commit(lambda: bulk_flush_users(user_profiles=user_profiles, realm=realm))
+    bulk_flush_users(user_profiles=user_profiles, realm=realm)
 
     user_ids = [u.id for u in user_profiles]
     send_event_on_commit(realm, event, user_ids)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -753,38 +753,60 @@ def generic_bulk_cached_fetch(
             pickled_tupled=False,
         )
 
-    cache_keys: dict[ObjKT, str] = {}
-    for object_id in object_ids:
-        cache_keys[object_id] = cache_key_function(object_id)
+    global _cache_fill_hit, _cache_fill_won, _cache_fill_race_detected
+    global _cache_fill_claim_lost, _cache_fill_saw_sentinel
 
-    cached_objects_compressed: dict[str, CompressedItemT] = safe_cache_get_many(
-        [cache_keys[object_id] for object_id in object_ids],
-    )
+    cache_keys: dict[ObjKT, str] = {oid: cache_key_function(oid) for oid in object_ids}
 
-    cached_objects = {key: extractor(val) for key, val in cached_objects_compressed.items()}
-    needed_ids = [
-        object_id for object_id in object_ids if cache_keys[object_id] not in cached_objects
+    # Initial read: one pipelined round-trip returning (value, cas_id) for every
+    # present key.
+    initial = cache_gets_many(list(cache_keys.values()))
+
+    # Drop sentinel entries -- a concurrent filler has written a sentinel we
+    # should not return to this caller.  These keys are treated as misses; our
+    # own add() below will fail, and we'll return the DB value without caching.
+    cached_objects: dict[str, CacheItemT] = {}
+    for key, (val, _cas) in initial.items():
+        if isinstance(val, _CacheFillSentinel):
+            _cache_fill_saw_sentinel += 1
+            continue
+        cached_objects[key] = extractor(val)
+    _cache_fill_hit += len(cached_objects)
+
+    needed: list[tuple[ObjKT, str]] = [
+        (oid, key) for oid, key in cache_keys.items() if key not in cached_objects
     ]
 
-    # Only call query_function if there are some ids to fetch from the database:
-    if len(needed_ids) > 0:
-        db_objects = query_function(needed_ids)
-    else:
-        db_objects = []
+    # Try to claim every missed key with the sentinel in a pipelined add_multi;
+    # we get back the new cas id for each successful add, which is our
+    # ownership token for the subsequent cas-commit.  Keys where we lose the
+    # add fell to another reader or already have a real value, and we won't
+    # write them.
+    owned_cas_ids: dict[str, int] = {}
+    if needed:
+        owned_cas_ids = cache_add_many(
+            {key: _CACHE_FILL_SENTINEL for _, key in needed},
+            CACHE_FILL_SENTINEL_TIMEOUT,
+        )
+        _cache_fill_claim_lost += len(needed) - len(owned_cas_ids)
 
-    items_for_remote_cache: dict[str, CompressedItemT] = {}
-    for obj in db_objects:
-        key = cache_keys[id_fetcher(obj)]
-        item = cache_transformer(obj)
-        items_for_remote_cache[key] = setter(item)
-        cached_objects[key] = item
-    if len(items_for_remote_cache) > 0:
-        safe_cache_set_many(items_for_remote_cache)
-    return {
-        object_id: cached_objects[cache_keys[object_id]]
-        for object_id in object_ids
-        if cache_keys[object_id] in cached_objects
-    }
+        # Collect values for pipelined cas writes.  Keys we don't own are still
+        # returned to the caller but never cached.
+        items_to_cas: dict[str, tuple[CompressedItemT, int]] = {}
+        for obj in query_function([oid for oid, _ in needed]):
+            key = cache_keys[id_fetcher(obj)]
+            item = cache_transformer(obj)
+            cached_objects[key] = item
+            if key in owned_cas_ids:
+                items_to_cas[key] = (setter(item), owned_cas_ids[key])
+
+        if items_to_cas:
+            committed = cache_cas_many(items_to_cas)
+            _cache_fill_won += len(committed)
+            # cas failures == writer's delete() landed during our DB fetch.
+            _cache_fill_race_detected += len(items_to_cas) - len(committed)
+
+    return {oid: cached_objects[key] for oid, key in cache_keys.items() if key in cached_objects}
 
 
 def bulk_cached_fetch(

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -2,6 +2,7 @@
 import hashlib
 import logging
 import os
+import pickle
 import re
 import secrets
 import sys
@@ -467,11 +468,18 @@ def _flush_buffered_ops(ops: dict[str, PendingOp]) -> None:
     deletes: list[str] = []
     write_through_by_timeout: dict[int | None, dict[str, Any]] = {}
     fills_by_timeout: dict[int | None, dict[str, tuple[Any, int]]] = {}
-    for key, (kind, val, timeout, mc_cas_id) in ops.items():
+    for key, (kind, val_bytes, timeout, mc_cas_id) in ops.items():
         if kind == "delete":
             deletes.append(key)
             continue
         assert kind == "set"
+        # The buffer stores 'set' values as pickled bytes (see
+        # cache_invalidation_buffer.record_set); unpickle here so we
+        # can detect the sentinel and so set_many sees a Python value.
+        # bmemcached's serialize() auto-pickles non-bytes values on
+        # the way out, so we cannot skip the re-pickle by passing
+        # raw bytes -- that would set the wrong flag for other readers.
+        val = pickle.loads(val_bytes)  # noqa: S301
         if isinstance(val, _CacheFillSentinel):
             # A read-through fill claimed the slot via cache_add but
             # the matching cache_cas never followed (e.g. the fetcher

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -17,7 +17,7 @@ from django.conf import settings
 from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
 from django.db.models import Q, QuerySet
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, override
 
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, get_recent_deployments
 
@@ -39,6 +39,16 @@ remote_cache_time_start = 0.0
 remote_cache_total_time = 0.0
 remote_cache_total_requests = 0
 
+# Counters for the read-through mark-then-fill path in read_through_cache().
+# These are in-process only; they match the existing
+# remote_cache_total_requests convention rather than introducing a separate
+# statsd pipeline.
+_cache_fill_hit = 0
+_cache_fill_won = 0
+_cache_fill_race_detected = 0
+_cache_fill_claim_lost = 0
+_cache_fill_saw_sentinel = 0
+
 
 def get_remote_cache_time() -> float:
     return remote_cache_total_time
@@ -46,6 +56,24 @@ def get_remote_cache_time() -> float:
 
 def get_remote_cache_requests() -> int:
     return remote_cache_total_requests
+
+
+def get_cache_fill_counts() -> dict[str, int]:
+    """Counters for read_through_cache outcomes.
+
+    race_detected counts misses where the reader's cas() failed (or the
+    sentinel disappeared between add and gets) -- i.e., a writer's
+    delete() landed during the fill.  A nonzero value here is the
+    point: it's a race that would previously have written a stale value
+    into the cache and is now being correctly rejected.
+    """
+    return {
+        "hit": _cache_fill_hit,
+        "won": _cache_fill_won,
+        "race_detected": _cache_fill_race_detected,
+        "claim_lost": _cache_fill_claim_lost,
+        "saw_sentinel": _cache_fill_saw_sentinel,
+    }
 
 
 def remote_cache_stats_start() -> None:
@@ -285,6 +313,10 @@ def cache_get(key: str, cache_name: str | None = None) -> Any:
     cache_backend = get_cache_backend(cache_name)
     ret = cache_backend.get(final_key)
     remote_cache_stats_finish()
+    if isinstance(ret, _CacheFillSentinel):
+        # A read_through_cache fill is in progress (or recently aborted);
+        # the sentinel is an internal marker, not a value to return.
+        return None
     return ret
 
 
@@ -295,7 +327,11 @@ def cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, 
     remote_cache_stats_start()
     ret = get_cache_backend(cache_name).get_many(keys)
     remote_cache_stats_finish()
-    return {key.removeprefix(KEY_PREFIX): value for key, value in ret.items()}
+    return {
+        key.removeprefix(KEY_PREFIX): value
+        for key, value in ret.items()
+        if not isinstance(value, _CacheFillSentinel)
+    }
 
 
 def safe_cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, Any]:
@@ -368,6 +404,185 @@ def cache_delete_many(items: Iterable[str], cache_name: str | None = None) -> No
             validate_cache_key(key, auto_prepend_prefix=False)
         get_cache_backend(cache_name).delete_many(batch)
     remote_cache_stats_finish()
+
+
+def _get_cache_fill_sentinel() -> "_CacheFillSentinel":
+    return _CACHE_FILL_SENTINEL
+
+
+class _CacheFillSentinel:
+    """Marker stored during a read-through fill to detect concurrent invalidation.
+
+    read_through_cache() writes this value via add(get_cas=True), keeps the
+    cas id memcached returns, and later cas-commits the fetched value with
+    that cas id.  If a writer's delete() (or any other write) intervenes,
+    the slot's cas changes, and the cas-commit fails atomically -- so the
+    (potentially stale) value is not cached.  The cas id is the ownership
+    token; the sentinel value just needs to be a non-collidable placeholder.
+
+    The sentinel pickles to a stable singleton via _get_cache_fill_sentinel
+    so identity / isinstance checks work after a memcached round-trip.
+    """
+
+    __slots__ = ()
+
+    @override
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        return (_get_cache_fill_sentinel, ())
+
+
+_CACHE_FILL_SENTINEL = _CacheFillSentinel()
+
+
+# Lifetime of the sentinel slot during a fill.  Must exceed any plausible
+# DB fetch; short enough that a crashed filler doesn't block the key for long.
+CACHE_FILL_SENTINEL_TIMEOUT = 30
+
+
+def _backend_gets(backend: BaseCache, pre_make_key: str) -> tuple[Any, int | None]:
+    """Memcached gets(); returns (None, None) on miss."""
+    if hasattr(backend, "gets"):
+        return backend.gets(pre_make_key)
+    raw_key = backend.make_key(pre_make_key)
+    return backend._cache.gets(raw_key)  # type: ignore[attr-defined] # not in stubs
+
+
+def _backend_cas(
+    backend: BaseCache, pre_make_key: str, value: Any, cas_id: int, timeout: int | None
+) -> bool:
+    """Memcached cas(): conditional set keyed on a matching cas_token."""
+    if hasattr(backend, "cas"):
+        return backend.cas(pre_make_key, value, cas_id, timeout)
+    raw_key = backend.make_key(pre_make_key)
+    return backend._cache.cas(  # type: ignore[attr-defined] # not in stubs
+        raw_key, value, cas_id, backend.get_backend_timeout(timeout)
+    )
+
+
+def _backend_add(
+    backend: BaseCache, pre_make_key: str, value: Any, timeout: int | None
+) -> tuple[bool, int | None]:
+    """Memcached add(); returns the new cas id on success."""
+    if hasattr(backend, "add_cas"):
+        return backend.add_cas(pre_make_key, value, timeout=timeout)
+    raw_key = backend.make_key(pre_make_key)
+    return backend._cache.add(  # type: ignore[attr-defined] # not in stubs
+        raw_key, value, backend.get_backend_timeout(timeout), get_cas=True
+    )
+
+
+def cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
+    final_key = KEY_PREFIX + key
+    validate_cache_key(final_key)
+
+    remote_cache_stats_start()
+    ret = _backend_gets(get_cache_backend(cache_name), final_key)
+    remote_cache_stats_finish()
+    return ret
+
+
+def cache_add(
+    key: str, val: Any, timeout: int, cache_name: str | None = None
+) -> tuple[bool, int | None]:
+    """Add-if-absent that returns the cas id of the just-added value.
+
+    On success returns (True, cas_id); on failure (key already present)
+    returns (False, None).  The cas id can be passed to a later cache_cas()
+    to write conditionally on the value still being ours.
+    """
+    final_key = KEY_PREFIX + key
+    validate_cache_key(final_key)
+
+    remote_cache_stats_start()
+    try:
+        added, cas_id = _backend_add(get_cache_backend(cache_name), final_key, val, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        added, cas_id = False, None
+    remote_cache_stats_finish()
+    return added, cas_id
+
+
+def cache_cas(
+    key: str,
+    val: Any,
+    cas_id: int,
+    timeout: int | None = None,
+    cache_name: str | None = None,
+) -> bool:
+    final_key = KEY_PREFIX + key
+    validate_cache_key(final_key)
+
+    remote_cache_stats_start()
+    try:
+        ok = _backend_cas(get_cache_backend(cache_name), final_key, val, cas_id, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        ok = False
+    remote_cache_stats_finish()
+    return ok
+
+
+def read_through_cache(
+    key: str,
+    fetcher: Callable[[], ReturnT],
+    *,
+    cache_name: str | None = None,
+    timeout: int | None = None,
+    pickled_tupled: bool = True,
+) -> ReturnT:
+    """Fetch a value through the cache, mark-then-fill to avoid stale writes.
+
+    On miss, we claim the fill slot with the _CACHE_FILL_SENTINEL via add(),
+    which gives us back the cas id of the just-added sentinel.  After the
+    DB fetch we cas-commit the value with that cas id; the cas succeeds
+    only if the slot has not been touched since (same value, same cas id).
+    A writer's delete() during the fetch -- or a delete followed by another
+    reader's add of their own sentinel -- changes the slot's cas, so the
+    cas-commit fails atomically and the (possibly stale) value is not
+    cached.  Callers that lose the initial add race -- or that see an
+    existing sentinel -- fall back to the DB directly and do not write to
+    the cache.
+
+    When pickled_tupled=True (the default), the value is wrapped in a
+    1-tuple on write and unwrapped on read, so that a cached None is
+    distinguishable from a missing key.  Setting pickled_tupled=False
+    skips the wrap (and the pickle it would force) -- a performance
+    optimization, reasonable when the value is a string or bytes that
+    cannot be None.  The sentinel class is separate, so
+    isinstance(val, _CacheFillSentinel) reliably distinguishes it from
+    any wrapped real value.
+    """
+    global _cache_fill_hit, _cache_fill_won, _cache_fill_race_detected
+    global _cache_fill_claim_lost, _cache_fill_saw_sentinel
+
+    val, _cas_id = cache_gets(key, cache_name=cache_name)
+
+    if isinstance(val, _CacheFillSentinel):
+        _cache_fill_saw_sentinel += 1
+        return fetcher()
+    if val is not None:
+        _cache_fill_hit += 1
+        return val[0] if pickled_tupled else val
+
+    # Genuine miss.  Claim the fill; the cas id we get back is our
+    # ownership token for the subsequent cas-commit.
+    claimed, our_cas = cache_add(
+        key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT, cache_name=cache_name
+    )
+    if not claimed:
+        _cache_fill_claim_lost += 1
+        return fetcher()
+    assert our_cas is not None
+
+    value = fetcher()
+
+    payload: Any = (value,) if pickled_tupled else value
+    if cache_cas(key, payload, our_cas, timeout=timeout, cache_name=cache_name):
+        _cache_fill_won += 1
+    else:
+        _cache_fill_race_detected += 1
+    return value
 
 
 def filter_good_and_bad_keys(keys: list[str]) -> tuple[list[str], list[str]]:

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -156,6 +156,26 @@ def get_cache_backend(cache_name: str | None) -> BaseCache:
     return caches[cache_name]
 
 
+def _no_queryset_returns(
+    func: Callable[ParamT, ReturnT],
+) -> Callable[ParamT, ReturnT]:
+    """Dev/test guard: assert a @cache_with_key-decorated function never
+    returns a QuerySet.  Production skips the check.
+    """
+
+    @wraps(func)
+    def wrapped(*args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
+        val = func(*args, **kwargs)
+        if isinstance(val, QuerySet):
+            raise AssertionError(
+                f"@cache_with_key {func.__qualname__} returned a QuerySet; "
+                f"materialize (e.g. list(qs)) before returning."
+            )
+        return val
+
+    return wrapped
+
+
 def cache_with_key(
     keyfunc: Callable[ParamT, str],
     cache_name: str | None = None,
@@ -170,6 +190,11 @@ def cache_with_key(
     other uses of caching."""
 
     def decorator(func: Callable[ParamT, ReturnT]) -> Callable[ParamT, ReturnT]:
+        if settings.TEST_SUITE or settings.DEBUG:
+            checked = _no_queryset_returns(func)
+        else:
+            checked = func
+
         @wraps(func)
         def func_with_caching(*args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
             key = keyfunc(*args, **kwargs)
@@ -179,7 +204,7 @@ def cache_with_key(
             except InvalidCacheKeyError:
                 stack_trace = traceback.format_exc()
                 log_invalid_cache_keys(stack_trace, [key])
-                return func(*args, **kwargs)
+                return checked(*args, **kwargs)
 
             # Values are singleton tuples so that we can distinguish a
             # result of None from a missing key.  Setting
@@ -189,16 +214,10 @@ def cache_with_key(
             if val is not None and pickled_tupled:
                 return val[0]
 
-            val = func(*args, **kwargs)
-            if isinstance(val, QuerySet):
-                logging.error(
-                    "cache_with_key attempted to store a full QuerySet object -- declining to cache",
-                    stack_info=True,
-                )
-            else:
-                cache_set(
-                    key, val, cache_name=cache_name, timeout=timeout, pickled_tupled=pickled_tupled
-                )
+            val = checked(*args, **kwargs)
+            cache_set(
+                key, val, cache_name=cache_name, timeout=timeout, pickled_tupled=pickled_tupled
+            )
 
             return val
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -228,26 +228,19 @@ def cache_with_key(
             key = keyfunc(*args, **kwargs)
 
             try:
-                val = cache_get(key, cache_name=cache_name)
+                validate_cache_key(KEY_PREFIX + key)
             except InvalidCacheKeyError:
                 stack_trace = traceback.format_exc()
                 log_invalid_cache_keys(stack_trace, [key])
                 return checked(*args, **kwargs)
 
-            # Values are singleton tuples so that we can distinguish a
-            # result of None from a missing key.  Setting
-            # pickled_tupled=False avoids pickling the result (if it's
-            # a raw string or bytes) at the cost of losing this
-            # distinction.
-            if val is not None and pickled_tupled:
-                return val[0]
-
-            val = checked(*args, **kwargs)
-            cache_set(
-                key, val, cache_name=cache_name, timeout=timeout, pickled_tupled=pickled_tupled
+            return read_through_cache(
+                key,
+                lambda: checked(*args, **kwargs),
+                cache_name=cache_name,
+                timeout=timeout,
+                pickled_tupled=pickled_tupled,
             )
-
-            return val
 
         return func_with_caching
 

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -464,6 +464,56 @@ def _backend_add(
     )
 
 
+def _backend_gets_multi(backend: BaseCache, pre_make_keys: list[str]) -> dict[str, tuple[Any, int]]:
+    """Pipelined gets across N keys in one round-trip; absent keys are omitted."""
+    if hasattr(backend, "gets_multi"):
+        return backend.gets_multi(pre_make_keys)
+    raw_to_orig = {backend.make_key(k): k for k in pre_make_keys}
+    raw = backend._cache.get_multi(  # type: ignore[attr-defined] # not in stubs
+        list(raw_to_orig), get_cas=True
+    )
+    return {raw_to_orig[rk]: (val, cas) for rk, (val, cas) in raw.items()}
+
+
+def _backend_add_multi(
+    backend: BaseCache, items: dict[str, Any], timeout: int | None
+) -> dict[str, int]:
+    """Pipelined add across N keys; returns cas ids of successful adds."""
+    if hasattr(backend, "add_multi_cas"):
+        return backend.add_multi_cas(items, timeout=timeout)
+    raw_to_orig = {backend.make_key(k): k for k in items}
+    # bmemcached.set_multi_cas with a (key, cas=0) mapping turns into a
+    # pipelined add, with per-key new cas ids returned for successful adds
+    # and None for keys that already existed.
+    raw_mappings = {(rk, 0): items[raw_to_orig[rk]] for rk in raw_to_orig}
+    raw_result: dict[str, int | None] = backend._cache.set_multi_cas(  # type: ignore[attr-defined] # not in stubs
+        raw_mappings, backend.get_backend_timeout(timeout)
+    )
+    return {raw_to_orig[rk]: cas for rk, cas in raw_result.items() if cas is not None}
+
+
+def _backend_cas_multi(
+    backend: BaseCache, items_with_cas: dict[str, tuple[Any, int]], timeout: int | None
+) -> set[str]:
+    """Pipelined cas across N keys; returns keys whose set committed."""
+    if hasattr(backend, "cas_multi"):
+        return backend.cas_multi(items_with_cas, timeout=timeout)
+    raw_to_orig = {backend.make_key(k): k for k in items_with_cas}
+    # bmemcached.set_multi treats a (key, cas != 0) mapping as a pipelined setq
+    # with the CAS field set, matching a single-key cas() call.
+    raw_mappings = {
+        (rk, items_with_cas[raw_to_orig[rk]][1]): items_with_cas[raw_to_orig[rk]][0]
+        for rk in raw_to_orig
+    }
+    failed_raw = backend._cache.set_multi(  # type: ignore[attr-defined] # not in stubs
+        raw_mappings, backend.get_backend_timeout(timeout)
+    )
+    failed_orig = {
+        raw_to_orig[entry[0] if isinstance(entry, tuple) else entry] for entry in failed_raw
+    }
+    return set(items_with_cas) - failed_orig
+
+
 def cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
     final_key = KEY_PREFIX + key
     validate_cache_key(final_key)
@@ -514,6 +564,60 @@ def cache_cas(
         ok = False
     remote_cache_stats_finish()
     return ok
+
+
+def cache_gets_many(keys: list[str], cache_name: str | None = None) -> dict[str, tuple[Any, int]]:
+    """Pipelined gets_many returning (value, cas_id) for each present key."""
+    final_keys = [KEY_PREFIX + k for k in keys]
+    for fk in final_keys:
+        validate_cache_key(fk)
+
+    remote_cache_stats_start()
+    raw = _backend_gets_multi(get_cache_backend(cache_name), final_keys)
+    remote_cache_stats_finish()
+    return {fk.removeprefix(KEY_PREFIX): v for fk, v in raw.items()}
+
+
+def cache_add_many(
+    items: dict[str, Any], timeout: int, cache_name: str | None = None
+) -> dict[str, int]:
+    """Pipelined add_many returning the new cas id for each successful add.
+
+    The cas ids can be passed back into cache_cas_many() to write
+    conditionally on the slots still being ours.
+    """
+    final_items = {KEY_PREFIX + k: v for k, v in items.items()}
+    for fk in final_items:
+        validate_cache_key(fk)
+
+    remote_cache_stats_start()
+    try:
+        added = _backend_add_multi(get_cache_backend(cache_name), final_items, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        added = {}
+    remote_cache_stats_finish()
+    return {fk.removeprefix(KEY_PREFIX): cas for fk, cas in added.items()}
+
+
+def cache_cas_many(
+    items_with_cas: dict[str, tuple[Any, int]],
+    timeout: int | None = None,
+    cache_name: str | None = None,
+) -> set[str]:
+    """Pipelined cas_many.  Returns the keys where the conditional set committed."""
+    final_items = {KEY_PREFIX + k: v for k, v in items_with_cas.items()}
+    for fk in final_items:
+        validate_cache_key(fk)
+
+    remote_cache_stats_start()
+    try:
+        committed = _backend_cas_multi(get_cache_backend(cache_name), final_items, timeout)
+    except MemcachedException as e:
+        logger.exception(e)
+        committed = set()
+    remote_cache_stats_finish()
+    return {fk.removeprefix(KEY_PREFIX) for fk in committed}
 
 
 def read_through_cache(

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from zerver.models import Attachment, Message, MutedUser, Realm, Stream, SubMessage, UserProfile
 
 MEMCACHED_MAX_KEY_LENGTH = 250
+# Printable ASCII (! through ~).
+_VALID_CACHE_KEY_RE = re.compile(r"[!-~]+")
 
 ParamT = ParamSpec("ParamT")
 ReturnT = TypeVar("ReturnT")
@@ -229,7 +231,7 @@ def validate_cache_key(key: str, auto_prepend_prefix: bool = True) -> None:
     # the resulting keys fit the regex below.
     # The regex checks "all characters between ! and ~ in the ascii table",
     # which happens to be the set of all "nice" ascii characters.
-    if not bool(re.fullmatch(r"([!-~])+", key)):
+    if _VALID_CACHE_KEY_RE.fullmatch(key) is None:
         raise InvalidCacheKeyError("Invalid characters in the cache key: " + key)
     if len(key) > MEMCACHED_MAX_KEY_LENGTH:
         raise InvalidCacheKeyError(f"Cache key too long: {key} Length: {len(key)}")

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -20,6 +20,7 @@ from django.db.models import Q, QuerySet
 from typing_extensions import ParamSpec, override
 
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, get_recent_deployments
+from zerver.lib.cache_invalidation_buffer import PendingOp, get_buffer
 
 if TYPE_CHECKING:
     # These modules have to be imported for type annotations but
@@ -286,11 +287,18 @@ def cache_set(
 ) -> None:
     final_key = KEY_PREFIX + key
     validate_cache_key(final_key)
+    if pickled_tupled:
+        val = (val,)
+    buffer = get_buffer()
+    if buffer.in_transaction():
+        # Defer to commit-time so that a rollback leaves memcached
+        # untouched.  The buffered value is also returned to subsequent
+        # reads in the same transaction (read-your-writes).
+        buffer.record_set(key, val, timeout)
+        return
 
     remote_cache_stats_start()
     cache_backend = get_cache_backend(cache_name)
-    if pickled_tupled:
-        val = (val,)
     try:
         cache_backend.set(final_key, val, timeout=timeout)
     except MemcachedException as e:
@@ -299,6 +307,12 @@ def cache_set(
 
 
 def cache_get(key: str, cache_name: str | None = None) -> Any:
+    op = get_buffer().lookup(key)
+    if op is not None:
+        kind, val, _, _ = op
+        if kind == "delete" or isinstance(val, _CacheFillSentinel):
+            return None
+        return val
     final_key = KEY_PREFIX + key
     validate_cache_key(final_key)
 
@@ -314,17 +328,31 @@ def cache_get(key: str, cache_name: str | None = None) -> Any:
 
 
 def cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, Any]:
-    keys = [KEY_PREFIX + key for key in keys]
+    buffer = get_buffer()
+    result: dict[str, Any] = {}
+    remaining: list[str] = []
     for key in keys:
-        validate_cache_key(key)
-    remote_cache_stats_start()
-    ret = get_cache_backend(cache_name).get_many(keys)
-    remote_cache_stats_finish()
-    return {
-        key.removeprefix(KEY_PREFIX): value
-        for key, value in ret.items()
-        if not isinstance(value, _CacheFillSentinel)
-    }
+        op = buffer.lookup(key)
+        if op is None:
+            remaining.append(key)
+            continue
+        kind, val, _, _ = op
+        if kind == "set" and not isinstance(val, _CacheFillSentinel):
+            result[key] = val
+        # 'delete' or sentinel: treated as a miss; don't fall through to
+        # memcached, since the buffered op overrides what memcached holds.
+    if remaining:
+        final_keys = [KEY_PREFIX + key for key in remaining]
+        for fk in final_keys:
+            validate_cache_key(fk)
+        remote_cache_stats_start()
+        raw = get_cache_backend(cache_name).get_many(final_keys)
+        remote_cache_stats_finish()
+        for fk, val in raw.items():
+            if isinstance(val, _CacheFillSentinel):
+                continue
+            result[fk.removeprefix(KEY_PREFIX)] = val
+    return result
 
 
 def safe_cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, Any]:
@@ -345,24 +373,32 @@ def safe_cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[
 
 
 def cache_set_many(
-    items: dict[str, Any], cache_name: str | None = None, timeout: int | None = None
+    items: dict[str, Any],
+    cache_name: str | None = None,
+    timeout: int | None = None,
 ) -> None:
     new_items = {}
     for key, item in items.items():
         new_key = KEY_PREFIX + key
         validate_cache_key(new_key)
         new_items[new_key] = item
-    items = new_items
+    buffer = get_buffer()
+    if buffer.in_transaction():
+        for key, val in items.items():
+            buffer.record_set(key, val, timeout)
+        return
     remote_cache_stats_start()
     try:
-        get_cache_backend(cache_name).set_many(items, timeout=timeout)
+        get_cache_backend(cache_name).set_many(new_items, timeout=timeout)
     except MemcachedException as e:
         logger.exception(e)
     remote_cache_stats_finish()
 
 
 def safe_cache_set_many(
-    items: dict[str, Any], cache_name: str | None = None, timeout: int | None = None
+    items: dict[str, Any],
+    cache_name: str | None = None,
+    timeout: int | None = None,
 ) -> None:
     """Variant of cache_set_many that drops saving any keys that fail
     validation, rather than throwing an exception visible to the
@@ -387,6 +423,20 @@ def cache_delete(key: str, cache_name: str | None = None) -> None:
 
 
 def cache_delete_many(items: Iterable[str], cache_name: str | None = None) -> None:
+    items_list = list(items)
+    buffer = get_buffer()
+    if buffer.in_transaction():
+        # Defer the memcached delete to commit-time so that a rollback
+        # leaves memcached untouched.  Within this transaction, reads of
+        # the buffered key are forced to miss (see cache_get / cache_gets).
+        for key in items_list:
+            validate_cache_key(KEY_PREFIX + key)
+            buffer.record_delete(key)
+        return
+    _do_cache_delete_many(items_list, cache_name)
+
+
+def _do_cache_delete_many(items: list[str], cache_name: str | None) -> None:
     remote_cache_stats_start()
     keys = iter(e[0] + e[1] for e in product(get_all_cache_key_prefixes(), items))
     while True:
@@ -397,6 +447,50 @@ def cache_delete_many(items: Iterable[str], cache_name: str | None = None) -> No
             validate_cache_key(key, auto_prepend_prefix=False)
         get_cache_backend(cache_name).delete_many(batch)
     remote_cache_stats_finish()
+
+
+def _flush_buffered_ops(ops: dict[str, PendingOp]) -> None:
+    """Apply a committed-frame's merged ops to memcached.
+
+    Called by the cache_invalidation_buffer module's Atomic exit hook
+    when the outermost atomic block commits.  Sets and deletes go
+    out as pipelined batches; sets are split into:
+
+      * write-through (mc_cas_id == 0) -- flushed via unconditional
+        set_many, grouped by timeout.
+      * fills (mc_cas_id != 0) -- flushed via cas-conditional
+        cas_multi keyed on the captured memcached cas_id, grouped by
+        timeout.  cas failures (a concurrent invalidation landed on
+        the slot during this transaction) silently leave memcached
+        alone, preserving the other writer's intent.
+    """
+    deletes: list[str] = []
+    write_through_by_timeout: dict[int | None, dict[str, Any]] = {}
+    fills_by_timeout: dict[int | None, dict[str, tuple[Any, int]]] = {}
+    for key, (kind, val, timeout, mc_cas_id) in ops.items():
+        if kind == "delete":
+            deletes.append(key)
+            continue
+        assert kind == "set"
+        if isinstance(val, _CacheFillSentinel):
+            # A read-through fill claimed the slot via cache_add but
+            # the matching cache_cas never followed (e.g. the fetcher
+            # raised but an outer handler swallowed the exception and
+            # let the transaction commit anyway).  The sentinel is
+            # already in memcached -- don't re-cas it; let it expire
+            # on its short TTL so a future reader can refill normally.
+            continue
+        if mc_cas_id == 0:
+            write_through_by_timeout.setdefault(timeout, {})[key] = val
+        else:
+            fills_by_timeout.setdefault(timeout, {})[key] = (val, mc_cas_id)
+
+    if deletes:
+        _do_cache_delete_many(deletes, cache_name=None)
+    for timeout, items in write_through_by_timeout.items():
+        cache_set_many(items, timeout=timeout)
+    for timeout, items_with_cas in fills_by_timeout.items():
+        cache_cas_many(items_with_cas, timeout=timeout)
 
 
 def _get_cache_fill_sentinel() -> "_CacheFillSentinel":
@@ -515,6 +609,15 @@ def _backend_cas_multi(
 
 
 def cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
+    op = get_buffer().lookup(key)
+    if op is not None:
+        kind, val, _, _ = op
+        if kind == "delete":
+            return None, None
+        # Buffered 'set' from cache_set: read-your-writes for this tx.
+        # cas_id is unused for buffered hits (cache_cas goes to memcached
+        # directly, see cache_add); return 0 as a placeholder.
+        return val, 0
     final_key = KEY_PREFIX + key
     validate_cache_key(final_key)
 
@@ -532,9 +635,38 @@ def cache_add(
     On success returns (True, cas_id); on failure (key already present)
     returns (False, None).  The cas id can be passed to a later cache_cas()
     to write conditionally on the value still being ours.
+
+    Inside a transaction we still hit memcached -- cache_add writes the
+    sentinel directly so it claims the slot from other connections via
+    memcached's own CAS, and we capture memcached's cas_id for the
+    matching cache_cas to flush against at commit.  See
+    cache_invalidation_buffer for the full semantics.
     """
     final_key = KEY_PREFIX + key
     validate_cache_key(final_key)
+
+    buffer = get_buffer()
+    if buffer.in_transaction():
+        op = buffer.lookup(key)
+        if op is not None and op[0] == "set":
+            # Slot already claimed in this transaction (by an in-progress
+            # fill or a previous cache_set).  Refuse the add without
+            # touching memcached, the same way memcached's own add would.
+            return False, None
+        if op is not None and op[0] == "delete":
+            # The writer has buffered an invalidation but is now
+            # refilling the slot (e.g. a post_save cache_delete
+            # followed by a @cache_with_key-decorated lookup in the
+            # same transaction).  Drop the delete to memcached
+            # eagerly so cache_add finds the slot empty; record_set
+            # below will overwrite the buffered delete with the
+            # sentinel.  Trades buffered-rollback-safety for in-tx-
+            # fill correctness; over-invalidating on rollback is
+            # benign.
+            try:
+                get_cache_backend(cache_name).delete(final_key)
+            except MemcachedException as e:
+                logger.exception(e)
 
     remote_cache_stats_start()
     try:
@@ -543,6 +675,13 @@ def cache_add(
         logger.exception(e)
         added, cas_id = False, None
     remote_cache_stats_finish()
+    if added and buffer.in_transaction():
+        # Stash the captured memcached cas_id alongside the sentinel; the
+        # matching cache_cas updates this entry to the fetched value, and
+        # the commit-time flush issues a cas-conditional set keyed on
+        # mc_cas_id so we don't clobber a concurrent invalidation.
+        assert cas_id is not None
+        buffer.record_set(key, val, timeout, mc_cas_id=cas_id)
     return added, cas_id
 
 
@@ -556,6 +695,20 @@ def cache_cas(
     final_key = KEY_PREFIX + key
     validate_cache_key(final_key)
 
+    buffer = get_buffer()
+    if buffer.in_transaction():
+        # CAS in the buffer: succeed iff the slot still holds the
+        # sentinel cache_add stashed under this mc_cas_id.  A buffered
+        # delete or a buffered cache_set would have overwritten the
+        # entry with mc_cas_id=0 and we'd correctly fail.  The cas
+        # only updates the buffer; memcached gets the value at commit
+        # via the cas-conditional flush keyed on the same mc_cas_id.
+        op = buffer.lookup(key)
+        if op is None or op[0] != "set" or op[3] != cas_id:
+            return False
+        buffer.record_set(key, val, timeout, mc_cas_id=cas_id)
+        return True
+
     remote_cache_stats_start()
     try:
         ok = _backend_cas(get_cache_backend(cache_name), final_key, val, cas_id, timeout)
@@ -568,14 +721,28 @@ def cache_cas(
 
 def cache_gets_many(keys: list[str], cache_name: str | None = None) -> dict[str, tuple[Any, int]]:
     """Pipelined gets_many returning (value, cas_id) for each present key."""
-    final_keys = [KEY_PREFIX + k for k in keys]
-    for fk in final_keys:
-        validate_cache_key(fk)
-
-    remote_cache_stats_start()
-    raw = _backend_gets_multi(get_cache_backend(cache_name), final_keys)
-    remote_cache_stats_finish()
-    return {fk.removeprefix(KEY_PREFIX): v for fk, v in raw.items()}
+    buffer = get_buffer()
+    result: dict[str, tuple[Any, int]] = {}
+    remaining: list[str] = []
+    for key in keys:
+        op = buffer.lookup(key)
+        if op is None:
+            remaining.append(key)
+            continue
+        kind, val, _, _ = op
+        if kind == "set":
+            result[key] = (val, 0)
+        # 'delete': skip; this transaction's view is "key absent".
+    if remaining:
+        final_keys = [KEY_PREFIX + k for k in remaining]
+        for fk in final_keys:
+            validate_cache_key(fk)
+        remote_cache_stats_start()
+        raw = _backend_gets_multi(get_cache_backend(cache_name), final_keys)
+        remote_cache_stats_finish()
+        for fk, v in raw.items():
+            result[fk.removeprefix(KEY_PREFIX)] = v
+    return result
 
 
 def cache_add_many(
@@ -583,21 +750,40 @@ def cache_add_many(
 ) -> dict[str, int]:
     """Pipelined add_many returning the new cas id for each successful add.
 
-    The cas ids can be passed back into cache_cas_many() to write
-    conditionally on the slots still being ours.
+    Like cache_add, the memcached add hits the server even inside a
+    transaction so the sentinel claims slots from other connections;
+    successful adds are also recorded in the buffer (with the captured
+    memcached cas_id) so the matching cache_cas_many can flush against
+    them at commit.
     """
     final_items = {KEY_PREFIX + k: v for k, v in items.items()}
     for fk in final_items:
         validate_cache_key(fk)
 
+    buffer = get_buffer()
+    if buffer.in_transaction():
+        # Drop keys whose slot is already buffered as a 'set' in this
+        # transaction, the same way cache_add would refuse them.
+        eligible_items = {
+            k: v for k, v in items.items() if (op := buffer.lookup(k)) is None or op[0] != "set"
+        }
+        eligible_final_items = {KEY_PREFIX + k: v for k, v in eligible_items.items()}
+    else:
+        eligible_items = items
+        eligible_final_items = final_items
+
     remote_cache_stats_start()
     try:
-        added = _backend_add_multi(get_cache_backend(cache_name), final_items, timeout)
+        added_raw = _backend_add_multi(get_cache_backend(cache_name), eligible_final_items, timeout)
     except MemcachedException as e:
         logger.exception(e)
-        added = {}
+        added_raw = {}
     remote_cache_stats_finish()
-    return {fk.removeprefix(KEY_PREFIX): cas for fk, cas in added.items()}
+    added = {fk.removeprefix(KEY_PREFIX): cas for fk, cas in added_raw.items()}
+    if buffer.in_transaction():
+        for k, cas_id in added.items():
+            buffer.record_set(k, eligible_items[k], timeout, mc_cas_id=cas_id)
+    return added
 
 
 def cache_cas_many(
@@ -610,14 +796,28 @@ def cache_cas_many(
     for fk in final_items:
         validate_cache_key(fk)
 
+    buffer = get_buffer()
+    if buffer.in_transaction():
+        # CAS in the buffer: per-key, succeed iff the slot still holds
+        # the sentinel cache_add_many stashed under this mc_cas_id.  See
+        # cache_cas for the single-key form.
+        committed: set[str] = set()
+        for key, (val, cas_id) in items_with_cas.items():
+            op = buffer.lookup(key)
+            if op is None or op[0] != "set" or op[3] != cas_id:
+                continue
+            buffer.record_set(key, val, timeout, mc_cas_id=cas_id)
+            committed.add(key)
+        return committed
+
     remote_cache_stats_start()
     try:
-        committed = _backend_cas_multi(get_cache_backend(cache_name), final_items, timeout)
+        committed_raw = _backend_cas_multi(get_cache_backend(cache_name), final_items, timeout)
     except MemcachedException as e:
         logger.exception(e)
-        committed = set()
+        committed_raw = set()
     remote_cache_stats_finish()
-    return {fk.removeprefix(KEY_PREFIX) for fk in committed}
+    return {fk.removeprefix(KEY_PREFIX) for fk in committed_raw}
 
 
 def read_through_cache(

--- a/zerver/lib/cache_invalidation_buffer.py
+++ b/zerver/lib/cache_invalidation_buffer.py
@@ -70,17 +70,21 @@ commit-style but on_commit didn't fire.  In production, on_commit
 always fires and the safety net is a no-op.
 """
 
-import copy
+import pickle
 import threading
 from typing import Any
 
 from django.db import connection, transaction
 
 # Op tuple: (kind, value, timeout, mc_cas_id).  Kind is 'set' or 'delete'.
-# For 'delete' value and timeout are None.  mc_cas_id is the memcached
-# cas_id captured by cache_add for read-through fill entries; 0 for any
-# other entry (deletes, write-through cache_set).  The flush uses
-# mc_cas_id != 0 to decide between cas-conditional and unconditional
+# For 'delete' value and timeout are None.  For 'set' value is the
+# pickle of the original Python value -- we store bytes so the buffer's
+# snapshot is independent of caller references (matching memcached's
+# pickle-round-trip semantics) without paying for a deepcopy on every
+# record_set / lookup.  See record_set / lookup.  mc_cas_id is the
+# memcached cas_id captured by cache_add for read-through fill entries;
+# 0 for any other entry (deletes, write-through cache_set).  The flush
+# uses mc_cas_id != 0 to decide between cas-conditional and unconditional
 # memcached writes -- see _flush_buffered_ops.
 PendingOp = tuple[str, Any, int | None, int]
 
@@ -139,26 +143,22 @@ class CacheInvalidationBuffer:
         calls that overwrite a prior fill entry.  The flush uses it to
         decide between cas-conditional and unconditional memcached writes.
 
-        record_set deepcopies the value so the buffer holds an
-        independent snapshot at write time (matching memcached's
-        cache_set-time pickle); lookup also deepcopies on read so
-        callers can mutate returned values without polluting the
-        cache (matching memcached's read-side unpickle).  Both are
-        needed -- the pickle the flush does at commit captures the
-        buffer's *then-current* value, which would miss intermediate
-        mutations of either reference.
+        The value is pickled and stored as bytes so the buffer holds an
+        independent snapshot at write time, and lookup unpickles on
+        read -- matching memcached's pickle-round-trip semantics.
         """
         assert self._stack, "record_set called outside an atomic block"
-        self._stack[-1][key] = ("set", copy.deepcopy(value), timeout, mc_cas_id)
+        self._stack[-1][key] = ("set", pickle.dumps(value), timeout, mc_cas_id)
 
     def lookup(self, key: str) -> PendingOp | None:
-        """Most recent op on `key` across all open frames, or None.  See
-        record_set for why the 'set' value is deepcopied."""
+        """Most recent op on `key` across all open frames, or None.  For
+        'set' ops the stored bytes are unpickled to a fresh value (see
+        record_set)."""
         for frame in reversed(self._stack):
             if key in frame:
                 kind, val, timeout, mc_cas_id = frame[key]
                 if kind == "set":
-                    val = copy.deepcopy(val)
+                    val = pickle.loads(val)  # noqa: S301
                 return (kind, val, timeout, mc_cas_id)
         return None
 

--- a/zerver/lib/cache_invalidation_buffer.py
+++ b/zerver/lib/cache_invalidation_buffer.py
@@ -1,0 +1,264 @@
+"""Per-transaction buffer of pending cache mutations.
+
+Cache mutations issued inside an `atomic()` block are recorded here and
+applied to memcached only when the outermost transaction commits.  This
+gives them the same all-or-nothing semantics as the DB writes that
+triggered them:
+
+  * The writer's own transaction sees its own mutations immediately --
+    a buffered set returns the new value on subsequent reads, a buffered
+    delete forces a miss.
+  * Other connections see the mutations only after the outermost
+    `atomic()` exits successfully.
+  * On rollback, the rolled-back frame's buffered mutations are
+    discarded and (for the rolled-back portion) memcached is untouched
+    -- in particular, no value the writer fetched from its own
+    pre-commit DB snapshot ends up cached.
+
+Two kinds of mutation flow through the buffer:
+
+  * Write-through writes (cache_set / cache_set_many) and
+    writer-side invalidations (cache_delete / cache_delete_many).
+    These are recorded with no memcached cas_id; the commit-time
+    flush issues them as unconditional set_many / delete_many.
+  * Read-through fills (the cache_add + cache_cas pair).  These have
+    to coexist with cross-connection mark-then-fill: cache_add writes
+    the sentinel directly into memcached and captures memcached's
+    own cas_id, then records that cas_id in the buffer entry.  cache_cas
+    *only* updates the buffer (no memcached write).  At commit, the
+    flush issues cas-conditional set_many for those entries, keyed on
+    the captured cas_id; if a concurrent invalidation landed on the
+    slot during our transaction, our flush correctly fails and we
+    don't overwrite that other writer's invalidation.  The sentinel
+    itself has a 30s TTL, so a writer that rolls back leaves a brief
+    "fill in progress" marker on the slot that other readers see and
+    bypass; no committed-but-rolled-back value ever lands in memcached.
+
+The buffer is per-thread, modeled as a stack of frames with one frame
+per open atomic block.  Each frame is a dict mapping key -> pending
+op, where the op is one of:
+
+  * ('delete', None, None, 0)            -- pending delete
+  * ('set', value, timeout, 0)           -- pending write-through set
+  * ('set', value, timeout, mc_cas_id)   -- pending fill set, cas
+                                            commits against mc_cas_id
+
+Within a frame, later ops on the same key overwrite earlier ones (the
+final intended state wins, e.g. set-then-delete collapses to delete
+and delete-then-set collapses to set).  Savepoint commit merges the
+inner frame into its parent (later wins again); savepoint rollback
+discards the inner frame.
+
+Flush ordering: at the moment the outermost atomic begins, we register
+a `transaction.on_commit(_drain_buffer)` callback.  on_commit hooks
+fire only on actual successful commit (Django clears them on rollback,
+including the silent rollback paths -- `connection.needs_rollback`
+having been set by an inner `savepoint=False` block, a DatabaseError
+out of COMMIT, or `connection.closed_in_transaction`).  Registering at
+__enter__ also puts our flush at the head of the on_commit queue so
+user `transaction.on_commit(lambda: cache_delete(...))` callbacks --
+the existing pre-buffer idiom -- run *after* our flush, preserving
+their delete-wins semantics.
+
+Django's TestCase wraps each test in an atomic block and rolls that
+wrapper back at tearDown, so on_commit hooks queued against it never
+fire.  Two pieces handle this: (a) atomics with `_from_testcase` set
+are skipped entirely by the buffer, so user atomics inside a test
+become the buffer's outermost; (b) the patched __exit__ runs a direct
+flush as a safety net when the outermost buffer frame exited
+commit-style but on_commit didn't fire.  In production, on_commit
+always fires and the safety net is a no-op.
+"""
+
+import copy
+import threading
+from typing import Any
+
+from django.db import connection, transaction
+
+# Op tuple: (kind, value, timeout, mc_cas_id).  Kind is 'set' or 'delete'.
+# For 'delete' value and timeout are None.  mc_cas_id is the memcached
+# cas_id captured by cache_add for read-through fill entries; 0 for any
+# other entry (deletes, write-through cache_set).  The flush uses
+# mc_cas_id != 0 to decide between cas-conditional and unconditional
+# memcached writes -- see _flush_buffered_ops.
+PendingOp = tuple[str, Any, int | None, int]
+
+
+class CacheInvalidationBuffer:
+    """Thread-local stack of buffered cache mutations.
+
+    One frame per open atomic() block; the stack mirrors Django's
+    savepoint nesting.  See module docstring.
+    """
+
+    def __init__(self) -> None:
+        self._stack: list[dict[str, PendingOp]] = []
+        # Set by exit_atomic at outermost commit; consumed by
+        # _drain_buffer (the on_commit callback) or, in tests where
+        # on_commit doesn't fire, by the patched __exit__'s safety net.
+        self._pending_flush_ops: dict[str, PendingOp] | None = None
+
+    def in_transaction(self) -> bool:
+        return bool(self._stack)
+
+    def enter_atomic(self) -> None:
+        self._stack.append({})
+
+    def exit_atomic(self, *, committed: bool) -> None:
+        """Pop the innermost frame.
+
+        On rollback the frame is discarded.  On savepoint commit it is
+        merged into the parent.  On outermost commit the merged frame
+        is stashed in `_pending_flush_ops` for the on_commit callback
+        (or the patched __exit__'s safety net, in tests) to apply.
+        """
+        frame = self._stack.pop()
+        if not committed:
+            return
+        if self._stack:
+            self._stack[-1].update(frame)
+            return
+        self._pending_flush_ops = frame
+
+    def take_pending_flush_ops(self) -> dict[str, PendingOp] | None:
+        ops = self._pending_flush_ops
+        self._pending_flush_ops = None
+        return ops
+
+    def record_delete(self, key: str) -> None:
+        assert self._stack, "record_delete called outside an atomic block"
+        self._stack[-1][key] = ("delete", None, None, 0)
+
+    def record_set(self, key: str, value: Any, timeout: int | None, mc_cas_id: int = 0) -> None:
+        """Record a buffered set.
+
+        mc_cas_id is the memcached cas_id captured by cache_add when this
+        entry originates from a read-through fill (cache_add + cache_cas);
+        0 for write-through cache_set entries and for follow-up cache_set
+        calls that overwrite a prior fill entry.  The flush uses it to
+        decide between cas-conditional and unconditional memcached writes.
+
+        record_set deepcopies the value so the buffer holds an
+        independent snapshot at write time (matching memcached's
+        cache_set-time pickle); lookup also deepcopies on read so
+        callers can mutate returned values without polluting the
+        cache (matching memcached's read-side unpickle).  Both are
+        needed -- the pickle the flush does at commit captures the
+        buffer's *then-current* value, which would miss intermediate
+        mutations of either reference.
+        """
+        assert self._stack, "record_set called outside an atomic block"
+        self._stack[-1][key] = ("set", copy.deepcopy(value), timeout, mc_cas_id)
+
+    def lookup(self, key: str) -> PendingOp | None:
+        """Most recent op on `key` across all open frames, or None.  See
+        record_set for why the 'set' value is deepcopied."""
+        for frame in reversed(self._stack):
+            if key in frame:
+                kind, val, timeout, mc_cas_id = frame[key]
+                if kind == "set":
+                    val = copy.deepcopy(val)
+                return (kind, val, timeout, mc_cas_id)
+        return None
+
+
+_buffer_local = threading.local()
+
+
+def get_buffer() -> CacheInvalidationBuffer:
+    buf = getattr(_buffer_local, "buffer", None)
+    if buf is None:
+        buf = CacheInvalidationBuffer()
+        _buffer_local.buffer = buf
+    return buf
+
+
+def _drain_buffer() -> None:
+    """on_commit callback (and patched __exit__ safety net) that applies
+    the stashed ops to memcached."""
+    ops = get_buffer().take_pending_flush_ops()
+    if ops:
+        # Lazy import to avoid a circular dependency: cache.py imports
+        # this module, and we need its low-level memcached helpers here.
+        from zerver.lib.cache import _flush_buffered_ops
+
+        _flush_buffered_ops(ops)
+
+
+# Hook into Django's atomic() lifecycle.  Importing this module from
+# zerver/lib/cache.py at module load installs the patch before any
+# cache call that depends on the buffer.
+
+_original_atomic_enter = transaction.Atomic.__enter__
+_original_atomic_exit = transaction.Atomic.__exit__
+
+
+def _patched_atomic_enter(self: transaction.Atomic) -> None:
+    if getattr(self, "_from_testcase", False):
+        # Django's TestCase wraps each test class and each test method
+        # in atomic() blocks that get rolled back at teardown; ignore
+        # them so the buffer's "outermost" mirrors user-level atomics.
+        _original_atomic_enter(self)
+        return
+    _original_atomic_enter(self)
+    buffer = get_buffer()
+    is_outermost = not buffer.in_transaction()
+    buffer.enter_atomic()
+    if is_outermost:
+        # If a previous outermost atomic exited commit-style but Django
+        # silently rolled it back (needs_rollback / closed_in_transaction
+        # / a DatabaseError out of COMMIT), the on_commit hooks were
+        # cleared and our drain never ran.  Drop the stash so it can't
+        # leak into the new transaction.
+        buffer.take_pending_flush_ops()
+        # Register the flush at the head of the on_commit queue so it
+        # fires after the DB commit but before any user on_commit
+        # callbacks registered later.
+        transaction.on_commit(_drain_buffer)
+
+
+def _patched_atomic_exit(
+    self: transaction.Atomic,
+    exc_type: type[BaseException] | None,
+    exc_value: BaseException | None,
+    traceback: Any,
+) -> bool | None:
+    if getattr(self, "_from_testcase", False):
+        return _original_atomic_exit(self, exc_type, exc_value, traceback)
+
+    buffer = get_buffer()
+    is_outermost_buffer_frame = len(buffer._stack) == 1
+
+    # Decide commit vs rollback the same way Django will: an exception
+    # is one trigger; `connection.needs_rollback` (set by an inner
+    # `savepoint=False` whose body raised and was caught between the
+    # two `with` blocks) and `closed_in_transaction` are the others.
+    # Zulip is single-DB; if a second DB is ever added, this needs to
+    # consult connections[self.using] instead.
+    committed = (
+        exc_type is None and not connection.needs_rollback and not connection.closed_in_transaction
+    )
+    buffer.exit_atomic(committed=committed)
+
+    try:
+        return _original_atomic_exit(self, exc_type, exc_value, traceback)
+    except Exception:  # nocoverage
+        # COMMIT itself raised (e.g. a DatabaseError); Django ran a
+        # rollback internally and cleared on_commit hooks.  Discard the
+        # stash so it can't leak into the next transaction.
+        buffer.take_pending_flush_ops()
+        raise
+    finally:
+        # Safety net for environments where on_commit hooks don't fire
+        # -- chiefly Django's TestCase, whose wrapping atomic rolls
+        # back at tearDown, dropping every on_commit registered against
+        # it.  In production with a real outermost atomic, on_commit
+        # has already drained the stash and this is a no-op.  Peek at
+        # the stash without consuming it; _drain_buffer takes ownership.
+        if is_outermost_buffer_frame and buffer._pending_flush_ops is not None:
+            _drain_buffer()
+
+
+transaction.Atomic.__enter__ = _patched_atomic_enter  # type: ignore[method-assign] # monkey-patch hook into Django
+transaction.Atomic.__exit__ = _patched_atomic_exit  # type: ignore[method-assign,assignment] # monkey-patch hook into Django

--- a/zerver/lib/test_cache_backends.py
+++ b/zerver/lib/test_cache_backends.py
@@ -1,0 +1,95 @@
+import itertools
+import pickle
+from typing import Any
+
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+from django.core.cache.backends.locmem import LocMemCache
+from typing_extensions import override
+
+# Per-cache-name dict of {key: cas_token}. Keyed the same way LocMemCache keys
+# its _caches global so that multiple backend instances sharing a name also
+# share cas tokens, consistent with a real memcached server.
+_cas_tokens: dict[str, dict[str, int]] = {}
+
+
+class CASCapableLocMemCache(LocMemCache):
+    """LocMemCache with memcached-style gets/cas.
+
+    The production backend (bmemcached.Client) exposes gets/cas natively,
+    but LocMemCache does not. Tests of CAS-based read-through code paths
+    use this backend instead so they don't require a real memcached server.
+
+    Implementation approach: every write goes through LocMemCache._set,
+    which we override to also bump a per-key cas token under the same
+    lock.  incr() writes to self._cache directly instead of going through
+    _set, so it gets its own override.
+    """
+
+    def __init__(self, name: str, params: dict[str, Any]) -> None:
+        super().__init__(name, params)
+        self._cas_tokens = _cas_tokens.setdefault(name, {})
+        self._cas_counter = itertools.count(1)
+
+    # LocMemCache's _set / _delete / _cache / _lock / _has_expired / _expire_info
+    # are private and not declared in django-stubs, so mypy can't see them. The
+    # attribute-access ignores below are for that reason only.
+
+    def _set(self, key: str, value: bytes, timeout: Any = DEFAULT_TIMEOUT) -> None:
+        super()._set(key, value, timeout)  # type: ignore[misc] # not in stubs
+        self._cas_tokens[key] = next(self._cas_counter)
+
+    def _delete(self, key: str) -> bool:
+        self._cas_tokens.pop(key, None)
+        return super()._delete(key)  # type: ignore[misc] # not in stubs
+
+    @override
+    def clear(self) -> None:
+        super().clear()
+        self._cas_tokens.clear()
+
+    def gets(self, key: str, version: Any = None) -> tuple[Any, int | None]:
+        raw_key = self.make_and_validate_key(key, version=version)
+        with self._lock:  # type: ignore[attr-defined] # not in stubs
+            if self._has_expired(raw_key):  # type: ignore[attr-defined] # not in stubs
+                self._delete(raw_key)
+                return None, None
+            pickled = self._cache[raw_key]  # type: ignore[attr-defined] # not in stubs
+            cas_id = self._cas_tokens.get(raw_key)
+            self._cache.move_to_end(raw_key, last=False)  # type: ignore[attr-defined] # not in stubs
+        return pickle.loads(pickled), cas_id  # noqa: S301
+
+    def cas(
+        self,
+        key: str,
+        value: Any,
+        cas_id: int,
+        timeout: Any = DEFAULT_TIMEOUT,
+        version: Any = None,
+    ) -> bool:
+        raw_key = self.make_and_validate_key(key, version=version)
+        pickled = pickle.dumps(value, self.pickle_protocol)
+        with self._lock:  # type: ignore[attr-defined] # not in stubs
+            if self._has_expired(raw_key):  # type: ignore[attr-defined] # not in stubs
+                return False
+            if self._cas_tokens.get(raw_key) != cas_id:
+                return False
+            # _set is our override, so this also refreshes the cas token.
+            self._set(raw_key, pickled, timeout)
+            return True
+
+    def add_cas(
+        self, key: str, value: Any, timeout: Any = DEFAULT_TIMEOUT, version: Any = None
+    ) -> tuple[bool, int | None]:
+        """Add-if-absent that returns the cas id of the just-added value.
+
+        Mirrors bmemcached.Client.add(get_cas=True) so callers don't need a
+        follow-up gets() to recover the cas id of their own write.  Returns
+        (True, cas_id) on success, (False, None) if the slot was already set.
+        """
+        raw_key = self.make_and_validate_key(key, version=version)
+        pickled = pickle.dumps(value, self.pickle_protocol)
+        with self._lock:  # type: ignore[attr-defined] # not in stubs
+            if not self._has_expired(raw_key):  # type: ignore[attr-defined] # not in stubs
+                return False, None
+            self._set(raw_key, pickled, timeout)
+            return True, self._cas_tokens[raw_key]

--- a/zerver/lib/test_cache_backends.py
+++ b/zerver/lib/test_cache_backends.py
@@ -93,3 +93,45 @@ class CASCapableLocMemCache(LocMemCache):
                 return False, None
             self._set(raw_key, pickled, timeout)
             return True, self._cas_tokens[raw_key]
+
+    # The multi-key variants below are sequential in this in-memory test
+    # backend, but mirror the interface that bmemcached implements via
+    # pipelined memcached commands, so callers can be exercised by the
+    # test suite without spinning up a real memcached.
+
+    def gets_multi(self, keys: list[str], version: Any = None) -> dict[str, tuple[Any, int]]:
+        result: dict[str, tuple[Any, int]] = {}
+        for key in keys:
+            val, cas_id = self.gets(key, version=version)
+            if cas_id is not None:
+                result[key] = (val, cas_id)
+        return result
+
+    def add_multi_cas(
+        self, items: dict[str, Any], timeout: Any = DEFAULT_TIMEOUT, version: Any = None
+    ) -> dict[str, int]:
+        """Pipelined add returning the new cas id for each successful add.
+
+        Mirrors bmemcached.Client.set_multi_cas with (key, 0) tuples (which
+        the protocol turns into pipelined add operations) -- on success the
+        per-key new cas id is returned to the caller.
+        """
+        result: dict[str, int] = {}
+        for key, value in items.items():
+            success, cas_id = self.add_cas(key, value, timeout=timeout, version=version)
+            if success:
+                assert cas_id is not None
+                result[key] = cas_id
+        return result
+
+    def cas_multi(
+        self,
+        items: dict[str, tuple[Any, int]],
+        timeout: Any = DEFAULT_TIMEOUT,
+        version: Any = None,
+    ) -> set[str]:
+        return {
+            key
+            for key, (value, cas_id) in items.items()
+            if self.cas(key, value, cas_id, timeout=timeout, version=version)
+        }

--- a/zerver/lib/test_cache_backends.py
+++ b/zerver/lib/test_cache_backends.py
@@ -6,10 +6,14 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.core.cache.backends.locmem import LocMemCache
 from typing_extensions import override
 
-# Per-cache-name dict of {key: cas_token}. Keyed the same way LocMemCache keys
-# its _caches global so that multiple backend instances sharing a name also
-# share cas tokens, consistent with a real memcached server.
+# Per-cache-name dict of {key: cas_token} and a per-cache-name monotonic
+# counter for issuing new tokens.  Keyed the same way LocMemCache keys
+# its _caches global so that multiple backend instances sharing a name --
+# including the per-thread instances Django's CacheHandler creates --
+# also share cas tokens and a single counter, consistent with a real
+# memcached server's globally-monotonic cas semantics.
 _cas_tokens: dict[str, dict[str, int]] = {}
+_cas_counters: dict[str, "itertools.count[int]"] = {}
 
 
 class CASCapableLocMemCache(LocMemCache):
@@ -28,7 +32,7 @@ class CASCapableLocMemCache(LocMemCache):
     def __init__(self, name: str, params: dict[str, Any]) -> None:
         super().__init__(name, params)
         self._cas_tokens = _cas_tokens.setdefault(name, {})
-        self._cas_counter = itertools.count(1)
+        self._cas_counter = _cas_counters.setdefault(name, itertools.count(1))
 
     # LocMemCache's _set / _delete / _cache / _lock / _has_expired / _expire_info
     # are private and not declared in django-stubs, so mypy can't see them. The

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -135,17 +135,31 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
     cache_queries: list[tuple[str, str | list[str], str | None]] = []
 
     orig_get = cache.cache_get
+    orig_gets = cache.cache_gets
     orig_get_many = cache.cache_get_many
 
-    def my_cache_get(key: str, cache_name: str | None = None) -> dict[str, Any] | None:
+    def my_cache_get(  # nocoverage -- no current test exercises this path
+        key: str, cache_name: str | None = None
+    ) -> dict[str, Any] | None:
         cache_queries.append(("get", key, cache_name))
         return orig_get(key, cache_name)
 
-    def my_cache_get_many(keys: list[str], cache_name: str | None = None) -> dict[str, Any]:
+    def my_cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
+        cache_queries.append(("gets", key, cache_name))
+        return orig_gets(key, cache_name)
+
+    def my_cache_get_many(  # nocoverage -- no current test exercises this path
+        keys: list[str], cache_name: str | None = None
+    ) -> dict[str, Any]:
         cache_queries.append(("getmany", keys, cache_name))
         return orig_get_many(keys, cache_name)
 
-    with mock.patch.multiple(cache, cache_get=my_cache_get, cache_get_many=my_cache_get_many):
+    with mock.patch.multiple(
+        cache,
+        cache_get=my_cache_get,
+        cache_gets=my_cache_gets,
+        cache_get_many=my_cache_get_many,
+    ):
         yield cache_queries
 
 
@@ -153,9 +167,15 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
 def simulated_empty_cache() -> Iterator[list[tuple[str, str | list[str], str | None]]]:
     cache_queries: list[tuple[str, str | list[str], str | None]] = []
 
-    def my_cache_get(key: str, cache_name: str | None = None) -> dict[str, Any] | None:
+    def my_cache_get(  # nocoverage -- simulated code doesn't use this
+        key: str, cache_name: str | None = None
+    ) -> dict[str, Any] | None:
         cache_queries.append(("get", key, cache_name))
         return None
+
+    def my_cache_gets(key: str, cache_name: str | None = None) -> tuple[Any, int | None]:
+        cache_queries.append(("gets", key, cache_name))
+        return None, None
 
     def my_cache_get_many(
         keys: list[str], cache_name: str | None = None
@@ -163,7 +183,12 @@ def simulated_empty_cache() -> Iterator[list[tuple[str, str | list[str], str | N
         cache_queries.append(("getmany", keys, cache_name))
         return {}
 
-    with mock.patch.multiple(cache, cache_get=my_cache_get, cache_get_many=my_cache_get_many):
+    with mock.patch.multiple(
+        cache,
+        cache_get=my_cache_get,
+        cache_gets=my_cache_gets,
+        cache_get_many=my_cache_get_many,
+    ):
         yield cache_queries
 
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -137,6 +137,7 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
     orig_get = cache.cache_get
     orig_gets = cache.cache_gets
     orig_get_many = cache.cache_get_many
+    orig_gets_many = cache.cache_gets_many
 
     def my_cache_get(  # nocoverage -- no current test exercises this path
         key: str, cache_name: str | None = None
@@ -154,11 +155,18 @@ def cache_tries_captured() -> Iterator[list[tuple[str, str | list[str], str | No
         cache_queries.append(("getmany", keys, cache_name))
         return orig_get_many(keys, cache_name)
 
+    def my_cache_gets_many(
+        keys: list[str], cache_name: str | None = None
+    ) -> dict[str, tuple[Any, int]]:
+        cache_queries.append(("getsmany", keys, cache_name))
+        return orig_gets_many(keys, cache_name)
+
     with mock.patch.multiple(
         cache,
         cache_get=my_cache_get,
         cache_gets=my_cache_gets,
         cache_get_many=my_cache_get_many,
+        cache_gets_many=my_cache_gets_many,
     ):
         yield cache_queries
 
@@ -183,11 +191,18 @@ def simulated_empty_cache() -> Iterator[list[tuple[str, str | list[str], str | N
         cache_queries.append(("getmany", keys, cache_name))
         return {}
 
+    def my_cache_gets_many(  # nocoverage -- simulated code doesn't use this
+        keys: list[str], cache_name: str | None = None
+    ) -> dict[str, tuple[Any, int]]:
+        cache_queries.append(("getsmany", keys, cache_name))
+        return {}
+
     with mock.patch.multiple(
         cache,
         cache_get=my_cache_get,
         cache_gets=my_cache_gets,
         cache_get_many=my_cache_get_many,
+        cache_gets_many=my_cache_gets_many,
     ):
         yield cache_queries
 

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -2,7 +2,9 @@ from unittest.mock import Mock, patch
 
 from bmemcached.exceptions import MemcachedException
 from django.conf import settings
+from django.core.cache import caches
 from django.db.models import QuerySet
+from typing_extensions import override
 
 from zerver.apps import flush_cache
 from zerver.lib.cache import (
@@ -349,3 +351,61 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
             id_fetcher=get_user_email,
         )
         self.assertEqual(result, {})
+
+
+class CASCapableBackendTest(ZulipTestCase):
+    """Round-trip tests for the gets/cas/add backend operations that the
+    read-through race-protection code relies on. These exercise the test
+    suite's CASCapableLocMemCache directly, since LocMemCache has no
+    gets/cas of its own."""
+
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        from zerver.lib.test_cache_backends import CASCapableLocMemCache
+
+        backend = caches["default"]
+        assert isinstance(backend, CASCapableLocMemCache)
+        self.backend = backend
+        self.key = "CASCapableBackendTest:key"
+        # Ensure a clean slate; prior tests may have populated this key.
+        self.backend.delete(self.key)
+
+    def test_gets_miss_returns_none_none(self) -> None:
+        value, cas_id = self.backend.gets(self.key)
+        self.assertIsNone(value)
+        self.assertIsNone(cas_id)
+
+    def test_gets_hit_returns_value_and_token(self) -> None:
+        self.backend.set(self.key, "hello")
+        value, cas_id = self.backend.gets(self.key)
+        self.assertEqual(value, "hello")
+        self.assertIsNotNone(cas_id)
+
+    def test_cas_succeeds_with_matching_token(self) -> None:
+        self.backend.set(self.key, "v1")
+        _, cas_id = self.backend.gets(self.key)
+        assert cas_id is not None
+        self.assertTrue(self.backend.cas(self.key, "v2", cas_id))
+        self.assertEqual(self.backend.get(self.key), "v2")
+
+    def test_cas_fails_after_concurrent_write(self) -> None:
+        self.backend.set(self.key, "v1")
+        _, stale_cas_id = self.backend.gets(self.key)
+        assert stale_cas_id is not None
+        self.backend.set(self.key, "intervening")
+        self.assertFalse(self.backend.cas(self.key, "v2", stale_cas_id))
+        self.assertEqual(self.backend.get(self.key), "intervening")
+
+    def test_cas_fails_after_delete(self) -> None:
+        self.backend.set(self.key, "v1")
+        _, cas_id = self.backend.gets(self.key)
+        assert cas_id is not None
+        self.backend.delete(self.key)
+        self.assertFalse(self.backend.cas(self.key, "v2", cas_id))
+        self.assertIsNone(self.backend.get(self.key))
+
+    def test_add_is_atomic(self) -> None:
+        self.assertTrue(self.backend.add(self.key, "first"))
+        self.assertFalse(self.backend.add(self.key, "second"))
+        self.assertEqual(self.backend.get(self.key), "first")

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -362,6 +362,113 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
         )
         self.assertEqual(result, {})
 
+    def test_hit_miss_mix_only_queries_missing_ids(self) -> None:
+        """A bulk fetch of N ids where some are pre-populated should only
+        call query_function for the missing ones, fill the cache for
+        those, and return all N."""
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        othello = self.example_user("othello")
+
+        # Warm the cache for hamlet and iago only.
+        get_user_profile_by_id(hamlet.id)
+        get_user_profile_by_id(iago.id)
+        cache_delete(user_profile_by_id_cache_key(othello.id))
+
+        queried_ids: list[int] = []
+
+        def query_function(ids: list[int]) -> list[UserProfile]:
+            queried_ids.extend(ids)
+            return list(UserProfile.objects.filter(id__in=ids))
+
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=query_function,
+            object_ids=[hamlet.id, iago.id, othello.id],
+            id_fetcher=get_user_id,
+        )
+        self.assertEqual(set(result), {hamlet.id, iago.id, othello.id})
+        self.assertEqual(queried_ids, [othello.id])
+
+        # othello should now be cached; a second bulk fetch doesn't
+        # re-query.
+        queried_ids.clear()
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=query_function,
+            object_ids=[hamlet.id, iago.id, othello.id],
+            id_fetcher=get_user_id,
+        )
+        self.assertEqual(queried_ids, [])
+
+    def test_race_writer_delete_during_bulk_query(self) -> None:
+        """If a writer invalidates a key while the reader's query_function
+        is running, the reader's cas() must fail and the stale value
+        must not be cached."""
+        hamlet = self.example_user("hamlet")
+        key = user_profile_by_id_cache_key(hamlet.id)
+        cache_delete(key)
+
+        counts_before = get_cache_fill_counts()
+
+        def racing_query(ids: list[int]) -> list[UserProfile]:
+            # Simulate the writer's invalidation landing while we're
+            # "reading" from the database.
+            cache_delete(key)
+            return list(UserProfile.objects.filter(id__in=ids))
+
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=racing_query,
+            object_ids=[hamlet.id],
+            id_fetcher=get_user_id,
+        )
+
+        # The caller still gets the fetched value...
+        self.assertIn(hamlet.id, result)
+        # ...but the cache is NOT populated, and the race was detected.
+        self.assertIsNone(cache_get(key))
+        self.assertEqual(
+            get_cache_fill_counts()["race_detected"] - counts_before["race_detected"],
+            1,
+        )
+
+    def test_race_bulk_writer_delete_then_other_reader_adds(self) -> None:
+        """Bulk analog of ReadThroughCacheTest.test_race_writer_delete_then_other_reader_adds:
+        during our query_function, a writer deletes our sentinel and another
+        reader (simulated) adds their own.  The cas id we got back from our
+        own add no longer matches the slot's current cas, so cache_cas_many
+        rejects the write and the stale DB value is not cached."""
+        hamlet = self.example_user("hamlet")
+        key = user_profile_by_id_cache_key(hamlet.id)
+        cache_delete(key)
+
+        counts_before = get_cache_fill_counts()
+
+        def racing_query(ids: list[int]) -> list[UserProfile]:
+            cache_delete(key)
+            added, _cas = cache_add(key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+            self.assertTrue(added)
+            return list(UserProfile.objects.filter(id__in=ids))
+
+        result = bulk_cached_fetch(
+            cache_key_function=user_profile_by_id_cache_key,
+            query_function=racing_query,
+            object_ids=[hamlet.id],
+            id_fetcher=get_user_id,
+        )
+
+        # Caller gets the fetched value, cache holds the other reader's
+        # sentinel (not our stale 1-tuple), and the race was counted.
+        # cache_gets exposes the raw value; cache_get filters sentinels.
+        self.assertIn(hamlet.id, result)
+        raw, _cas = cache_gets(key)
+        self.assertIsInstance(raw, _CacheFillSentinel)
+        self.assertEqual(
+            get_cache_fill_counts()["race_detected"] - counts_before["race_detected"],
+            1,
+        )
+
 
 class CASCapableBackendTest(ZulipTestCase):
     """Round-trip tests for the gets/cas/add backend operations that the

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -420,6 +420,45 @@ class CASCapableBackendTest(ZulipTestCase):
         self.assertFalse(self.backend.add(self.key, "second"))
         self.assertEqual(self.backend.get(self.key), "first")
 
+    def test_gets_multi_absent_keys_omitted(self) -> None:
+        self.backend.set(self.key, "v1")
+        other_key = self.key + ":other"
+        self.backend.delete(other_key)
+        got = self.backend.gets_multi([self.key, other_key])
+        self.assertIn(self.key, got)
+        self.assertEqual(got[self.key][0], "v1")
+        self.assertNotIn(other_key, got)
+
+    def test_add_multi_cas_returns_cas_for_added_keys_only(self) -> None:
+        other_key = self.key + ":other"
+        self.backend.set(self.key, "existing")
+        self.backend.delete(other_key)
+        added = self.backend.add_multi_cas({self.key: "nope", other_key: "added"})
+        self.assertEqual(set(added), {other_key})
+        # The cas id we got back matches what gets() would return for the
+        # newly-added value.
+        _, cas_id = self.backend.gets(other_key)
+        self.assertEqual(added[other_key], cas_id)
+        # The prior value at self.key wasn't overwritten.
+        self.assertEqual(self.backend.get(self.key), "existing")
+        self.assertEqual(self.backend.get(other_key), "added")
+
+    def test_cas_multi_commits_only_matching_cas(self) -> None:
+        other_key = self.key + ":other"
+        self.backend.set(self.key, "v1")
+        self.backend.set(other_key, "v1")
+        _, good_cas = self.backend.gets(self.key)
+        _, stale_cas = self.backend.gets(other_key)
+        assert good_cas is not None and stale_cas is not None
+        # Invalidate one of the cas ids by an intervening write.
+        self.backend.set(other_key, "intervening")
+        committed = self.backend.cas_multi(
+            {self.key: ("v2", good_cas), other_key: ("v2", stale_cas)}
+        )
+        self.assertEqual(committed, {self.key})
+        self.assertEqual(self.backend.get(self.key), "v2")
+        self.assertEqual(self.backend.get(other_key), "intervening")
+
 
 class ReadThroughCacheTest(ZulipTestCase):
     """Tests for read_through_cache() and its mark-then-fill race protection."""

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -1,5 +1,8 @@
+import threading
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
+import time_machine
 from bmemcached.exceptions import MemcachedException
 from django.conf import settings
 from django.core.cache import caches
@@ -8,16 +11,23 @@ from typing_extensions import override
 
 from zerver.apps import flush_cache
 from zerver.lib.cache import (
+    _CACHE_FILL_SENTINEL,
+    CACHE_FILL_SENTINEL_TIMEOUT,
     MEMCACHED_MAX_KEY_LENGTH,
     InvalidCacheKeyError,
+    _CacheFillSentinel,
     bulk_cached_fetch,
+    cache_add,
     cache_delete,
     cache_delete_many,
     cache_get,
     cache_get_many,
+    cache_gets,
     cache_set,
     cache_set_many,
     cache_with_key,
+    get_cache_fill_counts,
+    read_through_cache,
     safe_cache_get_many,
     safe_cache_set_many,
     user_profile_by_id_cache_key,
@@ -409,3 +419,196 @@ class CASCapableBackendTest(ZulipTestCase):
         self.assertTrue(self.backend.add(self.key, "first"))
         self.assertFalse(self.backend.add(self.key, "second"))
         self.assertEqual(self.backend.get(self.key), "first")
+
+
+class ReadThroughCacheTest(ZulipTestCase):
+    """Tests for read_through_cache() and its mark-then-fill race protection."""
+
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        self.key = "ReadThroughCacheTest:key"
+        cache_delete(self.key)
+        # Snapshot counters so assertions can compare deltas.
+        self._counts_before = get_cache_fill_counts()
+
+    def _delta(self, name: str) -> int:
+        return get_cache_fill_counts()[name] - self._counts_before[name]
+
+    def test_hit_returns_cached_value(self) -> None:
+        cache_set(self.key, "stored")
+        fetcher = Mock()
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "stored")
+        fetcher.assert_not_called()
+        self.assertEqual(self._delta("hit"), 1)
+
+    def test_miss_fills_cache(self) -> None:
+        fetcher = Mock(return_value="fetched")
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "fetched")
+        fetcher.assert_called_once()
+        self.assertEqual(self._delta("won"), 1)
+
+        # Second read is a hit.
+        fetcher.reset_mock()
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "fetched")
+        fetcher.assert_not_called()
+
+    def test_writer_delete_during_fill_is_detected(self) -> None:
+        """The core race test: writer deletes during the reader's fetch,
+        reader's cas() must fail and the stale value must not be cached."""
+
+        def fetcher() -> str:
+            cache_delete(self.key)
+            return "stale"
+
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "stale")
+        self.assertEqual(self._delta("race_detected"), 1)
+        self.assertEqual(self._delta("won"), 0)
+
+        # Cache is empty; the next read causes a fresh fetch.
+        next_fetcher = Mock(return_value="fresh")
+        self.assertEqual(read_through_cache(self.key, next_fetcher), "fresh")
+        next_fetcher.assert_called_once()
+
+    def test_concurrent_readers_only_one_fills(self) -> None:
+        """Two readers miss simultaneously; only one wins the add()."""
+        reader_a_in_fetcher = threading.Event()
+        allow_a_to_finish = threading.Event()
+        fetcher_call_count = 0
+        call_count_lock = threading.Lock()
+
+        def slow_fetcher() -> str:
+            nonlocal fetcher_call_count
+            with call_count_lock:
+                fetcher_call_count += 1
+            reader_a_in_fetcher.set()
+            allow_a_to_finish.wait(timeout=5)
+            return "A-value"
+
+        results: dict[str, str] = {}
+
+        def reader_a() -> None:
+            results["A"] = read_through_cache(self.key, slow_fetcher)
+
+        thread = threading.Thread(target=reader_a)
+        thread.start()
+        self.assertTrue(reader_a_in_fetcher.wait(timeout=5))
+
+        # Reader B arrives mid-fill; it must see the sentinel and bypass.
+        def fast_fetcher() -> str:
+            nonlocal fetcher_call_count
+            with call_count_lock:
+                fetcher_call_count += 1
+            return "B-value"
+
+        results["B"] = read_through_cache(self.key, fast_fetcher)
+        self.assertEqual(results["B"], "B-value")
+
+        allow_a_to_finish.set()
+        thread.join(timeout=5)
+        self.assertEqual(results["A"], "A-value")
+
+        # Both fetchers ran.  B's path was saw_sentinel, not claim_lost,
+        # because the sentinel was visible when B arrived.
+        self.assertEqual(fetcher_call_count, 2)
+        self.assertEqual(self._delta("saw_sentinel"), 1)
+        self.assertEqual(self._delta("won"), 1)
+
+    def test_sentinel_expires_if_filler_crashes(self) -> None:
+        """If the filler raises before cas(), the sentinel must expire
+        so that the next reader can fill normally."""
+
+        class FillerError(Exception):
+            pass
+
+        def crashing_fetcher() -> str:
+            raise FillerError
+
+        t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        with time_machine.travel(t0, tick=False) as traveller:
+            with self.assertRaises(FillerError):
+                read_through_cache(self.key, crashing_fetcher)
+
+            # While the sentinel is still live, the next reader bypasses
+            # (saw_sentinel) and does not write to the cache.
+            recovered = Mock(return_value="recovered")
+            self.assertEqual(read_through_cache(self.key, recovered), "recovered")
+            recovered.assert_called_once()
+
+            # Advance past the sentinel's TTL.
+            traveller.shift(timedelta(seconds=CACHE_FILL_SENTINEL_TIMEOUT + 1))
+
+            recovered.reset_mock()
+            self.assertEqual(read_through_cache(self.key, recovered), "recovered")
+            recovered.assert_called_once()
+            # The cache is now populated with the recovered value.
+            self.assertEqual(cache_get(self.key), ("recovered",))
+
+    def test_cache_get_of_sentinel_is_not_exposed_to_callers(self) -> None:
+        """Belt-and-suspenders: a raw cache_get of a key mid-fill must not
+        leak the sentinel into application code via read_through_cache."""
+        # Manually plant a sentinel.
+        added, _cas = cache_add(self.key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+        self.assertTrue(added)
+
+        fetcher = Mock(return_value="real-value")
+        result = read_through_cache(self.key, fetcher)
+        self.assertEqual(result, "real-value")
+        fetcher.assert_called_once()
+        self.assertEqual(self._delta("saw_sentinel"), 1)
+
+    def test_cache_get_filters_sentinel(self) -> None:
+        """cache_get hides the in-progress-fill marker; an in-progress fill
+        looks the same as a missing key from the public API."""
+        added, _cas = cache_add(self.key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+        self.assertTrue(added)
+        self.assertIsNone(cache_get(self.key))
+
+    def test_cache_get_many_filters_sentinel(self) -> None:
+        """cache_get_many drops sentinel entries from the result dict, the
+        same way cache_get returns None for a sentinel."""
+        cache_set(self.key + ":real", "real-value")
+        added, _cas = cache_add(
+            self.key + ":fill", _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT
+        )
+        self.assertTrue(added)
+
+        result = cache_get_many([self.key + ":real", self.key + ":fill", self.key + ":missing"])
+        # cache_set wraps with pickled_tupled=True, so the value is a 1-tuple.
+        self.assertEqual(result, {self.key + ":real": ("real-value",)})
+
+    def test_fetcher_raise_does_not_leak_sentinel_via_cache_get(self) -> None:
+        """If the read_through_cache fetcher raises, the sentinel is left to
+        expire on its TTL.  A subsequent raw cache_get must not return it."""
+        fetcher = Mock(side_effect=RuntimeError("boom"))
+        with self.assertRaises(RuntimeError):
+            read_through_cache(self.key, fetcher)
+        self.assertIsNone(cache_get(self.key))
+
+    def test_race_writer_delete_then_other_reader_adds(self) -> None:
+        """The subtle race: while we're fetching, a writer deletes our sentinel
+        and another reader adds their own in the now-empty slot.  Our cas-
+        commit uses the cas id we got from our own add, so the slot's new
+        cas (assigned to the other reader's add) won't match and the cas
+        will fail -- we must not cache the stale value."""
+
+        def racing_fetcher() -> str:
+            # While we "fetch", simulate writer-delete + other-reader-add
+            # landing on the same key.
+            cache_delete(self.key)
+            added, _cas = cache_add(self.key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT)
+            self.assertTrue(added)
+            return "stale"
+
+        result = read_through_cache(self.key, racing_fetcher)
+        self.assertEqual(result, "stale")
+        self.assertEqual(self._delta("race_detected"), 1)
+        self.assertEqual(self._delta("won"), 0)
+        # The slot holds the other reader's sentinel, not our stale 1-tuple.
+        # cache_gets exposes the raw value; cache_get filters sentinels.
+        raw, _cas = cache_gets(self.key)
+        self.assertIsInstance(raw, _CacheFillSentinel)

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -1,4 +1,5 @@
 import threading
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
@@ -6,10 +7,12 @@ import time_machine
 from bmemcached.exceptions import MemcachedException
 from django.conf import settings
 from django.core.cache import caches
+from django.db import transaction
 from django.db.models import QuerySet
 from typing_extensions import override
 
 from zerver.apps import flush_cache
+from zerver.lib import cache as cache_module
 from zerver.lib.cache import (
     _CACHE_FILL_SENTINEL,
     CACHE_FILL_SENTINEL_TIMEOUT,
@@ -18,6 +21,7 @@ from zerver.lib.cache import (
     _CacheFillSentinel,
     bulk_cached_fetch,
     cache_add,
+    cache_cas,
     cache_delete,
     cache_delete_many,
     cache_get,
@@ -758,3 +762,337 @@ class ReadThroughCacheTest(ZulipTestCase):
         # cache_gets exposes the raw value; cache_get filters sentinels.
         raw, _cas = cache_gets(self.key)
         self.assertIsInstance(raw, _CacheFillSentinel)
+
+
+class _ResultThread(threading.Thread):
+    """threading.Thread that re-raises target's exception in the caller
+    when join() is called.  Plain Thread silently swallows exceptions
+    into a stderr message, which lets test-thread assertion failures
+    masquerade as test passes (the failing test method's main-thread
+    assertions can succeed for unrelated reasons)."""
+
+    def __init__(self, target: Callable[[], None]) -> None:
+        super().__init__(target=target)
+        self._exc: BaseException | None = None
+
+    @override
+    def run(self) -> None:
+        try:
+            super().run()
+        except BaseException as e:  # nocoverage
+            self._exc = e
+
+    @override
+    def join(self, timeout: float | None = None) -> None:
+        super().join(timeout)
+        if self.is_alive():
+            raise AssertionError(f"thread {self.name} did not complete in {timeout}s")
+        if self._exc is not None:
+            raise self._exc  # nocoverage
+
+
+class TransactionCacheBufferTest(ZulipTestCase):
+    """Cache mutations inside an atomic block are buffered and applied
+    only at outermost commit; rollback discards them.  Within the
+    transaction, reads of buffered keys see the buffered state
+    (read-your-writes)."""
+
+    @override
+    def setUp(self) -> None:
+        super().setUp()
+        self.key = "TransactionCacheBufferTest:" + self.id().rsplit(".", 1)[-1]
+        cache_delete(self.key)
+
+    def _raw_memcached_get(self) -> object:
+        """Read the slot directly from memcached, bypassing the buffer."""
+        return caches["default"].get(cache_module.KEY_PREFIX + self.key)
+
+    def test_set_inside_transaction_is_buffered_until_commit(self) -> None:
+        with transaction.atomic(savepoint=True):
+            cache_set(self.key, "value")
+            # Buffered: visible to this thread via cache_get, NOT visible
+            # to a raw memcached read.  cache_set wraps with pickled_tupled,
+            # so the buffered (and stored) value is a 1-tuple.
+            self.assertEqual(cache_get(self.key), ("value",))
+            self.assertIsNone(self._raw_memcached_get())
+        # Committed: now in memcached.
+        self.assertEqual(cache_get(self.key), ("value",))
+        self.assertEqual(self._raw_memcached_get(), ("value",))
+
+    def test_delete_inside_transaction_is_buffered_until_commit(self) -> None:
+        cache_set(self.key, "value")
+        self.assertEqual(self._raw_memcached_get(), ("value",))
+        with transaction.atomic(savepoint=True):
+            cache_delete(self.key)
+            # Buffered: this thread sees a miss, but memcached still has it.
+            self.assertIsNone(cache_get(self.key))
+            self.assertEqual(self._raw_memcached_get(), ("value",))
+        # Committed: delete now flushed.
+        self.assertIsNone(self._raw_memcached_get())
+
+    def test_rollback_discards_buffered_set(self) -> None:
+        with self.assertRaises(RuntimeError), transaction.atomic(savepoint=True):
+            cache_set(self.key, "rolled-back")
+            raise RuntimeError("boom")
+        self.assertIsNone(self._raw_memcached_get())
+
+    def test_rollback_discards_buffered_delete(self) -> None:
+        cache_set(self.key, "preserved")
+        with self.assertRaises(RuntimeError), transaction.atomic(savepoint=True):
+            cache_delete(self.key)
+            raise RuntimeError("boom")
+        # Memcached untouched: the original value survives.
+        self.assertEqual(self._raw_memcached_get(), ("preserved",))
+
+    def test_savepoint_rollback_discards_inner_frame(self) -> None:
+        with transaction.atomic(savepoint=True):
+            cache_set(self.key, "outer")
+            with self.assertRaises(RuntimeError), transaction.atomic(savepoint=True):
+                cache_set(self.key, "inner")
+                raise RuntimeError("boom")
+            # Inner rolled back; outer's buffered set survives.
+            self.assertEqual(cache_get(self.key), ("outer",))
+        self.assertEqual(self._raw_memcached_get(), ("outer",))
+
+    def test_savepoint_commit_promotes_to_parent(self) -> None:
+        cache_set(self.key, "preserved")
+        with self.assertRaises(RuntimeError), transaction.atomic(savepoint=True):
+            with transaction.atomic(savepoint=True):
+                cache_delete(self.key)
+            # Inner committed; the delete is now in the outer frame.
+            self.assertIsNone(cache_get(self.key))
+            raise RuntimeError("boom")
+        # Outer rolled back: the (savepoint-merged) delete is discarded.
+        self.assertEqual(self._raw_memcached_get(), ("preserved",))
+
+    def test_set_then_delete_collapses_to_delete(self) -> None:
+        cache_set(self.key, "old")
+        with transaction.atomic(savepoint=True):
+            cache_set(self.key, "transient")
+            cache_delete(self.key)
+        self.assertIsNone(self._raw_memcached_get())
+
+    def test_delete_then_set_collapses_to_set(self) -> None:
+        cache_set(self.key, "old")
+        with transaction.atomic(savepoint=True):
+            cache_delete(self.key)
+            cache_set(self.key, "fresh")
+        self.assertEqual(self._raw_memcached_get(), ("fresh",))
+
+    def test_read_through_fill_inside_transaction(self) -> None:
+        """Read-through fill: cache_add writes the sentinel direct to
+        memcached (so other connections see "fill in progress" and bypass),
+        but the val landed by cache_cas is buffered until commit and only
+        then flushed via cas-conditional set."""
+        fetcher = Mock(return_value="filled")
+        with transaction.atomic(savepoint=True):
+            result = read_through_cache(self.key, fetcher)
+            self.assertEqual(result, "filled")
+            # Inside the tx: the sentinel from cache_add is in memcached;
+            # the fetched val is only in our buffer.
+            self.assertIsInstance(self._raw_memcached_get(), _CacheFillSentinel)
+            # Our own re-read sees the buffered val (read-your-writes).
+            # read_through_cache stores the cas-payload as a 1-tuple.
+            self.assertEqual(cache_get(self.key), ("filled",))
+        # On commit the cas-conditional flush replaces the sentinel.
+        self.assertEqual(self._raw_memcached_get(), ("filled",))
+
+    def test_writer_rollback_leaves_no_value_in_memcached(self) -> None:
+        """A writer that fills the cache from its own pre-commit DB
+        snapshot and then rolls back must not leave that value cached.
+        Only the short-TTL sentinel from cache_add can persist, and that
+        expires on its own."""
+        fetcher = Mock(return_value="from-rolled-back-tx")
+        with self.assertRaises(RuntimeError), transaction.atomic(savepoint=True):
+            read_through_cache(self.key, fetcher)
+            # The sentinel is in memcached but the val is only buffered.
+            self.assertIsInstance(self._raw_memcached_get(), _CacheFillSentinel)
+            raise RuntimeError("boom")
+        # The buffer was discarded at rollback; only the sentinel remains
+        # in memcached, so the writer's pre-commit val never lands.
+        self.assertIsInstance(self._raw_memcached_get(), _CacheFillSentinel)
+        # cache_get filters sentinels, so application code sees a miss
+        # and the next reader will refill from the (rolled-back) DB.
+        self.assertIsNone(cache_get(self.key))
+
+    def test_concurrent_invalidation_during_fill_fails_flush(self) -> None:
+        """If another connection invalidates the key between our cache_add
+        and our commit, our flush's cas-conditional set must fail -- the
+        buffer must NOT overwrite the other writer's invalidation."""
+        from django.db import connections
+
+        a_buffered = threading.Event()
+        b_invalidated = threading.Event()
+
+        def thread_a() -> None:
+            try:
+                with transaction.atomic(savepoint=True):
+                    read_through_cache(self.key, Mock(return_value="from-A"))
+                    a_buffered.set()
+                    b_invalidated.wait(timeout=5)
+                # On commit, the buffered cas-conditional set should fail
+                # because B's cache_delete bumped memcached's cas.
+            finally:
+                connections.close_all()
+
+        def thread_b() -> None:
+            try:
+                a_buffered.wait(timeout=5)
+                # Concurrent invalidation lands on the slot.
+                cache_delete(self.key)
+                b_invalidated.set()
+            finally:
+                connections.close_all()
+
+        ta = _ResultThread(target=thread_a)
+        tb = _ResultThread(target=thread_b)
+        ta.start()
+        tb.start()
+        ta.join(timeout=10)
+        tb.join(timeout=10)
+
+        # Thread B's delete won; thread A's flush did not overwrite it.
+        self.assertIsNone(self._raw_memcached_get())
+
+    def test_concurrent_fill_in_other_connection_is_preserved(self) -> None:
+        """When a transaction's read-through fill is in flight, a fresh
+        value written to memcached by another connection (e.g. a different
+        reader's mark-then-fill that got there first) must not be
+        overwritten.  This is what mark-then-fill's CAS guarantees;
+        buffering fills would defeat it."""
+        from django.db import connections
+
+        a_claimed = threading.Event()
+        b_committed = threading.Event()
+
+        def thread_a() -> None:
+            try:
+                with transaction.atomic(savepoint=True):
+                    # Manually walk the read_through_cache steps so we
+                    # can interleave thread B between add and cas.
+                    added, our_cas = cache_add(
+                        self.key, _CACHE_FILL_SENTINEL, CACHE_FILL_SENTINEL_TIMEOUT
+                    )
+                    self.assertTrue(added)
+                    assert our_cas is not None
+                    a_claimed.set()
+                    b_committed.wait(timeout=5)
+                    # The buffer cas succeeds (the buffer doesn't see B's
+                    # direct memcached write); the actual CAS is enforced
+                    # at commit-time flush against memcached's bumped
+                    # cas_id, which the assertEqual at the bottom of the
+                    # test verifies indirectly via B's value surviving.
+                    self.assertTrue(cache_cas(self.key, ("from-A-stale",), our_cas))
+            finally:
+                connections.close_all()
+
+        def thread_b() -> None:
+            try:
+                a_claimed.wait(timeout=5)
+                # B is not in a transaction, so cache_set goes direct.
+                cache_set(self.key, "from-B-fresh")
+                b_committed.set()
+            finally:
+                connections.close_all()
+
+        ta = _ResultThread(target=thread_a)
+        tb = _ResultThread(target=thread_b)
+        ta.start()
+        tb.start()
+        ta.join(timeout=10)
+        tb.join(timeout=10)
+
+        # Thread B's fresh value must survive: A's cas correctly failed and
+        # nothing buffered for self.key gets flushed at A's commit.
+        self.assertEqual(self._raw_memcached_get(), ("from-B-fresh",))
+
+    def test_writer_invalidate_after_fill_collapses_to_delete(self) -> None:
+        """The realistic writer path: a read-through fill happens early in a
+        transaction (e.g. an @cache_with_key access), then the writer mutates
+        the row and the post_save signal calls cache_delete.  The buffer's
+        last-wins-per-key must produce a delete on flush, not a set with the
+        pre-write value."""
+        cache_set(self.key, "before")
+        with transaction.atomic(savepoint=True):
+            # Simulate: a read-through fill writes into the cache.
+            cache_set(self.key, "filled-during-tx")
+            # Then a writer-side invalidation lands.
+            cache_delete(self.key)
+        # Memcached should reflect the final invalidation, not the fill.
+        self.assertIsNone(self._raw_memcached_get())
+
+    def test_inner_savepoint_false_rollback_does_not_flush_outer(self) -> None:
+        """An inner `atomic(savepoint=False)` whose body raises sets
+        `connection.needs_rollback`.  When the exception is caught between the
+        two `with` blocks, the outer `__exit__` is called with `exc_type=None`
+        but Django still rolls back the whole transaction.  The buffer must
+        treat that as a rollback and discard, not flush, the buffered ops."""
+        with transaction.atomic(savepoint=True):
+            cache_set(self.key, "should-not-survive")
+            try:
+                with transaction.atomic(savepoint=False):
+                    raise RuntimeError("inner failure")
+            except RuntimeError:
+                pass
+            # The outer atomic exits next with exc_type=None, but Django's
+            # connection.needs_rollback is True, so it will roll back.
+        self.assertIsNone(self._raw_memcached_get())
+
+    def test_thread_isolation(self) -> None:
+        """Each thread has its own buffer.  A buffered set in thread A must be
+        invisible to thread B until A's transaction commits."""
+        from django.db import connections
+
+        from zerver.lib.cache_invalidation_buffer import get_buffer
+
+        a_recorded = threading.Event()
+        b_observed = threading.Event()
+        b_observation: list[object] = []
+
+        def thread_a() -> None:
+            try:
+                # Drive the buffer directly to avoid opening a second DB
+                # connection from this worker (which would block teardown).
+                buf = get_buffer()
+                buf.enter_atomic()
+                buf.record_set(self.key, ("thread-a",), None)
+                a_recorded.set()
+                b_observed.wait(timeout=5)
+                buf.exit_atomic(committed=False)
+            finally:
+                connections.close_all()
+
+        def thread_b() -> None:
+            try:
+                a_recorded.wait(timeout=5)
+                b_observation.append(cache_get(self.key))
+                b_observation.append(self._raw_memcached_get())
+                b_observed.set()
+            finally:
+                connections.close_all()
+
+        ta = _ResultThread(target=thread_a)
+        tb = _ResultThread(target=thread_b)
+        ta.start()
+        tb.start()
+        ta.join(timeout=10)
+        tb.join(timeout=10)
+
+        # B's buffer is its own (empty) stack, so cache_get falls through to
+        # memcached, which has nothing -- A's buffered value is invisible.
+        self.assertEqual(b_observation, [None, None])
+
+    def test_stale_pending_ops_cleared_on_next_atomic_enter(self) -> None:
+        """If a previous transaction's ops were stashed and Django then
+        silently rolled back (so the on_commit drain never ran), the next
+        atomic must not flush those stale ops on its own commit."""
+        from zerver.lib.cache_invalidation_buffer import get_buffer
+
+        # Plant a stale stash directly to simulate the post-rollback state.
+        buf = get_buffer()
+        buf._pending_flush_ops = {self.key: ("set", ("stale-from-prior-tx",), None, 0)}
+
+        with transaction.atomic(savepoint=True):
+            cache_set(self.key, "fresh")
+        # The fresh value flushed; the stale-stash ops are gone, not merged.
+        self.assertEqual(self._raw_memcached_get(), ("fresh",))

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 from bmemcached.exceptions import MemcachedException
 from django.conf import settings
+from django.db.models import QuerySet
 
 from zerver.apps import flush_cache
 from zerver.lib.cache import (
@@ -157,6 +158,23 @@ class CacheWithKeyDecoratorTest(ZulipTestCase):
             result_two = get_user_function_can_return_none(last_user_id + 1)
 
         self.assertEqual(result_two, None)
+
+    def test_cache_with_key_rejects_queryset_return(self) -> None:
+        """Returning a QuerySet from a @cache_with_key-decorated function
+        raises AssertionError under TEST_SUITE / DEBUG; production skips
+        the check."""
+
+        def cache_key_function(user_id: int) -> str:
+            return f"CacheWithKeyDecoratorTest:queryset_return:{user_id}"
+
+        @cache_with_key(cache_key_function, timeout=1000)
+        def buggy_returns_queryset(user_id: int) -> QuerySet[UserProfile]:
+            return UserProfile.objects.filter(id=user_id)
+
+        hamlet = self.example_user("hamlet")
+        with self.assertRaises(AssertionError) as cm:
+            buggy_returns_queryset(hamlet.id)
+        self.assertIn("returned a QuerySet", str(cm.exception))
 
 
 class SetCacheExceptionTest(ZulipTestCase):

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -491,8 +491,14 @@ class TestFollowupEmails(ZulipTestCase):
                 "zerver/emails/onboarding_team_to_zulip",
             )
 
-        # The insert into the deferred_email_senders queue
-        self.assert_length(callbacks, 1)
+        # The insert into the deferred_email_senders queue, plus
+        # one _drain_buffer per outermost atomic that mutated the
+        # cache invalidation buffer (one per send_account_registered_email
+        # / enqueue_welcome_emails call).
+        from zerver.lib.cache_invalidation_buffer import _drain_buffer
+
+        user_callbacks = [cb for cb in callbacks if cb is not _drain_buffer]
+        self.assert_length(user_callbacks, 1)
 
         # Exiting the block does the email-sending
         from django.core.mail import outbox

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -308,7 +308,8 @@ class HomeTest(ZulipTestCase):
         # Verify succeeds once logged-in
         with (
             self.assert_database_query_count(56),
-            patch("zerver.lib.cache.cache_set") as cache_mock,
+            patch("zerver.lib.cache.cache_set") as cache_set_mock,
+            patch("zerver.lib.cache.cache_cas") as cache_cas_mock,
         ):
             result = self._get_home_page(stream="Denmark")
             self.check_rendered_logged_in_app(result)
@@ -316,7 +317,9 @@ class HomeTest(ZulipTestCase):
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
 
-        self.assert_length(cache_mock.call_args_list, 7)
+        # Cache fills go through cache_cas (read-through mark-then-fill);
+        # direct cache_set calls are rare.
+        self.assert_length(cache_set_mock.call_args_list + cache_cas_mock.call_args_list, 7)
 
         html = result.content.decode()
 
@@ -659,11 +662,14 @@ class HomeTest(ZulipTestCase):
         self.login("iago")
         with (
             self.assert_database_query_count(58),
-            patch("zerver.lib.cache.cache_set") as cache_mock,
+            patch("zerver.lib.cache.cache_set") as cache_set_mock,
+            patch("zerver.lib.cache.cache_cas") as cache_cas_mock,
         ):
             result = self._get_home_page()
             self.check_rendered_logged_in_app(result)
-            self.assert_length(cache_mock.call_args_list, 9)
+            # Cache fills go through cache_cas (read-through mark-then-fill);
+            # direct cache_set calls are rare.
+            self.assert_length(cache_set_mock.call_args_list + cache_cas_mock.call_args_list, 9)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -160,9 +160,9 @@ class EventsTestCase(TornadoWebTestCase):
                 self.assert_length(cache_gets, 2)
                 self.assertEqual(
                     cache_gets[0],
-                    ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None),
+                    ("gets", user_profile_narrow_by_id_cache_key(user_profile.id), None),
                 )
-                self.assertEqual(cache_gets[1][0], "get")
+                self.assertEqual(cache_gets[1][0], "gets")
                 assert isinstance(cache_gets[1][1], str)
                 self.assertTrue(cache_gets[1][1].startswith("get_client:"))
 
@@ -187,7 +187,7 @@ class EventsTestCase(TornadoWebTestCase):
                 self.assert_length(cache_gets, 1)
                 self.assertEqual(
                     cache_gets[0],
-                    ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None),
+                    ("gets", user_profile_narrow_by_id_cache_key(user_profile.id), None),
                 )
                 # Client is cached in-process-memory, so doesn't even see
                 # a memcached hit

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -95,13 +95,7 @@ settings.ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS = False
 settings.ZULIP_SERVICE_SECURITY_ALERTS = False
 settings.ANALYTICS_DATA_UPLOAD_LEVEL = AnalyticsDataUploadLevel.NONE
 settings.USING_TORNADO = False
-# Disable using memcached caches to avoid 'unsupported pickle
-# protocol' errors if `populate_db` is run with a different Python
-# from `run-dev`.
 default_cache = settings.CACHES["default"]
-settings.CACHES["default"] = {
-    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-}
 
 DEFAULT_EMOJIS = [
     ("+1", "1f44d"),

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -111,9 +111,12 @@ else:
 WEBPACK_BUNDLES = "webpack-bundles/"
 
 if not PUPPETEER_TESTS:
-    # Use local memory cache for backend tests.
+    # Use local memory cache for backend tests. The CASCapableLocMemCache
+    # subclass adds the memcached-style gets/cas operations that the
+    # read-through helpers in zerver.lib.cache rely on to avoid
+    # stale-cache races; the stock LocMemCache has no such concept.
     CACHES["default"] = {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": "zerver.lib.test_cache_backends.CASCapableLocMemCache",
     }
 
     # Here we set various loggers to be less noisy for unit tests.


### PR DESCRIPTION
This is stacked atop #39188.

Fixes: #30995.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
