### PR TITLE
integrations: Use category name in search placeholder.

### DIFF
--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -36,7 +36,7 @@
                     <div class="searchbar">
                         <div class="searchbar-reset">
                             <i class="zulip-icon zulip-icon-search" aria-hidden="true"></i>
-                            <input type="text" class="search_input" placeholder="{{ _('Search integrations') }}"/>
+                            <input type="text" class="search_input" placeholder="{{ integration_search_placeholder }}"/>
                         </div>
                     </div>
                 </div>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -551,6 +551,19 @@ class DocPageTest(ZulipTestCase):
         og_title = '<meta property="og:title" content="Zulip integrations" />'
         self._test(url, [og_title, og_description, get_canonical_url(url)])
 
+    def test_integration_search_placeholder(self) -> None:
+        result = self.client_get("/integrations/")
+        self.assert_in_success_response(['placeholder="Search integrations"'], result)
+
+        result = self.client_get("/integrations/category/communication")
+        self.assert_in_success_response(['placeholder="Search communication integrations"'], result)
+
+        result = self.client_get("/integrations/category/bots")
+        self.assert_in_success_response(['placeholder="Search interactive bots"'], result)
+
+        result = self.client_get("/integrations/category/meta-integration")
+        self.assert_in_success_response(['placeholder="Search integration frameworks"'], result)
+
     def test_integration_404s(self) -> None:
         # We don't need to test all the pages for 404
         for integration in list(INTEGRATIONS.keys())[5]:

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.template import loader
 from django.template.response import TemplateResponse
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 from lxml import html
 from lxml.etree import Element, SubElement, XPath, _Element
@@ -34,6 +35,8 @@ from zerver.lib.templates import render_markdown_path
 from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.models import Realm
 from zerver.openapi.openapi import get_endpoint_from_operationid, get_openapi_summary
+
+STANDALONE_INTEGRATION_CATEGORY_PLACEHOLDER_SLUGS = {"bots", "meta-integration"}
 
 
 @dataclass
@@ -403,6 +406,17 @@ def get_visible_integrations_for_category(category_slug: str) -> list[Integratio
     return [integration for integration in enabled if category in integration.categories]
 
 
+def get_integration_search_placeholder(category_slug: str) -> str:
+    if category_slug == "all":
+        return _("Search integrations")
+
+    category_name = str(CATEGORIES[category_slug]).lower()
+    if category_slug in STANDALONE_INTEGRATION_CATEGORY_PLACEHOLDER_SLUGS:
+        return _("Search {category_name}").format(category_name=category_name)
+
+    return _("Search {category_name} integrations").format(category_name=category_name)
+
+
 def add_catalog_integrations_context(request: HttpRequest, category_slug: str) -> dict[str, Any]:
     enabled_integrations_count = sum(v.is_enabled_in_catalog() for v in INTEGRATIONS.values())
     # Subtract 1 so saying "Over X integrations" is correct. Then,
@@ -413,6 +427,7 @@ def add_catalog_integrations_context(request: HttpRequest, category_slug: str) -
     context.update(
         {
             "categories_dict": OrderedDict(sorted(CATEGORIES.items())),
+            "integration_search_placeholder": get_integration_search_placeholder(category_slug),
             "integrations_count_display": integrations_count_display,
             "selected_category_slug": category_slug,
             "visible_integrations": get_visible_integrations_for_category(category_slug),


### PR DESCRIPTION
Updates the integrations catalog search placeholder to reflect the selected category.

The main integrations page still says "Search integrations". Category pages now use the category name, like "Search communication integrations". For categories that already describe integration groups, like Interactive bots and Integration frameworks, the placeholder avoids adding another "integrations" suffix.

Fixes: #39019

**How changes were tested:**

- Added `DocPageTest.test_integration_search_placeholder`.
- Ran `python -m compileall -q zerver\views\documentation.py zerver\tests\test_docs.py`.
- Ran `git diff --check`.
- Could not run `tools/lint` or `tools/test-backend` in my native Windows checkout because they require Zulip's Linux development environment.

<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.