### PR TITLE
[ai] Attempt to fix missing #page-params error. 

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -77,6 +77,14 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
     align-items: center;
     visibility: hidden;
     }
+    body.app-loading-failed #app-loading-middle-content,
+    body.app-loading-failed #app-loading-bottom-content,
+    body.app-loading-failed .app {
+    display: none;
+    }
+    body.app-loading-failed #app-loading-error {
+    visibility: visible;
+    }
     :root.dark-theme #app-loading {
     background-color: hsl(0, 0%, 11%);
     color: hsl(236, 33%, 90%);

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -149,6 +149,7 @@ EXEMPT_FILES = make_set(
         "web/src/list_util.ts",
         "web/src/list_widget.ts",
         "web/src/loading.ts",
+        "web/src/loading_error.ts",
         "web/src/local_message.ts",
         "web/src/localstorage.ts",
         "web/src/message_actions_popover.ts",

--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -1,5 +1,7 @@
 import * as z from "zod/mini";
 
+import {show_loading_error} from "./loading_error.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import {narrow_term_schema, state_data_schema} from "./state_data.ts";
 
 const t1 = performance.now();
@@ -133,7 +135,45 @@ function take_params(): string {
     return params;
 }
 
-export const page_params = page_params_schema.parse(JSON.parse(take_params()));
+const PAGE_PARAMS_RETRY_CAP = 5;
+
+function reload_with_deferred_state_data(): void {
+    const url = new URL(window.location.href);
+    const previous_retries = Number.parseInt(url.searchParams.get("page_params_retry") ?? "0", 10);
+    if (previous_retries >= PAGE_PARAMS_RETRY_CAP) {
+        clear_page_params_retry_from_url();
+        show_loading_error();
+        return;
+    }
+    url.searchParams.set("state_data", "deferred");
+    url.searchParams.set("page_params_retry", String(previous_retries + 1));
+    const backoff_ms =
+        get_retry_backoff_seconds(undefined, previous_retries + 1, false, true) * 1000;
+    setTimeout(() => {
+        window.location.replace(url.toString());
+    }, backoff_ms);
+}
+
+function clear_page_params_retry_from_url(): void {
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("page_params_retry")) {
+        url.searchParams.delete("page_params_retry");
+        window.history.replaceState(window.history.state, "", url.toString());
+    }
+}
+
+function parse_page_params(): z.infer<typeof page_params_schema> {
+    try {
+        const params = page_params_schema.parse(JSON.parse(take_params()));
+        clear_page_params_retry_from_url();
+        return params;
+    } catch (error) {
+        reload_with_deferred_state_data();
+        throw error;
+    }
+}
+
+export const page_params = parse_page_params();
 
 const t2 = performance.now();
 export const page_params_parse_time = t2 - t1;

--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -137,13 +137,13 @@ function take_params(): string {
 
 const PAGE_PARAMS_RETRY_CAP = 5;
 
-function reload_with_deferred_state_data(): void {
+function reload_with_deferred_state_data(): boolean {
     const url = new URL(window.location.href);
     const previous_retries = Number.parseInt(url.searchParams.get("page_params_retry") ?? "0", 10);
     if (previous_retries >= PAGE_PARAMS_RETRY_CAP) {
         clear_page_params_retry_from_url();
         show_loading_error();
-        return;
+        return false;
     }
     url.searchParams.set("state_data", "deferred");
     url.searchParams.set("page_params_retry", String(previous_retries + 1));
@@ -152,6 +152,7 @@ function reload_with_deferred_state_data(): void {
     setTimeout(() => {
         window.location.replace(url.toString());
     }, backoff_ms);
+    return true;
 }
 
 function clear_page_params_retry_from_url(): void {
@@ -168,7 +169,12 @@ function parse_page_params(): z.infer<typeof page_params_schema> {
         clear_page_params_retry_from_url();
         return params;
     } catch (error) {
-        reload_with_deferred_state_data();
+        if (reload_with_deferred_state_data()) {
+            // Halt module loading without logging to Sentry; the
+            // user self-heals on the scheduled reload. The matching
+            // entry in sentry.ts's ignoreErrors keeps this quiet.
+            throw new Error("page_params parse failed; reload scheduled");
+        }
         throw error;
     }
 }

--- a/web/src/loading_error.ts
+++ b/web/src/loading_error.ts
@@ -1,0 +1,3 @@
+export function show_loading_error(): void {
+    document.body.classList.add("app-loading-failed");
+}

--- a/web/src/retry_backoff.ts
+++ b/web/src/retry_backoff.ts
@@ -1,0 +1,41 @@
+import * as z from "zod/mini";
+
+export let get_retry_backoff_seconds = (
+    xhr: JQuery.jqXHR<unknown> | undefined,
+    attempts: number,
+    tighter_backoff = false,
+): number => {
+    // We need to respect the server's rate-limiting headers, but beyond
+    // that, we also want to avoid contributing to a thundering herd if
+    // the server is giving us 500/502 responses.
+    //
+    // We do the maximum of the retry-after header and an exponential
+    // backoff.
+    let backoff_scale: number;
+    if (tighter_backoff) {
+        // Starts at 1-2s and ends at 16-32s after enough failures.
+        backoff_scale = Math.min(2 ** attempts, 32);
+    } else {
+        // Starts at 1-2s and ends at 45-90s after enough failures.
+        backoff_scale = Math.min(2 ** ((attempts + 1) / 2), 90);
+    }
+    // Add a bit jitter to backoff scale.
+    const backoff_delay_secs = ((1 + Math.random()) / 2) * backoff_scale;
+    let rate_limit_delay_secs = 0;
+    const rate_limited_error_schema = z.object({
+        "retry-after": z.number(),
+        code: z.literal("RATE_LIMIT_HIT"),
+    });
+    const parsed = rate_limited_error_schema.safeParse(xhr?.responseJSON);
+    if (xhr?.status === 429 && parsed?.success && parsed?.data) {
+        // Add a bit of jitter to the required delay suggested by the
+        // server, because we may be racing with other copies of the web
+        // app.
+        rate_limit_delay_secs = parsed.data["retry-after"] + Math.random() * 0.5;
+    }
+    return Math.max(backoff_delay_secs, rate_limit_delay_secs);
+};
+
+export function rewire_get_retry_backoff_seconds(value: typeof get_retry_backoff_seconds): void {
+    get_retry_backoff_seconds = value;
+}

--- a/web/src/retry_backoff.ts
+++ b/web/src/retry_backoff.ts
@@ -4,6 +4,7 @@ export let get_retry_backoff_seconds = (
     xhr: JQuery.jqXHR<unknown> | undefined,
     attempts: number,
     faster_backoff = false,
+    slower_backoff = false,
 ): number => {
     // We need to respect the server's rate-limiting headers, but beyond
     // that, we also want to avoid contributing to a thundering herd if
@@ -12,7 +13,11 @@ export let get_retry_backoff_seconds = (
     // We do the maximum of the retry-after header and an exponential
     // backoff.
     let backoff_scale: number;
-    if (faster_backoff) {
+    if (slower_backoff) {
+        // Starts at 2-4s and reaches the 45-90s cap by retry 4;
+        // 5 retries span ~3 minutes total.
+        backoff_scale = Math.min(4 ** attempts, 90);
+    } else if (faster_backoff) {
         // Starts at 1-2s and ends at 16-32s after enough failures.
         backoff_scale = Math.min(2 ** attempts, 32);
     } else {

--- a/web/src/retry_backoff.ts
+++ b/web/src/retry_backoff.ts
@@ -3,7 +3,7 @@ import * as z from "zod/mini";
 export let get_retry_backoff_seconds = (
     xhr: JQuery.jqXHR<unknown> | undefined,
     attempts: number,
-    tighter_backoff = false,
+    faster_backoff = false,
 ): number => {
     // We need to respect the server's rate-limiting headers, but beyond
     // that, we also want to avoid contributing to a thundering herd if
@@ -12,7 +12,7 @@ export let get_retry_backoff_seconds = (
     // We do the maximum of the retry-after header and an exponential
     // backoff.
     let backoff_scale: number;
-    if (tighter_backoff) {
+    if (faster_backoff) {
         // Starts at 1-2s and ends at 16-32s after enough failures.
         backoff_scale = Math.min(2 ** attempts, 32);
     } else {

--- a/web/src/sentry.ts
+++ b/web/src/sentry.ts
@@ -108,6 +108,10 @@ if (
         ignoreErrors: [
             // https://github.com/tus/tus-js-client/issues/808
             "ERR_UPLOAD_TERMINATION_REJECTED",
+            // base_page_params.ts schedules a deferred-shell reload
+            // on parse failure; only the terminal post-cap throw
+            // should reach Sentry, not each self-healing retry.
+            "page_params parse failed; reload scheduled",
         ],
     });
 } else {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -895,6 +895,8 @@ $(() => {
                         const retry_delay_secs = util.get_retry_backoff_seconds(
                             xhr,
                             register_failures,
+                            false,
+                            true,
                         );
                         setTimeout(fetch_state_data, retry_delay_secs * 1000);
                         return;

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -65,6 +65,7 @@ import * as left_sidebar_navigation_area_popovers from "./left_sidebar_navigatio
 import * as left_sidebar_tooltips from "./left_sidebar_tooltips.ts";
 import * as lightbox from "./lightbox.ts";
 import * as linkifiers from "./linkifiers.ts";
+import * as loading_error from "./loading_error.ts";
 import * as local_message from "./local_message.ts";
 import * as markdown from "./markdown.ts";
 import * as markdown_config from "./markdown_config.ts";
@@ -898,10 +899,7 @@ $(() => {
                         setTimeout(fetch_state_data, retry_delay_secs * 1000);
                         return;
                     }
-                    $("#app-loading-middle-content").hide();
-                    $("#app-loading-bottom-content").hide();
-                    $(".app").hide();
-                    $("#app-loading-error").css({visibility: "visible"});
+                    loading_error.show_loading_error();
                 },
             });
         }

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import * as z from "zod/mini";
 
 import * as blueslip from "./blueslip.ts";
 import {$t} from "./i18n.ts";
@@ -533,45 +532,7 @@ export function is_topic_name_considered_empty(topic: string): boolean {
     return false;
 }
 
-export let get_retry_backoff_seconds = (
-    xhr: JQuery.jqXHR<unknown> | undefined,
-    attempts: number,
-    tighter_backoff = false,
-): number => {
-    // We need to respect the server's rate-limiting headers, but beyond
-    // that, we also want to avoid contributing to a thundering herd if
-    // the server is giving us 500/502 responses.
-    //
-    // We do the maximum of the retry-after header and an exponential
-    // backoff.
-    let backoff_scale: number;
-    if (tighter_backoff) {
-        // Starts at 1-2s and ends at 16-32s after enough failures.
-        backoff_scale = Math.min(2 ** attempts, 32);
-    } else {
-        // Starts at 1-2s and ends at 45-90s after enough failures.
-        backoff_scale = Math.min(2 ** ((attempts + 1) / 2), 90);
-    }
-    // Add a bit jitter to backoff scale.
-    const backoff_delay_secs = ((1 + Math.random()) / 2) * backoff_scale;
-    let rate_limit_delay_secs = 0;
-    const rate_limited_error_schema = z.object({
-        "retry-after": z.number(),
-        code: z.literal("RATE_LIMIT_HIT"),
-    });
-    const parsed = rate_limited_error_schema.safeParse(xhr?.responseJSON);
-    if (xhr?.status === 429 && parsed?.success && parsed?.data) {
-        // Add a bit of jitter to the required delay suggested by the
-        // server, because we may be racing with other copies of the web
-        // app.
-        rate_limit_delay_secs = parsed.data["retry-after"] + Math.random() * 0.5;
-    }
-    return Math.max(backoff_delay_secs, rate_limit_delay_secs);
-};
-
-export function rewire_get_retry_backoff_seconds(value: typeof get_retry_backoff_seconds): void {
-    get_retry_backoff_seconds = value;
-}
+export {get_retry_backoff_seconds, rewire_get_retry_backoff_seconds} from "./retry_backoff.ts";
 
 export async function sha256_hash(text: string): Promise<string | undefined> {
     // The Web Crypto API is only available in secure contexts (HTTPS or localhost).

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -569,6 +569,16 @@ run_test("get_retry_backoff_seconds", () => {
     assert.ok(backoff >= 45);
     assert.ok(backoff <= 90);
 
+    // Slower backoff scale
+    // First retry should be between 2-4 seconds.
+    backoff = util.get_retry_backoff_seconds(xhr_500_error, 1, false, true);
+    assert.ok(backoff >= 2);
+    assert.ok(backoff <= 4);
+    // 100th retry should be between 45-90 seconds.
+    backoff = util.get_retry_backoff_seconds(xhr_500_error, 100, false, true);
+    assert.ok(backoff >= 45);
+    assert.ok(backoff <= 90);
+
     const xhr_rate_limit_error = {
         status: 429,
         responseJSON: {


### PR DESCRIPTION
"Missing #page-params" still appears in Sentry — both on direct loads
of `/` and on `#reload` navigations that already used
`state_data=deferred`. Two changes on top of #38521:

1. On parse failure, reload via `?state_data=deferred` with a capped
   retry counter. Real fix for direct loads; for already-deferred
   failures it mostly just buys another network attempt.
2. Switch `/json/register` to the new slower backoff so its 5 retries
   span ~3 minutes instead of ~17s — same cap, longer window for
   transient failures to recover.

----

Had sentry AI summarize the stats and fed that to claude for analysis and coming up with a fix.