### PR TITLE
Optimize limited guest sending dm

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -93,10 +93,10 @@ from zerver.lib.user_groups import (
 from zerver.lib.user_message import UserMessageLite, bulk_insert_ums
 from zerver.lib.users import (
     check_can_access_user,
-    get_inaccessible_user_ids,
     get_subscribers_of_target_user_subscriptions,
     get_user_ids_who_can_access_user,
     get_users_involved_in_dms_with_target_users,
+    has_inaccessible_users,
     user_access_restricted_in_realm,
 )
 from zerver.lib.validator import check_widget_content
@@ -1670,12 +1670,10 @@ def check_can_send_direct_message(
 
 
 def check_sender_can_access_recipients(
-    realm: Realm, sender: UserProfile, user_profiles: Sequence[UserProfile]
+    sender: UserProfile, user_profiles: Sequence[UserProfile]
 ) -> None:
     recipient_user_ids = [user.id for user in user_profiles]
-    inaccessible_recipients = get_inaccessible_user_ids(recipient_user_ids, sender)
-
-    if inaccessible_recipients:
+    if has_inaccessible_users(recipient_user_ids, sender):
         raise JsonableError(_("You do not have permission to access some of the recipients."))
 
 
@@ -1841,7 +1839,7 @@ def check_message(
             "JabberMirror",
         ]
 
-        check_sender_can_access_recipients(realm, sender, user_profiles)
+        check_sender_can_access_recipients(sender, user_profiles)
 
         recipients_for_user_creation_events = get_recipients_for_user_creation_events(
             realm, sender, user_profiles

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -116,7 +116,11 @@ from zerver.models import (
 )
 from zerver.models.clients import get_client
 from zerver.models.groups import SystemGroups, get_realm_system_groups_name_dict
-from zerver.models.recipients import get_direct_message_group_user_ids
+from zerver.models.recipients import (
+    DirectMessageGroup,
+    get_direct_message_group_hash,
+    get_direct_message_group_user_ids,
+)
 from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.streams import (
     StreamTopicsPolicyEnum,
@@ -1682,14 +1686,14 @@ def get_recipients_for_user_creation_events(
 ) -> dict[UserProfile, set[int]]:
     """
     This function returns a dictionary with data about which users would
-    receive stream creation events due to gaining access to a user.
+    receive user creation events due to gaining access to a user.
     The key of the dictionary is a user object and the value is a set of
     user_ids that would gain access to that user.
     """
     recipients_for_user_creation_events: dict[UserProfile, set[int]] = defaultdict(set)
 
-    # If none of the users in the direct message conversation are
-    # guests, then there is no possible can_access_all_users_group
+    # If none of the direct message recipients are guests,
+    # then there is no possible can_access_all_users_group
     # policy that would mean sending this message changes any user's
     # user access to other users.
     guest_recipients = [user for user in user_profiles if user.is_guest]
@@ -1704,6 +1708,20 @@ def get_recipients_for_user_creation_events(
             recipients_for_user_creation_events[sender].add(user_profiles[0].id)
         return recipients_for_user_creation_events
 
+    # Here, we check if all participants have a common DirectMessageGroup
+    # with at least one message, which would mean that every user
+    # already has access to every other user, and no need to proceed.
+    all_participant_ids = list({user.id for user in user_profiles} | {sender.id})
+    if DirectMessageGroup.objects.filter(
+        Exists(Message.objects.filter(realm=realm, recipient_id=OuterRef("recipient_id"))),
+        huddle_hash=get_direct_message_group_hash(all_participant_ids),
+    ).exists():
+        return recipients_for_user_creation_events
+
+    # TODO: The following 2 functions execute 4 queries.
+    # While this is only for a new DirectMessageGroup,
+    # it's still worth optimizing, also because these functions
+    # are called in other code paths.
     users_involved_in_dms = get_users_involved_in_dms_with_target_users(guest_recipients, realm)
     subscribers_of_guest_recipient_subscriptions = get_subscribers_of_target_user_subscriptions(
         guest_recipients

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -9,7 +9,7 @@ from typing import Any, TypedDict
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db.models import Q, QuerySet
+from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.db.models.functions import Upper
 from django.utils.translation import gettext as _
 from django_otp.middleware import is_verified
@@ -779,6 +779,41 @@ def check_can_access_user(
     ).exists()
 
 
+def get_inaccessible_users_queryset(
+    target_user_ids: list[int], acting_user: UserProfile
+) -> QuerySet[UserProfile]:
+    """
+    Fetch human users who have no subscription to a recipient
+    the acting_user is also subscribed to.
+    """
+    acting_user_recipient_ids = Subscription.objects.filter(
+        user_profile=acting_user,
+        active=True,
+        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
+    ).values("recipient_id")
+
+    # We fetch all inaccessible users without filtering
+    # by is_user_active.
+    common_subscriptions = Subscription.objects.filter(
+        recipient_id__in=acting_user_recipient_ids,
+        user_profile_id=OuterRef("pk"),
+        active=True,
+    )
+    # All users can access all the bots, so we exclude them.
+    target_human_users = UserProfile.objects.filter(id__in=target_user_ids, is_bot=False)
+    return target_human_users.exclude(Exists(common_subscriptions))
+
+
+def has_inaccessible_users(target_user_ids: list[int], acting_user: UserProfile) -> bool:
+    if len(target_user_ids) == 1 and target_user_ids[0] == acting_user.id:
+        return False
+
+    if check_user_can_access_all_users(acting_user):
+        return False
+
+    return get_inaccessible_users_queryset(target_user_ids, acting_user).exists()
+
+
 def get_inaccessible_user_ids(
     target_user_ids: list[int], acting_user: UserProfile | None
 ) -> set[int]:
@@ -787,33 +822,9 @@ def get_inaccessible_user_ids(
 
     assert acting_user is not None
 
-    # All users can access all the bots, so we just exclude them.
-    target_human_user_ids = UserProfile.objects.filter(
-        id__in=target_user_ids, is_bot=False
-    ).values_list("id", flat=True)
-
-    if not target_human_user_ids:
-        return set()
-
-    subscribed_recipient_ids = Subscription.objects.filter(
-        user_profile=acting_user,
-        active=True,
-        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
-    ).values_list("recipient_id", flat=True)
-
-    common_subscription_user_ids = (
-        Subscription.objects.filter(
-            recipient_id__in=subscribed_recipient_ids,
-            user_profile_id__in=target_human_user_ids,
-            active=True,
-            is_user_active=True,
-        )
-        .distinct("user_profile_id")
-        .values_list("user_profile_id", flat=True)
+    return set(
+        get_inaccessible_users_queryset(target_user_ids, acting_user).values_list("id", flat=True)
     )
-
-    possible_inaccessible_user_ids = set(target_human_user_ids) - set(common_subscription_user_ids)
-    return possible_inaccessible_user_ids
 
 
 def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -750,15 +750,18 @@ def check_can_access_user(
     # loaded but the caller has realm available from another source.
     realm: Realm | None = None,
 ) -> bool:
+    if user_profile is None:
+        # A spectator can access target_user since they
+        # have very limited access to users already.
+        return True
+
+    if user_profile.id == target_user.id:
+        return True
+
     if not user_access_restricted_in_realm(target_user, realm):
         return True
 
     if check_user_can_access_all_users(user_profile):
-        return True
-
-    assert user_profile is not None
-
-    if target_user.id == user_profile.id:
         return True
 
     # These include Subscription objects for streams as well as group DMs.

--- a/zerver/tests/test_handle_push_notification.py
+++ b/zerver/tests/test_handle_push_notification.py
@@ -686,15 +686,16 @@ class HandlePushNotificationTest(PushNotificationTestCase):
         test_end_to_end(missed_message, db_query_count=8)
 
         # Channel message
-        # 3 extra queries than 1:1 DM
+        # 2 extra queries than 1:1 DM
         # 1 : fetch Stream in `access_message_and_usermessage` codepath
-        # 1 : query NamedUserGroup in `check_can_access_user` codepath
         # 1 : fetch Stream in `get_message_payload` (TODO: we can avoid this)
+        # `check_can_access_user` adds no query here because the sender is the
+        # recipient themselves, so it short-circuits before any DB access.
         channel = get_stream("Denmark", realm)
         message = self.get_message(Recipient.STREAM, channel.id, realm.id)
         UserMessage.objects.create(user_profile=self.user_profile, message=message)
         missed_message = {"message_id": message.id, "trigger": NotificationTriggers.STREAM_PUSH}
-        test_end_to_end(missed_message, db_query_count=10)
+        test_end_to_end(missed_message, db_query_count=9)
 
         # Channel message: private channel + user-group mention
         # 3 extra queries than prev:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2826,26 +2826,19 @@ class PersonalMessageSendTest(ZulipTestCase):
         # Make prospero a guest user.
         self.set_user_role(prospero, UserProfile.ROLE_GUEST)
 
-        # Compared to a normal user, when a guest with limited
-        # user access sends a personal message, we do extra checks resulting
-        # in extra queries.
-        # TODO: Optimize the following 2 cases
-        # by refining the logic and reducing the query count
-        # inside check_sender_can_access_recipients.
-
         # A guest with limited user access sends a personal message
         # to another accessible user.
-        with self.assert_database_query_count(26):
+        with self.assert_database_query_count(25):
             self.send_personal_message(polonius, hamlet)
 
         # A guest with limited user access sends a personal message
         # to themself.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(21):
             self.send_personal_message(polonius, polonius)
 
         # A guest with limited user access sends a personal message
         # to another accessible guest.
-        with self.assert_database_query_count(23):
+        with self.assert_database_query_count(22):
             self.send_personal_message(polonius, prospero)
 
     def test_group_direct_message(self) -> None:
@@ -2895,15 +2888,14 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A guest with limited user access sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(32):
+        with self.assert_database_query_count(31):
             self.send_group_direct_message(polonius, recipients)
 
         # A guest with limited user access sends a message
         # to an existing DirectMessageGroup.
         # TODO: Query count could be reduced by
-        # optimizing get_recipients_for_user_creation_events
-        # and get_inaccessible_user_ids.
-        with self.assert_database_query_count(27):
+        # optimizing get_recipients_for_user_creation_events.
+        with self.assert_database_query_count(26):
             self.send_group_direct_message(polonius, recipients)
 
     def test_direct_message_initiator_group_setting(self) -> None:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2840,7 +2840,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A guest with limited user access sends a personal message
         # to themself.
-        with self.assert_database_query_count(25):
+        with self.assert_database_query_count(24):
             self.send_personal_message(polonius, polonius)
 
         # A guest with limited user access sends a personal message

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2812,11 +2812,99 @@ class PersonalMessageSendTest(ZulipTestCase):
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_personal_message(self) -> None:
-        user_profile = self.example_user("hamlet")
+        hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
+        prospero = self.example_user("prospero")
 
+        # A normal user sends a personal message.
         with self.assert_database_query_count(24):
-            self.send_personal_message(user_profile, cordelia)
+            self.send_personal_message(hamlet, cordelia)
+
+        # Give guests limited user access.
+        self.set_up_db_for_testing_user_access()
+        polonius = self.example_user("polonius")
+        # Make prospero a guest user.
+        self.set_user_role(prospero, UserProfile.ROLE_GUEST)
+
+        # Compared to a normal user, when a guest with limited
+        # user access sends a personal message, we do extra checks resulting
+        # in extra queries.
+        # TODO: Optimize the following 2 cases
+        # by refining the logic and reducing the query count
+        # inside check_sender_can_access_recipients.
+
+        # A guest with limited user access sends a personal message
+        # to another accessible user.
+        with self.assert_database_query_count(26):
+            self.send_personal_message(polonius, hamlet)
+
+        # A guest with limited user access sends a personal message
+        # to themself.
+        with self.assert_database_query_count(25):
+            self.send_personal_message(polonius, polonius)
+
+        # A guest with limited user access sends a personal message
+        # to another accessible guest.
+        with self.assert_database_query_count(23):
+            self.send_personal_message(polonius, prospero)
+
+    def test_group_direct_message(self) -> None:
+        """
+        When a guest with limited user access sends a group Direct Message
+        to recipients with another guest included, we do extra checks resulting
+        in extra queries as opposed to a normal user.
+        This test tracks query count for these different cases.
+        """
+        # Give guests limited user access.
+        self.set_up_db_for_testing_user_access()
+        polonius = self.example_user("polonius")
+        prospero = self.example_user("prospero")
+
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        bot = self.create_test_bot("test2", cordelia, full_name="Test bot")
+
+        # Make prospero a guest user.
+        self.set_user_role(prospero, UserProfile.ROLE_GUEST)
+
+        # Direct message group recipients including a guest (prospero).
+        recipients = [cordelia, hamlet, bot, prospero]
+
+        # A normal user sends the first message
+        # to a new DirectMessageGroup.
+        with self.assert_database_query_count(29):
+            self.send_group_direct_message(iago, recipients)
+
+        # A normal user sends a message
+        # to an existing DirectMessageGroup.
+        with self.assert_database_query_count(24):
+            self.send_group_direct_message(iago, recipients)
+
+        # Subscribe polonius to Verona to make the recipients
+        # below accessible for polonius.
+        self.subscribe(polonius, "Verona")
+
+        # polonius and prospero have already exchanged 1:1 DM
+        # via set_up_db_for_testing_user_access,
+        # and we need this interaction because:
+        # 1- It's very common for the message recipients
+        # to have 1:1 DM partners.
+        # 2- This triggers 2 queries by get_users_involved_in_dms_with_target_users,
+        # so we can capture that.
+
+        # A guest with limited user access sends the first message
+        # to a new DirectMessageGroup.
+        with self.assert_database_query_count(32):
+            self.send_group_direct_message(polonius, recipients)
+
+        # A guest with limited user access sends a message
+        # to an existing DirectMessageGroup.
+        # TODO: Query count could be reduced by
+        # optimizing get_recipients_for_user_creation_events
+        # and get_inaccessible_user_ids.
+        with self.assert_database_query_count(27):
+            self.send_group_direct_message(polonius, recipients)
 
     def test_direct_message_initiator_group_setting(self) -> None:
         """

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2866,12 +2866,12 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A normal user sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(29):
+        with self.assert_database_query_count(30):
             self.send_group_direct_message(iago, recipients)
 
         # A normal user sends a message
         # to an existing DirectMessageGroup.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(21):
             self.send_group_direct_message(iago, recipients)
 
         # Subscribe polonius to Verona to make the recipients
@@ -2888,14 +2888,12 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A guest with limited user access sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(31):
+        with self.assert_database_query_count(32):
             self.send_group_direct_message(polonius, recipients)
 
         # A guest with limited user access sends a message
         # to an existing DirectMessageGroup.
-        # TODO: Query count could be reduced by
-        # optimizing get_recipients_for_user_creation_events.
-        with self.assert_database_query_count(26):
+        with self.assert_database_query_count(23):
             self.send_group_direct_message(polonius, recipients)
 
     def test_direct_message_initiator_group_setting(self) -> None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3282,7 +3282,7 @@ class StreamAdminTest(ZulipTestCase):
         ]
         result = self.attempt_unsubscribe_of_principal(
             query_count=22,
-            cache_count=13,
+            cache_count=12,
             target_users=target_users,
             is_realm_admin=True,
             is_subbed=True,
@@ -4879,7 +4879,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         with (
             self.assert_database_query_count(20),
-            self.assert_memcached_count(11),
+            self.assert_memcached_count(10),
             mock.patch("zerver.views.streams.send_user_subscribed_and_new_channel_notifications"),
         ):
             self.subscribe_via_post(

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -3784,6 +3784,26 @@ class GetProfileTest(ZulipTestCase):
         # no personal messages history between desdemona and polonius
         self.assertFalse(check_can_access_user(desdemona, polonius))
 
+    def test_check_can_access_user_for_a_guest_with_themself(self) -> None:
+        """
+        Test that the behaviour is the same and record query count
+        for both cases, a normal guest and a guest with limited user access,
+        when calling check_can_access_user() for a user on themself.
+        """
+        # A guest is not limited by default.
+        polonius = self.example_user("polonius")
+        with self.assert_database_query_count(1):
+            self.assertTrue(check_can_access_user(polonius, polonius))
+
+        # Give guests limited user access.
+        self.set_up_db_for_testing_user_access()
+        polonius = self.example_user("polonius")
+
+        # TODO: When guest has limited user access,
+        # we execute an extra query; we should avoid this.
+        with self.assert_database_query_count(2):
+            self.assertTrue(check_can_access_user(polonius, polonius))
+
     def test_get_users_involved_in_dms_excludes_deactivated_users(self) -> None:
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -3786,23 +3786,29 @@ class GetProfileTest(ZulipTestCase):
 
     def test_check_can_access_user_for_a_guest_with_themself(self) -> None:
         """
-        Test that the behaviour is the same and record query count
+        Test that the behaviour and query count are the same
         for both cases, a normal guest and a guest with limited user access,
         when calling check_can_access_user() for a user on themself.
         """
         # A guest is not limited by default.
         polonius = self.example_user("polonius")
-        with self.assert_database_query_count(1):
+        with self.assert_database_query_count(0):
             self.assertTrue(check_can_access_user(polonius, polonius))
 
         # Give guests limited user access.
         self.set_up_db_for_testing_user_access()
         polonius = self.example_user("polonius")
 
-        # TODO: When guest has limited user access,
-        # we execute an extra query; we should avoid this.
-        with self.assert_database_query_count(2):
+        # When guest has limited user access,
+        # query count should not increase.
+        with self.assert_database_query_count(0):
             self.assertTrue(check_can_access_user(polonius, polonius))
+
+    def test_check_can_access_user_for_a_spectator(self) -> None:
+        # A spectator can always access users since spectators
+        # already have very limited access to users.
+        hamlet = self.example_user("hamlet")
+        self.assertTrue(check_can_access_user(hamlet, None))
 
     def test_get_users_involved_in_dms_excludes_deactivated_users(self) -> None:
         hamlet = self.example_user("hamlet")


### PR DESCRIPTION
Fixes #27835

## Background
When a limited guest sends a 1:1 or group DM, we have to do extra checks (as opposed to non-limited guest) which results in expenseive work and extra queries.

**Limited Guest:**  A guest is limited when the guest role is excluded from “Who can view all other users in the organization?” configuration inside organization permissions.

The two relevant functions for this bottleneck are the following, which are only used in the DM code path:

## check_sender_can_access_recipients
I replaced `get_inaccessible_user_ids` with a new function `has_inaccessible_users` which is **logically exactly the same** but more efficient for our case:
- A cheaper 2nd query: We only need to check for the existence of any "inaccessible" user as opposed to fetching all "accessible" users only to exclude them later in code; We are essentialy now asking a cheaper question: "does even one inaccessible user exist?"

- The following check inside  `get_inaccessible_user_ids`
 
```python
if not target_human_user_ids:
    return set()
``` 
forces an early execution of an extra query. While this "early" check can be benefical in other cases, in this case I believe it's not worth it especially because it's always more common for any user to send a DM to recipents that include humans. 


## get_recipients_for_user_creation_events
### Check for the existence of `DirectMessageGroup`:
 When a limited guest sends a group DM to recipients (> 1 recipient) that include at least one guest, we call `get_users_involved_in_dms_with_target_users()` and `get_subscribers_of_target_user_subscriptions` which are expensive as each executes `2` queries, so `4` queries.

**Change:**  Just before that expensive code path, we check if all DM participants have a common `DirectMessageGroup` with at least one message becuase this  would mean that every user already has access to every other user and no need to proceed.
 

### check_can_access_user():
I put the check `target_user.id == user_profile.id` early just before `check_user_can_access_all_users()` (which executes a query). This saves us a query in the case a limited guest is sending a message to themself.

**Note:**
I tried putting `target_user.id == user_profile.id` as the first check in the function and it reduced query count in some tests but [test_realm_admin_remove_multiple_users_from_stream](https://github.com/zulip/zulip/blob/main/zerver/tests/test_subs.py#L3179) failed with a lower `cache_count` than expected, so I'm not sure about the effect of this on cache and how cache is related to this.

## Performance changes

Changes in number of db queries when a  **Limited guest** sends :

| Case | Before |  After |
| -------- | -------- | -------- |
| DM to themself| 25 | 21 |
| DM to another user| 26 | 25 |
| First message to a **new** `DirectMessageGroup` that includes at least one guest|  32 | 32 (no change) |
| a message in an **existing** `DirectMessageGroup` that includes at least one guest| 27 | 23 (huge save!) |
