### PR TITLE
embeds: Show placeholder thumbnail for links without og:image

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1765,6 +1765,10 @@
         hsl(0deg 0% 80%),
         hsl(0deg 0% 33%)
     );
+    --color-background-message-embed-placeholder: light-dark(
+        hsl(0deg 0% 88%),
+        hsl(0deg 0% 20%)
+    );
 
     /* Tab-switcher colors */
     /* The non-selected colors here are shared with numerous other

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -831,6 +831,20 @@
             background-position: center;
         }
 
+        .message_embed_image_placeholder {
+            grid-area: thumbnail;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: var(--color-background-message-embed-placeholder);
+            border-radius: 4px;
+
+            .zulip-icon {
+                font-size: 1.5em;
+                opacity: 0.4;
+            }
+        }
+
         .data-container {
             grid-area: data-container;
         }

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -710,23 +710,26 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             self.add_oembed_data(root, link, extracted_data)
             return
 
-        if extracted_data.image is None:
-            # Don't add an embed if an image is not found
-            return
-
         container = SubElement(root, "div")
         container.set("class", "message_embed")
 
-        img_link = get_camo_url(extracted_data.image)
-        img = SubElement(container, "a")
-        img.set(
-            "style",
-            'background-image: url("'
-            + img_link.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\a ")
-            + '")',
-        )
-        img.set("href", link)
-        img.set("class", "message_embed_image")
+        if extracted_data.image is not None:
+            img_link = get_camo_url(extracted_data.image)
+            img = SubElement(container, "a")
+            img.set(
+                "style",
+                'background-image: url("'
+                + img_link.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\a ")
+                + '")',
+            )
+            img.set("href", link)
+            img.set("class", "message_embed_image")
+        else:
+            placeholder = SubElement(container, "a")
+            placeholder.set("href", link)
+            placeholder.set("class", "message_embed_image message_embed_image_placeholder")
+            icon = SubElement(placeholder, "i")
+            icon.set("class", "zulip-icon zulip-icon-link")
 
         data_container = SubElement(container, "div")
         data_container.set("class", "data-container")

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -858,7 +858,7 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
         self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
+            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>\n<div class="message_embed"><a class="message_embed_image message_embed_image_placeholder" href="http://test.org/foo.html"><i class="zulip-icon zulip-icon-link"></i></a><div class="data-container"><div class="message_embed_title"><a href="http://test.org/foo.html" title="The Rock">The Rock</a></div><div class="message_embed_description">Description text</div></div></div>',
             msg.rendered_content,
         )
 
@@ -899,7 +899,7 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
         self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
+            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>\n<div class="message_embed"><a class="message_embed_image message_embed_image_placeholder" href="http://test.org/foo.html"><i class="zulip-icon zulip-icon-link"></i></a><div class="data-container"><div class="message_embed_title"><a href="http://test.org/foo.html" title="The Rock">The Rock</a></div><div class="message_embed_description">Description text</div></div></div>',
             msg.rendered_content,
         )
 
@@ -936,7 +936,7 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
         self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
+            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>\n<div class="message_embed"><a class="message_embed_image message_embed_image_placeholder" href="http://test.org/foo.html"><i class="zulip-icon zulip-icon-link"></i></a><div class="data-container"><div class="message_embed_title"><a href="http://test.org/foo.html" title="The Rock">The Rock</a></div><div class="message_embed_description">Description text</div></div></div>',
             msg.rendered_content,
         )
 


### PR DESCRIPTION
Previously, URL embeds were silently skipped when a link had title and description metadata but no og:image. This caused embed previews to not render at all for sites like Hugo blogs using the Blowfish theme, even when valid Open Graph metadata was present.

Add a placeholder thumbnail element when og:image is missing but title or description is available, so the embed still renders. The placeholder uses the same grid layout as image-based embeds to keep the DOM structure consistent, and is styled with a muted background and a link icon via Zulip's class-based icon font system.

Fixes #38967

**How changes were tested:**

 - [x] UI Testing, backend tests

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
### Preview with dark mode
<img width="1102" height="553" alt="github-pr-1" src="https://github.com/user-attachments/assets/0eeb81d2-6473-4b9e-80f6-104aecc65be8" />

### Preview with light mode
<img width="1110" height="552" alt="github-pr-2" src="https://github.com/user-attachments/assets/7b9a56a0-6f8b-4ab4-b89b-6308e1a86d03" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
