### PR TITLE
Icon: Change to new Decorated channel icon all surfaces.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -14,12 +14,14 @@ import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as recent_view_util from "./recent_view_util.ts";
 import * as stream_data from "./stream_data.ts";
+import type {StreamSubscription} from "./sub_store.ts";
 import * as util from "./util.ts";
 
 type RecipientLabel = {
-    label_text: string;
+    label_text?: string;
     has_empty_string_topic?: boolean;
-    stream_name?: string;
+    stream?: StreamSubscription;
+    topic_display_name?: string;
     is_dm_with_self?: boolean;
 };
 
@@ -28,9 +30,9 @@ function get_stream_recipient_label(stream_id: number, topic: string): Recipient
     const topic_display_name = util.get_final_topic_display_name(topic);
     if (stream) {
         const recipient_label: RecipientLabel = {
-            label_text: "#" + stream.name + " > " + topic_display_name,
             has_empty_string_topic: topic === "",
-            stream_name: stream.name,
+            stream,
+            topic_display_name,
         };
         return recipient_label;
     }
@@ -247,7 +249,8 @@ export function update_recipient_text_for_reply_button(
         const empty_string_topic_display_name = util.get_final_topic_display_name("");
         const rendered_recipient_label = render_reply_recipient_label({
             has_empty_string_topic: recipient_label.has_empty_string_topic,
-            channel_name: recipient_label.stream_name,
+            stream: recipient_label.stream,
+            topic_display_name: recipient_label.topic_display_name,
             is_dm_with_self: recipient_label.is_dm_with_self,
             empty_string_topic_display_name,
             label_text: recipient_label.label_text,

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -598,7 +598,7 @@ export function inform_if_topic_is_moved(
         topic_name,
         narrow_url,
         orig_topic,
-        old_stream: old_stream.name,
+        old_stream,
         classname: compose_banner.CLASSNAMES.topic_is_moved,
         show_colored_icon: false,
         is_empty_string_topic,

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -24,6 +24,7 @@ import * as people from "./people.ts";
 import {postprocess_content} from "./postprocess_content.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
 import * as stream_data from "./stream_data.ts";
+import type {StreamSubscription} from "./sub_store.ts";
 import * as user_card_popover from "./user_card_popover.ts";
 import * as user_group_popover from "./user_group_popover.ts";
 
@@ -229,30 +230,39 @@ function format_drafts(data: Record<string, LocalStorageDraft>): FormattedDraft[
     return sorted_formatted_drafts;
 }
 
-function get_header_for_narrow_drafts(): string {
+type NarrowDraftsHeaderContext = {
+    is_dm_with_self?: boolean;
+    dm_recipient_string?: string;
+    stream?: StreamSubscription | undefined;
+    channel_name_fallback?: string | undefined;
+    topic?: string | undefined;
+};
+
+function get_header_context_for_narrow_drafts(): NarrowDraftsHeaderContext {
     const {stream_name, topic, private_recipient_ids} = drafts.current_recipient_data();
     if (private_recipient_ids && private_recipient_ids.length > 0) {
         if (private_recipient_ids.length === 1) {
             const user = people.get_by_user_id(private_recipient_ids[0]!);
             if (user && people.is_direct_message_conversation_with_self([user.user_id])) {
-                return $t({defaultMessage: "Drafts from conversation with yourself"});
+                return {is_dm_with_self: true};
             }
         }
-        return $t(
-            {defaultMessage: "Drafts from conversation with {recipient}"},
-            {
-                recipient: people.user_ids_to_full_names_string(private_recipient_ids),
-            },
-        );
+        return {
+            dm_recipient_string: people.user_ids_to_full_names_string(private_recipient_ids),
+        };
     }
-    const recipient = topic ? `#${stream_name} > ${topic}` : `#${stream_name}`;
-    return $t({defaultMessage: "Drafts from {recipient}"}, {recipient});
+    const stream = stream_name ? stream_data.get_sub_by_name(stream_name) : undefined;
+    return {
+        stream,
+        channel_name_fallback: stream_name,
+        topic,
+    };
 }
 
 function get_formatted_drafts_data(): {
     narrow_drafts: FormattedDraft[];
     other_drafts: FormattedDraft[];
-    narrow_drafts_header: string;
+    narrow_drafts_header: NarrowDraftsHeaderContext;
 } {
     const all_drafts = drafts.draft_model.get();
     const narrow_drafts_raw = drafts.filter_drafts_by_compose_box_and_recipient(all_drafts);
@@ -262,7 +272,7 @@ function get_formatted_drafts_data(): {
     );
     const narrow_drafts = format_drafts(narrow_drafts_raw);
     const other_drafts = format_drafts(other_drafts_raw);
-    const narrow_drafts_header = get_header_for_narrow_drafts();
+    const narrow_drafts_header = get_header_context_for_narrow_drafts();
     return {narrow_drafts, other_drafts, narrow_drafts_header};
 }
 
@@ -300,7 +310,7 @@ function fetch_server_rendered_drafts(formatted_drafts: FormattedDraft[]): void 
 function render_widgets(
     narrow_drafts: FormattedDraft[],
     other_drafts: FormattedDraft[],
-    narrow_drafts_header: string,
+    narrow_drafts_header: NarrowDraftsHeaderContext,
 ): void {
     const $drafts_table = $("#drafts_table");
     if ($(".drafts-list").length === 0) {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1630,7 +1630,13 @@ type ToastParams = {
 };
 
 function show_message_moved_toast(toast_params: ToastParams): void {
-    const new_stream_name = sub_store.maybe_get_stream_name(toast_params.new_stream_id);
+    const new_stream = sub_store.get(toast_params.new_stream_id);
+    if (new_stream === undefined) {
+        blueslip.error("Cannot find stream for message moved toast", {
+            stream_id: toast_params.new_stream_id,
+        });
+        return;
+    }
     const new_topic_display_name = util.get_final_topic_display_name(toast_params.new_topic_name);
     const is_empty_string_topic = toast_params.new_topic_name === "";
     const new_location_url = hash_util.by_stream_topic_url(
@@ -1640,7 +1646,7 @@ function show_message_moved_toast(toast_params: ToastParams): void {
     feedback_widget.show({
         populate($container) {
             const widget_body_html = render_message_moved_widget_body({
-                new_stream_name,
+                stream: new_stream,
                 new_topic_display_name,
                 new_location_url,
                 is_empty_string_topic,

--- a/web/templates/compose_banner/topic_moved_banner.hbs
+++ b/web/templates/compose_banner/topic_moved_banner.hbs
@@ -4,7 +4,7 @@
             The topic you were composing to (<z-link></z-link>) was moved, and the destination for your message has been updated to its new location.
             {{#*inline "z-link"~}}
                 <a class="above_compose_banner_action_link" href="{{narrow_url}}">
-                    {{~> ../inline_topic_link_label channel_name=old_stream topic_display_name=orig_topic is_empty_string_topic=is_empty_string_topic~}}
+                    {{~> ../inline_topic_link_label stream=old_stream topic_display_name=orig_topic is_empty_string_topic=is_empty_string_topic~}}
                 </a>
             {{~/inline}}
         {{/tr}}

--- a/web/templates/drafts_list.hbs
+++ b/web/templates/drafts_list.hbs
@@ -4,7 +4,27 @@
     </div>
 
     <div id="drafts-from-conversation">
-        <h2>{{narrow_drafts_header}}</h2>
+        {{#with narrow_drafts_header}}
+            {{#if is_dm_with_self}}
+                <h2>{{t "Drafts from conversation with yourself"}}</h2>
+            {{else if dm_recipient_string}}
+                <h2>{{#tr}}Drafts from conversation with {dm_recipient_string}{{/tr}}</h2>
+            {{else}}
+                <h2>
+                    {{~#tr}}
+                        Drafts from <z-recipient></z-recipient>
+                        {{#*inline "z-recipient"}}
+                            {{#if stream}}
+                                {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+                            {{else if channel_name_fallback~}}
+                                #{{channel_name_fallback}}
+                            {{~/if}}
+                            {{~#if topic}} &gt; {{topic}}{{/if}}
+                        {{/inline}}
+                    {{/tr~}}
+                </h2>
+            {{/if}}
+        {{/with}}
         {{#each narrow_drafts}}
             {{> draft .}}
         {{/each}}

--- a/web/templates/inline_topic_link_label.hbs
+++ b/web/templates/inline_topic_link_label.hbs
@@ -1,13 +1,13 @@
 {{#if is_empty_string_topic}}
 <span class="stream-topic">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; <em class="empty-topic-display">{{t "general chat"}}</em>
+    {{> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}} &gt; <em class="empty-topic-display">{{t "general chat"}}</em>
     {{~!-- squash whitespace --~}}
 </span>
 {{~else}}
 <span class="stream-topic">
     {{~!-- squash whitespace --~}}
-    #{{channel_name}} &gt; {{topic_display_name}}
+    {{> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}} &gt; {{topic_display_name}}
     {{~!-- squash whitespace --~}}
 </span>
 {{~/if}}

--- a/web/templates/message_moved_widget_body.hbs
+++ b/web/templates/message_moved_widget_body.hbs
@@ -4,7 +4,7 @@
         {{#*inline "z-link"~}}
             <a class="white-space-preserve-wrap" href="{{new_location_url}}">
                 {{~!-- squash whitespace --~}}
-                #{{new_stream_name}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{new_topic_display_name}}</span>
+                {{> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{new_topic_display_name}}</span>
                 {{~!-- squash whitespace --~}}
             </a>
         {{~/inline}}

--- a/web/templates/reply_recipient_label.hbs
+++ b/web/templates/reply_recipient_label.hbs
@@ -6,11 +6,12 @@
 {{#tr}}
     Message <z-recipient-label></z-recipient-label>
     {{#*inline "z-recipient-label"}}
-        {{#if has_empty_string_topic~}}
-        #{{channel_name}} &gt; <span class="empty-topic-display">{{empty_string_topic_display_name}}</span>
-        {{~else~}}
-        {{label_text}}
+        {{#if stream}}
+            {{~> decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}
+            {{~#if has_empty_string_topic}} &gt; <span class="empty-topic-display">{{empty_string_topic_display_name}}</span>{{else}} &gt; {{topic_display_name}}{{/if~}}
+        {{else~}}
+            {{label_text}}
         {{~/if}}
-    {{~/inline}}
+    {{/inline}}
 {{/tr}}
 {{/if}}

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -74,7 +74,12 @@ function test_reply_label(expected_label) {
     );
 }
 
-run_test("reply_label", () => {
+run_test("reply_label", ({mock_template}) => {
+    mock_template(
+        "decorated_channel_name.hbs",
+        false,
+        (data) => `<rendered-channel-stub:${data.stream.name}>`,
+    );
     // Mocking up a test message list
     const filter = new Filter([]);
     const list = new MessageList({
@@ -165,10 +170,10 @@ run_test("reply_label", () => {
     );
 
     const expected_labels = [
-        "#first_stream &gt; first_topic",
-        "#first_stream &gt; second_topic",
-        "#second_stream &gt; third_topic",
-        "#second_stream &gt; second_topic",
+        "<rendered-channel-stub:first_stream> &gt; first_topic",
+        "<rendered-channel-stub:first_stream> &gt; second_topic",
+        "<rendered-channel-stub:second_stream> &gt; third_topic",
+        "<rendered-channel-stub:second_stream> &gt; second_topic",
         "Bob",
         "Bob, Zoe",
     ];
@@ -193,7 +198,7 @@ run_test("reply_label", () => {
     const label_html = $("#left_bar_compose_reply_button_big").html();
     assert.equal(
         label_html,
-        `translated: Message #second_stream &gt; <span class="empty-topic-display">translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}</span>`,
+        `translated: Message <rendered-channel-stub:second_stream> &gt; <span class="empty-topic-display">translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}</span>`,
     );
 });
 
@@ -204,7 +209,12 @@ run_test("empty_narrow", () => {
     assert.equal(label, "translated: Compose message");
 });
 
-run_test("test_non_message_list_input", () => {
+run_test("test_non_message_list_input", ({mock_template}) => {
+    mock_template(
+        "decorated_channel_name.hbs",
+        false,
+        (data) => `<rendered-channel-stub:${data.stream.name}>`,
+    );
     message_lists.current = undefined;
     recent_view_util.is_visible = () => true;
     const stream = make_stream({
@@ -219,7 +229,7 @@ run_test("test_non_message_list_input", () => {
         stream_id: stream.stream_id,
         topic: "topic test",
     });
-    test_reply_label("#stream test &gt; topic test");
+    test_reply_label("<rendered-channel-stub:stream test> &gt; topic test");
 
     // Direct message conversation with current user row.
     compose_closed_ui.update_recipient_text_for_reply_button({


### PR DESCRIPTION
Previously, several UI surfaces were displaying the channel name with a plain `#` prefix instead of the decorated channel icon. This PR fixes the following surfaces:

- **Message moved banner** (`message_edit.ts` + `message_moved_widget_body.hbs`) Pass the `stream` object to
`render_message_moved_widget_body` and use the `decorated_channel_name` partial to show the correct channel type icon.

- **Reply Compose box label** (`compose_closed_ui.ts` + `reply_recipient_label.hbs`) Pass the `stream` object to `render_reply_recipient_label` and use the `decorated_channel_name` partial to show the correct channel type icon.

- **Topic moved banner** (`compose_validate.ts` + `inline_topic_link_label.hbs`). Pass the `stream` object to the `inline_topic_link_label` partial, and use the `decorated_channel_name` partial to display the correct channel-type icon.

- **Drafts overlay header** (`drafts_overlay_ui.ts` + `drafts_list.hbs`) Use `render_decorated_channel_name` to show the correct channel type icon in the drafts header.

Fixes: [#design > Forwarded messages still uses the old # stream icon @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Forwarded.20messages.20still.20uses.20the.20old.20.23.20stream.20icon/near/2455046)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

<details><summary> message moved banner</summary>
<p>

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="304" height="90" alt="2026-05-14_16-37-25" src="https://github.com/user-attachments/assets/c246c3a1-e4cf-41e6-9121-2b198ff91f7b" />|<img width="304" height="90" alt="2026-05-14_16-35-48" src="https://github.com/user-attachments/assets/ad1dc532-fb5b-4370-b8a2-40886a5f56b4" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="302" height="87" alt="2026-05-14_16-39-10" src="https://github.com/user-attachments/assets/4935a849-4f33-417d-b103-919e16e6a5a4" />|<img width="302" height="88" alt="2026-05-14_16-41-39" src="https://github.com/user-attachments/assets/b9b18b89-45e1-421f-b969-845e7cf40ffd" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="302" height="88" alt="2026-05-14_16-44-41" src="https://github.com/user-attachments/assets/ad8d1960-ddc0-41ac-8d25-07359a13919b" />|<img width="302" height="88" alt="2026-05-14_16-43-24" src="https://github.com/user-attachments/assets/a5c91d3c-2020-48f0-aca3-796e401b3826" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="302" height="88" alt="2026-05-14_16-47-05" src="https://github.com/user-attachments/assets/93bf461d-62e3-46ad-bc06-f2d569173389" />|<img width="302" height="86" alt="2026-05-14_16-49-32" src="https://github.com/user-attachments/assets/5edf9c75-b06c-47fd-b7d2-6c316b8df781" />|

</p>
</details> 

<details><summary> decorated channel icon in compose box reply label </summary>
<p>

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-14-14" src="https://github.com/user-attachments/assets/0d63cc4c-254e-4fe1-8a59-50fd3890d233" />|<img width="518" height="32" alt="2026-05-14_18-13-35" src="https://github.com/user-attachments/assets/687a3ff2-5293-45f9-871a-bd6683dd28c2" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-17-38" src="https://github.com/user-attachments/assets/8ee801ad-9b95-4179-bf17-a77412c88931" />|<img width="518" height="32" alt="2026-05-14_18-18-24" src="https://github.com/user-attachments/assets/1fd4daaf-d041-4a72-afa8-f772c9f840c3" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-14-46" src="https://github.com/user-attachments/assets/fd2bae0f-7396-4bcc-9d36-57d4b2ae2b3a" />|<img width="518" height="32" alt="2026-05-14_18-15-24" src="https://github.com/user-attachments/assets/3a52d649-1595-458a-9de4-9c056ad28198" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-19-15" src="https://github.com/user-attachments/assets/2cbdcb96-5c05-43c8-b5e7-d813301717b2" />|<img width="518" height="32" alt="2026-05-14_18-18-43" src="https://github.com/user-attachments/assets/0cd8556d-e314-4637-ab96-d3093241d7e2" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-16-50" src="https://github.com/user-attachments/assets/ef08e6fd-5288-4000-be9f-a9f8e75b9e72" />|<img width="518" height="32" alt="2026-05-14_18-16-08" src="https://github.com/user-attachments/assets/4a5f08b3-82d1-40e7-88b8-99c71c8183c8" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="518" height="32" alt="2026-05-14_18-19-57" src="https://github.com/user-attachments/assets/0a1cad40-d3bf-40fa-b509-4f19ecfb4215" />|<img width="518" height="32" alt="2026-05-14_18-20-21" src="https://github.com/user-attachments/assets/4ad7845d-7836-47be-a972-581d6e551db4" />|

</p>
</details> 

<details><summary> moved banner was displaying the channel name </summary>
<p>


| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-05-13" src="https://github.com/user-attachments/assets/249307fa-ee3d-4075-91b2-022a7d10752e" />|<img width="417" height="58" alt="2026-05-14_19-03-12" src="https://github.com/user-attachments/assets/1666cabc-6441-4ac2-b938-535306a495df" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-06-16" src="https://github.com/user-attachments/assets/e098a50d-1263-4959-8d2f-fa61c27ce968" />|<img width="417" height="58" alt="2026-05-14_19-11-12" src="https://github.com/user-attachments/assets/c043e050-844c-4ab1-808c-907664848a03" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-16-08" src="https://github.com/user-attachments/assets/3768700f-ac3a-4c8c-9df1-50a101d516fa" />|<img width="417" height="58" alt="2026-05-14_19-13-47" src="https://github.com/user-attachments/assets/e821d873-9375-4c04-b536-008255f20e5e" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="417" height="58" alt="2026-05-14_19-16-15" src="https://github.com/user-attachments/assets/dfb9ba50-5454-40ec-8665-65101d683c51" />|<img width="417" height="58" alt="2026-05-14_19-14-03" src="https://github.com/user-attachments/assets/7099edda-ed61-458b-a711-4a91515738f7" />|


</p>
</details> 

<details><summary> Drafts Header</summary>
<p>


| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/99aff69a-8893-43d0-a538-1f8221f20d30" />|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/45c8f670-6eee-4eeb-85b7-891ac2fca5b4" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/afa506de-d1a1-4d7f-a9b7-d50737e16333" />|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/3d0905ed-f5fb-4c61-8ca0-68518fd02f58" />|

| Dark theme comparision | Dark theme comparision |
|--------|-------|
|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/4b4173f5-eb38-48aa-b750-ae147b66de09" />|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/dccd2ab6-4160-471f-9daf-ce866e801ccf" />|

| Light theme comparision | Light theme comparision |
|--------|-------|
|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/88180541-de77-49df-a256-ecc9c6cb58d6" />|<img width="1115" height="255" alt="image" src="https://github.com/user-attachments/assets/be05077d-2b08-468f-bbf3-c486a7ae675f" />|


</p>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
