### PR TITLE
message_fetch: Display server-side error messages in narrow banner

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -479,7 +479,12 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
                     !opts.msg_list.is_combined_feed_view &&
                     opts.msg_list.visibly_empty()
                 ) {
-                    narrow_banner.show_empty_narrow_message(opts.msg_list.data.filter);
+                    const parsed_error = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
+                    if (parsed_error.success) {
+                        narrow_banner.show_error_narrow_message(parsed_error.data.msg);
+                    } else {
+                        narrow_banner.show_empty_narrow_message(opts.msg_list.data.filter);
+                    }
                 }
 
                 // TODO: This should probably do something explicit with

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -571,6 +571,12 @@ export function show_empty_narrow_message(current_filter: Filter): void {
     $(".empty_feed_notice_main").html(rendered_narrow_banner);
 }
 
+export function show_error_narrow_message(error_message: string): void {
+    $(".empty_feed_notice_main").empty();
+    const rendered_narrow_banner = narrow_error({title: error_message});
+    $(".empty_feed_notice_main").html(rendered_narrow_banner);
+}
+
 export function hide_empty_narrow_message(): void {
     $(".empty_feed_notice_main").empty();
 }

--- a/web/tests/message_fetch.test.cjs
+++ b/web/tests/message_fetch.test.cjs
@@ -2,13 +2,17 @@
 
 const assert = require("node:assert/strict");
 
-const {zrequire} = require("./lib/namespace.cjs");
+const {zrequire, mock_esm} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 
 const {Filter} = zrequire("filter");
 const {MessageListData} = zrequire("message_list_data");
+const channel = mock_esm("../src/channel");
 const message_fetch = zrequire("message_fetch");
+const message_lists = zrequire("message_lists");
+const narrow_banner = mock_esm("../src/narrow_banner");
+const popup_banners = mock_esm("../src/popup_banners");
 
 run_test("get_parameters_for_message_fetch_api date anchor", () => {
     const msg_list_data = new MessageListData({
@@ -37,4 +41,54 @@ run_test("get_parameters_for_message_fetch_api date anchor", () => {
         msg_list_data,
     });
     assert.equal(missing_date.anchor_date, undefined);
+});
+
+run_test("load_messages uses server msg for 400 error in empty narrow", ({override}) => {
+    const msg_list_data = new MessageListData({
+        excludes_muted_topics: false,
+        filter: new Filter([{operator: "stream", operand: "missing-stream"}]),
+    });
+
+    const msg_list = {
+        data: msg_list_data,
+        is_combined_feed_view: false,
+        visibly_empty: () => true,
+    };
+    message_lists.set_current(msg_list);
+
+    let shown_error_message;
+    override(narrow_banner, "show_error_narrow_message", (error_message) => {
+        shown_error_message = error_message;
+    });
+    override(popup_banners, "close_connection_error_popup_banner", () => {});
+
+    let showed_empty_banner = false;
+    override(
+        narrow_banner,
+        "show_empty_narrow_message",
+        () => {
+            showed_empty_banner = true;
+        },
+        {unused: false},
+    );
+
+    override(channel, "get", (args) => {
+        args.error({
+            status: 400,
+            responseJSON: {msg: "No channel with name 'missing-stream'"},
+        });
+    });
+
+    message_fetch.load_messages({
+        anchor: "newest",
+        num_before: 0,
+        num_after: 20,
+        cont() {},
+        msg_list_data,
+        msg_list,
+    });
+
+    assert.equal(shown_error_message, "No channel with name 'missing-stream'");
+    assert.equal(showed_empty_banner, false);
+    message_lists.set_current(undefined);
 });


### PR DESCRIPTION
### Description

Currently, when a message fetch or search query fails on the backend (for example, due to an invalid search term, a query syntax error, or filtering by a stream that does not exist), the frontend displays a generic "No search results" or empty feed banner. This is confusing because the query actually failed with a server-side error rather than just returning zero results.

This PR introduces robust handling and display of server-side errors in the narrow banner:
1. **Error Parsing in `web/src/message_fetch.ts`**:
   - Used Zod (`z.object({msg: z.string()})`) to safely parse server-side error payloads from `xhr.responseJSON` when a message load fails.
   - If an error message is successfully parsed, we call the new `show_error_narrow_message` handler. Otherwise, we gracefully fall back to the default empty feed notice.

2. **Displaying the Error in `web/src/narrow_banner.ts`**:
   - Added a new `show_error_narrow_message(error_message: string)` function.
   - Leveraged the existing `narrow_error` utility to construct and inject the error banner into the `.empty_feed_notice_main` container.

Fixes: Fixes the issue where server-side search or narrow query errors were hidden behind a generic empty feed notice.

**How changes were tested:**

1. Started the development server using `./tools/run-dev` in GitHub Codespaces.
2. Navigated to a view and entered an invalid search query (e.g., searching for a stream name that does not exist or entering invalid search operators) to trigger a server-side error.
3. Verified that the custom error banner displays the precise error message returned by the server (e.g., `"Invalid stream: ..."`).
4. Ran the linter locally using `./tools/lint --modified` to verify styling and TypeScript checks pass.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>