### PR TITLE
outgoing_webhooks: Separate command and text in Slack-compatible payload

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -130,7 +130,8 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
         # timestamp=1504640775.000005
         # user_id=U2147483697
         # user_name=Steve
-        # text=googlebot: What is the air-speed velocity of an unladen swallow?
+        # command=googlebot:
+        # text=What is the air-speed velocity of an unladen swallow?
         # trigger_word=googlebot:
 
         request_data = [
@@ -143,7 +144,8 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
+            ("command", event["command"].split(" ", 1)[0] if event["command"] else ""),
+            ("text", event["command"].split(" ", 1)[1] if " " in event["command"] else ""),
             ("trigger_word", event["trigger"]),
             ("service_id", event["user_profile_id"]),
         ]


### PR DESCRIPTION
Fixes #39095

In the Slack-compatible outgoing webhook payload, the `text` field
previously contained the full message including the bot mention
(e.g. `@bot do something`).

This PR separates it into:
- `command`: the bot trigger word (e.g. `@bot`)
- `text`: the actual message content (e.g. `do something`)

This matches Slack's actual outgoing webhook format.

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Each commit is a coherent idea
- [x] Commit messages explain reasoning and motivation for changes