### PR TITLE
users: Scrub per-user PII on user deletion.

### DIFF
--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -24,7 +24,11 @@ from zerver.actions.user_groups import (
     do_send_user_group_members_update_event,
     update_users_in_full_members_system_group,
 )
-from zerver.actions.user_settings import do_change_avatar_fields, do_change_full_name
+from zerver.actions.user_settings import (
+    do_change_avatar_fields,
+    do_change_full_name,
+    do_scrub_avatar_images,
+)
 from zerver.lib.bot_config import ConfigError, get_bot_config, get_bot_configs, set_bot_config
 from zerver.lib.cache import bot_dict_fields, flush_user_profile
 from zerver.lib.create_user import create_user_profile
@@ -120,6 +124,7 @@ def do_delete_user_core(
       just typing the user's name in their own messages.
     """
     do_deactivate_user(user_profile, acting_user=None)
+    do_scrub_avatar_images(user_profile, acting_user=acting_user)
 
     user_id = user_profile.id
     realm = user_profile.realm
@@ -152,6 +157,12 @@ def do_delete_user_core(
             default_language=UserProfile._meta.get_field("default_language").get_default(),
             email_address_visibility=UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
         )
+        # do_scrub_avatar_images above deleted the user's uploaded avatar
+        # files but did not generate a replacement. Point the deleted
+        # user at Gravatar so the /avatar/<id> endpoint redirects to a
+        # random gravatar for the synthesized deleteduser{id}@... email
+        # rather than 404ing on a non-existent local file.
+        temp_replacement_user.avatar_source = UserProfile.AVATAR_FROM_GRAVATAR
 
         overwrite_data = model_to_dict(
             temp_replacement_user,

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -59,6 +59,7 @@ from zerver.lib.users import (
     user_access_restricted_in_realm,
 )
 from zerver.models import (
+    CustomProfileFieldValue,
     Draft,
     GroupGroupMembership,
     NamedUserGroup,
@@ -196,6 +197,7 @@ def do_delete_user_core(
             (SavedSnippet, "user_profile"),
             (ScheduledMessage, "sender"),
             (Draft, "user_profile"),
+            (CustomProfileFieldValue, "user_profile"),
         ]
         for table, field_name in fks_to_delete:
             table.objects.filter(**{field_name: user_profile}).delete()

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -34,6 +34,7 @@ from zerver.lib.cache import bot_dict_fields, flush_user_profile
 from zerver.lib.create_user import create_user_profile
 from zerver.lib.event_types import BotServicesOutgoing
 from zerver.lib.invites import revoke_invites_generated_by_user
+from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.send_email import FromAddress, clear_scheduled_emails, send_email
 from zerver.lib.sessions import delete_user_sessions
@@ -63,10 +64,14 @@ from zerver.lib.users import (
     user_access_restricted_in_realm,
 )
 from zerver.models import (
+    AlertWord,
     CustomProfileFieldValue,
+    Device,
     Draft,
+    EmailChangeStatus,
     GroupGroupMembership,
     NamedUserGroup,
+    PushDeviceToken,
     Realm,
     RealmAuditLog,
     Recipient,
@@ -76,6 +81,7 @@ from zerver.models import (
     UserGroup,
     UserGroupMembership,
     UserProfile,
+    UserStatus,
 )
 from zerver.models.bots import get_bot_services
 from zerver.models.messages import UserMessage
@@ -209,9 +215,24 @@ def do_delete_user_core(
             (ScheduledMessage, "sender"),
             (Draft, "user_profile"),
             (CustomProfileFieldValue, "user_profile"),
+            (UserStatus, "user_profile"),
+            (AlertWord, "user_profile"),
+            (PushDeviceToken, "user"),
+            (Device, "user"),
+            (EmailChangeStatus, "user_profile"),
         ]
         for table, field_name in fks_to_delete:
             table.objects.filter(**{field_name: user_profile}).delete()
+        # The loop above deletes this server's PushDeviceToken rows, but
+        # on servers using the push notifications bouncer the
+        # registrations also live on the bouncer and must be unregistered
+        # there. This is safe to defer past the deletion because uuid is
+        # excluded from overwrite_data above, so the bouncer can still
+        # identify the user.
+        queue_event_on_commit(
+            "deferred_work",
+            {"type": "clear_push_device_tokens", "user_profile_id": user_profile.id},
+        )
         # There's also a many-to-many relationship between UserProfile and ScheduledEmail,
         # which would require separate handling from foreign keys. But the clearing out
         # of this data is handled by do_deactivate_user already, so we don't need to do

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -24,7 +24,11 @@ from zerver.actions.user_groups import (
     do_send_user_group_members_update_event,
     update_users_in_full_members_system_group,
 )
-from zerver.actions.user_settings import do_change_avatar_fields, do_change_full_name
+from zerver.actions.user_settings import (
+    do_change_avatar_fields,
+    do_change_full_name,
+    do_scrub_avatar_images,
+)
 from zerver.lib.bot_config import ConfigError, get_bot_config, get_bot_configs, set_bot_config
 from zerver.lib.cache import bot_dict_fields, flush_user_profile
 from zerver.lib.create_user import create_user_profile
@@ -119,6 +123,7 @@ def do_delete_user_core(
       just typing the user's name in their own messages.
     """
     do_deactivate_user(user_profile, acting_user=None)
+    do_scrub_avatar_images(user_profile, acting_user=acting_user)
 
     user_id = user_profile.id
     realm = user_profile.realm
@@ -151,6 +156,10 @@ def do_delete_user_core(
             default_language=UserProfile._meta.get_field("default_language").get_default(),
             email_address_visibility=UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
         )
+        # do_scrub_avatar_images above deleted the user's uploaded avatar
+        # files but did not generate a replacement. We need to use Gravatar
+        # as the fallback.
+        temp_replacement_user.avatar_source = UserProfile.AVATAR_FROM_GRAVATAR
 
         overwrite_data = model_to_dict(
             temp_replacement_user,

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -34,6 +34,7 @@ from zerver.lib.cache import bot_dict_fields, flush_user_profile
 from zerver.lib.create_user import create_user_profile
 from zerver.lib.event_types import BotServicesOutgoing
 from zerver.lib.invites import revoke_invites_generated_by_user
+from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.send_email import FromAddress, clear_scheduled_emails, send_email
 from zerver.lib.sessions import delete_user_sessions
@@ -62,10 +63,16 @@ from zerver.lib.users import (
     user_access_restricted_in_realm,
 )
 from zerver.models import (
+    AlertWord,
     CustomProfileFieldValue,
+    Device,
     Draft,
+    EmailChangeStatus,
     GroupGroupMembership,
+    MutedUser,
     NamedUserGroup,
+    NavigationView,
+    PushDeviceToken,
     Realm,
     RealmAuditLog,
     Recipient,
@@ -75,6 +82,8 @@ from zerver.models import (
     UserGroup,
     UserGroupMembership,
     UserProfile,
+    UserStatus,
+    UserTopic,
 )
 from zerver.models.bots import get_bot_services
 from zerver.models.messages import UserMessage
@@ -206,9 +215,27 @@ def do_delete_user_core(
             (ScheduledMessage, "sender"),
             (Draft, "user_profile"),
             (CustomProfileFieldValue, "user_profile"),
+            (UserStatus, "user_profile"),
+            (AlertWord, "user_profile"),
+            (PushDeviceToken, "user"),
+            (Device, "user"),
+            (EmailChangeStatus, "user_profile"),
+            (MutedUser, "user_profile"),
+            (NavigationView, "user"),
+            (UserTopic, "user_profile"),
         ]
         for table, field_name in fks_to_delete:
             table.objects.filter(**{field_name: user_profile}).delete()
+        # The loop above deletes this server's PushDeviceToken rows, but
+        # on servers using the push notifications bouncer the
+        # registrations also live on the bouncer and must be unregistered
+        # there. This is safe to defer past the deletion because uuid is
+        # excluded from overwrite_data above, so the bouncer can still
+        # identify the user.
+        queue_event_on_commit(
+            "deferred_work",
+            {"type": "clear_push_device_tokens", "user_profile_id": user_profile.id},
+        )
         # There's also a many-to-many relationship between UserProfile and ScheduledEmail,
         # which would require separate handling from foreign keys. But the clearing out
         # of this data is handled by do_deactivate_user already, so we don't need to do

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -58,6 +58,7 @@ from zerver.lib.users import (
     user_access_restricted_in_realm,
 )
 from zerver.models import (
+    CustomProfileFieldValue,
     Draft,
     GroupGroupMembership,
     NamedUserGroup,
@@ -195,6 +196,7 @@ def do_delete_user_core(
             (SavedSnippet, "user_profile"),
             (ScheduledMessage, "sender"),
             (Draft, "user_profile"),
+            (CustomProfileFieldValue, "user_profile"),
         ]
         for table, field_name in fks_to_delete:
             table.objects.filter(**{field_name: user_profile}).delete()

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -257,6 +257,9 @@ def do_delete_user_core(
             AuditLogEventType.USER_EMAIL_CHANGED,
             AuditLogEventType.USER_FULL_NAME_CHANGED,
             AuditLogEventType.USER_SETTING_CHANGED,
+            AuditLogEventType.USER_MUTED,
+            AuditLogEventType.USER_UNMUTED,
+            AuditLogEventType.SUBSCRIPTION_PROPERTY_CHANGED,
         ]
         RealmAuditLog.objects.filter(
             modified_user=user_profile, event_type__in=audit_log_event_types_for_scrubbing

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -79,8 +79,11 @@ from zerver.models import (
     Service,
     Stream,
     Subscription,
+    UserActivity,
+    UserActivityInterval,
     UserGroup,
     UserGroupMembership,
+    UserPresence,
     UserProfile,
     UserStatus,
     UserTopic,
@@ -223,6 +226,13 @@ def do_delete_user_core(
             (MutedUser, "user_profile"),
             (NavigationView, "user"),
             (UserTopic, "user_profile"),
+            # UserActivity and UserActivityInterval are documented as
+            # org-level analytics data, but a deleted user's per-endpoint
+            # access pattern is still inferable from them, and the data we
+            # consider important for auditing lives in RealmAuditLog.
+            (UserActivity, "user_profile"),
+            (UserActivityInterval, "user_profile"),
+            (UserPresence, "user_profile"),
         ]
         for table, field_name in fks_to_delete:
             table.objects.filter(**{field_name: user_profile}).delete()

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -26,6 +26,7 @@ from corporate.lib.stripe import BillingUserCounts
 from zerver.actions.message_flags import do_mark_stream_messages_as_read, do_update_message_flags
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.user_settings import do_regenerate_api_key
+from zerver.actions.users import do_delete_user
 from zerver.lib.avatar import absolute_avatar_url, get_avatar_for_inaccessible_user
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.push_notifications import (
@@ -1278,6 +1279,43 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
         remote_realm.refresh_from_db()
         self.assertEqual(remote_realm.last_request_datetime, time_sent)
+
+    @activate_push_notification_service()
+    @responses.activate
+    def test_delete_user_unregisters_push_devices_from_bouncer(self) -> None:
+        """Deleting a user must also drop the device registrations held by
+        the bouncer; deleting only this server's PushDeviceToken rows would
+        leave the deleted user's device tokens associated with their uuid on
+        the bouncer.
+        """
+        self.add_mock_response()
+        user = self.example_user("cordelia")
+        self.login_user(user)
+        server = self.server
+
+        endpoints: list[tuple[str, str, Mapping[str, str]]] = [
+            (
+                "/json/users/me/apns_device_token",
+                "c0fFeE",
+                {"appid": "org.zulip.Zulip"},
+            ),
+            ("/json/users/me/android_gcm_reg_id", "android-token", {}),
+        ]
+        for endpoint, token, appid in endpoints:
+            result = self.client_post(endpoint, {"token": token, **appid}, subdomain="zulip")
+            self.assert_json_success(result)
+
+        self.assert_length(
+            RemotePushDeviceToken.objects.filter(user_uuid=user.uuid, server=server), 2
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            do_delete_user(user, acting_user=None)
+
+        self.assert_length(
+            RemotePushDeviceToken.objects.filter(user_uuid=user.uuid, server=server), 0
+        )
+        self.assert_length(PushDeviceToken.objects.filter(user=user), 0)
 
 
 class TestAPNs(PushNotificationTestCase):

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -26,6 +26,7 @@ from corporate.lib.stripe import BillingUserCounts
 from zerver.actions.message_flags import do_mark_stream_messages_as_read, do_update_message_flags
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.user_settings import do_regenerate_api_key
+from zerver.actions.users import do_delete_user
 from zerver.lib.avatar import absolute_avatar_url, get_avatar_for_inaccessible_user
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.push_notifications import (
@@ -1278,6 +1279,41 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
         remote_realm.refresh_from_db()
         self.assertEqual(remote_realm.last_request_datetime, time_sent)
+
+    @activate_push_notification_service()
+    @responses.activate
+    def test_delete_user_unregisters_push_devices_from_bouncer(self) -> None:
+        """Deleting a user must also drop the device registrations held by
+        the bouncer.
+        """
+        self.add_mock_response()
+        user = self.example_user("cordelia")
+        self.login_user(user)
+        server = self.server
+
+        endpoints: list[tuple[str, str, Mapping[str, str]]] = [
+            (
+                "/json/users/me/apns_device_token",
+                "c0fFeE",
+                {"appid": "org.zulip.Zulip"},
+            ),
+            ("/json/users/me/android_gcm_reg_id", "android-token", {}),
+        ]
+        for endpoint, token, appid in endpoints:
+            result = self.client_post(endpoint, {"token": token, **appid}, subdomain="zulip")
+            self.assert_json_success(result)
+
+        self.assert_length(
+            RemotePushDeviceToken.objects.filter(user_uuid=user.uuid, server=server), 2
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            do_delete_user(user, acting_user=None)
+
+        self.assert_length(
+            RemotePushDeviceToken.objects.filter(user_uuid=user.uuid, server=server), 0
+        )
+        self.assert_length(PushDeviceToken.objects.filter(user=user), 0)
 
 
 class TestAPNs(PushNotificationTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -74,11 +74,15 @@ from zerver.lib.users import (
 )
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
+    AlertWord,
     CustomProfileField,
     CustomProfileFieldValue,
+    Device,
+    EmailChangeStatus,
     Message,
     OnboardingStep,
     PreregistrationUser,
+    PushDeviceToken,
     RealmAuditLog,
     RealmDomain,
     RealmUserDefault,
@@ -88,6 +92,7 @@ from zerver.models import (
     Subscription,
     UserGroupMembership,
     UserProfile,
+    UserStatus,
     UserTopic,
 )
 from zerver.models.clients import get_client
@@ -4110,6 +4115,45 @@ class DeleteUserTest(ZulipTestCase):
 
         hamlet.refresh_from_db()
         self.assertEqual(hamlet.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+
+    def test_do_delete_user_scrubs_user_linked_pii_tables(self) -> None:
+        hamlet = self.example_user("hamlet")
+        realm = hamlet.realm
+        test_client = get_client("test")
+
+        UserStatus.objects.create(
+            user_profile=hamlet,
+            client=test_client,
+            timestamp=timezone_now(),
+            status_text="On vacation",
+        )
+        AlertWord.objects.create(realm=realm, user_profile=hamlet, word="urgent")
+        PushDeviceToken.objects.create(
+            user=hamlet,
+            kind=PushDeviceToken.APNS,
+            token="apns-token-test-deadbeef",
+        )
+        Device.objects.create(user=hamlet)
+        EmailChangeStatus.objects.create(
+            realm=realm,
+            user_profile=hamlet,
+            new_email="newhamlet@zulip.com",
+            old_email=hamlet.delivery_email,
+        )
+
+        self.assertTrue(UserStatus.objects.filter(user_profile=hamlet).exists())
+        self.assertTrue(AlertWord.objects.filter(user_profile=hamlet).exists())
+        self.assertTrue(PushDeviceToken.objects.filter(user=hamlet).exists())
+        self.assertTrue(Device.objects.filter(user=hamlet).exists())
+        self.assertTrue(EmailChangeStatus.objects.filter(user_profile=hamlet).exists())
+
+        do_delete_user(hamlet, acting_user=None)
+
+        self.assertFalse(UserStatus.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(AlertWord.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(PushDeviceToken.objects.filter(user=hamlet).exists())
+        self.assertFalse(Device.objects.filter(user=hamlet).exists())
+        self.assertFalse(EmailChangeStatus.objects.filter(user_profile=hamlet).exists())
 
 
 class FakeEmailDomainTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -56,7 +56,7 @@ from zerver.lib.test_helpers import (
     reset_email_visibility_to_everyone_in_zulip_realm,
     simulated_empty_cache,
 )
-from zerver.lib.types import Invitee
+from zerver.lib.types import Invitee, ProfileDataElementUpdateDict
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.user_groups import get_system_user_group_for_user
 from zerver.lib.users import (
@@ -4069,6 +4069,21 @@ class DeleteUserTest(ZulipTestCase):
             Message.objects.filter(realm_id=realm.id, sender_id=hamlet_user_id).count(),
             original_messages_from_hamlet_count,
         )
+
+    def test_do_delete_user_scrubs_custom_profile_field_values(self) -> None:
+        hamlet = self.example_user("hamlet")
+        phone_field = CustomProfileField.objects.get(name="Phone number", realm=hamlet.realm)
+        data: list[ProfileDataElementUpdateDict] = [
+            {"id": phone_field.id, "value": "555-test-1234"},
+        ]
+        self.set_user_custom_profile_data(hamlet, data)
+        self.assertTrue(
+            CustomProfileFieldValue.objects.filter(user_profile=hamlet, field=phone_field).exists()
+        )
+
+        do_delete_user(hamlet, acting_user=None)
+
+        self.assertFalse(CustomProfileFieldValue.objects.filter(user_profile=hamlet).exists())
 
 
 class FakeEmailDomainTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Iterable
 from datetime import timedelta
 from email.headerregistry import Address
@@ -49,6 +50,7 @@ from zerver.lib.stream_subscription import get_user_subscribed_streams
 from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
+    avatar_disk_path,
     get_subscription,
     get_test_image_file,
     get_user_sent_message_ids,
@@ -4084,6 +4086,30 @@ class DeleteUserTest(ZulipTestCase):
         do_delete_user(hamlet, acting_user=None)
 
         self.assertFalse(CustomProfileFieldValue.objects.filter(user_profile=hamlet).exists())
+
+    def test_do_delete_user_scrubs_avatar_images(self) -> None:
+        self.login("hamlet")
+        with get_test_image_file("img.png") as image_file:
+            self.client_post("/json/users/me/avatar", {"file": image_file})
+
+        hamlet = self.example_user("hamlet")
+        avatar_path = avatar_disk_path(hamlet)
+        avatar_original_path = avatar_disk_path(hamlet, original=True)
+        avatar_medium_path = avatar_disk_path(hamlet, medium=True)
+
+        self.assertEqual(hamlet.avatar_source, UserProfile.AVATAR_FROM_USER)
+        self.assertTrue(os.path.isfile(avatar_path))
+        self.assertTrue(os.path.isfile(avatar_original_path))
+        self.assertTrue(os.path.isfile(avatar_medium_path))
+
+        do_delete_user(hamlet, acting_user=None)
+
+        self.assertFalse(os.path.isfile(avatar_path))
+        self.assertFalse(os.path.isfile(avatar_original_path))
+        self.assertFalse(os.path.isfile(avatar_medium_path))
+
+        hamlet.refresh_from_db()
+        self.assertEqual(hamlet.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
 
 
 class FakeEmailDomainTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Iterable
 from datetime import timedelta
 from email.headerregistry import Address
@@ -50,6 +51,7 @@ from zerver.lib.stream_subscription import get_user_subscribed_streams
 from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
+    avatar_disk_path,
     get_subscription,
     get_test_image_file,
     get_user_sent_message_ids,
@@ -4199,6 +4201,30 @@ class DeleteUserTest(ZulipTestCase):
         do_delete_user(hamlet, acting_user=None)
 
         self.assertFalse(CustomProfileFieldValue.objects.filter(user_profile=hamlet).exists())
+
+    def test_do_delete_user_scrubs_avatar_images(self) -> None:
+        self.login("hamlet")
+        with get_test_image_file("img.png") as image_file:
+            self.client_post("/json/users/me/avatar", {"file": image_file})
+
+        hamlet = self.example_user("hamlet")
+        avatar_path = avatar_disk_path(hamlet)
+        avatar_original_path = avatar_disk_path(hamlet, original=True)
+        avatar_medium_path = avatar_disk_path(hamlet, medium=True)
+
+        self.assertEqual(hamlet.avatar_source, UserProfile.AVATAR_FROM_USER)
+        self.assertTrue(os.path.isfile(avatar_path))
+        self.assertTrue(os.path.isfile(avatar_original_path))
+        self.assertTrue(os.path.isfile(avatar_medium_path))
+
+        do_delete_user(hamlet, acting_user=None)
+
+        self.assertFalse(os.path.isfile(avatar_path))
+        self.assertFalse(os.path.isfile(avatar_original_path))
+        self.assertFalse(os.path.isfile(avatar_medium_path))
+
+        hamlet.refresh_from_db()
+        self.assertEqual(hamlet.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
 
 
 class FakeEmailDomainTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -94,7 +94,10 @@ from zerver.models import (
     ScheduledEmail,
     Stream,
     Subscription,
+    UserActivity,
+    UserActivityInterval,
     UserGroupMembership,
+    UserPresence,
     UserProfile,
     UserStatus,
     UserTopic,
@@ -4287,6 +4290,31 @@ class DeleteUserTest(ZulipTestCase):
         self.assertFalse(MutedUser.objects.filter(user_profile=hamlet).exists())
         self.assertFalse(NavigationView.objects.filter(user=hamlet).exists())
         self.assertFalse(UserTopic.objects.filter(user_profile=hamlet).exists())
+
+    def test_do_delete_user_deletes_activity_and_presence_data(self) -> None:
+        hamlet = self.example_user("hamlet")
+        realm = hamlet.realm
+        test_client = get_client("test")
+
+        UserActivity.objects.create(
+            user_profile=hamlet,
+            client=test_client,
+            query="/json/users",
+            count=3,
+            last_visit=timezone_now(),
+        )
+        UserActivityInterval.objects.create(
+            user_profile=hamlet,
+            start=timezone_now(),
+            end=timezone_now() + timedelta(minutes=20),
+        )
+        UserPresence.objects.create(user_profile=hamlet, realm=realm)
+
+        do_delete_user(hamlet, acting_user=None)
+
+        self.assertFalse(UserActivity.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(UserActivityInterval.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(UserPresence.objects.filter(user_profile=hamlet).exists())
 
 
 class FakeEmailDomainTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -76,11 +76,17 @@ from zerver.lib.users import (
 )
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
+    AlertWord,
     CustomProfileField,
     CustomProfileFieldValue,
+    Device,
+    EmailChangeStatus,
     Message,
+    MutedUser,
+    NavigationView,
     OnboardingStep,
     PreregistrationUser,
+    PushDeviceToken,
     RealmAuditLog,
     RealmDomain,
     RealmUserDefault,
@@ -90,6 +96,7 @@ from zerver.models import (
     Subscription,
     UserGroupMembership,
     UserProfile,
+    UserStatus,
     UserTopic,
 )
 from zerver.models.clients import get_client
@@ -4225,6 +4232,61 @@ class DeleteUserTest(ZulipTestCase):
 
         hamlet.refresh_from_db()
         self.assertEqual(hamlet.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
+
+    def test_do_delete_user_scrubs_user_sensitive_data_tables(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        realm = hamlet.realm
+        test_client = get_client("test")
+        stream = get_stream("Denmark", realm)
+
+        UserStatus.objects.create(
+            user_profile=hamlet,
+            client=test_client,
+            timestamp=timezone_now(),
+            status_text="On vacation",
+        )
+        AlertWord.objects.create(realm=realm, user_profile=hamlet, word="urgent")
+        PushDeviceToken.objects.create(
+            user=hamlet,
+            kind=PushDeviceToken.APNS,
+            token="apns-token-test-deadbeef",
+        )
+        Device.objects.create(user=hamlet)
+        EmailChangeStatus.objects.create(
+            realm=realm,
+            user_profile=hamlet,
+            new_email="newhamlet@zulip.com",
+            old_email=hamlet.delivery_email,
+        )
+        MutedUser.objects.create(user_profile=hamlet, muted_user=cordelia)
+        NavigationView.objects.create(user=hamlet, fragment="narrow/is/starred", is_pinned=True)
+        do_set_user_topic_visibility_policy(
+            hamlet,
+            stream,
+            "secret topic",
+            visibility_policy=UserTopic.VisibilityPolicy.MUTED,
+        )
+
+        self.assertTrue(UserStatus.objects.filter(user_profile=hamlet).exists())
+        self.assertTrue(AlertWord.objects.filter(user_profile=hamlet).exists())
+        self.assertTrue(PushDeviceToken.objects.filter(user=hamlet).exists())
+        self.assertTrue(Device.objects.filter(user=hamlet).exists())
+        self.assertTrue(EmailChangeStatus.objects.filter(user_profile=hamlet).exists())
+        self.assertTrue(MutedUser.objects.filter(user_profile=hamlet).exists())
+        self.assertTrue(NavigationView.objects.filter(user=hamlet).exists())
+        self.assertTrue(UserTopic.objects.filter(user_profile=hamlet).exists())
+
+        do_delete_user(hamlet, acting_user=None)
+
+        self.assertFalse(UserStatus.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(AlertWord.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(PushDeviceToken.objects.filter(user=hamlet).exists())
+        self.assertFalse(Device.objects.filter(user=hamlet).exists())
+        self.assertFalse(EmailChangeStatus.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(MutedUser.objects.filter(user_profile=hamlet).exists())
+        self.assertFalse(NavigationView.objects.filter(user=hamlet).exists())
+        self.assertFalse(UserTopic.objects.filter(user_profile=hamlet).exists())
 
 
 class FakeEmailDomainTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -19,11 +19,12 @@ from zerver.actions.create_user import do_create_user, do_reactivate_user
 from zerver.actions.custom_profile_fields import do_update_user_custom_profile_data_if_changed
 from zerver.actions.invites import do_create_multiuse_invite_link, do_invite_users
 from zerver.actions.message_send import RecipientInfoResult, get_recipient_info
-from zerver.actions.muted_users import do_mute_user
+from zerver.actions.muted_users import do_mute_user, do_unmute_user
 from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_set_realm_property,
 )
+from zerver.actions.streams import do_change_subscription_property
 from zerver.actions.user_settings import (
     bulk_regenerate_api_keys,
     do_change_avatar_fields,
@@ -4315,6 +4316,41 @@ class DeleteUserTest(ZulipTestCase):
         self.assertFalse(UserActivity.objects.filter(user_profile=hamlet).exists())
         self.assertFalse(UserActivityInterval.objects.filter(user_profile=hamlet).exists())
         self.assertFalse(UserPresence.objects.filter(user_profile=hamlet).exists())
+
+    def test_do_delete_user_scrubs_audit_log_extra_data(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        realm = hamlet.realm
+        stream = get_stream("Denmark", realm)
+        self.subscribe(hamlet, "Denmark")
+
+        do_mute_user(hamlet, cordelia)
+        do_unmute_user(MutedUser.objects.get(user_profile=hamlet, muted_user=cordelia))
+        do_change_subscription_property(
+            hamlet,
+            get_subscription("Denmark", hamlet),
+            stream,
+            "color",
+            "#ff0000",
+            acting_user=hamlet,
+        )
+
+        scrubbed_audit_log_ids = {}
+        for event_type in [
+            AuditLogEventType.USER_MUTED,
+            AuditLogEventType.USER_UNMUTED,
+            AuditLogEventType.SUBSCRIPTION_PROPERTY_CHANGED,
+        ]:
+            audit_log = RealmAuditLog.objects.get(modified_user=hamlet, event_type=event_type)
+            self.assertNotEqual(audit_log.extra_data, {})
+            scrubbed_audit_log_ids[event_type] = audit_log.id
+
+        do_delete_user(hamlet, acting_user=None)
+
+        for event_type, audit_log_id in scrubbed_audit_log_ids.items():
+            audit_log = RealmAuditLog.objects.get(id=audit_log_id)
+            self.assertEqual(audit_log.extra_data, {})
+            self.assertTrue(audit_log.scrubbed)
 
 
 class FakeEmailDomainTest(ZulipTestCase):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -57,7 +57,7 @@ from zerver.lib.test_helpers import (
     reset_email_visibility_to_everyone_in_zulip_realm,
     simulated_empty_cache,
 )
-from zerver.lib.types import Invitee
+from zerver.lib.types import Invitee, ProfileDataElementUpdateDict
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.user_groups import get_system_user_group_for_user
 from zerver.lib.users import (
@@ -4184,6 +4184,21 @@ class DeleteUserTest(ZulipTestCase):
             Message.objects.filter(realm_id=realm.id, sender_id=hamlet_user_id).count(),
             original_messages_from_hamlet_count,
         )
+
+    def test_do_delete_user_scrubs_custom_profile_field_values(self) -> None:
+        hamlet = self.example_user("hamlet")
+        phone_field = CustomProfileField.objects.get(name="Phone number", realm=hamlet.realm)
+        data: list[ProfileDataElementUpdateDict] = [
+            {"id": phone_field.id, "value": "555-test-1234"},
+        ]
+        self.set_user_custom_profile_data(hamlet, data)
+        self.assertTrue(
+            CustomProfileFieldValue.objects.filter(user_profile=hamlet, field=phone_field).exists()
+        )
+
+        do_delete_user(hamlet, acting_user=None)
+
+        self.assertFalse(CustomProfileFieldValue.objects.filter(user_profile=hamlet).exists())
 
 
 class FakeEmailDomainTest(ZulipTestCase):


### PR DESCRIPTION
`do_delete_user_core` retained substantial per-user PII in the database after user deletion: custom profile field values (bio, phone, etc.) remained readable via the profile-by-URL view, uploaded avatar files persisted on disk, and five additional FK-linked tables (`UserStatus`, `AlertWord`, `PushDeviceToken`, `Device`, `EmailChangeStatus`) were never cleared.

This PR addresses the "In scope / definite PII" subsection of #39347 in three commits:

1. **Add `CustomProfileFieldValue` to `fks_to_delete`** - the leak that triggered the issue, [discovered](https://github.com/zulip/zulip/pull/38374#issuecomment-4029861899) during review of #38374.
2. **Call `do_scrub_avatar_images` after `do_deactivate_user`** - deletes uploaded avatar files. Also overrides `temp_replacement_user.avatar_source = AVATAR_FROM_GRAVATAR` before computing `overwrite_data`, so the post-deletion `/avatar/<id>` URL redirects to a random gravatar (matching @timabbott's [original CZO design](https://chat.zulip.org/#narrow/channel/378-api-design/topic/deleting.20spammer.20avatars/near/2027657)) instead of 404'ing on the missing local jdenticon file that `do_scrub_avatar_images` deliberately doesn't generate.
3. **Add the five remaining definite-PII tables to `fks_to_delete`, and unregister push devices from the bouncer.** Deleting the local `PushDeviceToken` rows turned out not to be enough. On servers using the push notifications bouncer, the registrations also live on the bouncer as `RemotePushDeviceToken` rows keyed to the user's `user_uuid`, and nothing in the deletion path told the bouncer to drop them - so a deleted user's APNs/FCM tokens stayed registered against their uuid indefinitely. That's the same class of leak this PR exists to fix, one hop out.

   Fixed by enqueueing `clear_push_device_tokens` on `deferred_work`, following the existing precedent in `do_regenerate_api_key`. Notes on the shape of that fix:
   - The local delete stays, because the bouncer branch of `clear_push_device_tokens` returns before deleting local rows.
   - Doing it async matters: talking to the bouncer is a network call, and the `deferred_work` worker already has retry handling for `PushNotificationBouncerRetryLaterError`. `queue_event_on_commit` also means we don't unregister devices for a deletion that rolled back.
   - Deferring past the deletion is safe because `uuid` is excluded from `overwrite_data`, so the user is still identifiable to the bouncer by the time the worker runs.

Fixes: part of #39347.

**How changes were tested:**

- [x] New `test_delete_user_unregisters_push_devices_from_bouncer` registers real APNs and FCM tokens through the normal endpoints so they land on the bouncer as well as locally, deletes the user inside `captureOnCommitCallbacks(execute=True)` so the deferred work actually runs, then asserts both the bouncer's `RemotePushDeviceToken` rows and the local `PushDeviceToken` rows are gone. I confirmed the test genuinely catches the bug by stashing the fix and re-running it - without the fix, 2 registrations survive on the bouncer.
- [x] Manual smoke test in dev: created hamlet with a "Phone number" CPF value + uploaded avatar, ran `python manage.py delete_user`, verified via `manage.py shell` that all seven In-scope tables are empty for the deleted user and avatar files are gone; verified the profile-by-URL view at `#user/<id>` shows "Deleted User N" with no bio/phone leak and a gravatar identicon (rather than the pre-fix 404 black square).

**Remaining question:**

`Device` rows also carry a `push_token_id` referencing a bouncer-side registration, and this PR deletes them directly rather than unregistering them. I followed the precedent in `do_regenerate_api_key`, which deletes `Device` rows the same way - but I'm not confident that's sufficient for E2EE registrations, and I'd rather have someone who knows that pathway to confirm than guessing it. 

**Screenshots and screen captures:**

Profile modal at `#user/<deleted-user-id>` after deletion - no bio or phone leak, default gravatar identicon, "Deleted User N" name:

<img width="786" height="727" alt="image" src="https://github.com/user-attachments/assets/86d98371-5d82-4f48-940c-372736fcaeed" />

(Here I deleted Hamlet, userid = 10)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
