### PR TITLE
email_notifications: Convert inline `![]()` images to links.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -2,7 +2,9 @@
 
 import base64
 import logging
+import os
 import re
+import urllib.parse
 import zoneinfo
 from collections import defaultdict
 from dataclasses import dataclass
@@ -109,6 +111,20 @@ def relative_to_full_url(fragment: lxml.html.HtmlElement, base_url: str) -> None
         inline_image_containers = fragment.find_class("message_inline_image")
         for container in inline_image_containers:
             container.drop_tree()
+
+    # `![alt](url)` markdown produces a bare <img class="inline-image">.
+    # These images can't be displayed in the emails as the request
+    # from the mail server can't be authenticated.
+    # We replace each <img> with a link to the original upload.
+    for img in fragment.cssselect("img.inline-image"):
+        original_src = img.get("data-original-src")
+        assert original_src is not None
+        link_text = img.get("alt") or urllib.parse.unquote(os.path.basename(original_src))
+        new_a = e.A(link_text, href=original_src, target="_blank")
+        new_a.tail = img.tail
+        parent = img.getparent()
+        assert parent is not None
+        parent.replace(img, new_a)
 
     fragment.make_links_absolute(base_url)
 

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1692,6 +1692,60 @@ class TestMessageNotificationEmails(ZulipTestCase):
         )
         self.assertEqual(actual_output, expected_output)
 
+        # `![alt](url)` markdown renders as a bare <img class="inline-image">,
+        # not wrapped in a `message_inline_image` div. We synthesize a link
+        # from `data-original-src` for emails. Verify different cases:
+
+        # Message with only an uploaded image as content.
+        test_data = (
+            '<p><img alt="chart.png" class="inline-image"'
+            ' data-original-content-type="image/png" data-original-dimensions="1900x1062"'
+            ' data-original-src="/user_uploads/{realm_id}/43/K8YE1_LG9a4n_oILSgtpoCf0/chart.png"'
+            ' src="/user_uploads/thumbnail/{realm_id}/43/K8YE1_LG9a4n_oILSgtpoCf0/chart.png/840x560.webp"></p>'
+        )
+        test_data = test_data.format(realm_id=zulip_realm.id)
+        actual_output = convert(test_data)
+        expected_output = (
+            '<div><p><a href="http://example.com/user_uploads/{realm_id}/43/K8YE1_LG9a4n_oILSgtpoCf0/chart.png"'
+            ' target="_blank">chart.png</a></p></div>'
+        )
+        expected_output = expected_output.format(realm_id=zulip_realm.id)
+        self.assertEqual(actual_output, expected_output)
+
+        # Uploaded image with surrounding text.
+        test_data = (
+            "<p>Before <br>"
+            ' <img alt="logo.png" class="inline-image"'
+            ' data-original-content-type="image/png" data-original-dimensions="385x156"'
+            ' data-original-src="/user_uploads/{realm_id}/dd/5_wtVM7mYODx9_m5vXHoE92_/logo.png"'
+            ' src="/user_uploads/thumbnail/{realm_id}/dd/5_wtVM7mYODx9_m5vXHoE92_/logo.png/840x560.webp"><br>'
+            " after</p>"
+        )
+        test_data = test_data.format(realm_id=zulip_realm.id)
+        actual_output = convert(test_data)
+        expected_output = (
+            '<div><p>Before <br> <a href="http://example.com/user_uploads/{realm_id}/dd/5_wtVM7mYODx9_m5vXHoE92_/logo.png"'
+            ' target="_blank">logo.png</a><br> after</p></div>'
+        )
+        expected_output = expected_output.format(realm_id=zulip_realm.id)
+        self.assertEqual(actual_output, expected_output)
+
+        # Empty `alt` falls back to the URL-decoded basename of `data-original-src`.
+        test_data = (
+            '<p><img alt="" class="inline-image"'
+            ' data-original-content-type="image/png" data-original-dimensions="1900x1062"'
+            ' data-original-src="/user_uploads/{realm_id}/ab/cd/My%20Chart.png"'
+            ' src="/user_uploads/thumbnail/{realm_id}/ab/cd/My%20Chart.png/840x560.webp"></p>'
+        )
+        test_data = test_data.format(realm_id=zulip_realm.id)
+        actual_output = convert(test_data)
+        expected_output = (
+            '<div><p><a href="http://example.com/user_uploads/{realm_id}/ab/cd/My%20Chart.png"'
+            ' target="_blank">My Chart.png</a></p></div>'
+        )
+        expected_output = expected_output.format(realm_id=zulip_realm.id)
+        self.assertEqual(actual_output, expected_output)
+
     def test_spoilers_in_html_emails(self) -> None:
         test_data = '<div class="spoiler-block"><div class="spoiler-header">\n\n<p><a>header</a> text</p>\n</div><div class="spoiler-content" aria-hidden="true">\n\n<p>content</p>\n</div></div>\n\n<p>outside spoiler</p>'
         fragment = lxml.html.fromstring(test_data)


### PR DESCRIPTION
In emails, thumbnails were displaying an image of a 403 http code "You are not authorized to see this image".

This PR fixes the bug.


**How changes were tested:**

Added unit tests + did manual testing.

**Screenshots and screen captures:**

### Before:
<img width="357" height="594" alt="Screenshot 2026-05-13 at 5 53 43 PM" src="https://github.com/user-attachments/assets/42cc6ae2-e83a-4cea-84df-78006ba20b18" />

### After:
<img width="561" height="308" alt="Screenshot 2026-05-13 at 5 49 57 PM" src="https://github.com/user-attachments/assets/e84950bc-0206-47ea-badd-422c407661da" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
