### PR TITLE
message: Apply edit/move button classes on re-render.

### DIFF
--- a/web/src/message_list_hover.ts
+++ b/web/src/message_list_hover.ts
@@ -49,6 +49,31 @@ export function message_hover($message_row: JQuery): void {
     change_edit_content_button($message_row, message);
 }
 
+export function reapply_hover_on_row_replace(
+    $old_row: JQuery,
+    $new_row: JQuery,
+    message: Message,
+): void {
+    // When a hovered message row is re-rendered (e.g., after an edit),
+    // the browser does not refire `mouseover` for the replacement row
+    // even if the cursor is still positioned over it. Without this
+    // transfer, the new row would be missing the
+    // `can-edit-content` / `can-move-message` classes that the hover
+    // handler normally applies, and `$current_message_hover` would
+    // still point at the detached old row.
+    if ($current_message_hover === undefined) {
+        return;
+    }
+    if (rows.id($current_message_hover) !== rows.id($old_row)) {
+        return;
+    }
+    $current_message_hover = $new_row;
+    if (!message.sent_by_me || message.locally_echoed) {
+        return;
+    }
+    change_edit_content_button($new_row, message);
+}
+
 function change_edit_content_button($message_row: JQuery, message: Message): void {
     // But the message edit hover icon is determined by whether the message is still editable
     const is_content_editable = message_edit.is_content_editable(message);

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -21,6 +21,7 @@ import {$t} from "./i18n.ts";
 import * as internal_url from "./internal_url.ts";
 import * as message_edit from "./message_edit.ts";
 import type {MessageList} from "./message_list.ts";
+import * as message_list_hover from "./message_list_hover.ts";
 import * as message_list_tooltips from "./message_list_tooltips.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_reminder from "./message_reminder.ts";
@@ -1716,6 +1717,8 @@ export class MessageListView {
         }
         this._post_process($rendered_msg);
         $row.replaceWith($rendered_msg);
+
+        message_list_hover.reapply_hover_on_row_replace($row, $rendered_msg, message_container.msg);
 
         // If this list not currently displayed, we don't need to select the message.
         if (was_selected && this.list === message_lists.current) {


### PR DESCRIPTION
When a message is re-rendered, we currently don't apply the edit/move button classes to the newly created DOM element.

Now, when a message is re-rendered, the edit/move button classes are applied.

Fixes: [#issues > need to rehover to see edit message after editing a message](https://chat.zulip.org/#narrow/channel/9-issues/topic/need.20to.20rehover.20to.20see.20edit.20message.20after.20editing.20a.20message/with/2448648)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**


| Before | After |
| ------ | ------ |
| ![image-after](https://github.com/user-attachments/assets/7b2a4862-91de-4886-9252-9202c7cde942) | ![image-after](https://github.com/user-attachments/assets/042ea2fd-f056-47a0-9dfb-236d9fe6cbad)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
