### PR TITLE
api docs: Document POST and DELETE /users/me/avatar.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -552,6 +552,10 @@ element to plain escaped text.
 * [`PATCH /messages/{message_id}`](/api/update-message): The `create_time` and
   `date_sent` fields in `detached_uploads` object will now return UNIX timestamps
   in seconds. Previously, these values were returned in milliseconds.
+* [`DELETE /users/me/avatar`](/api/delete-avatar): This endpoint is now
+  idempotent. Previously, calling it when the current user had not
+  uploaded a custom profile picture would still increment their avatar
+  version and send a redundant user update event to clients.
 
 **Feature level 442**
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -98,6 +98,8 @@
 * [Update user status](/api/update-status-for-user)
 * [Update your profile data](/api/update-profile-data)
 * [Remove your profile data](/api/remove-profile-data)
+* [Upload your profile picture](/api/upload-avatar)
+* [Delete your profile picture](/api/delete-avatar)
 * [Set "typing" status](/api/set-typing-status)
 * [Set "typing" status for message editing](/api/set-typing-status-for-message-edit)
 * [Get a user's presence](/api/get-user-presence)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -16064,7 +16064,169 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SuccessIgnoredParameters"
+  /users/me/avatar:
+    post:
+      operationId: upload-avatar
+      summary: Upload your profile picture
+      tags: ["users"]
+      description: |
+        Upload a new [profile picture](/help/change-your-profile-picture)
+        for the current user.
 
+        The maximum allowed file size is available in the `max_avatar_file_size_mib`
+        field in the [`POST /register`](/api/register-queue) response.
+
+        In organizations that
+        [restrict profile picture changes](/help/restrict-profile-picture-changes),
+        only administrators can use this endpoint.
+      x-parameter-description: |
+        The profile picture image file must be provided in the request's body
+        as multipart form data.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  example: "zerver/tests/images/img.png"
+              required:
+                - file
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      avatar_url:
+                        type: string
+                        description: |
+                          The URL of the current user's new profile picture.
+                example:
+                  {
+                    "avatar_url": "/user_avatars/2/c4ce28dde2d44a08b2a72cb371fe78d99cffd7c4.png",
+                    "msg": "",
+                    "result": "success",
+                  }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the request did not include
+                          exactly one file:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "You must upload exactly one avatar.",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file exceeds the
+                          maximum allowed size:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Uploaded file is larger than the allowed limit of 5 MiB",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file
+                          is not a supported image format:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Invalid image format",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when a non-administrator attempts
+                          to change their profile picture in an organization that has
+                          disabled profile picture changes:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Avatar changes are disabled in this organization.",
+                            "result": "error",
+                          }
+    delete:
+      operationId: delete-avatar
+      summary: Delete your profile picture
+      tags: ["users"]
+      description: |
+        Delete the current user's uploaded [profile picture](/help/change-your-profile-picture),
+        reverting to the organization's
+        [default style for profile pictures](/help/configure-default-profile-pictures).
+
+        This endpoint is idempotent: if the current user has not uploaded a
+        custom profile picture, the request succeeds without making any
+        changes.
+
+        In organizations that
+        [restrict profile picture changes](/help/restrict-profile-picture-changes),
+        only administrators can use this endpoint.
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      avatar_url:
+                        type: string
+                        description: |
+                          The URL of the current user's profile picture, which
+                          now uses the organization's default style for profile
+                          pictures. Its format depends on whether that style is
+                          the default abstract design or Gravatar.
+                example:
+                  {
+                    "avatar_url": "/user_avatars/2/3a7bd3e2360a3d29eea436fcfb7e44c735d117c4.png",
+                    "msg": "",
+                    "result": "success",
+                  }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - description: |
+                      An example JSON response for when a non-administrator attempts
+                      to change their profile picture in an organization that has
+                      disabled profile picture changes:
+                    example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "Avatar changes are disabled in this organization.",
+                        "result": "error",
+                      }
   /users/me/subscriptions/properties:
     post:
       operationId: update-subscription-settings

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -16185,6 +16185,12 @@ paths:
         In organizations that
         [restrict profile picture changes](/help/restrict-profile-picture-changes),
         only administrators can use this endpoint.
+
+        **Changes**: Prior to Zulip 12.0 (feature level 443), this endpoint
+        was not idempotent; calling it when the current user had not
+        uploaded a custom profile picture would still increment their
+        avatar version and send a redundant user update event to
+        clients.
       responses:
         "200":
           description: Success.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -222,8 +222,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/default_stream_groups/create",
         "/default_stream_groups/{group_id}",
         "/default_stream_groups/{group_id}/streams",
-        #### These personal settings endpoints have modest value to document:
-        "/users/me/avatar",
         #### Should be documented as part of interactive bots documentation
         "/submessage",
         "/zcommand",


### PR DESCRIPTION
Continues #38510 by @mostafabahaa25, the original commit's content is preserved via `Co-authored-by`.

Fixes: documents two endpoints from the `pending_endpoints` set in `zerver/tests/test_openapi.py`.

Documents `POST` and `DELETE /users/me/avatar` with their schemas, success responses, 400 error variants, and sidebar links. Curl examples only. the Python example will be a small follow-up PR.

**How changes were tested:**

- [x] `./tools/test-api`
- [x] `./tools/test-backend zerver.tests.test_openapi zerver.tests.test_upload.AvatarTest`
- [x] Manual rendered-doc check at `/api/upload-avatar` and `/api/delete-avatar`

<details>
<summary> Screenshots: </summary>

**api/changelog.md**:
<img width="2014" height="602" alt="changelog-fl443" src="https://github.com/user-attachments/assets/afb036f6-34a6-45ec-b1c6-8730c6cf7594" />


**Sidebar:**
<img width="351" height="167" alt="image" src="https://github.com/user-attachments/assets/f06ec579-c8ab-45f0-8564-ec04f17f4976" />
**`/api/upload-avatar`:**
<img width="1958" height="2916" alt="delete-avatar" src="https://github.com/user-attachments/assets/256f6185-652c-4269-aadf-1bd4fa69d9fa" />

**`/api/delete-avatar`:**
<img width="1958" height="2916" alt="delete-avatar" src="https://github.com/user-attachments/assets/feefe2f1-9366-444c-9453-0cf21881d4d3" />

</details>


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
