### PR TITLE
[ai] tippy: Fall back to document.body when reference is detached.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -90,7 +90,24 @@ tippy.default.setDefaultProps({
     // with appending it to `body` which has side effect of tooltips
     // sticking around due to browser not communicating to tippy that
     // the element has been removed without having a Mutation Observer.
-    appendTo: "parent",
+    //
+    // Append to reference.parentElement (equivalent to tippy's "parent"
+    // shorthand), or document.body if the reference has been detached,
+    // since tippy crashes on a null parent when show() fires after the
+    // reference is removed mid-delay.
+    appendTo: (reference) => reference.parentElement ?? document.body,
+    // If the reference was removed from the DOM during the show delay,
+    // destroy the instance instead of mounting a tooltip with no
+    // anchor. Per-instance `onShow` overrides this default, so the
+    // `appendTo` fallback above also exists as a backstop for those
+    // call sites.
+    onShow(instance) {
+        if (!instance.reference.isConnected) {
+            instance.destroy();
+            return false;
+        }
+        return undefined;
+    },
     // To add a text tooltip, override this by setting data-tippy-content.
     // To add an HTML tooltip, set data-tooltip-template-id to the id of a <template>.
     // Or, override this with a function returning string (text) or DocumentFragment (HTML).


### PR DESCRIPTION
Tippy schedules show() via setTimeout to honor the hover delay. With
our default appendTo: "parent", the mount path resolves "parent" to
reference.parentNode. If the reference was removed from the DOM
during the delay (e.g., the user hovers a recipient-bar icon, then
narrows away before the 100ms delay elapses, causing the feed to
re-render and detach the icon), parentNode is null and tippy
crashes on parentNode.contains(popper).

Replace the string "parent" with a function that falls back to
document.body when parentNode is null. Every other call site already
overrides appendTo to a function returning document.body (or
similar), so this only affects tooltips that inherit the default
(notably the .tippy-zulip-tooltip and .tippy-zulip-delayed-tooltip
delegations, which are the ones hitting this in production).

Reported in Sentry as ~50 events from 41 users over 90 days; the
stack trace lands in the setTimeout callback at the
parentNode.contains line, consistent with this scenario.
[#kandra js errors > TypeError: Cannot read properties of null (reading 'conta...](https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/TypeError.3A.20Cannot.20read.20properties.20of.20null.20.28reading.20.27conta.2E.2E.2E/with/2255349)