### PR TITLE
kandra: Close down services on prometheus host.

### DIFF
--- a/puppet/kandra/files/weblate_exporter
+++ b/puppet/kandra/files/weblate_exporter
@@ -259,7 +259,7 @@ def main() -> None:
         token = secrets_file["secrets"]["weblate_api_key"]
 
     handler = create_handler(WeblateMetricsCollector(token=token))
-    server = HTTPServer(("", args.port), handler)
+    server = HTTPServer(("127.0.0.1", args.port), handler)
 
     logger.info("Metrics available at http://localhost:%d/metrics", args.port)
 

--- a/puppet/kandra/manifests/profile/grafana.pp
+++ b/puppet/kandra/manifests/profile/grafana.pp
@@ -42,7 +42,6 @@ class kandra::profile::grafana inherits kandra::profile::base {
   }
 
   kandra::teleport::application { 'monitoring': port => '3000' }
-  kandra::firewall_allow { 'grafana': port => '3000' }
   file { "${zulip::common::supervisor_conf_dir}/grafana.conf":
     ensure  => file,
     require => [

--- a/puppet/kandra/manifests/vector.pp
+++ b/puppet/kandra/manifests/vector.pp
@@ -54,7 +54,7 @@ class kandra::vector {
       type = "internal_metrics"
     [sinks.prometheus_exporter]
       type = "prometheus_exporter"
-      address = "0.0.0.0:9081"
+      address = "127.0.0.1:9081"
       flush_period_secs = 120
       suppress_timestamp = true
       buckets = [0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5]

--- a/puppet/kandra/templates/supervisor/conf.d/prometheus_pushgateway.conf.template.erb
+++ b/puppet/kandra/templates/supervisor/conf.d/prometheus_pushgateway.conf.template.erb
@@ -1,5 +1,5 @@
 [program:prometheus_pushgateway]
-command=<%= @bin %>
+command=<%= @bin %> --web.listen-address=127.0.0.1:9091
 priority=10
 autostart=true
 autorestart=true


### PR DESCRIPTION
These were missed in e317fb55829821195a5108992c48d5ece7bb8187.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
