### PR TITLE
search: Use decorated channel icon in search pills and description.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -209,7 +209,7 @@ async function search_tests(page: Page): Promise<void> {
     await search_and_check(
         page,
         "Verona",
-        "#Verona",
+        "channel: Verona",
         expect_verona_stream,
         "#Verona - Zulip Dev - Zulip",
     );

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -17,6 +17,7 @@ import * as resolved_topic from "./resolved_topic.ts";
 import {current_user, narrow_canonical_term_schema, narrow_operator_schema} from "./state_data.ts";
 import type {NarrowCanonicalTerm, NarrowTerm, NarrowTermSuggestion} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
+import type {StreamSubscription} from "./sub_store.ts";
 import * as sub_store from "./sub_store.ts";
 import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
@@ -41,14 +42,14 @@ type Part =
       }
     | {
           type: "channel_topic";
-          channel: string;
+          stream: StreamSubscription;
           topic_display_name: string;
           is_empty_string_topic: boolean;
       }
     | {
           type: "channel";
           prefix_for_operator: string;
-          operand: string;
+          stream: StreamSubscription;
       }
     | {
           type: "is_operator";
@@ -859,13 +860,13 @@ export class Filter {
                 term_1.operator === "topic" &&
                 !term_1.negated
             ) {
-                // `channel` might be undefined if it's coming from a text query
-                const channel = stream_data.get_sub_by_id_string(term_0.operand)?.name;
-                if (channel) {
+                // `sub` might be undefined if it's coming from a text query.
+                const sub = stream_data.get_sub_by_id_string(term_0.operand);
+                if (sub) {
                     const topic = term_1.operand;
                     parts.push({
                         type: "channel_topic",
-                        channel,
+                        stream: sub,
                         topic_display_name: util.get_final_topic_display_name(topic),
                         is_empty_string_topic: topic === "",
                     });
@@ -931,8 +932,8 @@ export class Filter {
                     if (stream) {
                         return {
                             type: "channel",
-                            prefix_for_operator: verb + "messages in #",
-                            operand: stream.name,
+                            prefix_for_operator: verb + "messages in ",
+                            stream,
                         };
                     }
                     // Assume the operand is a partially formed name and return

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -14,6 +14,7 @@ import type {User} from "./people.ts";
 import {type Suggestion, search_term_description_html} from "./search_suggestion.ts";
 import type {NarrowCanonicalTerm, NarrowTermSuggestion} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
+import type {StreamSubscription} from "./sub_store.ts";
 import * as user_status from "./user_status.ts";
 import type {UserStatusEmojiInfo} from "./user_status.ts";
 import * as util from "./util.ts";
@@ -48,7 +49,7 @@ type PillRenderData =
               topic_display_name?: string;
               description_html?: string;
               is_combined_channel_topic?: boolean;
-              combined_channel_name?: string;
+              stream?: StreamSubscription;
           })
     | SearchUserPill;
 
@@ -166,11 +167,11 @@ function maybe_generate_combined_channel_topic_pill(
 
     const sign = search_pill.negated ? "-" : "";
     const channel_operand = search_terms[index - 1]!.operand;
-    const channel_name = stream_data.get_valid_sub_by_id_string(channel_operand).name;
+    const sub = stream_data.get_valid_sub_by_id_string(channel_operand);
     return {
         ...search_pill,
         sign,
-        combined_channel_name: channel_name,
+        stream: sub,
         is_combined_channel_topic: true,
         topic_display_name: util.get_final_topic_display_name(search_pill.operand),
         is_empty_string_topic: search_pill.operand === "",

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -21,7 +21,7 @@
                 {{> decorated_channel_name stream=stream }}
             {{else}}
                 {{#if is_combined_channel_topic}}
-                {{sign}}#{{combined_channel_name}} &gt;<span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}> {{topic_display_name}}</span>
+                {{sign}}{{> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}} &gt;<span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}> {{topic_display_name}}</span>
                 {{else}}
                 {{#if is_empty_string_topic}}
                 {{sign}}topic:{{#if topic_display_name}}<span class="empty-topic-display"> {{topic_display_name}}</span>{{/if}}

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -4,13 +4,13 @@
         {{~this.content~}}
     {{else if (eq this.type "channel_topic")}}
         {{~#if is_empty_string_topic~}}
-        messages in #{{this.channel}} > <span class="empty-topic-display">{{this.topic_display_name}}</span>
+        messages in {{> decorated_channel_name stream=this.stream inline_with_text=true show_colored_icon=false}} > <span class="empty-topic-display">{{this.topic_display_name}}</span>
         {{~else~}}
-        messages in #{{this.channel}} > {{this.topic_display_name}}
+        messages in {{> decorated_channel_name stream=this.stream inline_with_text=true show_colored_icon=false}} > {{this.topic_display_name}}
         {{~/if~}}
     {{else if (eq this.type "channel")}}
         {{~!-- squash whitespace --~}}
-        {{this.prefix_for_operator}}{{this.operand}}
+        {{this.prefix_for_operator}}{{> decorated_channel_name stream=this.stream inline_with_text=true show_colored_icon=false}}
         {{~!-- squash whitespace --~}}
     {{else if (eq this.type "invalid_has")}}
         {{~!-- squash whitespace --~}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1894,6 +1894,8 @@ test("describe", ({mock_template, override}) => {
     assert.equal(Filter.search_description_as_html(narrow, false), string);
     page_params.is_spectator = false;
 
+    const devel_decorated = `<span class="decorated-channel-name-wrapper inline-decorated-channel-name"><span class="channel-privacy-type-icon"><i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i></span><span class="decorated-channel-name">devel</span></span>`;
+    const river_decorated = `<span class="decorated-channel-name-wrapper inline-decorated-channel-name"><span class="channel-privacy-type-icon"><i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i></span><span class="decorated-channel-name">river</span></span>`;
     const devel_id = new_stream_id();
     make_sub("devel", devel_id);
 
@@ -1901,7 +1903,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "is", operand: "starred"},
     ];
-    string = "messages in #devel, starred messages";
+    string = `messages in ${devel_decorated}, starred messages`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     const river_id = new_stream_id();
@@ -1910,14 +1912,14 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: river_id.toString()},
         {operator: "is", operand: "unread"},
     ];
-    string = "messages in #river, unread messages";
+    string = `messages in ${river_decorated}, unread messages`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: "JS"},
     ];
-    string = "messages in #devel > JS";
+    string = `messages in ${devel_decorated} > JS`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
@@ -1976,7 +1978,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: "JS", negated: true},
     ];
-    string = "messages in #devel, exclude topic JS";
+    string = `messages in ${devel_decorated}, exclude topic JS`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
@@ -1990,28 +1992,28 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "is", operand: "starred", negated: true},
     ];
-    string = "messages in #devel, exclude starred messages";
+    string = `messages in ${devel_decorated}, exclude starred messages`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "has", operand: "image", negated: true},
     ];
-    string = "messages in #devel, exclude messages with images";
+    string = `messages in ${devel_decorated}, exclude messages with images`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "has", operand: "abc", negated: true},
         {operator: "channel", operand: devel_id.toString()},
     ];
-    string = "invalid abc operand for has operator, messages in #devel";
+    string = `invalid abc operand for has operator, messages in ${devel_decorated}`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "has", operand: "image", negated: true},
         {operator: "channel", operand: devel_id.toString()},
     ];
-    string = "exclude messages with images, messages in #devel";
+    string = `exclude messages with images, messages in ${devel_decorated}`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [];
@@ -2022,7 +2024,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "subject", operand: "JS", negated: true},
     ];
-    string = "messages in #devel, exclude topic JS";
+    string = `messages in ${devel_decorated}, exclude topic JS`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     // Empty string topic involved.
@@ -2031,8 +2033,7 @@ test("describe", ({mock_template, override}) => {
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: ""},
     ];
-    string =
-        'messages in #devel > <span class="empty-topic-display">translated: general chat</span>';
+    string = `messages in ${devel_decorated} > <span class="empty-topic-display">translated: general chat</span>`;
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -125,7 +125,8 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             assert.equal(opts.item_html("ver")(search_suggestions[0]), expected_value);
 
             const search_string = "channel: Verona";
-            description_html = "Messages in #Verona";
+            const verona_decorated = `<span class="decorated-channel-name-wrapper inline-decorated-channel-name"><span class="channel-privacy-type-icon"><i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i></span><span class="decorated-channel-name">Verona</span></span>`;
+            description_html = `Messages in ${verona_decorated}`;
             expected_value = `<div class="search_list_item">\n            <span class="pill-container"><div class='pill ' tabindex=0>\n    <span class="pill-label">\n        <span class="pill-value">\n${search_string}\n        </span></span>\n    <div class="exit">\n        <a role="button" class="zulip-icon zulip-icon-close pill-close-button" aria-label="translated: Remove"></a>\n    </div>\n</div>\n</span>\n            <div class="description">${description_html}</div>\n</div>\n`;
             assert.equal(opts.item_html("ver")(search_suggestions[1]), expected_value);
 


### PR DESCRIPTION
Previously, channel names in search pills and search description displayed with a plain `#` prefix instead of the decorated channel icon.


1. `search_pill.ts`  Passes the `stream` object to the `input_pill` template and uses the `decorated_channel_name` partial to show the correct channel type icon in channel+topic search pills.

2. `filter.ts`  Passes the `stream` object to the `search_description` template and uses the `decorated_channel_name` partial to show the correct channel type icon in the search description bar.

Fixes: [#design > Forwarded messages still uses the old # stream icon @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Forwarded.20messages.20still.20uses.20the.20old.20.23.20stream.20icon/near/2455046)
<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="517" height="215" alt="2026-05-15_11-24-01" src="https://github.com/user-attachments/assets/d403944a-aab3-4e24-802c-6b5221b6e2e9" />|<img width="517" height="215" alt="2026-05-15_11-25-08" src="https://github.com/user-attachments/assets/a5a2c932-d94b-4690-8bec-29700b8ad4f4" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="517" height="215" alt="2026-05-15_11-14-35" src="https://github.com/user-attachments/assets/19539e94-e684-42f5-b6e2-a012decf8ba4" />|<img width="517" height="215" alt="2026-05-15_11-13-36" src="https://github.com/user-attachments/assets/42dc7770-c635-43e2-8f7d-7d693cdc77c2" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="517" height="215" alt="2026-05-15_11-27-15" src="https://github.com/user-attachments/assets/2c3fb6e7-4536-4406-ac0c-6ed9c433b596" />|<img width="517" height="215" alt="2026-05-15_11-26-18" src="https://github.com/user-attachments/assets/d8bd2fb8-5ab2-42ec-afb0-3caee825a088" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="518" height="217" alt="2026-05-15_11-20-30" src="https://github.com/user-attachments/assets/e60cba15-8f43-4b54-ab01-fc20cfae2e79" />|<img width="518" height="217" alt="2026-05-15_11-19-25" src="https://github.com/user-attachments/assets/2b84faf7-50af-4c53-adbd-59a64f774f4b" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
