### PR TITLE
markdown: convert leading tabs to spaces for nested lists

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1579,6 +1579,53 @@ class Fence:
     is_code: bool
 
 
+class TabToSpacePreprocessor(markdown.preprocessors.Preprocessor):
+    """Replace leading tabs with 2 spaces each, outside fenced code blocks.
+
+    Zulip uses 2-space indentation for nested bulleted lists, but
+    Python-Markdown's NormalizeWhitespace expands tabs to 4 spaces
+    (the default tab_length).  That makes tab-indented nested lists
+    appear double-indented and fail to nest correctly.
+
+    Running before NormalizeWhitespace, this preprocessor converts
+    each leading tab to 2 spaces so that one tab equals one level of
+    list nesting, matching Zulip's 2-space convention.  Lines inside
+    fenced code blocks are left untouched.
+    """
+
+    LEADING_TABS_RE = re.compile(r"^\t+")
+
+    @override
+    def run(self, lines: list[str]) -> list[str]:
+        result: list[str] = []
+        in_code_fence = False
+        open_fences: list[Fence] = []
+        for line in lines:
+            m = FENCE_RE.match(line)
+            if m:
+                fence_str = m.group("fence")
+                lang: str | None = m.group("lang")
+                is_code = lang not in ("quote", "quoted")
+                matches_last_fence = (
+                    fence_str == open_fences[-1].fence_str if open_fences else False
+                )
+                closes_last_fence = not lang and matches_last_fence
+
+                if closes_last_fence:
+                    open_fences.pop()
+                else:
+                    open_fences.append(Fence(fence_str, is_code))
+
+                in_code_fence = any(fence.is_code for fence in open_fences)
+
+            if not in_code_fence:
+                line = self.LEADING_TABS_RE.sub(
+                    lambda m: "  " * len(m.group()), line
+                )
+            result.append(line)
+        return result
+
+
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     """Allows list blocks that come directly after another block
     to be rendered as a list.
@@ -2277,6 +2324,7 @@ class ZulipMarkdown(markdown.Markdown):
         # html_block - insecure
         # reference - references don't make sense in a chat context.
         preprocessors = markdown.util.Registry[markdown.preprocessors.Preprocessor]()
+        preprocessors.register(TabToSpacePreprocessor(self), "tab_to_space", 38)
         preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 35)
         preprocessors.register(
             markdown.preprocessors.NormalizeWhitespace(self), "normalize_whitespace", 30

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1619,9 +1619,7 @@ class TabToSpacePreprocessor(markdown.preprocessors.Preprocessor):
                 in_code_fence = any(fence.is_code for fence in open_fences)
 
             if not in_code_fence:
-                line = self.LEADING_TABS_RE.sub(
-                    lambda m: "  " * len(m.group()), line
-                )
+                line = self.LEADING_TABS_RE.sub(lambda m: "  " * len(m.group()), line)
             result.append(line)
         return result
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -278,6 +278,12 @@
       "text_content": "Nested list\n\nI am outer list\nI am inner nested list first item\nI am inner nested list second item\n\n\n"
     },
     {
+      "name": "ulist_nested_ulist_tab_indent",
+      "input": "- outer\n\t- inner first\n\t- inner second\n\t\t- deep nested",
+      "expected_output": "<ul>\n<li>outer<ul>\n<li>inner first</li>\n<li>inner second<ul>\n<li>deep nested</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>",
+      "text_content": "\nouter\ninner first\ninner second\ndeep nested\n\n\n"
+    },
+    {
       "name": "ulist_list_two_space_indent",
       "input": "* I am outer list\n  I am something inside",
       "expected_output": "<ul>\n<li>I am outer list<br>\n  I am something inside</li>\n</ul>",


### PR DESCRIPTION
## Summary
- Add a Markdown preprocessor that converts leading tabs to 2-space indentation, enabling tab-indented nested lists to render correctly
- The Python-Markdown parser requires space indentation for nested list detection; tabs were silently breaking nesting

Fixes #38436

## Test plan
- Added test case for tab-indented nested lists in `markdown_test_cases.json`
- Existing Markdown rendering tests pass unchanged