### PR TITLE
unread: Mark all narrow-matching messages as read from banner.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -422,7 +422,7 @@ function initialize_unread_ui() {
     );
     unread_ui.register_update_unread_counts_hook(inbox_ui.update);
 
-    unread_ui.initialize({notify_server_messages_read: unread_ops.notify_server_messages_read});
+    unread_ui.initialize({mark_narrow_as_read: unread_ops.mark_narrow_as_read});
 }
 
 export async function initialize_everything(state_data) {

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -827,6 +827,13 @@ export function mark_all_as_read(modal_id?: string): void {
     bulk_update_read_flags_for_narrow(all_unread_messages_narrow, "add", {}, modal_id);
 }
 
+export function mark_narrow_as_read(filter: Filter): void {
+    bulk_update_read_flags_for_narrow(
+        [{operator: "is", operand: "unread", negated: false}, ...filter.terms()],
+        "add",
+    );
+}
+
 export function mark_muted_topic_messages_as_read(modal_id?: string): void {
     bulk_update_read_flags_for_narrow(
         [

--- a/web/src/unread_ui.ts
+++ b/web/src/unread_ui.ts
@@ -5,8 +5,8 @@ import render_mark_as_read_disabled_banner from "../templates/unread_banner/mark
 import render_mark_as_read_only_in_conversation_view from "../templates/unread_banner/mark_as_read_only_in_conversation_view.hbs";
 import render_mark_as_read_turned_off_banner from "../templates/unread_banner/mark_as_read_turned_off_banner.hbs";
 
+import type {Filter} from "./filter.ts";
 import * as message_lists from "./message_lists.ts";
-import type {Message} from "./message_store.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {web_mark_read_on_scroll_policy_values} from "./settings_config.ts";
 import * as unread from "./unread.ts";
@@ -104,23 +104,19 @@ export function update_unread_counts(skip_animations = false): void {
 }
 
 export function initialize({
-    notify_server_messages_read,
+    mark_narrow_as_read,
 }: {
-    notify_server_messages_read: (unread_messages: Message[]) => void;
+    mark_narrow_as_read: (filter: Filter) => void;
 }): void {
     const skip_animations = true;
     update_unread_counts(skip_animations);
     $("body").on("click", "#mark_view_read", () => {
         assert(message_lists.current !== undefined);
-        // Mark all messages in the current view as read.
-        //
-        // BUG: This logic only supports marking messages visible in
-        // the present view as read; we need a server API to mark
-        // every message matching the current search as read.
-        const unread_messages = message_lists.current
-            .all_messages()
-            .filter((message) => message.unread);
-        notify_server_messages_read(unread_messages);
+        // Mark all messages matching the current narrow as read on
+        // the server, so that unreads outside the locally fetched
+        // range (e.g., older DM conversations in the DM feed) are
+        // also marked as read.
+        mark_narrow_as_read(message_lists.current.data.filter);
         // New messages received may be marked as read based on narrow type.
         message_lists.current.resume_reading();
 


### PR DESCRIPTION
The "Mark as read" banner click handler previously only marked messages currently loaded in the message list as read, missing unreads outside the locally fetched range. For example, in the DM feed (is:dm), older DM conversations with unreads would not get marked as read.

Fix this by using the server-side narrow API
(bulk_update_read_flags_for_narrow) to mark every message matching the current narrow as read, the same pattern used by mark_stream_as_read and mark_topic_as_read.

This banner can appear in any non-conversation feed view (channel feed, DM feed, combined feed, mentions, starred, search, etc.), so the fix applies broadly.

The narrow API was added in b1ca1fd606dc, after the BUG comment in 6afdf2410d0b flagged this limitation.

Reported at: https://chat.zulip.org/#narrow/channel/9-issues/topic/DM.20mark.20all.20as.20read.20only.20marking.20some.20unreads/with/2463479