### PR TITLE
[ai] people: Demote "Added user late" log during initial events catchup.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -12,6 +12,7 @@ import * as message_user_ids from "./message_user_ids.ts";
 import * as muted_users from "./muted_users.ts";
 import {page_params} from "./page_params.ts";
 import * as reload_state from "./reload_state.ts";
+import * as server_events_state from "./server_events_state.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
 import type {CurrentUser, StateData, profile_datum_schema} from "./state_data.ts";
@@ -1536,9 +1537,17 @@ export function report_late_add(user_id: number, email: string): void {
     // we will fetch messages from the server that were sent by users
     // who don't exist in our users data set. This can happen because
     // we're in the middle of a reload (and thus stopped our event
-    // queue polling) or because we are a spectator and never had an
-    // event queue in the first place.
-    if (reload_state.is_in_progress() || page_params.is_spectator) {
+    // queue polling), because we are a spectator and never had an
+    // event queue in the first place, or because the first
+    // /json/events poll for this page's queue hasn't yet returned —
+    // in which case the message fetch may reference users created
+    // after the /register snapshot, and the corresponding
+    // realm_user/add event simply hasn't been delivered yet.
+    if (
+        reload_state.is_in_progress() ||
+        page_params.is_spectator ||
+        !server_events_state.has_received_first_events_response()
+    ) {
         blueslip.log("Added user late", {user_id, email});
     } else if (!settings_data.user_can_access_all_other_users()) {
         blueslip.log("Message was sent by an inaccessible user", {user_id});

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -12,7 +12,7 @@ import * as reload from "./reload.ts";
 import * as reload_state from "./reload_state.ts";
 import * as sent_messages from "./sent_messages.ts";
 import * as server_events_dispatch from "./server_events_dispatch.js";
-import {queue_id} from "./server_events_state.ts";
+import {mark_first_events_response_received, queue_id} from "./server_events_state.ts";
 import {server_message_schema} from "./server_message.ts";
 import * as util from "./util.ts";
 import * as watchdog from "./watchdog.ts";
@@ -198,6 +198,7 @@ function get_events({dont_block = false} = {}) {
                 popup_banners.close_connection_error_popup_banner("server_events");
 
                 get_events_success(data.events);
+                mark_first_events_response_received();
             } catch (error) {
                 blueslip.error("Failed to handle get_events success", undefined, error);
             }

--- a/web/src/server_events_state.ts
+++ b/web/src/server_events_state.ts
@@ -4,6 +4,21 @@ export let queue_id: string | null;
 export let assert_get_events_running: (error_message: string) => void;
 export let restart_get_events: () => void;
 
+// True once /json/events has successfully returned at least once
+// since this page's queue was created. Until then, the people store
+// may legitimately lack users that exist server-side but were created
+// after the /register snapshot's last_event_id; report_late_add uses
+// this to demote "Added user late" from blueslip.error to a log.
+let first_events_response_received = false;
+
+export function has_received_first_events_response(): boolean {
+    return first_events_response_received;
+}
+
+export function mark_first_events_response_received(): void {
+    first_events_response_received = true;
+}
+
 export function initialize(
     params: StateData["server_events_state"] & {
         assert_get_events_running: (error_message: string) => void;

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -18,6 +18,9 @@ const message_user_ids = mock_esm("../src/message_user_ids");
 const settings_data = mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
 });
+mock_esm("../src/server_events_state", {
+    has_received_first_events_response: () => true,
+});
 const channel = mock_esm("../src/channel");
 
 let additional_calls_before_set_timeout = noop;

--- a/web/tests/people_errors.test.cjs
+++ b/web/tests/people_errors.test.cjs
@@ -11,6 +11,9 @@ const blueslip = require("./lib/zblueslip.cjs");
 const reload_state = mock_esm("../src/reload_state", {
     is_in_progress: () => false,
 });
+const server_events_state = mock_esm("../src/server_events_state", {
+    has_received_first_events_response: () => true,
+});
 const settings_data = mock_esm("../src/settings_data");
 
 const people = zrequire("people");
@@ -34,8 +37,15 @@ run_test("report_late_add", ({override}) => {
     blueslip.expect("error", "Added user late");
     people.report_late_add(55, "foo@example.com");
 
+    // Before the first /json/events poll has returned, the people
+    // store may legitimately lack users created after the /register
+    // snapshot, so we demote the error to a log.
+    override(server_events_state, "has_received_first_events_response", () => false);
+    blueslip.expect("log", "Added user late", 2);
+    people.report_late_add(55, "foo@example.com");
+    override(server_events_state, "has_received_first_events_response", () => true);
+
     override(settings_data, "user_can_access_all_other_users", () => false);
-    blueslip.expect("log", "Added user late");
     override(reload_state, "is_in_progress", () => true);
     people.report_late_add(55, "foo@example.com");
 


### PR DESCRIPTION
## Summary

Follow-up to #38633.

After a reload, `/register` populates the people store and `server_events` starts polling `/json/events`. Between `/register` returning and the first `get_events` response, `/json/messages` can fetch messages referencing users created **after** the `/register` snapshot, before the corresponding `realm_user/add` events have been delivered. This is benign — a placeholder user is created and later updated by the event — but produced a spurious `blueslip.error`, with most volume on realms that have frequent user creation.

A representative breadcrumb trace:

```
(May 9)  navigation /?state_data=deferred#reload:... → /#reload:...
(May 13) POST /json/register      200      ← deferred state_data fetch
         navigation /#reload:... → /#narrow/...
         "Restarting get_events due to unsuspend"
         GET /json/events  status:0        ← cancelled by restart
         "We are narrowing as part of a reload"
         GET /json/messages  200
         ERROR: Added user late
```

In this post-reload init flow, \`reload_state.is_in_progress()\` is false (the new page is a fresh JS context), so the existing reload/spectator branches in \`report_late_add\` don't fire and the error path was taken. PR #38633 fixed a narrower variant of this race **during** the reload itself; this completes the fix for the post-reload init window.

### Fix

Track whether \`/json/events\` has successfully returned at least once since this queue was created (new \`events_initial_catchup_complete\` flag in \`server_events_state.ts\`, set by \`server_events.js\` on the first successful response). Until it flips, \`report_late_add\` demotes the \`blueslip.error\` to a log, matching the existing reload/spectator branches. After the first poll, the original error semantics are preserved so genuine bugs still surface.

----

Had Claude investigate the sentry traceback for the issue and provided it enough context. This fix looks reasonable. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)