### PR TITLE
compose_closed_ui: Use decorated channel icon in compose box reply label.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -14,12 +14,15 @@ import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as recent_view_util from "./recent_view_util.ts";
 import * as stream_data from "./stream_data.ts";
+import type {StreamSubscription} from "./sub_store.ts";
 import * as util from "./util.ts";
 
 type RecipientLabel = {
     label_text: string;
     has_empty_string_topic?: boolean;
     stream_name?: string;
+    stream?: StreamSubscription;
+    topic_display_name?: string;
     is_dm_with_self?: boolean;
 };
 
@@ -31,6 +34,8 @@ function get_stream_recipient_label(stream_id: number, topic: string): Recipient
             label_text: "#" + stream.name + " > " + topic_display_name,
             has_empty_string_topic: topic === "",
             stream_name: stream.name,
+            stream,
+            topic_display_name,
         };
         return recipient_label;
     }
@@ -248,6 +253,8 @@ export function update_recipient_text_for_reply_button(
         const rendered_recipient_label = render_reply_recipient_label({
             has_empty_string_topic: recipient_label.has_empty_string_topic,
             channel_name: recipient_label.stream_name,
+            stream: recipient_label.stream,
+            topic_display_name: recipient_label.topic_display_name,
             is_dm_with_self: recipient_label.is_dm_with_self,
             empty_string_topic_display_name,
             label_text: recipient_label.label_text,

--- a/web/templates/reply_recipient_label.hbs
+++ b/web/templates/reply_recipient_label.hbs
@@ -6,11 +6,12 @@
 {{#tr}}
     Message <z-recipient-label></z-recipient-label>
     {{#*inline "z-recipient-label"}}
-        {{#if has_empty_string_topic~}}
-        #{{channel_name}} &gt; <span class="empty-topic-display">{{empty_string_topic_display_name}}</span>
-        {{~else~}}
-        {{label_text}}
-        {{~/if}}
+    {{#if stream~}}
+    {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+    {{~#if has_empty_string_topic}} &gt; <span class="empty-topic-display">{{empty_string_topic_display_name}}</span>{{else}} &gt; {{topic_display_name}}{{/if}}
+    {{~else~}}
+    {{label_text}}
+    {{~/if}}
     {{~/inline}}
 {{/tr}}
 {{/if}}

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -74,7 +74,12 @@ function test_reply_label(expected_label) {
     );
 }
 
-run_test("reply_label", () => {
+run_test("reply_label", ({mock_template}) => {
+    mock_template(
+        "decorated_channel_name.hbs",
+        false,
+        (data) => `<span>${data.stream.name}</span>`,
+    );
     // Mocking up a test message list
     const filter = new Filter([]);
     const list = new MessageList({
@@ -165,10 +170,10 @@ run_test("reply_label", () => {
     );
 
     const expected_labels = [
-        "#first_stream &gt; first_topic",
-        "#first_stream &gt; second_topic",
-        "#second_stream &gt; third_topic",
-        "#second_stream &gt; second_topic",
+        `<span>first_stream</span> &gt; first_topic`,
+        `<span>first_stream</span> &gt; second_topic`,
+        `<span>second_stream</span> &gt; third_topic`,
+        `<span>second_stream</span> &gt; second_topic`,
         "Bob",
         "Bob, Zoe",
     ];
@@ -193,7 +198,7 @@ run_test("reply_label", () => {
     const label_html = $("#left_bar_compose_reply_button_big").html();
     assert.equal(
         label_html,
-        `translated: Message #second_stream &gt; <span class="empty-topic-display">translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}</span>`,
+        `translated: Message <span>second_stream</span> &gt; <span class="empty-topic-display">translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}</span>`,
     );
 });
 
@@ -204,9 +209,14 @@ run_test("empty_narrow", () => {
     assert.equal(label, "translated: Compose message");
 });
 
-run_test("test_non_message_list_input", () => {
+run_test("test_non_message_list_input", ({mock_template}) => {
     message_lists.current = undefined;
     recent_view_util.is_visible = () => true;
+    mock_template(
+        "decorated_channel_name.hbs",
+        false,
+        (data) => `<span>${data.stream.name}</span>`,
+    );
     const stream = make_stream({
         subscribed: true,
         name: "stream test",
@@ -219,7 +229,7 @@ run_test("test_non_message_list_input", () => {
         stream_id: stream.stream_id,
         topic: "topic test",
     });
-    test_reply_label("#stream test &gt; topic test");
+    test_reply_label(`<span>stream test</span> &gt; topic test`);
 
     // Direct message conversation with current user row.
     compose_closed_ui.update_recipient_text_for_reply_button({


### PR DESCRIPTION
The reply button label was displaying the channel name with a plain `#` prefix instead of the decorated channel icon.

Pass the `stream` object to `render_reply_recipient_label` and use the `decorated_channel_name` partial in the template to display the correct channel-type icon (public, private, web-public, or archived, etc.), consistent with how channel names appear elsewhere in the UI.

Fixes: [#design > Forwarded messages still uses the old # stream icon @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Forwarded.20messages.20still.20uses.20the.20old.20.23.20stream.20icon/near/2455046)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**


| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-14-14" src="https://github.com/user-attachments/assets/0d63cc4c-254e-4fe1-8a59-50fd3890d233" />|<img width="518" height="32" alt="2026-05-14_18-13-35" src="https://github.com/user-attachments/assets/687a3ff2-5293-45f9-871a-bd6683dd28c2" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-17-38" src="https://github.com/user-attachments/assets/8ee801ad-9b95-4179-bf17-a77412c88931" />|<img width="518" height="32" alt="2026-05-14_18-18-24" src="https://github.com/user-attachments/assets/1fd4daaf-d041-4a72-afa8-f772c9f840c3" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-14-46" src="https://github.com/user-attachments/assets/fd2bae0f-7396-4bcc-9d36-57d4b2ae2b3a" />|<img width="518" height="32" alt="2026-05-14_18-15-24" src="https://github.com/user-attachments/assets/3a52d649-1595-458a-9de4-9c056ad28198" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-19-15" src="https://github.com/user-attachments/assets/2cbdcb96-5c05-43c8-b5e7-d813301717b2" />|<img width="518" height="32" alt="2026-05-14_18-18-43" src="https://github.com/user-attachments/assets/0cd8556d-e314-4637-ab96-d3093241d7e2" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-16-50" src="https://github.com/user-attachments/assets/ef08e6fd-5288-4000-be9f-a9f8e75b9e72" />|<img width="518" height="32" alt="2026-05-14_18-16-08" src="https://github.com/user-attachments/assets/4a5f08b3-82d1-40e7-88b8-99c71c8183c8" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-19-57" src="https://github.com/user-attachments/assets/0a1cad40-d3bf-40fa-b509-4f19ecfb4215" />|<img width="518" height="32" alt="2026-05-14_18-20-21" src="https://github.com/user-attachments/assets/4ad7845d-7836-47be-a972-581d6e551db4" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
