### PR TITLE
puppet: handle empty YAML data safely

### DIFF
--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -80,7 +80,8 @@ def noop_would_change(puppet_cmd: list[str]) -> bool:
 
         # Reopen the file since Puppet rewrote it with a new inode
         with open(lastrun_file.name) as lastrun:
-            lastrun_data = yaml.safe_load(lastrun)
+            # yaml.safe_load() may return None for empty files.
+            lastrun_data = yaml.safe_load(lastrun) or {}
             resources = lastrun_data.get("resources", {})
             if resources.get("failed", 0) != 0:
                 sys.exit(2)


### PR DESCRIPTION
According to the PyYAML documentation, `yaml.safe_load()` returns `None` when there are no documents in the stream: https://pyyaml.org/wiki/PyYAMLDocumentation

> safe_load(stream) parses the given stream and returns a Python object constructed from for the first document in the stream. If there are no documents in the stream, it returns None. safe_load recognizes only standard YAML tags and cannot construct an arbitrary Python object.

This change avoids a potential `AttributeError` when accessing `.get()` on the parsed data.

### Self-review checklist

* [x] The changes are fully tested.
* [x] I have manually reviewed my changes for correctness.
* [x] This is a small, isolated change with no unrelated modifications.