### PR TITLE
export: Include timestamp in tarball filename.

### DIFF
--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -345,7 +345,7 @@ cd /home/zulip/deployments/current
 the default organization hosted at the Zulip server's root domain.)
 
 This will generate a compressed archive with a name like
-`/tmp/zulip-export-zcmpxfm6.tar.gz`. The archive contains several JSON
+`/tmp/zulip-export-2026-05-25-09-30-45-zcmpxfm6.tar.gz`. The archive contains several JSON
 files (containing the Zulip organization's data) as well as an archive
 of all the organization's uploaded files.
 
@@ -412,9 +412,9 @@ of all the organization's uploaded files.
 
    ```bash
    cd ~
-   tar -xf /path/to/export/file/zulip-export-zcmpxfm6.tar.gz
+   tar -xf /path/to/export/file/zulip-export-2026-05-25-09-30-45-zcmpxfm6.tar.gz
    cd /home/zulip/deployments/current
-   ./manage.py import '' ~/zulip-export-zcmpxfm6
+   ./manage.py import '' ~/zulip-export-2026-05-25-09-30-45-zcmpxfm6
    ./scripts/start-server
    ```
 
@@ -433,7 +433,7 @@ root domain. Replace the last two lines above with the following, after replacin
 `<subdomain>` with the desired subdomain.
 
 ```bash
-./manage.py import <subdomain> ~/zulip-export-zcmpxfm6
+./manage.py import <subdomain> ~/zulip-export-2026-05-25-09-30-45-zcmpxfm6
 ./scripts/start-server
 ```
 

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -37,6 +37,7 @@ from psycopg2 import sql
 
 import zerver.lib.upload
 from analytics.models import RealmCount, StreamCount, UserCount
+from scripts.lib.zulip_tools import TIMESTAMP_FORMAT
 from version import ZULIP_VERSION
 from zerver.lib.avatar_hash import user_avatar_base_path_from_ids
 from zerver.lib.display_recipient import get_display_recipient
@@ -331,6 +332,11 @@ ANALYTICS_TABLES = {
     "analytics_streamcount",
     "analytics_usercount",
 }
+
+
+def export_tarball_prefix(realm: Realm) -> str:
+    string_id_segment = f"{realm.string_id}-" if realm.string_id else ""
+    return f"zulip-export-{string_id_segment}{timezone_now().strftime(TIMESTAMP_FORMAT)}-"
 
 
 @functools.cache

--- a/zerver/management/commands/export.py
+++ b/zerver/management/commands/export.py
@@ -9,7 +9,7 @@ from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from zerver.actions.realm_settings import do_deactivate_realm
-from zerver.lib.export import export_realm_wrapper
+from zerver.lib.export import export_realm_wrapper, export_tarball_prefix
 from zerver.lib.management import ZulipBaseCommand
 from zerver.models import RealmExport
 
@@ -132,7 +132,7 @@ class Command(ZulipBaseCommand):
             raise CommandError(f"The realm {realm.string_id} is already deactivated.  Aborting...")
 
         if output_dir is None:
-            output_dir = tempfile.mkdtemp(prefix="zulip-export-")
+            output_dir = tempfile.mkdtemp(prefix=export_tarball_prefix(realm))
         else:
             output_dir = os.path.realpath(os.path.expanduser(output_dir))
             if os.path.exists(output_dir):

--- a/zerver/management/commands/export_single_user.py
+++ b/zerver/management/commands/export_single_user.py
@@ -7,7 +7,7 @@ from typing import Any
 from django.core.management.base import CommandError
 from typing_extensions import override
 
-from zerver.lib.export import do_export_user
+from zerver.lib.export import do_export_user, export_tarball_prefix
 from zerver.lib.management import ZulipBaseCommand
 
 
@@ -35,7 +35,7 @@ class Command(ZulipBaseCommand):
 
         output_dir = options["output_dir"]
         if output_dir is None:
-            output_dir = tempfile.mkdtemp(prefix="zulip-export-")
+            output_dir = tempfile.mkdtemp(prefix=export_tarball_prefix(user_profile.realm))
         else:
             output_dir = os.path.abspath(output_dir)
             if os.path.exists(output_dir) and os.listdir(output_dir):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17018,7 +17018,7 @@ paths:
                               "deleted_timestamp": null,
                               "export_type": "public",
                               "export_time": 1722243168.134179,
-                              "export_url": "http://example.zulipchat.com/user_avatars/exports/2/FprbwiF0c_sCN0O-rf-ryFtc/zulip-export-p6yuxc45.tar.gz",
+                              "export_url": "http://example.zulipchat.com/user_avatars/exports/2/FprbwiF0c_sCN0O-rf-ryFtc/zulip-export-example-2024-07-29-10-12-48-p6yuxc45.tar.gz",
                               "id": 323,
                               "failed_timestamp": null,
                               "pending": false,

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -1,15 +1,18 @@
 import os
+from datetime import datetime, timezone
 from unittest.mock import patch
 from urllib.parse import urlsplit
 
 import botocore.exceptions
 import orjson
+import time_machine
 from django.conf import settings
 from django.utils.timezone import now as timezone_now
 
 from analytics.models import RealmCount
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.lib.exceptions import JsonableError
+from zerver.lib.export import export_tarball_prefix
 from zerver.lib.queue import queue_json_publish_rollback_unsafe
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
@@ -48,6 +51,7 @@ class RealmExportTest(ZulipTestCase):
         tarball_path = create_dummy_file("test-export.tar.gz")
 
         # Test the export logic.
+        export_time = datetime(2026, 5, 25, 10, 11, 16, tzinfo=timezone.utc)
         with patch(
             "zerver.lib.export.do_export_realm", return_value=(tarball_path, dict())
         ) as mock_export:
@@ -55,6 +59,7 @@ class RealmExportTest(ZulipTestCase):
                 self.settings(LOCAL_UPLOADS_DIR=None),
                 stdout_suppressed(),
                 self.assertLogs(level="INFO") as info_logs,
+                time_machine.travel(export_time, tick=False),
                 self.captureOnCommitCallbacks(execute=True),
             ):
                 result = self.client_post("/json/export/realm")
@@ -64,7 +69,11 @@ class RealmExportTest(ZulipTestCase):
         args = mock_export.call_args_list[0][1]
         self.assertEqual(args["realm"], admin.realm)
         self.assertEqual(args["export_type"], RealmExport.EXPORT_PUBLIC)
-        self.assertTrue(os.path.basename(args["output_dir"]).startswith("zulip-export-"))
+        self.assertTrue(
+            os.path.basename(args["output_dir"]).startswith(
+                "zulip-export-zulip-2026-05-25-10-11-16-"
+            )
+        )
         self.assertEqual(args["processes"], 6)
 
         # Get the entry and test that iago initiated it.
@@ -130,7 +139,9 @@ class RealmExportTest(ZulipTestCase):
         ) -> tuple[str, dict[str, int | dict[str, int]]]:
             self.assertEqual(realm, admin.realm)
             self.assertEqual(export_type, RealmExport.EXPORT_PUBLIC)
-            self.assertTrue(os.path.basename(output_dir).startswith("zulip-export-"))
+            self.assertTrue(
+                os.path.basename(output_dir).startswith("zulip-export-zulip-2026-05-25-10-11-16-")
+            )
             self.assertEqual(processes, 6)
 
             # Check that the export shows up as in progress
@@ -151,12 +162,14 @@ class RealmExportTest(ZulipTestCase):
 
             return tarball_path, dict()
 
+        export_time = datetime(2026, 5, 25, 10, 11, 16, tzinfo=timezone.utc)
         with patch(
             "zerver.lib.export.do_export_realm", side_effect=fake_export_realm
         ) as mock_export:
             with (
                 stdout_suppressed(),
                 self.assertLogs(level="INFO") as info_logs,
+                time_machine.travel(export_time, tick=False),
                 self.captureOnCommitCallbacks(execute=True),
             ):
                 result = self.client_post("/json/export/realm")
@@ -205,6 +218,17 @@ class RealmExportTest(ZulipTestCase):
         # Now try to delete a non-existent export.
         result = self.client_delete("/json/export/realm/0")
         self.assert_json_error(result, "Invalid data export ID")
+
+    def test_export_tarball_prefix(self) -> None:
+        realm = self.example_user("iago").realm
+        with time_machine.travel(
+            datetime(2026, 5, 25, 10, 11, 16, tzinfo=timezone.utc), tick=False
+        ):
+            self.assertEqual(
+                export_tarball_prefix(realm), "zulip-export-zulip-2026-05-25-10-11-16-"
+            )
+            realm.string_id = ""
+            self.assertEqual(export_tarball_prefix(realm), "zulip-export-2026-05-25-10-11-16-")
 
     def test_export_failure(self) -> None:
         admin = self.example_user("iago")

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -15,7 +15,7 @@ from zerver.actions.message_flags import do_mark_stream_messages_as_read
 from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_export import notify_realm_export
 from zerver.actions.realm_settings import scrub_deactivated_realm
-from zerver.lib.export import export_realm_wrapper
+from zerver.lib.export import export_realm_wrapper, export_tarball_prefix
 from zerver.lib.push_notifications import clear_push_device_tokens
 from zerver.lib.queue import retry_event
 from zerver.lib.remote_server import (
@@ -80,9 +80,9 @@ class DeferredWorker(QueueProcessingWorker):
 
                 retry_event(self.queue_name, event, failure_processor)
         elif event["type"] == "realm_export":
-            output_dir = tempfile.mkdtemp(prefix="zulip-export-")
             user_profile = get_user_profile_by_id(event["user_profile_id"])
             realm = user_profile.realm
+            output_dir = tempfile.mkdtemp(prefix=export_tarball_prefix(realm))
             export_event = None
 
             if "realm_export_id" in event:


### PR DESCRIPTION
The download URL for a realm export tarball previously contained only a random suffix, making it easy to download the wrong file when multiple exports were available in the admin UI. Embed the UTC timestamp of the export in the tempdir prefix so the resulting tarball is named like zulip-export-2026-05-25-09-30-45-<rand>.tar.gz, matching the convention used by `./manage.py backup`.

I've kept around the random suffix for same second exports.

Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/discrepancies.20in.20data.20export/with/2467409

<!-- Describe your pull request here.-->

**How changes were tested:**
- Ran `./manage.py export -r zulip` and got `Tarball written to /tmp/zulip-export-2026-05-25-10-24-31-g3o7eo2w.tar.gz`
- Ran `./manage.py export_single_user -r zulip iago@zulip.com` and got `Tarball written to /tmp/zulip-export-2026-05-25-10-23-29-onzrelvf.tar.gz`.
- Ran `./manage.py export -r zulip --output /tmp/my-export` and got `Tarball written to /tmp/my-export.tar.gz`
- Ran `./manage.py export -r zulip --upload` and got `Uploaded to http://zulip.shubham-padia.zulipdev.org:9991/user_avatars/exports/2/p_VOYCSa6iC1Ks-_D2KLyQ3h/zulip-export-2026-05-25-10-25-55-n4dih890.tar.gz`

Ran

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
