### PR TITLE
settings: Make error element consistent.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -568,7 +568,11 @@ export function get_dropdown_list_widget_setting_value($input_elem: JQuery): num
     return setting_value;
 }
 
-export function change_save_button_state($element: JQuery, state: string): void {
+export function change_save_button_state(
+    $element: JQuery,
+    state: string,
+    error_callback?: () => void,
+): void {
     function show_hide_element(
         $element: JQuery,
         show: boolean,
@@ -606,6 +610,14 @@ export function change_save_button_state($element: JQuery, state: string): void 
         return;
     }
 
+    if (state === "failed") {
+        assert(error_callback !== undefined);
+        show_hide_element($element, false, 0, () => {
+            error_callback();
+        });
+        return;
+    }
+
     if (state === "succeeded" && $save_button.attr("data-status") === "unsaved") {
         // We don't show the "saved" state if the save button is in the "unsaved"
         // state, as that would indicate that user has made some other changes
@@ -636,10 +648,6 @@ export function change_save_button_state($element: JQuery, state: string): void 
 
             $element.find(".discard-button").hide();
             buttons.show_button_loading_indicator($save_button);
-            break;
-        case "failed":
-            data_status = "failed";
-            is_show = true;
             break;
         case "succeeded":
             button_text = $t({defaultMessage: "Saved"});

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1307,7 +1307,7 @@ function switching_to_private(properties_elements: HTMLElement[]): boolean {
 }
 
 export function save_discard_realm_settings_widget_status_handler($subsection: JQuery): void {
-    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".alert-notification").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
     const show_change_process_button = properties_elements.some((elem) =>
@@ -1323,7 +1323,7 @@ export function save_discard_stream_settings_widget_status_handler(
     $subsection: JQuery,
     sub: StreamSubscription | undefined,
 ): void {
-    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".alert-notification").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
     let show_change_process_button = false;
@@ -1373,7 +1373,7 @@ export function save_discard_group_widget_status_handler(
     $subsection: JQuery,
     group: UserGroup,
 ): void {
-    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".alert-notification").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
     const show_change_process_button = properties_elements.some((elem) =>
@@ -1387,7 +1387,7 @@ export function save_discard_group_widget_status_handler(
 export function save_discard_default_realm_settings_widget_status_handler(
     $subsection: JQuery,
 ): void {
-    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".alert-notification").hide();
     $subsection.find(".save-button").show();
     const properties_elements = get_subsection_property_elements($subsection);
     const show_change_process_button = properties_elements.some((elem) =>

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1295,9 +1295,9 @@ export function save_organization_settings(
             settings_components.resize_textareas_in_subsection($subsection_parent);
         },
         error(xhr) {
-            settings_components.change_save_button_state($save_button_container, "failed");
-            $save_button.hide();
-            ui_report.error($t_html({defaultMessage: "Save failed"}), xhr, $failed_alert_elem);
+            settings_components.change_save_button_state($save_button_container, "failed", () => {
+                ui_report.error($t_html({defaultMessage: "Save failed"}), xhr, $failed_alert_elem);
+            });
         },
     });
 }

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1276,7 +1276,7 @@ export function save_organization_settings(
 ): void {
     const $subsection_parent = $save_button.closest(".settings-subsection-parent");
     const $save_button_container = $subsection_parent.find(".save-button-controls");
-    const $failed_alert_elem = $subsection_parent.find(".subsection-failed-status p");
+    const $failed_alert_elem = $subsection_parent.find(".alert-notification");
     settings_components.change_save_button_state($save_button_container, "saving");
     channel.patch({
         url: patch_url,

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -491,7 +491,7 @@ export function show_settings_for(node: HTMLElement): void {
 
     $(".nothing-selected").hide();
     $("#subscription_overlay .stream_change_property_info").hide();
-    $("#subscription_overlay .stream_email_address_error").hide();
+    $("#subscription_overlay .channel-general-settings-status").hide();
     $("#id_topics_policy").val(sub.topics_policy);
 
     $edit_container.addClass("show");
@@ -824,7 +824,7 @@ export function initialize(): void {
                     ui_report.error(
                         $t_html({defaultMessage: "Failed"}),
                         xhr,
-                        $(".stream_email_address_error"),
+                        $(".channel-general-settings-status"),
                     );
                 },
             });

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -634,7 +634,7 @@ function update_membership_status_text(group: UserGroup): void {
 }
 
 function save_discard_widget_handler_for_permissions_panel($subsection: JQuery): void {
-    $subsection.find(".subsection-failed-status p").hide();
+    $subsection.find(".alert-notification").hide();
     $subsection.find(".save-button").show();
     const properties_elements = settings_components.get_subsection_property_elements($subsection);
     const show_change_process_button = properties_elements.some((elem) => !$(elem).prop("checked"));

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1802,13 +1802,6 @@ label.preferences-radio-choice-label {
     }
 }
 
-.subsection-failed-status p {
-    background-color: hsl(0deg 43% 91%);
-    padding: 2px 6px;
-    border-radius: 4px;
-    margin: 0 0 0 5px;
-}
-
 #muted_topics_table {
     width: 90%;
     margin: 0 auto;
@@ -2019,10 +2012,6 @@ label.preferences-radio-choice-label {
     .user-avatar-section,
     .realm-icon-section {
         display: block;
-    }
-
-    .subsection-failed-status p {
-        margin: 5px 0 0;
     }
 }
 

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -5,7 +5,7 @@
             {{#if for_realm_settings}}
                 {{> ../components/icon_button icon="reset" intent="neutral" custom_classes="reset-user-setting-to-default" data-tippy-content=(t "Reset users to default") aria-label=(t "Reset users to default") }}
             {{/if}}
-            {{> settings_save_discard_widget section_name="general-notify-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+            {{> settings_save_discard_widget section_name="general-notify-settings" show_save_discard_buttons=for_realm_settings }}
         </div>
         <p>{{t "Configure how Zulip notifies you about new messages." }}</p>
         <table class="notification-table table table-bordered wrapped-table">
@@ -79,7 +79,7 @@
             <h3>{{t "Topic notifications" }}
                 {{> ../help_link_widget link="/help/topic-notifications" }}
             </h3>
-            {{> settings_save_discard_widget section_name="topic-notifications-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+            {{> settings_save_discard_widget section_name="topic-notifications-settings" show_save_discard_buttons=for_realm_settings }}
         </div>
         <p>
             {{#tr}}
@@ -143,7 +143,7 @@
             <h3>{{t "Desktop message notifications" }}
                 {{> ../help_link_widget link="/help/desktop-notifications" }}
             </h3>
-            {{> settings_save_discard_widget section_name="desktop-message-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+            {{> settings_save_discard_widget section_name="desktop-message-settings" show_save_discard_buttons=for_realm_settings }}
         </div>
 
         {{#if (eq prefix "user_")}}
@@ -210,7 +210,7 @@
             <h3>{{t "Mobile message notifications" }}
                 {{> ../help_link_widget link="/help/mobile-notifications" }}
             </h3>
-            {{> settings_save_discard_widget section_name="mobile-message-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+            {{> settings_save_discard_widget section_name="mobile-message-settings" show_save_discard_buttons=for_realm_settings }}
         </div>
         {{#unless realm_push_notifications_enabled}}
         <div class="mobile-push-notifications-banner-container banner-wrapper">
@@ -234,7 +234,7 @@
             <h3>{{t "Email message notifications" }}
                 {{> ../help_link_widget link="/help/email-notifications" }}
             </h3>
-            {{> settings_save_discard_widget section_name="email-message-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+            {{> settings_save_discard_widget section_name="email-message-settings" show_save_discard_buttons=for_realm_settings }}
         </div>
 
         <div class="input-group time-limit-setting">
@@ -290,7 +290,7 @@
 
         <div class="subsection-header">
             <h3>{{t "Other emails" }}</h3>
-            {{> settings_save_discard_widget section_name="other-emails-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+            {{> settings_save_discard_widget section_name="other-emails-settings" show_save_discard_buttons=for_realm_settings }}
         </div>
         {{#each notification_settings.other_email_settings}}
             {{> settings_checkbox

--- a/web/templates/settings/preferences_emoji.hbs
+++ b/web/templates/settings/preferences_emoji.hbs
@@ -1,7 +1,7 @@
 <div class="emoji-preferences {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
         <h3 class="light">{{t "Emoji" }}</h3>
-        {{> settings_save_discard_widget section_name="emoji-preferences-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+        {{> settings_save_discard_widget section_name="emoji-preferences-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 
     <div class="input-group">

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -3,7 +3,7 @@
     it. If there's not an alert, don't make it inline-block.-->
     <div class="subsection-header">
         <h3>{{t "General" }}</h3>
-        {{> settings_save_discard_widget section_name="general-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+        {{> settings_save_discard_widget section_name="general-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
     {{#unless for_realm_settings}}
         {{> ../dropdown_widget_with_label

--- a/web/templates/settings/preferences_information.hbs
+++ b/web/templates/settings/preferences_information.hbs
@@ -1,7 +1,7 @@
 <div class="information-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
         <h3 class="light">{{t "Information" }}</h3>
-        {{> settings_save_discard_widget section_name="information-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+        {{> settings_save_discard_widget section_name="information-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 
     <div class="input-group">

--- a/web/templates/settings/preferences_left_sidebar.hbs
+++ b/web/templates/settings/preferences_left_sidebar.hbs
@@ -1,7 +1,7 @@
 <div class="left-sidebar-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
         <h3 class="light">{{t "Left sidebar" }}</h3>
-        {{> settings_save_discard_widget section_name="left-sidebar-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+        {{> settings_save_discard_widget section_name="left-sidebar-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 
     <div class="input-group">

--- a/web/templates/settings/preferences_navigation.hbs
+++ b/web/templates/settings/preferences_navigation.hbs
@@ -1,7 +1,7 @@
 <div class="navigation-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
         <h3 class="light">{{t "Navigation" }}</h3>
-        {{> settings_save_discard_widget section_name="navigation-settings" show_save_discard_buttons=for_realm_settings show_saving_indicator=true }}
+        {{> settings_save_discard_widget section_name="navigation-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 
     <div class="input-group">

--- a/web/templates/settings/privacy_settings.hbs
+++ b/web/templates/settings/privacy_settings.hbs
@@ -6,7 +6,7 @@
         {{> settings_save_discard_widget section_name="privacy-setting" show_save_discard_buttons=true }}
         {{else}}
         <h3 class="inline-block">{{t "Privacy"}}</h3>
-        {{> settings_save_discard_widget section_name="privacy-setting" show_saving_indicator=true }}
+        {{> settings_save_discard_widget section_name="privacy-setting" }}
         {{/if}}
     </div>
 

--- a/web/templates/settings/settings_save_discard_widget.hbs
+++ b/web/templates/settings/settings_save_discard_widget.hbs
@@ -6,7 +6,6 @@
     <div class="inline-block subsection-changes-discard">
         {{> ../components/action_button custom_classes="discard-button" variant="subtle" intent="neutral" label=(t "Discard") }}
     </div>
-    <div class="inline-block subsection-failed-status"><p class="hide"></p></div>
 </div>
 {{/if}}
 <div class="alert-notification {{#if section_name}}{{section_name}}-status{{/if}}"></div>

--- a/web/templates/settings/settings_save_discard_widget.hbs
+++ b/web/templates/settings/settings_save_discard_widget.hbs
@@ -9,6 +9,4 @@
     <div class="inline-block subsection-failed-status"><p class="hide"></p></div>
 </div>
 {{/if}}
-{{#if show_saving_indicator}}
-<div class="alert-notification {{section_name}}-status"></div>
-{{/if}}
+<div class="alert-notification {{#if section_name}}{{section_name}}-status{{/if}}"></div>

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -11,7 +11,7 @@
         <h3>{{t "Topic settings"}}
             {{> ../help_link_widget link="/help/topic-notifications" }}
         </h3>
-        {{> settings_save_discard_widget section_name="user-topics-settings" show_saving_indicator=true }}
+        {{> settings_save_discard_widget section_name="user-topics-settings" }}
         {{> filter_text_input id="user_topics_search" placeholder=(t 'Filter') aria_label=(t 'Filter invitations')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -45,7 +45,6 @@
                     <h3 class="stream_setting_subsection_title">
                         {{t "Settings" }}
                     </h3>
-                    <div class="stream_email_address_error alert-notification"></div>
                     {{> ../settings/settings_save_discard_widget section_name="channel-general-settings" show_save_discard_buttons=true}}
                 </div>
 

--- a/web/tests/lib/zjquery_element.cjs
+++ b/web/tests/lib/zjquery_element.cjs
@@ -417,9 +417,10 @@ exports.FakeJQuery = class extends RejectMissing {
         }
         return this;
     }
-    fadeOut() {
+    fadeOut(_duration, callback) {
         for (const element of this) {
             fake_element_state.get(element).shown = false;
+            callback.call();
         }
         return this;
     }

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -74,10 +74,7 @@ function createSaveButtons(subsection) {
     const $stub_save_button = $(".save-button");
     const $stub_discard_button = $(".discard-button");
     const $stub_save_button_text = $(".action-button-label");
-    $stub_save_button_header.set_find_results(
-        ".subsection-failed-status p",
-        $("<failed-status-stub>"),
-    );
+    $stub_save_button_header.set_find_results(".alert-notification", $("<failed-status-stub>"));
     $stub_save_button.set_closest_results(".settings-subsection-parent", $stub_save_button_header);
     $save_button_controls.set_parent($stub_save_button_header);
     $save_button_controls.set_find_results(".save-button", $stub_save_button);

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -204,10 +204,17 @@ function test_change_save_button_state() {
         assert.equal($save_button_text.text(), "translated: Saved");
     }
     {
-        settings_components.change_save_button_state($save_button_controls, "failed");
-        assert.equal($save_button_controls.visible(), true);
-        assert.equal($save_button.attr("data-status"), "failed");
-        assert.equal($save_button_text.text(), "translated: Save changes");
+        let error_callback_called = false;
+        function error_callback() {
+            error_callback_called = true;
+        }
+        settings_components.change_save_button_state(
+            $save_button_controls,
+            "failed",
+            error_callback,
+        );
+        assert.equal($save_button_controls.visible(), false);
+        assert.equal(error_callback_called, true);
     }
 }
 


### PR DESCRIPTION
This PR updates code to make error element, shown at the places where we use
save-discard buttons, consistent with how we show error for other places in settings
where we just show "Saving" indicator on change without any save/discard buttons.

So, this changes the error element design in organization, channel and group settings,
basically all the places where we show save/discard buttons.

https://chat.zulip.org/#narrow/channel/101-design/topic/failed.20status.20in.20settings/with/2457232

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| | Before | After |
| ------ | ------ | ------ |
| Organization settings light theme | <img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/a792dd0a-ccf4-4004-b8e6-67cf2401b586" /> | <img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/211107af-0e3e-42a1-b286-58c177a5e824" /> |
| Organization settings dark theme | <img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/926bb04e-6baa-4885-9ef4-5748ff01624a" /> | <img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/6b7a9fe8-4951-48df-968f-6a299bba0c21" /> |
| Channel settings light theme |<img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/609b8807-02b5-43e5-8e73-7ed10f4b699c" /> | <img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/3578a8ab-18df-426b-9499-012953c241c4" /> |
| Channel settings dark theme | <img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/aa3bc14c-76d7-4a55-bc35-b2f6fd6e9814" /> | <img width="1252" height="884" alt="image" src="https://github.com/user-attachments/assets/7d72d3ce-15f8-4cd5-891e-459e1eea38d1" /> |
| Group settings light theme | <img width="1252" height="570" alt="image" src="https://github.com/user-attachments/assets/3b5d394d-6ce7-44ec-85e3-27028a0748ea" /> | <img width="1252" height="570" alt="image" src="https://github.com/user-attachments/assets/daed40c8-2bec-42b7-b593-1f6398815973" /> |
| Group settings dark theme | <img width="1252" height="570" alt="image" src="https://github.com/user-attachments/assets/58e3b269-7d78-4198-819d-cb34623284c7" /> |<img width="1252" height="570" alt="image" src="https://github.com/user-attachments/assets/e5f0ad74-d6dc-4c12-9623-9198359f10a5" /> |




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
