### PR TITLE
message_send: Optimize code path for DirectMessageGroup.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1834,17 +1834,17 @@ def check_message(
             raise TopicsNotAllowedError(empty_topic_display_name)
 
     elif addressee.is_private():
-        user_profiles = addressee.user_profiles()
+        recipient_users = addressee.user_profiles()
         mirror_message = client.name in [
             "irc_mirror",
             "jabber_mirror",
             "JabberMirror",
         ]
 
-        check_sender_can_access_recipients(realm, sender, user_profiles)
+        check_sender_can_access_recipients(realm, sender, recipient_users)
 
         recipients_for_user_creation_events = get_recipients_for_user_creation_events(
-            realm, sender, user_profiles
+            realm, sender, recipient_users
         )
 
         # API super-users who set the `forged` flag are allowed to
@@ -1853,13 +1853,13 @@ def check_message(
         forwarded_mirror_message = mirror_message and not forged
         try:
             recipient = recipient_for_user_profiles(
-                user_profiles, forwarded_mirror_message, forwarder_user_profile, sender
+                recipient_users, forwarded_mirror_message, forwarder_user_profile, sender
             )
         except ValidationError as e:
             assert isinstance(e.messages[0], str)
             raise JsonableError(e.messages[0])
 
-        check_can_send_direct_message(realm, sender, user_profiles, recipient)
+        check_can_send_direct_message(realm, sender, recipient_users, recipient)
     else:
         # This is defensive code--Addressee already validates
         # the message type.

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -248,6 +248,7 @@ def get_recipient_info(
     possibly_mentioned_user_ids: AbstractSet[int] = set(),
     possible_topic_wildcard_mention: bool = True,
     possible_stream_wildcard_mention: bool = True,
+    dm_involved_user_ids: set[int] | None = None,
 ) -> RecipientInfoResult:
     stream_push_user_ids: set[int] = set()
     stream_email_user_ids: set[int] = set()
@@ -426,7 +427,15 @@ def get_recipient_info(
             )
 
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
-        message_to_user_id_set = set(get_direct_message_group_user_ids(recipient))
+        if dm_involved_user_ids is not None:
+            # For production path when sending a direct message
+            # passing through check_message. This avoids an extra db query.
+            message_to_user_id_set = dm_involved_user_ids
+        else:
+            # Other paths like:
+            # Message edit via update_message_content.
+            # Tests that bypass check_message.
+            message_to_user_id_set = set(get_direct_message_group_user_ids(recipient))
 
     else:
         raise ValueError("Bad recipient type")
@@ -657,6 +666,7 @@ def build_message_send_dict(
     recipients_for_user_creation_events: dict[UserProfile, set[int]] | None = None,
     acting_user: UserProfile | None = None,
     no_previews: bool = False,
+    dm_involved_user_ids: set[int] | None = None,
 ) -> SendMessageRequest:
     """Returns a dictionary that can be passed into do_send_messages.  In
     production, this is always called by check_message, but some
@@ -690,6 +700,7 @@ def build_message_send_dict(
         possibly_mentioned_user_ids=mention_data.get_user_ids(),
         possible_topic_wildcard_mention=mention_data.message_has_topic_wildcards(),
         possible_stream_wildcard_mention=mention_data.message_has_stream_wildcards(),
+        dm_involved_user_ids=dm_involved_user_ids,
     )
 
     # Render our message_dicts.
@@ -789,6 +800,7 @@ def build_message_send_dict(
         disable_external_notifications=disable_external_notifications,
         topic_participant_user_ids=topic_participant_user_ids,
         recipients_for_user_creation_events=recipients_for_user_creation_events,
+        dm_involved_user_ids=dm_involved_user_ids,
     )
 
     return message_send_dict
@@ -1119,7 +1131,11 @@ def do_send_messages(
 
         # Deliver events to the real-time push system, as well as
         # enqueuing any additional processing triggered by the message.
-        wide_message_dict = MessageDict.wide_dict(send_request.message, realm_id)
+        wide_message_dict = MessageDict.wide_dict(
+            send_request.message,
+            realm_id,
+            dm_involved_user_ids=send_request.dm_involved_user_ids,
+        )
 
         user_flags = user_message_flags.get(send_request.message.id, {})
 
@@ -1768,6 +1784,10 @@ def check_message(
     if realm is None:
         realm = sender.realm
 
+    # IDs of the DM sender and recipient users, deduplicated.
+    # None for stream message.
+    dm_involved_user_ids: set[int] | None = None
+
     recipients_for_user_creation_events = None
     if addressee.is_stream():
         topic_name = addressee.topic_name()
@@ -1840,6 +1860,8 @@ def check_message(
             "jabber_mirror",
             "JabberMirror",
         ]
+
+        dm_involved_user_ids = {user.id for user in recipient_users} | {sender.id}
 
         check_sender_can_access_recipients(realm, sender, recipient_users)
 
@@ -1916,6 +1938,7 @@ def check_message(
         recipients_for_user_creation_events=recipients_for_user_creation_events,
         acting_user=acting_user,
         no_previews=no_previews,
+        dm_involved_user_ids=dm_involved_user_ids,
     )
 
     if (

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1921,17 +1921,17 @@ def check_message(
             raise TopicsNotAllowedError(empty_topic_display_name)
 
     elif addressee.is_private():
-        user_profiles = addressee.user_profiles()
+        recipient_users = addressee.user_profiles()
         mirror_message = client.name in [
             "irc_mirror",
             "jabber_mirror",
             "JabberMirror",
         ]
 
-        check_sender_can_access_recipients(sender, user_profiles)
+        check_sender_can_access_recipients(sender, recipient_users)
 
         recipients_for_user_creation_events = get_recipients_for_user_creation_events(
-            realm, sender, user_profiles
+            realm, sender, recipient_users
         )
 
         # API super-users who set the `forged` flag are allowed to
@@ -1940,13 +1940,13 @@ def check_message(
         forwarded_mirror_message = mirror_message and not forged
         try:
             recipient = recipient_for_user_profiles(
-                user_profiles, forwarded_mirror_message, forwarder_user_profile, sender
+                recipient_users, forwarded_mirror_message, forwarder_user_profile, sender
             )
         except ValidationError as e:
             assert isinstance(e.messages[0], str)
             raise JsonableError(e.messages[0])
 
-        check_can_send_direct_message(realm, sender, user_profiles, recipient)
+        check_can_send_direct_message(realm, sender, recipient_users, recipient)
     else:
         # This is defensive code--Addressee already validates
         # the message type.

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -262,6 +262,7 @@ def get_recipient_info(
     possibly_mentioned_user_ids: AbstractSet[int] = set(),
     possible_topic_wildcard_mention: bool = True,
     possible_stream_wildcard_mention: bool = True,
+    dm_involved_user_ids: set[int] | None = None,
 ) -> RecipientInfoResult:
     stream_push_user_ids: set[int] = set()
     stream_email_user_ids: set[int] = set()
@@ -440,7 +441,15 @@ def get_recipient_info(
             )
 
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
-        message_to_user_id_set = set(get_direct_message_group_user_ids(recipient))
+        if dm_involved_user_ids is not None:
+            # For production path when sending a direct message
+            # passing through check_message. This avoids an extra db query.
+            message_to_user_id_set = dm_involved_user_ids
+        else:
+            # Other paths like:
+            # Message edit via update_message_content.
+            # Tests that bypass check_message.
+            message_to_user_id_set = set(get_direct_message_group_user_ids(recipient))
 
     else:
         raise ValueError("Bad recipient type")
@@ -673,6 +682,7 @@ def build_message_send_dict(
     no_previews: bool = False,
     user_group_membership_details: UserGroupMembershipDetails | None = None,
     sender_is_subscribed: bool | None = None,
+    dm_involved_user_ids: set[int] | None = None,
 ) -> SendMessageRequest:
     """Returns a dictionary that can be passed into do_send_messages.  In
     production, this is always called by check_message, but some
@@ -706,6 +716,7 @@ def build_message_send_dict(
         possibly_mentioned_user_ids=mention_data.get_user_ids(),
         possible_topic_wildcard_mention=mention_data.message_has_topic_wildcards(),
         possible_stream_wildcard_mention=mention_data.message_has_stream_wildcards(),
+        dm_involved_user_ids=dm_involved_user_ids,
     )
 
     # Render our message_dicts.
@@ -827,6 +838,7 @@ def build_message_send_dict(
         disable_external_notifications=disable_external_notifications,
         topic_participant_user_ids=topic_participant_user_ids,
         recipients_for_user_creation_events=recipients_for_user_creation_events,
+        dm_involved_user_ids=dm_involved_user_ids,
     )
 
     return message_send_dict
@@ -1191,7 +1203,11 @@ def do_send_messages(
 
         # Deliver events to the real-time push system, as well as
         # enqueuing any additional processing triggered by the message.
-        wide_message_dict = MessageDict.wide_dict(send_request.message, realm_id)
+        wide_message_dict = MessageDict.wide_dict(
+            send_request.message,
+            realm_id,
+            dm_involved_user_ids=send_request.dm_involved_user_ids,
+        )
 
         send_request.message_url, send_request.message_link = get_message_url_and_link(
             send_request, wide_message_dict
@@ -1854,6 +1870,10 @@ def check_message(
     if realm is None:
         realm = sender.realm
 
+    # IDs of the DM sender and recipient users, deduplicated.
+    # None for stream message.
+    dm_involved_user_ids: set[int] | None = None
+
     recipients_for_user_creation_events = None
     if addressee.is_stream():
         topic_name = addressee.topic_name()
@@ -1927,6 +1947,8 @@ def check_message(
             "jabber_mirror",
             "JabberMirror",
         ]
+
+        dm_involved_user_ids = {user.id for user in recipient_users} | {sender.id}
 
         check_sender_can_access_recipients(sender, recipient_users)
 
@@ -2005,6 +2027,7 @@ def check_message(
         no_previews=no_previews,
         user_group_membership_details=user_group_membership_details,
         sender_is_subscribed=sender_is_subscribed,
+        dm_involved_user_ids=dm_involved_user_ids,
     )
 
     if (

--- a/zerver/lib/display_recipient.py
+++ b/zerver/lib/display_recipient.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Optional, TypedDict
 
 from django.db.models import QuerySet
@@ -132,10 +133,15 @@ def bulk_fetch_stream_names(
 
 def bulk_fetch_user_display_recipients(
     recipient_tuples: set[tuple[int, int, int]],
+    recipient_dm_user_ids: Mapping[int, set[int]] = {},
 ) -> dict[int, list[UserDisplayRecipient]]:
     """
     Takes set of tuples of the form (recipient_id, recipient_type, recipient_type_id)
     Returns dict mapping recipient_id to corresponding display_recipient
+
+    The participants of a DirectMessageGroup are fixed when it is created, so
+    a caller that already knows them for some recipients can pass them in via
+    dm_involved_user_ids to avoid looking them up again.
     """
 
     from zerver.models.recipients import bulk_get_direct_message_group_user_ids
@@ -146,9 +152,16 @@ def bulk_fetch_user_display_recipients(
     get_recipient_id = lambda tup: tup[0]
 
     direct_message_group_recipient_ids = [get_recipient_id(tup) for tup in recipient_tuples]
+
+    # Query only DirectMessageGroup participants who are not already loaded.
     user_ids_in_direct_message_groups = bulk_get_direct_message_group_user_ids(
-        direct_message_group_recipient_ids
+        [
+            recipient_id
+            for recipient_id in direct_message_group_recipient_ids
+            if recipient_id not in recipient_dm_user_ids
+        ]
     )
+    user_ids_in_direct_message_groups.update(recipient_dm_user_ids)
 
     # Find all user ids whose UserProfiles we will need to fetch:
     user_ids_to_fetch: set[int] = set()
@@ -172,6 +185,7 @@ def bulk_fetch_user_display_recipients(
 
 def bulk_fetch_display_recipients(
     recipient_tuples: set[tuple[int, int, int]],
+    recipient_dm_user_ids: Mapping[int, set[int]] = {},
 ) -> dict[int, DisplayRecipientT]:
     """
     Takes set of tuples of the form (recipient_id, recipient_type, recipient_type_id)
@@ -187,7 +201,7 @@ def bulk_fetch_display_recipients(
 
     stream_display_recipients = bulk_fetch_stream_names(stream_recipients)
     direct_message_display_recipients = bulk_fetch_user_display_recipients(
-        direct_message_recipients
+        direct_message_recipients, recipient_dm_user_ids
     )
 
     # Glue the dicts together and return:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -187,6 +187,8 @@ class SendMessageRequest:
     disable_external_notifications: bool = False
     automatic_new_visibility_policy: int | None = None
     recipients_for_user_creation_events: dict[UserProfile, set[int]] | None = None
+    # None for a channel message or for caller that bypass check_message.
+    dm_involved_user_ids: set[int] | None = None
     reminder_target_message_id: int | None = None
     reminder_note: str | None = None
     # Computed during do_send_messages, for the POST /messages response.

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -183,6 +183,8 @@ class SendMessageRequest:
     disable_external_notifications: bool = False
     automatic_new_visibility_policy: int | None = None
     recipients_for_user_creation_events: dict[UserProfile, set[int]] | None = None
+    # None for a channel message or for caller that bypass check_message.
+    dm_involved_user_ids: set[int] | None = None
     reminder_target_message_id: int | None = None
     reminder_note: str | None = None
 

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -1,5 +1,5 @@
 import copy
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime
 from email.headerregistry import Address
 from typing import Any, TypedDict
@@ -134,7 +134,12 @@ class MessageDict:
     """
 
     @staticmethod
-    def wide_dict(message: Message, realm_id: int | None = None) -> dict[str, Any]:
+    def wide_dict(
+        message: Message,
+        realm_id: int | None = None,
+        *,
+        dm_involved_user_ids: set[int] | None = None,
+    ) -> dict[str, Any]:
         """
         The next two lines get the cacheable field related
         to our message object, with the side effect of
@@ -150,7 +155,10 @@ class MessageDict:
         processor.
         """
         MessageDict.bulk_hydrate_sender_info([obj])
-        MessageDict.bulk_hydrate_recipient_info([obj])
+        MessageDict.bulk_hydrate_recipient_info(
+            [obj],
+            {} if dm_involved_user_ids is None else {obj["recipient_id"]: dm_involved_user_ids},
+        )
 
         return obj
 
@@ -544,7 +552,10 @@ class MessageDict:
             obj["stream_id"] = recipient_type_id
 
     @staticmethod
-    def bulk_hydrate_recipient_info(objs: list[dict[str, Any]]) -> None:
+    def bulk_hydrate_recipient_info(
+        objs: list[dict[str, Any]],
+        recipient_dm_user_ids: Mapping[int, set[int]] = {},
+    ) -> None:
         recipient_tuples = {  # We use set to eliminate duplicate tuples.
             (
                 obj["recipient_id"],
@@ -553,7 +564,7 @@ class MessageDict:
             )
             for obj in objs
         }
-        display_recipients = bulk_fetch_display_recipients(recipient_tuples)
+        display_recipients = bulk_fetch_display_recipients(recipient_tuples, recipient_dm_user_ids)
 
         for obj in objs:
             MessageDict.hydrate_recipient_info(obj, display_recipients[obj["recipient_id"]])

--- a/zerver/lib/recipient_users.py
+++ b/zerver/lib/recipient_users.py
@@ -19,7 +19,7 @@ def get_recipient_from_user_profiles(
     create: bool = True,
 ) -> Recipient:
     # Avoid mutating the passed in list of recipient_profiles.
-    recipient_profiles_map = {user_profile.id: user_profile for user_profile in recipient_profiles}
+    recipient_user_ids = {user_profile.id for user_profile in recipient_profiles}
 
     if forwarded_mirror_message:
         # In our mirroring integrations with some third-party
@@ -31,12 +31,12 @@ def get_recipient_from_user_profiles(
         # for whether forwarder_user_profile is among the private
         # message recipients of the message.
         assert forwarder_user_profile is not None
-        if forwarder_user_profile.id not in recipient_profiles_map:
+        if forwarder_user_profile.id not in recipient_user_ids:
             raise ValidationError(_("User not authorized for this query"))
 
-    # Make sure the sender is included in the group direct messages.
-    recipient_profiles_map[sender.id] = sender
-    user_ids = list(recipient_profiles_map)
+    # Make sure the sender is included in the group direct message.
+    recipient_user_ids.add(sender.id)
+    user_ids = list(recipient_user_ids)
 
     if create:
         direct_message_group = get_or_create_direct_message_group(user_ids)

--- a/zerver/models/recipients.py
+++ b/zerver/models/recipients.py
@@ -2,8 +2,9 @@ import hashlib
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from django.db import models, transaction
+from django.db import connection, models, transaction
 from django.db.models import QuerySet
+from psycopg2.sql import SQL, Identifier
 from typing_extensions import override
 
 from zerver.lib.display_recipient import get_display_recipient
@@ -156,23 +157,69 @@ def get_or_create_direct_message_group(id_list: list[int]) -> DirectMessageGroup
             huddle_hash=direct_message_group_hash,
             group_size=len(id_list),
         )
-        if created:
-            recipient = Recipient.objects.create(
-                type_id=direct_message_group.id, type=Recipient.DIRECT_MESSAGE_GROUP
-            )
-            direct_message_group.recipient = recipient
-            direct_message_group.save(update_fields=["recipient"])
-            subs_to_create = [
-                Subscription(
-                    recipient=recipient,
-                    user_profile_id=user_profile_id,
-                    is_user_active=is_active,
+
+        if not created:
+            return direct_message_group
+
+        recipient = Recipient.objects.create(
+            type_id=direct_message_group.id, type=Recipient.DIRECT_MESSAGE_GROUP
+        )
+
+        # The equivalent effect of doing
+        # direct_message_group.save(update_fields=["recipient"]) is handled
+        # in the following raw query via UPDATE to save us a query.
+        direct_message_group.recipient = recipient
+
+        # In a single raw query, we do 2 required things after creating
+        # a new DirectMessageGroup object:
+        # 1. Update the recipient field to reflect the above assignment in db.
+        # 2. Bulk create subscriptions for the participants.
+        query = SQL(
+            """
+            UPDATE {dmg_table}
+            SET recipient_id = %(recipient_id)s
+            WHERE {dmg_table}.id = %(dmg_id)s;
+
+            INSERT INTO {subscription_table}
+                (
+                    user_profile_id,
+                    is_user_active,
+                    recipient_id,
+                    active,
+                    is_muted,
+                    color,
+                    pin_to_top
                 )
-                for user_profile_id, is_active in UserProfile.objects.filter(id__in=id_list)
-                .distinct("id")
-                .values_list("id", "is_active")
-            ]
-            Subscription.objects.bulk_create(subs_to_create)
+            SELECT
+                {user_profile_table}.id,
+                {user_profile_table}.is_active,
+                %(recipient_id)s,
+                %(active)s,
+                %(is_muted)s,
+                %(color)s,
+                %(pin_to_top)s
+            FROM {user_profile_table}
+            WHERE {user_profile_table}.id = ANY(%(participant_ids)s);
+        """
+        ).format(
+            dmg_table=Identifier(DirectMessageGroup._meta.db_table),
+            subscription_table=Identifier(Subscription._meta.db_table),
+            user_profile_table=Identifier(UserProfile._meta.db_table),
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(
+                query,
+                {
+                    "recipient_id": recipient.id,
+                    "dmg_id": direct_message_group.id,
+                    "active": Subscription._meta.get_field("active").get_default(),
+                    "is_muted": Subscription._meta.get_field("is_muted").get_default(),
+                    "color": Subscription._meta.get_field("color").get_default(),
+                    "pin_to_top": Subscription._meta.get_field("pin_to_top").get_default(),
+                    "participant_ids": id_list,
+                },
+            )
+
         return direct_message_group
 
 

--- a/zerver/tests/test_channel_fetch.py
+++ b/zerver/tests/test_channel_fetch.py
@@ -883,7 +883,7 @@ class GetSubscribersTest(ZulipTestCase):
             polonius.id,
         ]
 
-        with self.assert_database_query_count(67):
+        with self.assert_database_query_count(61):
             self.subscribe_via_post(
                 self.user_profile,
                 stream_names,

--- a/zerver/tests/test_channel_fetch.py
+++ b/zerver/tests/test_channel_fetch.py
@@ -883,7 +883,7 @@ class GetSubscribersTest(ZulipTestCase):
             polonius.id,
         ]
 
-        with self.assert_database_query_count(73):
+        with self.assert_database_query_count(67):
             self.subscribe_via_post(
                 self.user_profile,
                 stream_names,

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1314,7 +1314,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("othello")
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message
@@ -1359,7 +1359,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("cordelia")
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             process_message(incoming_valid_message)
 
         # Confirm Iago received the message.

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1336,7 +1336,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             othello, mm_address, "TestMissedMessageEmailMessages body"
         )
 
-        with self.assert_database_query_count(23):
+        with self.assert_database_query_count(21):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message
@@ -1364,7 +1364,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             cordelia, mm_address, "TestMissedGroupDirectMessageEmailMessages body"
         )
 
-        with self.assert_database_query_count(23):
+        with self.assert_database_query_count(21):
             process_message(incoming_valid_message)
 
         # Confirm Iago and Othello received the message.

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -365,7 +365,7 @@ class TestQueryCounts(ZulipTestCase):
         cordelia = self.example_user("cordelia")
 
         # when direct message group doesn't exist and should be created as part of the flow
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -365,7 +365,7 @@ class TestQueryCounts(ZulipTestCase):
         cordelia = self.example_user("cordelia")
 
         # when direct message group doesn't exist and should be created as part of the flow
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(22):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,
@@ -373,7 +373,7 @@ class TestQueryCounts(ZulipTestCase):
             )
 
         # when direct message group exists
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(16):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2815,7 +2815,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_personal_message(user_profile, cordelia)
 
     def test_direct_message_initiator_group_setting(self) -> None:
@@ -2908,7 +2908,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         othello = self.example_user("othello")
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(19):
             self.send_personal_message(user_profile, othello)
 
     def test_direct_message_permission_group_setting(self) -> None:
@@ -2936,7 +2936,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         # Tests if the user is allowed to send to administrators.
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_personal_message(user_profile, admin)
         self.send_personal_message(admin, user_profile)
         # Tests if we can send messages to self irrespective of the value of the setting.
@@ -2954,7 +2954,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # We can send to this direct message group as it has administrator as one of the
         # recipient.
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_group_direct_message(user_profile, direct_message_group)
         self.send_group_direct_message(admin, direct_message_group)
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -3010,7 +3010,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         prospero = self.example_user("prospero")
 
         # A normal user sends a personal message.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(22):
             self.send_personal_message(hamlet, cordelia)
 
         # Give guests limited user access.
@@ -3021,17 +3021,17 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A guest with limited user access sends a personal message
         # to another accessible user.
-        with self.assert_database_query_count(25):
+        with self.assert_database_query_count(23):
             self.send_personal_message(polonius, hamlet)
 
         # A guest with limited user access sends a personal message
         # to themself.
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(19):
             self.send_personal_message(polonius, polonius)
 
         # A guest with limited user access sends a personal message
         # to another accessible guest.
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_personal_message(polonius, prospero)
 
     def test_group_direct_message(self) -> None:
@@ -3059,12 +3059,12 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A normal user sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(28):
+        with self.assert_database_query_count(26):
             self.send_group_direct_message(iago, recipients)
 
         # A normal user sends a message
         # to an existing DirectMessageGroup.
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(19):
             self.send_group_direct_message(iago, recipients)
 
         # Subscribe polonius to Verona to make the recipients
@@ -3078,12 +3078,12 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A guest with limited user access sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(30):
+        with self.assert_database_query_count(28):
             self.send_group_direct_message(polonius, recipients)
 
         # A guest with limited user access sends a message
         # to an existing DirectMessageGroup.
-        with self.assert_database_query_count(23):
+        with self.assert_database_query_count(21):
             self.send_group_direct_message(polonius, recipients)
 
     def test_direct_message_initiator_group_setting(self) -> None:
@@ -3126,7 +3126,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # Have the administrator send a message, and verify that allows the user to reply.
         self.send_personal_message(admin, user_profile)
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, admin)
 
         # Tests that user cannot initiate direct message thread in groups.
@@ -3136,7 +3136,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         # Have the administrator send a message to the direct message group, and verify
         # that allows the user to reply.
         self.send_group_direct_message(admin, direct_message_group_1)
-        with self.assert_database_query_count(20):
+        with self.assert_database_query_count(18):
             self.send_group_direct_message(user_profile, direct_message_group_1)
 
         # We cannot sent to `direct_message_group_2` as no message has been sent to this group yet.
@@ -3162,7 +3162,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             user_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -3176,7 +3176,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         othello = self.example_user("othello")
-        with self.assert_database_query_count(23):
+        with self.assert_database_query_count(21):
             self.send_personal_message(user_profile, othello)
 
     def test_direct_message_permission_group_setting(self) -> None:
@@ -3204,7 +3204,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         # Tests if the user is allowed to send to administrators.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(22):
             self.send_personal_message(user_profile, admin)
         self.send_personal_message(admin, user_profile)
         # Tests if we can send messages to self irrespective of the value of the setting.
@@ -3222,7 +3222,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # We can send to this direct message group as it has administrator as one of the
         # recipient.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(22):
             self.send_group_direct_message(user_profile, direct_message_group)
         self.send_group_direct_message(admin, direct_message_group)
 
@@ -3254,7 +3254,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         with self.assertRaises(DirectMessagePermissionError):
             self.send_personal_message(cordelia, polonius)
 
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -3267,7 +3267,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             members_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, cordelia)
 
         do_change_realm_permission_group_setting(

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -3010,7 +3010,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         prospero = self.example_user("prospero")
 
         # A normal user sends a personal message.
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_personal_message(hamlet, cordelia)
 
         # Give guests limited user access.
@@ -3021,12 +3021,12 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A guest with limited user access sends a personal message
         # to another accessible user.
-        with self.assert_database_query_count(23):
+        with self.assert_database_query_count(21):
             self.send_personal_message(polonius, hamlet)
 
         # A guest with limited user access sends a personal message
         # to themself.
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(17):
             self.send_personal_message(polonius, polonius)
 
         # A guest with limited user access sends a personal message
@@ -3059,7 +3059,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A normal user sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(26):
+        with self.assert_database_query_count(24):
             self.send_group_direct_message(iago, recipients)
 
         # A normal user sends a message
@@ -3078,7 +3078,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A guest with limited user access sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(28):
+        with self.assert_database_query_count(26):
             self.send_group_direct_message(polonius, recipients)
 
         # A guest with limited user access sends a message
@@ -3176,7 +3176,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         othello = self.example_user("othello")
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(19):
             self.send_personal_message(user_profile, othello)
 
     def test_direct_message_permission_group_setting(self) -> None:
@@ -3204,7 +3204,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         # Tests if the user is allowed to send to administrators.
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_personal_message(user_profile, admin)
         self.send_personal_message(admin, user_profile)
         # Tests if we can send messages to self irrespective of the value of the setting.
@@ -3222,7 +3222,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # We can send to this direct message group as it has administrator as one of the
         # recipient.
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(20):
             self.send_group_direct_message(user_profile, direct_message_group)
         self.send_group_direct_message(admin, direct_message_group)
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2815,7 +2815,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(22):
             self.send_personal_message(user_profile, cordelia)
 
     def test_direct_message_initiator_group_setting(self) -> None:
@@ -2858,7 +2858,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # Have the administrator send a message, and verify that allows the user to reply.
         self.send_personal_message(admin, user_profile)
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, admin)
 
         # Tests that user cannot initiate direct message thread in groups.
@@ -2868,7 +2868,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         # Have the administrator send a message to the direct message group, and verify
         # that allows the user to reply.
         self.send_group_direct_message(admin, direct_message_group_1)
-        with self.assert_database_query_count(20):
+        with self.assert_database_query_count(18):
             self.send_group_direct_message(user_profile, direct_message_group_1)
 
         # We cannot sent to `direct_message_group_2` as no message has been sent to this group yet.
@@ -2894,7 +2894,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             user_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2908,7 +2908,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         othello = self.example_user("othello")
-        with self.assert_database_query_count(23):
+        with self.assert_database_query_count(21):
             self.send_personal_message(user_profile, othello)
 
     def test_direct_message_permission_group_setting(self) -> None:
@@ -2936,7 +2936,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             acting_user=None,
         )
         # Tests if the user is allowed to send to administrators.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(22):
             self.send_personal_message(user_profile, admin)
         self.send_personal_message(admin, user_profile)
         # Tests if we can send messages to self irrespective of the value of the setting.
@@ -2954,7 +2954,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # We can send to this direct message group as it has administrator as one of the
         # recipient.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(22):
             self.send_group_direct_message(user_profile, direct_message_group)
         self.send_group_direct_message(admin, direct_message_group)
 
@@ -2986,7 +2986,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         with self.assertRaises(DirectMessagePermissionError):
             self.send_personal_message(cordelia, polonius)
 
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(17):
             self.send_personal_message(user_profile, cordelia)
 
         # Test that query count decreases if setting is set to a system group.
@@ -2999,7 +2999,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             members_group,
             acting_user=None,
         )
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(16):
             self.send_personal_message(user_profile, cordelia)
 
         do_change_realm_permission_group_setting(

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1068,7 +1068,7 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(99),
+            self.assert_database_query_count(97),
             self.assert_memcached_count(19),
             self.captureOnCommitCallbacks(execute=True),
         ):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1068,7 +1068,7 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(101),
+            self.assert_database_query_count(99),
             self.assert_memcached_count(19),
             self.captureOnCommitCallbacks(execute=True),
         ):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1147,7 +1147,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(99),
+            self.assert_database_query_count(95),
             self.assert_memcached_count(24),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1147,7 +1147,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(95),
+            self.assert_database_query_count(91),
             self.assert_memcached_count(24),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1154,7 +1154,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(95),
+            self.assert_database_query_count(91),
             self.assert_memcached_count(24),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1154,7 +1154,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(99),
+            self.assert_database_query_count(95),
             self.assert_memcached_count(24),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):


### PR DESCRIPTION
Fixes #37139

Optimize the code path for sending a message (1:1 dm or group message)  for a new or existing `DirectMessageGroup`. Specifially we reduce the query count inside `get_or_create_direct_message_group` and `get_recipient_info`


# get_or_create_direct_message_group
For new `DirectMessageGroup`:

### Before 
The following code executes **3** queries:
```python
direct_message_group.save(update_fields=["recipient"])
subs_to_create = [
    Subscription(
        recipient=recipient,
        user_profile_id=user_profile_id,
        is_user_active=is_active,
    )
    for user_profile_id, is_active in UserProfile.objects.filter(id__in=id_list)
    .distinct("id")
    .values_list("id", "is_active")
]
Subscription.objects.bulk_create(subs_to_create)
```
**Another issue with that code:** On inspecting the raw query for `Subscription.objects.bulk_create()`, it tries to `INSERT` the folloing non-related (as pert Subscription definition) fields:

`is_muted`, `color`, `pin_to_top`, `desktop_notifications`, `audible_notifications`, `push_notifications`, `email_notifications`, `wildcard_mentions_notify`.

### After
A single sql query, which reproduces the exact behavior
```sql
UPDATE {dmg_table}
SET recipient_id = %(recipient_id)s
WHERE {dmg_table}.id = %(dmg_id)s;

INSERT INTO {subscription_table}
    (user_profile_id, is_user_active, recipient_id, active)
SELECT
    {user_profile_table}.id,
    {user_profile_table}.is_active,
    %(recipient_id)s,
    %(active)s
FROM {user_profile_table}
WHERE {user_profile_table}.id = ANY(%(participant_ids)s);
```
**Addresing the mentioned issue in the "before" code:** I added `db_default` to `is_muted`, `color`, `pin_to_top` (rest of fields already have `null=True`), so that raw `INSERT` only inserts the relevant columns, which is the case for Subscription of 1:1 and group direct message (our case).

### Savings:
Replaced 3 queries with a **single** query, saving us 2 db round trips for each new `DirectMessageGroup`


# get_recipient_info

### Before 
A call to `get_direct_message_group_user_ids` to fetch DM participants.

### After

`check_message` (an early function in the call chain) already has the full list of participant ids, so we construct
those participants as `dm_involved_user_ids` set which is used as follows:
1. we pass it along the call chain to reach `get_recipient_info` and avoids that extra query. 
2. in  `check_can_send_direct_message`.
3. in `get_recipients_for_user_creation_events` in #39270

The fallback  to `get_direct_message_group_user_ids` is preserved for message edit and tests that bypass `check_message`.


### Savings:
Avoiding an extra query by `get_direct_message_group_user_ids` for each message sent via `DirectMessageGroup`

# PR overall performance gains

Savings in number of db queries  for each  message sendt via `DirectMessageGroup`:

| Case | DB round trips saved |  
| -------- | -------- | 
| **New**  `DirectMessageGroup`| 3  |
| **Existing** `DirectMessageGroup` | 2 |


# Upcoming in the same PR
- I believe this [TODO](https://github.com/zulip/zulip/blob/main/zerver/actions/message_send.py#L1659-L1662) in `check_can_send_direct_message()` is relevant ?