### PR TITLE
[ai] markdown: Skip Dropbox preview fetch when previews are disabled.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -794,6 +794,8 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         return None
 
     def dropbox_media(self, url: str) -> DropboxMediaInfo | None:
+        if not self.zmd.image_preview_enabled:
+            return None
         parsed_url = urlsplit(url)
         if parsed_url.netloc == "dropbox.com" or parsed_url.netloc.endswith(".dropbox.com"):
             # See https://www.dropboxforum.com/discussions/101001012/shared-link--scl-to-s/689070/replies/695266

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1262,6 +1262,25 @@ class MarkdownEmbedsTest(ZulipTestCase):
             '<p><a href="https://zulip-test.dropbox.com/photos/cl/ROmr9K1XYtmpneM">https://zulip-test.dropbox.com/photos/cl/ROmr9K1XYtmpneM</a></p>',
         )
 
+    def test_inline_dropbox_no_previews(self) -> None:
+        # When previews are disabled (e.g., for channel descriptions),
+        # dropbox_media should not invoke fetch_open_graph_image, since
+        # network calls in that context can time out and abort rendering.
+        # Use a non-image/non-video file link so that, without the fix,
+        # dropbox_media would reach the fetch_open_graph_image call.
+        url = "https://www.dropbox.com/scl/fi/8xq0p2m4n6k8j1h3g5f7d/quarterly-report.pdf?dl=0"
+        with mock.patch(
+            "zerver.lib.markdown.fetch_open_graph_image"
+        ) as mock_fetch_open_graph_image:
+            converted = markdown_convert(
+                url, message_realm=get_realm("zulip"), no_previews=True
+            ).rendered_content
+        mock_fetch_open_graph_image.assert_not_called()
+        self.assertEqual(
+            converted,
+            f'<p><a href="{url}">{url}</a></p>',
+        )
+
     def test_inline_github_preview(self) -> None:
         # Test github URL translation
         url = "https://github.com/zulip/zulip/blob/main/static/images/logo/zulip-icon-128x128.png"


### PR DESCRIPTION
dropbox_media() was unconditionally calling fetch_open_graph_image for folder and non-image/non-video Dropbox file links, even when the markdown engine had previews disabled via no_previews=True (as used by render_stream_description, channel folders, realm description, and custom profile fields).

When a channel description contained several Dropbox file links, the resulting OpenGraph HTTP fetches could exceed do_convert's 5-second unsafe_timeout, surfacing as a MarkdownRenderingError / HTTP 500 on PATCH /json/streams/<id>.

Mirror the early-return pattern used by youtube_id and vimeo_id so dropbox_media respects image_preview_enabled.


---

Fed a sentry traceback to claude. Verified locally by saving a dropbox link in channel description.