### PR TITLE
left_sidebar: Add search-topics button to expanded channel row.

### DIFF
--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -139,7 +139,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: ".stream-list-section-container .add-stream-tooltip, .left-sidebar-controls .channel-new-topic-button",
+        target: ".stream-list-section-container .add-stream-tooltip, .left-sidebar-controls .channel-new-topic-button, .left-sidebar-controls .channel-search-topics-button",
         appendTo: () => document.body,
     });
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1339,6 +1339,16 @@ export function initialize({
         }
     });
 
+    $("#stream_filters").on("click", ".channel-search-topics-button", (e) => {
+        on_show_more_topics(e);
+    });
+
+    $("#stream_filters").on("keydown", ".channel-search-topics-button", (e) => {
+        if (keydown_util.is_enter_event(e)) {
+            on_show_more_topics(e);
+        }
+    });
+
     $("body").on("click", ".zoom-in-topics .left-sidebar-modal-close-area", (e) => {
         zoom_out();
         browser_history.update_current_history_state_data({show_more_topics: false});

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -209,7 +209,8 @@
     }
 
     .stream-expanded {
-        .channel-new-topic-button {
+        .channel-new-topic-button,
+        .channel-search-topics-button {
             display: flex;
         }
 
@@ -1973,6 +1974,7 @@ li.active-sub-filter {
     /* We won't know in advance how many controls a given
        row has, but this allows grid to generate as many
        as needed, sized to a shared icon width. */
+    grid-auto-flow: column;
     grid-auto-columns: var(--left-sidebar-header-icon-width);
     grid-template-rows: var(--line-height-sidebar-row-prominent);
     place-content: stretch stretch;
@@ -2075,7 +2077,8 @@ li.active-sub-filter {
     }
 }
 
-.channel-new-topic-button {
+.channel-new-topic-button,
+.channel-search-topics-button {
     /* display: flex; is set on visible channels and
        channel-row hovers. */
     display: none;

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -10,6 +10,9 @@
             <span class="stream-name">{{name}}</span>
 
             <div class="left-sidebar-controls">
+                <div class="channel-search-topics-button" tabindex="0" data-tippy-content="{{t 'Search topics' }}" data-stream-id="{{id}}">
+                    <i class="zulip-icon zulip-icon-search" aria-hidden="true"></i>
+                </div>
                 {{#if can_post_messages}}
                 <div class="channel-new-topic-button hidden-for-spectators auto-hide-left-sidebar-overlay" tabindex="0"  data-tippy-content="{{#if (or is_empty_topic_only_channel cannot_create_topics_in_channel)}}{{t 'New message'}}{{else}}{{t 'Start a new topic'}}{{/if}}" data-stream-id="{{id}}">
                     <i class="channel-new-topic-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>


### PR DESCRIPTION
Filtering across all of a channel's topics (rather than just the cached ones) requires clicking "Show all topics," which is not discoverable. This adds a search icon in the expanded channel's row, to the left of the "+ new topic" button, that opens the "show all topics" view with the filter input focused — giving users a clear visual affordance for searching topics within a channel.

The icon only appears on the expanded channel row, mirroring the zoom-in mechanism, which only operates on the active channel. The grid container for the left-sidebar controls now flows in columns so multiple icons sit side-by-side rather than stacking.

Discussion:
https://chat.zulip.org/#narrow/channel/101-design/topic/Filter.20topics.20within.20channel.20button/with/2369643

<img height="600" alt="Kapture 2026-05-25 at 16 45 58" src="https://github.com/user-attachments/assets/081a6797-b543-4aa7-be84-bcc130dbe9af" />
