### PR TITLE
[ai] hooks: Make deploy notifications best-effort.

### DIFF
--- a/puppet/zulip/files/hooks/common/zulip_notify.sh
+++ b/puppet/zulip/files/hooks/common/zulip_notify.sh
@@ -29,12 +29,18 @@ deploy_environment=$(crudini --get /etc/zulip/zulip.conf machine deploy_type || 
 # shellcheck disable=SC2034
 commit_count=$(git rev-list "${from}..${to}" | wc -l)
 
+# Sending the notification is best-effort: a failure to deliver it
+# (e.g. the bot lacks posting permission, or the server is
+# unreachable) must never abort a deploy, so we swallow the error
+# after logging it.
 zulip_send() {
-    uv run --no-sync zulip-send \
+    if ! uv run --no-sync zulip-send \
         --site "$zulip_notify_server" \
         --user "$zulip_notify_bot_email" \
         --api-key "$zulip_api_key" \
         --stream "$zulip_notify_stream" \
         --subject "$deploy_environment deploy" \
-        --message "$1"
+        --message "$1"; then
+        echo "zulip_notify: Failed to send deploy notification; continuing anyway."
+    fi
 }


### PR DESCRIPTION
The pre-deploy zulip_notify hook posts an informational "Starting deploy" message; combined with `set -e`, a failure to deliver it (e.g. the bot lacks posting permission on the target channel, or the server is unreachable) propagated out of the hook, and run_hooks.py treats any pre-deploy hook failure as fatal. A transient chat-notification problem could thus block an urgent deploy.

Swallow delivery failures in the shared zulip_send helper after logging them, so neither the pre- nor post-deploy notification can abort a deploy. The post-deploy hooks were already best-effort; this brings the gating pre-deploy notification in line.
