### PR TITLE
reactions: Avoid layout shift when adding/removing reactions.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -34,13 +34,6 @@
             color: var(--color-message-reaction-text-reacted);
             background-color: var(--color-message-reaction-background-reacted);
             border-color: var(--color-message-reaction-border-reacted);
-            /* Make this border thicker by half a pixel,
-               to make own reactions more prominent. */
-            border-width: 1.5px;
-            /* Reduce the padding top and bottom by half
-               a pixel accordingly, to maintain the same
-               pill height. */
-            padding: 1px 4px 1px 3px;
             font-weight: var(--font-weight-message-reaction);
             box-shadow: none;
         }


### PR DESCRIPTION
The `.reacted` state used `border-width: 1.5px` with `padding` but was unreliable across browsers and caused surrounding messages to shift position when toggling own reactions in messages with preexisting reactions.

This fix removes `border-width` and `padding` from `.reacted` entirely. There are no layout shifts anymore but as a side effect the reacted border is thinner by 0.5px.

Originally investigated in #38691 by @Yogesh-Shivaji365.

Fixes #38923.
Related discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20later.20messages.20move.20up.2Fdown.20when.20adding.20reactji/with/2409001

<!-- Describe your pull request here.-->


**How changes were tested:**
Tested manually across following scenarios:
- Adding a reaction to a message with no existing reactions
- Adding a reaction to a message with one reaction
- Adding a reaction to a consecutive message from the same person with two reactions
- Adding a reaction with three reactions
- Adding a reaction to a message with multiple different reactions
- Toggling all reactions in the same message

Each scenario includes before/after screenshots showing the message with and without a reaction added. More zoomed in screenshots on the reactions row also included.

**Screenshots and screen captures:**


<details>
<summary>1. No existing reactions</summary>

| Before | After |
|--------|-------|
| <img width="1800" height="802" alt="before-no reaction" src="https://github.com/user-attachments/assets/66976b8c-6775-4480-b73a-261dbb33a6ea" /> | <img width="1800" height="802" alt="after-no reaction" src="https://github.com/user-attachments/assets/5693f29e-bd7e-47ce-b0f1-78e6295d11be" /> |
| <img width="1800" height="802" alt="before-added reaction" src="https://github.com/user-attachments/assets/72df85c5-02a1-4a67-9a32-3ffd58d0ca14" /> | <img width="1800" height="802" alt="after-added reaction" src="https://github.com/user-attachments/assets/c263625f-96c9-41c1-9a25-45bd8cbef7e5" /> |
| <img width="243" height="126" alt="before-zero" src="https://github.com/user-attachments/assets/2c90583a-d4be-43be-82d4-633e9905acdc" /> | <img width="243" height="126" alt="after-zero" src="https://github.com/user-attachments/assets/8253cf61-da90-4a0c-b36a-c1724c43f6d5" /> |

</details>


<details>
<summary>2. One existing reaction</summary>

| Before | After |
|--------|-------|
| <img width="2160" height="1051" alt="before-one-no reaction" src="https://github.com/user-attachments/assets/47c490c3-8e55-4fa4-a1ea-f11084968ba3" /> | <img width="2160" height="1051" alt="after-one-no reaction" src="https://github.com/user-attachments/assets/9680c96e-eefc-48a8-bb37-de535d81d38f" /> |
| <img width="2160" height="1051" alt="before-one-added reaction" src="https://github.com/user-attachments/assets/e1940ab1-605e-4a95-8b4b-15a1bd7158d6" /> | <img width="2160" height="1051" alt="after-one-added reaction" src="https://github.com/user-attachments/assets/02f0bd0d-01c6-4c2f-b127-c05cb980b40e" /> |
| Zoomed in: <img width="396" height="136" alt="before-zoomed-one-no" src="https://github.com/user-attachments/assets/7b8f5e2d-c317-4802-986b-5ea9eb5c331d" />| Zoomed in: <img width="396" height="136" alt="after-soomed-one-no" src="https://github.com/user-attachments/assets/35541893-c910-4316-8cdd-41f43d769d82" /> |
|<img width="396" height="136" alt="before-zoomed-one-added" src="https://github.com/user-attachments/assets/224cd8e3-cdff-43ef-85eb-fa71e716baf8" />| <img width="396" height="136" alt="after-zoomed-one-added" src="https://github.com/user-attachments/assets/1ec979ef-6139-49d8-afd3-14057023c98b" />|


</details>

<details>
<summary>3. Consecutive messages with two existing reactions</summary>

| Before | After |
|--------|-------|
| <img width="2793" height="793" alt="before-twow-no reaction" src="https://github.com/user-attachments/assets/bb882d67-a3f9-43d0-bb82-184cd79cb428" /> | <img width="2793" height="796" alt="after-twow-no reaction" src="https://github.com/user-attachments/assets/08fbb7b0-d548-4629-8ea0-c2d17b420e4d" /> |
| <img width="2793" height="793" alt="before-twow-added reaction" src="https://github.com/user-attachments/assets/d3e6ff9a-b53f-4857-b8af-cad63fad7057" /> | <img width="2793" height="796" alt="after-twow-added reaction" src="https://github.com/user-attachments/assets/44eef0b8-82d2-40a3-a005-85b738ee5002" /> |
| Zoomed in: <img width="580" height="136" alt="before-zoomed-two-no" src="https://github.com/user-attachments/assets/193325b8-ee96-4b5d-9fd9-b3bda5c62c29" />| Zoomed in: <img width="580" height="136" alt="after-zoomed-two-no" src="https://github.com/user-attachments/assets/f6524908-2329-4f40-9de6-e854552c5946" /> |
|<img width="580" height="133" alt="before-zoomed-two-added" src="https://github.com/user-attachments/assets/60a8373e-0655-43eb-8631-a4f4eb76e22a" />| <img width="580" height="136" alt="after-zoomed-two-added" src="https://github.com/user-attachments/assets/ece2290e-1ecf-4e7d-9062-91e86cb55fe9" />|
</details>

<details>
<summary>4. Three existing reactions </summary>

| Before | After |
|--------|-------|
| <img width="2676" height="912" alt="before-three-no reaction" src="https://github.com/user-attachments/assets/b5bb9f9a-9a6b-4b77-b346-f807d803b638" /> | <img width="2676" height="912" alt="after-three-no reaction" src="https://github.com/user-attachments/assets/587b5a51-6977-41b1-8518-2fbf38ea6991" /> |
| <img width="2676" height="912" alt="before-three-added reaction" src="https://github.com/user-attachments/assets/4e035407-2962-4c54-8e6e-a36635e4385e" /> | <img width="2676" height="912" alt="after-three-added reaction" src="https://github.com/user-attachments/assets/ce39f7a3-27d3-45b4-9c68-870bbfed6fcb" /> |
| Zoomed in: <img width="1003" height="113" alt="before-zoomed-three-no" src="https://github.com/user-attachments/assets/f4957332-e659-45e0-be80-2947e1c26e39" />| Zoomed in: <img width="1003" height="113" alt="after-zoomed-three-no" src="https://github.com/user-attachments/assets/93ad13b5-cd47-4fe7-b6aa-8a5267ed9ce8" /> |
|<img width="163" height="86" alt="before-zoomed-three-added" src="https://github.com/user-attachments/assets/c09fe360-3cc3-43e5-99ef-3bed40c2d4f4" />| <img width="160" height="86" alt="after-zoomed-three-added" src="https://github.com/user-attachments/assets/5f655759-780b-4c5d-807f-d365babded70" />|

</details>

<details>
<summary>5. Multiple different reactions </summary>

| Before | After |
|--------|-------|
| <img width="2833" height="1010" alt="before-multipl-no reaction" src="https://github.com/user-attachments/assets/219b40d9-d1a0-4ffa-bb74-397cdc716334" /> | <img width="2833" height="1010" alt="after-multiple-no reaction" src="https://github.com/user-attachments/assets/58de94b6-b5f2-49bc-b801-75b33ac1c67a" /> |
| <img width="2833" height="1010" alt="before-multiple-added reaction" src="https://github.com/user-attachments/assets/6374a5c1-054f-43a1-91c1-59a4b6f147b3" /> | <img width="2833" height="1010" alt="after-multiple-added reaction" src="https://github.com/user-attachments/assets/0a55856f-de66-4a5d-b926-ca41b9de94fb" /> |
| Zoomed in: <img width="763" height="136" alt="before-zoomed-mult-no" src="https://github.com/user-attachments/assets/8092c0ea-7f5a-4336-a1ea-e703a0a557b1" />| Zoomed in: <img width="763" height="136" alt="after-zoomed-mult-no" src="https://github.com/user-attachments/assets/11604aea-4eaf-4ebf-a00a-59a1b012a804" /> |
|<img width="763" height="136" alt="before-zoomed-mult-added" src="https://github.com/user-attachments/assets/922c4733-e234-436e-991e-61cc642be87a" />| <img width="763" height="136" alt="after-zoomed-mult-added" src="https://github.com/user-attachments/assets/30e75eb0-2765-47ef-b411-004a74c69e9a" />|

</details>

<details>
<summary>6. Toggle all reactions </summary>

| Before | After |
|--------|-------|
| <img width="2833" height="1010" alt="before-multipl-no reaction" src="https://github.com/user-attachments/assets/219b40d9-d1a0-4ffa-bb74-397cdc716334" /> | <img width="2833" height="1010" alt="after-multiple-no reaction" src="https://github.com/user-attachments/assets/58de94b6-b5f2-49bc-b801-75b33ac1c67a" /> |
| <img width="2833" height="1010" alt="before-multiple more-added reaction" src="https://github.com/user-attachments/assets/4a3edd06-5609-44b1-b1b3-0392d418d318" /> | <img width="2833" height="1010" alt="after-multiple more-added reaction" src="https://github.com/user-attachments/assets/8dfee7e9-75c4-43de-b5d0-b9a975c66427" /> |
| Zoomed in: <img width="763" height="136" alt="before-zoomed-all" src="https://github.com/user-attachments/assets/456af3ae-1123-4134-b1a4-22af7fac5f6b" />| Zoomed in: <img width="763" height="136" alt="after-zoomed-all" src="https://github.com/user-attachments/assets/7dafd6f1-c41d-4344-814d-27228fcea929" /> |
</details>

**`git grep` for `.reacted` in templates:**
```
$ git grep '.reacted' web/templates/
web/templates/popovers/emoji/emoji_popover_emoji.hbs:<div class="emoji-popover-emoji {{#if has_reacted}}reacted{{/if}}" data-emoji-name="{{#if emoji_name}}{{emoji_name}}{{else}}{{name}}{{/if}}" tabindex="0" data-emoji-id="{{../type}},{{../section}},{{../index}}">
```

<details>
<summary>Self-review checklist</summary>
<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

> Note: I used AI assistance (Claude) as a learning aid while working
> through this, per the AI use policy.
</details>
