### PR TITLE
[ai] corporate: Return 400 when Stripe-Signature header is missing.

### DIFF
--- a/corporate/views/webhook.py
+++ b/corporate/views/webhook.py
@@ -27,10 +27,13 @@ def stripe_webhook(request: HttpRequest) -> HttpResponse:
         stripe_webhook_endpoint_secret and not settings.TEST_SUITE
     ):  # nocoverage: We can't verify the signature in test suite since we fetch the events
         # from Stripe events API and manually post to the webhook endpoint.
+        stripe_signature = request.headers.get("Stripe-Signature")
+        if stripe_signature is None:
+            return HttpResponse(status=400)
         try:
             stripe_event = stripe.Webhook.construct_event(
                 request.body,
-                request.headers["Stripe-Signature"],
+                stripe_signature,
                 stripe_webhook_endpoint_secret,
             )
         except ValueError:


### PR DESCRIPTION
The Stripe webhook handler read request.headers["Stripe-Signature"] directly, raising an unhandled KeyError when a request reached /stripe/webhook/ without the header (e.g., a curl probe in production). The surrounding except blocks for ValueError and stripe.SignatureVerificationError did not cover the missing-key case, so the error surfaced in Sentry rather than as a clean 400 response.

---

This stops us from receiving errors on bad requests made to setry webhook. Fixed by using a traceback in sentry.