### PR TITLE
message_row: Move hover action icons to bottom of long messages.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -588,6 +588,17 @@
     /* Ensure square icons for better centering. */
     line-height: 1;
 
+    /* For long messages, move the hover action icons down to the
+       "Show more" row so users don't have to scroll back to the top
+       of the message to react, star, or open the menu. Row 3 and
+       column 3 line up with the controls column in every layout
+       variant (no-sender, with-sender, is-me-message). */
+    .messagebox-content:has(.message_content.could-be-condensed) & {
+        grid-row: 3;
+        grid-column: 3;
+        align-self: center;
+    }
+
     @container message-lists (width < $cq_sm_min) {
         /* This is intended to target the first message_controls child
            when there are 3 displayed. */


### PR DESCRIPTION
Move per-message hover action icons (emoji react, edit, ••• menu, star) to the bottom right of long messages so users don't have to scroll up to react after reading.

Fixes: [#39226](https://github.com/zulip/zulip/issues/39226)

**How changes were tested:**

Tested in a local dev server by comparing hover behavior on `main` vs this branch:

- **Long message** (1:1 DM): the emoji reaction, star, and ••• menu icons previously appeared at the **top right** on hover. After the change, they appear at the **bottom right**, next to the "Show more" toggle. See before/after screenshots below.
- **Short message**: icons still appear in their expected position on hover — short messages are unaffected by the change. Demonstrated in the screen recording.

**Screenshots and screen captures:**
<img width="924" height="232" alt="Screenshot 2026-05-08 at 5 37 11 PM" src="https://github.com/user-attachments/assets/4c3733c0-1f54-48b3-b365-5784b6183b5f" />

<img width="921" height="228" alt="Screenshot 2026-05-08 at 5 35 45 PM" src="https://github.com/user-attachments/assets/d8baa59d-8a62-4713-b734-53db89a437d9" />

**Screen recording:**

https://github.com/user-attachments/assets/5b4a6ce4-ece0-480a-b9df-cdc90bbb4bcb

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->
<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.
- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>