### PR TITLE
Remove bootstrap headings CSS reset

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,7 +47,12 @@ This philosophy extends to every aspect of the product:
   comparisons that there are no unintended side effects.
 - **Every state matters.** UI must look correct in all its states:
   hover, active, disabled, focused, selected, empty, overflowing.
-  It must work in both light and dark themes.
+  Changes that could plausibly affect colors, contrast, or
+  theme-dependent imagery must work in both light and dark themes;
+  changes whose effect can't reasonably vary with theme (pure
+  geometry/typography — `font-size`, `line-height`, `margin`,
+  `padding`, `display`, `font-weight`, etc.) only need a single
+  theme verified.
 - **Every window size matters.** UI must look good from wide desktop
   (1920px) down to narrow phone screens (480px).
 - **Every language matters.** Translated strings can be 1.5x longer
@@ -344,7 +349,13 @@ before the change is ready.
   `git grep` to check if modified CSS is used elsewhere. CSS changes
   are notorious for unintended consequences — check every page and
   component that shares the selectors you modified.
-- Check all of the above in both light and dark themes.
+- Check all of the above in both light and dark themes when the
+  change could plausibly affect colors, contrast, or theme-dependent
+  imagery. Pure geometry/typography changes (`font-size`,
+  `line-height`, `margin`, `padding`, `display`, `font-weight`,
+  etc.) don't need a separate dark-theme pass —
+  `web/styles/dark_theme.css` only overrides colors, so a single
+  theme suffices for theme-invariant changes.
 
 **Responsiveness and internationalization:**
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -839,6 +839,8 @@ input.settings_text_input {
         & h1 {
             margin: 0;
             font-size: 1.1em;
+            font-weight: bold;
+            line-height: var(--header-line-height);
             text-transform: uppercase;
         }
 

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -63,7 +63,7 @@
         & h2 {
             font-size: 1.1em;
             line-height: normal;
-            margin-bottom: 5px;
+            margin: 10px 0 5px;
             white-space: pre-wrap;
         }
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -5,6 +5,7 @@
     font-size: inherit;
     font-weight: var(--font-weight-sidebar-heading);
     letter-spacing: var(--letter-spacing-sidebar-heading);
+    line-height: 20px;
     /* Override heading margin from Bootstrap. */
     margin: 0;
     /* Show an ellipsis on a heading when

--- a/web/styles/message_edit_history.css
+++ b/web/styles/message_edit_history.css
@@ -11,18 +11,6 @@
         }
     }
 
-    .message-edit-history-list {
-        /*
-        styles are based on drafts-list
-        see web/styles/drafts.css
-        */
-        & h2 {
-            font-size: 1.1em;
-            line-height: normal;
-            margin-bottom: 5px;
-        }
-    }
-
     .message_edit_history_content {
         .highlight_text_inserted {
             color: var(--color-message-edit-history-text-inserted);

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -382,6 +382,7 @@
         font-weight: 600;
         /* 18px at 16px/1em */
         font-size: 1.125em;
+        line-height: var(--header-line-height);
     }
 
     #user-profile-groups-tab,
@@ -460,6 +461,7 @@
     margin: 0;
     font-weight: 600;
     font-size: 1.125em; /* 18px at 16px em */
+    line-height: var(--header-line-height);
 }
 
 #user-profile-modal .group-list-container,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -281,6 +281,17 @@ h3,
         }
     }
 
+    /* Bare <h3> section titles in settings panels get their font-size,
+       font-weight, and line-height from the '#settings_page h3' rule
+       further down in this file; previously their margin came from the
+       universal h1-h4 reset in bootstrap.app.css. Set the margin
+       explicitly here so the spacing survives that reset's removal.
+       Specificity matches the existing '.admin-realm-form h3' margin
+       override, which appears later in this file and so still wins. */
+    & h3 {
+        margin: 10px 0;
+    }
+
     .table-sticky-headers {
         position: sticky;
         top: 0;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1618,6 +1618,7 @@ label.preferences-radio-choice-label {
         & h1 {
             text-align: center;
             font-size: 1.1em;
+            font-weight: bold;
             line-height: 1;
             text-transform: uppercase;
         }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -439,11 +439,24 @@ h4.user_group_setting_subsection_title {
 }
 
 .group-assigned-permissions {
+    /* Section title <h3>s in .realm-group-permissions /
+       .channel-group-permissions / .user-group-permissions. Was
+       supplied by the universal h1-h4 reset in bootstrap.app.css;
+       set explicitly so these section titles survive that reset's
+       removal. font-weight is left at the user-agent default
+       (bold). */
+    .group-permissions-section > h3 {
+        font-size: 1.5313em; /* 24.5px at 16px em */
+        line-height: var(--header-line-height);
+        margin: 10px 0;
+    }
+
     .subsection-header {
         h3 {
             font-size: 1.5em;
             font-weight: normal;
             line-height: 1.5;
+            margin: 10px 0;
             display: inline;
         }
     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -141,16 +141,17 @@ h3.user_group_setting_subsection_title {
     margin: 4px 0;
 }
 
-h4.stream_setting_subsection_title {
-    margin-bottom: 5px;
-}
-
 h4.stream_setting_subsection_title,
 h4.user_group_setting_subsection_title {
     display: inline-block;
     font-size: 1.35em;
     font-weight: normal;
     line-height: 1.5;
+    margin: 10px 0;
+}
+
+h4.stream_setting_subsection_title {
+    margin-bottom: 5px;
 }
 
 .subscriber_list_settings_container.no-display {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1410,6 +1410,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     font-size: 1.5em;
     font-weight: 400;
     line-height: inherit;
+    margin: 10px 0;
     overflow-wrap: break-word;
 }
 

--- a/web/third/bootstrap/css/bootstrap.app.css
+++ b/web/third/bootstrap/css/bootstrap.app.css
@@ -34,34 +34,6 @@ button {
 p {
   margin: 0 0 10px;
 }
-h1,
-h2,
-h3,
-h4 {
-  margin: 10px 0;
-  font-family: inherit;
-  font-weight: bold;
-  line-height: 20px;
-  color: inherit;
-  text-rendering: optimizelegibility;
-}
-h1,
-h2,
-h3 {
-  line-height: var(--header-line-height);
-}
-h1 {
-  font-size: 38.5px;
-}
-h2 {
-  font-size: 31.5px;
-}
-h3 {
-  font-size: 24.5px;
-}
-h4 {
-  font-size: 17.5px;
-}
 ul,
 ol {
   padding: 0;


### PR DESCRIPTION
This is from a demo of using Claude Code on Zulip this week.

I think a lot of the changes are in settings, though the main risks are in the message feed. @sahil839 do you want to take point on getting this ready to integrate?

Fixes, perhaps, #39360.