### PR TITLE
compose_box: Fix mentioned user card popover in expanded compose preview mode.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -2057,6 +2057,13 @@ textarea.new_message_textarea {
            controls offscreen when previewing a very tall message. */
         height: 0;
         flex: 1;
+
+        /* Without this, .simplebar-wrapper has overflow: hidden and
+           height: 0, so Popper treats it as a zero-height clipping
+           ancestor and hides popovers anchored inside the preview. */
+        .simplebar-wrapper {
+            overflow: visible;
+        }
     }
 }
 


### PR DESCRIPTION
The user card popover fails to open when clicking a @mentioned user in the expanded compose preview mode.

In expanded compose mode, `#preview_message_area` has `height: 0; flex: 1`. Simplebar `.simplebar-wrapper` inherits `height: 0` and has `overflow: hidden`, so Popper treats it as a zero-height clipping ancestor and hides the popover immediately when clicking a @mention in the preview area.

Fix by setting `.simplebar-wrapper { overflow: visible }`.

Fixes: [#issues > Mentioned user popover not opening in Expanded compose box](https://chat.zulip.org/#narrow/channel/9-issues/topic/Mentioned.20user.20popover.20not.20opening.20in.20Expanded.20compose.20box/with/2449165)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**### Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/f372620b-2d92-4da2-9b06-808d6964a055" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/d21cba4e-67a1-4176-913d-323d57f5266a" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
