### PR TITLE
import_util: Use `Response.iter_content` to write file stream. 

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -625,8 +625,7 @@ def get_avatar(avatar_dir: str, size_url_suffix: str, avatar_upload_item: list[s
         avatar_url += size_url_suffix
 
     response = request_file_stream(avatar_url)
-    with open(image_path, "wb") as image_file:
-        shutil.copyfileobj(response.raw, image_file)
+    write_response_file_stream_to_path(response, image_path)
     shutil.copy(image_path, original_image_path)
 
 
@@ -721,6 +720,18 @@ def request_file_stream(
     return response
 
 
+WRITE_RESPONSE_FILE_STREAM_CHUNK_SIZE = 64 * 1024
+
+
+def write_response_file_stream_to_path(
+    response: requests.Response,
+    file_path: str,
+    chunk_size: int = WRITE_RESPONSE_FILE_STREAM_CHUNK_SIZE,
+) -> None:
+    with open(file_path, "wb") as file_destination:
+        file_destination.writelines(response.iter_content(chunk_size=chunk_size))
+
+
 def download_and_export_upload_file(
     output_dir: str, upload_file_request: UploadFileRequest
 ) -> None:
@@ -734,8 +745,7 @@ def download_and_export_upload_file(
     )
 
     os.makedirs(os.path.dirname(file_output_path), exist_ok=True)
-    with open(file_output_path, "wb") as upload_file:
-        shutil.copyfileobj(response.raw, upload_file)
+    write_response_file_stream_to_path(response, file_output_path)
 
 
 def build_realm_emoji(realm_id: int, name: str, id: int, file_name: str) -> ZerverFieldsT:
@@ -786,8 +796,7 @@ def get_emojis(
     upload_emoji_path = os.path.join(emoji_dir, emoji_path)
 
     os.makedirs(os.path.dirname(upload_emoji_path), exist_ok=True)
-    with open(upload_emoji_path, "wb") as emoji_file:
-        shutil.copyfileobj(response.raw, emoji_file)
+    write_response_file_stream_to_path(response, upload_emoji_path)
 
     return GetEmojiResult(path_id=emoji_path, filename=emoji_file_name)
 

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -762,7 +762,7 @@ def get_emojis(
     Raises `BadImageError` when the content-type is not guessable, or
     not in both `THUMBNAIL_ACCEPT_IMAGE_TYPES` and `INLINE_MIME_TYPES`.
     """
-    response = _data_import_session.get(emoji_url, stream=True)
+    response = request_file_stream(emoji_url)
     content_type_raw = response.headers.get("Content-Type")
     if content_type_raw is None:
         logging.warning(
@@ -785,7 +785,6 @@ def get_emojis(
     )
     upload_emoji_path = os.path.join(emoji_dir, emoji_path)
 
-    response = request_file_stream(emoji_url)
     os.makedirs(os.path.dirname(upload_emoji_path), exist_ok=True)
     with open(upload_emoji_path, "wb") as emoji_file:
         shutil.copyfileobj(response.raw, emoji_file)

--- a/zerver/data_import/microsoft_teams.py
+++ b/zerver/data_import/microsoft_teams.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import shutil
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -35,6 +34,7 @@ from zerver.data_import.import_util import (
     make_subscriber_map,
     request_file_stream,
     validate_user_emails_for_import,
+    write_response_file_stream_to_path,
 )
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE, do_common_export_processes
@@ -459,8 +459,7 @@ def download_and_export_microsoft_teams_upload_file(
     )
 
     os.makedirs(os.path.dirname(file_output_path), exist_ok=True)
-    with open(file_output_path, "wb") as upload_file:
-        shutil.copyfileobj(response.raw, upload_file)
+    write_response_file_stream_to_path(response, file_output_path)
 
     raw_content_type = response.headers.get("Content-Type")
     assert raw_content_type is not None

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -47,6 +47,7 @@ from zerver.data_import.import_util import (
     process_emojis,
     request_file_stream,
     validate_user_emails_for_import,
+    write_response_file_stream_to_path,
 )
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack_message_conversion import (
@@ -1508,14 +1509,13 @@ def fetch_team_icons(
         return []
 
     response = request_file_stream(icon_url)
-    response_raw = response.raw
 
     realm_id = zerver_realm["id"]
     os.makedirs(os.path.join(output_dir, str(realm_id)), exist_ok=True)
 
     original_icon_output_path = os.path.join(output_dir, str(realm_id), "icon.original")
-    with open(original_icon_output_path, "wb") as output_file:
-        shutil.copyfileobj(response_raw, output_file)
+    write_response_file_stream_to_path(response, original_icon_output_path)
+
     records.append(
         {
             "realm_id": realm_id,


### PR DESCRIPTION
It's typically not recommended to use Response.raw to retrieve the file
content since if the content is decoded, we will be writting the
compressed bytes.

Using Response.iter_content handles a lot of what would otherwise need
to be handled manually when using Response.raw directly.

https://requests.readthedocs.io/en/latest/user/quickstart/#raw-response-content

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
