### PR TITLE
compose_banner: Use decorated channel icon in topic moved banner in compose box.

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -599,6 +599,7 @@ export function inform_if_topic_is_moved(
         narrow_url,
         orig_topic,
         old_stream: old_stream.name,
+        stream: old_stream,
         classname: compose_banner.CLASSNAMES.topic_is_moved,
         show_colored_icon: false,
         is_empty_string_topic,

--- a/web/templates/compose_banner/topic_moved_banner.hbs
+++ b/web/templates/compose_banner/topic_moved_banner.hbs
@@ -4,7 +4,7 @@
             The topic you were composing to (<z-link></z-link>) was moved, and the destination for your message has been updated to its new location.
             {{#*inline "z-link"~}}
                 <a class="above_compose_banner_action_link" href="{{narrow_url}}">
-                    {{~> ../inline_topic_link_label channel_name=old_stream topic_display_name=orig_topic is_empty_string_topic=is_empty_string_topic~}}
+                    {{~> ../inline_topic_link_label channel_name=old_stream stream=stream topic_display_name=orig_topic is_empty_string_topic=is_empty_string_topic~}}
                 </a>
             {{~/inline}}
         {{/tr}}

--- a/web/templates/inline_topic_link_label.hbs
+++ b/web/templates/inline_topic_link_label.hbs
@@ -1,13 +1,21 @@
 {{#if is_empty_string_topic}}
 <span class="stream-topic">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; <em class="empty-topic-display">{{t "general chat"}}</em>
+    {{#if stream~}}
+    {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+    {{~else~}}
+    #{{channel_name}}
+    {{~/if}} &gt; <em class="empty-topic-display">{{t "general chat"}}</em>
     {{~!-- squash whitespace --~}}
 </span>
 {{~else}}
 <span class="stream-topic">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; {{topic_display_name}}
+    {{#if stream~}}
+    {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+    {{~else~}}
+    #{{channel_name}}
+    {{~/if}} &gt; {{topic_display_name}}
     {{~!-- squash whitespace --~}}
 </span>
 {{~/if}}


### PR DESCRIPTION
The topic moved banner was displaying the channel name with a plain `#` prefix instead of the decorated channel icon.

Pass the `stream` object to the `inline_topic_link_label` partial, and use the `decorated_channel_name` partial to display the correct channel-type icon (public, private, web-public, or archived, etc.), consistent with how channel names appear elsewhere in the UI.

Fixes: [#design > Forwarded messages still uses the old # stream icon @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Forwarded.20messages.20still.20uses.20the.20old.20.23.20stream.20icon/near/2455046)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-05-13" src="https://github.com/user-attachments/assets/249307fa-ee3d-4075-91b2-022a7d10752e" />|<img width="417" height="58" alt="2026-05-14_19-03-12" src="https://github.com/user-attachments/assets/1666cabc-6441-4ac2-b938-535306a495df" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-06-16" src="https://github.com/user-attachments/assets/e098a50d-1263-4959-8d2f-fa61c27ce968" />|<img width="417" height="58" alt="2026-05-14_19-11-12" src="https://github.com/user-attachments/assets/c043e050-844c-4ab1-808c-907664848a03" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-16-08" src="https://github.com/user-attachments/assets/3768700f-ac3a-4c8c-9df1-50a101d516fa" />|<img width="417" height="58" alt="2026-05-14_19-13-47" src="https://github.com/user-attachments/assets/e821d873-9375-4c04-b536-008255f20e5e" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-16-15" src="https://github.com/user-attachments/assets/dfb9ba50-5454-40ec-8665-65101d683c51" />|<img width="417" height="58" alt="2026-05-14_19-14-03" src="https://github.com/user-attachments/assets/7099edda-ed61-458b-a711-4a91515738f7" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
