### PR TITLE
streams: Allow unsubscribing user groups from channels.

### DIFF
--- a/starlight_help/src/content/include/_UnsubscribeUserFromChannel.mdx
+++ b/starlight_help/src/content/include/_UnsubscribeUserFromChannel.mdx
@@ -20,9 +20,12 @@ import CloseIcon from "~icons/zulip-icon/close";
 
       <SelectChannelViewSubscribers />
 
-      1. Under **Subscribers**, find the user you would like
-         to unsubscribe from the channel.
-      1. Click the **unsubscribe** (<CloseIcon />) icon in that row.
+      1. To unsubscribe a single user, find them under **Subscribers** and
+         click the **unsubscribe** (<CloseIcon />) icon in that row.
+      1. To unsubscribe users in bulk, under **Remove subscribers**, enter
+         user names, [user roles](/help/user-roles), or [user
+         groups](/help/user-groups) to select the users to unsubscribe. Click
+         **Remove**.
     </FlattenedSteps>
 
     <ChannelSettingsNavbarTip />

--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -154,7 +154,10 @@ export function create({
     });
 
     if (with_add_button) {
-        add_subscribers_pill.set_up_handlers_for_add_button_state(pill_widget, $pill_container);
+        add_subscribers_pill.set_up_handlers_for_pill_action_button_state(
+            pill_widget,
+            $pill_container,
+        );
     }
 
     return pill_widget;

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -104,31 +104,31 @@ export function generate_pill_html(item: CombinedPill): string {
     return stream_pill.generate_pill_html(item);
 }
 
-export function set_up_handlers_for_add_button_state(
+export function set_up_handlers_for_pill_action_button_state(
     pill_widget: CombinedPillContainer | user_group_pill.UserGroupPillWidget,
     $pill_container: JQuery,
     pill_update_callback?: () => void,
 ): void {
     const $pill_widget_input = $pill_container.find(".input");
-    const $pill_widget_button = $pill_container.closest(".add-button-container").find("button");
-    // Disable the add button first time the pill container is created.
+    const $pill_widget_button = $pill_container.closest(".pill-action-container").find("button");
+    // Disable the action button first time the pill container is created.
     $pill_widget_button.prop("disabled", true);
 
-    // If all the pills are removed, disable the add button.
+    // If all the pills are removed, disable the action button.
     pill_widget.onPillRemove(() => {
         $pill_widget_button.prop("disabled", pill_widget.items().length === 0);
         if (pill_update_callback) {
             pill_update_callback();
         }
     });
-    // If a pill is added, enable the add button.
+    // If a pill is added, enable the action button.
     pill_widget.onPillCreate(() => {
         $pill_widget_button.prop("disabled", false);
         if (pill_update_callback) {
             pill_update_callback();
         }
     });
-    // Disable the add button when there is no pending text that can be converted
+    // Disable the action button when there is no pending text that can be converted
     // into a pill and the number of existing pills is zero.
     $pill_widget_input.on("input", () =>
         $pill_widget_button.prop(
@@ -142,19 +142,19 @@ export function create({
     $pill_container,
     get_potential_subscribers,
     get_user_groups,
-    with_add_button,
+    with_action_button,
     onPillCreateAction,
     onPillRemoveAction,
-    add_button_pill_update_callback,
+    action_button_pill_update_callback,
     onTextInputCallback,
 }: {
     $pill_container: JQuery;
     get_potential_subscribers: () => User[];
     get_user_groups: () => UserGroup[];
-    with_add_button: boolean;
+    with_action_button: boolean;
     onPillCreateAction?: (pill_user_ids: number[]) => void;
     onPillRemoveAction?: (pill_user_ids: number[]) => void;
-    add_button_pill_update_callback?: () => void;
+    action_button_pill_update_callback?: () => void;
     onTextInputCallback?: () => void;
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
@@ -213,11 +213,11 @@ export function create({
         for_stream_subscribers: true,
     });
 
-    if (with_add_button) {
-        set_up_handlers_for_add_button_state(
+    if (with_action_button) {
+        set_up_handlers_for_pill_action_button_state(
             pill_widget,
             $pill_container,
-            add_button_pill_update_callback,
+            action_button_pill_update_callback,
         );
     }
 

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -17,9 +17,10 @@ import * as user_pill from "./user_pill.ts";
 export function create_item_from_text(
     text: string,
     current_items: CombinedPill[],
+    include_stream_pill = true,
 ): CombinedPill | undefined {
     const funcs = [
-        stream_pill.create_item_from_stream_name,
+        ...(include_stream_pill ? [stream_pill.create_item_from_stream_name] : []),
         user_group_pill.create_item_from_group_name,
         user_pill.create_item_from_user_id,
     ];
@@ -54,27 +55,31 @@ export function set_up_pill_typeahead({
     get_users,
     get_user_groups,
     for_stream_subscribers,
+    include_stream_pill = true,
 }: {
     pill_widget: CombinedPillContainer;
     $pill_container: JQuery;
     get_users: () => User[];
     get_user_groups?: () => UserGroup[];
     for_stream_subscribers: boolean;
+    include_stream_pill?: boolean;
 }): void {
     const opts: {
         user_source: () => User[];
-        stream: boolean;
+        stream?: boolean;
         user_group: boolean;
         user: boolean;
         user_group_source?: () => UserGroup[];
         for_stream_subscribers: boolean;
     } = {
         user_source: get_users,
-        stream: true,
         user_group: true,
         user: true,
         for_stream_subscribers,
     };
+    if (include_stream_pill) {
+        opts.stream = true;
+    }
     if (get_user_groups !== undefined) {
         opts.user_group_source = get_user_groups;
     }
@@ -143,6 +148,7 @@ export function create({
     get_potential_subscribers,
     get_user_groups,
     with_action_button,
+    include_stream_pill = true,
     onPillCreateAction,
     onPillRemoveAction,
     action_button_pill_update_callback,
@@ -152,6 +158,7 @@ export function create({
     get_potential_subscribers: () => User[];
     get_user_groups: () => UserGroup[];
     with_action_button: boolean;
+    include_stream_pill?: boolean;
     onPillCreateAction?: (pill_user_ids: number[]) => void;
     onPillRemoveAction?: (pill_user_ids: number[]) => void;
     action_button_pill_update_callback?: () => void;
@@ -159,7 +166,8 @@ export function create({
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
-        create_item_from_text,
+        create_item_from_text: (text, current_items) =>
+            create_item_from_text(text, current_items, include_stream_pill),
         get_text_from_item,
         get_display_value_from_item,
         generate_pill_html,
@@ -211,6 +219,7 @@ export function create({
         get_users,
         get_user_groups: get_groups,
         for_stream_subscribers: true,
+        include_stream_pill,
     });
 
     if (with_action_button) {

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -57,7 +57,7 @@ function build_pill_widget({
         $pill_container,
         get_potential_subscribers,
         get_user_groups,
-        with_add_button: false,
+        with_action_button: false,
         onPillCreateAction: add_user_ids,
         // It is better to sync the current set of user ids in the input
         // instead of removing user_ids from the user_ids_set, otherwise

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -164,9 +164,9 @@ export function enable_subscriber_management({
         get_potential_subscribers,
         onPillCreateAction: pill_update_callback,
         onPillRemoveAction: pill_update_callback,
-        add_button_pill_update_callback: pill_update_callback,
+        action_button_pill_update_callback: pill_update_callback,
         get_user_groups: user_groups.get_all_realm_user_groups,
-        with_add_button: true,
+        with_action_button: true,
     });
 
     $pill_container.find(".input").on("input", () => {

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -3,6 +3,7 @@ import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
 import render_subscription_banner from "../templates/components/subscription_banner.hbs";
+import render_confirm_bulk_unsubscribe_modal from "../templates/confirm_dialog/confirm_bulk_unsubscribe.hbs";
 import render_unsubscribe_private_stream_modal from "../templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs";
 import render_decorated_channel_name from "../templates/decorated_channel_name.hbs";
 import render_stream_member_list_entry from "../templates/stream_settings/stream_member_list_entry.hbs";
@@ -43,6 +44,7 @@ const add_user_ids_api_response_schema = z.object({
 });
 
 export let pill_widget: CombinedPillContainer;
+export let remove_pill_widget: CombinedPillContainer;
 let current_stream_id: number;
 let subscribers_list_widget: ListWidgetType<User, User>;
 
@@ -79,6 +81,49 @@ function show_stream_subscription_request_error_result(error_message: string): v
     scroll_util
         .get_content_element($stream_subscription_req_result_elem)
         .html(rendered_error_banner);
+}
+
+function show_stream_unsubscription_request_error_result(error_message: string): void {
+    const $stream_unsubscription_req_result_elem = $(
+        ".stream_unsubscription_request_result",
+    ).expectOne();
+    const rendered_error_banner = render_subscription_banner({
+        error_message,
+        intent: "danger",
+    });
+    scroll_util
+        .get_content_element($stream_unsubscription_req_result_elem)
+        .html(rendered_error_banner);
+}
+
+function show_stream_unsubscription_request_success_result({
+    unsubscribed_users,
+    already_not_subscribed_users,
+}: {
+    unsubscribed_users: User[];
+    already_not_subscribed_users: User[];
+}): void {
+    const unsubscribed_users_count = unsubscribed_users.length;
+    const already_not_subscribed_users_count = already_not_subscribed_users.length;
+    const is_total_user_count_more_than_five =
+        unsubscribed_users_count + already_not_subscribed_users_count > 5;
+
+    const $stream_unsubscription_req_result_elem = $(
+        ".stream_unsubscription_request_result",
+    ).expectOne();
+
+    const rendered_success_banner = render_subscription_banner({
+        intent: "success",
+        is_unsubscribe: true,
+        unsubscribed_users,
+        already_not_subscribed_users,
+        unsubscribed_users_count,
+        already_not_subscribed_users_count,
+        is_total_user_count_more_than_five,
+    });
+    scroll_util
+        .get_content_element($stream_unsubscription_req_result_elem)
+        .html(rendered_success_banner);
 }
 
 function show_stream_subscription_request_success_result({
@@ -138,6 +183,15 @@ async function stream_edit_update_notification_choice(): Promise<void> {
     loading.destroy_indicator($(".add-subscriber-loading-spinner"));
 }
 
+function update_remove_subscribers_section(
+    user_can_remove_subscribers: boolean,
+    $parent_container: JQuery,
+): void {
+    $parent_container
+        .find(".remove-subscribers-section")
+        .toggleClass("no-display", !user_can_remove_subscribers);
+}
+
 export function enable_subscriber_management({
     sub,
     $parent_container,
@@ -147,7 +201,7 @@ export function enable_subscriber_management({
 }): void {
     const stream_id = sub.stream_id;
 
-    const $pill_container = $parent_container.find(".pill-container");
+    const $pill_container = $parent_container.find(".add_subscribers_container .pill-container");
 
     // current_stream_id and pill_widget are module-level variables
     current_stream_id = stream_id;
@@ -173,7 +227,33 @@ export function enable_subscriber_management({
         $parent_container.find(".stream_subscription_request_result").empty();
     });
 
+    const $remove_pill_container = $parent_container.find(
+        ".remove_subscribers_container .pill-container",
+    );
+
+    function get_current_subscribers(): User[] {
+        const subscriber_ids = peer_data.get_subscriber_ids_assert_loaded(stream_id);
+        return people.get_users_from_ids(subscriber_ids);
+    }
+
+    remove_pill_widget = add_subscribers_pill.create({
+        $pill_container: $remove_pill_container,
+        get_potential_subscribers: get_current_subscribers,
+        get_user_groups: user_groups.get_all_realm_user_groups,
+        with_action_button: true,
+        // The add-subscribers widget accepts a #channel pill to act on
+        // everyone subscribed to that channel; that has no clear use case
+        // when removing subscribers, so this widget omits #channel pills.
+        include_stream_pill: false,
+    });
+
+    $remove_pill_container.find(".input").on("input", () => {
+        $parent_container.find(".stream_unsubscription_request_result").empty();
+    });
+
     const user_can_remove_subscribers = stream_data.can_unsubscribe_others(sub);
+    update_remove_subscribers_section(user_can_remove_subscribers, $parent_container);
+
     void render_subscriber_list_widget(sub, user_can_remove_subscribers, $parent_container);
 }
 
@@ -363,6 +443,237 @@ function subscribe_new_users({pill_user_ids}: {pill_user_ids: number[]}): void {
     );
 }
 
+// Bulk removals of at least this many subscribers prompt a confirmation,
+// since they unsubscribe a lot of people at once and are tedious to undo.
+const BULK_UNSUBSCRIBE_CONFIRMATION_THRESHOLD = 10;
+
+export type UnsubscribeModalProps = {
+    needs_modal: boolean;
+    show_private_stream_warning: boolean;
+    unsubscribing_other_user: boolean;
+    organization_will_lose_content_access: boolean;
+};
+
+export function compute_unsubscribe_modal_props({
+    invite_only,
+    subscribed_target_ids,
+    sub_count,
+    self_user_id,
+    self_can_rejoin,
+    nobody_can_subscribe,
+}: {
+    invite_only: boolean;
+    subscribed_target_ids: number[];
+    sub_count: number;
+    self_user_id: number;
+    self_can_rejoin: boolean;
+    nobody_can_subscribe: boolean;
+}): UnsubscribeModalProps {
+    if (subscribed_target_ids.length === 0) {
+        return {
+            needs_modal: false,
+            show_private_stream_warning: false,
+            unsubscribing_other_user: true,
+            organization_will_lose_content_access: false,
+        };
+    }
+
+    let show_private_stream_warning = false;
+    let unsubscribing_other_user = true;
+    let organization_will_lose_content_access = false;
+
+    if (invite_only) {
+        const unsubscribing_self = subscribed_target_ids.includes(self_user_id);
+        const self_without_rejoin = unsubscribing_self && !self_can_rejoin;
+        const will_empty_channel = subscribed_target_ids.length === sub_count;
+        const organization_will_lose_access = will_empty_channel && nobody_can_subscribe;
+        // Only warn when the modal has something to say; emptying a channel
+        // that still allows subscribing is recoverable, so it needs no warning.
+        if (self_without_rejoin || organization_will_lose_access) {
+            show_private_stream_warning = true;
+            unsubscribing_other_user = !self_without_rejoin;
+            organization_will_lose_content_access = organization_will_lose_access;
+        }
+    }
+
+    const is_large_removal =
+        subscribed_target_ids.length >= BULK_UNSUBSCRIBE_CONFIRMATION_THRESHOLD;
+
+    return {
+        needs_modal: show_private_stream_warning || is_large_removal,
+        show_private_stream_warning,
+        unsubscribing_other_user,
+        organization_will_lose_content_access,
+    };
+}
+
+function unsubscribe_users({pill_user_ids}: {pill_user_ids: number[]}): void {
+    const sub = get_sub(current_stream_id);
+    if (!sub) {
+        return;
+    }
+
+    const subscriber_ids = new Set(peer_data.get_subscriber_ids_assert_loaded(current_stream_id));
+    const user_id_set = new Set(pill_user_ids);
+
+    const subscribed_target_ids: number[] = [];
+    const already_not_subscribed_ids: number[] = [];
+    for (const user_id of user_id_set) {
+        if (subscriber_ids.has(user_id)) {
+            subscribed_target_ids.push(user_id);
+        } else {
+            already_not_subscribed_ids.push(user_id);
+        }
+    }
+
+    const already_not_subscribed_users = already_not_subscribed_ids.map((user_id) =>
+        people.get_by_user_id(user_id),
+    );
+
+    if (subscribed_target_ids.length === 0) {
+        remove_pill_widget.clear();
+        show_stream_unsubscription_request_success_result({
+            unsubscribed_users: [],
+            already_not_subscribed_users,
+        });
+        return;
+    }
+
+    function do_unsubscribe(): void {
+        assert(sub !== undefined);
+        const stream_sub = sub;
+        const $pill_widget_button_wrapper = $(".remove_subscriber_button_wrapper");
+        const $remove_button = $pill_widget_button_wrapper.find(".remove-subscriber-button-bulk");
+        $remove_button.prop("disabled", true);
+        $(".remove_subscribers_container").addClass("remove_subscribers_disabled");
+        buttons.show_button_loading_indicator($remove_button);
+
+        function removal_success(raw_data: unknown): void {
+            if (stream_sub.stream_id !== current_stream_id) {
+                blueslip.info("Response for subscription removal came too late.");
+                return;
+            }
+            $(".remove_subscribers_container").removeClass("remove_subscribers_disabled");
+            // The API response is per-stream, not per-user, so we report
+            // our client-side intersection in the banner.
+            const data = remove_user_id_api_response_schema.parse(raw_data);
+            remove_pill_widget.clear();
+
+            const stream_was_updated = data.removed.includes(stream_sub.name);
+            const targeted_users = subscribed_target_ids.map((user_id) =>
+                people.get_by_user_id(user_id),
+            );
+            // If the server removed nobody here (e.g. a concurrent removal got
+            // there first), report the targets as already unsubscribed.
+            const unsubscribed_users = stream_was_updated ? targeted_users : [];
+            const banner_already_not_subscribed_users = stream_was_updated
+                ? already_not_subscribed_users
+                : [...already_not_subscribed_users, ...targeted_users];
+
+            const $check_icon = $pill_widget_button_wrapper.find(".check");
+            $check_icon.removeClass("hidden-below");
+            $remove_button.addClass("hidden-below");
+            setTimeout(() => {
+                $check_icon.addClass("hidden-below");
+                $remove_button.removeClass("hidden-below");
+                buttons.hide_button_loading_indicator($remove_button);
+                $remove_button.prop("disabled", true);
+            }, 1000);
+
+            show_stream_unsubscription_request_success_result({
+                unsubscribed_users,
+                already_not_subscribed_users: banner_already_not_subscribed_users,
+            });
+        }
+
+        function removal_failure(xhr: JQuery.jqXHR): void {
+            if (stream_sub.stream_id !== current_stream_id) {
+                blueslip.info("Response for subscription removal came too late.");
+                return;
+            }
+            buttons.hide_button_loading_indicator($remove_button);
+            $(".remove_subscribers_container").removeClass("remove_subscribers_disabled");
+
+            let error_message = $t({defaultMessage: "Error removing users from this channel."});
+            const parsed = z
+                .object({
+                    result: z.literal("error"),
+                    msg: z.string(),
+                    code: z.string(),
+                })
+                .safeParse(xhr.responseJSON);
+
+            if (parsed.success) {
+                error_message = parsed.data.msg;
+            }
+            show_stream_unsubscription_request_error_result(error_message);
+        }
+
+        subscriber_api.remove_user_ids_from_stream(
+            subscribed_target_ids,
+            stream_sub,
+            removal_success,
+            removal_failure,
+        );
+    }
+
+    const nobody_can_subscribe =
+        user_groups.is_setting_group_set_to_nobody_group(sub.can_subscribe_group) &&
+        user_groups.is_setting_group_set_to_nobody_group(sub.can_add_subscribers_group);
+    const modal_props = compute_unsubscribe_modal_props({
+        invite_only: sub.invite_only,
+        subscribed_target_ids,
+        sub_count: peer_data.get_subscriber_count(current_stream_id),
+        self_user_id: current_user.user_id,
+        self_can_rejoin: stream_data.has_content_access_via_group_permissions(sub),
+        nobody_can_subscribe,
+    });
+
+    if (!modal_props.needs_modal) {
+        do_unsubscribe();
+        return;
+    }
+
+    const stream_name_with_privacy_symbol_html = render_decorated_channel_name({
+        inline_with_text: true,
+        stream: sub,
+    });
+    const modal_content_html = modal_props.show_private_stream_warning
+        ? render_unsubscribe_private_stream_modal({
+              unsubscribing_other_user: modal_props.unsubscribing_other_user,
+              organization_will_lose_content_access:
+                  modal_props.organization_will_lose_content_access,
+          })
+        : render_confirm_bulk_unsubscribe_modal({
+              unsubscribed_count: subscribed_target_ids.length,
+              already_not_subscribed_count: already_not_subscribed_ids.length,
+          });
+
+    const unsubscribing_self_only =
+        subscribed_target_ids.length === 1 && subscribed_target_ids[0] === current_user.user_id;
+    const modal_title_html = unsubscribing_self_only
+        ? $t_html(
+              {defaultMessage: "Unsubscribe from <z-link></z-link>?"},
+              {"z-link": () => stream_name_with_privacy_symbol_html},
+          )
+        : $t_html(
+              {
+                  defaultMessage:
+                      "Unsubscribe {count, plural, one {# user} other {# users}} from <z-link></z-link>?",
+              },
+              {
+                  count: subscribed_target_ids.length,
+                  "z-link": () => stream_name_with_privacy_symbol_html,
+              },
+          );
+
+    confirm_dialog.launch({
+        modal_title_html,
+        modal_content_html,
+        on_click: do_unsubscribe,
+    });
+}
+
 function remove_subscriber({
     stream_id,
     target_user_id,
@@ -400,7 +711,7 @@ function remove_subscriber({
         show_stream_subscription_request_error_result(error_message);
     }
 
-    function remove_user_from_private_stream(): void {
+    function do_remove_subscriber(): void {
         buttons.show_button_loading_indicator($remove_button);
         assert(sub !== undefined);
         subscriber_api.remove_user_id_from_stream(
@@ -411,73 +722,50 @@ function remove_subscriber({
         );
     }
 
-    if (sub.invite_only) {
-        const sub_count = peer_data.get_subscriber_count(stream_id);
-        const unsubscribing_other_user = !people.is_my_user_id(target_user_id);
+    const modal_props = compute_unsubscribe_modal_props({
+        invite_only: sub.invite_only,
+        subscribed_target_ids: [target_user_id],
+        sub_count: peer_data.get_subscriber_count(stream_id),
+        self_user_id: current_user.user_id,
+        self_can_rejoin: stream_data.has_content_access_via_group_permissions(sub),
+        nobody_can_subscribe:
+            user_groups.is_setting_group_set_to_nobody_group(sub.can_subscribe_group) &&
+            user_groups.is_setting_group_set_to_nobody_group(sub.can_add_subscribers_group),
+    });
 
-        if (!people.is_my_user_id(target_user_id) && sub_count !== 1) {
-            // We do not show any confirmation modal if any other user is
-            // being unsubscribed and that user is not the last subscriber
-            // of that stream.
-            remove_user_from_private_stream();
-            return;
-        }
-
-        if (
-            people.is_my_user_id(target_user_id) &&
-            stream_data.has_content_access_via_group_permissions(sub)
-        ) {
-            // We do not show any confirmation modal if user is unsubscribing
-            // themselves and also has the permission to subscribe to the
-            // stream again.
-            remove_user_from_private_stream();
-            return;
-        }
-
-        const stream_name_with_privacy_symbol_html = render_decorated_channel_name({
-            inline_with_text: true,
-            stream: sub,
-        });
-
-        const modal_content_html = render_unsubscribe_private_stream_modal({
-            unsubscribing_other_user,
-            organization_will_lose_content_access:
-                sub_count === 1 &&
-                user_groups.is_setting_group_set_to_nobody_group(sub.can_subscribe_group) &&
-                user_groups.is_setting_group_set_to_nobody_group(sub.can_add_subscribers_group),
-        });
-
-        let modal_title_html;
-        if (unsubscribing_other_user) {
-            modal_title_html = $t_html(
-                {defaultMessage: "Unsubscribe {full_name} from <z-link></z-link>?"},
-                {
-                    full_name: people.get_full_name(target_user_id),
-                    "z-link": () => stream_name_with_privacy_symbol_html,
-                },
-            );
-        } else {
-            modal_title_html = $t_html(
-                {defaultMessage: "Unsubscribe from <z-link></z-link>?"},
-                {"z-link": () => stream_name_with_privacy_symbol_html},
-            );
-        }
-
-        confirm_dialog.launch({
-            modal_title_html,
-            modal_content_html,
-            on_click: remove_user_from_private_stream,
-        });
+    if (!modal_props.needs_modal) {
+        do_remove_subscriber();
         return;
     }
 
-    buttons.show_button_loading_indicator($remove_button);
-    subscriber_api.remove_user_id_from_stream(
-        target_user_id,
-        sub,
-        removal_success,
-        removal_failure,
-    );
+    const stream_name_with_privacy_symbol_html = render_decorated_channel_name({
+        inline_with_text: true,
+        stream: sub,
+    });
+
+    const modal_content_html = render_unsubscribe_private_stream_modal({
+        unsubscribing_other_user: modal_props.unsubscribing_other_user,
+        organization_will_lose_content_access: modal_props.organization_will_lose_content_access,
+    });
+
+    const modal_title_html = people.is_my_user_id(target_user_id)
+        ? $t_html(
+              {defaultMessage: "Unsubscribe from <z-link></z-link>?"},
+              {"z-link": () => stream_name_with_privacy_symbol_html},
+          )
+        : $t_html(
+              {defaultMessage: "Unsubscribe {full_name} from <z-link></z-link>?"},
+              {
+                  full_name: people.get_full_name(target_user_id),
+                  "z-link": () => stream_name_with_privacy_symbol_html,
+              },
+          );
+
+    confirm_dialog.launch({
+        modal_title_html,
+        modal_content_html,
+        on_click: do_remove_subscriber,
+    });
 }
 
 export function update_subscribers_list(sub: StreamSubscription): void {
@@ -547,6 +835,7 @@ export function rerender_subscribers_list(sub: sub_store.StreamSubscription): vo
             can_remove_subscribers: user_can_remove_subscribers,
         }),
     );
+    update_remove_subscribers_section(user_can_remove_subscribers, $parent_container);
     void render_subscriber_list_widget(sub, user_can_remove_subscribers, $parent_container);
 }
 
@@ -554,9 +843,17 @@ export function initialize(): void {
     add_subscribers_pill.set_up_handlers({
         get_pill_widget: () => pill_widget,
         $parent_container: $("#channels_overlay_container"),
-        pill_selector: ".edit_subscribers_for_stream .pill-container",
+        pill_selector: ".edit_subscribers_for_stream .add_subscribers_container .pill-container",
         button_selector: ".edit_subscribers_for_stream .add-subscriber-button",
         action: subscribe_new_users,
+    });
+
+    add_subscribers_pill.set_up_handlers({
+        get_pill_widget: () => remove_pill_widget,
+        $parent_container: $("#channels_overlay_container"),
+        pill_selector: ".edit_subscribers_for_stream .remove_subscribers_container .pill-container",
+        button_selector: ".edit_subscribers_for_stream .remove-subscriber-button-bulk",
+        action: unsubscribe_users,
     });
 
     $("#channels_overlay_container").on(

--- a/web/src/subscriber_api.ts
+++ b/web/src/subscriber_api.ts
@@ -50,11 +50,20 @@ export function remove_user_id_from_stream(
     success: (data: unknown) => void,
     failure: (xhr: JQuery.jqXHR<unknown>) => void,
 ): void {
+    remove_user_ids_from_stream([user_id], sub, success, failure);
+}
+
+export function remove_user_ids_from_stream(
+    user_ids: number[],
+    sub: StreamSubscription,
+    success: (data: unknown) => void,
+    failure: (xhr: JQuery.jqXHR<unknown>) => void,
+): void {
     // TODO: use stream_id when backend supports it
     const stream_name = sub.name;
     void channel.del({
         url: "/json/users/me/subscriptions",
-        data: {subscriptions: JSON.stringify([stream_name]), principals: JSON.stringify([user_id])},
+        data: {subscriptions: JSON.stringify([stream_name]), principals: JSON.stringify(user_ids)},
         success,
         error: failure,
     });

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -586,11 +586,11 @@ export function initialize(): void {
                 !$button.hasClass("hidden-below") &&
                 !has_loading_button
             ) {
-                instance.setContent(
-                    $t({
-                        defaultMessage: "Enter who should be added.",
-                    }),
-                );
+                if ($wrapper.closest(".remove_subscribers_container").length > 0) {
+                    instance.setContent($t({defaultMessage: "Enter who should be removed."}));
+                } else {
+                    instance.setContent($t({defaultMessage: "Enter who should be added."}));
+                }
                 return undefined;
             }
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -570,11 +570,11 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: ".add-users-button-wrapper",
+        target: ".pill-action-button-wrapper",
         onShow(instance) {
             const $wrapper = $(instance.reference);
-            const $button = $wrapper.find(".add-users-button");
-            const $container = $wrapper.closest(".add-button-container").find(".pill-container");
+            const $button = $wrapper.find(".pill-action-button");
+            const $container = $wrapper.closest(".pill-action-container").find(".pill-container");
 
             const button_is_disabled = Boolean($button.prop("disabled"));
             const container_is_enabled =

--- a/web/src/user_group_picker_pill.ts
+++ b/web/src/user_group_picker_pill.ts
@@ -1,6 +1,6 @@
 import render_input_pill from "../templates/input_pill.hbs";
 
-import {set_up_handlers_for_add_button_state} from "./add_subscribers_pill.ts";
+import {set_up_handlers_for_pill_action_button_state} from "./add_subscribers_pill.ts";
 import * as input_pill from "./input_pill.ts";
 import {set_up_user_group} from "./pill_typeahead.ts";
 import * as settings_data from "./settings_data.ts";
@@ -95,7 +95,7 @@ export function create(
 
     set_up_pill_typeahead({pill_widget, $pill_container: $user_group_pill_container}, user_id);
     if (user_id) {
-        set_up_handlers_for_add_button_state(pill_widget, $user_group_pill_container);
+        set_up_handlers_for_pill_action_button_state(pill_widget, $user_group_pill_container);
     }
     return pill_widget;
 }

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -300,6 +300,7 @@
 }
 
 .add_subscribers_container .pill-container,
+.remove_subscribers_container .pill-container,
 .add_streams_container .pill-container,
 .add-user-group-container .pill-container,
 .add_members_container .pill-container {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -282,7 +282,8 @@ h4.stream_setting_subsection_title {
 }
 
 .add_members_container,
-.add_subscribers_container {
+.add_subscribers_container,
+.remove_subscribers_container {
     display: inline-flex;
     width: 100%;
     align-items: center;
@@ -334,7 +335,8 @@ h4.stream_setting_subsection_title {
 }
 
 .user_group_subscription_request_result,
-.stream_subscription_request_result {
+.stream_subscription_request_result,
+.stream_unsubscription_request_result {
     & a {
         color: inherit;
     }
@@ -359,6 +361,7 @@ h4.stream_setting_subsection_title {
 }
 
 .add_subscriber_button_wrapper,
+.remove_subscriber_button_wrapper,
 .add_member_button_wrapper {
     display: grid;
     grid-template-columns: 1fr;
@@ -367,6 +370,7 @@ h4.stream_setting_subsection_title {
 
     .check,
     .add-subscriber-button,
+    .remove-subscriber-button-bulk,
     .add-member-button {
         grid-column: 1 / 2;
         grid-row: 1 / 2;
@@ -384,11 +388,13 @@ h4.stream_setting_subsection_title {
 }
 
 .add_subscribers_container .add_subscriber_button_wrapper,
+.remove_subscribers_container .remove_subscriber_button_wrapper,
 .add_members_container .add_member_button_wrapper {
     padding-left: 5px;
 }
 
 .add-subscribers-subtitle,
+.remove-subscribers-subtitle,
 .add-members-subtitle {
     opacity: 0.7;
 }
@@ -405,8 +411,17 @@ h4.stream_setting_subsection_title {
 }
 
 #stream_settings .add-subscribers-subtitle,
+#stream_settings .remove-subscribers-subtitle,
 #user_group_settings .add-members-subtitle {
     margin-bottom: 10px;
+}
+
+h4.remove-subscribers-heading {
+    margin-top: 20px;
+}
+
+.remove-subscribers-section.no-display {
+    display: none;
 }
 
 .choose-subscribers-label {
@@ -1160,6 +1175,7 @@ h4.stream_setting_subsection_title {
 }
 
 .add_subscribers_container.add_subscribers_disabled,
+.remove_subscribers_container.remove_subscribers_disabled,
 .add_members_container.add_members_disabled {
     cursor: not-allowed;
 

--- a/web/templates/confirm_dialog/confirm_bulk_unsubscribe.hbs
+++ b/web/templates/confirm_dialog/confirm_bulk_unsubscribe.hbs
@@ -1,0 +1,8 @@
+<p>
+    {{t "{unsubscribed_count, plural, one {This will unsubscribe # user from the channel.} other {This will unsubscribe # users from the channel.}}" }}
+</p>
+{{#unless (eq already_not_subscribed_count 0)}}
+    <p>
+        {{t "{already_not_subscribed_count, plural, one {# of the selected users is not subscribed and will be skipped.} other {# of the selected users are not subscribed and will be skipped.}}" }}
+    </p>
+{{/unless}}

--- a/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
@@ -3,6 +3,6 @@
 {{/unless}}
 {{#if organization_will_lose_content_access}}
     <p>
-        {{t "Your organization will lose access content in this channel, and nobody will be able to subscribe to it in the future."}}
+        {{t "Your organization will lose access to content in this channel, and nobody will be able to subscribe to it in the future."}}
     </p>
 {{/if}}

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -1,4 +1,4 @@
-<div class="add_subscribers_container add-button-container">
+<div class="add_subscribers_container pill-action-container">
     <div class="subscriber-input-scrollable-container" data-simplebar>
         <div class="pill-container person_picker">
             <div class="input" contenteditable="true"
@@ -8,10 +8,10 @@
         </div>
     </div>
     {{#if (not hide_add_button)}}
-        <div class="add_subscriber_button_wrapper add-users-button-wrapper inline-block">
+        <div class="add_subscriber_button_wrapper pill-action-button-wrapper inline-block">
             {{> ../components/action_button
               label=(t "Add")
-              custom_classes="add-subscriber-button add-users-button"
+              custom_classes="add-subscriber-button pill-action-button"
               variant="subtle"
               intent="brand"
               type="submit"

--- a/web/templates/stream_settings/remove_subscribers_form.hbs
+++ b/web/templates/stream_settings/remove_subscribers_form.hbs
@@ -1,0 +1,26 @@
+<div class="remove_subscribers_container pill-action-container remove-subscribers-section">
+    <div class="subscriber-input-scrollable-container" data-simplebar>
+        <div class="pill-container person_picker">
+            <div class="input" contenteditable="true"
+              data-placeholder="{{t 'Remove subscribers.' }}">
+                {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
+            </div>
+        </div>
+    </div>
+    <div class="remove_subscriber_button_wrapper pill-action-button-wrapper inline-block">
+        {{> ../components/action_button
+          label=(t "Remove")
+          custom_classes="remove-subscriber-button-bulk pill-action-button"
+          variant="subtle"
+          intent="danger"
+          type="submit"
+          }}
+
+        {{> ../components/icon_button
+          icon="check"
+          intent="success"
+          custom_classes="check hidden-below"
+          disabled=true
+          }}
+    </div>
+</div>

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -33,5 +33,18 @@
     <div class="subscriber-list-box">
         {{> stream_members_table .}}
     </div>
+    <h4 class="stream_setting_subsection_title remove-subscribers-heading remove-subscribers-section">
+        {{t "Remove subscribers" }}
+    </h4>
+    <div class="stream_unsubscription_request_result banner-wrapper remove-subscribers-section"></div>
+    {{> remove_subscribers_form .}}
+    <div class="remove-subscribers-subtitle remove-subscribers-section">
+        {{#tr}}
+            Enter a <z-user-roles-link>user role</z-user-roles-link> or
+            <z-user-groups-link>user group</z-user-groups-link> to remove multiple users at once.
+            {{#*inline "z-user-roles-link"}}<a href="/help/user-roles" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{#*inline "z-user-groups-link"}}<a href="/help/user-groups" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    </div>
 </div>
 <div class="subscriber-list-settings-loading"></div>

--- a/web/templates/stream_settings/stream_subscription_request_result.hbs
+++ b/web/templates/stream_settings/stream_subscription_request_result.hbs
@@ -1,5 +1,31 @@
 {{#if error_message}}
     {{error_message}}
+{{else if is_unsubscribe}}
+    {{#if (and (eq unsubscribed_users_count 0) (eq already_not_subscribed_users_count 0))}}
+        {{t "No users to unsubscribe."}}
+    {{else}}
+        {{#if (not is_total_user_count_more_than_five)}}
+            {{#unless (eq unsubscribed_users_count 0)}}
+                {{t "Unsubscribed:" }} {{> user_links users=unsubscribed_users}}.
+            {{/unless}}
+            {{#unless (eq already_not_subscribed_users_count 0)}}
+                {{t "Already unsubscribed:" }} {{> user_links users=already_not_subscribed_users}}.
+            {{/unless}}
+        {{else}}
+            {{#unless (eq unsubscribed_users_count 0)}}
+                {{t "{unsubscribed_users_count, plural,
+                  one {Unsubscribed: {unsubscribed_users_count} user.}
+                other {Unsubscribed: {unsubscribed_users_count} users.}
+            }"}}
+            {{/unless}}
+            {{#unless (eq already_not_subscribed_users_count 0)}}
+                {{t "{already_not_subscribed_users_count, plural,
+                  one {Already unsubscribed: {already_not_subscribed_users_count} user.}
+                other {Already unsubscribed: {already_not_subscribed_users_count} users.}
+            }"}}
+            {{/unless}}
+        {{/if}}
+    {{/if}}
 {{else}}
     {{!-- We want to show ignored deactivated users message even when there are
     no new subscribers --}}

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -1,4 +1,4 @@
-<div class="add_members_container add-button-container">
+<div class="add_members_container pill-action-container">
     <div class="members-input-scrollable-container" data-simplebar>
         <div class="pill-container person_picker">
             <div class="input" contenteditable="true"
@@ -8,10 +8,10 @@
         </div>
     </div>
     {{#if (not hide_add_button)}}
-        <div class="add_member_button_wrapper add-users-button-wrapper inline-block">
+        <div class="add_member_button_wrapper pill-action-button-wrapper inline-block">
             {{> ../components/action_button
               label=(t "Add")
-              custom_classes="add-member-button add-users-button"
+              custom_classes="add-member-button pill-action-button"
               id="add_member"
               variant="subtle"
               intent="brand"

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -174,7 +174,7 @@
                             <div class="header-section">
                                 <h3 class="group-tab-element-header">{{t 'Add {full_name} to groups'}}</h3>
                             </div>
-                            <div id="groups-to-add" class="add-button-container">
+                            <div id="groups-to-add" class="pill-action-container">
                                 <div id="user-group-to-add">
                                     <div class="add-user-group-container">
                                         <div class="pill-container">

--- a/web/tests/stream_edit_subscribers.test.cjs
+++ b/web/tests/stream_edit_subscribers.test.cjs
@@ -1,0 +1,286 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_user} = require("./lib/example_user.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const {compute_unsubscribe_modal_props} = zrequire("stream_edit_subscribers");
+
+const me = make_user({email: "me@zulip.com", full_name: "Me", user_id: 1});
+const alice = make_user({email: "alice@zulip.com", full_name: "Alice", user_id: 2});
+const bob = make_user({email: "bob@zulip.com", full_name: "Bob", user_id: 3});
+
+run_test("compute_unsubscribe_modal_props: public channel never shows modal", () => {
+    const props = compute_unsubscribe_modal_props({
+        invite_only: false,
+        subscribed_target_ids: [me.user_id, alice.user_id],
+        sub_count: 5,
+        self_user_id: me.user_id,
+        self_can_rejoin: false,
+        nobody_can_subscribe: true,
+    });
+    assert.equal(props.needs_modal, false);
+});
+
+run_test("compute_unsubscribe_modal_props: empty target list never shows modal", () => {
+    const props = compute_unsubscribe_modal_props({
+        invite_only: true,
+        subscribed_target_ids: [],
+        sub_count: 5,
+        self_user_id: me.user_id,
+        self_can_rejoin: false,
+        nobody_can_subscribe: true,
+    });
+    assert.equal(props.needs_modal, false);
+});
+
+run_test("compute_unsubscribe_modal_props: self with rejoin permission alone, no modal", () => {
+    const props = compute_unsubscribe_modal_props({
+        invite_only: true,
+        subscribed_target_ids: [me.user_id],
+        sub_count: 5,
+        self_user_id: me.user_id,
+        self_can_rejoin: true,
+        nobody_can_subscribe: false,
+    });
+    assert.equal(props.needs_modal, false);
+});
+
+run_test(
+    "compute_unsubscribe_modal_props: self without rejoin shows modal with rejoin warning",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: [me.user_id],
+            sub_count: 5,
+            self_user_id: me.user_id,
+            self_can_rejoin: false,
+            nobody_can_subscribe: false,
+        });
+        assert.deepEqual(props, {
+            needs_modal: true,
+            show_private_stream_warning: true,
+            unsubscribing_other_user: false,
+            organization_will_lose_content_access: false,
+        });
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: removing others without emptying channel, no modal",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: [alice.user_id, bob.user_id],
+            sub_count: 5,
+            self_user_id: me.user_id,
+            self_can_rejoin: false,
+            nobody_can_subscribe: true,
+        });
+        assert.equal(props.needs_modal, false);
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: emptying a still-subscribable private channel shows no warning modal",
+    () => {
+        // Regression: this used to warn with no text to show (empty modal
+        // body); an emptying-but-still-subscribable channel needs no warning.
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: [alice.user_id, bob.user_id],
+            sub_count: 2,
+            self_user_id: me.user_id,
+            self_can_rejoin: false,
+            nobody_can_subscribe: false,
+        });
+        assert.equal(props.needs_modal, false);
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: emptying channel with no re-subscribers shows org warning",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: [alice.user_id, bob.user_id],
+            sub_count: 2,
+            self_user_id: me.user_id,
+            self_can_rejoin: false,
+            nobody_can_subscribe: true,
+        });
+        assert.deepEqual(props, {
+            needs_modal: true,
+            show_private_stream_warning: true,
+            unsubscribing_other_user: true,
+            organization_will_lose_content_access: true,
+        });
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: mixed self+others, self has rejoin, won't empty, no modal",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: [me.user_id, alice.user_id],
+            sub_count: 5,
+            self_user_id: me.user_id,
+            self_can_rejoin: true,
+            nobody_can_subscribe: false,
+        });
+        assert.equal(props.needs_modal, false);
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: mixed self+others, self has rejoin, emptying a still-subscribable channel -> no modal",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: [me.user_id, alice.user_id],
+            sub_count: 2,
+            self_user_id: me.user_id,
+            self_can_rejoin: true,
+            nobody_can_subscribe: false,
+        });
+        assert.equal(props.needs_modal, false);
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: mixed self+others, self no rejoin, will empty -> both warnings",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: [me.user_id, alice.user_id],
+            sub_count: 2,
+            self_user_id: me.user_id,
+            self_can_rejoin: false,
+            nobody_can_subscribe: true,
+        });
+        assert.deepEqual(props, {
+            needs_modal: true,
+            show_private_stream_warning: true,
+            unsubscribing_other_user: false,
+            organization_will_lose_content_access: true,
+        });
+    },
+);
+
+run_test("compute_unsubscribe_modal_props: removing 10+ users shows a volume confirmation", () => {
+    const props = compute_unsubscribe_modal_props({
+        invite_only: false,
+        subscribed_target_ids: Array.from({length: 10}, (_, i) => i + 100),
+        sub_count: 50,
+        self_user_id: me.user_id,
+        self_can_rejoin: true,
+        nobody_can_subscribe: false,
+    });
+    assert.deepEqual(props, {
+        needs_modal: true,
+        show_private_stream_warning: false,
+        unsubscribing_other_user: true,
+        organization_will_lose_content_access: false,
+    });
+});
+
+run_test(
+    "compute_unsubscribe_modal_props: removing fewer than 10 users on a public channel, no modal",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: false,
+            subscribed_target_ids: Array.from({length: 9}, (_, i) => i + 100),
+            sub_count: 50,
+            self_user_id: me.user_id,
+            self_can_rejoin: true,
+            nobody_can_subscribe: false,
+        });
+        assert.equal(props.needs_modal, false);
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: large private removal without edge cases shows volume confirmation only",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: Array.from({length: 12}, (_, i) => i + 100),
+            sub_count: 50,
+            self_user_id: me.user_id,
+            self_can_rejoin: false,
+            nobody_can_subscribe: true,
+        });
+        assert.deepEqual(props, {
+            needs_modal: true,
+            show_private_stream_warning: false,
+            unsubscribing_other_user: true,
+            organization_will_lose_content_access: false,
+        });
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: large removal that empties a private channel keeps the private warning",
+    () => {
+        const props = compute_unsubscribe_modal_props({
+            invite_only: true,
+            subscribed_target_ids: Array.from({length: 10}, (_, i) => i + 100),
+            sub_count: 10,
+            self_user_id: me.user_id,
+            self_can_rejoin: false,
+            nobody_can_subscribe: true,
+        });
+        assert.deepEqual(props, {
+            needs_modal: true,
+            show_private_stream_warning: true,
+            unsubscribing_other_user: true,
+            organization_will_lose_content_access: true,
+        });
+    },
+);
+
+run_test(
+    "compute_unsubscribe_modal_props: a private-stream warning always has body copy to render",
+    () => {
+        // The warning modal only renders text when the acting user can't
+        // rejoin or the org loses access; if we set the warning without one of
+        // those, its body is empty.
+        for (const self_in_targets of [false, true]) {
+            for (const self_can_rejoin of [false, true]) {
+                for (const will_empty of [false, true]) {
+                    for (const nobody_can_subscribe of [false, true]) {
+                        const subscribed_target_ids = self_in_targets
+                            ? [me.user_id, alice.user_id]
+                            : [alice.user_id, bob.user_id];
+                        const sub_count = will_empty
+                            ? subscribed_target_ids.length
+                            : subscribed_target_ids.length + 3;
+                        const props = compute_unsubscribe_modal_props({
+                            invite_only: true,
+                            subscribed_target_ids,
+                            sub_count,
+                            self_user_id: me.user_id,
+                            self_can_rejoin,
+                            nobody_can_subscribe,
+                        });
+                        if (props.show_private_stream_warning) {
+                            assert.ok(
+                                !props.unsubscribing_other_user ||
+                                    props.organization_will_lose_content_access,
+                                `empty private-warning body for ${JSON.stringify({
+                                    self_in_targets,
+                                    self_can_rejoin,
+                                    will_empty,
+                                    nobody_can_subscribe,
+                                })}`,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    },
+);


### PR DESCRIPTION
## Fixes: #21292.

Admins could already subscribe a user group, user role, or #channel to a channel, but unsubscribing them required removing each member individually through the per-row × icon. This PR adds a bulk-unsubscribe widget on the channel **Subscribers** tab, parallel to the existing **Add subscribers** widget, which accepts users, user groups, and user roles. Members behind each pill are resolved to user IDs on the client, following the same pattern as the subscribe widget, so no backend changes are required.

For private channels, a confirmation modal mirrors the decision logic used by the per-row unsubscribe modal. It warns when the acting user is being unsubscribed without permission to rejoin, or when the action would leave the channel without subscribers and no group would remain that could re-add them.

## Screenshots and screen captures:
### *1. New Remove subscribers section on the Subscribers tab*
<img width="859" height="1138" alt="image" src="https://github.com/user-attachments/assets/4ad81e51-02df-4188-9044-ad89f6623d5d" />

--- 

### *2. Video: Removing two individual users*  

https://github.com/user-attachments/assets/9a25f6fd-84f8-4dc7-bf8f-229c9bff7c0d





---

### *3. Private channel: confirmation when unsubscribing yourself without permission to rejoin.*
<img width="1433" height="1137" alt="image" src="https://github.com/user-attachments/assets/a49d52a6-23dc-4b11-978b-2b0abf4023d5" />

---

### *4. Private channel: confirmation when removing the last subscribers (organization loses access)*
<img width="1434" height="1136" alt="image" src="https://github.com/user-attachments/assets/50943695-1d50-4309-b584-b4024ed21504" />

---

### *5. Volume confirmation modal when removing 10 or more users*

<img width="1071" height="886" alt="image" src="https://github.com/user-attachments/assets/92d66b64-7401-4985-a373-38aac0fb85a4" />

---



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
