### PR TITLE
url_encoding: Refactor URL encoding functions to use typed parameters.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -345,13 +345,13 @@ def send_message_moved_breadcrumbs(
     new_topic_name = message_edit_request.target_topic_name
     old_topic_link = get_stream_topic_link_syntax(old_stream.id, old_stream.name, old_topic_name)
     new_topic_link = get_stream_topic_link_syntax(new_stream.id, new_stream.name, new_topic_name)
-    message = {
-        "id": target_message.id,
-        "stream_id": new_stream.id,
-        "display_recipient": new_stream.name,
-        "topic": new_topic_name,
-    }
-    moved_message_link = stream_message_url(target_message.realm, message)
+    moved_message_link = stream_message_url(
+        target_message.realm,
+        message_id=target_message.id,
+        stream_id=new_stream.id,
+        stream_name=new_stream.name,
+        topic_name=new_topic_name,
+    )
 
     if new_thread_notification_string is not None:
         with override_language(new_stream.realm.default_language):

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -28,7 +28,6 @@ from confirmation.models import one_click_unsubscribe_link
 from zerver.lib.display_recipient import get_display_recipient
 from zerver.lib.markdown.fenced_code import FENCE_RE
 from zerver.lib.message import bulk_access_messages
-from zerver.lib.message_cache import MessageDict
 from zerver.lib.notification_data import get_mentioned_user_group
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.send_email import FromAddress, send_future_email
@@ -597,7 +596,12 @@ def do_send_missedmessage_events_reply_in_zulip(
         assert message.recipient.type == Recipient.STREAM
         stream = Stream.objects.only("id", "name").get(id=message.recipient.type_id)
         narrow_url = message_link_url(
-            user_profile.realm, MessageDict.wide_dict(message), conversation_link=not mention
+            user_profile.realm,
+            message.id,
+            stream.name,
+            stream.id,
+            message.topic_name(),
+            conversation_link=not mention,
         )
         context.update(narrow_url=narrow_url)
         topic_resolved, bare_topic_name = get_topic_resolution_and_bare_name(message.topic_name())

--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -117,10 +117,8 @@ def send_message_report(
     else:
         direct_message_link = pm_message_url(
             realm,
-            dict(
-                id=reported_message.id,
-                display_recipient=get_display_recipient(reported_message.recipient),
-            ),
+            reported_message.id,
+            get_display_recipient(reported_message.recipient),
         )
         original_message_string = _("[Original message]({direct_message_link})").format(
             direct_message_link=direct_message_link

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -250,9 +250,13 @@ def get_message_url(event: dict[str, Any]) -> str:
     message = event["message"]
     realm = bot_user.realm
 
+    is_stream_message = message["type"] == "stream"
     return message_link_url(
         realm=realm,
-        message=message,
+        message_id=message["id"],
+        display_recipient=message["display_recipient"],
+        stream_id=message["stream_id"] if is_stream_message else None,
+        topic_name=get_topic_from_message_info(message) if is_stream_message else None,
     )
 
 

--- a/zerver/lib/reminders.py
+++ b/zerver/lib/reminders.py
@@ -8,7 +8,6 @@ from zerver.lib.exceptions import JsonableError, ResourceNotFoundError
 from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.message import get_user_mentions_for_display, truncate_content
-from zerver.lib.message_cache import MessageDict
 from zerver.lib.topic_link_util import (
     TOPIC_LINK_SYNTAX_FOR_DISPLAY,
     escape_invalid_stream_topic_characters,
@@ -48,7 +47,6 @@ def get_reminder_formatted_content(
 
     format_recipient_type_key: ReminderRecipientType
     user_silent_mention = silent_mention_syntax_for_user(message.sender)
-    conversation_url = message_link_url(current_user.realm, MessageDict.wide_dict(message))
 
     if message.is_channel_message:
         # We don't need to check access here since we already have the message
@@ -57,14 +55,19 @@ def get_reminder_formatted_content(
             id=message.recipient.type_id,
             realm=current_user.realm,
         )
+        conversation_url = message_link_url(
+            current_user.realm,
+            message.id,
+            stream.name,
+            stream.id,
+            message.topic_name(),
+        )
         url = stream_message_url(
             realm=None,
-            message={
-                "id": message.id,
-                "stream_id": stream.id,
-                "display_recipient": stream.name,
-                "topic": message.topic_name(),
-            },
+            message_id=message.id,
+            stream_id=stream.id,
+            stream_name=stream.name,
+            topic_name=message.topic_name(),
             conversation_link=True,
             include_base_url=False,
         )
@@ -89,6 +92,8 @@ def get_reminder_formatted_content(
             topic_pretty_link=f"[{topic_pretty_link}]({url})",
         )
     else:
+        display_recipient = get_display_recipient(message.recipient)
+        conversation_url = message_link_url(current_user.realm, message.id, display_recipient)
         if note:
             content = _(
                 "You requested a reminder for the following direct message. Note:\n > {note}"
@@ -98,9 +103,7 @@ def get_reminder_formatted_content(
         else:
             content = _("You requested a reminder for the following direct message.")
         recipients: list[UserProfile | UserDisplayRecipient] = [
-            user
-            for user in get_display_recipient(message.recipient)
-            if user["id"] != message.sender.id
+            user for user in display_recipient if user["id"] != message.sender.id
         ]
 
         if not recipients:

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,13 +1,11 @@
 # See the Zulip URL spec at https://zulip.com/api/zulip-urls
 
 import urllib.parse
-from typing import Any
 from urllib.parse import urlsplit
 
 import re2
 
-from zerver.lib.topic import get_topic_from_message_info
-from zerver.lib.types import UserDisplayRecipient
+from zerver.lib.types import DisplayRecipientT, UserDisplayRecipient
 from zerver.models import Realm, Stream, UserProfile
 
 hash_replacements = {
@@ -141,19 +139,32 @@ def topic_narrow_url(*, realm: Realm, stream: Stream, topic_name: str) -> str:
 
 
 def message_link_url(
-    realm: Realm, message: dict[str, Any], *, conversation_link: bool = False
+    realm: Realm,
+    message_id: int,
+    display_recipient: DisplayRecipientT,
+    stream_id: int | None = None,
+    topic_name: str | None = None,
+    *,
+    conversation_link: bool = False,
 ) -> str:
-    if message["type"] == "stream":
+    if stream_id:
+        assert isinstance(display_recipient, str)
+        assert topic_name is not None
         url = stream_message_url(
             realm=realm,
-            message=message,
+            message_id=message_id,
+            stream_id=stream_id,
+            stream_name=display_recipient,
+            topic_name=topic_name,
             conversation_link=conversation_link,
         )
         return url
 
+    assert not isinstance(display_recipient, str)
     url = pm_message_url(
         realm=realm,
-        message=message,
+        message_id=message_id,
+        display_recipient=display_recipient,
         conversation_link=conversation_link,
     )
     return url
@@ -161,7 +172,10 @@ def message_link_url(
 
 def stream_message_url(
     realm: Realm | None,
-    message: dict[str, Any],
+    message_id: int,
+    stream_id: int,
+    stream_name: str,
+    topic_name: str,
     *,
     conversation_link: bool = False,
     include_base_url: bool = True,
@@ -172,10 +186,6 @@ def stream_message_url(
         with_or_near = "with"
     else:
         with_or_near = "near"
-    message_id = str(message["id"])
-    stream_id = message["stream_id"]
-    stream_name = message["display_recipient"]
-    topic_name = get_topic_from_message_info(message)
     encoded_topic_name = encode_hash_component(topic_name)
     encoded_stream = encode_channel(stream_id, stream_name)
 
@@ -189,15 +199,18 @@ def stream_message_url(
 
 
 def pm_message_url(
-    realm: Realm, message: dict[str, Any], *, conversation_link: bool = False
+    realm: Realm,
+    message_id: int,
+    display_recipient: list[UserDisplayRecipient],
+    *,
+    conversation_link: bool = False,
 ) -> str:
     if conversation_link:
         with_or_near = "with"
     else:
         with_or_near = "near"
 
-    message_id = str(message["id"])
-    user_ids = [recipient["id"] for recipient in message["display_recipient"]]
+    user_ids = [recipient["id"] for recipient in display_recipient]
 
     direct_message_slug = encode_user_ids(user_ids)
 
@@ -207,7 +220,7 @@ def pm_message_url(
         "dm",
         direct_message_slug,
         with_or_near,
-        message_id,
+        str(message_id),
     ]
     full_url = "/".join(parts)
     return full_url

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -6159,23 +6159,21 @@ class MessageVisibilityTest(ZulipTestCase):
 class PersonalMessagesTest(ZulipTestCase):
     def test_pm_message_url(self) -> None:
         realm = get_realm("zulip")
-        message = dict(
-            type="personal",
-            id=555,
-            display_recipient=[
-                dict(id=77),
-                dict(id=80),
-            ],
-        )
+        display_recipient: list[UserDisplayRecipient] = [
+            dict(id=77, email="a@example.com", full_name="A", is_mirror_dummy=False),
+            dict(id=80, email="b@example.com", full_name="B", is_mirror_dummy=False),
+        ]
         url = message_link_url(
             realm=realm,
-            message=message,
+            message_id=555,
+            display_recipient=display_recipient,
         )
         self.assertEqual(url, "http://zulip.testserver/#narrow/dm/77,80/near/555")
 
         url = message_link_url(
             realm=realm,
-            message=message,
+            message_id=555,
+            display_recipient=display_recipient,
             conversation_link=True,
         )
         self.assertEqual(url, "http://zulip.testserver/#narrow/dm/77,80/with/555")

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -738,13 +738,9 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, new_stream, "test")
-        message = {
-            "id": msg_id_later,
-            "stream_id": new_stream.id,
-            "display_recipient": new_stream.name,
-            "topic": "test",
-        }
-        moved_message_link = stream_message_url(messages[1].realm, message)
+        moved_message_link = stream_message_url(
+            messages[1].realm, msg_id_later, new_stream.id, new_stream.name, "test"
+        )
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].id, msg_id_later)
         self.assertEqual(
@@ -783,13 +779,9 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, new_stream, "test")
-        message = {
-            "id": msg_id_later,
-            "stream_id": new_stream.id,
-            "display_recipient": new_stream.name,
-            "topic": "test",
-        }
-        moved_message_link = stream_message_url(messages[2].realm, message)
+        moved_message_link = stream_message_url(
+            messages[2].realm, msg_id_later, new_stream.id, new_stream.name, "test"
+        )
         self.assert_length(messages, 3)
         self.assertEqual(messages[0].id, msg_id_later)
         self.assertEqual(
@@ -1848,13 +1840,9 @@ class MessageMoveStreamTest(ZulipTestCase):
         self.assertEqual(messages[1].content, "Third")
 
         messages = get_topic_messages(user_profile, stream, "edited")
-        message = {
-            "id": msg_id,
-            "stream_id": stream.id,
-            "display_recipient": stream.name,
-            "topic": "edited",
-        }
-        moved_message_link = stream_message_url(messages[1].realm, message)
+        moved_message_link = stream_message_url(
+            messages[1].realm, msg_id, stream.id, stream.name, "edited"
+        )
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].content, "First")
         self.assertEqual(
@@ -1895,13 +1883,9 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, stream, "edited")
-        message = {
-            "id": msg_id,
-            "stream_id": stream.id,
-            "display_recipient": stream.name,
-            "topic": "edited",
-        }
-        moved_message_link = stream_message_url(messages[0].realm, message)
+        moved_message_link = stream_message_url(
+            messages[0].realm, msg_id, stream.id, stream.name, "edited"
+        )
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].content, "First")
         self.assertEqual(

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -108,12 +108,10 @@ class ReportMessageTest(ZulipTestCase):
         # Make sure channel message link is accessible.
         message_link = stream_message_url(
             None,
-            dict(
-                id=reported_message.id,
-                stream_id=channel_id,
-                display_recipient=channel_name,
-                topic=topic_name,
-            ),
+            reported_message.id,
+            channel_id,
+            channel_name,
+            topic_name,
             include_base_url=False,
         )
 
@@ -173,10 +171,8 @@ class ReportMessageTest(ZulipTestCase):
 
         direct_message_link = pm_message_url(
             realm,
-            dict(
-                id=reported_dm.id,
-                display_recipient=get_display_recipient(reported_dm.recipient),
-            ),
+            reported_dm.id,
+            get_display_recipient(reported_dm.recipient),
         )
         expected_message = self.build_direct_message_report_template(
             direct_message_link=direct_message_link,
@@ -212,10 +208,8 @@ class ReportMessageTest(ZulipTestCase):
         message_sent_to = f"{reporting_user_mention} reported a message sent by {reported_user_mention} to {list_of_direct_message_recipients} at {reported_gdm_date_sent}."
         direct_message_link = pm_message_url(
             realm,
-            dict(
-                id=reported_gdm.id,
-                display_recipient=get_display_recipient(reported_gdm.recipient),
-            ),
+            reported_gdm.id,
+            get_display_recipient(reported_gdm.recipient),
         )
         expected_message = self.build_direct_message_report_template(
             direct_message_link=direct_message_link,

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -17,6 +17,7 @@ from zerver.lib.outgoing_webhook import (
 )
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.topic import TOPIC_NAME
+from zerver.lib.types import UserDisplayRecipient
 from zerver.lib.url_encoding import message_link_url
 from zerver.lib.users import add_service
 from zerver.models import Recipient, Service, SubMessage, UserProfile
@@ -530,15 +531,17 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
 
             self.assert_length(responses.calls, 1)
 
-            # create message dict to get the message url
-            message = {
-                "display_recipient": [{"id": bot.id}, {"id": sender.id}],
-                "stream_id": 999,
-                TOPIC_NAME: "Foo",
-                "id": message_id,
-                "type": "",
-            }
-            message_url = message_link_url(realm, message)
+            # create the display recipient to get the message url
+            display_recipient: list[UserDisplayRecipient] = [
+                dict(id=bot.id, email=bot.email, full_name=bot.full_name, is_mirror_dummy=False),
+                dict(
+                    id=sender.id,
+                    email=sender.email,
+                    full_name=sender.full_name,
+                    is_mirror_dummy=False,
+                ),
+            ]
+            message_url = message_link_url(realm, message_id, display_recipient)
 
             last_message = self.get_last_message()
             self.assertEqual(
@@ -653,14 +656,13 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
         )
 
         last_message = self.get_last_message()
-        message_dict = {
-            "stream_id": get_stream("Denmark", realm).id,
-            "display_recipient": "Denmark",
-            TOPIC_NAME: "bar",
-            "id": sent_message_id,
-            "type": "stream",
-        }
-        message_url = message_link_url(realm, message_dict)
+        message_url = message_link_url(
+            realm,
+            sent_message_id,
+            "Denmark",
+            get_stream("Denmark", realm).id,
+            "bar",
+        )
         self.assertEqual(
             last_message.content,
             f"[A message]({message_url}) to your bot @_**{bot.full_name}** triggered an outgoing webhook.\n"

--- a/zerver/tests/test_url_encoding.py
+++ b/zerver/tests/test_url_encoding.py
@@ -73,25 +73,35 @@ class URLEncodeTest(ZulipTestCase):
             sender=self.example_user("hamlet"), stream_name=channel.name, topic_name=topic
         )
         channel_message = Message.objects.get(id=channel_message_id, realm=realm)
-        message_dict = dict(
-            id=channel_message_id,
-            stream_id=channel.id,
-            display_recipient=channel_message.recipient.label(),
-            topic=topic,
-        )
+        stream_name = channel_message.recipient.label()
         channel_message_url = stream_message_url(
             realm,
-            message_dict,
+            channel_message_id,
+            channel.id,
+            stream_name,
+            topic,
         )
         expected_channel_message_url = f"{realm.url}/#narrow/{encode_channel(channel.id, channel.name, True)}/topic/{encode_hash_component(topic)}/near/{channel_message_id}"
         self.assertEqual(channel_message_url, expected_channel_message_url)
 
         relative_channel_message_url = stream_message_url(
-            realm, message_dict, include_base_url=False
+            realm,
+            channel_message_id,
+            channel.id,
+            stream_name,
+            topic,
+            include_base_url=False,
         )
         expected_relative_channel_message_url = f"#narrow/{encode_channel(channel.id, channel.name, True)}/topic/{encode_hash_component(topic)}/near/{channel_message_id}"
         self.assertEqual(relative_channel_message_url, expected_relative_channel_message_url)
 
         with self.assertRaises(ValueError) as e:
-            stream_message_url(realm=None, message=message_dict, include_base_url=True)
+            stream_message_url(
+                None,
+                channel_message_id,
+                channel.id,
+                stream_name,
+                topic,
+                include_base_url=True,
+            )
         self.assertEqual(str(e.exception), "realm is required when include_base_url=True")


### PR DESCRIPTION
Previously, `message_link_url`, `stream_message_url`, and `pm_message_url` in `zerver/lib/url_encoding.py` accepted a `dict[str, Any]` of unspecified type, extracting fields like `message["id"]`, `message["stream_id"]`, and `message["display_recipient"]` internally.

This refactors them to accept typed individual parameters (`message_id: int`, `stream_id: int`, `stream_name: str`, `topic_name: str`, `display_recipient: DisplayRecipientT`), so callers pass values directly instead of constructing throwaway dicts.

All callers are updated to pass typed arguments instead of building intermediate dicts (removing `MessageDict.wide_dict()` calls in `reminders.py` and `email_notifications.py`, and manual `dict(...)` constructions elsewhere).

Callers updated:
- `zerver/actions/message_edit.py`
- `zerver/lib/reminders.py`
- `zerver/lib/email_notifications.py`
- `zerver/lib/outgoing_webhook.py`
- `zerver/lib/message_report.py`

Fixes #25021.

**How changes were tested:**

Ran the following test suites, all passing:
- zerver/tests/test_message_fetch.py
- zerver/tests/test_message_move_stream.py
- zerver/tests/test_outgoing_webhook_system.py
- zerver/tests/test_reminders.py
- zerver/tests/test_url_encoding.py
- zerver/tests/test_message_report.py

Also verified with mypy on all modified files.

<details>
<summary>Self-review checklist</summary>


- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.
</details>
