### PR TITLE
right_sidebar: Fix keyboard focus styling for invite link.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -598,6 +598,12 @@
     margin-top: calc(25px - (var(--legacy-body-line-height-unitless) * 1em));
     margin-bottom: var(--sidebar-bottom-spacing);
 
+    &:has(.invite-user-link:focus-visible) {
+        outline: 2px solid var(--color-outline-focus);
+        outline-offset: -2px;
+        background-color: var(--color-background-hover-narrow-filter);
+    }
+
     .invite-user-link {
         /* TODO: We should eventually change the grid to use the correct
            --right-sidebar-presence-circle-width with left spacing, and


### PR DESCRIPTION
Fixes #39172.

  When the "Invite to organization" link at the bottom of the right
  sidebar receives keyboard focus, it now shows the same outline and
  background highlight as the focused link at the bottom of the left
  sidebar.

  **Change:** Added `&:has(.invite-user-link:focus-visible)` inside
  `.invite-user-shortcut` in `web/styles/right_sidebar.css`, using the
  same `outline: 2px solid var(--color-outline-focus)` + `outline-offset: -2px`
  + `background-color: var(--color-background-hover-narrow-filter)` pattern
  already used for the left sidebar's `.subscribe-more-link:focus-visible`.

  **Test plan:**
  - [ ] Tab to "Invite to organization" in the right sidebar and verify the
  focus ring and background appear, matching the left sidebar link.
  - [ ] Verify hover behavior is unchanged.
  - [ ] Check both light and dark themes.