### PR TITLE
kandra: Gracefully reload Teleport when its config changes.

### DIFF
--- a/puppet/kandra/manifests/profile/teleport.pp
+++ b/puppet/kandra/manifests/profile/teleport.pp
@@ -6,7 +6,8 @@ class kandra::profile::teleport inherits kandra::profile::base {
     group  => 'root',
     mode   => '0644',
     source => 'puppet:///modules/kandra/teleport_server.yaml',
-    notify => Service['teleport_server'],
+    before => Kandra::Teleport::Part['server'],
+    notify => Exec['reload teleport_server'],
   }
   file { '/var/lib/teleport-server':
     ensure => directory,

--- a/puppet/kandra/manifests/teleport/db.pp
+++ b/puppet/kandra/manifests/teleport/db.pp
@@ -15,7 +15,8 @@ class kandra::teleport::db {
     group   => 'root',
     mode    => '0644',
     content => template('kandra/teleport_db.yaml.template.erb'),
-    notify  => Service['teleport_db'],
+    before  => Kandra::Teleport::Part['db'],
+    notify  => Exec['reload teleport_db'],
   }
 
   kandra::teleport::part { 'db': }

--- a/puppet/kandra/manifests/teleport/node.pp
+++ b/puppet/kandra/manifests/teleport/node.pp
@@ -13,7 +13,8 @@ class kandra::teleport::node {
     owner  => 'root',
     group  => 'root',
     mode   => '0644',
-    notify => Service['teleport_node'],
+    before => Kandra::Teleport::Part['node'],
+    notify => Exec['reload teleport_node'],
   }
   concat::fragment { 'teleport_node_base':
     target  => '/etc/teleport_node.yaml',

--- a/puppet/kandra/manifests/teleport/part.pp
+++ b/puppet/kandra/manifests/teleport/part.pp
@@ -20,4 +20,13 @@ define kandra::teleport::part() {
     enable  => true,
     require => [Service['supervisor'], Service['teleport'], Exec['reload systemd']],
   }
+
+  # Notify this from YAML config changes (rather than the service)
+  # to get a SIGHUP-based graceful restart -- Teleport forks a new
+  # daemon and drains the old -- instead of a hard stop+start.
+  exec { "reload teleport_${part}":
+    command     => "/bin/systemctl reload teleport_${part}",
+    refreshonly => true,
+    require     => Service["teleport_${part}"],
+  }
 }

--- a/puppet/kandra/manifests/teleport/tbot.pp
+++ b/puppet/kandra/manifests/teleport/tbot.pp
@@ -9,7 +9,8 @@ class kandra::teleport::tbot {
     group  => 'root',
     mode   => '0644',
     source => 'puppet:///modules/kandra/tbot.yaml',
-    notify => Service['tbot'],
+    before => Service['tbot'],
+    notify => Exec['reload tbot'],
   }
 
   file { '/etc/systemd/system/tbot.service':
@@ -36,5 +37,12 @@ class kandra::teleport::tbot {
     ensure  => running,
     enable  => true,
     require => [Service['teleport'], Exec['reload systemd']],
+  }
+
+  # See the equivalent in kandra::teleport::part.
+  exec { 'reload tbot':
+    command     => '/bin/systemctl reload tbot',
+    refreshonly => true,
+    require     => Service['tbot'],
   }
 }


### PR DESCRIPTION
A change to /etc/teleport_*.yaml today triggers a hard stop+start of the teleport_$part unit, severing every active SSH, database, and app-proxy session holding a connection through that node.  If your zulip-puppet-apply is being controlled via Teleport SSH, this can easily lead to bad state.

Teleport's signal handling supports a fork+drain reload on SIGHUP[^1], which spawns a new daemon to serve new connections, and only shuts the old process down after existing connections close.

Route the YAML config notifies through a `systemctl reload` exec so we actually use the `ExecReload` we already defined, which which exercises that codepath.  Unit-file and package changes still notify the service directly to get a real restart.

[^1]: https://goteleport.com/docs/reference/deployment/signals/

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
