### PR TITLE
docs: Fix typos and grammar errors across documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,8 @@ excited to:
 - **Take pride in your work**. Strive to write the best
   [commits][commit discipline] you can, carefully [review][reviewing code] your
   own work, and take the time to [explain][submitting a PR] it clearly to
-  project maintainers. Do your very best to overcome any challenges you run in
-  to before asking for help.
+  project maintainers. Do your very best to overcome any challenges you run into
+  before asking for help.
 - **Learn from feedback.** Every pull request undergoes a rigorous [review
   process][review process]. We need contributors to carefully apply and respond
   to the feedback they receive, and to take advantage of the learning experience

--- a/docs/contributing/commit-discipline.md
+++ b/docs/contributing/commit-discipline.md
@@ -41,7 +41,7 @@ rest of the project.
   change the functionality of the product, make those changes into a
   series of preparatory commits that can be merged independently of
   building the feature itself.
-- Moving code from one file to another should be done in a separate
+- Moving code from one file to another should be done in separate
   commits from functional changes or even refactoring within a file.
 - 2 different refactorings should be done in different commits.
 - 2 different features should be done in different commits.

--- a/docs/contributing/design-discussions.md
+++ b/docs/contributing/design-discussions.md
@@ -162,7 +162,7 @@ design discussion:
   can serve as a good reset.
 
 If a conversation is going off-track and you are not sure how to fix it, please
-ping someone on the core team to intervene and help get the conversion into a
+ping someone on the core team to intervene and help get the conversation into a
 better state.
 
 ### Moving threads to the most appropriate channel
@@ -244,7 +244,7 @@ good use of everyone's time and attention, and getting useful feedback.
 
 ### From discussion to decision
 
-There is a number of factors that affect when it’s time to move a thread from
+There are a number of factors that affect when it’s time to move a thread from
 discussion to a decision. In part, this depends on how significant a commitment
 we are making with the decision at hand:
 

--- a/docs/contributing/how-we-communicate.md
+++ b/docs/contributing/how-we-communicate.md
@@ -8,7 +8,7 @@ to how we communicate on GitHub issues and pull requests, but other pages in
 this section go into greater detail about expectations that are specific to pull
 requests.
 
-We are deeply committed to maintaining a respectful, collaborative atmosphere in
+We are deeply committed to maintaining a respectful, collaborative atmosphere
 across all interactions in the Zulip community. To get a feel for what that
 means to us, please review the [code of conduct](../code-of-conduct.md) for our
 community.

--- a/docs/contributing/presenting-visual-changes.md
+++ b/docs/contributing/presenting-visual-changes.md
@@ -12,7 +12,7 @@ decision, include those variants in the comments.
 ## What to capture
 
 Always include screenshots of _all_ the UI components and states affected by
-your PR. For example, a PR that adds a new dropwdown setting would need
+your PR. For example, a PR that adds a new dropdown setting would need
 screenshots to demonstrate:
 
 - What the setting looks like in the settings UI (with some surrounding context).

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -8,7 +8,7 @@ of available RAM**.
 
 Installing the Zulip development environment requires downloading several hundred
 megabytes of dependencies, so you will need an **active, reasonably fast,
-internet connection throughout the entire installation processes.** You can
+internet connection throughout the entire installation process.** You can
 [configure a proxy][configure-proxy] if you need one.
 
 ## Recommended setup

--- a/docs/git/the-git-difference.md
+++ b/docs/git/the-git-difference.md
@@ -46,10 +46,10 @@ Here are the top things to know:
 - **Cloning a repository creates a working copy.** Every working copy has a
   `.git` subdirectory, which contains its own Git repository. The `.git`
   subdirectory also tracks the _index_, a staging area for changes that will
-  become part of the next commit. All files outside of `.git` is the _working
+  become part of the next commit. All files outside of `.git` are the _working
   tree_.
 
-- **Files tracked with Git have possible three states: committed, modified, and
+- **Files tracked with Git have three possible states: committed, modified, and
   staged.** Committed files are those safely stored in your local `.git`
   repository/database. Staged files have changes and have been marked for
   inclusion in the next commit; they are part of the index. Modified files have

--- a/docs/git/using.md
+++ b/docs/git/using.md
@@ -131,7 +131,7 @@ push a new commit, you can also run them locally. See
 
 ## Stage changes
 
-Recall that files tracked with Git have possible three states:
+Recall that files tracked with Git have three possible states:
 committed, modified, and staged.
 
 To prepare a commit, first add the files with changes that you want


### PR DESCRIPTION
## Summary

Fixes typos and grammar errors across 8 documentation files:

- **CONTRIBUTING.md**: "run in to" → "run into"
- **docs/contributing/presenting-visual-changes.md**: "dropwdown" → "dropdown"
- **docs/contributing/how-we-communicate.md**: Remove stray "in" — "atmosphere in across" → "atmosphere across"
- **docs/contributing/design-discussions.md**: "There is a number" → "There are a number"; "conversion" → "conversation"
- **docs/contributing/commit-discipline.md**: "in a separate commits" → "in separate commits"
- **docs/git/the-git-difference.md**: "is the working tree" → "are the working tree"; "possible three states" → "three possible states"
- **docs/git/using.md**: "possible three states" → "three possible states"
- **docs/development/overview.md**: "installation processes" → "installation process"