### PR TITLE
stripe: Reset current plan status if deleting fixed-price plan renewal.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1705,23 +1705,27 @@ class BillingSession(ABC):
         return f"Customer can now buy a fixed price {required_plan_tier_name} plan."
 
     def delete_fixed_price_plan(self) -> str:
-        # See configure_fixed_price_plan above for how these CustomerPlan
-        # and CustomerPlanOffer objects are created for fixed-price plans.
         customer = self.get_customer()
         assert customer is not None
-        current_plan = get_current_plan_by_customer(customer)
-        if current_plan is not None and self.check_plan_tier_is_billable(current_plan.tier):
-            fixed_price_next_plan = CustomerPlan.objects.filter(
-                customer=customer,
-                status=CustomerPlan.NEVER_STARTED,
-                fixed_price__isnull=False,
-            ).first()
-            assert fixed_price_next_plan is not None
-            fixed_price_next_plan.delete()
 
+        # A NEVER_STARTED fixed-price CustomerPlan can be scheduled on top of
+        # any current plan whose status is SWITCH_PLAN_TIER_AT_PLAN_END, which
+        # includes complimentary access plans whose tier is not billable.
+        fixed_price_next_plan = CustomerPlan.objects.filter(
+            customer=customer,
+            status=CustomerPlan.NEVER_STARTED,
+            fixed_price__isnull=False,
+        ).first()
+        if fixed_price_next_plan is not None:
+            current_plan = get_current_plan_by_customer(customer)
+            assert current_plan is not None
             assert current_plan.status == CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END
+            fixed_price_next_plan.delete()
             do_change_plan_status(current_plan, CustomerPlan.ACTIVE)
             return "Fixed-price scheduled plan deleted"
+
+        # Otherwise, we expect to have a configured CustomerPlanOffer for this
+        # customer.
         fixed_price_offer = CustomerPlanOffer.objects.filter(
             customer=customer, status=CustomerPlanOffer.CONFIGURED
         ).first()

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1730,6 +1730,18 @@ class BillingSession(ABC):
             customer=customer, status=CustomerPlanOffer.CONFIGURED
         ).first()
         assert fixed_price_offer is not None
+        if fixed_price_offer.sent_invoice_id is not None:
+            # Void the Stripe invoice and local Invoice object associated
+            # with this CustomerPlanOffer.
+            stripe_invoice = stripe.Invoice.retrieve(fixed_price_offer.sent_invoice_id)
+            if stripe_invoice.status == "open":
+                stripe.Invoice.void_invoice(fixed_price_offer.sent_invoice_id)
+            local_invoice = Invoice.objects.get(
+                customer=customer,
+                stripe_invoice_id=fixed_price_offer.sent_invoice_id,
+            )
+            local_invoice.status = Invoice.VOID
+            local_invoice.save(update_fields=["status"])
         fixed_price_offer.delete()
         return "Fixed-price plan offer deleted"
 

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1718,6 +1718,9 @@ class BillingSession(ABC):
             ).first()
             assert fixed_price_next_plan is not None
             fixed_price_next_plan.delete()
+
+            assert current_plan.status == CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END
+            do_change_plan_status(current_plan, CustomerPlan.ACTIVE)
             return "Fixed-price scheduled plan deleted"
         fixed_price_offer = CustomerPlanOffer.objects.filter(
             customer=customer, status=CustomerPlanOffer.CONFIGURED

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json
@@ -1,0 +1,33 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1000000000,
+  "currency": null,
+  "customer_account": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip.testserver 1d252c31-5f2",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+  "invoice_prefix": "NORMALIZED",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": null,
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "remote_realm_host": "zulip.testserver",
+    "remote_realm_uuid": "1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.modify.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.modify.1.json
@@ -1,0 +1,33 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1000000000,
+  "currency": null,
+  "customer_account": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip.testserver 1d252c31-5f2",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+  "invoice_prefix": "NORMALIZED",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": "pm_NORMALIZED",
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "remote_realm_host": "zulip.testserver",
+    "remote_realm_uuid": "1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json
@@ -1,0 +1,85 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1000000000,
+  "currency": null,
+  "customer_account": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip.testserver 1d252c31-5f2",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+  "invoice_prefix": "NORMALIZED",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": {
+      "allow_redisplay": "unspecified",
+      "billing_details": {
+        "address": {
+          "city": "San Francisco",
+          "country": "US",
+          "line1": "123 Main St",
+          "line2": null,
+          "postal_code": "12345",
+          "state": "CA"
+        },
+        "email": null,
+        "name": "John Doe",
+        "phone": null,
+        "tax_id": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": "pass",
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 1,
+        "exp_year": 9999,
+        "fingerprint": "NORMALIZED",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1000000000,
+      "customer": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+      "customer_account": null,
+      "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json",
+      "livemode": false,
+      "metadata": {},
+      "object": "payment_method",
+      "shared_payment_granted_token": null,
+      "type": "card"
+    },
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "remote_realm_host": "zulip.testserver",
+    "remote_realm_uuid": "1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.2.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.2.json
@@ -1,0 +1,85 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1000000000,
+  "currency": null,
+  "customer_account": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip.testserver 1d252c31-5f2",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+  "invoice_prefix": "NORMALIZED",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": {
+      "allow_redisplay": "unspecified",
+      "billing_details": {
+        "address": {
+          "city": "San Francisco",
+          "country": "US",
+          "line1": "123 Main St",
+          "line2": null,
+          "postal_code": "12345",
+          "state": "CA"
+        },
+        "email": null,
+        "name": "John Doe",
+        "phone": null,
+        "tax_id": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": "pass",
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 1,
+        "exp_year": 9999,
+        "fingerprint": "NORMALIZED",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1000000000,
+      "customer": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+      "customer_account": null,
+      "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json",
+      "livemode": false,
+      "metadata": {},
+      "object": "payment_method",
+      "shared_payment_granted_token": null,
+      "type": "card"
+    },
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "remote_realm_host": "zulip.testserver",
+    "remote_realm_uuid": "1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.3.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.3.json
@@ -1,0 +1,85 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1000000000,
+  "currency": null,
+  "customer_account": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip.testserver 1d252c31-5f2",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+  "invoice_prefix": "NORMALIZED",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": {
+      "allow_redisplay": "unspecified",
+      "billing_details": {
+        "address": {
+          "city": "San Francisco",
+          "country": "US",
+          "line1": "123 Main St",
+          "line2": null,
+          "postal_code": "12345",
+          "state": "CA"
+        },
+        "email": null,
+        "name": "John Doe",
+        "phone": null,
+        "tax_id": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": "pass",
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 1,
+        "exp_year": 9999,
+        "fingerprint": "NORMALIZED",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1000000000,
+      "customer": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+      "customer_account": null,
+      "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json",
+      "livemode": false,
+      "metadata": {},
+      "object": "payment_method",
+      "shared_payment_granted_token": null,
+      "type": "card"
+    },
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "remote_realm_host": "zulip.testserver",
+    "remote_realm_uuid": "1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.4.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.4.json
@@ -1,0 +1,85 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1000000000,
+  "currency": null,
+  "customer_account": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip.testserver 1d252c31-5f2",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+  "invoice_prefix": "NORMALIZED",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": {
+      "allow_redisplay": "unspecified",
+      "billing_details": {
+        "address": {
+          "city": "San Francisco",
+          "country": "US",
+          "line1": "123 Main St",
+          "line2": null,
+          "postal_code": "12345",
+          "state": "CA"
+        },
+        "email": null,
+        "name": "John Doe",
+        "phone": null,
+        "tax_id": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": "pass",
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 1,
+        "exp_year": 9999,
+        "fingerprint": "NORMALIZED",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1000000000,
+      "customer": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+      "customer_account": null,
+      "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json",
+      "livemode": false,
+      "metadata": {},
+      "object": "payment_method",
+      "shared_payment_granted_token": null,
+      "type": "card"
+    },
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "remote_realm_host": "zulip.testserver",
+    "remote_realm_uuid": "1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.5.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.5.json
@@ -1,0 +1,85 @@
+{
+  "address": null,
+  "balance": 0,
+  "created": 1000000000,
+  "currency": null,
+  "customer_account": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": "zulip.testserver 1d252c31-5f2",
+  "discount": null,
+  "email": "hamlet@zulip.com",
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+  "invoice_prefix": "NORMALIZED",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": {
+      "allow_redisplay": "unspecified",
+      "billing_details": {
+        "address": {
+          "city": "San Francisco",
+          "country": "US",
+          "line1": "123 Main St",
+          "line2": null,
+          "postal_code": "12345",
+          "state": "CA"
+        },
+        "email": null,
+        "name": "John Doe",
+        "phone": null,
+        "tax_id": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": "pass",
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 1,
+        "exp_year": 9999,
+        "fingerprint": "NORMALIZED",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1000000000,
+      "customer": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.create.1.json",
+      "customer_account": null,
+      "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json",
+      "livemode": false,
+      "metadata": {},
+      "object": "payment_method",
+      "shared_payment_granted_token": null,
+      "type": "card"
+    },
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "remote_realm_host": "zulip.testserver",
+    "remote_realm_uuid": "1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a"
+  },
+  "name": null,
+  "next_invoice_sequence": 1,
+  "object": "customer",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Invoice.list.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Invoice.list.1.json
@@ -1,0 +1,6 @@
+{
+  "data": [],
+  "has_more": false,
+  "object": "list",
+  "url": "/v1/invoices"
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--PaymentMethod.create.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--PaymentMethod.create.1.json
@@ -1,0 +1,53 @@
+{
+  "allow_redisplay": "unspecified",
+  "billing_details": {
+    "address": {
+      "city": "San Francisco",
+      "country": "US",
+      "line1": "123 Main St",
+      "line2": null,
+      "postal_code": "12345",
+      "state": "CA"
+    },
+    "email": null,
+    "name": "John Doe",
+    "phone": null,
+    "tax_id": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": "unchecked",
+      "address_postal_code_check": "unchecked",
+      "cvc_check": "unchecked"
+    },
+    "country": "US",
+    "display_brand": "visa",
+    "exp_month": 1,
+    "exp_year": 9999,
+    "fingerprint": "NORMALIZED",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "networks": {
+      "available": [
+        "visa"
+      ],
+      "preferred": null
+    },
+    "regulated_status": "unregulated",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1000000000,
+  "customer": null,
+  "customer_account": null,
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--Customer.retrieve.1.json",
+  "livemode": false,
+  "metadata": {},
+  "object": "payment_method",
+  "shared_payment_granted_token": null,
+  "type": "card"
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.create.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.create.1.json
@@ -1,0 +1,39 @@
+{
+  "application": null,
+  "automatic_payment_methods": null,
+  "cancellation_reason": null,
+  "client_secret": "NORMALIZED",
+  "created": 1000000000,
+  "customer": "cus_NORMALIZED",
+  "customer_account": null,
+  "description": null,
+  "excluded_payment_method_types": null,
+  "flow_directions": null,
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.create.1.json",
+  "last_setup_error": null,
+  "latest_attempt": "setatt_NORMALIZED",
+  "livemode": false,
+  "managed_payments": {
+    "enabled": false
+  },
+  "mandate": null,
+  "metadata": {},
+  "next_action": null,
+  "object": "setup_intent",
+  "on_behalf_of": null,
+  "payment_method": "pm_NORMALIZED",
+  "payment_method_configuration_details": null,
+  "payment_method_options": {
+    "card": {
+      "mandate_options": null,
+      "network": null,
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "single_use_mandate": null,
+  "status": "succeeded",
+  "usage": "off_session"
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.list.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.list.1.json
@@ -1,0 +1,46 @@
+{
+  "data": [
+    {
+      "application": null,
+      "automatic_payment_methods": null,
+      "cancellation_reason": null,
+      "client_secret": "NORMALIZED",
+      "created": 1000000000,
+      "customer": "cus_NORMALIZED",
+      "customer_account": null,
+      "description": null,
+      "excluded_payment_method_types": null,
+      "flow_directions": null,
+      "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.list.1.json",
+      "last_setup_error": null,
+      "latest_attempt": null,
+      "livemode": false,
+      "managed_payments": {
+        "enabled": false
+      },
+      "mandate": null,
+      "metadata": {},
+      "next_action": null,
+      "object": "setup_intent",
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "card": {
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "single_use_mandate": null,
+      "status": "requires_payment_method",
+      "usage": "off_session"
+    }
+  ],
+  "has_more": false,
+  "object": "list",
+  "url": "/v1/setup_intents"
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.retrieve.1.json
@@ -1,0 +1,39 @@
+{
+  "application": null,
+  "automatic_payment_methods": null,
+  "cancellation_reason": null,
+  "client_secret": "NORMALIZED",
+  "created": 1000000000,
+  "customer": "cus_NORMALIZED",
+  "customer_account": null,
+  "description": null,
+  "excluded_payment_method_types": null,
+  "flow_directions": null,
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--SetupIntent.create.1.json",
+  "last_setup_error": null,
+  "latest_attempt": "setatt_NORMALIZED",
+  "livemode": false,
+  "managed_payments": {
+    "enabled": false
+  },
+  "mandate": null,
+  "metadata": {},
+  "next_action": null,
+  "object": "setup_intent",
+  "on_behalf_of": null,
+  "payment_method": "pm_NORMALIZED",
+  "payment_method_configuration_details": null,
+  "payment_method_options": {
+    "card": {
+      "mandate_options": null,
+      "network": null,
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "single_use_mandate": null,
+  "status": "succeeded",
+  "usage": "off_session"
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--checkout.Session.create.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--checkout.Session.create.1.json
@@ -1,0 +1,112 @@
+{
+  "adaptive_pricing": {
+    "enabled": false
+  },
+  "after_expiration": null,
+  "allow_promotion_codes": null,
+  "amount_subtotal": null,
+  "amount_total": null,
+  "automatic_tax": {
+    "enabled": false,
+    "liability": null,
+    "provider": null,
+    "status": null
+  },
+  "billing_address_collection": "required",
+  "branding_settings": {
+    "background_color": "#dbedff",
+    "border_style": "rounded",
+    "button_color": "#3e6bfe",
+    "display_name": "Violet Beam",
+    "font_family": "source_sans_pro",
+    "icon": {
+      "file": "file_1RxpnoDwzgQ85STgf3bBl5KY",
+      "type": "file"
+    },
+    "logo": {
+      "file": "file_1RxpnoDwzgQ85STgvEm4ntJu",
+      "type": "file"
+    }
+  },
+  "cancel_url": "http://selfhosting.testserver/realm/1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a/upgrade/?manual_license_management=false&tier=1",
+  "client_reference_id": null,
+  "client_secret": null,
+  "collected_information": {
+    "business_name": null,
+    "individual_name": null,
+    "shipping_details": null
+  },
+  "consent": null,
+  "consent_collection": null,
+  "created": 1000000000,
+  "currency": null,
+  "currency_conversion": null,
+  "custom_fields": [],
+  "custom_text": {
+    "after_submit": null,
+    "shipping_address": null,
+    "submit": null,
+    "terms_of_service_acceptance": null
+  },
+  "customer": "cus_NORMALIZED",
+  "customer_account": null,
+  "customer_creation": null,
+  "customer_details": {
+    "address": null,
+    "business_name": null,
+    "email": "hamlet@zulip.com",
+    "individual_name": null,
+    "name": null,
+    "phone": null,
+    "tax_exempt": null,
+    "tax_ids": null
+  },
+  "customer_email": null,
+  "discounts": null,
+  "expires_at": 1000000000,
+  "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--checkout.Session.create.1.json",
+  "integration_identifier": null,
+  "invoice": null,
+  "invoice_creation": null,
+  "livemode": false,
+  "locale": null,
+  "managed_payments": null,
+  "metadata": {
+    "remote_realm_user_id": "1",
+    "type": "card_update"
+  },
+  "mode": "setup",
+  "object": "checkout.session",
+  "origin_context": null,
+  "payment_intent": null,
+  "payment_link": null,
+  "payment_method_collection": "always",
+  "payment_method_configuration_details": null,
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "payment_status": "no_payment_required",
+  "permissions": null,
+  "phone_number_collection": {
+    "enabled": false
+  },
+  "recovered_from": null,
+  "saved_payment_method_options": null,
+  "setup_intent": "seti_NORMALIZED",
+  "shipping_address_collection": null,
+  "shipping_cost": null,
+  "shipping_options": [],
+  "status": "open",
+  "submit_type": null,
+  "subscription": null,
+  "success_url": "http://selfhosting.testserver/realm/1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a/billing/event_status/?stripe_session_id={CHECKOUT_SESSION_ID}",
+  "total_details": null,
+  "ui_mode": "hosted",
+  "url": "https://checkout.stripe.com/c/pay/cs_test_NORMALIZED",
+  "wallet_options": null
+}

--- a/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--checkout.Session.list.1.json
+++ b/corporate/tests/stripe_fixtures/delete_scheduled_fixed_price_plan_on_complimentary_access_plan--checkout.Session.list.1.json
@@ -1,0 +1,119 @@
+{
+  "data": [
+    {
+      "adaptive_pricing": {
+        "enabled": false
+      },
+      "after_expiration": null,
+      "allow_promotion_codes": null,
+      "amount_subtotal": null,
+      "amount_total": null,
+      "automatic_tax": {
+        "enabled": false,
+        "liability": null,
+        "provider": null,
+        "status": null
+      },
+      "billing_address_collection": "required",
+      "branding_settings": {
+        "background_color": "#dbedff",
+        "border_style": "rounded",
+        "button_color": "#3e6bfe",
+        "display_name": "Violet Beam",
+        "font_family": "source_sans_pro",
+        "icon": {
+          "file": "file_1RxpnoDwzgQ85STgf3bBl5KY",
+          "type": "file"
+        },
+        "logo": {
+          "file": "file_1RxpnoDwzgQ85STgvEm4ntJu",
+          "type": "file"
+        }
+      },
+      "cancel_url": "http://selfhosting.testserver/realm/1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a/upgrade/?manual_license_management=false&tier=1",
+      "client_reference_id": null,
+      "client_secret": null,
+      "collected_information": {
+        "business_name": null,
+        "individual_name": null,
+        "shipping_details": null
+      },
+      "consent": null,
+      "consent_collection": null,
+      "created": 1000000000,
+      "currency": null,
+      "currency_conversion": null,
+      "custom_fields": [],
+      "custom_text": {
+        "after_submit": null,
+        "shipping_address": null,
+        "submit": null,
+        "terms_of_service_acceptance": null
+      },
+      "customer": "cus_NORMALIZED",
+      "customer_account": null,
+      "customer_creation": null,
+      "customer_details": {
+        "address": null,
+        "business_name": null,
+        "email": "hamlet@zulip.com",
+        "individual_name": null,
+        "name": null,
+        "phone": null,
+        "tax_exempt": null,
+        "tax_ids": null
+      },
+      "customer_email": null,
+      "discounts": null,
+      "expires_at": 1000000000,
+      "id": "delete_scheduled_fixed_price_plan_on_complimentary_access_plan--checkout.Session.create.1.json",
+      "integration_identifier": null,
+      "invoice": null,
+      "invoice_creation": null,
+      "livemode": false,
+      "locale": null,
+      "managed_payments": null,
+      "metadata": {
+        "remote_realm_user_id": "1",
+        "type": "card_update"
+      },
+      "mode": "setup",
+      "object": "checkout.session",
+      "origin_context": null,
+      "payment_intent": null,
+      "payment_link": null,
+      "payment_method_collection": "always",
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "card": {
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "payment_status": "no_payment_required",
+      "permissions": null,
+      "phone_number_collection": {
+        "enabled": false
+      },
+      "recovered_from": null,
+      "saved_payment_method_options": null,
+      "setup_intent": "seti_NORMALIZED",
+      "shipping_address_collection": null,
+      "shipping_cost": null,
+      "shipping_options": [],
+      "status": "open",
+      "submit_type": null,
+      "subscription": null,
+      "success_url": "http://selfhosting.testserver/realm/1d252c31-5f2c-4b77-a4b9-e7c486e5fe9a/billing/event_status/?stripe_session_id={CHECKOUT_SESSION_ID}",
+      "total_details": null,
+      "ui_mode": "hosted",
+      "url": "https://checkout.stripe.com/c/pay/cs_test_NORMALIZED",
+      "wallet_options": null
+    }
+  ],
+  "has_more": false,
+  "object": "list",
+  "url": "/v1/checkout/sessions"
+}

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -8909,6 +8909,65 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         self.assertEqual(realm_complimentary_access_plan.status, CustomerPlan.ACTIVE)
 
     @responses.activate
+    def test_delete_configured_fixed_price_plan_offer_with_sent_invoice(self) -> None:
+        self.login("iago")
+        self.add_mock_response()
+        with time_machine.travel(self.now, tick=False):
+            send_server_data_to_push_bouncer(consider_usage_statistics=False)
+
+        self.client_post(
+            "/activity/remote/support",
+            {
+                "remote_realm_id": f"{self.remote_realm.id}",
+                "required_plan_tier": CustomerPlan.TIER_SELF_HOSTED_BASIC,
+            },
+        )
+
+        annual_fixed_price = 1200
+        sent_invoice_id = "test_sent_invoice_id"
+        stripe_customer_id = "cus_123"
+        hamlet = self.example_user("hamlet")
+        mock_invoice = MagicMock()
+        mock_invoice.status = "open"
+        with (
+            patch(
+                "stripe.Customer.retrieve",
+                return_value=Mock(id=stripe_customer_id, email=hamlet.delivery_email),
+            ),
+            patch("stripe.Invoice.retrieve", return_value=mock_invoice),
+        ):
+            self.client_post(
+                "/activity/remote/support",
+                {
+                    "remote_realm_id": f"{self.remote_realm.id}",
+                    "fixed_price": annual_fixed_price,
+                    "sent_invoice_id": sent_invoice_id,
+                },
+            )
+
+        customer = Customer.objects.get(remote_realm=self.remote_realm)
+        fixed_price_plan_offer = CustomerPlanOffer.objects.get(customer=customer)
+        self.assertEqual(fixed_price_plan_offer.status, CustomerPlanOffer.CONFIGURED)
+        self.assertEqual(fixed_price_plan_offer.sent_invoice_id, sent_invoice_id)
+        local_invoice = Invoice.objects.get(stripe_invoice_id=sent_invoice_id)
+        self.assertEqual(local_invoice.status, Invoice.SENT)
+
+        with (
+            patch("stripe.Invoice.retrieve", return_value=mock_invoice),
+            patch("stripe.Invoice.void_invoice") as mock_void,
+        ):
+            support_request = SupportViewRequest(
+                support_type=SupportType.delete_fixed_price_next_plan,
+            )
+            success_message = self.billing_session.process_support_view_request(support_request)
+        self.assertEqual(success_message, "Fixed-price plan offer deleted")
+        mock_void.assert_called_once_with(sent_invoice_id)
+
+        self.assertFalse(CustomerPlanOffer.objects.exists())
+        local_invoice.refresh_from_db()
+        self.assertEqual(local_invoice.status, Invoice.VOID)
+
+    @responses.activate
     @mock_stripe()
     def test_schedule_fixed_price_plan_upgrade_to_another_fixed_price_plan(
         self, *mocks: Mock

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -8802,6 +8802,114 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
 
     @responses.activate
     @mock_stripe()
+    def test_delete_scheduled_fixed_price_plan_on_complimentary_access_plan(
+        self, *mocks: Mock
+    ) -> None:
+        hamlet = self.example_user("hamlet")
+
+        remote_realm = RemoteRealm.objects.get(uuid=hamlet.realm.uuid)
+        remote_realm_billing_session = RemoteRealmBillingSession(remote_realm=remote_realm)
+
+        # Create complimentary access plan for realm.
+        with time_machine.travel(self.now, tick=False):
+            start_date = timezone_now()
+            end_date = add_months(start_date, months=3)
+            remote_realm_billing_session.create_complimentary_access_plan(start_date, end_date)
+
+        customer = Customer.objects.get(remote_realm=self.remote_realm)
+        complimentary_access_plan = get_current_plan_by_customer(customer)
+        assert complimentary_access_plan is not None
+        self.assertEqual(complimentary_access_plan.tier, CustomerPlan.TIER_SELF_HOSTED_LEGACY)
+        self.assertEqual(complimentary_access_plan.next_invoice_date, end_date)
+
+        # Upload data.
+        self.add_mock_response()
+        with time_machine.travel(self.now, tick=False):
+            send_server_data_to_push_bouncer(consider_usage_statistics=False)
+
+        self.login("iago")
+
+        # Schedule a fixed-price business plan at current plan end_date.
+        self.assertFalse(CustomerPlanOffer.objects.exists())
+
+        # Configure required_plan_tier and fixed_price.
+        annual_fixed_price = 1200
+        result = self.client_post(
+            "/activity/remote/support",
+            {
+                "remote_realm_id": f"{self.remote_realm.id}",
+                "required_plan_tier": CustomerPlan.TIER_SELF_HOSTED_BUSINESS,
+            },
+        )
+        self.assert_in_success_response(
+            ["Required plan tier for Zulip Dev set to Zulip Business."], result
+        )
+
+        result = self.client_post(
+            "/activity/remote/support",
+            {"remote_realm_id": f"{self.remote_realm.id}", "fixed_price": annual_fixed_price},
+        )
+        self.assert_in_success_response(
+            ["Customer can now buy a fixed price Zulip Business plan."],
+            result,
+        )
+        fixed_price_plan_offer = CustomerPlanOffer.objects.get(customer=customer)
+        self.assertEqual(fixed_price_plan_offer.status, CustomerPlanOffer.CONFIGURED)
+        self.assertEqual(fixed_price_plan_offer.tier, CustomerPlanOffer.TIER_SELF_HOSTED_BUSINESS)
+
+        self.logout()
+        self.login("hamlet")
+
+        # Login.
+        self.execute_remote_billing_authentication_flow(hamlet)
+
+        # Schedule upgrade to business plan
+        with time_machine.travel(self.now, tick=False):
+            stripe_customer = self.add_card_and_upgrade(
+                remote_server_plan_start_date="billing_cycle_end_date", talk_to_stripe=False
+            )
+
+        zulip_realm_customer = Customer.objects.get(stripe_customer_id=stripe_customer.id)
+        assert zulip_realm_customer is not None
+        realm_complimentary_access_plan = get_current_plan_by_customer(zulip_realm_customer)
+        assert realm_complimentary_access_plan is not None
+        self.assertEqual(realm_complimentary_access_plan.tier, CustomerPlan.TIER_SELF_HOSTED_LEGACY)
+        self.assertEqual(
+            realm_complimentary_access_plan.status, CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END
+        )
+        self.assertEqual(realm_complimentary_access_plan.next_invoice_date, end_date)
+
+        new_plan = self.billing_session.get_next_plan(realm_complimentary_access_plan)
+        assert new_plan is not None
+        self.assertEqual(new_plan.tier, CustomerPlan.TIER_SELF_HOSTED_BUSINESS)
+        self.assertEqual(new_plan.status, CustomerPlan.NEVER_STARTED)
+        self.assertEqual(
+            new_plan.invoicing_status, CustomerPlan.INVOICING_STATUS_INITIAL_INVOICE_TO_BE_SENT
+        )
+        self.assertEqual(new_plan.next_invoice_date, end_date)
+        self.assertEqual(new_plan.billing_cycle_anchor, end_date)
+
+        support_request = SupportViewRequest(
+            support_type=SupportType.delete_fixed_price_next_plan,
+        )
+        with (
+            self.assertLogs("corporate.stripe", "INFO") as m,
+        ):
+            success_message = self.billing_session.process_support_view_request(support_request)
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {realm_complimentary_access_plan.id}, status: {CustomerPlan.ACTIVE}"
+            self.assertEqual(m.output[0], expected_log)
+        self.assertEqual(success_message, "Fixed-price scheduled plan deleted")
+
+        self.assertFalse(
+            CustomerPlan.objects.filter(
+                customer=zulip_realm_customer, status=CustomerPlan.NEVER_STARTED
+            ).exists()
+        )
+        realm_complimentary_access_plan.refresh_from_db()
+        self.assertEqual(realm_complimentary_access_plan.status, CustomerPlan.ACTIVE)
+
+    @responses.activate
+    @mock_stripe()
     def test_schedule_fixed_price_plan_upgrade_to_another_fixed_price_plan(
         self, *mocks: Mock
     ) -> None:

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -1817,19 +1817,28 @@ class TestSupportEndpoint(ZulipTestCase):
         self.assertTrue(next_plan.automanage_licenses)
 
         # Test deleting the fixed-price next plan via support.
-        result = self.client_post(
-            "/activity/support",
-            {
-                "realm_id": f"{lear_realm.id}",
-                "delete_fixed_price_next_plan": "true",
-            },
-        )
+        with (
+            self.assertLogs("corporate.stripe", "INFO") as m,
+        ):
+            result = self.client_post(
+                "/activity/support",
+                {
+                    "realm_id": f"{lear_realm.id}",
+                    "delete_fixed_price_next_plan": "true",
+                },
+            )
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.ACTIVE}"
+            self.assertEqual(m.output[0], expected_log)
         self.assert_in_success_response(
             ["Fixed-price scheduled plan deleted"],
             result,
         )
         next_plan = billing_session.get_next_plan(plan)
         self.assertIsNone(next_plan)
+
+        # Confirm that the existing plan's status has been reset to active.
+        plan.refresh_from_db()
+        self.assertEqual(plan.status, CustomerPlan.ACTIVE)
 
     def test_deactivated_realm_support_view_and_actions(self) -> None:
         support_admin = self.example_user("iago")


### PR DESCRIPTION
When deleting a configured renewal for fixed-price plan, the current fixed-price plan needs to be reset from `SWITCH_PLAN_TIER_AT_PLAN_END` to `ACTIVE`, so that it is shown correctly on the support panel and so that it is downgraded appropriately when the plan ends.

**Notes**:
- When configuring the fixed-price plan renewal, we also set the current plan's `next_invoice_date` to the current plan's `end_date`.
  - If the current fixed-price plan was on monthly billing, then this won't have changed. We require all invoices for the current plan to be processed before scheduling the renewal.
  - If the current fixed-price plan was on annual billing, then this would have changed. But this seems fine in that we don't need to check these fixed-price plans each month for additional licenses at this point in time (adding some sort of max licenses in the future to a fixed-price plan would change this though).

[CODE LINK - *for notes*](https://github.com/zulip/zulip/blob/5e7994bc011911b8ceff39720f38a3bc81f10e19/corporate/lib/stripe.py#L1610-L1656)
```python
# corporate/lib/stripe.py

    def configure_fixed_price_plan(self, fixed_price: int, sent_invoice_id: str | None) -> str:
        ...

        current_plan = get_current_plan_by_customer(customer)
        if current_plan is not None and self.check_plan_tier_is_billable(current_plan.tier):
            ...
            # Handles the case when the current_plan is a fixed-price plan with
            # a monthly billing schedule. We can't schedule a new plan until the
            # invoice for the 12th month is processed.
            if current_plan.end_date != get_next_billing_cycle_for_plan(current_plan):
                raise SupportRequestError(
                    f"New plan for {self.billing_entity_display_name} cannot be scheduled until all the invoices of the current plan are processed."
                )

            self.create_customer_plan(
                ...
            )

            current_plan.status = CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END
            current_plan.next_invoice_date = current_plan.end_date
            current_plan.save(update_fields=["status", "next_invoice_date"])
            return f"Fixed price {required_plan_tier_name} plan scheduled to start on {current_plan.end_date.date()}."
```

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
