### PR TITLE
[ai] Fix `Invalid host / origin` error.

### DIFF
--- a/tools/webpack
+++ b/tools/webpack
@@ -73,7 +73,12 @@ def build_for_dev_server(host: str, port: str, minify: bool, disable_host_check:
     if disable_host_check:
         webpack_args.append("--allowed-hosts=all")
     else:
-        webpack_args.append(f"--allowed-hosts={host},.zulipdev.com,.zulipdev.org")
+        # webpack-dev-server's --allowed-hosts CLI flag does not split
+        # on commas; each host must be passed as a separate argument.
+        webpack_args.extend(
+            f"--allowed-hosts={allowed_host}"
+            for allowed_host in [host, ".zulipdev.com", ".zulipdev.org"]
+        )
 
     # Tell webpack-dev-server to fall back to periodic polling on
     # filesystems where inotify is known to be broken.


### PR DESCRIPTION
Fixes `Invalid host / origin` error in browser console when running `./tools/run-dev` outside of VM locally.

I realized I was using `--interface=` for a long time on my laptop to avoid this error but it was unsafe. Asked Claude to investigate and this works for me to fix the error of `Invalid host / origin` when running `./tools/run-dev` on my laptop.