### PR TITLE
ci: Pin Docker base images to linux/amd64.

### DIFF
--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -11,7 +11,9 @@
 # tools/ci/build-docker-images will rebuild all images, but not push them.
 
 ARG BASE_IMAGE
-FROM $BASE_IMAGE
+# Pin to linux/amd64 so builds on Apple Silicon (or other non-amd64
+# hosts) still produce images compatible with our GitHub Actions runners.
+FROM --platform=linux/amd64 $BASE_IMAGE
 
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 

--- a/tools/ci/Dockerfile.prod
+++ b/tools/ci/Dockerfile.prod
@@ -7,7 +7,8 @@
 #   docker push zulip/ci:bookworm-7.0
 
 ARG BASE_IMAGE
-FROM $BASE_IMAGE
+# See tools/ci/Dockerfile for why we pin to linux/amd64.
+FROM --platform=linux/amd64 $BASE_IMAGE
 
 # Download the release tarball, start rabbitmq server and install the server
 ARG VERSION


### PR DESCRIPTION
GitHub Actions runners we target are linux/amd64, but images on Apple Silicon (arm64) hosts produces an arm64 image and `docker push` publishes a manifest CI cannot run.

Pinning at the FROM line forces qemu emulation on arm64 hosts, trading build time for a reproducible amd64 artifact regardless of where the build happens.

---

```
   - InvalidBaseImagePlatform: Base image zulip/ci:resolute was pulled with platform "linux/amd64", expected "linux/arm64" for current build (line 10)
```

Was receiving this warning when doing docker build for #39366