### PR TITLE
api-docs: Revise description of shared Principals schema.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -30531,10 +30531,13 @@ components:
       description: |
         A list of user IDs (preferred) or Zulip API email
         addresses of the users to be subscribed to or unsubscribed
-        from the channels specified in the `subscriptions` parameter. If
-        not provided, then the requesting user/bot is subscribed.
+        from the channels specified in the `subscriptions` parameter.
 
-        **Changes**: The integer format is new in Zulip 3.0 (feature level 9).
+        If not provided, then the requesting user/bot will be
+        subscribed/unsubscribed from the specified channels.
+
+        **Changes**: Before Zulip 3.0 (feature level 9), only the
+        Zulip API email address string format was supported.
       oneOf:
         - type: array
           items:
@@ -30542,7 +30545,7 @@ components:
         - type: array
           items:
             type: integer
-      example: ["ZOE@zulip.com"]
+      example: [11]
     ReactionType:
       description: |
         A string indicating the type of emoji. Each emoji `reaction_type`


### PR DESCRIPTION
As the "Principals" schema is used for both the [subscribe](https://zulip.com/api/subscribe) and [unsubscribe](https://zulip.com/api/unsubscribe) endpoint parameters, the description should note both actions for the current user case.

**Notes**:
- Since the description notes that the preferred format is the list of integer user IDs, updated the example to use that format.
- Also, updated the changes note to better follow our current style for these notes, e.g., "Before Zulip ..." vs "X format is new in..."

---

**Screenshots and screen captures:**

[CURRENT DOCUMENTATION](https://zulip.com/api/unsubscribe#parameter-principals)
| Version | Screenshot |
| --- | --- |
| Current | <img width="1498" height="426" alt="Screenshot From 2026-05-12 16-45-27" src="https://github.com/user-attachments/assets/5aed9820-7786-482f-b6dd-bfd2c4f97a65" />
| Updated | <img width="1498" height="492" alt="Screenshot From 2026-05-12 16-36-42" src="https://github.com/user-attachments/assets/cdc3c870-a83e-4275-a9f1-27c95682b251" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
