### PR TITLE
zilencer: Type RemoteServerNotificationPayload fields with Pydantic models

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -588,9 +588,6 @@ class PushBouncerNotificationTest(BouncerTestCase):
             "user_id": hamlet.id,
             "user_uuid": str(hamlet.uuid),
             "realm_uuid": str(hamlet.realm.uuid),
-            "gcm_payload": {},
-            "apns_payload": {},
-            "gcm_options": {},
         }
         with (
             mock.patch("zilencer.views.send_android_push_notification", return_value=1),
@@ -656,7 +653,13 @@ class PushBouncerNotificationTest(BouncerTestCase):
             "user_id": hamlet.id,
             "user_uuid": str(hamlet.uuid),
             "realm_uuid": str(hamlet.realm.uuid),
-            "gcm_payload": {"event": "remove", "zulip_message_ids": many_ids},
+            "gcm_payload": {
+                "realm_url": hamlet.realm.url,
+                "realm_name": hamlet.realm.name,
+                "user_id": hamlet.id,
+                "event": "remove",
+                "zulip_message_ids": many_ids,
+            },
             "apns_payload": {
                 "badge": 0,
                 "custom": {"zulip": {"event": "remove", "zulip_message_ids": many_ids}},
@@ -724,7 +727,13 @@ class PushBouncerNotificationTest(BouncerTestCase):
         android_push.assert_called_once_with(
             user_identity,
             uuid_android_tokens,
-            {"event": "remove", "zulip_message_ids": ",".join(str(i) for i in range(50, 250))},
+            {
+                "realm_url": hamlet.realm.url,
+                "realm_name": hamlet.realm.name,
+                "user_id": hamlet.id,
+                "event": "remove",
+                "zulip_message_ids": ",".join(str(i) for i in range(50, 250)),
+            },
             {},
             remote=server,
         )
@@ -733,6 +742,74 @@ class PushBouncerNotificationTest(BouncerTestCase):
         server.refresh_from_db()
         self.assertEqual(remote_realm.last_request_datetime, time_sent)
         self.assertEqual(server.last_request_datetime, time_sent)
+
+    def test_send_notification_endpoint_single_platform_device(self) -> None:
+        """When a user has devices on only one platform, the server sends
+        a literal empty dict for the other platform's payload (see
+        get_payload_legacy in push_notifications.py). This must still
+        validate successfully rather than being rejected as malformed.
+        """
+        hamlet = self.example_user("hamlet")
+        server = self.server
+
+        android_token = RemotePushDeviceToken.objects.create(
+            kind=RemotePushDeviceToken.FCM,
+            token="android-only",
+            user_uuid=hamlet.uuid,
+            server=server,
+        )
+
+        payload = {
+            "user_id": hamlet.id,
+            "user_uuid": str(hamlet.uuid),
+            "realm_uuid": str(hamlet.realm.uuid),
+            "gcm_payload": {
+                "realm_url": hamlet.realm.url,
+                "realm_name": hamlet.realm.name,
+                "user_id": hamlet.id,
+                "event": "remove",
+                "zulip_message_ids": "1,2,3",
+            },
+            "apns_payload": {},
+            "gcm_options": {"priority": "normal"},
+        }
+
+        with (
+            mock.patch(
+                "zilencer.views.send_android_push_notification", return_value=1
+            ) as android_push,
+            mock.patch("zilencer.views.send_apple_push_notification", return_value=0) as apple_push,
+            mock.patch(
+                "corporate.lib.stripe.RemoteRealmBillingSession.current_counts_for_billed_users",
+                return_value=BillingUserCounts(10, 0),
+            ),
+            self.assertLogs("zilencer.views", level="INFO"),
+        ):
+            result = self.uuid_post(
+                self.server_uuid,
+                "/api/v1/remotes/push/notify",
+                payload,
+                content_type="application/json",
+            )
+        data = self.assert_json_success(result)
+        self.assertEqual(data["total_android_devices"], 1)
+        self.assertEqual(data["total_apple_devices"], 0)
+
+        user_identity = UserPushIdentityCompat(user_id=hamlet.id, user_uuid=str(hamlet.uuid))
+        android_push.assert_called_once_with(
+            user_identity,
+            [android_token],
+            {
+                "realm_url": hamlet.realm.url,
+                "realm_name": hamlet.realm.name,
+                "user_id": hamlet.id,
+                "event": "remove",
+                "zulip_message_ids": "1,2,3",
+            },
+            {"priority": "normal"},
+            remote=server,
+        )
+        apple_push.assert_called_once_with(user_identity, [], {}, remote=server)
 
     def test_send_notification_endpoint_on_free_plans(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -760,7 +837,10 @@ class PushBouncerNotificationTest(BouncerTestCase):
         )
         message.save()
 
-        # Test old zulip server case.
+        # Test old zulip server case. This uses a payload shape from
+        # before `realm_url` existed (it only had `realm_uri`; see
+        # commit ac4dde24ae), to verify we still accept payloads from
+        # self-hosted servers running old versions of Zulip.
         self.assertIsNone(remote_server.last_api_feature_level)
         old_apns_payload = {
             "alert": {
@@ -779,12 +859,13 @@ class PushBouncerNotificationTest(BouncerTestCase):
                     "server": settings.EXTERNAL_HOST,
                     "realm_id": hamlet.realm.id,
                     "realm_uri": hamlet.realm.url,
-                    "realm_url": hamlet.realm.url,
                     "user_id": othello.id,
                 }
             },
         }
         old_gcm_payload = {
+            "realm_uri": hamlet.realm.url,
+            "realm_name": hamlet.realm.name,
             "user_id": othello.id,
             "event": "message",
             "alert": "New private message from King Hamlet",
@@ -793,8 +874,6 @@ class PushBouncerNotificationTest(BouncerTestCase):
             "content": message.content,
             "server": settings.EXTERNAL_HOST,
             "realm_id": hamlet.realm.id,
-            "realm_uri": hamlet.realm.url,
-            "realm_url": hamlet.realm.url,
             "sender_id": hamlet.id,
             "sender_email": hamlet.email,
             "sender_full_name": "King Hamlet",

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -6,7 +6,7 @@ from collections import Counter
 from datetime import datetime, timedelta, timezone
 from email.headerregistry import Address
 from email.utils import formatdate as email_formatdate
-from typing import Annotated, Any, TypedDict, TypeVar
+from typing import Annotated, Any, Literal, TypedDict, TypeVar
 from urllib.parse import urljoin, urlsplit
 from uuid import UUID
 
@@ -901,13 +901,53 @@ class PushNotificationsDisallowedError(JsonableError):
         super().__init__(msg)
 
 
+class GcmOptions(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    priority: Literal["high", "normal"] | None = None
+
+
+class GcmPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    realm_url: str | None = None
+    # TODO/compatibility: `realm_uri` predates `realm_url` (added in
+    # ac4dde24ae) and is still sent by older self-hosted servers.
+    realm_uri: str | None = None
+    realm_name: str | None = None
+    user_id: int | None = None
+
+
+class ApnsAlert(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    title: str | None = None
+    subtitle: str | None = None
+    body: str | None = None
+
+
+class ApnsCustom(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    zulip: dict[str, Any] = {}
+
+
+class ApnsPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    alert: ApnsAlert | None = None
+    sound: str | None = None
+    badge: int | None = None
+    custom: ApnsCustom | None = None
+
+
 class RemoteServerNotificationPayload(BaseModel):
     user_id: int | None = None
     user_uuid: str | None = None
     realm_uuid: str | None = None
-    gcm_payload: dict[str, Any] = {}
-    apns_payload: dict[str, Any] = {}
-    gcm_options: dict[str, Any] = {}
+    gcm_payload: GcmPayload | None = None
+    apns_payload: ApnsPayload | None = None
+    gcm_options: GcmOptions | None = None
 
     android_devices: list[str] = []
     apple_devices: list[str] = []
@@ -926,9 +966,17 @@ def remote_server_notify_push(
     user_uuid = payload.user_uuid
     user_identity = UserPushIdentityCompat(user_id, user_uuid)
 
-    gcm_payload = payload.gcm_payload
-    apns_payload = payload.apns_payload
-    gcm_options = payload.gcm_options
+    gcm_payload = (
+        payload.gcm_payload.model_dump(exclude_none=True) if payload.gcm_payload is not None else {}
+    )
+    apns_payload = (
+        payload.apns_payload.model_dump(exclude_none=True)
+        if payload.apns_payload is not None
+        else {}
+    )
+    gcm_options = (
+        payload.gcm_options.model_dump(exclude_none=True) if payload.gcm_options is not None else {}
+    )
 
     realm_uuid = payload.realm_uuid
     remote_realm = None


### PR DESCRIPTION
Replace the three `dict[str, Any]` fields in `RemoteServerNotificationPayload` with typed Pydantic models so that `typed_endpoint` can validate the structure of incoming push notification payloads.

New models added in `zilencer/views.py`:
* `GcmOptions`: `priority: Literal["high", "normal"] | None`, `extra="allow"`
* `GcmPayload`: optional base fields (`realm_url`, `realm_uri`, `realm_name`, `user_id`), `extra="allow"` for variable message-type fields
* `ApnsAlert`, `ApnsCustom`, `ApnsPayload`: typed structure of the APNs payload, all with `extra="allow"`

All fields are optional and all models use `extra="allow"` because this endpoint receives requests from self-hosted servers of any Zulip version, and current servers send `{}` for unused-platform payloads (e.g. `apns_payload: {}` for Android-only users).

The view calls `.model_dump(exclude_none=True)` on each model before passing the result to downstream functions that still expect `dict[str, Any]`.

Fixes: #29469

**How changes were tested:**

- Ran `./tools/test-backend zerver.tests.test_push_notifications` 
- Ran `./tools/run-mypy zilencer/views.py` 
- Ran `./tools/lint zilencer/views.py`

<details>
<summary>Self-review checklist</summary>

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.
</details>
