### PR TITLE
docs: Document keypress visualizers for screencasts.

### DIFF
--- a/docs/contributing/presenting-visual-changes.md
+++ b/docs/contributing/presenting-visual-changes.md
@@ -244,9 +244,11 @@ that modified some interactions on the compose box:
 It's worth noting here that [the full PR](https://github.com/zulip/zulip/pull/35969)
 included plenty of static screenshots in addition to the GIFs showing off interactivity.
 
-Finally, make sure a person watching your video can see where on the screen you're
-tapping or clicking. Use the "show touches" or "include the mouse pointer" feature
-if your screen-recording software supports it.
+Finally, make sure a person watching your video can see what you're typing, or where on
+the screen you're tapping or clicking. Use the "show touches" or "include the mouse
+pointer" feature if your screen-recording software supports it. To show keyboard
+interactions, e.g., using a [keyboard shortcut](https://zulip.com/help/keyboard-shortcuts),
+you can use a [keypress visualizer](#keypress-visualizers-by-platform) while recording.
 
 ## Presenting screenshots on your pull request
 
@@ -371,3 +373,18 @@ You can check out the following tools for capturing screenshots and videos/GIFs.
 
 - [Peek](https://github.com/phw/peek)
 - [SilentCast](https://github.com/colinkeenan/silentcast)
+
+### Keypress visualizers by platform
+
+#### macOS
+
+- [KeyCastr](https://github.com/keycastr/keycastr)
+
+#### Windows
+
+- [YetAnotherKeyDisplayer(YAKD)](https://github.com/Jagailo/YetAnotherKeyDisplayer)
+
+#### Linux
+
+- [hibiki](https://github.com/linuxmobile/hibiki), for X11.
+- [screenkey](https://gitlab.com/screenkey/screenkey), for Wayland.


### PR DESCRIPTION
Fixes: [#documentation > keyboard interactions in PR screencasts](https://chat.zulip.org/#narrow/channel/19-documentation/topic/keyboard.20interactions.20in.20PR.20screencasts/with/2455554)

<img width="1530" height="1634" alt="Screenshot From 2026-05-21 16-31-09" src="https://github.com/user-attachments/assets/b7a0e57d-cb94-4182-b2d4-5b708d9783a7" />

<img width="1530" height="732" alt="Screenshot From 2026-05-21 16-31-19" src="https://github.com/user-attachments/assets/0538d81c-e92d-498b-8f99-ee2f8ccd5aea" />
