### PR TITLE
mattermost import: Batch html2text calls.

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -921,6 +921,29 @@ def convert_html_to_text(content: str) -> str:
     return subprocess.check_output(["html2text", "--unicode-snob"], input=content, text=True)
 
 
+def convert_html_to_text_batch(contents: list[str]) -> list[str]:
+    if len(contents) == 0:
+        return []
+
+    separator = f"ZULIP_HTML_TO_TEXT_BATCH_SEPARATOR_{secrets.token_urlsafe(18)}"
+    while any(separator in content for content in contents):
+        separator = f"ZULIP_HTML_TO_TEXT_BATCH_SEPARATOR_{secrets.token_urlsafe(18)}"
+
+    converted = subprocess.check_output(
+        ["html2text", "--unicode-snob"],
+        input=f"\n\n<p>{separator}</p>\n\n".join(contents),
+        text=True,
+    )
+    converted_parts = converted.split(separator)
+    if len(converted_parts) != len(contents):
+        raise ValueError("Unexpected html2text batch conversion output.")
+
+    return [
+        converted_content.removeprefix("\n\n") if index > 0 else converted_content
+        for index, converted_content in enumerate(converted_parts)
+    ]
+
+
 def get_data_file(path: str) -> Any:
     with open(path, "rb") as fp:
         data = orjson.loads(fp.read())

--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -33,6 +33,7 @@ from zerver.data_import.import_util import (
     build_user_profile,
     build_zerver_realm,
     convert_html_to_text,
+    convert_html_to_text_batch,
     create_converted_data_files,
     get_attachment_path_and_content,
     get_domain_name_for_import,
@@ -531,21 +532,39 @@ def process_raw_message_batch(
     mention_map: dict[int, set[int]] = {}
     zerver_message = []
 
+    prepared_messages: list[tuple[dict[str, Any], set[int], str]] = []
     for raw_message in raw_messages:
-        message_id = NEXT_ID("message")
         mention_user_ids = get_mentioned_user_ids(raw_message, user_id_mapper)
-        mention_map[message_id] = mention_user_ids
-
         content = fix_mentions(
             content=raw_message["content"],
             mention_user_ids=mention_user_ids,
         )
+        prepared_messages.append((raw_message, mention_user_ids, content))
 
-        try:
-            content = convert_html_to_text(content)
-        except Exception:  # nocoverage
-            logging.warning("Error converting HTML to text for message: '%s'; continuing", content)
-            logging.warning(str(raw_message))
+    raw_contents = [content for _, _, content in prepared_messages]
+    try:
+        converted_contents = convert_html_to_text_batch(raw_contents)
+    except Exception as e:
+        logging.warning(
+            "Batch HTML-to-text conversion failed with %s; falling back to per-message conversion.",
+            type(e).__name__,
+        )
+        converted_contents = []
+        for raw_message, _, content in prepared_messages:
+            try:
+                content = convert_html_to_text(content)
+            except Exception:  # nocoverage
+                logging.warning(
+                    "Error converting HTML to text for message: '%s'; continuing", content
+                )
+                logging.warning(str(raw_message))
+            converted_contents.append(content)
+
+    for (raw_message, mention_user_ids, _), content in zip(
+        prepared_messages, converted_contents, strict=True
+    ):
+        message_id = NEXT_ID("message")
+        mention_map[message_id] = mention_user_ids
 
         date_sent = raw_message["date_sent"]
         sender_user_id = raw_message["sender_id"]

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -1,6 +1,7 @@
 import filecmp
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -18,6 +19,7 @@ from zerver.data_import.import_util import SubscriberHandler, UploadRecordData, 
 from zerver.data_import.mattermost import (
     COMPILED_CHANNEL_ID_FORMAT,
     DEFAULT_SINGLE_TEAM_OBJECT,
+    ChannelMetadata,
     backfill_user_data_from_posts,
     build_reactions,
     check_user_in_team,
@@ -30,6 +32,7 @@ from zerver.data_import.mattermost import (
     make_realm,
     mattermost_data_file_to_dict,
     process_message_attachments,
+    process_raw_message_batch,
     process_user,
     reset_mirror_dummy_users,
     write_emoticon_data,
@@ -735,6 +738,148 @@ class MatterMostImporter(MattermostImportTestBase):
             {malfoy_id, pansy_id},
         )
 
+    def test_process_raw_message_batch_converts_html_in_one_subprocess(self) -> None:
+        output_dir = self.make_import_output_dir("mattermost")
+        raw_messages = [
+            {
+                "sender_id": 1,
+                "content": "<p>first</p>",
+                "date_sent": 1600000000,
+                "reactions": [],
+                "channel_name": "town-square",
+            },
+            {
+                "sender_id": 2,
+                "content": "<p>second</p>",
+                "date_sent": 1600000001,
+                "reactions": [],
+                "channel_name": "town-square",
+            },
+        ]
+
+        def fake_html2text(args: list[str], *, input: str, text: bool) -> str:
+            self.assertEqual(args, ["html2text", "--unicode-snob"])
+            self.assertTrue(text)
+            separator = re.search(r"ZULIP_HTML_TO_TEXT_BATCH_SEPARATOR_[A-Za-z0-9_-]+", input)
+            self.assertIsNotNone(separator)
+            assert separator is not None
+            return (
+                input.replace("<p>first</p>", "first")
+                .replace("<p>second</p>", "second")
+                .replace(f"<p>{separator.group(0)}</p>", separator.group(0))
+                + "\n\n"
+            )
+
+        with patch(
+            "zerver.data_import.import_util.subprocess.check_output",
+            side_effect=fake_html2text,
+        ) as mock_html2text:
+            process_raw_message_batch(
+                realm_id=1,
+                raw_messages=raw_messages,
+                subscriber_map={10: {1, 2}},
+                user_id_mapper=IdMapper[str](),
+                user_handler=UserHandler(),
+                added_channels={
+                    "town-square": ChannelMetadata(
+                        zulip_channel_id=1,
+                        zulip_recipient_id=10,
+                    ),
+                },
+                subscriber_handler=SubscriberHandler[frozenset[str]](),
+                is_pm_data=False,
+                output_dir=output_dir,
+                zerver_realmemoji=[],
+                total_reactions=[],
+                uploads_list=[],
+                zerver_attachment=[],
+                mattermost_data_dir=self.fixture_file_name("", "mattermost_fixtures"),
+            )
+
+        self.assertEqual(mock_html2text.call_count, 1)
+        message_files = [
+            filename for filename in os.listdir(output_dir) if filename.startswith("messages-")
+        ]
+        self.assert_length(message_files, 1)
+        messages = self.read_file(output_dir, message_files[0])["zerver_message"]
+        self.assertEqual(
+            [message["content"] for message in messages],
+            ["first\n\n", "second\n\n"],
+        )
+
+    def test_process_raw_message_batch_falls_back_after_batch_failure(self) -> None:
+        output_dir = self.make_import_output_dir("mattermost")
+        raw_messages = [
+            {
+                "sender_id": 1,
+                "content": "<p>first</p>",
+                "date_sent": 1600000000,
+                "reactions": [],
+                "channel_name": "town-square",
+            },
+            {
+                "sender_id": 2,
+                "content": "<p>second</p>",
+                "date_sent": 1600000001,
+                "reactions": [],
+                "channel_name": "town-square",
+            },
+        ]
+
+        def fake_convert_html_to_text(content: str) -> str:
+            return content.removeprefix("<p>").removesuffix("</p>") + "\n\n"
+
+        with (
+            patch(
+                "zerver.data_import.mattermost.convert_html_to_text_batch",
+                side_effect=ValueError("bad batch"),
+            ) as mock_batch_converter,
+            patch(
+                "zerver.data_import.mattermost.convert_html_to_text",
+                side_effect=fake_convert_html_to_text,
+            ) as mock_converter,
+            self.assertLogs(level="WARNING") as warn_log,
+        ):
+            process_raw_message_batch(
+                realm_id=1,
+                raw_messages=raw_messages,
+                subscriber_map={10: {1, 2}},
+                user_id_mapper=IdMapper[str](),
+                user_handler=UserHandler(),
+                added_channels={
+                    "town-square": ChannelMetadata(
+                        zulip_channel_id=1,
+                        zulip_recipient_id=10,
+                    ),
+                },
+                subscriber_handler=SubscriberHandler[frozenset[str]](),
+                is_pm_data=False,
+                output_dir=output_dir,
+                zerver_realmemoji=[],
+                total_reactions=[],
+                uploads_list=[],
+                zerver_attachment=[],
+                mattermost_data_dir=self.fixture_file_name("", "mattermost_fixtures"),
+            )
+
+        self.assertEqual(mock_batch_converter.call_count, 1)
+        self.assertEqual(mock_converter.call_count, 2)
+        self.assertEqual(
+            warn_log.output,
+            [
+                "WARNING:root:Batch HTML-to-text conversion failed with ValueError; falling back to per-message conversion."
+            ],
+        )
+        message_files = [
+            filename for filename in os.listdir(output_dir) if filename.startswith("messages-")
+        ]
+        self.assert_length(message_files, 1)
+        messages = self.read_file(output_dir, message_files[0])["zerver_message"]
+        self.assertEqual(
+            [message["content"] for message in messages],
+            ["first\n\n", "second\n\n"],
+        )
+
     def test_convert_direct_message_group_data(self) -> None:
         fixture_file_name = self.fixture_file_name(
             "export.json", "mattermost_fixtures/direct_channel"
@@ -1090,6 +1235,8 @@ class MatterMostImporter(MattermostImportTestBase):
                 *(
                     [
                         # Check error log when trying to process a message with faulty HTML.
+                        "WARNING:root:Batch HTML-to-text conversion failed with CalledProcessError; "
+                        "falling back to per-message conversion.",
                         "WARNING:root:Error converting HTML to text for message: 'This will crash html2text!!! <g:brand><![CDATSALOMON NORTH AMERICA, IN}}]]></g:brand>'; continuing",
                         "WARNING:root:{'sender_id': 2, 'content': 'This will crash html2text!!! <g:brand><![CDATSALOMON NORTH AMERICA, IN}}]]></g:brand>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
                     ]
@@ -1327,6 +1474,8 @@ class MatterMostImporter(MattermostImportTestBase):
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
                 *(
                     [
+                        "WARNING:root:Batch HTML-to-text conversion failed with CalledProcessError; "
+                        "falling back to per-message conversion.",
                         "WARNING:root:Error converting HTML to text for message: 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>'; continuing",
                         "WARNING:root:{'sender_id': 2, 'content': 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
                     ]
@@ -1358,6 +1507,8 @@ class MatterMostImporter(MattermostImportTestBase):
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
                 *(
                     [
+                        "WARNING:root:Batch HTML-to-text conversion failed with CalledProcessError; "
+                        "falling back to per-message conversion.",
                         "WARNING:root:Error converting HTML to text for message: 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>'; continuing",
                         "WARNING:root:{'sender_id': 2, 'content': 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
                     ]


### PR DESCRIPTION
 Mattermost imports were spawning `html2text` once for every message. This batches the messages passed to `html2text` inside each import batch, while keeping the old per-message fallback if the batch conversion fails.

  Fixes #39375.

  **How changes were tested:**

  - `git diff --check`
  - `python -m py_compile zerver\data_import\import_util.py zerver\data_import\mattermost.py zerver\tests\test_mattermost_importer.py`
  - `python -m ruff check zerver\data_import\import_util.py zerver\data_import\mattermost.py zerver\tests\test_mattermost_importer.py`
  - `python -m ruff format --check zerver\data_import\import_util.py zerver\data_import\mattermost.py zerver\tests\test_mattermost_importer.py`

  I could not run `tools/test-backend zerver.tests.test_mattermost_importer.MatterMostImporter.test_process_raw_message_batch_converts_html_in_one_subp
  rocess` in this Windows shell because the test runner requires a Unix `fork` context.

  **Screenshots and screen captures:**

  Not included; this is a data import change with no UI changes.

  <details>
  <summary>Self-review checklist</summary>

  - [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)
  the changes for clarity and maintainability
        (variable names, code reuse, readability, etc.).
  - [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-
  policy-and-guidelines).

  Communicate decisions, questions, and potential concerns.

  - [x] Explains differences from previous plans (e.g., issue description).
  - [x] Highlights technical choices and bugs encountered.
  - [x] Calls out remaining decisions and concerns.
  - [x] Automated tests verify logic where appropriate.

  Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/
  contributing/commit-discipline.html)).

  - [x] Each commit is a coherent idea.
  - [x] Commit message(s) explain reasoning and motivation for changes.

  Completed manual review and testing of the following:

  - [ ] Visual appearance of the changes.
  - [ ] Responsiveness and internationalization.
  - [ ] Strings and tooltips.
  - [ ] End-to-end functionality of buttons, interactions and flows.
  - [x] Corner cases, error conditions, and easily imagined bugs.
  </details>