### PR TITLE
modals: Correct close-button alignment.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -685,6 +685,9 @@
     --length-user-status-circle-popover-menu: 8px;
     --length-user-popover-menu-avatar: 64px;
 
+    /* Buttons */
+    --icon-button-padding: 0.375em;
+
     /* Overlay heights for streams modal */
     --overlay-container-height: 95vh;
     --overlay-container-max-height: 1000px;

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -424,7 +424,7 @@
     aspect-ratio: 1;
     font-size: var(--base-font-size-px);
     background-color: transparent; /* Override button default background color */
-    padding: 0.375em;
+    padding: var(--icon-button-padding);
     cursor: pointer;
     border: none;
     border-radius: 4px;

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -264,8 +264,12 @@
         line-height: 1;
     }
 
+    .tab-switcher {
+        margin: 2px;
+    }
+
     .tabcontent {
-        margin: 1px 5px 0;
+        margin: 1px 2.5px 0 1.5px;
     }
 
     #profile-tab {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -65,7 +65,7 @@
        right padding and the column to its left accounts for the
        space of modal close button icon width - right padding. */
     grid-template:
-        ". modal-header-content modal-close-button modal-close-button" 2.75em /* 44px at 16px/1em */
+        ". modal-header-content modal-close-button ." 2.75em /* 44px at 16px/1em */
         ". modal-header-content .                  ." minmax(0, auto)
         ". modal-tab-switcher   modal-tab-switcher ." minmax(0, auto)
         / 1em minmax(0, 1fr) minmax(0, auto) 1em; /* 16px at 16px/1em */
@@ -142,6 +142,10 @@
 .modal__close {
     grid-area: modal-close-button;
     align-self: center;
+    /* Offset the close button to the right so that the
+       X lines up with the other visual elements, but
+       the padded clickable area is maintained. */
+    margin-right: calc(var(--icon-button-padding) * -1);
 
     &:focus-visible {
         outline-offset: -2px !important;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -469,7 +469,7 @@ select.settings_select {
     But here the buttons have bottom padding of 0.375em and thus there is
     already some extra space between this and the section below it, so we
     reduce the bottom margin by 0.375em. */
-    margin-bottom: 0.875em;
+    margin-bottom: calc(1.25em - var(--icon-button-padding));
 
     .modal-field-label {
         margin-bottom: 0;


### PR DESCRIPTION
This PR simplifies the grid definitions for the modal header, including the placement of the modal-close button.

To maintain the clickable area while keeping the visible `X` portion of the icon correctly aligned, the close button is offset to the right by the same value as the padding on icon-buttons. A preparatory commit introduces that variable, and adjusts one other place in the codebase where there's a comparable offset adjustment.

Additionally, a fiddly little commit fixes up the alignment on user-profile elements, though that area should be getting a proper redesign soon.

Fixes: [#issues > modal "x" button alignment](https://chat.zulip.org/#narrow/channel/9-issues/topic/modal.20.22x.22.20button.20alignment/with/2457535)


_Single-line topics, with and without the grid overlay:_

| Before | After |
| --- | --- |
| <img width="1400" height="1600" alt="modal-close-before--grid" src="https://github.com/user-attachments/assets/2df5c1f0-8454-412e-a3af-4d9146ea58f1" /> | <img width="1400" height="1600" alt="modal-close-after--grid" src="https://github.com/user-attachments/assets/91157c47-3478-4a44-aafe-c69d0cb020e2" /> |
| <img width="1400" height="1600" alt="modal-close-before" src="https://github.com/user-attachments/assets/2186b4ff-6461-4725-8f6b-305805e378ec" /> | <img width="1400" height="1600" alt="modal-close-after" src="https://github.com/user-attachments/assets/8ce4569c-25df-424c-93f7-9fdf01f83c05" /> |

_Multiline topics, which is the problem in the original report linked to above:_

| Before | After |
| --- | --- |
| <img width="1180" height="1600" alt="modal-close-two-line-topic-before" src="https://github.com/user-attachments/assets/a281cebc-3b03-42db-b15e-b011195506eb" /> | <img width="1180" height="1600" alt="modal-close-two-line-topic-after" src="https://github.com/user-attachments/assets/eb65bc95-901b-4026-b00d-344917f660a7" /> |


**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>