### PR TITLE
webhooks/grafana: Validate webhook payload structure before processing.

### DIFF
--- a/zerver/webhooks/grafana/fixtures/alert_test_anomalous_notification.json
+++ b/zerver/webhooks/grafana/fixtures/alert_test_anomalous_notification.json
@@ -1,0 +1,3 @@
+{
+    "text": "🚨 TestAlert - Notification test"
+}

--- a/zerver/webhooks/grafana/fixtures/alert_v8_missing_field.json
+++ b/zerver/webhooks/grafana/fixtures/alert_v8_missing_field.json
@@ -1,0 +1,25 @@
+{
+  "receiver": "webhook",
+  "status": "firing",
+  "alerts": [
+    {
+      "labels": {
+        "alertname": "TestAlert",
+        "instance": "Grafana",
+        "_dummy": ""
+      },
+      "annotations": {
+        "summary": "Notification test",
+        "_dummy": ""
+      },
+      "startsAt": "2026-05-27 15:36:00.112013015 +0000 UTC m=+8560.285724134",
+      "endsAt": "0001-01-01 00:00:00 +0000 UTC",
+      "generatorURL": "",
+      "fingerprint": "57c6d9296de2ad39",
+      "silenceURL": "https://grafana-alertmanager-prod-ap-south-1.grafana.net/alertmanager/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DTestAlert&matcher=instance%3DGrafana",
+      "dashboardURL": "",
+      "panelURL": "",
+      "valueString": "[ metric='foo' labels={instance=bar} value=10 ]"
+    }
+  ]
+}

--- a/zerver/webhooks/grafana/tests.py
+++ b/zerver/webhooks/grafana/tests.py
@@ -296,3 +296,26 @@ Annotations:
             expected_message,
             content_type="application/x-www-form-urlencoded",
         )
+
+    def test_anomalous_webhook_payload_test_notification(self) -> None:
+        with self.assertRaises(AssertionError) as e:
+            self.check_webhook(
+                fixture_name="alert_test_anomalous_notification",
+                expected_topic_name="",
+                expected_message="",
+                expect_noop=True,
+            )
+
+        self.assertIn(
+            "Unable to parse request: Did Grafana generate this event?",
+            e.exception.args[0],
+        )
+
+    def test_unsupported_webhook_payload_v8_missing_field(self) -> None:
+        self.check_webhook(
+            fixture_name="alert_v8_missing_field",
+            expected_topic_name="",
+            expected_message="",
+            expect_noop=True,
+            content_type="application/json",
+        )

--- a/zerver/webhooks/grafana/tests.py
+++ b/zerver/webhooks/grafana/tests.py
@@ -296,3 +296,17 @@ Annotations:
             expected_message,
             content_type="application/x-www-form-urlencoded",
         )
+
+    def test_anomalous_webhook_payload_test_notification(self) -> None:
+        with self.assertRaises(AssertionError) as e:
+            self.check_webhook(
+                fixture_name="alert_test_anomalous_notification",
+                expected_topic_name="",
+                expected_message="",
+                expect_noop=True,
+            )
+
+        self.assertIn(
+            "Unable to parse request: Did Grafana generate this event?",
+            e.exception.args[0],
+        )

--- a/zerver/webhooks/grafana/view.py
+++ b/zerver/webhooks/grafana/view.py
@@ -3,11 +3,14 @@ from datetime import datetime
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import AnomalousWebhookPayloadError, UnsupportedWebhookEventTypeError
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_global_time
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
 from zerver.lib.validator import (
     WildValue,
+    WildValueDict,
+    WildValueList,
     check_anything,
     check_float,
     check_int,
@@ -70,7 +73,20 @@ def api_grafana_webhook(
         # - https://grafana.com/docs/grafana/v9.0/alerting/contact-points/notifiers/webhook-notifier/
         # - https://grafana.com/docs/grafana/v10.0/alerting/alerting-rules/manage-contact-points/webhook-notifier/
         # - https://grafana.com/docs/grafana/v11.0/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/
+
+        # Verify that alerts is a list
+        if not isinstance(payload["alerts"], WildValueList):  # nocoverage
+            raise UnsupportedWebhookEventTypeError("unknown_event")
+
         for alert in payload["alerts"]:
+            if not (
+                isinstance(alert, WildValueDict)
+                and all(
+                    key in alert
+                    for key in ("status", "labels", "fingerprint", "startsAt", "endsAt")
+                )
+            ):
+                raise UnsupportedWebhookEventTypeError("unknown_event")
             status = alert["status"].tame(check_string_in(["firing", "resolved"]))
             if status == "firing":
                 body = ALERT_STATUS_TEMPLATE.format(
@@ -147,7 +163,7 @@ def api_grafana_webhook(
 
         return json_success(request)
 
-    else:
+    elif all(key in payload for key in ("title", "state", "ruleName", "ruleUrl")):
         # Grafana 7.0 alerts:
         # https://grafana.com/docs/grafana/v7.0/alerting/notifications/#webhook
         topic_name = OLD_TOPIC_TEMPLATE.format(alert_title=payload["title"].tame(check_string))
@@ -199,3 +215,6 @@ def api_grafana_webhook(
         check_send_webhook_message(request, user_profile, topic_name, body, state)
 
         return json_success(request)
+
+    else:
+        raise AnomalousWebhookPayloadError

--- a/zerver/webhooks/grafana/view.py
+++ b/zerver/webhooks/grafana/view.py
@@ -147,55 +147,47 @@ def api_grafana_webhook(
 
         return json_success(request)
 
+    # Grafana 7.0 alerts:
+    # https://grafana.com/docs/grafana/v7.0/alerting/notifications/#webhook
+    topic_name = OLD_TOPIC_TEMPLATE.format(alert_title=payload["title"].tame(check_string))
+
+    eval_matches_text = ""
+    if "evalMatches" in payload and payload["evalMatches"] is not None:
+        for match in payload["evalMatches"]:
+            eval_matches_text += "**{}:** {}\n".format(
+                match["metric"].tame(check_string),
+                match["value"].tame(check_none_or(check_union([check_int, check_float]))),
+            )
+
+    message_text = ""
+    if "message" in payload:
+        message_text = payload["message"].tame(check_string) + "\n\n"
+
+    state = payload["state"].tame(
+        check_string_in(["no_data", "paused", "alerting", "ok", "pending", "unknown"])
+    )
+    if state == "alerting":
+        alert_status = ALERT_STATUS_TEMPLATE.format(alert_icon=":alert:", alert_state=state.upper())
+    elif state == "ok":
+        alert_status = ALERT_STATUS_TEMPLATE.format(
+            alert_icon=":squared_ok:", alert_state=state.upper()
+        )
     else:
-        # Grafana 7.0 alerts:
-        # https://grafana.com/docs/grafana/v7.0/alerting/notifications/#webhook
-        topic_name = OLD_TOPIC_TEMPLATE.format(alert_title=payload["title"].tame(check_string))
+        alert_status = ALERT_STATUS_TEMPLATE.format(alert_icon=":info:", alert_state=state.upper())
 
-        eval_matches_text = ""
-        if "evalMatches" in payload and payload["evalMatches"] is not None:
-            for match in payload["evalMatches"]:
-                eval_matches_text += "**{}:** {}\n".format(
-                    match["metric"].tame(check_string),
-                    match["value"].tame(check_none_or(check_union([check_int, check_float]))),
-                )
+    body = OLD_MESSAGE_TEMPLATE.format(
+        alert_message=message_text,
+        alert_status=alert_status,
+        rule_name=payload["ruleName"].tame(check_string),
+        rule_url=payload["ruleUrl"].tame(check_string),
+        eval_matches=eval_matches_text,
+    )
 
-        message_text = ""
-        if "message" in payload:
-            message_text = payload["message"].tame(check_string) + "\n\n"
-
-        state = payload["state"].tame(
-            check_string_in(["no_data", "paused", "alerting", "ok", "pending", "unknown"])
-        )
-        if state == "alerting":
-            alert_status = ALERT_STATUS_TEMPLATE.format(
-                alert_icon=":alert:", alert_state=state.upper()
-            )
-        elif state == "ok":
-            alert_status = ALERT_STATUS_TEMPLATE.format(
-                alert_icon=":squared_ok:", alert_state=state.upper()
-            )
-        else:
-            alert_status = ALERT_STATUS_TEMPLATE.format(
-                alert_icon=":info:", alert_state=state.upper()
-            )
-
-        body = OLD_MESSAGE_TEMPLATE.format(
-            alert_message=message_text,
-            alert_status=alert_status,
-            rule_name=payload["ruleName"].tame(check_string),
-            rule_url=payload["ruleUrl"].tame(check_string),
-            eval_matches=eval_matches_text,
+    if "imageUrl" in payload:
+        body += "\n[Click to view visualization]({visualization})".format(
+            visualization=payload["imageUrl"].tame(check_string)
         )
 
-        if "imageUrl" in payload:
-            body += "\n[Click to view visualization]({visualization})".format(
-                visualization=payload["imageUrl"].tame(check_string)
-            )
-
-        body = body.strip()
-
-        # send the message
-        check_send_webhook_message(request, user_profile, topic_name, body, state)
-
-        return json_success(request)
+    body = body.strip()
+    check_send_webhook_message(request, user_profile, topic_name, body, state)
+    return json_success(request)

--- a/zerver/webhooks/grafana/view.py
+++ b/zerver/webhooks/grafana/view.py
@@ -1,8 +1,11 @@
+from dataclasses import dataclass
 from datetime import datetime
 
+from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import webhook_view
+from zerver.lib.exceptions import AnomalousWebhookPayloadError
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_global_time
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
@@ -53,6 +56,29 @@ ALL_EVENT_TYPES = LEGACY_EVENT_TYPES + NEW_EVENT_TYPES
 def get_global_time(dt_str: str) -> str:
     dt = datetime.fromisoformat(dt_str)
     return datetime_to_global_time(dt)
+
+
+# The fields that this webhook needs from a Grafana 7.0 alert payload.
+@dataclass
+class GrafanaLegacyAlert:
+    title: str
+    state: str
+    rule_name: str
+    rule_url: str
+
+
+def parse_legacy_alert(payload: WildValue) -> GrafanaLegacyAlert:
+    """Parses the fields that this webhook needs from a Grafana 7.0
+    alert payload, raising ValidationError if any is missing or is
+    not the type that we expect.
+    """
+    title = payload["title"].tame(check_string)
+    state = payload["state"].tame(
+        check_string_in(["no_data", "paused", "alerting", "ok", "pending", "unknown"])
+    )
+    rule_name = payload["ruleName"].tame(check_string)
+    rule_url = payload["ruleUrl"].tame(check_string)
+    return GrafanaLegacyAlert(title, state, rule_name, rule_url)
 
 
 @webhook_view("Grafana", all_event_types=ALL_EVENT_TYPES)
@@ -147,9 +173,16 @@ def api_grafana_webhook(
 
         return json_success(request)
 
-    # Grafana 7.0 alerts:
-    # https://grafana.com/docs/grafana/v7.0/alerting/notifications/#webhook
-    topic_name = OLD_TOPIC_TEMPLATE.format(alert_title=payload["title"].tame(check_string))
+    try:
+        # Grafana 7.0 alerts:
+        # https://grafana.com/docs/grafana/v7.0/alerting/notifications/#webhook
+        legacy_alert = parse_legacy_alert(payload)
+    except ValidationError:
+        # The payload did not include the expected fields for either
+        # current or legacy Grafana webhooks.
+        raise AnomalousWebhookPayloadError
+
+    topic_name = OLD_TOPIC_TEMPLATE.format(alert_title=legacy_alert.title)
 
     eval_matches_text = ""
     if "evalMatches" in payload and payload["evalMatches"] is not None:
@@ -163,9 +196,7 @@ def api_grafana_webhook(
     if "message" in payload:
         message_text = payload["message"].tame(check_string) + "\n\n"
 
-    state = payload["state"].tame(
-        check_string_in(["no_data", "paused", "alerting", "ok", "pending", "unknown"])
-    )
+    state = legacy_alert.state
     if state == "alerting":
         alert_status = ALERT_STATUS_TEMPLATE.format(alert_icon=":alert:", alert_state=state.upper())
     elif state == "ok":
@@ -178,8 +209,8 @@ def api_grafana_webhook(
     body = OLD_MESSAGE_TEMPLATE.format(
         alert_message=message_text,
         alert_status=alert_status,
-        rule_name=payload["ruleName"].tame(check_string),
-        rule_url=payload["ruleUrl"].tame(check_string),
+        rule_name=legacy_alert.rule_name,
+        rule_url=legacy_alert.rule_url,
         eval_matches=eval_matches_text,
     )
 


### PR DESCRIPTION
 Currently if the payload doesn't contain `alerts`, we directly try the v7 codepath without checking whether the payload contains the fields required for v7 processing. Also, in v8 we were directly processing the payload without validating its structure first.

<!-- Describe your pull request here.-->
This PR adds validation for Grafana v7 required fields before processing and verify Grafana v8 alert payload structure to reject malformed webhook requests with AnomalousWebhookPayloadError instead of allowing unexpected failures.

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Grafana.20500.20errors.2E/with/2465035)[#integrations > Grafana 500 errors.](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Grafana.20500.20errors.2E/with/2465035)

**How changes were tested:**
Added new tests and tested with `./tools/test-backend zerver/webhooks/grafana` All tests are passing
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
I have added two new fixtures
`zerver/webhooks/grafana/fixtures/alert_test_anomalous_notification.json` This is taken from the issue itself mentioned by @amanagr 
`zerver/webhooks/grafana/fixtures/alert_v8_missing_field.json` Captured by custom template with `status` field missing

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
