### PR TITLE
restore-backup: Preserve symlinked uploads and config directories.

### DIFF
--- a/scripts/setup/restore-backup
+++ b/scripts/setup/restore-backup
@@ -46,6 +46,7 @@ def restore_backup(tarball_file: IO[bytes], keep_settings: bool, keep_zulipconf:
         [
             "tar",
             "--directory=/etc/zulip",
+            "--keep-directory-symlink",
             *excludes,
             "--strip-components=2",
             "-xz",
@@ -86,7 +87,10 @@ def restore_backup(tarball_file: IO[bytes], keep_settings: bool, keep_zulipconf:
 
         os.mkdir(os.path.join(tmp, "zulip-backup"))
         tarball_file.seek(0, 0)
-        run(["tar", "-C", tmp, *transform_args, "-xPz"], stdin=tarball_file)
+        run(
+            ["tar", "-C", tmp, "--keep-directory-symlink", *transform_args, "-xPz"],
+            stdin=tarball_file,
+        )
 
         # Now, extract the database backup, destroy the old
         # database, and create a new, empty database.


### PR DESCRIPTION
When the destination of an extracted file is a symlink to a directory (e.g. in the docker-zulip container, where /home/zulip/uploads -> /data/uploads), modern GNU tar replaces the symlink with a real directory before extracting through it, as a security precaution.  As a result, uploads (and potentially configuration files) get restored improper (and, in the case of docker-zulip, non-persistent) paths.

Pass `--keep-directory-symlink` to both tar invocations so the extractor follows symlinks-to-directories rather than replacing them. The non-docker case is unaffected (these paths are real directories in a standard install), and the security mitigation is not meaningfully weakened: destinations are pinned to /etc/zulip, /home/zulip/uploads, and zproject, and the archive is one the operator just produced.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
