### PR TITLE
[ai] dev_settings: Switch topic summarization to Groq's OpenAI-compatible API.

### DIFF
--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -230,7 +230,8 @@ DEMO_ORG_DEADLINE_DAYS = 30
 if external_host_env is None and not IS_DEV_DROPLET:
     USING_CAPTCHA = True
 
-TOPIC_SUMMARIZATION_MODEL = "groq/llama-3.3-70b-versatile"
+TOPIC_SUMMARIZATION_MODEL = "llama-3.3-70b-versatile"
+TOPIC_SUMMARIZATION_API_BASE = "https://api.groq.com/openai/v1"
 # Defaults based on groq's pricing for Llama 3.3 70B Versatile 128k.
 # https://groq.com/pricing/
 OUTPUT_COST_PER_GIGATOKEN = 590


### PR DESCRIPTION
The `groq/llama-3.3-70b-versatile` model name was litellm-style
provider routing. After a2fb7b672a replaced litellm with the OpenAI
Python SDK, dev needs the bare model name plus an explicit
`TOPIC_SUMMARIZATION_API_BASE` pointing at Groq's OpenAI-compatible
endpoint, so that the OpenAI client actually reaches Groq.

## Testing

- [x] Set `topic_summarization_api_key` in `zproject/dev-secrets.conf`
      to a Groq API key, started the dev server, and verified topic
      summarization works from the UI.

## Self-review

- [x] Each commit is a minimal coherent idea
- [x] Commit message explains why, not what
- [x] No debugging code or unnecessary comments
- [x] Follows existing patterns (mirrors the Hugging Face example in
      `zproject/prod_settings_template.py`)