### PR TITLE
[ai] alertmanager: Tolerate alerts missing the generatorURL field.

### DIFF
--- a/zerver/webhooks/alertmanager/fixtures/single_alert_no_url.json
+++ b/zerver/webhooks/alertmanager/fixtures/single_alert_no_url.json
@@ -1,0 +1,33 @@
+{
+    "receiver": "ops-zulip",
+    "status": "firing",
+    "groupLabels": {},
+    "commonLabels": {
+        "alertname": "High CPU Temperature",
+        "severity": "critical"
+    },
+    "commonAnnotations": {
+        "summary": "High CPU core temperature"
+    },
+    "externalURL": "http://ops1:9093",
+    "version": "4",
+    "groupKey": "{}/{}:{}",
+    "alerts": [
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "High CPU Temperature",
+                "host": "andromeda",
+                "severity": "critical"
+            },
+            "annotations": {
+                "description": "CPU core temperature is 34.75C",
+                "topic": "andromeda",
+                "summary": "High CPU core temperature"
+            },
+            "startsAt": "2020-02-06T00:17:58.432911368Z",
+            "endsAt": "0001-01-01T00:00:00Z",
+            "fingerprint": "a1bc48475b20e73d"
+        }
+    ]
+}

--- a/zerver/webhooks/alertmanager/tests.py
+++ b/zerver/webhooks/alertmanager/tests.py
@@ -31,3 +31,14 @@ class AlertmanagerHookTests(WebhookTestCase):
             expected_message,
             "application/json",
         )
+
+    def test_single_alert_no_generator_url(self) -> None:
+        expected_topic_name = "andromeda"
+        expected_message = ":alert: **FIRING** CPU core temperature is 34.75C"
+
+        self.check_webhook(
+            "single_alert_no_url",
+            expected_topic_name,
+            expected_message,
+            "application/json",
+        )

--- a/zerver/webhooks/alertmanager/view.py
+++ b/zerver/webhooks/alertmanager/view.py
@@ -33,9 +33,11 @@ def api_alertmanager_webhook(
             desc_field, annotations.get(desc_field, f"<missing field: {desc_field}>")
         ).tame(check_string)
 
-        url = alert["generatorURL"].tame(check_string).replace("tab=1", "tab=0")
-
-        body = f"{desc} ([source]({url}))"
+        if "generatorURL" in alert:
+            url = alert["generatorURL"].tame(check_string).replace("tab=1", "tab=0")
+            body = f"{desc} ([source]({url}))"
+        else:
+            body = desc
         if name not in topics:
             topics[name] = {"firing": [], "resolved": []}
         topics[name][alert["status"].tame(check_string)].append(body)


### PR DESCRIPTION
The webhook unconditionally dereferenced alert["generatorURL"], so any payload without that field raised ValidationError before any message was sent.  generatorURL is normally populated by Prometheus Alertmanager, but it can be absent for alerts inserted manually via the Alertmanager API or by tools that emulate the webhook format, and the integration shouldn't crash in those cases.

Guard the lookup the same way the grafana webhook does, and drop the trailing "([source](...))" suffix when the URL is unavailable.

---

Asked Claude to debug a this trace:
```py
Traceback (most recent call last):
  File "zerver/decorator.py", line 399, in _wrapped_func_arguments
    return view_func(request, user_profile, *args, **kwargs)
  File "zerver/lib/typed_endpoint.py", line 548, in _wrapped_view_func
    return_value = view_func(request, *args, **kwargs)
  File "zerver/webhooks/alertmanager/view.py", line 36, in api_alertmanager_webhook
    url = alert["generatorURL"].tame(check_string).replace("tab=1", "tab=0")
  File "zerver/lib/validator.py", line 698, in __getitem__
    raise ValidationError(_("{var_name} is missing").format(var_name=var_name)) from None
ValidationError: request['alerts'][0]['generatorURL'] is missing
```