### PR TITLE
auth: Add support for OIDC user avatar sync during login.

### DIFF
--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -166,8 +166,8 @@ def absolute_avatar_url(
     return urljoin(realm_url, avatar)
 
 
-def is_avatar_new(ldap_avatar: bytes, user_profile: UserProfile) -> bool:
-    new_avatar_hash = user_avatar_content_hash(ldap_avatar)
+def is_avatar_new(avatar_content: bytes, user_profile: UserProfile) -> bool:
+    new_avatar_hash = user_avatar_content_hash(avatar_content)
 
     if user_profile.avatar_hash and user_profile.avatar_hash == new_avatar_hash:
         # If an avatar exists and is the same as the new avatar,

--- a/zerver/lib/avatar_hash.py
+++ b/zerver/lib/avatar_hash.py
@@ -37,5 +37,5 @@ def user_avatar_base_path_from_ids(user_profile_id: int, version: int, realm_id:
     return f"{realm_id}/{user_id_hash}"
 
 
-def user_avatar_content_hash(ldap_avatar: bytes) -> str:
-    return hashlib.sha256(ldap_avatar).hexdigest()
+def user_avatar_content_hash(avatar_content: bytes) -> str:
+    return hashlib.sha256(avatar_content).hexdigest()

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -680,9 +680,10 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
         default=DEFAULT_AVATAR_SOURCE, choices=AVATAR_SOURCES, max_length=1
     )
     avatar_version = models.PositiveSmallIntegerField(default=1)
-    # This is only used for LDAP-provided avatars; it contains the
-    # SHA256 hex digest of most recent raw contents that LDAP provided
-    # us, pre-thumbnailing.
+    # Used for avatars synced from an external source (currently LDAP
+    # and OIDC); it contains the SHA256 hex digest of the most recent
+    # raw contents that source provided us, pre-thumbnailing. This lets
+    # a subsequent sync skip re-uploading an unchanged avatar.
     avatar_hash = models.CharField(null=True, max_length=64)
 
     # A place to store the user's state related to third-party API

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -679,9 +679,10 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
         default=DEFAULT_AVATAR_SOURCE, choices=AVATAR_SOURCES, max_length=1
     )
     avatar_version = models.PositiveSmallIntegerField(default=1)
-    # This is only used for LDAP-provided avatars; it contains the
-    # SHA256 hex digest of most recent raw contents that LDAP provided
-    # us, pre-thumbnailing.
+    # Used for avatars synced from an external source (currently LDAP
+    # and OIDC); it contains the SHA256 hex digest of the most recent
+    # raw contents that source provided us, pre-thumbnailing. This lets
+    # a subsequent sync skip re-uploading an unchanged avatar.
     avatar_hash = models.CharField(null=True, max_length=64)
 
     # A place to store the user's state related to third-party API

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -9,6 +9,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import timedelta
 from email.headerregistry import Address
 from typing import TYPE_CHECKING, Any
@@ -3681,6 +3682,30 @@ class SAMLAuthBackendTest(SocialAuthBaseWithSyncAttrTest):
                 result,
             )
 
+    def test_social_auth_avatar_sync_unsupported_backend(self) -> None:
+        # SAML is in USER_ATTRIBUTE_SYNC_SUPPORTED_BACKENDS but doesn't
+        # implement avatar fetching (that's OIDC-only), so configuring avatar
+        # sync logs a warning and leaves the avatar unchanged rather than
+        # crashing.
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        sync_attrs_dict = {"zulip": {self.BACKEND_CLASS.name: {"avatar": True}}}
+        with self.assertLogs(self.logger_string, level="INFO") as m:
+            result = self.social_auth_test_with_sync_attrs(
+                self.get_account_data_dict(email=self.email, name=self.name),
+                subdomain="zulip",
+                extra_attrs={},
+                sync_attrs_config=sync_attrs_dict,
+            )
+        self.assertEqual(result.status_code, 302)
+
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        self.assertIn(
+            f"WARNING:{self.logger_string}:Failed to sync user avatar. "
+            f"This feature is not yet supported for {self.BACKEND_CLASS.name}",
+            m.output,
+        )
+
     @override_settings(TERMS_OF_SERVICE_VERSION=None)
     def test_social_auth_registration_auto_signup(self) -> None:
         """
@@ -4999,6 +5024,17 @@ class AppleAuthBackendNativeFlowTest(AppleAuthMixin, SocialAuthBase):
         """
 
 
+@dataclass
+class AvatarResponseMock:
+    """Configures the avatar an OIDC IdP serves during a test login, for
+    get_user_avatar_from_provider to fetch from the "picture" claim's URL."""
+
+    avatar_url: str | None = None
+    body: bytes = b""
+    content_type: str = "image/png"
+    status: int = 200
+
+
 class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
     BACKEND_CLASS = GenericOpenIdConnectBackend
     CLIENT_KEY_SETTING = "SOCIAL_AUTH_TESTOIDC_KEY"
@@ -5080,8 +5116,6 @@ class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
         # successfully pass validation by validate_and_return_id_token is impractical
         # and unnecessary (see python-social-auth implementation of the method for
         # how the validation works).
-        # We can simply mock the method to make it succeed and return an empty dict, because
-        # the return value is not used for anything.
         with mock.patch.object(
             GenericOpenIdConnectBackend, "validate_and_return_id_token", return_value={}
         ):
@@ -5109,6 +5143,20 @@ class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
             status=200,
             body=body,
             content_type="application/json",
+        )
+
+        # When a test enables avatar sync, serve the avatar from the "picture"
+        # claim's URL so get_user_avatar_from_provider can fetch it.
+        avatar_mock = extra_data.get("avatar_mock")
+        if avatar_mock is None or not avatar_mock.avatar_url:
+            return
+
+        requests_mock.add(
+            requests_mock.GET,
+            avatar_mock.avatar_url,
+            status=avatar_mock.status,
+            body=avatar_mock.body,
+            content_type=avatar_mock.content_type,
         )
 
     @override
@@ -5150,9 +5198,14 @@ class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
         extra_attrs: dict[str, Any],
         sync_attrs_config: dict[str, Any],
         multiuse_object_key: str = "",
+        avatar_mock: AvatarResponseMock | None = None,
     ) -> "TestHttpResponse":
         # Include additional claims in account_data_dict.
         account_data_dict.update(**extra_attrs)
+        # Deliver the "picture" claim via the UserInfo response so
+        # get_user_details captures it.
+        if avatar_mock is not None and avatar_mock.avatar_url:
+            account_data_dict["picture"] = avatar_mock.avatar_url
         idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS)
 
         if oidc_sync_attrs_dict := sync_attrs_config.get(subdomain, {}).get("oidc"):
@@ -5169,7 +5222,186 @@ class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
                 subdomain=subdomain,
                 is_signup=is_signup,
                 multiuse_object_key=multiuse_object_key,
+                avatar_mock=avatar_mock,
             )
+
+    def test_social_auth_avatar_sync_on_login(self) -> None:
+        example_avatar = read_test_image_file("img.png")
+        # hamlet starts without a user-uploaded avatar.
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+
+        sync_attrs_dict = {"zulip": {self.BACKEND_CLASS.name: {"avatar": True}}}
+        with self.assertLogs(self.logger_string, level="INFO"):
+            result = self.social_auth_test_with_sync_attrs(
+                self.get_account_data_dict(email=self.email, name=self.name),
+                subdomain="zulip",
+                extra_attrs={},
+                sync_attrs_config=sync_attrs_dict,
+                avatar_mock=AvatarResponseMock(
+                    avatar_url="https://idp.example.com/me/photo.png", body=example_avatar
+                ),
+            )
+        data = load_subdomain_token(result)
+        self.assertEqual(data["email"], self.email)
+        self.assertEqual(result.status_code, 302)
+
+        # The avatar from the IdP's "picture" endpoint is applied.
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_USER)
+        url = avatar_url(self.user_profile)
+        assert url is not None
+        response = self.client_get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.getvalue(), resize_avatar(example_avatar, DEFAULT_AVATAR_SIZE))
+
+    def test_social_auth_avatar_sync_skips_non_image(self) -> None:
+        avatar_url = "https://idp.example.com/me/photo"
+        sync_attrs_dict = {"zulip": {self.BACKEND_CLASS.name: {"avatar": True}}}
+        with self.assertLogs(self.logger_string, level="INFO") as m:
+            result = self.social_auth_test_with_sync_attrs(
+                self.get_account_data_dict(email=self.email, name=self.name),
+                subdomain="zulip",
+                extra_attrs={},
+                sync_attrs_config=sync_attrs_dict,
+                avatar_mock=AvatarResponseMock(
+                    avatar_url=avatar_url,
+                    body=b"<html>not an image</html>",
+                    content_type="text/html",
+                ),
+            )
+        self.assertEqual(result.status_code, 302)
+
+        # A non-image response is rejected and the avatar is left unchanged.
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        self.assertIn(
+            f"INFO:{self.logger_string}:User avatar is not an image file. Content type: text/html",
+            m.output,
+        )
+
+    def test_social_auth_avatar_sync_skips_unchanged_avatar(self) -> None:
+        example_avatar = read_test_image_file("img.png")
+        avatar_url = "https://idp.example.com/me/photo"
+
+        avatar_mock = AvatarResponseMock(avatar_url=avatar_url, body=example_avatar)
+
+        sync_attrs_dict = {"zulip": {self.BACKEND_CLASS.name: {"avatar": True}}}
+
+        # The first login uploads the avatar and records its content hash.
+        with self.assertLogs(self.logger_string, level="INFO"):
+            self.social_auth_test_with_sync_attrs(
+                self.get_account_data_dict(email=self.email, name=self.name),
+                subdomain="zulip",
+                extra_attrs={},
+                sync_attrs_config=sync_attrs_dict,
+                avatar_mock=avatar_mock,
+            )
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_USER)
+        avatar_version_after_first_login = self.user_profile.avatar_version
+
+        # On the next login with the same avatar, is_avatar_new short-circuits,
+        # so we neither re-upload the image nor bump the avatar version.
+        with (
+            self.assertLogs(self.logger_string, level="INFO"),
+            mock.patch("zerver.lib.upload.upload_avatar_image") as mock_upload,
+        ):
+            self.social_auth_test_with_sync_attrs(
+                self.get_account_data_dict(email=self.email, name=self.name),
+                subdomain="zulip",
+                extra_attrs={},
+                sync_attrs_config=sync_attrs_dict,
+                avatar_mock=avatar_mock,
+            )
+        mock_upload.assert_not_called()
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_version, avatar_version_after_first_login)
+
+    def test_social_auth_avatar_sync_no_picture_claim(self) -> None:
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        sync_attrs_dict = {"zulip": {self.BACKEND_CLASS.name: {"avatar": True}}}
+        with self.assertLogs(self.logger_string, level="INFO") as m:
+            result = self.social_auth_test_with_sync_attrs(
+                self.get_account_data_dict(email=self.email, name=self.name),
+                subdomain="zulip",
+                extra_attrs={},
+                sync_attrs_config=sync_attrs_dict,
+            )
+        self.assertEqual(result.status_code, 302)
+
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        self.assertIn(
+            f"INFO:{self.logger_string}:Unable to sync user avatar because the 'picture' "
+            "claim from 'testoidc' could not be found.",
+            m.output,
+        )
+
+    def test_social_auth_avatar_sync_fetch_http_error(self) -> None:
+        # If the avatar download fails, the avatar is left unchanged.
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        sync_attrs_dict = {"zulip": {self.BACKEND_CLASS.name: {"avatar": True}}}
+        with self.assertLogs(self.logger_string, level="INFO") as m:
+            result = self.social_auth_test_with_sync_attrs(
+                self.get_account_data_dict(email=self.email, name=self.name),
+                subdomain="zulip",
+                extra_attrs={},
+                sync_attrs_config=sync_attrs_dict,
+                avatar_mock=AvatarResponseMock(
+                    avatar_url="https://idp.example.com/me/photo.png",
+                    body=b"not found",
+                    status=404,
+                ),
+            )
+        self.assertEqual(result.status_code, 302)
+
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        self.assertIn(
+            f"INFO:{self.logger_string}:Failed to fetch user avatar from 'oidc:testoidc'. HTTP error: 404",
+            m.output,
+        )
+
+    def test_social_auth_avatar_sync_entra(self) -> None:
+        # Entra ID's "picture" claim is the Microsoft Graph avatar endpoint,
+        # which the backend must fetch using the OAuth access token.
+        example_avatar = read_test_image_file("img.png")
+        graph_avatar_url = "https://graph.microsoft.com/v1.0/me/photo/$value"
+
+        self.LOGIN_URL = "/accounts/login/social/oidc/entra"
+
+        idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS)
+        idps_dict["entra"] = copy.deepcopy(idps_dict["testoidc"])
+        idps_dict["entra"]["display_name"] = "Entra ID"
+        sync_attrs_dict = {"zulip": {self.BACKEND_CLASS.name: {"avatar": True}}}
+
+        # This test drives social_auth_test directly, so deliver the "picture"
+        # claim (the Graph URL) via the UserInfo response ourselves.
+        account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
+        account_data_dict["picture"] = graph_avatar_url
+
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+        with (
+            self.settings(
+                SOCIAL_AUTH_OIDC_ENABLED_IDPS=idps_dict,
+                SOCIAL_AUTH_SYNC_ATTRS_DICT=sync_attrs_dict,
+            ),
+            self.assertLogs(self.logger_string, level="INFO"),
+        ):
+            result = self.social_auth_test(
+                account_data_dict,
+                subdomain="zulip",
+                avatar_mock=AvatarResponseMock(avatar_url=graph_avatar_url, body=example_avatar),
+            )
+        self.assertEqual(result.status_code, 302)
+
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.avatar_source, UserProfile.AVATAR_FROM_USER)
+        url = avatar_url(self.user_profile)
+        assert url is not None
+        response = self.client_get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.getvalue(), resize_avatar(example_avatar, DEFAULT_AVATAR_SIZE))
 
     @override_settings(TERMS_OF_SERVICE_VERSION=None)
     def test_social_auth_registration_auto_signup(self) -> None:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
 import ldap
 import magic
 import orjson
+import requests
 from decorator import decorator
 from django.conf import settings
 from django.contrib.auth import authenticate, get_backends, logout
@@ -73,6 +74,7 @@ from social_core.strategy import HttpResponseProtocol
 from social_django.strategy import DjangoStrategy
 from social_django.utils import load_backend, load_strategy
 from typing_extensions import override
+from urllib3 import Retry
 from zxcvbn import zxcvbn
 
 from zerver.actions.create_user import do_create_user, do_reactivate_user
@@ -93,12 +95,15 @@ from zerver.lib.avatar_hash import user_avatar_content_hash
 from zerver.lib.dev_ldap_directory import init_fakeldap
 from zerver.lib.email_validation import email_allowed_for_realm, validate_email_not_already_in_realm
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.mime_types import bare_content_type
 from zerver.lib.mobile_auth_otp import is_valid_otp
+from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.rate_limiter import RateLimitedObject, client_is_exempt_from_rate_limiting
 from zerver.lib.redis_utils import get_dict_from_redis, get_redis_client, put_dict_in_redis
 from zerver.lib.request import RequestNotes
 from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.subdomains import get_subdomain
+from zerver.lib.thumbnail import THUMBNAIL_ACCEPT_IMAGE_TYPES
 from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.lib.user_groups import check_user_group_name, get_role_based_system_groups_dict
 from zerver.lib.users import check_full_name, validate_user_custom_profile_field
@@ -138,6 +143,47 @@ if TYPE_CHECKING:
 redis_client = get_redis_client()
 
 EMAIL_WITH_ENCODED_DISCORD_ID = "{discord_user_id}@discordexport.zulip.com"
+
+_avatar_download_session = OutgoingSession(
+    role="auth",
+    timeout=10,
+    max_retries=Retry(total=0),
+)
+
+
+def download_user_avatar_from_provider(
+    url: str,
+    logger: logging.Logger,
+    provider_name: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> tuple[bytes, str] | None:
+
+    if "stream" not in kwargs:
+        kwargs.update(stream=True)
+
+    response = _avatar_download_session.get(
+        url,
+        params=params,
+        headers=headers,
+        **kwargs,
+    )
+
+    if response.status_code != requests.codes.ok:
+        logger.info(
+            "Failed to fetch user avatar from '%s'. HTTP error: %s",
+            provider_name,
+            response.status_code,
+        )
+        return None
+
+    content_type = bare_content_type(response.headers.get("Content-Type", ""))
+    if content_type not in THUMBNAIL_ACCEPT_IMAGE_TYPES:
+        logger.info("User avatar is not an image file. Content type: %s", content_type)
+        return None
+
+    return (response.content, content_type)
 
 
 def all_default_backend_names() -> list[str]:
@@ -2351,6 +2397,8 @@ def social_auth_sync_user_attributes(
     full_name: str | None,
     extra_attrs: dict[str, Any],
     backend: Any,
+    access_token: str | None,
+    avatar_url: str | None,
 ) -> SocialAuthSyncNewUserInfo | None:
     """
     Syncs user attributes based on the SOCIAL_AUTH_SYNC_ATTRS_DICT setting.
@@ -2363,6 +2411,9 @@ def social_auth_sync_user_attributes(
        existing users upon login; new signups already get their name from
        the IdP via the regular registration flow plumbing.
     3. Syncing custom attributes. This isn't supported for user creation,
+       so they'll only be synced during the user's next login, not during
+       signup.
+    4. Syncing user avatar. This isn't supported for user creation,
        so they'll only be synced during the user's next login, not during
        signup.
     """
@@ -2378,7 +2429,11 @@ def social_auth_sync_user_attributes(
 
     profile_field_name_to_attr_name = cast(
         dict[str, str],
-        {key: value for key, value in attrs_config.items() if key not in ("groups", "full_name")},
+        {
+            key: value
+            for key, value in attrs_config.items()
+            if key not in ("groups", "full_name", "avatar")
+        },
     )
 
     group_sync_config = process_social_auth_group_sync_info(
@@ -2386,7 +2441,13 @@ def social_auth_sync_user_attributes(
     )
     should_sync_user_attrs = extra_attrs and profile_field_name_to_attr_name
     should_sync_full_name = (attrs_config.get("full_name", False) is True) and full_name
-    if not (should_sync_user_attrs or should_sync_full_name or group_sync_config is not None):
+    should_sync_avatar = attrs_config.get("avatar", False) is True
+    if not (
+        should_sync_user_attrs
+        or should_sync_avatar
+        or should_sync_full_name
+        or group_sync_config is not None
+    ):
         return None
 
     user_id = None
@@ -2482,6 +2543,46 @@ def social_auth_sync_user_attributes(
             logger=backend.logger,
             create_missing_groups=True,
         )
+
+    if should_sync_avatar:
+        if backend.name not in USER_AVATAR_SYNC_SUPPORTED_BACKENDS:
+            backend.logger.warning(
+                "Failed to sync user avatar. This feature is not yet supported for %s",
+                str(backend.name),
+            )
+            return None
+
+        # TODO: backend.get_user_avatar_from_provider is extensible to other
+        #       providers, so potentially all of them could use this code path.
+        avatar_info = backend.get_user_avatar_from_provider(
+            access_token=access_token, avatar_url=avatar_url
+        )
+
+        # Each backend handles what to log if it fails to fetch the user's avatar.
+        if avatar_info is None:
+            return None
+
+        avatar_file, content_type = avatar_info
+
+        if not is_avatar_new(avatar_file, user_profile):
+            return None
+
+        # We do local imports here to avoid import loops
+        from io import BytesIO
+
+        from zerver.actions.user_settings import do_change_avatar_fields
+        from zerver.lib.upload import upload_avatar_image
+
+        upload_avatar_image(
+            BytesIO(avatar_file),
+            user_profile,
+            content_type=content_type,
+        )
+        do_change_avatar_fields(user_profile, UserProfile.AVATAR_FROM_USER, acting_user=None)
+        # Store the content hash so is_avatar_new above can skip re-uploading
+        # an unchanged avatar on the user's next login.
+        user_profile.avatar_hash = user_avatar_content_hash(avatar_file)
+        user_profile.save(update_fields=["avatar_hash"])
 
     return None
 
@@ -2642,6 +2743,7 @@ def social_associate_user_helper(
         return_data["full_name"] = f"{first_name or ''} {last_name or ''}".strip()
 
     return_data["extra_attrs"] = kwargs["details"].get("extra_attrs", {})
+    return_data["avatar_url"] = kwargs["details"].get("avatar_url")
 
     return user_profile
 
@@ -2752,8 +2854,16 @@ def social_auth_finish(
         is_signup = False
 
     extra_attrs = return_data.get("extra_attrs", {})
+    avatar_url = return_data.get("avatar_url")
+    access_token = response.get("access_token")
     social_auth_sync_new_user_info = social_auth_sync_user_attributes(
-        realm, user_profile, full_name, extra_attrs, backend
+        realm,
+        user_profile,
+        full_name,
+        extra_attrs,
+        backend,
+        access_token,
+        avatar_url,
     )
 
     if user_profile:
@@ -2982,6 +3092,14 @@ class SocialAuthMixin(ZulipAuthMixin, ExternalAuthMethod, BaseAuth):
                 signup_url=reverse("signup-social", args=(cls.name,)),
             )
         ]
+
+    def get_user_avatar_from_provider(
+        self, access_token: str | None, avatar_url: str | None
+    ) -> tuple[bytes, str] | None:
+        """
+        This is used to support user avatar sync during login.
+        """
+        raise NotImplementedError
 
 
 @external_auth_method
@@ -4165,6 +4283,7 @@ class GenericOpenIdConnectBackend(SocialAuthMixin, OpenIdConnectAuth):
         result = {
             **user_details,
             "email_verified": get_value("email_verified"),
+            "avatar_url": get_value("picture"),
             "extra_attrs": extra_attrs,
         }
         self.logger.debug("get_user_details for <%s>: %s", self.name, result)
@@ -4406,6 +4525,38 @@ class GenericOpenIdConnectBackend(SocialAuthMixin, OpenIdConnectAuth):
         assert isinstance(result, bool)
         return result
 
+    @override
+    def get_user_avatar_from_provider(
+        self, access_token: str | None, avatar_url: str | None
+    ) -> tuple[bytes, str] | None:
+        # A successful OIDC login always yields an access token (social-core
+        # rejects a token response without one), so it's never None here.
+        assert access_token is not None
+        provider_name = f"{self.name}:{self.get_idp_name()}"
+
+        if not avatar_url:
+            self.logger.info(
+                "Unable to sync user avatar because the 'picture' claim from '%s' could not be found.",
+                self.idp_name,
+            )
+            return None
+
+        match self.get_idp_name():
+            case "entra":
+                # Entra's "picture" claim is a Graph API endpoint that requires
+                # the access token.
+                # https://learn.microsoft.com/en-us/entra/identity-platform/userinfo
+                return download_user_avatar_from_provider(
+                    avatar_url,
+                    logger=self.logger,
+                    provider_name=provider_name,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+            case _:
+                return download_user_avatar_from_provider(
+                    avatar_url, logger=self.logger, provider_name=provider_name
+                )
+
 
 def validate_otp_params(
     mobile_flow_otp: str | None = None, desktop_flow_otp: str | None = None
@@ -4523,6 +4674,7 @@ def get_external_method_dicts(realm: Realm | None = None) -> list[ExternalAuthMe
 
 USER_ATTRIBUTE_SYNC_SUPPORTED_BACKENDS = [GenericOpenIdConnectBackend.name, SAMLAuthBackend.name]
 
+USER_AVATAR_SYNC_SUPPORTED_BACKENDS = [GenericOpenIdConnectBackend.name]
 
 AUTH_BACKEND_NAME_MAP: dict[str, Any] = {
     "Dev": DevAuthBackend,

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
 import ldap
 import magic
 import orjson
+import requests
 from decorator import decorator
 from django.conf import settings
 from django.contrib.auth import authenticate, get_backends, logout
@@ -73,6 +74,7 @@ from social_core.strategy import HttpResponseProtocol
 from social_django.strategy import DjangoStrategy
 from social_django.utils import load_backend, load_strategy
 from typing_extensions import override
+from urllib3 import Retry
 from zxcvbn import zxcvbn
 
 from zerver.actions.create_user import do_create_user, do_reactivate_user
@@ -93,12 +95,15 @@ from zerver.lib.avatar_hash import user_avatar_content_hash
 from zerver.lib.dev_ldap_directory import init_fakeldap
 from zerver.lib.email_validation import email_allowed_for_realm, validate_email_not_already_in_realm
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.mime_types import bare_content_type
 from zerver.lib.mobile_auth_otp import is_valid_otp
+from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.rate_limiter import RateLimitedObject, client_is_exempt_from_rate_limiting
 from zerver.lib.redis_utils import get_dict_from_redis, get_redis_client, put_dict_in_redis
 from zerver.lib.request import RequestNotes
 from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.subdomains import get_subdomain
+from zerver.lib.thumbnail import THUMBNAIL_ACCEPT_IMAGE_TYPES
 from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.lib.user_groups import check_user_group_name, get_role_based_system_groups_dict
 from zerver.lib.users import check_full_name, validate_user_custom_profile_field
@@ -138,6 +143,47 @@ if TYPE_CHECKING:
 redis_client = get_redis_client()
 
 EMAIL_WITH_ENCODED_DISCORD_ID = "{discord_user_id}@discordexport.zulip.com"
+
+_avatar_download_session = OutgoingSession(
+    role="auth",
+    timeout=10,
+    max_retries=Retry(total=0),
+)
+
+
+def download_user_avatar_from_provider(
+    url: str,
+    logger: logging.Logger,
+    provider_name: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> tuple[bytes, str] | None:
+
+    if "stream" not in kwargs:
+        kwargs.update(stream=True)
+
+    response = _avatar_download_session.get(
+        url,
+        params=params,
+        headers=headers,
+        **kwargs,
+    )
+
+    if response.status_code != requests.codes.ok:
+        logger.info(
+            "Failed to fetch user avatar from '%s'. HTTP error: %s",
+            provider_name,
+            response.status_code,
+        )
+        return None
+
+    content_type = bare_content_type(response.headers.get("Content-Type", ""))
+    if content_type not in THUMBNAIL_ACCEPT_IMAGE_TYPES:
+        logger.info("User avatar is not an image file. Content type: %s", content_type)
+        return None
+
+    return (response.content, content_type)
 
 
 def all_default_backend_names() -> list[str]:
@@ -2351,6 +2397,8 @@ def social_auth_sync_user_attributes(
     full_name: str | None,
     extra_attrs: dict[str, Any],
     backend: Any,
+    access_token: str | None,
+    avatar_url: str | None,
 ) -> SocialAuthSyncNewUserInfo | None:
     """
     Syncs user attributes based on the SOCIAL_AUTH_SYNC_ATTRS_DICT setting.
@@ -2363,6 +2411,9 @@ def social_auth_sync_user_attributes(
        existing users upon login; new signups already get their name from
        the IdP via the regular registration flow plumbing.
     3. Syncing custom attributes. This isn't supported for user creation,
+       so they'll only be synced during the user's next login, not during
+       signup.
+    4. Syncing user avatar. This isn't supported for user creation,
        so they'll only be synced during the user's next login, not during
        signup.
     """
@@ -2378,7 +2429,11 @@ def social_auth_sync_user_attributes(
 
     profile_field_name_to_attr_name = cast(
         dict[str, str],
-        {key: value for key, value in attrs_config.items() if key not in ("groups", "full_name")},
+        {
+            key: value
+            for key, value in attrs_config.items()
+            if key not in ("groups", "full_name", "avatar")
+        },
     )
 
     group_sync_config = process_social_auth_group_sync_info(
@@ -2386,7 +2441,13 @@ def social_auth_sync_user_attributes(
     )
     should_sync_user_attrs = extra_attrs and profile_field_name_to_attr_name
     should_sync_full_name = (attrs_config.get("full_name", False) is True) and full_name
-    if not (should_sync_user_attrs or should_sync_full_name or group_sync_config is not None):
+    should_sync_avatar = attrs_config.get("avatar", False) is True
+    if not (
+        should_sync_user_attrs
+        or should_sync_avatar
+        or should_sync_full_name
+        or group_sync_config is not None
+    ):
         return None
 
     user_id = None
@@ -2482,6 +2543,46 @@ def social_auth_sync_user_attributes(
             logger=backend.logger,
             create_missing_groups=True,
         )
+
+    if should_sync_avatar:
+        if backend.name not in USER_AVATAR_SYNC_SUPPORTED_BACKENDS:
+            backend.logger.warning(
+                "Failed to sync user avatar. This feature is not yet supported for %s",
+                str(backend.name),
+            )
+            return None
+
+        # TODO: backend.get_user_avatar_from_provider is extensible to other
+        #       providers, so potentially all of them could use this code path.
+        avatar_info = backend.get_user_avatar_from_provider(
+            access_token=access_token, avatar_url=avatar_url
+        )
+
+        # Each backend handles what to log if it fails to fetch the user's avatar.
+        if avatar_info is None:
+            return None
+
+        avatar_file, content_type = avatar_info
+
+        if not is_avatar_new(avatar_file, user_profile):
+            return None
+
+        # We do local imports here to avoid import loops
+        from io import BytesIO
+
+        from zerver.actions.user_settings import do_change_avatar_fields
+        from zerver.lib.upload import upload_avatar_image
+
+        upload_avatar_image(
+            BytesIO(avatar_file),
+            user_profile,
+            content_type=content_type,
+        )
+        do_change_avatar_fields(user_profile, UserProfile.AVATAR_FROM_USER, acting_user=None)
+        # Store the content hash so is_avatar_new above can skip re-uploading
+        # an unchanged avatar on the user's next login.
+        user_profile.avatar_hash = user_avatar_content_hash(avatar_file)
+        user_profile.save(update_fields=["avatar_hash"])
 
     return None
 
@@ -2642,6 +2743,7 @@ def social_associate_user_helper(
         return_data["full_name"] = f"{first_name or ''} {last_name or ''}".strip()
 
     return_data["extra_attrs"] = kwargs["details"].get("extra_attrs", {})
+    return_data["avatar_url"] = kwargs["details"].get("avatar_url")
 
     return user_profile
 
@@ -2752,8 +2854,16 @@ def social_auth_finish(
         is_signup = False
 
     extra_attrs = return_data.get("extra_attrs", {})
+    avatar_url = return_data.get("avatar_url")
+    access_token = response.get("access_token")
     social_auth_sync_new_user_info = social_auth_sync_user_attributes(
-        realm, user_profile, full_name, extra_attrs, backend
+        realm,
+        user_profile,
+        full_name,
+        extra_attrs,
+        backend,
+        access_token,
+        avatar_url,
     )
 
     if user_profile:
@@ -2982,6 +3092,14 @@ class SocialAuthMixin(ZulipAuthMixin, ExternalAuthMethod, BaseAuth):
                 signup_url=reverse("signup-social", args=(cls.name,)),
             )
         ]
+
+    def get_user_avatar_from_provider(
+        self, access_token: str | None, avatar_url: str | None
+    ) -> tuple[bytes, str] | None:
+        """
+        This is used to support user avatar sync during login.
+        """
+        raise NotImplementedError
 
 
 @external_auth_method
@@ -4163,6 +4281,7 @@ class GenericOpenIdConnectBackend(SocialAuthMixin, OpenIdConnectAuth):
                 extra_attrs[extra_attr_name] = value
 
         result = {**user_details, "extra_attrs": extra_attrs}
+        result["avatar_url"] = get_value("picture")
         self.logger.debug("get_user_details for <%s>: %s", self.name, result)
         return result
 
@@ -4387,6 +4506,38 @@ class GenericOpenIdConnectBackend(SocialAuthMixin, OpenIdConnectAuth):
         assert isinstance(result, bool)
         return result
 
+    @override
+    def get_user_avatar_from_provider(
+        self, access_token: str | None, avatar_url: str | None
+    ) -> tuple[bytes, str] | None:
+        # A successful OIDC login always yields an access token (social-core
+        # rejects a token response without one), so it's never None here.
+        assert access_token is not None
+        provider_name = f"{self.name}:{self.get_idp_name()}"
+
+        if not avatar_url:
+            self.logger.info(
+                "Unable to sync user avatar because the 'picture' claim from '%s' could not be found.",
+                self.idp_name,
+            )
+            return None
+
+        match self.get_idp_name():
+            case "entra":
+                # Entra's "picture" claim is a Graph API endpoint that requires
+                # the access token.
+                # https://learn.microsoft.com/en-us/entra/identity-platform/userinfo
+                return download_user_avatar_from_provider(
+                    avatar_url,
+                    logger=self.logger,
+                    provider_name=provider_name,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+            case _:
+                return download_user_avatar_from_provider(
+                    avatar_url, logger=self.logger, provider_name=provider_name
+                )
+
 
 def validate_otp_params(
     mobile_flow_otp: str | None = None, desktop_flow_otp: str | None = None
@@ -4504,6 +4655,7 @@ def get_external_method_dicts(realm: Realm | None = None) -> list[ExternalAuthMe
 
 USER_ATTRIBUTE_SYNC_SUPPORTED_BACKENDS = [GenericOpenIdConnectBackend.name, SAMLAuthBackend.name]
 
+USER_AVATAR_SYNC_SUPPORTED_BACKENDS = [GenericOpenIdConnectBackend.name]
 
 AUTH_BACKEND_NAME_MAP: dict[str, Any] = {
     "Dev": DevAuthBackend,

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -596,6 +596,9 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 #             # the list of group names sent in the "zulip_groups"
 #             # attribute in the SAMLResponse.
 #             "groups": ["group1", "group2", ("samlgroup3", "zulipgroup3"), "group4"],
+#             # Avatar sync is currently only available for OICD and only done on user
+#             # login and not sign up.
+#             "avatar": False,
 #         }
 #     }
 # }


### PR DESCRIPTION
This adds support for syncing user avatars on login with OIDC
providers, using the `SOCIAL_AUTH_SYNC_ATTRS_DICT`-based user
attribute sync.

Currently only Entra ID OIDC has proper code for fetching the
user's avatar. All other OIDC providers default to downloading the
URL in the "picture" claim if it's supported.

Fixes part of: #39283

**How changes were tested:**
my entra id profile:
<img width="419" height="315" alt="image" src="https://github.com/user-attachments/assets/4df483b4-bac1-4cca-940c-0bdd47384a19" />

(retested on May 16)

https://github.com/user-attachments/assets/50a39e5c-3e1d-4fd8-8206-0846bafffc56


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
