### PR TITLE
Dropdown widget list stream sort.

### DIFF
--- a/web/src/channel_folders_ui.ts
+++ b/web/src/channel_folders_ui.ts
@@ -32,10 +32,6 @@ let channel_folder_stream_list_widget: ListWidgetType<StreamSubscription> | unde
 let stream_list_widget_stream_ids: Set<number> | undefined;
 let add_channel_folder_widget: DropdownWidget | undefined;
 
-function compare_by_name(a: dropdown_widget.Option, b: dropdown_widget.Option): number {
-    return util.strcmp(a.name, b.name);
-}
-
 export function add_channel_folder(on_create?: (folder_id: number) => void): void {
     const modal_content_html = render_create_channel_folder_modal({
         max_channel_folder_name_length: realm.max_channel_folder_name_length,
@@ -296,7 +292,7 @@ function get_channel_folder_candidates(folder_id: number): dropdown_widget.Optio
                   ]
                 : [],
         )
-        .toSorted(compare_by_name);
+        .toSorted((a, b) => util.compare_stream_by_archived_then_name(a.stream, b.stream));
 }
 
 function get_channel_folder_candidates_for_dropdown(): dropdown_widget.Option[] {

--- a/web/src/channel_folders_ui.ts
+++ b/web/src/channel_folders_ui.ts
@@ -191,11 +191,7 @@ export function handle_archiving_channel_folder(folder_id: number): void {
 
 function format_channel_item_html(stream: StreamSubscription): string {
     return render_channel_list_item({
-        name: stream.name,
-        stream_id: stream.stream_id,
-        stream_color: stream.color,
-        invite_only: stream.invite_only,
-        is_web_public: stream.is_web_public,
+        stream,
         can_manage_folder: settings_data.can_user_manage_folder(),
     });
 }

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -282,7 +282,7 @@ function get_fetched_user_unsub_streams(user_id: number): dropdown_widget.Option
             unique_id: stream.stream_id,
             stream,
         }))
-        .toSorted((a, b) => compare_by_name(a.stream, b.stream));
+        .toSorted((a, b) => util.compare_stream_by_archived_then_name(a.stream, b.stream));
 }
 
 function format_user_stream_list_item_html(stream: StreamSubscription, user: User): string {

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -293,11 +293,7 @@ function format_user_stream_list_item_html(stream: StreamSubscription, user: Use
     const show_last_user_in_private_stream_unsub_tooltip =
         stream.invite_only && peer_data.get_subscriber_count(stream.stream_id) === 1;
     return render_channel_list_item({
-        name: stream.name,
-        stream_id: stream.stream_id,
-        stream_color: stream.color,
-        invite_only: stream.invite_only,
-        is_web_public: stream.is_web_public,
+        stream,
         show_unsubscribe_button,
         show_private_stream_unsub_tooltip,
         show_last_user_in_private_stream_unsub_tooltip,

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -282,15 +282,7 @@ function get_fetched_user_unsub_streams(user_id: number): dropdown_widget.Option
             unique_id: stream.stream_id,
             stream,
         }))
-        .toSorted((a, b) => {
-            if (a.name.toLowerCase() < b.name.toLowerCase()) {
-                return -1;
-            }
-            if (a.name.toLowerCase() > b.name.toLowerCase()) {
-                return 1;
-            }
-            return 0;
-        });
+        .toSorted((a, b) => compare_by_name(a.stream, b.stream));
 }
 
 function format_user_stream_list_item_html(stream: StreamSubscription, user: User): string {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -146,6 +146,20 @@ export function make_strcmp(): (x: string, y: string) => number {
 
 export const strcmp = make_strcmp();
 
+type StreamInfo = {
+    name: string;
+    is_archived: boolean;
+};
+
+export function compare_stream_by_archived_then_name(a: StreamInfo, b: StreamInfo): number {
+    // We show non-archived streams first
+    if (a.is_archived !== b.is_archived) {
+        return Number(a.is_archived) - Number(b.is_archived);
+    }
+
+    return strcmp(a.name, b.name);
+}
+
 export const array_compare = function util_array_compare<T>(a: T[], b: T[]): boolean {
     if (a.length !== b.length) {
         return false;

--- a/web/templates/channel_list_item.hbs
+++ b/web/templates/channel_list_item.hbs
@@ -1,10 +1,10 @@
-<li class="stream-list-item modal-list-item" role="presentation" data-stream-id="{{stream_id}}">
+<li class="stream-list-item modal-list-item" role="presentation" data-stream-id="{{stream.stream_id}}">
     <div class="modal-channel-list-row hidden-remove-button-row">
-        <span class="view-stream-card modal-channel-list-row-content list-row-content" data-stream-id="{{stream_id}}" tabindex="0">
-            <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
-                {{> stream_privacy . }}
+        <span class="view-stream-card modal-channel-list-row-content list-row-content" data-stream-id="{{stream.stream_id}}" tabindex="0">
+            <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
+                {{> stream_privacy stream }}
             </span>
-            <span class="stream-name list-item-name">{{name}}</span>
+            <span class="stream-name list-item-name">{{stream.name}}</span>
         </span>
         <div class="remove-button-wrapper">
             {{#if show_unsubscribe_button}}

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -127,6 +127,45 @@ run_test("dumb_strcmp", ({override}) => {
     assert.equal(strcmp("z", "y"), 1);
 });
 
+run_test("compare_stream_by_archived_then_name", () => {
+    const make_archived_stream = (name) => ({name, is_archived: true});
+    const make_non_archived_stream = (name) => ({name, is_archived: false});
+
+    let streams = [
+        make_non_archived_stream("beta"),
+        make_archived_stream("zeta"),
+        make_non_archived_stream("delta"),
+        make_archived_stream("alpha"),
+        make_non_archived_stream("alpha"),
+        make_archived_stream("beta"),
+    ];
+
+    const sorted_streams = streams.toSorted((a, b) =>
+        util.compare_stream_by_archived_then_name(a, b),
+    );
+
+    // archived streams are placed at the end after sorting.
+    assert.deepEqual(sorted_streams, [
+        make_non_archived_stream("alpha"),
+        make_non_archived_stream("beta"),
+        make_non_archived_stream("delta"),
+        make_archived_stream("alpha"),
+        make_archived_stream("beta"),
+        make_archived_stream("zeta"),
+    ]);
+
+    // Intl.Collator sorts "ä" near "a", placing "ärger" before "zeta".
+    streams = [make_non_archived_stream("zeta"), make_non_archived_stream("ärger")];
+
+    const sorted_locale_aware = streams.toSorted((a, b) =>
+        util.compare_stream_by_archived_then_name(a, b),
+    );
+    assert.deepEqual(sorted_locale_aware, [
+        make_non_archived_stream("ärger"),
+        make_non_archived_stream("zeta"),
+    ]);
+});
+
 run_test("get_edit_event_orig_topic", () => {
     assert.equal(util.get_edit_event_orig_topic({orig_subject: "lunch"}), "lunch");
 });


### PR DESCRIPTION
Changes the user subscribe widget dropdown list to sort archived and non-archived stream separately and place them in the order:
- Non-archived streams
- Archived streams

Also shows archived icon in the channel list in user profile and channel folder modal.

Fixes: [#issues > sort archived channels at the bottom @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/sort.20archived.20channels.20at.20the.20bottom/near/2453463)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="263" height="157" alt="Screenshot from 2026-05-12 01-10-11" src="https://github.com/user-attachments/assets/c10f85cd-7d1f-49ac-8da4-d6e9dd39a6be" />|<img width="276" height="157" alt="Screenshot from 2026-05-12 01-08-57" src="https://github.com/user-attachments/assets/0343dfcc-19be-43b2-bbb7-70e83053f60e" />|
|<img width="340" height="157" alt="Screenshot from 2026-05-12 01-09-55" src="https://github.com/user-attachments/assets/8c34a0fa-8986-4ede-9a15-743bcef6e85c" />|<img width="340" height="157" alt="Screenshot from 2026-05-12 01-09-13" src="https://github.com/user-attachments/assets/a5649011-ac88-49e8-b4d2-0bf2fdce52a5" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
