### PR TITLE
backport: Give a sensible error when trying to backport an unmerged PR.

### DIFF
--- a/tools/backport-pull-request
+++ b/tools/backport-pull-request
@@ -60,6 +60,8 @@ query($pr_id:Int!) {
 '
 )"
 
+[ -n "$merge_commit" ] || fail "PR #$pr_id is not merged into 'main'. Merge it first before backporting."
+
 # We cannot trust the "commits" count on the PR, since only part of it
 # may get merged, or it may have commits squashed during the merge.
 # Walk backwards on `main` from the merge commit we found, checking


### PR DESCRIPTION
When trying to backport a pull request that hasn't yet been merged on GitHub, we'd get an unhelpful error due to the empty `$merge_commit` value:
```
gh: ` 0` does not appear to be a valid cursor.
```

This commit introduces an explicit check and a clear error.

