### PR TITLE
Replace hardcoded text color with color-text-default variable

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -20,7 +20,7 @@
     }
 
     .enter_sends_choices {
-        color:var(--color-text-default);
+        color: var(--color-text-default);
 
         .enter_sends_minor {
             color: hsl(0deg 0% 80%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -20,7 +20,7 @@
     }
 
     .enter_sends_choices {
-        color: hsl(236deg 33% 90%);
+        color:var(--color-text-default);
 
         .enter_sends_minor {
             color: hsl(0deg 0% 80%);
@@ -71,7 +71,7 @@
 
     & select option {
         background-color: var(--color-background);
-        color: hsl(236deg 33% 90%);
+        color: var(--color-text-default);
     }
 
     .pill-container.not-editable-by-user {
@@ -149,7 +149,7 @@
     }
 
     .alert.home-error-bar {
-        color: hsl(236deg 33% 90%);
+        color: var(--color-text-default);
         background-color: hsl(35deg 84% 62% / 25%);
         border: 1px solid hsl(11deg 46% 54%);
     }


### PR DESCRIPTION
## Summary

Replaced hardcoded text colors in `dark_theme.css` with the existing `--color-text-default` CSS variable.
fixed #39354 
## Testing
after : 
<img width="1019" height="771" alt="Screenshot 2026-05-22 at 12 50 00 PM" src="https://github.com/user-attachments/assets/cf44dbb3-2cd3-4f11-9209-77d313236971" />

Testing
Opened Send Later popover in dark theme.
Verified enter_sends_choices text renders unchanged after replacing hardcoded color with --color-text-default.