### PR TITLE
settings: Fix x button and arrow bugs in date custom profile field

### DIFF
--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -376,12 +376,15 @@ export function initialize_custom_date_type_fields(
         });
 
     $(element_id)
-        .find<HTMLInputElement>(".custom_user_field input.datepicker")
+        .find<HTMLInputElement>(".custom_user_field input.date-field-alt-input")
         .on("mouseenter", function () {
+            const $remove_date = $(this)
+                .closest(".settings-profile-user-field")
+                .find(".remove_date");
             if ($(this).val()!.length <= 0) {
-                $(this).parent().find(".remove_date").hide();
+                $remove_date.removeClass("visible");
             } else {
-                $(this).parent().find(".remove_date").show();
+                $remove_date.addClass("visible");
             }
         });
 


### PR DESCRIPTION
When a date custom profile field has no date selected, the x button
was still showing up. It should only appear when there is actually
a date to clear.

This was happening for two reasons:
1. The remove_date button had no display: none CSS rule in the date
  field context, so it was always visible.
2. The mouseenter handler was on the hidden flatpickr input, so it
  never actually fired for the user.

Fixed by hiding the button via CSS by default, and pointing the
mouseenter handler to the visible .date-field-alt-input instead.

Also fixed a small issue where an arrow was appearing at the bottom
of the date picker unnecessarily.

How changes were tested:

Tested manually on Chrome DevTools mobile emulator.
Verified x button is hidden when no date is selected.
Verified x button appears correctly when a date is selected.
Verified arrow no longer appears at bottom of date picker.

Also fixed a small issue where an arrow was appearing at the 
bottom of the date picker unnecessarily.

 Self-Review Checklist
- [x] Self-reviewed the changes for clarity and maintainability
(variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.
- [x] Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans.
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flow

**Before:**
<img width="590" height="241" alt="Screenshot 2026-05-16 142041" src="https://github.com/user-attachments/assets/f18444aa-a309-4ef6-9b4b-e73cfffd441f" />

**After:**
<img width="589" height="245" alt="Screenshot 2026-05-16 142057" src="https://github.com/user-attachments/assets/0d22b9da-9843-4c7f-9832-a8fe67344648" />