### PR TITLE
puppeteer: Wait for password strength checker before submitting.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -77,6 +77,12 @@ async function test_change_password(page: Page): Promise<void> {
     await page.type("#old_password", test_credentials.default_user.password);
     test_credentials.default_user.password = "new_password";
     await page.type("#new_password", test_credentials.default_user.password);
+
+    // The password strength checker (zxcvbn) is imported asynchronously,
+    // and submitting before it loads makes the handler bail out with an
+    // internal error, leaving the modal open. The strength bar is hidden
+    // until the module finishes loading, so wait for it to become visible.
+    await page.waitForSelector("#pw_strength .bar", {visible: true});
     await page.click(change_password_button_selector);
 
     // On success the change password modal gets closed.


### PR DESCRIPTION
`test_change_password` could flake with a 30s timeout in `wait_for_micromodal_to_close`, because the change-password modal never closed.

The submit handler `do_change_password` requires the password strength checker (zxcvbn, in `password_quality.ts`) to be loaded; it is imported asynchronously when the modal opens. If the test types the passwords and clicks "Change" before that import resolves, the handler bails out early with an internal error and leaves the modal open, so the subsequent `wait_for_micromodal_to_close` times out. This raced rarely on developer machines but showed up under CI load.

Wait for the password strength bar to drop its `hide` class, which happens exactly when the module finishes loading, before clicking submit.

---

Fed claude the following CI flake:
```log
  webpack:///src/blueslip.ts:33:20: debug: open modal: dialog_widget_modal_1
  http://zulip.zulipdev.com:9981/#settings/account-and-privacy: verbose: [DOM] Password forms should have (optionally hidden) username fields for accessibility: (More info: https://goo.gl/9p2vKq) %o
  2026-05-25 11:49:02.375 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:04.747 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:06.755 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:09.133 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:11.156 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:13.569 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:15.739 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:17.793 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:19.705 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:21.888 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:23.915 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:25.779 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:27.661 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:29.744 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  2026-05-25 11:49:31.464 INFO [:9983] Client disconnected for queue a9522563-276b-476f-aa1e-96da7f0d54d7 (9 via website)
  file:///__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@24.43.1/node_modules/puppeteer-core/lib/esm/puppeteer/common/WaitTask.js:46
              this.#timeoutError = new TimeoutError(`Waiting failed: ${options.timeout}ms exceeded`);
                                   ^

  TimeoutError: Waiting failed: 30000ms exceeded
      at new WaitTask (file:///__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@24.43.1/node_modules/puppeteer-core/lib/esm/puppeteer/common/WaitTask.js:46:34)
      at IsolatedWorld.waitForFunction (file:///__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@24.43.1/node_modules/puppeteer-core/lib/esm/puppeteer/api/Realm.js:49:26)
      at CdpFrame.waitForFunction (file:///__npm/puppeteer-core@24.43.1/node_modules/puppeteer-core/lib/esm/puppeteer/api/Frame.js:580:43)
      at CdpFrame.<anonymous> (file:///__w/zupuppeteer-core@24.43.1/node_modules/puppeteer-core/lib/esm/puppeteer/util/decorators.js:101:27)
      at CdpPage.waitForFunction (file:///__wpm/puppeteer-core@24.43.1/node_modules/puppeteer-core/lib/esm/puppeteer/api/Page.js:1447:37)
      at Module.wait_for_micromodal_to_close e2e-tests/lib/common.ts:621:16)
      at test_change_password (file:///__w/zulip/zulip/web/e2e-tests/settings.test.ts:83:18)
      at async settings_tests (file:///__w/zungs.test.ts:519:5)
      at async Module.run_test (file:///__w/zulip/zulip/web/e2e-tests/lib/common.ts:713:9)
      at async file:///__w/zulip/zulip/web/e21
```