### PR TITLE
ci: Disable interactive prompts from apt in production tests

### DIFF
--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -43,13 +43,16 @@ ZULIP_PATH=/root/zulip-latest
 mkdir -p "$ZULIP_PATH"
 tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1
 
+# Disable interactive prompts from apt.
+echo 'Dpkg::Options { "--force-confdef" "--force-confold" }' >/etc/apt/apt.conf.d/noninteractive
+export DEBIAN_FRONTEND=noninteractive
+
 # Do an apt upgrade to start with an up-to-date machine
-APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')
 apt-get update
 
-if ! apt-get dist-upgrade -y "${APT_OPTIONS[@]}"; then
+if ! apt-get dist-upgrade -y; then
     echo "\`apt-get dist-upgrade\`: Failure occurred while trying to perform distribution upgrade, Retrying..."
-    apt-get dist-upgrade -y "${APT_OPTIONS[@]}"
+    apt-get dist-upgrade -y
 fi
 
 os_info="$(

--- a/tools/ci/production-upgrade
+++ b/tools/ci/production-upgrade
@@ -19,6 +19,10 @@ sudo service rabbitmq-server start
 # Start the supervisor
 sudo service supervisor start
 
+# Disable interactive prompts from apt.
+echo 'Dpkg::Options { "--force-confdef" "--force-confold" }' >/etc/apt/apt.conf.d/noninteractive
+export DEBIAN_FRONTEND=noninteractive
+
 # Zulip releases before 2.1.8/3.5/4.4 have a bug in their
 # `upgrade-zulip` scripts, resulting in them exiting with status 0
 # unconditionally. We work around that by running


### PR DESCRIPTION
[Discussion](https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/main.20failing/near/2461485).