### PR TITLE
[ai] Add production upgrade ci test for 12.x branch.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -271,6 +271,9 @@ jobs:
           - docker_image: zulip/ci:trixie-11.0
             name: 11.0 Version Upgrade
             os: trixie
+          - docker_image: zulip/ci:resolute-12.0
+            name: 12.0 Version Upgrade
+            os: resolute
 
     name: ${{ matrix.name  }}
     container:

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -253,12 +253,6 @@ jobs:
         include:
           # Docker images are built from 'tools/ci/Dockerfile.prod'; the comments at
           # the top explain how to build and upload these images.
-          - docker_image: zulip/ci:jammy-6.0
-            name: 6.0 Version Upgrade
-            os: jammy
-          - docker_image: zulip/ci:bookworm-7.0
-            name: 7.0 Version Upgrade
-            os: bookworm
           - docker_image: zulip/ci:bookworm-8.0
             name: 8.0 Version Upgrade
             os: bookworm


### PR DESCRIPTION
Adds production test upgrade ci builds 12.x branch and drops 6.0 and 7.0 as per discussion in [#release management > production upgrade CI](https://chat.zulip.org/#narrow/channel/438-release-management/topic/production.20upgrade.20CI/with/2445452)