### PR TITLE
mobile: Scroll compose box into view when keyboard appears

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -235,6 +235,19 @@ export function set_focus(opts: ComposeTriggeredOptions): void {
     if (window.getSelection()!.toString() === "" || opts.trigger !== "message click") {
         const focus_area = get_focus_area(opts);
         $(focus_area).trigger("focus");
+
+        // On mobile, the virtual keyboard shrinks the viewport when it
+        // appears, which can hide the compose box behind it. We wait
+        // for the keyboard animation to finish (~300ms) and then scroll
+        // the focused element into view so it is always visible.
+        if (util.is_mobile()) {
+            setTimeout(() => {
+                document.querySelector<HTMLElement>(focus_area)?.scrollIntoView({
+                    behavior: "smooth",
+                    block: "nearest",
+                });
+            }, 300);
+        }
     }
 }
 


### PR DESCRIPTION
On mobile web, tapping + to write a message opens the keyboard,
but the keyboard covers the compose box and you can't see it
until you pick a channel.

This fix waits for the keyboard to finish opening (~300ms) and
then smoothly scrolls the compose box into view automatically.

Fixes: #36676

## How changes were tested:
Tested on Chrome DevTools mobile emulator (Android)
on Samsung Galaxy S8+ and Pixel 5.
Confirmed compose box is visible above keyboard after fix.
Desktop behavior unchanged (util.is_mobile() guard).
Ran tools/test-js-with-node compose_ui — all tests passed.
Tested on Chrome DevTools mobile emulator 
(Samsung Galaxy S8+ and Pixel 5)

Self-review checklist:

- [x] Self-reviewed the changes for clarity and maintainability
(variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.
- [x] Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans.
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

Screenshots and screen captures :-

Before:

<img width="348" height="172" alt="Screenshot 2026-06-06 181711" src="https://github.com/user-attachments/assets/fb464e09-2c1b-4661-acad-76d9da3bb4f2" />

After:

<img width="362" height="162" alt="Screenshot 2026-06-06 181646(1)" src="https://github.com/user-attachments/assets/1a1f8a3d-2d12-4533-bd79-cc01c7d4288a" />