### PR TITLE
webhooks/stripe: Use object field to determine display type.

### DIFF
--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -1,6 +1,8 @@
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import orjson
+
 from zerver.lib.test_classes import WebhookTestCase
 
 
@@ -23,6 +25,23 @@ class StripeHookTests(WebhookTestCase):
             expected_topic_name,
             expected_message,
             content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_charge_dispute_created_pdp_prefix(self) -> None:
+        self.subscribe(self.test_user, self.channel_name)
+        payload = orjson.loads(self.get_body("charge_dispute_created"))
+        payload["data"]["object"]["id"] = "pdp_00000000000000"
+        msg = self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            orjson.dumps(payload).decode(),
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name="disputes",
+            content="[Dispute](https://dashboard.stripe.com/disputes/pdp_00000000000000) created. Current status: needs response.",
         )
 
     def test_charge_failed(self) -> None:

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -1,6 +1,7 @@
 # Webhooks for external integrations.
 import time
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from django.http import HttpRequest, HttpResponse
 
@@ -314,48 +315,57 @@ def amount_string(amount: int, currency: str) -> str:
     return decimal_amount + f" {currency.upper()}"
 
 
-def linkified_id(object_id: str, lower: bool = False) -> str:
-    names_and_urls: dict[str, tuple[str, str | None]] = {
-        # Core resources
-        "ch": ("Charge", "charges"),
-        "cus": ("Customer", "customers"),
-        "dp": ("Dispute", "disputes"),
-        "du": ("Dispute", "disputes"),
-        "file": ("File", "files"),
-        "link": ("File link", "file_links"),
-        "pi": ("Payment intent", "payment_intents"),
-        "po": ("Payout", "payouts"),
-        "prod": ("Product", "products"),
-        "re": ("Refund", "refunds"),
-        "tok": ("Token", "tokens"),
-        # Payment methods
-        # payment methods have URL prefixes like /customers/cus_id/sources
-        "ba": ("Bank account", None),
-        "card": ("Card", None),
-        "src": ("Source", None),
-        # Billing
-        # coupons have a configurable id, but the URL prefix is /coupons
-        # discounts don't have a URL, I think
-        "in": ("Invoice", "invoices"),
-        "ii": ("Invoice item", "invoiceitems"),
-        # products are covered in core resources
-        # plans have a configurable id, though by default they are created with this pattern
-        # 'plan': ('Plan', 'plans'),
-        "sub": ("Subscription", "subscriptions"),
-        "si": ("Subscription item", "subscription_items"),
-        # I think usage records have URL prefixes like /subscription_items/si_id/usage_record_summaries
-        "mbur": ("Usage record", None),
-        # Undocumented :|
-        "py": ("Payment", "payments"),
-        "pyr": ("Refund", "refunds"),  # Pseudo refunds. Not fully tested.
-        # Connect, Fraud, Orders, etc not implemented
-    }
-    name, url_prefix = names_and_urls[object_id.split("_", 1)[0]]
+@dataclass
+class DisplayInfo:
+    name: str
+    url_prefix: str | None = None
+
+
+STRIPE_OBJECT_TYPES: dict[str, DisplayInfo] = {
+    # CORE RESOURCES
+    "ch": DisplayInfo("Charge", "charges"),
+    "cus": DisplayInfo("Customer", "customers"),
+    "dp": DisplayInfo("Dispute", "disputes"),
+    "du": DisplayInfo("Dispute", "disputes"),
+    "file": DisplayInfo("File", "files"),
+    "link": DisplayInfo("File link", "file_links"),
+    "pi": DisplayInfo("Payment intent", "payment_intents"),
+    "po": DisplayInfo("Payout", "payouts"),
+    "prod": DisplayInfo("Product", "products"),
+    "re": DisplayInfo("Refund", "refunds"),
+    "tok": DisplayInfo("Token", "tokens"),
+    # PAYMENT METHODS
+    # Payment methods have URL prefixes like /customers/cus_id/sources.
+    "ba": DisplayInfo("Bank account"),
+    "card": DisplayInfo("Card"),
+    "src": DisplayInfo("Source"),
+    # BILLING
+    # Coupons have a configurable id, but the URL prefix is /coupons.
+    # It's not clear if discounts have a URL.
+    "in": DisplayInfo("Invoice", "invoices"),
+    "ii": DisplayInfo("Invoice item", "invoiceitems"),
+    # Products are covered in core resources.
+    # Plans have a configurable id, though by default they are created with this pattern:
+    # 'plan': ('Plan', 'plans').
+    "sub": DisplayInfo("Subscription", "subscriptions"),
+    "si": DisplayInfo("Subscription item", "subscription_items"),
+    # Usage records seem to have URL prefixes like /subscription_items/si_id/usage_record_summaries.
+    "mbur": DisplayInfo("Usage record"),
+    # UNDOCUMENTED
+    "py": DisplayInfo("Payment", "payments"),
+    "pyr": DisplayInfo("Refund", "refunds"),
+    # Connect, Fraud, Orders, etc not implemented.
+}
+
+
+def linkified_id(id: str, lower: bool = False) -> str:
+    display_info = STRIPE_OBJECT_TYPES[id.split("_", 1)[0]]
+    name = display_info.name
     if lower:  # nocoverage
         name = name.lower()
-    if url_prefix is None:  # nocoverage
+    if display_info.url_prefix is None:  # nocoverage
         return name
-    return f"[{name}](https://dashboard.stripe.com/{url_prefix}/{object_id})"
+    return f"[{name}](https://dashboard.stripe.com/{display_info.url_prefix}/{id})"
 
 
 def stringify(value: object) -> str:

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -84,6 +84,10 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         topic_name = customer_id
     body = None
 
+    def charge_object_type(charge_id: str) -> str:
+        # Legacy ACH-style payments report object_type "charge" but use a "py_" id prefix.
+        return "payment" if charge_id.startswith("py_") else "charge"
+
     def update_string(blacklist: Sequence[str] = []) -> str:
         assert "previous_attributes" in payload["data"]
         previous_attributes = set(payload["data"]["previous_attributes"].keys()).difference(
@@ -100,8 +104,11 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         )
 
     def default_body(update_blacklist: Sequence[str] = []) -> str:
+        id = object_["id"].tame(check_string)
+        type = object_["object"].tame(check_string)
         body = "{resource} {verbed}".format(
-            resource=linkified_id(object_["id"].tame(check_string)), verbed=event.replace("_", " ")
+            resource=linkified_id(id, type),
+            verbed=event.replace("_", " "),
         )
         if event == "updated":
             return body + update_string(blacklist=update_blacklist)
@@ -127,8 +134,10 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         if resource == "charge":
             if not topic_name:  # only in legacy fixtures
                 topic_name = "charges"
+            object_id = object_["id"].tame(check_string)
+            charge_type = charge_object_type(object_id)
             body = "{resource} for {amount} {verbed}".format(
-                resource=linkified_id(object_["id"].tame(check_string)),
+                resource=linkified_id(object_id, charge_type),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
                 ),
@@ -143,9 +152,13 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
             )
         if resource == "refund":
             topic_name = "refunds"
+            id = object_["id"].tame(check_string)
+            type = object_["object"].tame(check_string)
+            charge_id = object_["charge"].tame(check_string)
+            charge_type = charge_object_type(charge_id)
             body = "A {resource} for a {charge} of {amount} was updated.".format(
-                resource=linkified_id(object_["id"].tame(check_string), lower=True),
-                charge=linkified_id(object_["charge"].tame(check_string), lower=True),
+                resource=linkified_id(id, type, lower=True),
+                charge=linkified_id(charge_id, charge_type, lower=True),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
                 ),
@@ -323,45 +336,43 @@ class DisplayInfo:
 
 STRIPE_OBJECT_TYPES: dict[str, DisplayInfo] = {
     # CORE RESOURCES
-    "ch": DisplayInfo("Charge", "charges"),
-    "cus": DisplayInfo("Customer", "customers"),
-    "dp": DisplayInfo("Dispute", "disputes"),
-    "du": DisplayInfo("Dispute", "disputes"),
+    "charge": DisplayInfo("Charge", "charges"),
+    "customer": DisplayInfo("Customer", "customers"),
+    "dispute": DisplayInfo("Dispute", "disputes"),
     "file": DisplayInfo("File", "files"),
-    "link": DisplayInfo("File link", "file_links"),
-    "pi": DisplayInfo("Payment intent", "payment_intents"),
-    "po": DisplayInfo("Payout", "payouts"),
-    "prod": DisplayInfo("Product", "products"),
-    "re": DisplayInfo("Refund", "refunds"),
-    "tok": DisplayInfo("Token", "tokens"),
+    "file_link": DisplayInfo("File link", "file_links"),
+    "payment_intent": DisplayInfo("Payment intent", "payment_intents"),
+    "payout": DisplayInfo("Payout", "payouts"),
+    "product": DisplayInfo("Product", "products"),
+    "refund": DisplayInfo("Refund", "refunds"),
+    "token": DisplayInfo("Token", "tokens"),
     # PAYMENT METHODS
     # Payment methods have URL prefixes like /customers/cus_id/sources.
-    "ba": DisplayInfo("Bank account"),
+    "bank_account": DisplayInfo("Bank account"),
     "card": DisplayInfo("Card"),
-    "src": DisplayInfo("Source"),
+    "source": DisplayInfo("Source"),
     # BILLING
     # Coupons have a configurable id, but the URL prefix is /coupons.
     # It's not clear if discounts have a URL.
-    "in": DisplayInfo("Invoice", "invoices"),
-    "ii": DisplayInfo("Invoice item", "invoiceitems"),
+    "invoice": DisplayInfo("Invoice", "invoices"),
+    "invoiceitem": DisplayInfo("Invoice item", "invoiceitems"),
     # Products are covered in core resources.
     # Plans have a configurable id, though by default they are created with this pattern:
     # 'plan': ('Plan', 'plans').
-    "sub": DisplayInfo("Subscription", "subscriptions"),
-    "si": DisplayInfo("Subscription item", "subscription_items"),
+    "subscription": DisplayInfo("Subscription", "subscriptions"),
+    "subscription_item": DisplayInfo("Subscription item", "subscription_items"),
     # Usage records seem to have URL prefixes like /subscription_items/si_id/usage_record_summaries.
-    "mbur": DisplayInfo("Usage record"),
+    "usage_record": DisplayInfo("Usage record"),
     # UNDOCUMENTED
-    "py": DisplayInfo("Payment", "payments"),
-    "pyr": DisplayInfo("Refund", "refunds"),
+    "payment": DisplayInfo("Payment", "payments"),
     # Connect, Fraud, Orders, etc not implemented.
 }
 
 
-def linkified_id(id: str, lower: bool = False) -> str:
-    display_info = STRIPE_OBJECT_TYPES[id.split("_", 1)[0]]
+def linkified_id(id: str, type: str, lower: bool = False) -> str:
+    display_info = STRIPE_OBJECT_TYPES[type]
     name = display_info.name
-    if lower:  # nocoverage
+    if lower:
         name = name.lower()
     if display_info.url_prefix is None:  # nocoverage
         return name


### PR DESCRIPTION

<!-- Describe your pull request here.-->
Replaced the fragile method of finding the display type using prefix of the id with the method using the `object` field instaed. 
The current fixtures only includes `charge`, `customer`, `dispute`, `invoice`, `invoiceitem`, `refund`, and `subscription` object types from the dict so referred [Stripe API docs](https://docs.stripe.com/api) to determine the accurate names(mostly as the webhooks usually includes the same name as their APIs) for other objects.

The URLs used for some entites like charge are legacy(but they still work as they redirect to the correct URL) as well as some fileds, I will raise a follow up PR to fix these. 
Fixes: #20967 


**How changes were tested:**
The existing tests work.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] Visual appearance of the changes.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
