### PR TITLE
pm_list: Show unread DMs with deactivated users in unzoomed view.

### DIFF
--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -167,9 +167,11 @@ export function get_list_info(
         // We don't need to filter muted users here, because
         // pm_conversations.ts takes care of this for us.
 
-        // Conversations that include any deactivated users should
-        // only be visible in the unzoomed view.
-        if (conversation.includes_deactivated_user) {
+        // Conversations that include any deactivated users are
+        // hidden from the unzoomed view to declutter the sidebar,
+        // unless they have unread messages since that's still worth
+        // showing.
+        if (conversation.includes_deactivated_user && conversation.unread === 0) {
             return false;
         }
 

--- a/web/tests/pm_list_data.test.cjs
+++ b/web/tests/pm_list_data.test.cjs
@@ -494,23 +494,21 @@ test("get_list_info_deactivated_users", ({override}) => {
 
     override(unread, "num_unread_for_user_ids_string", () => 1);
 
-    // Verify with unread messages that conversations with Bob are still
-    // not shown in the unzoomed case, and the unread count for more
-    // conversations is updated for those 2 conversations.
+    // Verify that with unread messages, conversations with Bob
+    // (deactivated) are shown in the unzoomed case.
     list_info = pm_list_data.get_list_info(false);
-    assert.deepEqual(list_info.conversations_to_be_shown.length, 11);
-    assert.deepEqual(list_info.more_conversations_unread_count, 2);
-    // Verify that Bob (deactivated) is not included.
-    check_list_info(list_info, 11, 2, [
+    check_list_info(list_info, 13, 0, [
         "Cardelio, Iago",
         "Alice, Zoe",
         "Iago",
         "Iago, Zoe",
         "Alice, Cardelio",
         "Alice, Iago",
+        "Bob, Cardelio",
         "Cardelio, Zoe",
         "Cardelio",
         "Zoe",
+        "Bob",
         "Me Myself",
         "Alice",
     ]);


### PR DESCRIPTION
Previously, direct message conversations including a deactivated user were unconditionally hidden from the unzoomed left sidebar, even when they had unread messages.  Their unread counts were silently rolled into the "More conversations" total, leaving a user with an unread DM from someone whose account was later deactivated no obvious path from the sidebar to that unread message.

Only hide deactivated-user DMs that have no unread messages, so the decluttering benefit is preserved without stranding unread messages out of sight.

Reported at:
https://chat.zulip.org/#narrow/channel/9-issues/topic/Ordering.20of.20topics.20to.20include.20unread.20first/with/2462695