### PR TITLE
linear: Ignore Comment events fired for comments on Documents.

### DIFF
--- a/zerver/webhooks/linear/doc.md
+++ b/zerver/webhooks/linear/doc.md
@@ -23,6 +23,11 @@ Get Linear notifications in Zulip!
 
 {!event-filtering-additional-feature.md!}
 
+!!! warn ""
+
+    **Note**: `comment` events are only supported for comments on
+    issues. Comments on Linear documents do not trigger notifications.
+
 ### Related documentation
 
 - [Linear webhook events documentation][linear-webhooks]

--- a/zerver/webhooks/linear/fixtures/comment_on_document.json
+++ b/zerver/webhooks/linear/fixtures/comment_on_document.json
@@ -1,0 +1,34 @@
+{
+    "action": "create",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruv@example.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruv",
+        "type": "user"
+    },
+    "createdAt": "2026-05-19T13:08:19.956Z",
+    "data": {
+        "id": "e3ff103c-53ac-4267-bdfc-cd05f7e49dc7",
+        "createdAt": "2026-05-19T13:08:19.956Z",
+        "updatedAt": "2026-05-19T13:08:19.927Z",
+        "body": "This is an comment on a Document",
+        "documentContentId": "49567929-242f-43b6-a7bf-193744e4279a",
+        "userId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "quotedText": "This is an comment",
+        "reactionData": [],
+        "isArtificialAgentSessionRoot": false,
+        "botActor": null,
+        "user": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruv@example.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruv"
+        }
+    },
+    "url": "https://linear.app/zulipdhruv/document/hello-ddb80e78e24b#comment-e3ff103c",
+    "type": "Comment",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779196118345,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/tests.py
+++ b/zerver/webhooks/linear/tests.py
@@ -79,3 +79,12 @@ class LinearHookTests(WebhookTestCase):
             content_type="application/json",
         )
         self.assert_json_success(result)
+
+    def test_comment_on_document(self) -> None:
+        payload = self.get_body("comment_on_document")
+        result = self.client_post(
+            self.url,
+            payload,
+            content_type="application/json",
+        )
+        self.assert_json_success(result)

--- a/zerver/webhooks/linear/view.py
+++ b/zerver/webhooks/linear/view.py
@@ -154,7 +154,9 @@ def get_event_type(payload: WildValue) -> str | None:
         has_parent_id = "parentId" in payload["data"]
         return "issue" if not has_parent_id else "sub_issue"
     elif event_type == "Comment":
-        return "comment"
+        # Document comments also arrive as Comment events but carry
+        # no nested issue object to route a topic to.
+        return "comment" if "issue" in payload["data"] else None
     elif event_type in IGNORED_EVENTS:
         return None
 


### PR DESCRIPTION
Linear emits `type: "Comment"` webhooks for comments on both Issues and Documents. Document-comment payloads carry a `documentContentId` and no nested `data.issue` object, so the existing handler crashed with a ValidationError.

Drop these payloads in `get_event_type`.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x]  Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
