### PR TITLE
kandra: Allow frontend access to camo from port 9292.

### DIFF
--- a/puppet/kandra/manifests/camo.pp
+++ b/puppet/kandra/manifests/camo.pp
@@ -3,5 +3,6 @@ class kandra::camo {
     listen_address => '0.0.0.0',
   }
 
+  kandra::firewall_allow { 'camo': port => '9292' }
   kandra::teleport::prometheus_app { 'camo': port => '9292' }
 }


### PR DESCRIPTION
Partial revert from d8f47d7cc254c4cfb655ab2123ef6a59961cee2a.

Port 9292 is used both to serve metrics to prometheus and for serving frontend. Only allowing prometheus access to port 9292 broke image previews for external image uploads since frontend was not able to access camo via port 9292.
