### PR TITLE
channel folder: Improve selector spacing and row alignment

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1966,7 +1966,8 @@ textarea.new_message_textarea {
 }
 
 .saved_snippets-dropdown-list-container {
-    width: 17.8571em; /* 250px at 14px/em */
+    width: max-content;
+    max-width: 25rem;
 
     .dropdown-list .dropdown-list-item-common-styles {
         padding: 0.3571em 0.7143em; /* 5px 10px at 14px/em */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2220,8 +2220,10 @@ body:not(.spectator-view) {
     .dropdown-list-wrapper {
         /* Sync with `max-height` in dropdown_widget. */
         max-height: 210px;
-        /* 200px/14px */
-        min-width: 14.285em;
+        /* We set a low min-width so that the dropdown can cinch
+           tightly to its content, but still has a baseline
+           presence. */
+        min-width: 8em;
 
         .dropdown-list {
             list-style: none;
@@ -2234,12 +2236,15 @@ body:not(.spectator-view) {
     }
 
     &.folder_id-dropdown-list-container {
-        width: calc(var(--modal-input-width) * 0.75);
+        width: max-content;
+        max-width: calc(var(--modal-input-width) * 0.85);
 
         /* Alignment adjustments on channel-folder selector. */
-        .dropdown-list-item-name:has(.dropdown-list-buttons) {
-            /* We hold the first row height to 28px at 16px/1em
-               for the sake of the buttons plus their padding. */
+        .dropdown-list-item-name {
+            /* We hold the row height to 28px at 16px/1em
+               for the sake of the buttons plus their padding.
+               This also ensures the "None" row matches the height
+               of rows with buttons (34px total with padding). */
             grid-template-rows: 1.75em minmax(0, auto);
             /* We also align everything to start, so that we can
                offset the text from the top to align it with the
@@ -2271,7 +2276,9 @@ body:not(.spectator-view) {
             "item-description" minmax(0, min-content)
             / minmax(0, 1fr);
         color: var(--color-dropdown-item);
-        padding: 3px 10px 3px 8px;
+        /* Padding is balanced to accommodate the scrollbar space
+           on the right while maintaining symmetry. */
+        padding: 3px 12px;
         font-weight: 400;
         white-space: normal;
         /* Keep the line-height stable, instead of using the


### PR DESCRIPTION
## Channel-folder and saved-snippets dropdown selector refinements

Previously, the channel-folder selector had inconsistent padding and row alignment compared to other dropdown rows. The "None" row also rendered at a slightly different height,
which made the selector appear visually uneven.

This PR updates the selector spacing, alignment, and sizing behavior to improve consistency across dropdown rows and reduce excessive unused width in the selector UI. It also improves sizing behavior for saved-snippets dropdowns by making the wrapper width more content-aware.

Fixes #37647.

### Manual review / demo

<details>
<summary>Descriptive summary of image group</summary>

| Before | After |
| --- | --- |
| ![image-before](https://github.com/user-attachments/assets/2c6d89d9-d764-4c68-8d70-c0635d90894f)  | ![image-after](https://github.com/user-attachments/assets/06624e14-acfc-4141-9875-351bb76cc96e) |

</details>

<details>
<summary>Demo Video of changed version</summary>


https://github.com/user-attachments/assets/678e7dea-731b-48f1-8bc6-7a20fb54d101


</details>



