### PR TITLE
Revert "ci: Drop upgrade tests for 6.0 and 7.0."

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -253,6 +253,12 @@ jobs:
         include:
           # Docker images are built from 'tools/ci/Dockerfile.prod'; the comments at
           # the top explain how to build and upload these images.
+          - docker_image: zulip/ci:jammy-6.0
+            name: 6.0 Version Upgrade
+            os: jammy
+          - docker_image: zulip/ci:bookworm-7.0
+            name: 7.0 Version Upgrade
+            os: bookworm
           - docker_image: zulip/ci:bookworm-8.0
             name: 8.0 Version Upgrade
             os: bookworm


### PR DESCRIPTION
This reverts commit 0dee9415663d1b48925aad68fe639aa439c45d0e.

We will drop them when dropping support for the OSes.

discussion: [#release management > production upgrade CI @ 💬](https://chat.zulip.org/#narrow/channel/438-release-management/topic/production.20upgrade.20CI/near/2466508)