### PR TITLE
Icons: Replace fa-icons to zulip-icons for stream/message UI.

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -956,14 +956,14 @@ function setup_page(callback: () => void): void {
                 },
                 {
                     label_html: render_stream_sorter_toggle_label({
-                        icon_class: "fa fa-user-o",
+                        icon_class: "zulip-icon zulip-icon-user",
                         tooltip: $t({defaultMessage: "Sort by number of subscribers"}),
                     }),
                     key: "by-subscriber-count",
                 },
                 {
                     label_html: render_stream_sorter_toggle_label({
-                        icon_class: "fa fa-bar-chart",
+                        icon_class: "zulip-icon zulip-icon-bar-chart",
                         tooltip: $t({defaultMessage: "Sort by estimated weekly traffic"}),
                     }),
                     key: "by-weekly-traffic",

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -960,14 +960,14 @@ function setup_page(callback: () => void): void {
                 },
                 {
                     label_html: render_stream_sorter_toggle_label({
-                        icon_class: "fa fa-user-o",
+                        icon_class: "zulip-icon zulip-icon-user",
                         tooltip: $t({defaultMessage: "Sort by number of subscribers"}),
                     }),
                     key: "by-subscriber-count",
                 },
                 {
                     label_html: render_stream_sorter_toggle_label({
-                        icon_class: "fa fa-bar-chart",
+                        icon_class: "zulip-icon zulip-icon-bar-chart",
                         tooltip: $t({defaultMessage: "Sort by estimated weekly traffic"}),
                     }),
                     key: "by-weekly-traffic",

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1680,11 +1680,6 @@ textarea.new_message_textarea {
         }
     }
 
-    .fa-eye {
-        position: relative;
-        top: -0.7px;
-    }
-
     .divider {
         margin: 0 5px;
         /* Coordinate with the value of

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1698,11 +1698,6 @@ textarea.new_message_textarea {
         }
     }
 
-    .fa-eye {
-        position: relative;
-        top: -0.7px;
-    }
-
     .divider {
         margin: 0 5px;
         /* Coordinate with the value of

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -100,23 +100,25 @@
         margin: 0;
 
         .help_link_widget,
-        .fa {
+        .zulip-icon {
             margin: 0;
         }
 
-        .fa-question-circle-o {
+        .zulip-icon-help {
             /* Override relative position for sake of
                Chrome paint bug that keeps the circle
                visible when ellipses are showing. */
             position: static;
+            vertical-align: -0.1em;
+            font-size: 0.88em;
         }
 
         .help_link_widget {
             /* With relative positioning no longer
                in effect, we vertically align the
-               help icon with an inline-block assist,
-               which is present on the .fa class. */
+               help icon with an inline-block assist. */
             vertical-align: middle;
+            text-decoration: none;
         }
     }
 

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -100,23 +100,21 @@
         margin: 0;
 
         .help_link_widget,
-        .fa {
+        .zulip-icon {
             margin: 0;
         }
 
-        .fa-question-circle-o {
-            /* Override relative position for sake of
-               Chrome paint bug that keeps the circle
-               visible when ellipses are showing. */
-            position: static;
+        .zulip-icon-help {
+            /* Eyeballed to sit on the description's baseline. */
+            font-size: 0.88em;
+            vertical-align: -0.1em;
         }
 
         .help_link_widget {
-            /* With relative positioning no longer
-               in effect, we vertically align the
-               help icon with an inline-block assist,
-               which is present on the .fa class. */
+            /* Align the icon against the description text. */
             vertical-align: middle;
+            /* Unlike .fa, .zulip-icon inherits the link's underline. */
+            text-decoration: none;
         }
     }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -138,7 +138,7 @@
         padding: 0.25em; /* 4px at 16px/1em */
     }
 
-    /* help_link_widget margin for the fa-circle-o. */
+    /* help_link_widget margin for the zulip-icon-help. */
     .help_link_widget {
         margin-left: 5px;
     }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1056,6 +1056,13 @@ ul.popover-group-menu-member-list {
             height: 1em;
             text-align: center;
         }
+
+        .popover-menu-icon.zulip-icon-eye {
+            position: relative;
+            top: -0.0313em;
+            font-size: 1.1em;
+            width: 0.97em;
+        }
     }
 
     .text-item {

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -467,8 +467,10 @@
             padding-right: 0;
         }
 
-        .fa-user {
+        .zulip-icon-user {
             opacity: 0.7;
+            font-size: 1em;
+            margin-left: 0.1em;
         }
     }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -467,7 +467,7 @@
             padding-right: 0;
         }
 
-        .fa-user {
+        .zulip-icon-user {
             opacity: 0.7;
         }
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -16,7 +16,7 @@ h3,
 
 /* TODO: This should ideally be added to help_link_widget.hbs,
    allowing us to deduplicate at least the opacity CSS with the
-   fa-question-circle-o logic above. */
+   zulip-icon-help logic above. */
 .settings-info-icon {
     padding-left: 3px;
     opacity: 0.7;
@@ -31,9 +31,9 @@ a.help_link_widget {
     color: inherit;
     margin-left: 3px;
 
-    .fa-question-circle-o {
-        position: relative;
-        top: 1px;
+    .zulip-icon-help {
+        vertical-align: -0.16em;
+        font-size: 0.88em;
     }
 
     &:hover {
@@ -47,6 +47,10 @@ h3,
 .settings-section-title {
     .help_link_widget {
         margin-left: 5px;
+
+        .zulip-icon-help {
+            vertical-align: -0.15em;
+        }
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -37,7 +37,7 @@ label,
 
 /* TODO: This should ideally be added to help_link_widget.hbs,
    allowing us to deduplicate at least the opacity CSS with the
-   fa-question-circle-o logic above. */
+   zulip-icon-help logic above. */
 .settings-info-icon {
     padding-left: 3px;
     opacity: 0.7;
@@ -52,9 +52,10 @@ a.help_link_widget {
     color: inherit;
     margin-left: 3px;
 
-    .fa-question-circle-o {
-        position: relative;
-        top: 1px;
+    .zulip-icon-help {
+        /* Eyeballed to sit on the text baseline. */
+        font-size: 0.88em;
+        vertical-align: -0.16em;
     }
 
     &:hover {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -494,6 +494,10 @@ h4.stream_setting_subsection_title {
 
     .tab-switcher.stream_sorter_toggle {
         margin-left: auto;
+
+        .zulip-icon-bar-chart {
+            font-size: 1.115em;
+        }
     }
 
     .tab-switcher,
@@ -1116,6 +1120,21 @@ h4.stream_setting_subsection_title {
         .bottom-bar .stream-message-count {
             white-space: nowrap;
             color: hsl(0deg 0% 67%);
+            display: flex;
+            align-items: center;
+            gap: 0.1em;
+        }
+
+        .top-bar .subscriber-count .zulip-icon-user {
+            font-size: 1.1em;
+        }
+
+        .top-bar .subscriber-count .zulip-icon-lock {
+            font-size: 0.82em;
+        }
+
+        .bottom-bar .stream-message-count .zulip-icon-bar-chart {
+            font-size: 1.2em;
         }
 
         .top-bar .subscriber-count-text,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -449,6 +449,11 @@
 
     .tab-switcher.stream_sorter_toggle {
         margin-left: auto;
+
+        .zulip-icon-bar-chart {
+            /* Eyeballed to match the other sort icons. */
+            font-size: 1.1em;
+        }
     }
 
     .tab-switcher,
@@ -1080,6 +1085,23 @@
         .bottom-bar .stream-message-count {
             white-space: nowrap;
             color: hsl(0deg 0% 67%);
+            /* Center the icon against its count, rather than nudging it. */
+            display: flex;
+            align-items: center;
+            gap: 0.1em;
+        }
+
+        /* Eyeballed to match the count text; glyph sizes vary. */
+        .top-bar .subscriber-count .zulip-icon-user {
+            font-size: 1.1em;
+        }
+
+        .top-bar .subscriber-count .zulip-icon-lock {
+            font-size: 0.82em;
+        }
+
+        .bottom-bar .stream-message-count .zulip-icon-bar-chart {
+            font-size: 1.2em;
         }
 
         .top-bar .subscriber-count-text,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -211,12 +211,15 @@ p.n-margin {
 .history-limited-box {
     border-radius: 4px;
     display: none;
-    /* Difference should be 16px to accommodate the icon. */
-    /* This emulates hanging indent. */
+    /* Accommodate the icon with hanging indent. */
     padding-left: 26px;
-    text-indent: -10px;
+    text-indent: -1px;
     color: hsl(16deg 60% 45%);
     border: 1px solid hsl(16deg 60% 45%);
+
+    .zulip-icon-exclamation-circle {
+        vertical-align: -0.1em;
+    }
     box-shadow: 0 0 2px hsl(16deg 60% 45%);
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -230,6 +230,11 @@ p.n-margin {
     color: hsl(16deg 60% 45%);
     border: 1px solid hsl(16deg 60% 45%);
     box-shadow: 0 0 2px hsl(16deg 60% 45%);
+
+    .zulip-icon-exclamation-circle {
+        /* Eyeballed to center the icon against the text. */
+        vertical-align: -0.15em;
+    }
 }
 
 .messages-logo-svg {

--- a/web/templates/help_link_widget.hbs
+++ b/web/templates/help_link_widget.hbs
@@ -1,3 +1,3 @@
 <a class="help_link_widget" href="{{ link }}" target="_blank" rel="noopener noreferrer">
-    <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+    <i class="zulip-icon zulip-icon-help" aria-hidden="true"></i>
 </a>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -1,6 +1,6 @@
 <div class="history-limited-box">
     <p>
-        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+        <i class="zulip-icon zulip-icon-exclamation-circle" aria-hidden="true"></i>
         {{#tr}}
         Some older messages are unavailable.
         <z-link>Upgrade your organization</z-link>

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -31,7 +31,7 @@
     <span class="narrow_description rendered_markdown single-line-rendered-markdown">{{description}}
         {{#if link}}
         <a class="help_link_widget" href="{{link}}" target="_blank" rel="noopener noreferrer">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+            <i class="zulip-icon zulip-icon-help" aria-hidden="true"></i>
         </a>
         {{/if}}
     </span>

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -240,7 +240,7 @@
             {{#if can_unmute}}
                 <li role="none" class="popover-menu-list-item link-item">
                     <a role="menuitem" class="sidebar-popover-unmute-user popover-menu-link hidden-for-spectators" tabindex="0">
-                        <i class="popover-menu-icon fa fa-eye" aria-hidden="true"></i>
+                        <i class="popover-menu-icon zulip-icon zulip-icon-eye" aria-hidden="true"></i>
                         {{#if is_bot}}
                             <span class="popover-menu-label">{{t "Unmute this bot" }}</span>
                         {{else}}

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -59,7 +59,7 @@
             {{#each senders}}
                 {{#if this.is_muted}}
                 <li class="recent_view_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{t 'Muted user'}}" data-user-id="{{this.user_id}}">
-                    <span><i class="fa fa-user recent_view_participant_overflow"></i></span>
+                    <span><i class="zulip-icon zulip-icon-user recent_view_participant_overflow" aria-hidden="true"></i></span>
                 </li>
                 {{else}}
                 <li class="recent_view_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{this.full_name}}" data-user-id="{{this.user_id}}">

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -59,7 +59,7 @@
             {{#each senders}}
                 {{#if this.is_muted}}
                 <li class="recent_view_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{t 'Muted user'}}" data-user-id="{{this.user_id}}">
-                    <span><i class="fa fa-user recent_view_participant_overflow"></i></span>
+                    <span><i class="zulip-icon zulip-icon-user recent_view_participant_overflow"></i></span>
                 </li>
                 {{else}}
                 <li class="recent_view_participant_item participant_profile tippy-zulip-tooltip" data-tippy-content="{{this.full_name}}" data-user-id="{{this.user_id}}">

--- a/web/templates/stream_settings/browse_streams_list_item.hbs
+++ b/web/templates/stream_settings/browse_streams_list_item.hbs
@@ -57,7 +57,7 @@
             <div class="description rendered_markdown" data-no-description="{{t 'No description.'}}">{{rendered_markdown rendered_description}}</div>
             {{#if is_old_stream}}
             <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Estimated messages per week' }}">
-                <i class="fa fa-bar-chart"></i>
+                <i class="zulip-icon zulip-icon-bar-chart" aria-hidden="true"></i>
                 <span class="stream-message-count-text">{{stream_weekly_traffic}}</span>
             </div>
             {{else}}

--- a/web/templates/stream_settings/subscriber_count.hbs
+++ b/web/templates/stream_settings/subscriber_count.hbs
@@ -1,6 +1,6 @@
-<i class="fa fa-user-o" aria-hidden="true"></i>
+<i class="zulip-icon zulip-icon-user" aria-hidden="true"></i>
 {{#if can_access_subscribers}}
 <span class="subscriber-count-text">{{numberFormat subscriber_count}}</span>
 {{else}}
-<i class="subscriber-count-lock fa fa-lock" aria-hidden="true"></i>
+<i class="subscriber-count-lock zulip-icon zulip-icon-lock" aria-hidden="true"></i>
 {{/if}}


### PR DESCRIPTION
Replace decorative FontAwesome icons in stream/message UI with their Zulip icon.

- `fa-bar-chart` &rarr; `zulip-icon-bar-chart` (weekly traffic icon in the channel list and sort button)
- `fa-user-o` &rarr; `zulip-icon-user` (subscriber count icon and sort button)
- `fa-lock` &rarr; `zulip-icon-lock` (subscriber count lock icon for private channels)
- `fa-exclamation-circle` &rarr; `zulip-icon-exclamation-circle` (history limited and search caution banners)
- `fa-user` &rarr; `zulip-icon-user` (muted user icon in recent conversations)
- `fa-question-circle-o` &rarr; `zulip-icon-help` (help link widget and message view header)
- `fa-eye` &rarr; `zulip-icon-eye` (unmute user option in user card popover)

Also updates the corresponding CSS selectors in `message_view_header.css`, `recent_view.css`, `settings.css`, `subscriptions.css`, and `zulip.css`, and fixes alignment for the new icon classes.

Fixes: Part of #36224
<hr>


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

<details><summary>In Channel settings the channel subscriber count icon <code>fa-user-o</code> &rarr; <code>zulip-icon-user</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/a1fa5c2d-bcfd-4428-be60-c43db8e1400e" />|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/dcf4f12d-671f-457d-bae8-a5f935808e6b" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="721" height="112" alt="image" src="https://github.com/user-attachments/assets/acbad11e-df88-412e-bb35-613188ba1575" />|<img width="721" height="112" alt="image" src="https://github.com/user-attachments/assets/6735795f-699b-4fda-abe4-e2ebc2b5b343" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/ca21e925-ecae-4a01-babe-7445894a3cb2" />|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/5d9cf8c3-98f8-4e65-8f88-2da327568267" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="721" height="112" alt="image" src="https://github.com/user-attachments/assets/b3439385-a01e-4c0e-9a5b-78159415c887" />|<img width="721" height="112" alt="image" src="https://github.com/user-attachments/assets/68270131-15fa-4edf-9823-bea1f0a423c0" />|

</p>
</details> 

<details><summary>In Channel settings the channel weekly traffic icon <code>fa-bar-chart</code> &rarr; <code>zulip-icon-bar-chart</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/44f5151b-7f70-4349-8751-7120233fa1f1" />|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/3fc4f80b-4111-4dd9-bd6a-efc694fc4601" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="721" height="110" alt="image" src="https://github.com/user-attachments/assets/cb77d8a1-ac08-4fc1-bd27-2751b02a18f0" />|<img width="721" height="110" alt="image" src="https://github.com/user-attachments/assets/b802ee70-b9ed-45ab-a3b2-79d375616c05" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/a2b1868f-c08d-44c5-82df-f7e9a8dfbd1a" />|<img width="721" height="758" alt="image" src="https://github.com/user-attachments/assets/cccc5b62-79b5-4cb5-b12f-9a2c16dae525" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="721" height="110" alt="image" src="https://github.com/user-attachments/assets/b5ada207-4189-4cf3-93a8-804fa9f2b19b" />|<img width="721" height="110" alt="image" src="https://github.com/user-attachments/assets/b8146a95-7b89-4f5b-be3c-42155d6542f8" />|

</p>
</details> 

<details><summary>In Channel settings the channel sort by subscribers button <code>fa-user-o</code> &rarr; <code>zulip-icon-user</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="57" height="50" alt="image" src="https://github.com/user-attachments/assets/7eea9c63-6722-40d5-bb20-82820e8c3231" />|<img width="57" height="50" alt="image" src="https://github.com/user-attachments/assets/7238c6dd-e1e8-4ce2-b49d-20f84f9e0bc4" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="167" height="52" alt="image" src="https://github.com/user-attachments/assets/ad959f29-91ce-43e0-be13-366298e6e017" />|<img width="167" height="52" alt="image" src="https://github.com/user-attachments/assets/40888e4e-b9cf-4384-8313-e90d29751d49" />|

</p>
</details> 

<details><summary>In Channel settings the channel sort by weekly traffic button <code>fa-bar-chart</code> &rarr; <code>zulip-icon-bar-chart</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="60" height="50" alt="image" src="https://github.com/user-attachments/assets/33fd3954-7ba4-45b7-9ba1-f930ae2d10e4" />|<img width="60" height="50" alt="image" src="https://github.com/user-attachments/assets/36e6ab05-f474-45ee-b8c2-1d12bc3147f0" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="167" height="52" alt="image" src="https://github.com/user-attachments/assets/ad959f29-91ce-43e0-be13-366298e6e017" />|<img width="167" height="52" alt="image" src="https://github.com/user-attachments/assets/40888e4e-b9cf-4384-8313-e90d29751d49" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="59" height="48" alt="image" src="https://github.com/user-attachments/assets/4e6394f7-a948-4eab-8613-815cd6b540bb" />|<img width="59" height="48" alt="image" src="https://github.com/user-attachments/assets/01d1f44b-7843-4e6b-9aa1-d06e3bbec6f8" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="167" height="52" alt="image" src="https://github.com/user-attachments/assets/c32446a1-85c4-49fc-8d93-e0b177a0d663" />|<img width="167" height="52" alt="image" src="https://github.com/user-attachments/assets/1515d75f-b1d2-47e6-95d3-2b04e33e2114" />|

</p>
</details> 

<details><summary>In Channel settings, the channel Private channel subscriber count lock icon <code>fa-lock</code> &rarr; <code>zulip-icon-lock</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="722" height="758" alt="image" src="https://github.com/user-attachments/assets/1df1e8ed-91f5-4599-85a3-638b556847f8" />|<img width="722" height="758" alt="image" src="https://github.com/user-attachments/assets/1abbf648-a229-412e-b41a-fa04069dd93c" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="720" height="110" alt="image" src="https://github.com/user-attachments/assets/5b7f3aa8-244c-4d8c-a787-7ef16d3be220" />|<img width="720" height="110" alt="image" src="https://github.com/user-attachments/assets/ccab117f-98fd-4007-9628-15d3d44854cb" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="722" height="758" alt="image" src="https://github.com/user-attachments/assets/f81d3b46-610a-429a-a81e-c64285e3cd7f" />|<img width="722" height="758" alt="image" src="https://github.com/user-attachments/assets/718deb2a-79f4-4b48-8453-73271d754cca" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="720" height="110" alt="image" src="https://github.com/user-attachments/assets/830e43ec-260f-4d42-86cd-9254af707440" />|<img width="720" height="110" alt="image" src="https://github.com/user-attachments/assets/2d609c1b-ce73-452b-b673-faf75fef9e5f" />|

</p>
</details> 

<details><summary>In Message feed history acess limited banner <code>fa-exclamation-circle</code> &rarr; <code>zulip-icon-exclamation-circle</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="960" height="439" alt="2026-05-08_22-00-12" src="https://github.com/user-attachments/assets/4e1fbc46-b09d-49b3-8725-7de83df1e3c2" />|<img width="960" height="439" alt="2026-05-08_21-57-31" src="https://github.com/user-attachments/assets/b4497763-d81d-4610-8362-7dc744527c84" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="518" height="52" alt="2026-05-08_22-01-09" src="https://github.com/user-attachments/assets/f594f517-c7e3-4800-a263-dfa121dd1e97" />|<img width="518" height="52" alt="2026-05-08_22-02-54" src="https://github.com/user-attachments/assets/5d6e4dc5-e9e4-42e1-b647-8e7e5264810b" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="960" height="439" alt="2026-05-08_22-04-14" src="https://github.com/user-attachments/assets/46976245-8ff2-481c-a60f-6947e6671897" />|<img width="960" height="439" alt="2026-05-08_22-03-35" src="https://github.com/user-attachments/assets/0c107a3e-acc5-4c66-9298-05b507c44744" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="518" height="52" alt="2026-05-08_22-05-13" src="https://github.com/user-attachments/assets/63cb85f6-63be-481f-99b1-210c364043e4" />|<img width="518" height="52" alt="2026-05-08_22-06-48" src="https://github.com/user-attachments/assets/daeab207-c1d2-4cef-b023-5f7d6dcd32cd" />|

</p>
</details> 

<details><summary>In Recent conversations muted user icon <code>fa-user</code> &rarr; <code>zulip-icon-user</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="1032" height="695" alt="image" src="https://github.com/user-attachments/assets/2c42241b-ed68-40f5-8bb8-7b6b1ae9eded" />|<img width="1032" height="695" alt="image" src="https://github.com/user-attachments/assets/9bbc9763-87a6-4c9e-9f17-7bbf7ce1c59d" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="1021" height="177" alt="image" src="https://github.com/user-attachments/assets/9f521430-1531-4c61-8aaa-d4264494181a" />|<img width="1021" height="177" alt="image" src="https://github.com/user-attachments/assets/51c2873a-91b0-47e2-a4ae-4cff77388a30" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="1032" height="695" alt="image" src="https://github.com/user-attachments/assets/3e276cd6-f412-41d0-a152-e415de1c7332" />|<img width="1032" height="695" alt="image" src="https://github.com/user-attachments/assets/d32648c3-edf6-41d5-b631-7b3701bdc9b7" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="1021" height="177" alt="image" src="https://github.com/user-attachments/assets/7c6d5013-9a3a-4d30-826b-659267e0bad8" />|<img width="1021" height="177" alt="image" src="https://github.com/user-attachments/assets/67043c9e-e819-4dbb-b849-b61fd6ae9ca6" />|

</p>
</details> 

<details><summary>In Settings Tab all help link icons <code>fa-question-circle-o</code> &rarr; <code>zulip-icon-help</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="418" height="108" alt="image" src="https://github.com/user-attachments/assets/bbfc6c06-1eab-47ff-8995-e34900fdfafd" />|<img width="418" height="108" alt="image" src="https://github.com/user-attachments/assets/c92759ea-9b63-4de8-822a-a29a40e644b1" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="695" height="82" alt="image" src="https://github.com/user-attachments/assets/03aa3abf-d312-4178-a583-55491f4a1e8d" />|<img width="695" height="82" alt="image" src="https://github.com/user-attachments/assets/83abe85e-722f-4769-93c4-25a8f28f9397" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="418" height="108" alt="image" src="https://github.com/user-attachments/assets/15e07513-e38d-4e0d-8b25-a1a6245348e1" />|<img width="418" height="108" alt="image" src="https://github.com/user-attachments/assets/7988a18b-7aa6-4bbc-a658-36d0cdc632dd" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="695" height="82" alt="image" src="https://github.com/user-attachments/assets/ee3aee23-24ed-47ed-b574-f5d5fa99c298" />|<img width="695" height="82" alt="image" src="https://github.com/user-attachments/assets/db5ec314-1649-4732-a395-2f005f8a51fa" />|

</p>
</details> 

<details><summary>In Message view header help link icon <code>fa-question-circle-o</code> &rarr; <code>zulip-icon-help</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="612" height="43" alt="image" src="https://github.com/user-attachments/assets/016b8f67-66db-477b-b9c2-f944da129cd7" />|<img width="612" height="43" alt="image" src="https://github.com/user-attachments/assets/dac3e39a-42d0-4cfe-a1ac-731540da4ab3" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="612" height="43" alt="image" src="https://github.com/user-attachments/assets/8d8b9321-5b87-4003-a5e0-f590cc6e2ba7" />|<img width="612" height="43" alt="image" src="https://github.com/user-attachments/assets/7e835533-b4a5-4f5f-8c64-161a690bab6e" />|


</p>
</details> 

<details><summary>In User card popover user unmute icon<code>fa-eye</code> &rarr; <code>zulip-icon-eye</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="414" height="562" alt="image" src="https://github.com/user-attachments/assets/49b7490e-4f35-4e49-9cde-3405cada1a59" />|<img width="414" height="562" alt="image" src="https://github.com/user-attachments/assets/0782b451-353f-4224-8447-59eb6602a868" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="411" height="56" alt="image" src="https://github.com/user-attachments/assets/f5aee1d8-af5b-4aa8-b7bf-3ff0068183e1" />|<img width="411" height="56" alt="image" src="https://github.com/user-attachments/assets/cba6cd55-0a9d-4aa6-9962-2c4d70e7fd10" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="414" height="562" alt="image" src="https://github.com/user-attachments/assets/0bcfbc5a-dab2-4fa0-962e-febc4560e820" />|<img width="414" height="562" alt="image" src="https://github.com/user-attachments/assets/f9ed901c-e065-4593-9025-902eb31ceca0" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="411" height="56" alt="image" src="https://github.com/user-attachments/assets/a4b7c416-1b72-4ace-a17d-86a9a4a77091" />|<img width="411" height="56" alt="image" src="https://github.com/user-attachments/assets/9901beb0-27fe-4be6-b891-8e1f6e788f36" />|

</p>
</details> 

<details>
<summary>Self-review checklist</summary>


<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
