### PR TITLE
[ai] stop-server: Accept --help and reject unknown args.

### DIFF
--- a/scripts/stop-server
+++ b/scripts/stop-server
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import logging
 import os
 import pwd
@@ -20,6 +21,12 @@ from scripts.lib.zulip_tools import (
     has_process_fts_updates,
     su_to_zulip,
 )
+
+# Parse arguments before any side effects, so `--help` prints usage
+# instead of stopping the server.
+argparse.ArgumentParser(
+    description="Stop the Zulip server (Django, Tornado and workers).",
+).parse_args()
 
 deploy_path = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 os.chdir(deploy_path)


### PR DESCRIPTION
Running `sudo scripts/stop-server --help` previously stopped the server, since the script ignored sys.argv entirely. Add a no-arg argparse parse_args() call before any side effects so --help prints usage and unknown arguments are rejected.

The other server-control scripts (start-server, restart-server) are already safe; both go through start_arg_parser(), which uses argparse.

---

Asked claude to add `--help` to stop-server.