### PR TITLE
message_edit_history: Add option to delete prior versions.

### DIFF
--- a/api_docs/delete-message-edit-history-content-revisions.md
+++ b/api_docs/delete-message-edit-history-content-revisions.md
@@ -1,0 +1,31 @@
+{generate_api_header(/messages/{message_id}/edit_history/delete_content_revisions:post)}
+
+## Usage examples
+
+{start_tabs}
+
+{generate_code_example(python)|/messages/{message_id}/edit_history/delete_content_revisions:post|example}
+
+{generate_code_example(javascript)|/messages/{message_id}/edit_history/delete_content_revisions:post|example}
+
+{tab|curl}
+
+{generate_code_example(curl)|/messages/{message_id}/edit_history/delete_content_revisions:post|example}
+
+{end_tabs}
+
+## Parameters
+
+{generate_api_arguments_table|zulip.yaml|/messages/{message_id}/edit_history/delete_content_revisions:post}
+
+{generate_parameter_description(/messages/{message_id}/edit_history/delete_content_revisions:post)}
+
+## Response
+
+{generate_return_values_table|zulip.yaml|/messages/{message_id}/edit_history/delete_content_revisions:post}
+
+{generate_response_description(/messages/{message_id}/edit_history/delete_content_revisions:post)}
+
+#### Example response(s)
+
+{generate_code_example|/messages/{message_id}/edit_history/delete_content_revisions:post|fixture}

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -12,6 +12,7 @@
 * [Fetch a single message](/api/get-message)
 * [Check if messages match a narrow](/api/check-messages-match-narrow)
 * [Get a message's edit history](/api/get-message-history)
+* [Delete a message's prior content revisions](/api/delete-message-edit-history-content-revisions)
 * [Update personal message flags](/api/update-message-flags)
 * [Update personal message flags for narrow](/api/update-message-flags-for-narrow)
 * [Mark all messages as read](/api/mark-all-as-read)

--- a/api_docs/unmerged.d/ZF-bbdbb7.md
+++ b/api_docs/unmerged.d/ZF-bbdbb7.md
@@ -1,0 +1,14 @@
+* [`POST /messages/{message_id}/edit_history/delete_content_revisions`](/api/delete-message-edit-history-content-revisions):
+  New endpoint to delete all prior content revisions from a message's
+  edit history. The record that the message was edited is preserved.
+  Users with permission to delete a message also have permission to
+  delete its edit history; the realm's message deletion time limit does
+  not apply to this endpoint.
+* [`GET /messages/{message_id}/history`](/api/get-message-history):
+  Added `revision_deleted_by` (integer user ID) and `revision_deleted_at`
+  (Unix timestamp) fields to history snapshot objects. These fields are
+  present on content-edit entries whose previous content has been
+  removed via the new endpoint above.
+* [`GET /events`](/api/get-events): A new `message_edit_history` event
+  with `op: "delete"` is sent when content revisions are deleted from
+  a message's edit history.

--- a/starlight_help/src/content/docs/view-a-messages-edit-history.mdx
+++ b/starlight_help/src/content/docs/view-a-messages-edit-history.mdx
@@ -27,6 +27,22 @@ import MessageEditHistoryIntro from "../include/_MessageEditHistoryIntro.mdx";
   </TabItem>
 </Tabs>
 
+## Delete a message's edit history
+
+Users who have permission to [delete a message](/help/delete-a-message) can
+also delete its edit history. This removes the previous versions of the
+message content, while keeping a record that the edit history was deleted.
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <Steps>
+      1. Open the message's edit history.
+      1. Click **Delete prior versions of this message**.
+      1. Click **Confirm**.
+    </Steps>
+  </TabItem>
+</Tabs>
+
 ## Related articles
 
 * [Edit a message](/help/edit-a-message)

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -1,15 +1,20 @@
 import {$} from "jquery";
+import _ from "lodash";
 import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
+import render_confirm_delete_edit_history from "../templates/confirm_dialog/confirm_delete_edit_history.hbs";
 import render_message_edit_history from "../templates/message_edit_history.hbs";
 import render_message_history_overlay from "../templates/message_history_overlay.hbs";
 
 import {exit_overlay} from "./browser_history.ts";
 import * as channel from "./channel.ts";
+import * as confirm_dialog from "./confirm_dialog.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
+import * as message_delete from "./message_delete.ts";
 import * as message_lists from "./message_lists.ts";
+import * as message_store from "./message_store.ts";
 import type {Message} from "./message_store.ts";
 import * as messages_overlay_ui from "./messages_overlay_ui.ts";
 import * as overlays from "./overlays.ts";
@@ -45,6 +50,7 @@ type EditHistoryEntry = {
     prev_stream: string | undefined;
     prev_stream_id: number | undefined;
     new_stream: string | undefined;
+    revision_deleted_by_mention_html: string | undefined;
 };
 
 const server_message_history_schema = z.object({
@@ -61,6 +67,7 @@ const server_message_history_schema = z.object({
             prev_content: z.optional(z.string()),
             prev_rendered_content: z.optional(z.string()),
             content_html_diff: z.optional(z.string()),
+            revision_deleted_by: z.optional(z.number()),
         }),
     ),
 });
@@ -114,22 +121,10 @@ function hide_loading_indicator(): void {
     );
 }
 
-export function fetch_and_render_message_history(message: Message): void {
-    assert(message_lists.current !== undefined);
-    const message_container = message_lists.current.view.message_containers.get(message.id);
-    assert(message_container !== undefined);
+function refresh_edit_history(message: Message): void {
     const move_history_only =
         realm.realm_message_edit_history_visibility_policy ===
         message_edit_history_visibility_policy_values.moves_only.code;
-    $("#message-edit-history-overlay-container").html(
-        render_message_history_overlay({
-            moved: message_container.moved,
-            edited: message_container.edited,
-            move_history_only,
-        }),
-    );
-    $("#message-edit-history-overlay-container").attr("data-message-id", message.id);
-    open_overlay();
     show_loading_indicator();
     void channel.get({
         url: "/json/messages/" + message.id + "/history",
@@ -149,6 +144,9 @@ export function fetch_and_render_message_history(message: Message): void {
 
             const content_edit_history: EditHistoryEntry[] = [];
             let prev_stream_item: EditHistoryEntry | null = null;
+            const first_deleted_entry = data.message_history.find(
+                (e) => e.revision_deleted_by !== undefined,
+            );
             for (const [index, msg] of data.message_history.entries()) {
                 // Format times and dates nicely for display
                 const time = new Date(msg.timestamp * 1000);
@@ -173,15 +171,25 @@ export function fetch_and_render_message_history(message: Message): void {
                 let prev_stream_id;
                 let initial_entry_for_move_history = false;
 
+                const later_entries = data.message_history.slice(index + 1);
+                const has_later_content_edit = later_entries.some(
+                    (e) => e.prev_content !== undefined,
+                );
+                const has_later_deleted_edit = later_entries.some(
+                    (e) => e.revision_deleted_by !== undefined,
+                );
                 if (index === 0) {
+                    const history_deleted = data.message_history.some(
+                        (entry) => entry.revision_deleted_by !== undefined,
+                    );
                     edited_by_notice = $t({defaultMessage: "Posted by {full_name}"}, {full_name});
                     if (move_history_only) {
                         // If message history is limited to moves only, then we
                         // display the original topic and channel for the message.
                         initial_entry_for_move_history = true;
                         new_topic_display_name = util.get_final_topic_display_name(msg.topic);
-                    } else {
-                        // Otherwise, we display the original message content.
+                    } else if (!history_deleted) {
+                        // Only show content if history has not been deleted.
                         body_to_render = msg.rendered_content;
                     }
                 } else if (msg.prev_topic !== undefined && msg.prev_content) {
@@ -220,11 +228,35 @@ export function fetch_and_render_message_history(message: Message): void {
                     if (prev_stream_item !== null) {
                         prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
                     }
-                } else {
-                    // just a content edit
+                } else if (msg.revision_deleted_by !== undefined) {
+                    edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
+                    // Show current content only for the most recent deleted edit
+                    // (no later content edit or later deleted edit supersedes it).
+                    if (!has_later_content_edit && !has_later_deleted_edit) {
+                        body_to_render = msg.rendered_content;
+                    }
+                } else if (msg.content_html_diff !== undefined) {
                     edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
                     body_to_render = msg.content_html_diff;
+                } else {
+                    continue;
                 }
+                let revision_deleted_by_mention_html: string | undefined;
+                if (
+                    msg.revision_deleted_by !== undefined &&
+                    (has_later_content_edit || has_later_deleted_edit)
+                ) {
+                    const deleted_by_full_name = people.get_user_by_id_assert_valid(
+                        msg.revision_deleted_by,
+                    ).full_name;
+                    revision_deleted_by_mention_html = `<span class="user-mention silent" data-user-id="${msg.revision_deleted_by}">${_.escape(deleted_by_full_name)}</span>`;
+                } else if (index === 0 && first_deleted_entry !== undefined) {
+                    const deleted_by_user_id = first_deleted_entry.revision_deleted_by!;
+                    const deleted_by_full_name =
+                        people.get_user_by_id_assert_valid(deleted_by_user_id).full_name;
+                    revision_deleted_by_mention_html = `<span class="user-mention silent" data-user-id="${deleted_by_user_id}">${_.escape(deleted_by_full_name)}</span>`;
+                }
+
                 const item: EditHistoryEntry = {
                     initial_entry_for_move_history,
                     edited_at_time,
@@ -242,6 +274,7 @@ export function fetch_and_render_message_history(message: Message): void {
                     prev_stream,
                     prev_stream_id,
                     new_stream: undefined,
+                    revision_deleted_by_mention_html,
                 };
 
                 if (msg.prev_stream) {
@@ -289,6 +322,18 @@ export function fetch_and_render_message_history(message: Message): void {
             });
             $("#message-history-overlay").attr("data-message-id", message.id);
             hide_loading_indicator();
+            // Hide delete button if history was already deleted
+            // and no new content edits have happened since.
+            // Skip index 0 (Posted by entry) as it always has body_to_render.
+            const already_deleted = data.message_history.some(
+                (entry) => entry.revision_deleted_by !== undefined,
+            );
+            const has_new_content_edit_after_deletion = data.message_history.some(
+                (entry) => entry.prev_content !== undefined,
+            );
+            if (already_deleted && !has_new_content_edit_after_deletion) {
+                $(".delete-edit-history-button").hide();
+            }
             $("#message-history-overlay .overlay-messages-list").append($(rendered_list_html));
 
             // Pass the history through rendered_markdown.ts
@@ -333,6 +378,27 @@ export function fetch_and_render_message_history(message: Message): void {
     });
 }
 
+export function fetch_and_render_message_history(message: Message): void {
+    assert(message_lists.current !== undefined);
+    const message_container = message_lists.current.view.message_containers.get(message.id);
+    assert(message_container !== undefined);
+    const move_history_only =
+        realm.realm_message_edit_history_visibility_policy ===
+        message_edit_history_visibility_policy_values.moves_only.code;
+    $("#message-edit-history-overlay-container").html(
+        render_message_history_overlay({
+            moved: message_container.moved,
+            edited: message_container.edited,
+            move_history_only,
+            can_delete_history:
+                message_container.edited && message_delete.get_deletability(message),
+        }),
+    );
+    $("#message-edit-history-overlay-container").attr("data-message-id", message.id);
+    open_overlay();
+    refresh_edit_history(message);
+}
+
 export function open_overlay(): void {
     if (overlays.any_active()) {
         return;
@@ -349,6 +415,23 @@ export function open_overlay(): void {
 
 export function handle_keyboard_events(event_key: string): void {
     messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
+}
+
+export function handle_message_edit_history_delete_event(message_id: number): void {
+    if (!overlays.message_edit_history_open()) {
+        return;
+    }
+    if (
+        $("#message-edit-history-overlay-container").attr("data-message-id") !== String(message_id)
+    ) {
+        return;
+    }
+    const message = message_store.get(message_id);
+    if (message === undefined) {
+        return;
+    }
+    $("#message-history-overlay .overlay-messages-list").empty();
+    refresh_edit_history(message);
 }
 
 export function initialize(): void {
@@ -432,5 +515,34 @@ export function initialize(): void {
 
     $("body").on("click", "#message-history-overlay .message_edit_history_content", (e) => {
         messages_overlay_ui.handle_overlay_media_click(e, "message_edit_history");
+    });
+
+    $("body").on("click", ".delete-edit-history-button", () => {
+        const message_id = $("#message-edit-history-overlay-container").attr("data-message-id");
+        assert(message_id !== undefined);
+
+        confirm_dialog.launch({
+            modal_title_html: $t_html({defaultMessage: "Delete prior versions of this message?"}),
+            modal_content_html: render_confirm_delete_edit_history({}),
+            on_click() {
+                void channel.post({
+                    url: "/json/messages/" + message_id + "/edit_history/delete_content_revisions",
+                    success() {
+                        const message = message_store.get(Number.parseInt(message_id, 10));
+                        if (message !== undefined) {
+                            $("#message-history-overlay .overlay-messages-list").empty();
+                            refresh_edit_history(message);
+                        }
+                    },
+                    error(xhr) {
+                        ui_report.error(
+                            $t_html({defaultMessage: "Error deleting message edit history."}),
+                            xhr,
+                            $("#message-history-overlay #message-history-error"),
+                        );
+                    },
+                });
+            },
+        });
     });
 }

--- a/web/src/server_event_types.ts
+++ b/web/src/server_event_types.ts
@@ -96,6 +96,19 @@ export const update_message_event_schema = z.object({
 });
 export type UpdateMessageEvent = z.output<typeof update_message_event_schema>;
 
+export const message_edit_history_delete_event_schema = z.object({
+    id: z.number(),
+    type: z.literal("message_edit_history"),
+    op: z.literal("delete"),
+    message_id: z.number(),
+    scope: z.literal("all_content_revisions"),
+    user_id: z.number(),
+    timestamp: z.number(),
+});
+export type MessageEditHistoryDeleteEvent = z.output<
+    typeof message_edit_history_delete_event_schema
+>;
+
 export const message_details_schema = z.record(
     z.coerce.number<string>(),
     z.intersection(

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -29,6 +29,7 @@ import * as information_density from "./information_density.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import * as linkifiers from "./linkifiers.ts";
 import * as message_edit from "./message_edit.ts";
+import * as message_edit_history from "./message_edit_history.ts";
 import * as message_events from "./message_events.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_live_update from "./message_live_update.ts";
@@ -219,6 +220,19 @@ export function dispatch_normal_event(event) {
                 pm_list.update_private_messages();
             }
 
+            break;
+        }
+
+        case "message_edit_history": {
+            switch (event.op) {
+                case "delete":
+                    message_edit_history.handle_message_edit_history_delete_event(event.message_id);
+                    break;
+                default:
+                    blueslip.error("Unexpected op for message_edit_history event", {
+                        op: event.op,
+                    });
+            }
             break;
         }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -819,6 +819,10 @@ input.settings_text_input {
     }
 
     .overlay-messages-header {
+        .delete-edit-history-button {
+            display: block;
+            margin: 6px auto 0;
+        }
         padding-top: 4px;
         padding-bottom: 8px;
         text-align: center;

--- a/web/styles/message_edit_history.css
+++ b/web/styles/message_edit_history.css
@@ -12,6 +12,12 @@
     }
 
     .message_edit_history_content {
+        .message_edit_history_deleted_notice {
+            color: var(--color-text-item);
+            font-style: italic;
+            font-weight: 300;
+        }
+
         .highlight_text_inserted {
             color: var(--color-message-edit-history-text-inserted);
             background-color: var(

--- a/web/templates/confirm_dialog/confirm_delete_edit_history.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_edit_history.hbs
@@ -1,0 +1,3 @@
+<p>
+    {{t "Information about message edits will still be shown, but old message content will be removed." }}
+</p>

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -55,6 +55,11 @@
                             {{ rendered_markdown body_to_render}}
                         </div>
                         {{/if}}
+                        {{#if revision_deleted_by_mention_html}}
+                        <div class="message_content rendered_markdown message_edit_history_content">
+                            <p class="message_edit_history_deleted_notice">{{t "Content deleted from this message's history by" }} {{{revision_deleted_by_mention_html}}}.</p>
+                        </div>
+                        {{/if}}
                         {{/if}}
                     </div>
                 </div>

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -15,6 +15,14 @@
                     <h1>{{t "Message move history" }}</h1>
                 {{/if}}
                 {{/if}}
+                {{#if can_delete_history}}
+                {{> components/action_button
+                  label=(t "Delete prior versions of this message")
+                  variant="subtle"
+                  intent="danger"
+                  custom_classes="delete-edit-history-button"
+                  }}
+                {{/if}}
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -43,6 +43,7 @@ mock_esm("../src/compose_validate", {
     validate_and_update_send_button_status: noop,
     warn_if_guest_in_dm_recipient: noop,
 });
+const message_edit_history = mock_esm("../src/message_edit_history");
 const message_events = mock_esm("../src/message_events", {
     update_views_filtered_on_message_property: noop,
     update_current_view_for_topic_visibility: noop,
@@ -1580,6 +1581,15 @@ run_test("delete_message", ({override}) => {
     assert_same(args.opts.max_removed_msg_id, 1337);
 });
 
+run_test("message_edit_history", ({override}) => {
+    const event = event_fixtures.message_edit_history__delete;
+    const stub = make_stub();
+    override(message_edit_history, "handle_message_edit_history_delete_event", stub.f);
+    dispatch(event);
+    const args = stub.get_args("message_id");
+    assert_same(args.message_id, event.message_id);
+});
+
 run_test("delete_message_private", ({override}) => {
     const user4 = make_user({user_id: 4, email: "user4@example.com", full_name: "User 4"});
     people.add_active_user(user4);
@@ -1733,6 +1743,8 @@ run_test("server_event_dispatch_op_errors", () => {
     });
     blueslip.expect("error", "Unexpected event type user_group/other");
     server_events_dispatch.dispatch_normal_event({type: "user_group", op: "other"});
+    blueslip.expect("error", "Unexpected op for message_edit_history event");
+    server_events_dispatch.dispatch_normal_event({type: "message_edit_history", op: "other"});
 });
 
 run_test("realm_user_settings_defaults", ({override}) => {

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -261,6 +261,15 @@ exports.fixtures = {
         type: "invites_changed",
     },
 
+    message_edit_history__delete: {
+        type: "message_edit_history",
+        op: "delete",
+        message_id: 1,
+        scope: "all_content_revisions",
+        user_id: 5,
+        timestamp: 1530129122,
+    },
+
     message_edit_typing__start: {
         type: "typing_edit_message",
         op: "start",

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
+import orjson
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q, QuerySet
@@ -102,6 +103,7 @@ from zerver.models import (
     UserTopic,
 )
 from zerver.models.groups import get_realm_system_groups_name_dict
+from zerver.models.realms import MessageEditHistoryVisibilityPolicyEnum
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream_by_id_in_realm
 from zerver.models.users import ResolvedTopicNoticeAutoReadPolicyEnum, get_system_bot
 from zerver.tornado.django_api import send_event_on_commit
@@ -1854,6 +1856,52 @@ def check_update_message(
             notify_stream_is_recently_active_update(new_stream, is_stream_active)
 
     return updated_message_result
+
+
+@transaction.atomic(durable=True)
+def do_delete_message_edit_history(
+    message: Message,
+    acting_user: UserProfile,
+) -> None:
+    """Strip prev_content from all content-edit entries and record who deleted
+    them and when. Move-only entries are left untouched."""
+    if message.edit_history is None:  # nocoverage
+        return
+
+    deletion_timestamp = datetime_to_timestamp(timezone_now())
+    edit_history: list[EditHistoryEvent] = orjson.loads(message.edit_history)
+
+    for entry in edit_history:
+        if "prev_content" not in entry:
+            continue
+        entry.pop("prev_content")
+        entry.pop("prev_rendered_content", None)
+        entry.pop("prev_rendered_content_version", None)
+        entry["revision_deleted_by"] = acting_user.id
+        entry["revision_deleted_at"] = deletion_timestamp
+
+    message.edit_history = orjson.dumps(edit_history).decode()
+    message.save(update_fields=["edit_history"])
+
+    # Only notify users who are allowed to view edit history. Since
+    # message_edit_history_visibility_policy is realm-wide, a single check
+    # determines whether any event should be sent at all.
+    if (
+        acting_user.realm.message_edit_history_visibility_policy
+        == MessageEditHistoryVisibilityPolicyEnum.none.value
+    ):
+        return  # nocoverage
+
+    event: dict[str, object] = {
+        "type": "message_edit_history",
+        "op": "delete",
+        "message_id": message.id,
+        "scope": "all_content_revisions",
+        "user_id": acting_user.id,
+        "timestamp": deletion_timestamp,
+    }
+    user_ids = event_recipient_ids_for_action_on_messages([message.id], message.is_channel_message)
+    send_event_on_commit(acting_user.realm, event, list(user_ids))
 
 
 @transaction.atomic(durable=True)

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -46,6 +46,7 @@ from zerver.lib.event_types import (
     LegacyPresenceEvent,
     LogoData,
     MessageContentEditLimitSecondsData,
+    MessageEditHistoryDeleteEvent,
     MessageEvent,
     ModernPresenceEvent,
     MutedTopicsEvent,
@@ -194,6 +195,7 @@ check_draft_update = make_checker(DraftsUpdateEvent)
 check_heartbeat = make_checker(HeartbeatEvent)
 check_invites_changed = make_checker(InvitesChangedEvent)
 check_message = make_checker(MessageEvent)
+check_message_edit_history_delete = make_checker(MessageEditHistoryDeleteEvent)
 check_muted_users = make_checker(MutedUsersEvent)
 check_navigation_view_add = make_checker(NavigationViewAddEvent)
 check_navigation_view_remove = make_checker(NavigationViewRemoveEvent)

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -265,6 +265,15 @@ class MessageEvent(BaseEvent):
     message: MessageFieldForMessageEvent
 
 
+class MessageEditHistoryDeleteEvent(BaseEvent):
+    type: Literal["message_edit_history"]
+    op: Literal["delete"]
+    message_id: int
+    scope: Literal["all_content_revisions"]
+    user_id: int
+    timestamp: int
+
+
 class MutedTopicsEvent(BaseEvent):
     type: Literal["muted_topics"]
     muted_topics: list[list[str | int]]

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1815,6 +1815,9 @@ def apply_event(
         # from scratch.  Definitely don't need to re-query everything,
         # but this case is likely rare enough that it's reasonable to do so.
         state["raw_recent_private_conversations"] = get_recent_private_conversations(user_profile)
+    elif event["type"] == "message_edit_history":
+        # The client fetches edit history on demand; no state to update here.
+        pass
     elif event["type"] == "reaction":
         # The client will get the message with the reactions directly
         pass

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -351,7 +351,7 @@ def messages_for_ids(
                     item["topic"], item["prev_topic"]
                 ):
                     last_moved_timestamp = max(last_moved_timestamp, item["timestamp"])
-                if "prev_content" in item:
+                if "prev_content" in item or "revision_deleted_by" in item:
                     last_edit_timestamp = max(last_edit_timestamp, item["timestamp"])
             if last_moved_timestamp != 0:
                 msg_dict["last_moved_timestamp"] = last_moved_timestamp

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -118,6 +118,9 @@ class EditHistoryEvent(TypedDict, total=False):
     prev_content: str
     prev_rendered_content: str | None
     prev_rendered_content_version: int | None
+    # Set on content-edit entries when an administrator deletes their content.
+    revision_deleted_by: int
+    revision_deleted_at: int
 
 
 class FormattedEditHistoryEvent(TypedDict, total=False):
@@ -137,6 +140,9 @@ class FormattedEditHistoryEvent(TypedDict, total=False):
     prev_rendered_content: str | None
     rendered_content: str | None
     content_html_diff: str
+    # Set on content-edit entries when an administrator deletes their content.
+    revision_deleted_by: int
+    revision_deleted_at: int
 
 
 class UserTopicDict(TypedDict, total=False):

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -14,6 +14,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.channel_folders import check_add_channel_folder
 from zerver.actions.create_user import do_create_user
+from zerver.actions.message_edit import check_update_message
 from zerver.actions.presence import update_user_presence
 from zerver.actions.reactions import do_add_reaction
 from zerver.actions.realm_domains import do_add_realm_domain
@@ -124,6 +125,26 @@ def iago_message_id() -> dict[str, object]:
     return {
         "message_id": helpers.send_stream_message(iago, "Denmark"),
     }
+
+
+@openapi_param_value_generator(
+    ["/messages/{message_id}/edit_history/delete_content_revisions:post"]
+)
+def message_id_with_edit_history() -> dict[str, object]:
+    iago = helpers.example_user("iago")
+    helpers.subscribe(iago, "Denmark")
+    message_id = helpers.send_stream_message(iago, "Denmark", content="original content")
+    check_update_message(
+        iago,
+        message_id,
+        stream_id=None,
+        topic_name=None,
+        propagate_mode="change_one",
+        send_notification_to_old_thread=False,
+        send_notification_to_new_thread=False,
+        content="edited content",
+    )
+    return {"message_id": message_id}
 
 
 @openapi_param_value_generator(["/messages/{message_id}/reactions:delete"])

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2748,6 +2748,57 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
+                                Event sent when a user deletes the content of prior message
+                                revisions from a message's edit history. Sent to all users
+                                who have access to the message and whose realm's
+                                `message_edit_history_visibility_policy` is not `none`.
+
+                                **Changes**: New in Zulip 12.0 (feature level ZF-bbdbb7).
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - message_edit_history
+                                op:
+                                  type: string
+                                  enum:
+                                    - delete
+                                  description: |
+                                    The operation that was performed. Currently always `delete`.
+                                message_id:
+                                  type: integer
+                                  description: |
+                                    The ID of the message whose edit history content was deleted.
+                                scope:
+                                  type: string
+                                  enum:
+                                    - all_content_revisions
+                                  description: |
+                                    The scope of the deletion. Currently always `all_content_revisions`.
+                                user_id:
+                                  type: integer
+                                  description: |
+                                    The ID of the user who deleted the edit history content.
+                                timestamp:
+                                  type: integer
+                                  description: |
+                                    Unix timestamp of when the edit history content was deleted.
+                              example:
+                                {
+                                  "type": "message_edit_history",
+                                  "op": "delete",
+                                  "message_id": 1,
+                                  "scope": "all_content_revisions",
+                                  "user_id": 10,
+                                  "timestamp": 1781543193,
+                                  "id": 0,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
                                 Event sent when the set of onboarding steps to show for the current user
                                 has changed (e.g. because the user dismissed one).
 
@@ -9482,6 +9533,24 @@ paths:
                               type: integer
                               description: |
                                 The UNIX timestamp for this edit.
+                            revision_deleted_by:
+                              type: integer
+                              description: |
+                                Only present when a content-edit entry's previous
+                                content has been deleted. Contains the ID of the user
+                                who deleted it. Any user with permission to delete the
+                                message also has permission to delete its edit history.
+
+                                **Changes**: New in Zulip 13.0 (feature level ZF-bbdbb7).
+                            revision_deleted_at:
+                              type: integer
+                              description: |
+                                Only present when `revision_deleted_by` is present.
+
+                                The UNIX timestamp at which the previous message
+                                content was deleted from this entry's edit history.
+
+                                **Changes**: New in Zulip 13.0 (feature level ZF-bbdbb7).
                         description: |
                           A chronologically sorted, oldest to newest, array
                           of `snapshot` objects, each one with the values of
@@ -9521,6 +9590,44 @@ paths:
                   - $ref: "#/components/schemas/InvalidMessageError"
                   - description: |
                       An example JSON response for when the specified message does not exist:
+  /messages/{message_id}/edit_history/delete_content_revisions:
+    post:
+      operationId: delete-message-edit-history-content-revisions
+      summary: Delete a message's prior content revisions
+      tags: ["messages"]
+      description: |
+        Delete the prior content revisions from a message's edit history.
+        The record that the message was edited (including topic or channel
+        moves) is preserved, and each affected entry will record who
+        performed the deletion and when.
+
+        Users who have permission to [delete a message](/help/delete-a-message)
+        also have permission to delete its edit history. The time limit that
+        applies to message deletion does not apply here.
+
+        **Changes**: New in Zulip 13.0 (feature level ZF-bbdbb7).
+      parameters:
+        - $ref: "#/components/parameters/MessageId"
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonSuccess"
+              examples:
+                response:
+                  value: {"msg": "", "result": "success"}
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/InvalidMessageError"
+                  - description: |
+                      An example error response if the message has no
+                      content edits to delete.
   /messages/flags:
     post:
       operationId: update-message-flags

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -62,6 +62,7 @@ from zerver.actions.invites import (
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_edit import (
     build_message_edit_request,
+    do_delete_message_edit_history,
     do_update_embedded_data,
     do_update_message,
 )
@@ -190,6 +191,7 @@ from zerver.lib.event_schema import (
     check_invites_changed,
     check_legacy_presence,
     check_message,
+    check_message_edit_history_delete,
     check_modern_presence,
     check_muted_topics,
     check_muted_users,
@@ -1321,6 +1323,20 @@ class NormalActionsTest(BaseAction):
         with self.verify_action(state_change_expected=False) as events:
             do_add_reaction(self.user_profile, message, "tada", "1f389", "unicode_emoji")
         check_reaction_add("events[0]", events[0])
+
+    def test_delete_message_edit_history_event(self) -> None:
+        sender = self.example_user("hamlet")
+        message_id = self.send_stream_message(sender, "Verona", "original")
+        message = Message.objects.get(id=message_id)
+        self.login("hamlet")
+        self.client_patch(
+            f"/json/messages/{message_id}",
+            {"content": "edited"},
+        )
+        message.refresh_from_db()
+        with self.verify_action(state_change_expected=False) as events:
+            do_delete_message_edit_history(message, self.user_profile)
+        check_message_edit_history_delete("events[0]", events[0])
 
     def test_heartbeat_event(self) -> None:
         with self.verify_action(state_change_expected=False) as events:

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -2867,3 +2867,95 @@ class EditMessageTest(ZulipTestCase):
             ),
             {hamlet.id},
         )
+
+    def test_delete_message_edit_history(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        delete_url = "/json/messages/{msg_id}/edit_history/delete_content_revisions"
+
+        # Send and edit a message
+        msg_id = self.send_stream_message(
+            hamlet,
+            "Denmark",
+            topic_name="test topic",
+            content="original content",
+        )
+        self.login("hamlet")
+        result = self.client_patch(
+            f"/json/messages/{msg_id}",
+            {"content": "edited content"},
+        )
+        self.assert_json_success(result)
+
+        # Admin can delete edit history; the action emits a message_edit_history event.
+        self.login("iago")
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            result = self.client_post(delete_url.format(msg_id=msg_id))
+        self.assert_json_success(result)
+
+        event = events[0]["event"]
+        self.assertEqual(event["type"], "message_edit_history")
+        self.assertEqual(event["op"], "delete")
+        self.assertEqual(event["message_id"], msg_id)
+        self.assertEqual(event["scope"], "all_content_revisions")
+        self.assertEqual(event["user_id"], iago.id)
+        self.assertIn("timestamp", event)
+
+        # Verify prev_content is stripped and audit fields are set.
+        history = self.client_get(f"/json/messages/{msg_id}/history")
+        history_data = orjson.loads(history.content)["message_history"]
+        self.assertFalse(any("prev_content" in entry for entry in history_data))
+        deleted_entries = [e for e in history_data if "revision_deleted_by" in e]
+        self.assertGreater(len(deleted_entries), 0)
+        for entry in deleted_entries:
+            self.assertEqual(entry["revision_deleted_by"], iago.id)
+            self.assertIn("revision_deleted_at", entry)
+
+        # Non-admin cannot delete edit history.
+        self.login("cordelia")
+        result = self.client_post(delete_url.format(msg_id=msg_id))
+        self.assert_json_error(result, "You don't have permission to delete this message")
+
+        # Cannot delete history when there are no content edits at all.
+        msg_id_no_edit = self.send_stream_message(
+            hamlet, "Denmark", topic_name="test topic", content="no edits"
+        )
+        self.login("iago")
+        result = self.client_post(delete_url.format(msg_id=msg_id_no_edit))
+        self.assert_json_error(result, "This message has no edit history to delete.")
+
+        # Cannot delete history when only the topic was changed (no content edits).
+        msg_id_topic_only = self.send_stream_message(
+            hamlet, "Denmark", topic_name="original topic", content="some content"
+        )
+        self.login("hamlet")
+        result = self.client_patch(
+            f"/json/messages/{msg_id_topic_only}",
+            {"topic": "new topic"},
+        )
+        self.assert_json_success(result)
+        self.login("iago")
+        result = self.client_post(delete_url.format(msg_id=msg_id_topic_only))
+        self.assert_json_error(result, "This message has no content edits to delete.")
+
+        # Message with both content and topic edits: content entries get
+        # prev_content stripped; move-only entries are left untouched.
+        msg_id_mixed = self.send_stream_message(
+            hamlet, "Denmark", topic_name="original topic", content="original content"
+        )
+        self.login("hamlet")
+        self.client_patch(f"/json/messages/{msg_id_mixed}", {"content": "edited content"})
+        self.client_patch(f"/json/messages/{msg_id_mixed}", {"topic": "moved topic"})
+        self.login("iago")
+        result = self.client_post(delete_url.format(msg_id=msg_id_mixed))
+        self.assert_json_success(result)
+
+        history = self.client_get(f"/json/messages/{msg_id_mixed}/history")
+        history_data = orjson.loads(history.content)["message_history"]
+        content_deleted_entries = [e for e in history_data if "revision_deleted_by" in e]
+        self.assertGreater(len(content_deleted_entries), 0)
+        # Move-only entries must not carry revision_deleted_by.
+        move_only_entries = [
+            e for e in history_data if "prev_topic" in e and "revision_deleted_by" not in e
+        ]
+        self.assertGreater(len(move_only_entries), 0)

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from pydantic import Json, NonNegativeInt
 
 from zerver.actions.message_delete import do_delete_messages
-from zerver.actions.message_edit import check_update_message
+from zerver.actions.message_edit import check_update_message, do_delete_message_edit_history
 from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
@@ -93,6 +93,9 @@ def fill_edit_history_entries(
             formatted_entry["prev_stream"] = edit_history_event["prev_stream"]
             formatted_entry["stream"] = edit_history_event["stream"]
 
+        if "revision_deleted_by" in edit_history_event:
+            formatted_entry["revision_deleted_by"] = edit_history_event["revision_deleted_by"]
+            formatted_entry["revision_deleted_at"] = edit_history_event["revision_deleted_at"]
         formatted_edit_history.append(formatted_entry)
 
     initial_message_history: FormattedEditHistoryEvent = {
@@ -144,6 +147,31 @@ def get_message_edit_history(
     return json_success(
         request, data={"message_history": list(reversed(visible_message_edit_history))}
     )
+
+
+@typed_endpoint
+def delete_message_edit_history(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    message_id: PathOnly[NonNegativeInt],
+) -> HttpResponse:
+    message = access_message(user_profile, message_id, is_modifying_message=True)
+
+    # Only users who can delete the message can delete its history
+    validate_can_delete_message(user_profile, message)
+
+    # Only makes sense if message was actually content-edited
+    if message.edit_history is None:
+        raise JsonableError(_("This message has no edit history to delete."))
+
+    raw_history: list[EditHistoryEvent] = orjson.loads(message.edit_history)
+    has_content_edit = any("prev_content" in entry for entry in raw_history)
+    if not has_content_edit:
+        raise JsonableError(_("This message has no content edits to delete."))
+
+    do_delete_message_edit_history(message, user_profile)
+    return json_success(request)
 
 
 @typed_endpoint

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -72,6 +72,7 @@ from zerver.views.invite import (
 from zerver.views.llms_txt import llms_txt
 from zerver.views.message_edit import (
     delete_message_backend,
+    delete_message_edit_history,
     get_message_edit_history,
     json_fetch_raw_message,
     update_message_backend,
@@ -438,6 +439,10 @@ v1_api_and_json_patterns = [
     rest_path("messages/flags", POST=update_message_flags),
     rest_path("messages/flags/narrow", POST=update_message_flags_for_narrow),
     rest_path("messages/<int:message_id>/history", GET=get_message_edit_history),
+    rest_path(
+        "messages/<int:message_id>/edit_history/delete_content_revisions",
+        POST=delete_message_edit_history,
+    ),
     rest_path("messages/matches_narrow", GET=messages_in_narrow_backend),
     rest_path("users/me/subscriptions/properties", POST=update_subscription_properties_backend),
     rest_path("users/me/subscriptions/<int:stream_id>", PATCH=update_subscriptions_property),


### PR DESCRIPTION
This PR adds a button in edit overlay dialog of a message to allow the users, who have the permission to delete that message, to delete the prior versions of that message.

The content of the deleted message is replaced with an audit entry noting who deleted the versions.

For this, we send a DELETE request to `messages/<int:message_id>/history` which then calls `delete_message_edit_history` typed endpoint to perform this action.

Fixes: #19632 

## Screenshots

### Before Deletion

For the ones who have permission to delete the message:

<img width="1124" height="328" alt="image" src="https://github.com/user-attachments/assets/5af0c37f-3fac-4072-a25a-4b93d1edd75f" />

For the ones who don't have to permission to delete:

<img width="1124" height="328" alt="image" src="https://github.com/user-attachments/assets/5a925e10-e480-4e01-86a9-cfda19d4c2b0" />


### After Deletion

For the ones who have permission to delete the message:

<img width="1124" height="328" alt="image" src="https://github.com/user-attachments/assets/3542093f-e823-4a17-9f2e-e110113d4d4e" />

For the ones who don't have to permission to delete:

<img width="1124" height="328" alt="image" src="https://github.com/user-attachments/assets/2e5514e9-1e65-4c04-85b5-833fab0d4680" />

### Some complex cases

<img width="1154" height="878" alt="image" src="https://github.com/user-attachments/assets/910e0308-4f53-4c2a-b9be-c7435ac601c2" />

### Help Center 

<img width="869" height="354" alt="image" src="https://github.com/user-attachments/assets/17668695-5910-4b5f-9dac-e02c666b3009" />

### API Documentation

<img width="1137" height="1031" alt="image" src="https://github.com/user-attachments/assets/1f5bc26a-80e6-4389-97fa-4741f5fdd299" />


**API Design** : [#api design > Allow deleting items in a message's edit history](https://chat.zulip.org/#narrow/channel/378-api-design/topic/Allow.20deleting.20items.20in.20a.20message.27s.20edit.20history/with/2470554)


<details>
<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
