### PR TITLE
[ai] github: Handle ping events from GitHub Sponsors webhooks.

### DIFF
--- a/zerver/webhooks/github/fixtures/ping__sponsors.json
+++ b/zerver/webhooks/github/fixtures/ping__sponsors.json
@@ -1,0 +1,30 @@
+{
+    "zen": "Avoid administrative distraction.",
+    "hook_id": 624672630,
+    "hook": {
+        "type": "SponsorsListing",
+        "id": 624672630,
+        "name": "web",
+        "active": true,
+        "events": [
+            "sponsorship"
+        ],
+        "config": {
+            "content_type": "json",
+            "insecure_ssl": "0",
+            "url": "https://example.com/hook"
+        },
+        "updated_at": "2026-05-16T00:00:00Z",
+        "created_at": "2026-05-16T00:00:00Z"
+    },
+    "sender": {
+        "login": "marcphilipp",
+        "id": 111111,
+        "avatar_url": "https://avatars.githubusercontent.com/u/111111?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/marcphilipp",
+        "html_url": "https://github.com/marcphilipp",
+        "type": "User",
+        "site_admin": false
+    }
+}

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -906,3 +906,7 @@ class GitHubSponsorsHookTests(WebhookTestCase):
             TOPIC_SPONSORS,
             expected_message,
         )
+
+    def test_ping_message(self) -> None:
+        expected_message = "GitHub webhook has been successfully configured by marcphilipp."
+        self.check_webhook("ping__sponsors", TOPIC_SPONSORS, expected_message)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -1078,8 +1078,16 @@ def get_topic_based_on_type(payload: WildValue, event: str) -> str:
             branch="wiki pages",
         )
     elif event == "ping":
-        if not payload.get("repository"):
+        if "repository" in payload:
+            return get_repository_name(payload)
+        if "organization" in payload:
             return get_organization_name(payload)
+        # GitHub Sponsors webhook pings include neither "repository" nor
+        # "organization"; group them under the topic SPONSORS_EVENT_TYPES use.
+        hook_type = payload["hook"]["type"].tame(check_string)
+        if hook_type == "SponsorsListing":
+            return "sponsors"
+        raise UnsupportedWebhookEventTypeError(f"ping:{hook_type}")
     elif event == "check_run":
         return f"{get_repository_name(payload)} / checks"
     elif event.startswith("discussion"):


### PR DESCRIPTION
## Why

When GitHub Sponsors delivers its initial `ping` (sent once when a new webhook is created), the payload contains only `hook`, `hook_id`, `sender`, and `zen` — no `repository`, no `organization`. The existing `event == "ping"` branch in `get_topic_based_on_type` (`zerver/webhooks/github/view.py`) called `get_organization_name` whenever `repository` was absent, which then crashed on `payload["organization"]["login"]` with `ValidationError: request['organization'] is missing`, causing the `/api/v1/external/githubsponsors` endpoint to 500 on every Sponsors ping.

The Octokit webhook schema confirms both fields are optional on a ping — see [`octokit/webhooks` `payload-types/schema.d.ts`](https://github.com/octokit/webhooks/blob/main/payload-types/schema.d.ts), `PingEvent` interface:

```ts
repository?: Repository;
sender?: User;
organization?: Organization;
```

The other Sponsors events (`cancelled`, `created`, `edited`, …) already use the topic `"sponsors"` via `SPONSORS_EVENT_TYPES`; this change routes the Sponsors ping to the same topic.


---

Fed the sentry error to claude and had it debug it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)