### PR TITLE
slack: Add "video" to unhandled block types.

### DIFF
--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -281,6 +281,7 @@ def render_block(block: WildValue) -> str:
         "contact_card",
         "file",
         "table",
+        "video",
         # The "actions" block is used to format literal in-message clickable
         # buttons and similar elements, which Zulip currently doesn't support.
         # https://docs.slack.dev/reference/block-kit/blocks/actions-block


### PR DESCRIPTION
Same kind of change as 720b581712 - without this, the import crashes when it encounters a "video" block.
