### PR TITLE
Don't show quote message popover option when no message permission.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -65,6 +65,9 @@ type ComposeHook = () => void;
 const compose_clear_box_hooks: ComposeHook[] = [];
 const compose_cancel_hooks: ComposeHook[] = [];
 
+// Disallowed triggers for compose start.
+const disallowed_triggers = new Set(["hotkey", "hotkey enter", "message click"]);
+
 export function register_compose_box_clear_hook(hook: ComposeHook): void {
     compose_clear_box_hooks.push(hook);
 }
@@ -387,18 +390,22 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
     if (opts.message_type === "private") {
         compose_state.set_compose_recipient_id(compose_state.DIRECT_MESSAGE_ID);
         compose_recipient.on_compose_select_recipient_update();
-    } else if (opts.stream_id && opts.topic) {
+    } else if (opts.stream_id) {
         const stream = stream_data.get_sub_by_id(opts.stream_id);
-        compose_state.topic(opts.topic);
-        compose_state.set_stream_id(opts.stream_id);
-        compose_recipient.on_compose_select_recipient_update();
-        if (!(stream && stream_data.can_post_messages_in_stream(stream))) {
+        const can_post_messages_in_stream =
+            stream !== undefined && stream_data.can_post_messages_in_stream(stream);
+
+        // Close compose box if user doesn't have permission to post in the stream.
+        if (!can_post_messages_in_stream && disallowed_triggers.has(opts.trigger)) {
             hide_compose_box_and_maybe_display_missing_permissions_toast(opts.trigger);
             return;
         }
-    } else if (opts.stream_id) {
-        const stream = stream_data.get_sub_by_id(opts.stream_id);
-        if (stream && stream_data.can_post_messages_in_stream(stream)) {
+
+        // We set the compose recipient with the stream-topic details if the
+        // user has posting permissions to the stream or else we reset the
+        // recipients and open the stream selection dropdown.
+        if (stream && can_post_messages_in_stream) {
+            compose_state.topic(opts.topic);
             compose_state.set_stream_id(opts.stream_id);
             compose_recipient.on_compose_select_recipient_update();
         } else {

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -311,7 +311,7 @@ function same_recipient_as_before(opts: ComposeActionsOpts): boolean {
 }
 
 function hide_compose_box_and_maybe_display_missing_permissions_toast(trigger: string): void {
-    hide_box();
+    cancel();
     if (trigger === "hotkey") {
         feedback_widget.show({
             title_text: $t({defaultMessage: "Reply not allowed"}),
@@ -323,9 +323,6 @@ function hide_compose_box_and_maybe_display_missing_permissions_toast(trigger: s
             },
         });
     }
-    // This is done to avoid a faded group of messages on clicking a message
-    // to which we cannot reply when it is part of a mixed narrow.
-    compose_fade.start_compose("stream");
 }
 
 export let start = (raw_opts: ComposeActionsStartOpts): void => {

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -414,13 +414,14 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         }
         compose_state.set_compose_recipient_id(compose_state.DIRECT_MESSAGE_ID);
         compose_recipient.on_compose_select_recipient_update();
-    } else if (opts.stream_id) {
-        const stream = stream_data.get_sub_by_id(opts.stream_id);
+    } else {
+        const stream = opts.stream_id ? stream_data.get_sub_by_id(opts.stream_id) : undefined;
         const can_post_messages_in_stream =
             stream !== undefined && stream_data.can_post_messages_in_stream(stream);
 
         // Close compose box if user doesn't have permission to post in the stream.
         if (
+            opts.stream_id !== undefined &&
             !can_post_messages_in_stream &&
             disallowed_triggers.has(opts.trigger) &&
             !compose_state.get_is_processing_forward_message()
@@ -432,14 +433,14 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         // We set the compose recipient with the stream-topic details if the
         // user has posting permissions to the stream or else we reset the
         // recipients and open the stream selection dropdown.
-        if (stream && can_post_messages_in_stream) {
+        if (opts.stream_id && can_post_messages_in_stream) {
             compose_state.topic(opts.topic);
             compose_state.set_stream_id(opts.stream_id);
             compose_recipient.on_compose_select_recipient_update();
         } else {
+            opts.topic = opts.stream_id !== undefined ? "" : opts.topic;
             opts.stream_id = undefined;
             compose_state.set_stream_id("");
-            opts.topic = "";
             // For forward message, the caller opens the dropdown after start()
             // returns; we skip the toggle here to avoid canceling it out.
             if (!compose_state.get_is_processing_forward_message()) {
@@ -455,10 +456,6 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
             // Open the typahead so that user can select an existing topic.
             composebox_typeahead.stream_message_topic_typeahead.lookup(false, true);
         }
-    } else {
-        // Open stream selection dropdown if no stream is selected.
-        compose_state.set_stream_id("");
-        compose_recipient.toggle_compose_recipient_dropdown();
     }
     compose_recipient.update_topic_displayed_text(opts.topic);
 

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -66,7 +66,13 @@ const compose_clear_box_hooks: ComposeHook[] = [];
 const compose_cancel_hooks: ComposeHook[] = [];
 
 // Disallowed triggers for compose start.
-const disallowed_triggers = new Set(["hotkey", "hotkey enter", "message click", "hotkey pm"]);
+const disallowed_triggers = new Set([
+    "hotkey",
+    "hotkey enter",
+    "message click",
+    "hotkey pm",
+    "popover respond",
+]);
 
 export function register_compose_box_clear_hook(hook: ComposeHook): void {
     compose_clear_box_hooks.push(hook);
@@ -414,7 +420,11 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
             stream !== undefined && stream_data.can_post_messages_in_stream(stream);
 
         // Close compose box if user doesn't have permission to post in the stream.
-        if (!can_post_messages_in_stream && disallowed_triggers.has(opts.trigger)) {
+        if (
+            !can_post_messages_in_stream &&
+            disallowed_triggers.has(opts.trigger) &&
+            !compose_state.get_is_processing_forward_message()
+        ) {
             hide_compose_box_and_maybe_display_missing_permissions_toast(opts.trigger);
             return;
         }
@@ -430,7 +440,11 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
             opts.stream_id = undefined;
             compose_state.set_stream_id("");
             opts.topic = "";
-            compose_recipient.toggle_compose_recipient_dropdown();
+            // For forward message, the caller opens the dropdown after start()
+            // returns; we skip the toggle here to avoid canceling it out.
+            if (!compose_state.get_is_processing_forward_message()) {
+                compose_recipient.toggle_compose_recipient_dropdown();
+            }
         }
 
         if (

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -66,7 +66,7 @@ const compose_clear_box_hooks: ComposeHook[] = [];
 const compose_cancel_hooks: ComposeHook[] = [];
 
 // Disallowed triggers for compose start.
-const disallowed_triggers = new Set(["hotkey", "hotkey enter", "message click"]);
+const disallowed_triggers = new Set(["hotkey", "hotkey enter", "message click", "hotkey pm"]);
 
 export function register_compose_box_clear_hook(hook: ComposeHook): void {
     compose_clear_box_hooks.push(hook);
@@ -315,13 +315,19 @@ function same_recipient_as_before(opts: ComposeActionsOpts): boolean {
 
 function hide_compose_box_and_maybe_display_missing_permissions_toast(trigger: string): void {
     cancel();
-    if (trigger === "hotkey") {
+    if (trigger === "hotkey" || trigger === "hotkey pm") {
         feedback_widget.show({
             title_text: $t({defaultMessage: "Reply not allowed"}),
             populate($container) {
-                const message = $t({
-                    defaultMessage: "You don't have permission to reply to this conversation.",
-                });
+                const message =
+                    trigger === "hotkey"
+                        ? $t({
+                              defaultMessage:
+                                  "You don't have permission to reply to this conversation.",
+                          })
+                        : $t({
+                              defaultMessage: "You don't have permission to reply to the sender.",
+                          });
                 $container.text(message);
             },
         });
@@ -388,6 +394,18 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
     }
 
     if (opts.message_type === "private") {
+        const user_ids = opts.private_message_recipient_ids;
+
+        // we don't show compose if the user doesn't have permission to send direct
+        // message to the recipients.
+        if (
+            user_ids.length > 0 &&
+            !message_util.user_can_send_direct_message(user_ids.join(",")) &&
+            disallowed_triggers.has(opts.trigger)
+        ) {
+            hide_compose_box_and_maybe_display_missing_permissions_toast(opts.trigger);
+            return;
+        }
         compose_state.set_compose_recipient_id(compose_state.DIRECT_MESSAGE_ID);
         compose_recipient.on_compose_select_recipient_update();
     } else if (opts.stream_id) {

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -4,6 +4,7 @@
 import assert from "minimalistic-assert";
 
 import * as buddy_data from "./buddy_data.ts";
+import * as compose_state from "./compose_state.ts";
 import * as gear_menu_util from "./gear_menu_util.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
@@ -11,6 +12,7 @@ import * as message_delete from "./message_delete.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
+import * as message_util from "./message_util.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -41,6 +43,7 @@ type ActionPopoverContext = {
     should_display_remind_me_option: boolean;
     should_display_collapse: boolean;
     should_display_uncollapse: boolean;
+    should_display_forward_message: boolean;
     should_display_quote_message: boolean;
     conversation_time_url: string;
     should_display_delete_option: boolean;
@@ -204,7 +207,25 @@ export function get_actions_popover_content_context(message_id: number): ActionP
     const should_display_uncollapse =
         !message.locally_echoed && !message.is_me_message && message.collapsed;
 
-    const should_display_quote_message = not_spectator;
+    const should_display_quote_message = (): boolean => {
+        if (!not_spectator) {
+            return false;
+        }
+
+        // If the compose has some content in it, we allow quote message to work
+        // irrespective of posting permissions.
+        if (compose_state.has_message_content()) {
+            return true;
+        }
+
+        if (message.type === "stream") {
+            const stream = stream_data.get_sub_by_id(message.stream_id);
+            return stream !== undefined && stream_data.can_post_messages_in_stream(stream);
+        }
+
+        return message_util.user_can_send_direct_message(message.to_user_ids);
+    };
+    const should_display_forward_message = not_spectator;
 
     const conversation_time_url = hash_util.by_conversation_and_time_url(message);
 
@@ -254,7 +275,8 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         conversation_time_url,
         should_display_delete_option,
         should_display_read_receipts_option,
-        should_display_quote_message,
+        should_display_forward_message,
+        should_display_quote_message: should_display_quote_message(),
         should_display_message_report_option: should_display_message_report_option(),
     };
 }

--- a/web/templates/popovers/message_actions_popover.hbs
+++ b/web/templates/popovers/message_actions_popover.hbs
@@ -9,6 +9,8 @@
                 {{popover_hotkey_hints ">"}}
             </a>
         </li>
+        {{/if}}
+        {{#if should_display_forward_message}}
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" data-message-id="{{message_id}}" class="forward_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-forward-message" aria-hidden="true"></i>

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -276,6 +276,8 @@ test("start", ({override, override_rewire, mock_template}) => {
     const me = make_user();
     set_current_user(me);
 
+    override(realm, "realm_direct_message_permission_group", everyone.id);
+
     // Start direct message
     compose_defaults = {
         private_message_recipient_ids: [user1.user_id],

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -48,6 +48,9 @@ function MessageListView() {
 mock_esm("../src/message_list_view", {
     MessageListView,
 });
+mock_esm("../src/message_util", {
+    user_can_send_direct_message: () => true,
+});
 mock_esm("../src/ui_util", {
     listener_for_preferred_color_scheme_change: noop,
 });
@@ -60,6 +63,7 @@ mock_esm("../src/stream_data", {
     get_sub_by_id: () => noop,
     user_can_move_messages_within_channel: () => true,
     is_empty_topic_only_channel: () => false,
+    can_post_messages_in_stream: () => true,
 });
 mock_esm("../src/group_permission_settings", {
     get_group_permission_setting_config() {


### PR DESCRIPTION
First few commits address compose opening up when messages are clicked where user doesn't have permission to post. Related to #35866

4th commit changes forward message popover option to work for all messages.
Last commit conditionally hides quote message popover option when user doesn't have posting permission to the message conversation thread.

Fixes: [#issues > quoting a reply-locked message @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/quoting.20a.20reply-locked.20message/near/2447513)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Screenshots and screen captures:</summary>

### popover menu
[Screencast from 2026-05-08 03-32-26.webm](https://github.com/user-attachments/assets/ad5b3ae7-d7c2-4611-b342-e82c9685fffb)

## message click bug

### dm
[Screencast from 2026-05-08 03-35-11.webm](https://github.com/user-attachments/assets/005287cd-0cc6-45ef-8729-4c1796d292c8)

### general chat
[Screencast from 2026-05-08 03-34-41.webm](https://github.com/user-attachments/assets/117368ea-7395-42d2-8c60-d52fc841d845)

### Shift + R hotkey
<img width="985" height="812" alt="image" src="https://github.com/user-attachments/assets/7bd0c612-9e37-4fca-a9a9-d647c68bf3b7" />



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
