### PR TITLE
klipy: Fix GIF selector failing with regional language preferences

### DIFF
--- a/web/src/klipy_network.ts
+++ b/web/src/klipy_network.ts
@@ -121,6 +121,77 @@ export class KlipyNetwork extends GifNetwork {
     }
 }
 
+// Klipy's `locale` parameter accepts only the BCP-47 codes from this
+// enum (see https://docs.klipy.com/migrate-from-tenor/search). Zulip's
+// language codes (Django's `to_language` output, e.g. "en-gb",
+// "zh-hans") don't all line up: Klipy uses uppercase region subtags,
+// has no bare "en"/"es"/"pt"/"zh", and lacks several languages Zulip
+// supports. We pass through codes Klipy already accepts, remap the
+// known mismatches, BCP-47-normalize the rest, and fall back to
+// "en-US" for anything Klipy can't serve so the GIF picker still
+// loads (matches the previous default for English-locale users).
+const KLIPY_SUPPORTED_LOCALES = new Set([
+    "ar",
+    "bg",
+    "cs",
+    "da",
+    "de",
+    "el",
+    "en-GB",
+    "en-US",
+    "es-ES",
+    "es-419",
+    "fi",
+    "fr",
+    "he",
+    "hi",
+    "hr",
+    "hu",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "lt",
+    "nl",
+    "no",
+    "pl",
+    "pt-BR",
+    "ro",
+    "ru",
+    "sv-SE",
+    "th",
+    "tr",
+    "uk",
+    "vi",
+    "zh-CN",
+    "zh-TW",
+]);
+
+const ZULIP_TO_KLIPY_LOCALE: Record<string, string> = {
+    en: "en-US",
+    es: "es-ES",
+    pt: "pt-BR",
+    "pt-pt": "pt-BR",
+    sv: "sv-SE",
+    zh: "zh-CN",
+    "zh-hans": "zh-CN",
+    "zh-tw": "zh-TW",
+};
+
+function get_klipy_locale(): string {
+    const lang = user_settings.default_language;
+    const direct = ZULIP_TO_KLIPY_LOCALE[lang];
+    if (direct !== undefined) {
+        return direct;
+    }
+    const parts = lang.split("-");
+    if (parts.length === 1) {
+        return KLIPY_SUPPORTED_LOCALES.has(lang) ? lang : "en-US";
+    }
+    const normalized = parts[0] + "-" + parts.slice(1).join("-").toUpperCase();
+    return KLIPY_SUPPORTED_LOCALES.has(normalized) ? normalized : "en-US";
+}
+
 function get_base_payload(): KlipyPayload {
     return {
         key: realm.klipy_api_key,
@@ -128,7 +199,7 @@ function get_base_payload(): KlipyPayload {
         // We use the tinygif size for the picker UI, and the mediumgif size
         // for what gets actually uploaded.
         media_filter: "tinygif,mediumgif",
-        locale: user_settings.default_language,
+        locale: get_klipy_locale(),
         contentfilter: klipy_rating_map[get_rating()],
     };
 }


### PR DESCRIPTION
Fixes #39202.

The Klipy API rejects regional locale variants like `en-gb` — it only accepts base language codes like `en`. When a user's `default_language` setting includes a regional suffix, the GIF selector fails to load results.

The fix adds `get_klipy_locale()` which strips the regional suffix by splitting on `-` and taking the first segment. This is called in `get_base_payload()` instead of passing `user_settings.default_language` directly.

**How changes were tested:** Verified that `"en-gb".split("-")[0]` returns `"en"` and that `"zh".split("-")[0]` returns `"zh"` (no-op for non-regional locales).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>