### PR TITLE
message_edit: Use decorated channel icon in message moved banner.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1630,7 +1630,8 @@ type ToastParams = {
 };
 
 function show_message_moved_toast(toast_params: ToastParams): void {
-    const new_stream_name = sub_store.maybe_get_stream_name(toast_params.new_stream_id);
+    const new_stream = sub_store.get(toast_params.new_stream_id);
+    const new_stream_name = new_stream?.name;
     const new_topic_display_name = util.get_final_topic_display_name(toast_params.new_topic_name);
     const is_empty_string_topic = toast_params.new_topic_name === "";
     const new_location_url = hash_util.by_stream_topic_url(
@@ -1640,6 +1641,7 @@ function show_message_moved_toast(toast_params: ToastParams): void {
     feedback_widget.show({
         populate($container) {
             const widget_body_html = render_message_moved_widget_body({
+                stream: new_stream,
                 new_stream_name,
                 new_topic_display_name,
                 new_location_url,

--- a/web/templates/message_moved_widget_body.hbs
+++ b/web/templates/message_moved_widget_body.hbs
@@ -4,7 +4,11 @@
         {{#*inline "z-link"~}}
             <a class="white-space-preserve-wrap" href="{{new_location_url}}">
                 {{~!-- squash whitespace --~}}
-                #{{new_stream_name}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{new_topic_display_name}}</span>
+                {{#if stream~}}
+                {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+                {{~else~}}
+                #{{new_stream_name}}
+                {{~/if}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{new_topic_display_name}}</span>
                 {{~!-- squash whitespace --~}}
             </a>
         {{~/inline}}


### PR DESCRIPTION
The message moved banner was displaying the channel name with a plain `#` prefix instead of the `decorated channel icon`.

Pass the `stream` object to `render_message_moved_widget_body` and use the `decorated_channel_name` partial in the template to show the correct channel type icon (public, private, web-public, or archived, etc.), consistent with how channel names appear elsewhere in the UI.

Fixes: [#design > Forwarded messages still uses the old # stream icon](https://chat.zulip.org/#narrow/channel/101-design/topic/Forwarded.20messages.20still.20uses.20the.20old.20.23.20stream.20icon/with/2455030)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="304" height="90" alt="2026-05-14_16-37-25" src="https://github.com/user-attachments/assets/c246c3a1-e4cf-41e6-9121-2b198ff91f7b" />|<img width="304" height="90" alt="2026-05-14_16-35-48" src="https://github.com/user-attachments/assets/ad1dc532-fb5b-4370-b8a2-40886a5f56b4" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="302" height="87" alt="2026-05-14_16-39-10" src="https://github.com/user-attachments/assets/4935a849-4f33-417d-b103-919e16e6a5a4" />|<img width="302" height="88" alt="2026-05-14_16-41-39" src="https://github.com/user-attachments/assets/b9b18b89-45e1-421f-b969-845e7cf40ffd" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="302" height="88" alt="2026-05-14_16-44-41" src="https://github.com/user-attachments/assets/ad8d1960-ddc0-41ac-8d25-07359a13919b" />|<img width="302" height="88" alt="2026-05-14_16-43-24" src="https://github.com/user-attachments/assets/a5c91d3c-2020-48f0-aca3-796e401b3826" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="302" height="88" alt="2026-05-14_16-47-05" src="https://github.com/user-attachments/assets/93bf461d-62e3-46ad-bc06-f2d569173389" />|<img width="302" height="86" alt="2026-05-14_16-49-32" src="https://github.com/user-attachments/assets/5edf9c75-b06c-47fd-b7d2-6c316b8df781" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
