### PR TITLE
[ai] upgrade-zulip-from-git: Surface stage-3 options in --help.

### DIFF
--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -22,6 +22,7 @@ from scripts.lib.zulip_tools import (
     overwrite_symlink,
     release_deployment_lock,
     su_to_zulip,
+    upgrade_script_arg_parser,
 )
 
 config_file = get_config_file()
@@ -38,7 +39,7 @@ os.umask(0o22)
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-from-git: %(message)s", level=logging.INFO)
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("refname", help="Git reference, e.g. a branch, tag, or commit ID.")
 git_ref = parser.add_mutually_exclusive_group()
 git_ref.add_argument(
@@ -49,6 +50,14 @@ git_ref.add_argument(
     action="store_true",
     help="Provided branch name has been pushed directly to /srv/zulip.git already",
 )
+
+# Any unknown options are passed through verbatim to upgrade-zulip-stage-2
+# and on to upgrade-zulip-stage-3. To make those passthrough options
+# discoverable, when the user runs --help we show a combined help that
+# also documents the stage-3 options.
+if {"-h", "--help"} & set(sys.argv[1:]):
+    argparse.ArgumentParser(parents=[parser, upgrade_script_arg_parser()]).parse_args(["--help"])
+
 args, extra_options = parser.parse_known_args()
 
 refname = args.refname

--- a/scripts/lib/upgrade-zulip-stage-3
+++ b/scripts/lib/upgrade-zulip-stage-3
@@ -26,8 +26,8 @@ from scripts.lib.zulip_tools import (
     get_config,
     get_config_file,
     parse_version_from,
-    start_arg_parser,
     su_to_zulip,
+    upgrade_script_arg_parser,
 )
 
 assert_running_as_root()
@@ -41,35 +41,10 @@ logging.basicConfig(format="%(asctime)s upgrade-zulip-stage-3: %(message)s", lev
 # make sure we have appropriate file permissions
 os.umask(0o22)
 
-restart_parser = start_arg_parser(action="restart", add_help=False)
-
-parser = argparse.ArgumentParser(parents=[restart_parser])
+parser = argparse.ArgumentParser(parents=[upgrade_script_arg_parser()])
 parser.add_argument("deploy_path", metavar="deploy_path", help="Path to deployment directory")
 parser.add_argument(
-    "--skip-restart",
-    action="store_true",
-    help="Configure, but do not restart into, the new version; aborts if any system-wide changes would happen.",
-)
-parser.add_argument("--skip-puppet", action="store_true", help="Skip doing puppet/apt upgrades.")
-parser.add_argument("--skip-migrations", action="store_true", help="Skip doing migrations.")
-parser.add_argument(
-    "--skip-downgrade-check",
-    action="store_true",
-    help="Skip the safety check to prevent database downgrades.",
-)
-parser.add_argument(
     "--from-git", action="store_true", help="Upgrading from git, so run update-prod-static."
-)
-parser.add_argument(
-    "--ignore-static-assets",
-    action="store_true",
-    help="Do not attempt to copy/manage static assets.",
-)
-parser.add_argument(
-    "--skip-purge-old-deployments", action="store_true", help="Skip purging old deployments."
-)
-parser.add_argument(
-    "--audit-fts-indexes", action="store_true", help="Audit and fix full text search indexes."
 )
 args = parser.parse_args()
 

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -682,6 +682,48 @@ def start_arg_parser(action: str, add_help: bool = False) -> argparse.ArgumentPa
     return parser
 
 
+def upgrade_script_arg_parser() -> argparse.ArgumentParser:
+    """Options shared by upgrade-zulip-stage-3 and its wrapper scripts.
+
+    Wrappers like upgrade-zulip-from-git use this as a parent parser so
+    that --help advertises the same options stage-3 accepts, and forward
+    the parsed values through to stage-3.
+    """
+    parser = argparse.ArgumentParser(
+        add_help=False, parents=[start_arg_parser(action="restart", add_help=False)]
+    )
+    parser.add_argument(
+        "--skip-restart",
+        action="store_true",
+        help="Configure, but do not restart into, the new version; aborts if any system-wide changes would happen.",
+    )
+    parser.add_argument(
+        "--skip-puppet", action="store_true", help="Skip doing puppet/apt upgrades."
+    )
+    parser.add_argument("--skip-migrations", action="store_true", help="Skip doing migrations.")
+    parser.add_argument(
+        "--skip-downgrade-check",
+        action="store_true",
+        help="Skip the safety check to prevent database downgrades.",
+    )
+    parser.add_argument(
+        "--ignore-static-assets",
+        action="store_true",
+        help="Do not attempt to copy/manage static assets.",
+    )
+    parser.add_argument(
+        "--skip-purge-old-deployments",
+        action="store_true",
+        help="Skip purging old deployments.",
+    )
+    parser.add_argument(
+        "--audit-fts-indexes",
+        action="store_true",
+        help="Audit and fix full text search indexes.",
+    )
+    return parser
+
+
 def atomic_nagios_write(
     name: str,
     status: Literal["ok", "warning", "critical", "unknown"],

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -651,7 +651,7 @@ def deport(netloc: str) -> str:
     return "[" + r.hostname + "]" if ":" in r.hostname else r.hostname
 
 
-def start_arg_parser(action: str, add_help: bool = False) -> argparse.ArgumentParser:
+def start_script_arg_parser(action: str, add_help: bool = False) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=add_help)
     parser.add_argument("--fill-cache", action="store_true", help="Fill the memcached caches")
     parser.add_argument(
@@ -690,7 +690,7 @@ def upgrade_script_arg_parser() -> argparse.ArgumentParser:
     the parsed values through to stage-3.
     """
     parser = argparse.ArgumentParser(
-        add_help=False, parents=[start_arg_parser(action="restart", add_help=False)]
+        add_help=False, parents=[start_script_arg_parser(action="restart", add_help=False)]
     )
     parser.add_argument(
         "--skip-restart",

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -27,7 +27,7 @@ from scripts.lib.zulip_tools import (
     has_application_server,
     has_process_fts_updates,
     overwrite_symlink,
-    start_arg_parser,
+    start_script_arg_parser,
     su_to_zulip,
 )
 
@@ -39,7 +39,7 @@ verbing = action.title() + "ing"
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format=f"%(asctime)s {action}-server: %(message)s", level=logging.INFO)
 
-parser = start_arg_parser(action=action, add_help=True)
+parser = start_script_arg_parser(action=action, add_help=True)
 args = parser.parse_args()
 
 deploy_path = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
The wrapper accepts a `refname` plus its own `--remote-url`/`--local-ref` flags and quietly forwards anything else through to upgrade-zulip-stage-3. That meant `upgrade-zulip-from-git --help` advertised none of the operationally important options (`--skip-restart`, `--skip-puppet`, `--audit-fts-indexes`, etc.), and admins had to read the stage-3 source to discover them.

Extract stage-3's forwardable options into a shared `upgrade_arg_parser` helper in zulip_tools, used as a parent parser in both stage-3 and the git wrapper. The wrapper now parses these options itself (so they appear in `--help`) and reconstructs them when invoking stage-2.

---

Asked claude to show all possible args when user types `--help` instead of just those present in `upgrade-zulip-from-git`.  Directly tunneling the args caused us to have a non trivial code to get `extra_options`, so we use different arg parsers for when user types `--help` vs not.

Tested by typing in a python shell that this works as expected which otherwise would required a production server to test.