### PR TITLE
Restore complete node test coverage on user_groups.ts

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -312,7 +312,6 @@ EXEMPT_FILES = make_set(
         "web/src/user_group_edit_members.ts",
         "web/src/user_group_picker_pill.ts",
         "web/src/user_group_popover.ts",
-        "web/src/user_groups.ts",
         "web/src/user_pill.ts",
         "web/src/user_profile.ts",
         "web/src/user_sort.ts",

--- a/web/tests/user_groups.test.cjs
+++ b/web/tests/user_groups.test.cjs
@@ -11,10 +11,12 @@ const blueslip = require("./lib/zblueslip.cjs");
 
 const group_permission_settings = zrequire("group_permission_settings");
 const user_groups = zrequire("user_groups");
-const {set_realm} = zrequire("state_data");
+const {initialize_user_settings} = zrequire("user_settings");
+const {set_realm, set_current_user} = zrequire("state_data");
 
 const realm = make_realm();
 set_realm(realm);
+initialize_user_settings({user_settings: {default_language: "en"}});
 
 const get_test_subgroup = (id) =>
     make_user_group({
@@ -1301,4 +1303,773 @@ run_test("get_all_realm_user_groups", ({override}) => {
         user_groups.get_all_realm_user_groups(false, false, true),
         expected_groups_list,
     );
+});
+
+run_test("update_group_permission_settings", () => {
+    user_groups.init();
+    const group = make_user_group({
+        name: "Test Group",
+        id: 1,
+        members: [1],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+        can_add_members_group: 1,
+        can_join_group: 1,
+        can_leave_group: 1,
+        can_manage_group: 1,
+        can_mention_group: 1,
+        can_remove_members_group: 1,
+    });
+    user_groups.add(group);
+    const stored_group = user_groups.get_user_group_from_id(group.id);
+
+    user_groups.update({group_id: group.id, data: {can_add_members_group: 2}}, stored_group);
+    assert.equal(user_groups.get_user_group_from_id(group.id).can_add_members_group, 2);
+
+    user_groups.update({group_id: group.id, data: {can_mention_group: 3}}, stored_group);
+    assert.equal(user_groups.get_user_group_from_id(group.id).can_mention_group, 3);
+
+    user_groups.update({group_id: group.id, data: {can_manage_group: 4}}, stored_group);
+    assert.equal(user_groups.get_user_group_from_id(group.id).can_manage_group, 4);
+
+    user_groups.update({group_id: group.id, data: {can_join_group: 5}}, stored_group);
+    assert.equal(user_groups.get_user_group_from_id(group.id).can_join_group, 5);
+
+    user_groups.update({group_id: group.id, data: {can_leave_group: 6}}, stored_group);
+    assert.equal(user_groups.get_user_group_from_id(group.id).can_leave_group, 6);
+
+    user_groups.update({group_id: group.id, data: {can_remove_members_group: 7}}, stored_group);
+    assert.equal(user_groups.get_user_group_from_id(group.id).can_remove_members_group, 7);
+});
+
+run_test("realm_has_deactivated_user_groups", () => {
+    user_groups.init();
+    const active = make_user_group({
+        name: "Active",
+        id: 1,
+        members: [1],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+        deactivated: false,
+    });
+    user_groups.add(active);
+    assert.ok(!user_groups.realm_has_deactivated_user_groups());
+
+    const deactivated = make_user_group({
+        name: "Deactivated",
+        id: 2,
+        members: [2],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+        deactivated: true,
+    });
+    user_groups.add(deactivated);
+    assert.ok(user_groups.realm_has_deactivated_user_groups());
+});
+
+run_test("get_system_groups_list", ({override}) => {
+    user_groups.init();
+    const {nobody, owners, admins, moderators, members, everyone, full_members, internet} =
+        set_up_system_groups_for_test();
+
+    user_groups.initialize({
+        realm_user_groups: [
+            nobody,
+            owners,
+            admins,
+            moderators,
+            members,
+            everyone,
+            full_members,
+            internet,
+        ],
+    });
+
+    override(realm, "realm_waiting_period_threshold", 0);
+    let group_list = user_groups.get_system_groups_list();
+    // internet and nobody are always excluded; fullmembers excluded when threshold is 0.
+    // system_user_groups_list order after filter + toReversed:
+    // [owners, administrators, moderators, members, everyone]
+    assert.deepEqual(
+        group_list.map((g) => ({id: g.id, name: g.name})),
+        [
+            {id: owners.id, name: "translated: Owners"},
+            {id: admins.id, name: "translated: Administrators"},
+            {id: moderators.id, name: "translated: Moderators"},
+            {id: members.id, name: "translated: Everyone except guests"},
+            {id: everyone.id, name: "translated: Everyone including guests"},
+        ],
+    );
+
+    override(realm, "realm_waiting_period_threshold", 10);
+    group_list = user_groups.get_system_groups_list();
+    // fullmembers is included when threshold > 0.
+    assert.deepEqual(
+        group_list.map((g) => ({id: g.id, name: g.name})),
+        [
+            {id: owners.id, name: "translated: Owners"},
+            {id: admins.id, name: "translated: Administrators"},
+            {id: moderators.id, name: "translated: Moderators"},
+            {id: full_members.id, name: "translated: Full members"},
+            {id: members.id, name: "translated: Everyone except guests"},
+            {id: everyone.id, name: "translated: Everyone including guests"},
+        ],
+    );
+});
+
+run_test("get_user_groups_allowed_to_mention", () => {
+    user_groups.init();
+    set_current_user({user_id: 5});
+
+    // User 5 is listed as a direct member of the can_mention_group for mentionable.
+    const mentionable = make_user_group({
+        name: "Mentionable",
+        id: 1,
+        members: [1, 2],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+        can_mention_group: {direct_members: [5], direct_subgroups: []},
+    });
+    // User 5 is not in the can_mention_group for restricted.
+    const restricted = make_user_group({
+        name: "Restricted",
+        id: 2,
+        members: [6, 7],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+        can_mention_group: {direct_members: [6, 7], direct_subgroups: []},
+    });
+
+    user_groups.initialize({realm_user_groups: [mentionable, restricted]});
+
+    const result = user_groups.get_user_groups_allowed_to_mention();
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, mentionable.id);
+
+    user_groups.init();
+});
+
+run_test("is_empty_group", () => {
+    user_groups.init();
+    const empty_group = make_user_group({
+        name: "Empty",
+        id: 1,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const non_empty_group = make_user_group({
+        name: "NonEmpty",
+        id: 2,
+        members: [1],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const empty_subgroup = make_user_group({
+        name: "EmptySubgroup",
+        id: 3,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const group_with_empty_sub = make_user_group({
+        name: "GroupWithEmptySub",
+        id: 4,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [3],
+    });
+    const group_with_nonempty_sub = make_user_group({
+        name: "GroupWithNonEmptySub",
+        id: 5,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [2],
+    });
+    // Three-level chain: root → child → grandchild; all empty.
+    const grandchild = make_user_group({
+        name: "Grandchild",
+        id: 10,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const child = make_user_group({
+        name: "Child",
+        id: 11,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [10],
+    });
+    const root = make_user_group({
+        name: "Root",
+        id: 12,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [11],
+    });
+
+    user_groups.add(empty_group);
+    user_groups.add(non_empty_group);
+    user_groups.add(empty_subgroup);
+    user_groups.add(group_with_empty_sub);
+    user_groups.add(group_with_nonempty_sub);
+    user_groups.add(grandchild);
+    user_groups.add(child);
+    user_groups.add(root);
+
+    assert.ok(user_groups.is_empty_group(empty_group.id));
+    assert.ok(!user_groups.is_empty_group(non_empty_group.id));
+    assert.ok(user_groups.is_empty_group(group_with_empty_sub.id));
+    assert.ok(!user_groups.is_empty_group(group_with_nonempty_sub.id));
+
+    blueslip.expect("error", "Could not find user group");
+    assert.ok(!user_groups.is_empty_group(9999));
+
+    user_groups.add_subgroups(group_with_empty_sub.id, [9999]);
+    blueslip.expect("error", "Could not find subgroup");
+    assert.ok(!user_groups.is_empty_group(group_with_empty_sub.id));
+
+    // Subgroups discovered during BFS are themselves enqueued, verifying
+    // the traversal loop body executes more than one iteration.
+    assert.ok(user_groups.is_empty_group(root.id));
+});
+
+run_test("is_setting_group_empty", () => {
+    user_groups.init();
+    const empty_group = make_user_group({
+        name: "Empty",
+        id: 1,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const non_empty_group = make_user_group({
+        name: "NonEmpty",
+        id: 2,
+        members: [1],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const empty_subgroup = make_user_group({
+        name: "EmptySubgroup",
+        id: 3,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+
+    user_groups.add(empty_group);
+    user_groups.add(non_empty_group);
+    user_groups.add(empty_subgroup);
+
+    assert.ok(user_groups.is_setting_group_empty(empty_group.id));
+    assert.ok(!user_groups.is_setting_group_empty(non_empty_group.id));
+
+    assert.ok(user_groups.is_setting_group_empty({direct_members: [], direct_subgroups: []}));
+    assert.ok(!user_groups.is_setting_group_empty({direct_members: [1], direct_subgroups: []}));
+    assert.ok(
+        !user_groups.is_setting_group_empty({
+            direct_members: [],
+            direct_subgroups: [non_empty_group.id],
+        }),
+    );
+    assert.ok(
+        user_groups.is_setting_group_empty({
+            direct_members: [],
+            direct_subgroups: [empty_subgroup.id],
+        }),
+    );
+});
+
+run_test("is_setting_group_set_to_nobody_group", () => {
+    user_groups.init();
+    const empty_group = make_user_group({
+        name: "Empty",
+        id: 1,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const nobody = make_user_group({
+        name: "role:nobody",
+        id: 2,
+        members: [],
+        is_system_group: true,
+        direct_subgroup_ids: [],
+    });
+
+    user_groups.add(empty_group);
+    user_groups.add(nobody);
+
+    assert.ok(user_groups.is_setting_group_set_to_nobody_group(nobody.id));
+    assert.ok(!user_groups.is_setting_group_set_to_nobody_group(empty_group.id));
+
+    assert.ok(
+        user_groups.is_setting_group_set_to_nobody_group({
+            direct_members: [],
+            direct_subgroups: [],
+        }),
+    );
+    assert.ok(
+        !user_groups.is_setting_group_set_to_nobody_group({
+            direct_members: [1],
+            direct_subgroups: [],
+        }),
+    );
+});
+
+run_test("get_direct_subgroups_of_group", () => {
+    user_groups.init();
+    const sub_a = make_user_group({
+        name: "SubA",
+        id: 1,
+        members: [1],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const sub_b = make_user_group({
+        name: "SubB",
+        id: 2,
+        members: [2],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const parent = make_user_group({
+        name: "Parent",
+        id: 3,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [1, 2],
+    });
+    user_groups.add(sub_a);
+    user_groups.add(sub_b);
+    const parent_group = user_groups.add(parent);
+
+    const direct_subgroups = user_groups.get_direct_subgroups_of_group(parent_group);
+    assert.equal(direct_subgroups.length, 2);
+    assert.deepEqual(direct_subgroups.map((g) => g.id).toSorted(), [sub_a.id, sub_b.id]);
+});
+
+run_test("get_supergroups_of_user_group", () => {
+    user_groups.init();
+    const base = make_user_group({
+        name: "Base",
+        id: 1,
+        members: [1],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const parent_a = make_user_group({
+        name: "ParentA",
+        id: 2,
+        members: [2],
+        is_system_group: false,
+        direct_subgroup_ids: [1],
+    });
+    const parent_b = make_user_group({
+        name: "ParentB",
+        id: 3,
+        members: [3],
+        is_system_group: false,
+        direct_subgroup_ids: [1],
+    });
+    const unrelated = make_user_group({
+        name: "Unrelated",
+        id: 4,
+        members: [4],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+
+    user_groups.initialize({realm_user_groups: [base, parent_a, parent_b, unrelated]});
+
+    assert.deepEqual(
+        user_groups
+            .get_supergroups_of_user_group(base.id)
+            .map((g) => g.id)
+            .toSorted(),
+        [parent_a.id, parent_b.id],
+    );
+    assert.deepEqual(user_groups.get_supergroups_of_user_group(unrelated.id), []);
+});
+
+run_test("is_group_larger_than", () => {
+    user_groups.init();
+    const small = user_groups.add(
+        make_user_group({
+            name: "Small",
+            id: 1,
+            members: [1, 2],
+            is_system_group: false,
+            direct_subgroup_ids: [],
+        }),
+    );
+    user_groups.add(
+        make_user_group({
+            name: "Sub",
+            id: 2,
+            members: [3, 4, 5],
+            is_system_group: false,
+            direct_subgroup_ids: [],
+        }),
+    );
+    const with_sub = user_groups.add(
+        make_user_group({
+            name: "WithSub",
+            id: 3,
+            members: [1, 2],
+            is_system_group: false,
+            direct_subgroup_ids: [2],
+        }),
+    );
+
+    // small has 2 members: threshold 1 → larger; threshold 2 → not larger (2 > 2 is false)
+    assert.ok(user_groups.is_group_larger_than(small, 1));
+    assert.ok(!user_groups.is_group_larger_than(small, 2));
+
+    // with_sub: members [1,2] + sub [3,4,5] = 5 distinct; threshold 4 → larger; threshold 5 → not
+    assert.ok(user_groups.is_group_larger_than(with_sub, 4));
+    assert.ok(!user_groups.is_group_larger_than(with_sub, 5));
+
+    // get_recursive_subgroups returns undefined when a subgroup is missing → return false.
+    // Threshold must exceed small.members.size (2) so the early-return branch is not taken.
+    user_groups.add_subgroups(small.id, [9999]);
+    const small_group = user_groups.get_user_group_from_id(small.id);
+    blueslip.expect("error", "Could not find subgroup");
+    assert.ok(!user_groups.is_group_larger_than(small_group, 100));
+});
+
+run_test("check_group_can_be_subgroup", () => {
+    user_groups.init();
+    const active = user_groups.add(
+        make_user_group({
+            name: "Active",
+            id: 1,
+            members: [1],
+            is_system_group: false,
+            direct_subgroup_ids: [],
+            deactivated: false,
+        }),
+    );
+    const target = user_groups.add(
+        make_user_group({
+            name: "Target",
+            id: 2,
+            members: [2],
+            is_system_group: false,
+            direct_subgroup_ids: [],
+            deactivated: false,
+        }),
+    );
+    const deactivated_group = user_groups.add(
+        make_user_group({
+            name: "Deactivated",
+            id: 3,
+            members: [3],
+            is_system_group: false,
+            direct_subgroup_ids: [],
+            deactivated: true,
+        }),
+    );
+
+    assert.ok(user_groups.check_group_can_be_subgroup(active, target));
+    assert.ok(!user_groups.check_group_can_be_subgroup(deactivated_group, target));
+    assert.ok(!user_groups.check_group_can_be_subgroup(target, target));
+});
+
+run_test("is_user_in_any_group", () => {
+    user_groups.init();
+    const group_a = make_user_group({
+        name: "GroupA",
+        id: 1,
+        members: [1, 2],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const group_b = make_user_group({
+        name: "GroupB",
+        id: 2,
+        members: [3],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const sub = make_user_group({
+        name: "Sub",
+        id: 3,
+        members: [4],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const group_c = make_user_group({
+        name: "GroupC",
+        id: 4,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [3],
+    });
+
+    user_groups.add(group_a);
+    user_groups.add(group_b);
+    user_groups.add(sub);
+    user_groups.add(group_c);
+
+    assert.ok(user_groups.is_user_in_any_group([group_a.id, group_b.id], 1));
+    assert.ok(user_groups.is_user_in_any_group([group_a.id, group_b.id], 3));
+    assert.ok(!user_groups.is_user_in_any_group([group_a.id, group_b.id], 5));
+
+    // user 4 is in group_c via sub subgroup, but not a direct member of group_c
+    assert.ok(user_groups.is_user_in_any_group([group_c.id], 4));
+    assert.ok(!user_groups.is_user_in_any_group([group_c.id], 4, true));
+
+    user_groups.init();
+});
+
+run_test("format_group_list", () => {
+    const group_a = make_user_group({
+        name: "Alpha",
+        id: 1,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const group_b = make_user_group({
+        name: "Beta",
+        id: 2,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const group_c = make_user_group({
+        name: "Gamma",
+        id: 3,
+        members: [],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+
+    const result = user_groups.format_group_list([group_a, group_b, group_c]);
+    assert.equal(result, "Alpha, Beta, & Gamma");
+
+    const single = user_groups.format_group_list([group_a]);
+    assert.equal(single, "Alpha");
+});
+
+run_test("get_user_ids_in_setting_group", () => {
+    user_groups.init();
+    const group_a = make_user_group({
+        name: "GroupA",
+        id: 1,
+        members: [1, 2],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const sub = make_user_group({
+        name: "Sub",
+        id: 2,
+        members: [3],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const group_b = make_user_group({
+        name: "GroupB",
+        id: 3,
+        members: [4],
+        is_system_group: false,
+        direct_subgroup_ids: [2],
+    });
+
+    user_groups.add(group_a);
+    user_groups.add(sub);
+    user_groups.add(group_b);
+
+    // Number form: collects all recursive members of the referenced group.
+    assert.deepEqual(user_groups.get_user_ids_in_setting_group(group_a.id), new Set([1, 2]));
+    assert.deepEqual(user_groups.get_user_ids_in_setting_group(group_b.id), new Set([3, 4]));
+
+    // Anonymous group form: direct_members + recursive members of each direct_subgroup.
+    assert.deepEqual(
+        user_groups.get_user_ids_in_setting_group({
+            direct_members: [5, 6],
+            direct_subgroups: [group_a.id],
+        }),
+        new Set([1, 2, 5, 6]),
+    );
+
+    // Unknown group in direct_subgroups: blueslip error, rest of collection continues.
+    blueslip.expect("error", "Could not find user group");
+    assert.deepEqual(
+        user_groups.get_user_ids_in_setting_group({
+            direct_members: [7],
+            direct_subgroups: [9999],
+        }),
+        new Set([7]),
+    );
+});
+
+run_test("check_system_user_group_allowed_for_setting", ({override}) => {
+    const base_config = {
+        require_system_group: false,
+        allow_internet_group: false,
+        allow_nobody_group: true,
+        allow_everyone_group: true,
+        default_group_name: "role:members",
+        default_for_system_groups: null,
+        allowed_system_groups: [],
+    };
+
+    // role:internet blocked when allow_internet_group is false
+    assert.ok(
+        !user_groups.check_system_user_group_allowed_for_setting(
+            "role:internet",
+            base_config,
+            false,
+        ),
+    );
+    // role:internet allowed when allow_internet_group is true
+    assert.ok(
+        user_groups.check_system_user_group_allowed_for_setting(
+            "role:internet",
+            {...base_config, allow_internet_group: true},
+            false,
+        ),
+    );
+
+    // role:nobody blocked when allow_nobody_group is false
+    assert.ok(
+        !user_groups.check_system_user_group_allowed_for_setting(
+            "role:nobody",
+            {...base_config, allow_nobody_group: false},
+            false,
+        ),
+    );
+    // role:nobody allowed when allow_nobody_group is true and not new settings ui
+    assert.ok(
+        user_groups.check_system_user_group_allowed_for_setting("role:nobody", base_config, false),
+    );
+    // role:nobody blocked by for_new_settings_ui even when allow_nobody_group is true
+    assert.ok(
+        !user_groups.check_system_user_group_allowed_for_setting("role:nobody", base_config, true),
+    );
+
+    // role:everyone blocked when allow_everyone_group is false
+    assert.ok(
+        !user_groups.check_system_user_group_allowed_for_setting(
+            "role:everyone",
+            {...base_config, allow_everyone_group: false},
+            false,
+        ),
+    );
+    // role:everyone allowed when allow_everyone_group is true
+    assert.ok(
+        user_groups.check_system_user_group_allowed_for_setting(
+            "role:everyone",
+            base_config,
+            false,
+        ),
+    );
+
+    // allowed_system_groups filter: group not in list is blocked
+    assert.ok(
+        !user_groups.check_system_user_group_allowed_for_setting(
+            "role:administrators",
+            {...base_config, allowed_system_groups: ["role:members"]},
+            false,
+        ),
+    );
+    // allowed_system_groups filter: group in list is allowed
+    assert.ok(
+        user_groups.check_system_user_group_allowed_for_setting(
+            "role:members",
+            {...base_config, allowed_system_groups: ["role:members"]},
+            false,
+        ),
+    );
+
+    // role:fullmembers blocked when for_new_settings_ui and threshold is 0
+    override(realm, "realm_waiting_period_threshold", 0);
+    assert.ok(
+        !user_groups.check_system_user_group_allowed_for_setting(
+            "role:fullmembers",
+            base_config,
+            true,
+        ),
+    );
+    // role:fullmembers allowed when for_new_settings_ui is false regardless of threshold
+    assert.ok(
+        user_groups.check_system_user_group_allowed_for_setting(
+            "role:fullmembers",
+            base_config,
+            false,
+        ),
+    );
+    // role:fullmembers allowed when for_new_settings_ui but threshold > 0
+    override(realm, "realm_waiting_period_threshold", 10);
+    assert.ok(
+        user_groups.check_system_user_group_allowed_for_setting(
+            "role:fullmembers",
+            base_config,
+            true,
+        ),
+    );
+});
+
+run_test("is_subgroup_of_target_group_bad_subgroup", () => {
+    user_groups.init();
+    const leaf = make_user_group({
+        name: "Leaf",
+        id: 1,
+        members: [1],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const mid = make_user_group({
+        name: "Mid",
+        id: 2,
+        members: [2],
+        is_system_group: false,
+        direct_subgroup_ids: [1],
+    });
+    const top = make_user_group({
+        name: "Top",
+        id: 3,
+        members: [3],
+        is_system_group: false,
+        direct_subgroup_ids: [2],
+    });
+    user_groups.add(leaf);
+    user_groups.add(mid);
+    user_groups.add(top);
+
+    assert.ok(user_groups.is_subgroup_of_target_group(top.id, leaf.id));
+
+    // Adding an unknown subgroup to top causes get_recursive_subgroups to return undefined.
+    user_groups.add_subgroups(top.id, [9999]);
+    blueslip.expect("error", "Could not find subgroup");
+    assert.ok(!user_groups.is_subgroup_of_target_group(top.id, leaf.id));
+});
+
+run_test("get_associated_subgroups_bad_subgroup", () => {
+    // Verify that get_associated_subgroups returns [] when get_recursive_subgroups
+    // returns undefined due to a missing subgroup reference.
+    user_groups.init();
+    const sub = make_user_group({
+        name: "Sub",
+        id: 1,
+        members: [10],
+        is_system_group: false,
+        direct_subgroup_ids: [],
+    });
+    const group = make_user_group({
+        name: "Group",
+        id: 2,
+        members: [20],
+        is_system_group: false,
+        direct_subgroup_ids: [1, 9999],
+    });
+    user_groups.add(sub);
+    const group_obj = user_groups.add(group);
+
+    blueslip.expect("error", "Could not find subgroup");
+    assert.deepEqual(user_groups.get_associated_subgroups(group_obj, 10), []);
 });


### PR DESCRIPTION
Several functions in `user_groups.ts` lacked node test coverage:
    
- the `can_*` branches of `update()`,
- `realm_has_deactivated_user_groups()`,
 - `get_system_groups_list()`,
 - `get_user_groups_allowed_to_mention()`,
 - `is_empty_group()` / `is_setting_group_empty()` / `is_setting_group_set_to_nobody_group()`,
 - `get_supergroups_of_user_group()`,
 - `is_group_larger_than()`,
 - `check_group_can_be_subgroup()`,
 - `get_direct_subgroups_of_group()`,
 - `is_user_in_any_group()`,
 - `format_group_list()`,
 - `get_user_ids_in_setting_group()`,
 - `check_system_user_group_allowed_for_setting()`,
 - the undefined-return paths in `is_subgroup_of_target_group()` and `get_associated_subgroups()`.
    
This PR adds test blocks for each of these, together with the two module-level imports (`initialize_user_settings`, `set_current_user`) they require. `initialize_user_settings` is needed so that `format_group_list()`'s call into `util.format_array_as_list()` can access `user_settings.default_language without throwing.
    
 Fixes: #33208 

CZO : https://chat.zulip.org/#narrow/channel/6-frontend/topic/Restore.20node.20test.20coverage.20for.20user_group.2Ets/with/2462384

<details>
<summary> Self review checklist </summary>
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
