### PR TITLE
compose_reply: Use decorated channel icon in forwarded message context

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -13,7 +13,6 @@ import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
 import * as inbox_ui from "./inbox_ui.ts";
 import * as inbox_util from "./inbox_util.ts";
-import * as internal_url from "./internal_url.ts";
 import * as message_fetch_raw_content from "./message_fetch_raw_content.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
@@ -377,20 +376,14 @@ function generate_sender_only_quote_context(message: Message): string {
 function generate_channel_message_quote_context(message: Message): string {
     assert(message.type === "stream");
     const sender_mention = generate_sender_mention(message);
-    const topic_url = internal_url.by_stream_topic_url(
-        message.stream_id,
-        message.topic,
-        sub_store.maybe_get_stream_name,
-        message.id,
-    );
     const channel_name = sub_store.maybe_get_stream_name(message.stream_id)!;
-    const topic_link_text = topic_link_util.get_stream_topic_link_syntax(
+    const topic_link = topic_link_util.get_stream_topic_link_syntax(
         channel_name,
         message.topic,
-        true,
+        message.id.toString(),
     );
     // Final message looks like:
-    //     @_**Iago|5** [said](link to message) in [#channel > topic](topic URL):
+    //     @_**Iago|5** [said](link to message) in #**channel>topic**:
     //     ```quote
     //     message content
     //     ```
@@ -402,7 +395,7 @@ function generate_channel_message_quote_context(message: Message): string {
         {
             username: sender_mention,
             link_to_message: hash_util.by_conversation_and_time_url(message),
-            topic_link: topic_link_util.as_markdown_link_syntax(topic_link_text, topic_url),
+            topic_link,
         },
     );
 }

--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -126,7 +126,6 @@ export function get_fallback_markdown_link(
     stream_name: string,
     topic_name?: string,
     message_id?: string,
-    only_link_text = false,
 ): string {
     // Helper that should only be called by other methods in this file.
 
@@ -138,25 +137,30 @@ export function get_fallback_markdown_link(
         topic_name,
         message_id,
     });
-    return only_link_text ? label_text_markdown : as_markdown_link_syntax(label_text_markdown, url);
+    return as_markdown_link_syntax(label_text_markdown, url);
 }
 
 export function get_stream_topic_link_syntax(
     stream_name: string,
     topic_name: string,
-    only_link_text = false,
+    message_id?: string,
 ): string {
     // If the topic/stream name would produce an invalid #**stream>topic** syntax, fall back
-    // to markdown link syntax. If only_link_text is true, only the link label is returned.
+    // to markdown link syntax.
     if (
         will_produce_broken_stream_topic_link(topic_name) ||
         will_produce_broken_stream_topic_link(stream_name)
     ) {
-        return get_fallback_markdown_link(stream_name, topic_name, undefined, only_link_text);
-    }
-
-    if (only_link_text) {
-        return `#${stream_name} > ${topic_name}`;
+        if (message_id !== undefined) {
+            const stream = stream_data.get_sub(stream_name);
+            assert(stream !== undefined);
+            const stream_topic_url = hash_util.by_stream_topic_url(stream.stream_id, topic_name);
+            const topic_display_name = util.get_final_topic_display_name(topic_name);
+            const escape = html_escape_markdown_syntax_characters;
+            const label = `#${escape(stream_name)} > ${escape(topic_display_name)}`;
+            return as_markdown_link_syntax(label, `${stream_topic_url}/with/${message_id}`);
+        }
+        return get_fallback_markdown_link(stream_name, topic_name);
     }
     return `#**${stream_name}>${topic_name}**`;
 }

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -907,8 +907,9 @@ test("quote_messages", ({disallow, override, override_rewire}) => {
     const url_encoded_topic_name = ".5Bzulip.2Fzulip.3Etopic.5D";
 
     const near_url = `http://zulip.zulipdev.com/#narrow/channel/${selected_message.stream_id}-${channel_object.name}/topic/${url_encoded_topic_name}/near/${selected_message.id}`;
-    const with_url = `#narrow/channel/${selected_message.stream_id}-${channel_object.name}/topic/${url_encoded_topic_name}/with/${selected_message.id}`;
-    const topic_link_syntax = `[#${channel_object.name} > ${html_entity_encoded_topic_name}](${with_url})`;
+    const fallback_stream_id = stream_data.get_stream_id(channel_object.name);
+    const fallback_url = `#narrow/channel/${fallback_stream_id}-${channel_object.name}/topic/${url_encoded_topic_name}/with/${selected_message.id}`;
+    const topic_link_syntax = `[#${channel_object.name} > ${html_entity_encoded_topic_name}](${fallback_url})`;
 
     const fence = "```";
     expected_replacement = `translated: @_**${selected_message.sender_full_name}|${selected_message.sender_id}** [said](${near_url}) in ${topic_link_syntax}:

--- a/web/tests/lib/compose_helpers.cjs
+++ b/web/tests/lib/compose_helpers.cjs
@@ -188,8 +188,7 @@ function forward_channel_message_template(opts) {
     const channel_name = name;
     const {sender_full_name, sender_id, id, topic} = selected_message;
     const near_url = `http://zulip.zulipdev.com/#narrow/channel/${stream_id}-${channel_name}/topic/${topic}/near/${id}`;
-    const with_url = `#narrow/channel/${stream_id}-${channel_name}/topic/${topic}/with/${id}`;
-    const topic_link = `[#${channel_name} > ${topic}](${with_url})`;
+    const topic_link = `#**${channel_name}>${topic}**`;
     return `translated: @_**${sender_full_name}|${sender_id}** [said](${near_url}) in ${topic_link}:
 ${fence}quote
 ${content}


### PR DESCRIPTION
Previously, forwarded messages used plain markdown link syntax `[#channel > topic](url)` for the channel>topic reference, which `rendered_markdown.ts` could not process to apply the decorated channel icon introduced in #37847.


1. In `compose_reply.ts` I Use `#**channel>topic**` syntax instead of plain markdown link syntax. I could have directly called `render_decorated_channel_name`, but that would bypass the standard markdown rendering pipeline. Using new syntax goes through the normal rendering path that `rendered_markdown.ts` already handles.

2. `rendered_markdown.ts`: Extend the existing selector to also match old forwarded messages stored as plain `[#channel > topic](url)` links. We use `channel_topic.message_id` to distinguish topic links from message links, which also correctly handles fallback links for channel>topic names with special characters.


Fixes: [#design > Forwarded messages still uses the old # stream icon](https://chat.zulip.org/#narrow/channel/101-design/topic/Forwarded.20messages.20still.20uses.20the.20old.20.23.20stream.20icon/with/2455030)

<hr>
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="507" height="87" alt="2026-05-11_21-33-37" src="https://github.com/user-attachments/assets/3ee3ff8e-8a85-4e70-b02b-1aaecceb290b" />|<img width="507" height="87" alt="2026-05-11_21-34-13" src="https://github.com/user-attachments/assets/72e7e1f3-e925-44e9-bede-98f9048901cb" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="507" height="120" alt="2026-05-11_21-44-40" src="https://github.com/user-attachments/assets/b03ef967-f0c2-4531-a56e-0a3769c16c83" />|<img width="507" height="120" alt="2026-05-11_21-45-09" src="https://github.com/user-attachments/assets/102db00e-8cef-4e75-92ce-142db380adbf" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
