### PR TITLE
klipy: Fix locale format to match Klipy API expectations.

### DIFF
--- a/web/src/klipy_network.ts
+++ b/web/src/klipy_network.ts
@@ -121,6 +121,14 @@ export class KlipyNetwork extends GifNetwork {
     }
 }
 
+// Klipy expects locale in xx_YY format (ISO 639-1 language code +
+// ISO 3166-1 country code, e.g. en_US), but user_settings.default_language
+// uses Django's xx-yy format (e.g. en-gb).
+function to_klipy_locale(language: string): string {
+    const locale = new Intl.Locale(language).maximize();
+    return `${locale.language}_${locale.region}`;
+}
+
 function get_base_payload(): KlipyPayload {
     return {
         key: realm.klipy_api_key,
@@ -128,7 +136,7 @@ function get_base_payload(): KlipyPayload {
         // We use the tinygif size for the picker UI, and the mediumgif size
         // for what gets actually uploaded.
         media_filter: "tinygif,mediumgif",
-        locale: user_settings.default_language,
+        locale: to_klipy_locale(user_settings.default_language),
         contentfilter: klipy_rating_map[get_rating()],
     };
 }


### PR DESCRIPTION
Klipy's locale parameter expects the format described in their [docs](https://docs.klipy.com/migrate-from-tenor/search):

  >Specify the default language to interpret the search string. xx is
  the language's ISO 639-1 language code, while the optional _YY
  value is the two-letter ISO 3166-1 country code.

However, we were passing user_settings.default_language directly, which uses Django's lowercase hyphenated format (e.g. `en-gb`), causing a 422 error from the Klipy API.


CZO: https://chat.zulip.org/#narrow/channel/9-issues/topic/Klipy.20GIF.20selector.20fails.20to.20load.20w.20certain.20language.20.2339202/with/2456603

Fixes: #39202




Although some languages are [not supported](https://docs.klipy.com/migrate-from-tenor/response-objects#:~:text=Show%20more-,Localization,-KLIPY%20supports%20localization), KLIPY seems to fallback to using `en` as long as we are consistent with the xx_YY format for the locale.

Tested locally for en-gb, zh-hans, Welsh, en-us