### PR TITLE
Icons: Replace fa icons in widgets and failed(offline) messages.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -681,6 +681,28 @@
                 color: var(--color-message-star-action);
             }
         }
+        /* Reset default button styles for message-controls-icon
+           buttons (used by failed message controls). The press-scale
+           animation targets the child icon since the button's ::before
+           is empty. */
+        & button.message-controls-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border: none;
+            background: none;
+            font: inherit;
+            color: inherit;
+
+            & .zulip-icon::before {
+                display: block;
+            }
+
+            &:active .zulip-icon::before {
+                transform: scale(0.92);
+                transform-origin: center;
+            }
+        }
     }
 
     /* Tooltips should not follow the width restrictions of their parent element. */

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -713,7 +713,6 @@
     .failed_message_action {
         color: var(--color-failed-message-send-icon);
         font-weight: bold;
-        padding: 1px;
         opacity: 1;
         visibility: visible;
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -301,9 +301,14 @@ input {
 
 .poll-edit-question,
 .todo-edit-task-list-title {
+    padding: 0;
+    border: none;
+    background: none;
+    font-size: inherit;
     position: relative;
     top: 1px;
     color: var(--color-message-action-visible);
+    cursor: pointer;
 
     &:hover,
     &:focus-visible {

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -280,6 +280,9 @@ input {
 .poll-question-remove,
 .todo-task-list-title-check,
 .todo-task-list-title-remove {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     align-self: stretch;
     /* TODO: Re-express the 30.5px value here
        as part of information density work. */
@@ -298,6 +301,8 @@ input {
 
 .poll-edit-question,
 .todo-edit-task-list-title {
+    position: relative;
+    top: 1px;
     color: var(--color-message-action-visible);
 
     &:hover,

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -117,6 +117,10 @@
     .todo-task-list-title-header {
         font-size: 1.1em;
         font-weight: 600;
+        /* Zero out the margin inherited from Markdown styles;
+           we place the margin here on the header-area class,
+           making alignment of the flex items more predictable. */
+        margin-bottom: 0;
     }
 
     & li {
@@ -305,10 +309,16 @@ input {
     border: none;
     background: none;
     font-size: inherit;
-    position: relative;
-    top: 1px;
     color: var(--color-message-action-visible);
     cursor: pointer;
+    /* We're going to offset this manually with margin-top,
+       in ems, so the icon looks good even if a question
+       or list title spans multiple lines. */
+    align-self: flex-start;
+    /* Give the icon its own flexbox, so it is sized
+       nicely relative to the icon box. */
+    display: flex;
+    margin-top: 0.25em; /* 4px at 16px/1em; this is eyeballed, but correct. */
 
     &:hover,
     &:focus-visible {
@@ -332,6 +342,11 @@ input {
     display: flex;
     align-items: baseline;
     gap: 5px;
+    /* Keep the expected margin under the heading, but place it
+       here on the header area, rather than the heading itself,
+       so the flexbox for aligning text and icon button is
+       unaffected. */
+    margin-bottom: var(--markdown-interelement-space-px);
 }
 
 .current-user-vote {

--- a/web/templates/message_controls_failed_msg.hbs
+++ b/web/templates/message_controls_failed_msg.hbs
@@ -1,7 +1,7 @@
 <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
-    <i class="message-controls-icon zulip-icon zulip-icon-refresh-cw refresh-failed-message" aria-label="{{t 'Retry'}}" role="button" tabindex="0"></i>
+    <button type="button" class="message-controls-icon refresh-failed-message" aria-label="{{t 'Retry'}}"><i class="zulip-icon zulip-icon-refresh-cw" aria-hidden="true"></i></button>
 </div>
 
 <div class="message_control_button failed_message_action" data-tooltip-template-id="dismiss-failed-send-button-tooltip-template">
-    <i class="message-controls-icon zulip-icon zulip-icon-circle-x remove-failed-message" aria-label="{{t 'Dismiss'}}" role="button" tabindex="0"></i>
+    <button type="button" class="message-controls-icon remove-failed-message" aria-label="{{t 'Dismiss'}}"><i class="zulip-icon zulip-icon-circle-x" aria-hidden="true"></i></button>
 </div>

--- a/web/templates/message_controls_failed_msg.hbs
+++ b/web/templates/message_controls_failed_msg.hbs
@@ -1,7 +1,7 @@
 <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
-    <i class="message-controls-icon fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
+    <i class="message-controls-icon zulip-icon zulip-icon-refresh-cw refresh-failed-message" aria-label="{{t 'Retry'}}" role="button" tabindex="0"></i>
 </div>
 
 <div class="message_control_button failed_message_action" data-tooltip-template-id="dismiss-failed-send-button-tooltip-template">
-    <i class="message-controls-icon fa fa-times-circle remove-failed-message" aria-label="{{t 'Dismiss' }}" role="button" tabindex="0"></i>
+    <i class="message-controls-icon zulip-icon zulip-icon-circle-x remove-failed-message" aria-label="{{t 'Dismiss'}}" role="button" tabindex="0"></i>
 </div>

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -1,7 +1,7 @@
 <div class="poll-widget">
     <div class="poll-widget-header-area">
         <h4 class="poll-question-header"></h4>
-        <i class="zulip-icon zulip-icon-pencil poll-edit-question" aria-hidden="true"></i>
+        <button type="button" class="poll-edit-question" aria-label="{{t 'Edit question'}}"><i class="zulip-icon zulip-icon-pencil" aria-hidden="true"></i></button>
         <div class="poll-question-bar">
             <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
             <button type="button" class="poll-question-remove" aria-label="{{t 'Cancel edit'}}"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -1,11 +1,11 @@
 <div class="poll-widget">
     <div class="poll-widget-header-area">
         <h4 class="poll-question-header"></h4>
-        <i class="fa fa-pencil poll-edit-question"></i>
+        <i class="zulip-icon zulip-icon-pencil poll-edit-question" aria-hidden="true"></i>
         <div class="poll-question-bar">
             <input type="text" class="poll-question" placeholder="{{t 'Add question'}}" />
-            <button class="poll-question-remove"><i class="fa fa-remove"></i></button>
-            <button class="poll-question-check"><i class="fa fa-check"></i></button>
+            <button type="button" class="poll-question-remove" aria-label="{{t 'Cancel edit'}}"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>
+            <button type="button" class="poll-question-check" aria-label="{{t 'Save'}}"><i class="zulip-icon zulip-icon-check" aria-hidden="true"></i></button>
         </div>
     </div>
     <div class="poll-please-wait">

--- a/web/templates/widgets/poll_widget_example.hbs
+++ b/web/templates/widgets/poll_widget_example.hbs
@@ -1,6 +1,6 @@
 <div class="poll-widget">
     <h4 class="poll-question-header">{{t "What did you drink this morning?"}}</h4>
-    <i class="zulip-icon zulip-icon-pencil poll-edit-question" aria-hidden="true"></i>
+    <button type="button" class="poll-edit-question" aria-label="{{t 'Edit question'}}"><i class="zulip-icon zulip-icon-pencil" aria-hidden="true"></i></button>
     <ul class="poll-widget">
         <li>
             <button class="poll-vote">

--- a/web/templates/widgets/poll_widget_example.hbs
+++ b/web/templates/widgets/poll_widget_example.hbs
@@ -1,6 +1,6 @@
 <div class="poll-widget">
     <h4 class="poll-question-header">{{t "What did you drink this morning?"}}</h4>
-    <i class="fa fa-pencil poll-edit-question"></i>
+    <i class="zulip-icon zulip-icon-pencil poll-edit-question" aria-hidden="true"></i>
     <ul class="poll-widget">
         <li>
             <button class="poll-vote">

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -1,11 +1,11 @@
 <div class="todo-widget">
     <div class="todo-widget-header-area">
         <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
-        <i class="fa fa-pencil todo-edit-task-list-title"></i>
+        <i class="zulip-icon zulip-icon-pencil todo-edit-task-list-title" aria-hidden="true"></i>
         <div class="todo-task-list-title-bar">
             <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
-            <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
-            <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
+            <button type="button" class="todo-task-list-title-remove" aria-label="{{t 'Cancel edit'}}"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>
+            <button type="button" class="todo-task-list-title-check" aria-label="{{t 'Save'}}"><i class="zulip-icon zulip-icon-check" aria-hidden="true"></i></button>
         </div>
     </div>
     <ul class="todo-widget">

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -1,7 +1,7 @@
 <div class="todo-widget">
     <div class="todo-widget-header-area">
         <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
-        <i class="zulip-icon zulip-icon-pencil todo-edit-task-list-title" aria-hidden="true"></i>
+        <button type="button" class="todo-edit-task-list-title" aria-label="{{t 'Edit task list title'}}"><i class="zulip-icon zulip-icon-pencil" aria-hidden="true"></i></button>
         <div class="todo-task-list-title-bar">
             <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
             <button type="button" class="todo-task-list-title-remove" aria-label="{{t 'Cancel edit'}}"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>


### PR DESCRIPTION
Replace decorative FontAwesome icons in widgets and failed message with the Zulip icon.

- `fa-pencil` &rarr; `zulip-icon-pencil` in:
  - `poll_widget.hbs` (poll question edit icon)
  - `poll_widget_example.hbs` (poll question edit icon)
  - `todo_widget.hbs` (todo task list title edit icon)
- `fa-remove` &rarr; `zulip-icon-close` in:
  - `poll_widget.hbs` (poll question cancel edit icon)
  - `todo_widget.hbs` (todo task list title, cancel edit icon)
- `fa-check` &rarr; `zulip-icon-check` in:
  - `poll_widget.hbs` (poll question save icon)
  - `todo_widget.hbs` (todo task list title save icon)
- `fa-refresh` &rarr; `zulip-icon-refresh-cw` in:
  - `message_controls_failed_msg.hbs` (failed message retry icon)
- `fa-times-circle` &rarr; `zulip-icon-circle-x`in:
  - `message_controls_failed_msg.hbs` (failed message dismiss icon)

Also, correct the alignment in `widgets.css` for the new icon classes.

Fixes: Part of #36224
<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

<details><summary>In poll widget heading the edit icon (&#128393;) <code>fa-pencil</code> &rarr; <code>zulip-icon-pencil</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="1013" height="210" alt="image" src="https://github.com/user-attachments/assets/81403b4b-a3d7-4b6e-b455-9040c6a6e693" />|<img width="1013" height="210" alt="image" src="https://github.com/user-attachments/assets/90963553-e6f0-486d-b81a-65a31025cdc3" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="267" height="90" alt="image" src="https://github.com/user-attachments/assets/07984bef-964d-4678-83c1-5db2ae94cd57" />|<img width="267" height="90" alt="image" src="https://github.com/user-attachments/assets/9bce99cb-9ea7-44a6-bb1d-6b81ed54473a" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="1013" height="210" alt="image" src="https://github.com/user-attachments/assets/eddfddeb-96c3-447a-b0b9-7c8ee0374c83" />|<img width="1013" height="210" alt="image" src="https://github.com/user-attachments/assets/5be1853c-c9d0-4193-a92c-e1748bbc49a8" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="267" height="90" alt="image" src="https://github.com/user-attachments/assets/3f11ba82-be00-4d50-81b1-391061cd36d5" />|<img width="267" height="90" alt="image" src="https://github.com/user-attachments/assets/4cca6c91-5cd4-451c-be05-5203233a97a8" />|

</p>
</details> 

<details><summary>In poll widget edit bar the cancel button (&#10540;) <code>fa-remove</code> &rarr; <code>zulip-icon-close</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="94" height="94" alt="2026-05-09_12-26-57" src="https://github.com/user-attachments/assets/751a3251-c069-4f3d-828b-3b81e9e1a90e" />|<img width="94" height="94" alt="2026-05-09_12-27-02" src="https://github.com/user-attachments/assets/81112b71-0573-477f-be90-9e57f29ec625" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="334" height="28" alt="2026-05-09_12-29-18" src="https://github.com/user-attachments/assets/e5999ca5-cf9b-47ed-be5b-766b5132c834" />|<img width="334" height="28" alt="2026-05-09_12-28-37" src="https://github.com/user-attachments/assets/b169ab01-d561-4dc1-8172-d1071a612a19" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="94" height="94" alt="2026-05-09_12-24-31" src="https://github.com/user-attachments/assets/6725dc17-c3cf-46a1-81bc-d8209bfffd5a" />|<img width="94" height="94" alt="2026-05-09_12-24-37" src="https://github.com/user-attachments/assets/3eeed49b-5aaa-4c8c-9db0-411a850affbc" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="334" height="28" alt="2026-05-09_12-29-45" src="https://github.com/user-attachments/assets/9b842240-970c-4393-aa4b-6428b1a28706" />|<img width="334" height="28" alt="2026-05-09_12-30-13" src="https://github.com/user-attachments/assets/f0799077-1596-427f-a4a4-ae12412a2850" />|

</p>
</details>

<details><summary>In poll widget edit bar the save button (&#10003;) <code>fa-check</code> &rarr; <code>zulip-icon-check</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="92" height="94" alt="2026-05-09_12-35-23" src="https://github.com/user-attachments/assets/c72794b6-b7e0-4276-ad3a-dfa548d5fd28" />|<img width="92" height="94" alt="2026-05-09_12-35-33" src="https://github.com/user-attachments/assets/f6a7bd16-7e0f-432c-a797-a55992383a80" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="359" height="26" alt="2026-05-09_12-39-41" src="https://github.com/user-attachments/assets/35936985-8808-4a23-a433-8570ecd11a1c" />|<img width="359" height="26" alt="2026-05-09_12-38-59" src="https://github.com/user-attachments/assets/34253845-3873-4db7-9f28-777003f87c49" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="92" height="94" alt="2026-05-09_12-37-13" src="https://github.com/user-attachments/assets/29e021cf-5dca-4fa9-8181-46a4b9ea6bfd" />|<img width="92" height="94" alt="2026-05-09_12-37-20" src="https://github.com/user-attachments/assets/f6d40bc1-fba5-4fef-a554-e28f5eaab6b1" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="359" height="26" alt="2026-05-09_12-40-04" src="https://github.com/user-attachments/assets/f9f4c897-3f23-44fe-92e3-f5e7025de264" />|<img width="359" height="26" alt="2026-05-09_12-40-30" src="https://github.com/user-attachments/assets/3166c4c7-4d79-4888-9c7f-184e8e04d1bf" />|

</p>
</details>

<details><summary>In todo widget heading the edit icon (&#128393;) <code>fa-pencil</code> &rarr; <code>zulip-icon-pencil</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="1013" height="292" alt="image" src="https://github.com/user-attachments/assets/eeef3792-3d64-4116-bfe2-dc904eb7821b" />|<img width="1013" height="292" alt="image" src="https://github.com/user-attachments/assets/6297a519-dff6-4948-8b07-9e436817facb" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="272" height="88" alt="image" src="https://github.com/user-attachments/assets/a5bdc330-f35d-4887-8266-18964cd24628" />|<img width="272" height="88" alt="image" src="https://github.com/user-attachments/assets/226e4063-03b4-4979-b555-648b32d46a5c" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="1013" height="292" alt="image" src="https://github.com/user-attachments/assets/6636fcb8-18d8-48fb-8f72-217db6d51041" />|<img width="1013" height="292" alt="image" src="https://github.com/user-attachments/assets/e98a69ed-ed82-4523-bc18-2c97a734899d" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="272" height="88" alt="image" src="https://github.com/user-attachments/assets/f23d5d06-1090-435e-936a-7411a91a7e1d" />|<img width="272" height="88" alt="image" src="https://github.com/user-attachments/assets/55aead0c-639b-4e0e-afc4-324099397d3d" />|

</p>
</details>

<details><summary>In todo widget edit bar the cancel button (&#10540;) <code>fa-remove</code> &rarr; <code>zulip-icon-close</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="94" height="94" alt="2026-05-09_12-26-57" src="https://github.com/user-attachments/assets/751a3251-c069-4f3d-828b-3b81e9e1a90e" />|<img width="94" height="94" alt="2026-05-09_12-27-02" src="https://github.com/user-attachments/assets/81112b71-0573-477f-be90-9e57f29ec625" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="334" height="28" alt="2026-05-09_12-29-18" src="https://github.com/user-attachments/assets/e5999ca5-cf9b-47ed-be5b-766b5132c834" />|<img width="334" height="28" alt="2026-05-09_12-28-37" src="https://github.com/user-attachments/assets/b169ab01-d561-4dc1-8172-d1071a612a19" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="94" height="94" alt="2026-05-09_12-24-31" src="https://github.com/user-attachments/assets/6725dc17-c3cf-46a1-81bc-d8209bfffd5a" />|<img width="94" height="94" alt="2026-05-09_12-24-37" src="https://github.com/user-attachments/assets/3eeed49b-5aaa-4c8c-9db0-411a850affbc" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="334" height="28" alt="2026-05-09_12-29-45" src="https://github.com/user-attachments/assets/9b842240-970c-4393-aa4b-6428b1a28706" />|<img width="334" height="28" alt="2026-05-09_12-30-13" src="https://github.com/user-attachments/assets/f0799077-1596-427f-a4a4-ae12412a2850" />|

</p>
</details>

<details><summary>In todo widget edit bar the save button (&#10003;) <code>fa-check</code> &rarr; <code>zulip-icon-check</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="92" height="94" alt="2026-05-09_12-35-23" src="https://github.com/user-attachments/assets/c72794b6-b7e0-4276-ad3a-dfa548d5fd28" />|<img width="92" height="94" alt="2026-05-09_12-35-33" src="https://github.com/user-attachments/assets/f6a7bd16-7e0f-432c-a797-a55992383a80" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="359" height="26" alt="2026-05-09_12-39-41" src="https://github.com/user-attachments/assets/35936985-8808-4a23-a433-8570ecd11a1c" />|<img width="359" height="26" alt="2026-05-09_12-38-59" src="https://github.com/user-attachments/assets/34253845-3873-4db7-9f28-777003f87c49" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="92" height="94" alt="2026-05-09_12-37-13" src="https://github.com/user-attachments/assets/29e021cf-5dca-4fa9-8181-46a4b9ea6bfd" />|<img width="92" height="94" alt="2026-05-09_12-37-20" src="https://github.com/user-attachments/assets/f6d40bc1-fba5-4fef-a554-e28f5eaab6b1" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="359" height="26" alt="2026-05-09_12-40-04" src="https://github.com/user-attachments/assets/f9f4c897-3f23-44fe-92e3-f5e7025de264" />|<img width="359" height="26" alt="2026-05-09_12-40-30" src="https://github.com/user-attachments/assets/3166c4c7-4d79-4888-9c7f-184e8e04d1bf" />|

</p>
</details>

<details><summary>In failed message(offline message) controls the retry icon (&#8635;) <code>fa-refresh</code> &rarr; <code>zulip-icon-refresh-cw</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/3f9a45be-bc9a-44bb-b941-b12b1e4f39d0" />|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/04db443c-3ec8-41a9-8786-d6b3f0d88efb" />|

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="64" height="62" alt="2026-05-09_13-06-22" src="https://github.com/user-attachments/assets/aa3f82e5-786f-4c1e-9d19-04e2b21eeadb" />|<img width="64" height="62" alt="2026-05-09_13-06-14" src="https://github.com/user-attachments/assets/a09d131d-334e-44bd-9d5b-4046fd3052f1" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/89d030aa-5dcc-4d99-a295-9b0b7bec0407" />|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/30418b00-b88f-43af-b5ce-565558dbcb65" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="66" height="65" alt="2026-05-09_13-08-50" src="https://github.com/user-attachments/assets/b6a21629-f6ce-45c4-a538-317ec1b3d369" />|<img width="66" height="65" alt="2026-05-09_13-08-43" src="https://github.com/user-attachments/assets/3f044400-7689-4329-a5e7-069edbdfef4a" />|

</p>
</details>

<details><summary>In failed message the dismiss/cancel icon (&#9447;) <code>fa-times-circle</code> &rarr; <code>zulip-icon-circle-x</code> </summary>
<p>

| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/3f9a45be-bc9a-44bb-b941-b12b1e4f39d0" />|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/04db443c-3ec8-41a9-8786-d6b3f0d88efb" />|


| Dark mode Before | Dark Mode After |
|--------|-------|
|<img width="130" height="135" alt="image" src="https://github.com/user-attachments/assets/6dc6b170-e0fa-40ac-ae64-4006f8515401" />|<img width="132" height="132" alt="image" src="https://github.com/user-attachments/assets/a7af4041-f1d4-4776-b183-b1373cd34297" />|

| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/89d030aa-5dcc-4d99-a295-9b0b7bec0407" />|<img width="1341" height="55" alt="image" src="https://github.com/user-attachments/assets/30418b00-b88f-43af-b5ce-565558dbcb65" />|


| Light Mode Before | Light Mode After |
|--------|-------|
|<img width="137" height="130" alt="image" src="https://github.com/user-attachments/assets/131008bb-95c6-4f7c-868e-a1393ca43352" />|<img width="137" height="130" alt="image" src="https://github.com/user-attachments/assets/a677efa2-a550-436f-b6c2-dde0b39fd633" />|

</p>
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
