### PR TITLE
Replace the avatar of the spam user with that of an unknown user profile picture.

### DIFF
--- a/api_docs/unmerged.d/ZF-1b973a.md
+++ b/api_docs/unmerged.d/ZF-1b973a.md
@@ -1,0 +1,5 @@
+* [`GET /users`](/api/get-users), [`GET /users/{user_id}`](/api/get-user),
+  [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events):
+  The `avatar_url` for a user whose profile is deleted during deactivation
+  now returns the inaccessible user avatar URL, and their `avatar_source`
+  will be `"S"`.

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -516,10 +516,11 @@ def do_deactivate_user(
                         user_profile, "Deactivated bot", acting_user=acting_user, notify=False
                     )
 
-                # TODO: Change avatar image to that of an inaccessible user.
-                if user_profile.avatar_source != UserProfile.AVATAR_FROM_GRAVATAR:
+                if user_profile.avatar_source != UserProfile.AVATAR_FROM_SYSTEM:
                     do_change_avatar_fields(
-                        user_profile, UserProfile.AVATAR_FROM_GRAVATAR, acting_user=acting_user
+                        user_profile,
+                        UserProfile.AVATAR_FROM_SYSTEM,
+                        acting_user=acting_user,
                     )
 
             delete_deactivated_user_messages(

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -512,10 +512,11 @@ def do_deactivate_user(
                         user_profile, "Deactivated bot", acting_user=acting_user, notify=False
                     )
 
-                # TODO: Change avatar image to that of an inaccessible user.
-                if user_profile.avatar_source != UserProfile.AVATAR_FROM_GRAVATAR:
+                if user_profile.avatar_source != UserProfile.AVATAR_FROM_SYSTEM:
                     do_change_avatar_fields(
-                        user_profile, UserProfile.AVATAR_FROM_GRAVATAR, acting_user=acting_user
+                        user_profile,
+                        UserProfile.AVATAR_FROM_SYSTEM,
+                        acting_user=acting_user,
                     )
 
             delete_deactivated_user_messages(

--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -116,6 +116,9 @@ def get_avatar_field(
     avatar source, and then we'll add version info to try to avoid
     stale caches.
     """
+    if avatar_source == UserProfile.AVATAR_FROM_SYSTEM:
+        return get_avatar_for_inaccessible_user(medium)
+
     if avatar_source in [UserProfile.AVATAR_FROM_USER, UserProfile.AVATAR_FROM_JDENTICON]:
         hash_key = user_avatar_base_path_from_ids(user_id, avatar_version, realm_id)
         return get_avatar_url(hash_key, medium=medium)
@@ -177,8 +180,11 @@ def is_avatar_new(ldap_avatar: bytes, user_profile: UserProfile) -> bool:
     return True
 
 
-def get_avatar_for_inaccessible_user() -> str:
-    return staticfiles_storage.url("images/unknown-user-avatar.png")
+def get_avatar_for_inaccessible_user(medium: bool = False) -> str:
+    avatar_file_name = (
+        "images/unknown-user-avatar-medium.png" if medium else "images/unknown-user-avatar.png"
+    )
+    return staticfiles_storage.url(avatar_file_name)
 
 
 def generate_avatar_jdenticon(input: str, medium: bool) -> bytes:

--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -177,8 +177,11 @@ def is_avatar_new(ldap_avatar: bytes, user_profile: UserProfile) -> bool:
     return True
 
 
-def get_avatar_for_inaccessible_user() -> str:
-    return staticfiles_storage.url("images/unknown-user-avatar.png")
+def get_avatar_for_inaccessible_user(medium: bool) -> str:
+    avatar_file_name = (
+        "images/unknown-user-avatar-medium.png" if medium else "images/unknown-user-avatar.png"
+    )
+    return staticfiles_storage.url(avatar_file_name)
 
 
 def generate_avatar_jdenticon(input: str, medium: bool) -> bytes:

--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -99,6 +99,10 @@ def get_avatar_field(
     if is_cross_realm_bot_email(email):
         return get_static_avatar_url(email, medium)
 
+    # Avatars provided by Zulip are served from a static URL.
+    if avatar_source == UserProfile.AVATAR_FROM_SYSTEM:
+        return get_avatar_for_inaccessible_user(medium)
+
     """
     If our client knows how to calculate gravatar hashes, we
     will return None and let the client compute the gravatar

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -563,7 +563,7 @@ class MessageDict:
         obj: dict[str, Any], client_gravatar: bool, can_access_sender: bool = True
     ) -> None:
         if not can_access_sender:
-            obj["avatar_url"] = get_avatar_for_inaccessible_user()
+            obj["avatar_url"] = get_avatar_for_inaccessible_user(medium=False)
             return
 
         sender_id = obj["sender_id"]

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1206,7 +1206,7 @@ def get_message_payload_gcm(
         # inaccessible user as we allow unsubscribed users to send
         # messages to streams. For direct messages, the guest gains
         # access to the user if they where previously inaccessible.
-        sender_avatar_url = get_avatar_for_inaccessible_user()
+        sender_avatar_url = get_avatar_for_inaccessible_user(medium=False)
         sender_name = str(UserProfile.INACCESSIBLE_USER_NAME)
     else:
         sender_avatar_url = absolute_avatar_url(message.sender, message.realm.url)

--- a/zerver/lib/transfer.py
+++ b/zerver/lib/transfer.py
@@ -66,7 +66,12 @@ def _transfer_avatar_to_s3(user: UserProfile) -> None:
 def transfer_avatars_to_s3(processes: int) -> None:
     run_parallel(
         _transfer_avatar_to_s3,
-        UserProfile.objects.exclude(avatar_source=UserProfile.AVATAR_FROM_GRAVATAR),
+        UserProfile.objects.exclude(
+            avatar_source__in=[
+                UserProfile.AVATAR_FROM_GRAVATAR,
+                UserProfile.AVATAR_FROM_SYSTEM,
+            ]
+        ),
         processes,
     )
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -977,7 +977,7 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
         is_active=True,
         date_joined=user_date_joined.isoformat(),
         delivery_email=None,
-        avatar_url=get_avatar_for_inaccessible_user(),
+        avatar_url=get_avatar_for_inaccessible_user(medium=False),
         profile_data={},
         is_imported_stub=False,
     )

--- a/zerver/migrations/0001_squashed_0569.py
+++ b/zerver/migrations/0001_squashed_0569.py
@@ -1041,6 +1041,7 @@ class Migration(migrations.Migration):
                             ("G", "Hosted by Gravatar"),
                             ("J", "Generated using Jdenticon"),
                             ("U", "Uploaded by user"),
+                            ("S", "Provided by Zulip"),
                         ],
                         default="J",
                         max_length=1,

--- a/zerver/migrations/0031_remove_system_avatar_source.py
+++ b/zerver/migrations/0031_remove_system_avatar_source.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
                     ("G", "Hosted by Gravatar"),
                     ("J", "Generated using Jdenticon"),
                     ("U", "Uploaded by user"),
+                    ("S", "Provided by Zulip"),
                 ],
                 max_length=1,
                 default="J",

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -669,10 +669,12 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     AVATAR_FROM_GRAVATAR = "G"
     AVATAR_FROM_JDENTICON = "J"
     AVATAR_FROM_USER = "U"
+    AVATAR_FROM_SYSTEM = "S"
     AVATAR_SOURCES = (
         (AVATAR_FROM_GRAVATAR, "Hosted by Gravatar"),
         (AVATAR_FROM_JDENTICON, "Generated using Jdenticon"),
         (AVATAR_FROM_USER, "Uploaded by user"),
+        (AVATAR_FROM_SYSTEM, "Provided by Zulip"),
     )
     DEFAULT_AVATAR_SOURCE = AVATAR_FROM_JDENTICON
     avatar_source = models.CharField(

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -670,10 +670,12 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     AVATAR_FROM_GRAVATAR = "G"
     AVATAR_FROM_JDENTICON = "J"
     AVATAR_FROM_USER = "U"
+    AVATAR_FROM_SYSTEM = "S"
     AVATAR_SOURCES = (
         (AVATAR_FROM_GRAVATAR, "Hosted by Gravatar"),
         (AVATAR_FROM_JDENTICON, "Generated using Jdenticon"),
         (AVATAR_FROM_USER, "Uploaded by user"),
+        (AVATAR_FROM_SYSTEM, "Provided by Zulip"),
     )
     DEFAULT_AVATAR_SOURCE = AVATAR_FROM_JDENTICON
     avatar_source = models.CharField(

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -549,8 +549,13 @@ paths:
                                             - "G" = Hosted by Gravatar
                                             - "J" = Generated using Jdenticon
                                             - "U" = Uploaded by user
+                                            - "S" = System (provided by Zulip)
 
-                                            **Changes**: The "J" value is new in Zulip 12.0 (feature level 466).
+                                            Currently, the "S" value is only assigned to deactivated
+                                            users whose profile has been deleted.
+
+                                            **Changes**: The "S" value is new in Zulip 13.0 (feature level ZF-1b973a).
+                                            The "J" value is new in Zulip 12.0 (feature level 466).
                                         avatar_url_medium:
                                           type: string
                                           description: |
@@ -5469,8 +5474,11 @@ paths:
                                         - "G" = Hosted by Gravatar
                                         - "J" = Generated using Jdenticon
 
-                                        Note that "U" is not a supported value here, since there is
-                                        no such thing as a "default" user-uploaded avatar.
+                                        The "U" and "S" (System) values will not appear here, as
+                                        neither is ever used as a default source for new users.
+                                        There is no such thing as a "default" user-uploaded avatar
+                                        ("U"), and no user is created with a system-provided avatar
+                                        ("S").
 
                                         **Changes**: New in Zulip 12.0 (feature level 456).
                                     default_code_block_language:
@@ -21561,8 +21569,11 @@ paths:
                           - "G" = Hosted by Gravatar
                           - "J" = Generated using Jdenticon
 
-                          Note that "U" is not a supported value here, since there is
-                          no such thing as a "default" user-uploaded avatar.
+                          The "U" and "S" (System) values will not appear here, as
+                          neither is ever used as a default source for new users.
+                          There is no such thing as a "default" user-uploaded avatar
+                          ("U"), and no user is created with a system-provided avatar
+                          ("S").
 
                           **Changes**: New in Zulip 12.0 (feature level 456).
                       jitsi_server_url:
@@ -22495,8 +22506,16 @@ paths:
                           - "G" = Hosted by Gravatar
                           - "J" = Generated using Jdenticon
                           - "U" = Uploaded by user
+                          - "S" = System (provided by Zulip)
 
-                          **Changes**: The "J" value is new in Zulip 12.0 (feature level 466).
+                          The "S" value is normally only set for deactivated users
+                          whose profile has been deleted, who cannot authenticate.
+                          However, it can still appear here if such a user is later
+                          reactivated, since reactivation does not reset their
+                          avatar_source.
+
+                          **Changes**: The "S" value is new in Zulip 13.0 (feature level ZF-1b973a).
+                          The "J" value is new in Zulip 12.0 (feature level 466).
                       avatar_url_medium:
                         type: string
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -22497,7 +22497,6 @@ paths:
                           - "U" = Uploaded by user
 
                           **Changes**: The "J" value is new in Zulip 12.0 (feature level 466).
-                          The avatar data source type for the current user.
                       avatar_url_medium:
                         type: string
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -22738,7 +22738,6 @@ paths:
                           - "U" = Uploaded by user
 
                           **Changes**: The "J" value is new in Zulip 12.0 (feature level 466).
-                          The avatar data source type for the current user.
                       avatar_url_medium:
                         type: string
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -549,8 +549,13 @@ paths:
                                             - "G" = Hosted by Gravatar
                                             - "J" = Generated using Jdenticon
                                             - "U" = Uploaded by user
+                                            - "S" = System (provided by Zulip)
 
-                                            **Changes**: The "J" value is new in Zulip 12.0 (feature level 466).
+                                            Currently, the "S" value is only assigned to deactivated
+                                            users whose profile has been deleted.
+
+                                            **Changes**: The "S" value is new in Zulip 13.0 (feature level ZF-1b973a).
+                                            The "J" value is new in Zulip 12.0 (feature level 466).
                                         avatar_url_medium:
                                           type: string
                                           description: |
@@ -5470,8 +5475,11 @@ paths:
                                         - "G" = Hosted by Gravatar
                                         - "J" = Generated using Jdenticon
 
-                                        Note that "U" is not a supported value here, since there is
-                                        no such thing as a "default" user-uploaded avatar.
+                                        The "U" and "S" (System) values will not appear here, as
+                                        neither is ever used as a default source for new users.
+                                        There is no such thing as a "default" user-uploaded avatar
+                                        ("U"), and no user is created with a system-provided avatar
+                                        ("S").
 
                                         **Changes**: New in Zulip 12.0 (feature level 456).
                                     default_code_block_language:
@@ -21802,8 +21810,11 @@ paths:
                           - "G" = Hosted by Gravatar
                           - "J" = Generated using Jdenticon
 
-                          Note that "U" is not a supported value here, since there is
-                          no such thing as a "default" user-uploaded avatar.
+                          The "U" and "S" (System) values will not appear here, as
+                          neither is ever used as a default source for new users.
+                          There is no such thing as a "default" user-uploaded avatar
+                          ("U"), and no user is created with a system-provided avatar
+                          ("S").
 
                           **Changes**: New in Zulip 12.0 (feature level 456).
                       jitsi_server_url:
@@ -22736,8 +22747,16 @@ paths:
                           - "G" = Hosted by Gravatar
                           - "J" = Generated using Jdenticon
                           - "U" = Uploaded by user
+                          - "S" = System (provided by Zulip)
 
-                          **Changes**: The "J" value is new in Zulip 12.0 (feature level 466).
+                          The "S" value is normally only set for deactivated users
+                          whose profile has been deleted, who cannot authenticate.
+                          However, it can still appear here if such a user is later
+                          reactivated, since reactivation does not reset their
+                          avatar_source.
+
+                          **Changes**: The "S" value is new in Zulip 13.0 (feature level ZF-1b973a).
+                          The "J" value is new in Zulip 12.0 (feature level 466).
                       avatar_url_medium:
                         type: string
                         description: |

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1988,7 +1988,7 @@ class TestGetGCMPayload(PushNotificationTestCase):
                 "sender_id": hamlet.id,
                 "sender_email": f"user{hamlet.id}@zulip.testserver",
                 "sender_full_name": "Unknown user",
-                "sender_avatar_url": get_avatar_for_inaccessible_user(),
+                "sender_avatar_url": get_avatar_for_inaccessible_user(medium=False),
                 "recipient_type": "stream",
                 "stream": stream.name,
                 "stream_id": stream.id,

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1539,6 +1539,27 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
             response = self.client_get(f"/avatar/{cordelia.id}/medium", {"foo": "bar"})
             self.assertEqual(429, response.status_code)
 
+        self.set_up_db_for_testing_user_access()
+        self.login("polonius")
+
+        # Inaccessible users get the medium-sized variant of the
+        # unknown user avatar for medium avatar requests.
+        response = self.client_get(f"/avatar/{cordelia.id}/medium", {"foo": "bar"})
+        self.assertEqual(302, response.status_code)
+        redirect_url = response["Location"]
+        self.assertTrue(redirect_url.endswith("images/unknown-user-avatar-medium.png?foo=bar"))
+
+        response = self.client_get("/avatar/cordelia@zulip.com/medium", {"foo": "bar"})
+        self.assertEqual(302, response.status_code)
+        redirect_url = response["Location"]
+        self.assertTrue(redirect_url.endswith("images/unknown-user-avatar-medium.png?foo=bar"))
+
+        invalid_user_id = 999
+        response = self.client_get(f"/avatar/{invalid_user_id}/medium", {"foo": "bar"})
+        self.assertEqual(302, response.status_code)
+        redirect_url = response["Location"]
+        self.assertTrue(redirect_url.endswith("images/unknown-user-avatar-medium.png?foo=bar"))
+
     def test_get_user_avatar_medium(self) -> None:
         cordelia = self.example_user("cordelia")
         cordelia.avatar_source = UserProfile.AVATAR_FROM_USER

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -2862,11 +2862,20 @@ class DeactivateActionsTest(ZulipTestCase):
         self.assertFalse(bot.is_active)
 
         self.assertEqual(user.full_name, "Deleted user")
-        self.assertEqual(user.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+        self.assertEqual(user.avatar_source, UserProfile.AVATAR_FROM_SYSTEM)
         self.assertGreater(user.avatar_version, 0)
 
+        # The avatar URLs now point to the static unknown-user avatar,
+        # with the medium request served by the medium-sized variant.
+        user_avatar = avatar_url(user)
+        assert user_avatar is not None
+        self.assertTrue(user_avatar.endswith("images/unknown-user-avatar.png"))
+        user_avatar_medium = avatar_url(user, medium=True)
+        assert user_avatar_medium is not None
+        self.assertTrue(user_avatar_medium.endswith("images/unknown-user-avatar-medium.png"))
+
         self.assertEqual(bot.full_name, "Deactivated bot")
-        self.assertEqual(bot.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+        self.assertEqual(bot.avatar_source, UserProfile.AVATAR_FROM_SYSTEM)
         self.assertGreater(bot.avatar_version, 0)
 
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -2861,11 +2861,20 @@ class DeactivateActionsTest(ZulipTestCase):
         self.assertFalse(bot.is_active)
 
         self.assertEqual(user.full_name, "Deleted user")
-        self.assertEqual(user.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+        self.assertEqual(user.avatar_source, UserProfile.AVATAR_FROM_SYSTEM)
         self.assertGreater(user.avatar_version, 0)
 
+        # The avatar URLs now point to the static unknown-user avatar,
+        # with the medium request served by the medium-sized variant.
+        user_avatar = avatar_url(user)
+        assert user_avatar is not None
+        self.assertTrue(user_avatar.endswith("images/unknown-user-avatar.png"))
+        user_avatar_medium = avatar_url(user, medium=True)
+        assert user_avatar_medium is not None
+        self.assertTrue(user_avatar_medium.endswith("images/unknown-user-avatar-medium.png"))
+
         self.assertEqual(bot.full_name, "Deactivated bot")
-        self.assertEqual(bot.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+        self.assertEqual(bot.avatar_source, UserProfile.AVATAR_FROM_SYSTEM)
         self.assertGreater(bot.avatar_version, 0)
 
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -397,13 +397,13 @@ def avatar_by_id(
         if maybe_user_profile.is_authenticated and not check_can_access_user(
             avatar_user_profile, maybe_user_profile
         ):
-            url = get_avatar_for_inaccessible_user()
+            url = get_avatar_for_inaccessible_user(medium)
         else:
             # If there is a valid user account passed in, use its avatar
             url = avatar_url(avatar_user_profile, medium=medium)
         assert url is not None
     except UserProfile.DoesNotExist:
-        url = get_avatar_for_inaccessible_user()
+        url = get_avatar_for_inaccessible_user(medium)
 
     assert url is not None
     if request.META["QUERY_STRING"]:
@@ -432,7 +432,7 @@ def avatar_by_email(
         avatar_user_profile = get_user_including_cross_realm(email, realm)
         url: str | None = None
         if not check_can_access_user(avatar_user_profile, maybe_user_profile):
-            url = get_avatar_for_inaccessible_user()
+            url = get_avatar_for_inaccessible_user(medium)
         else:
             # If there is a valid user account passed in, use its avatar
             url = avatar_url(avatar_user_profile, medium=medium)


### PR DESCRIPTION
The problem was that when a user is marked as a spammer and deactivated, their avatar was being set to `AVATAR_FROM_GRAVATAR` (falling back to gravatar/jdenticon based on the reset email), instead of the dedicated unknown-user avatar (`unknown-user-avatar.png`) that Zulip already uses for inaccessible users.

What is being done:

- Added a new avatar source constant `AVATAR_FROM_INACCESSIBLE = I` to UserProfile, alongside the existing `G`, `J`, and `U` values. 
- Updated `get_avatar_field()` in `zerver/lib/avatar.py` to return `get_avatar_for_inaccessible_user()` (which serves `unknown-user-avatar.png`) whenever `avatar_source == AVATAR_FROM_INACCESSIBLE`. This works regardless of the `client_gravatar` flag.
- Updated `do_deactivate_user()` in `zerver/actions/users.py` to set `avatar_source = AVATAR_FROM_INACCESSIBLE` when deactivating a spam user.
- Added a migration (`0801_userprofile_avatar_from_inaccessible.py`) to update the `avatar_source` field choices.
- Updated tests in `test_users.py` to assert `AVATAR_FROM_INACCESSIBLE` instead of `AVATAR_FROM_GRAVATAR` after spam deactivation.

### Screenshot and screen record

Before deactivation

<img width="887" height="95" alt="image" src="https://github.com/user-attachments/assets/35832f8a-4dbd-405f-a0d7-0ec1d73898d1" />

After deactivation

<img width="885" height="64" alt="image" src="https://github.com/user-attachments/assets/c7c68040-0e72-4fea-8a68-2d889d311824" />

Screen record of the flow

https://github.com/user-attachments/assets/5bb59500-4ffe-4c0c-9798-e06fd63ecf1b

Fixes: #35542 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
