### PR TITLE
overlay: Replace heading element selectors with CSS classes.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -836,7 +836,7 @@ input.settings_text_input {
         background-color: var(--color-background-modal-bar);
         border-bottom: 1px solid var(--color-border-modal-bar);
 
-        & h1 {
+        .overlay-messages-title {
             margin: 0;
             font-size: 1.1em;
             text-transform: uppercase;

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -2,7 +2,7 @@
     <div class="flex overlay-content">
         <div class="drafts-container overlay-messages-container overlay-container">
             <div class="overlay-messages-header">
-                <h1>{{t 'Drafts' }}</h1>
+                <h1 class="overlay-messages-title">{{t 'Drafts' }}</h1>
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -3,16 +3,16 @@
         <div class="message-edit-history-container overlay-messages-container overlay-container">
             <div class="overlay-messages-header">
                 {{#if move_history_only}}
-                <h1>{{t "Message move history" }}</h1>
+                <h1 class="overlay-messages-title">{{t "Message move history"}}</h1>
                 {{else}}
                 {{#if edited}}
                     {{#if moved}}
-                    <h1>{{t "Message edit and move history" }}</h1>
+                    <h1>{{t "Message edit and move history"}}</h1>
                     {{else}}
-                    <h1>{{t "Message edit history" }}</h1>
+                    <h1>{{t "Message edit history"}}</h1>
                     {{/if}}
                 {{else if moved}}
-                    <h1>{{t "Message move history" }}</h1>
+                    <h1>{{t "Message move history"}}</h1>
                 {{/if}}
                 {{/if}}
                 <div class="exit">
@@ -27,4 +27,5 @@
         </div>
     </div>
 </div>
+
 

--- a/web/templates/reminders_overlay.hbs
+++ b/web/templates/reminders_overlay.hbs
@@ -2,14 +2,14 @@
     <div class="flex overlay-content">
         <div class="overlay-messages-container overlay-container reminders-container">
             <div class="overlay-messages-header">
-                <h1>{{t 'Scheduled reminders' }}</h1>
+                <h1 class="overlay-messages-title">{{t "Scheduled reminders"}}</h1>
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
             </div>
             <div class="reminders-list overlay-messages-list">
                 <div class="no-overlay-messages">
-                    {{t 'No reminders scheduled.'}}
+                    {{t "No reminders scheduled."}}
                 </div>
             </div>
         </div>

--- a/web/templates/scheduled_messages_overlay.hbs
+++ b/web/templates/scheduled_messages_overlay.hbs
@@ -2,7 +2,7 @@
     <div class="flex overlay-content">
         <div class="overlay-messages-container overlay-container scheduled-messages-container">
             <div class="overlay-messages-header">
-                <h1>{{t 'Scheduled messages' }}</h1>
+                <h1 class="overlay-messages-title">{{t 'Scheduled messages' }}</h1>
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>


### PR DESCRIPTION
overlay: Replace heading element selectors with CSS classes.

Fixes: #39360 

## Screenshots
**No visual changes intended; this PR only replaces element-based selectors with class-based styling**

before :
<img width="983" height="785" alt="Screenshot 2026-05-22 at 4 42 39 PM" src="https://github.com/user-attachments/assets/b11cf1c3-4a58-4f9f-a112-e089a339848d" />

after:
<img width="1019" height="787" alt="Screenshot 2026-05-22 at 4 51 48 PM" src="https://github.com/user-attachments/assets/70b30363-719d-4a3d-bdb8-8d860c2c534d" />

Replaced heading element selectors in overlay message components with dedicated CSS classes.

## Changes made:
- Added overlay-messages-title class for overlay headings
- Updated overlay templates to use class-based styling instead of element selectors.

## Testing:
- Ran tools/lint
- Verified template and CSS updates
