### PR TITLE
portico: Redesign realm redirect URL input as grouped input.

### DIFF
--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -20,11 +20,13 @@
                     <div class="input-box horizontal">
                         <div class="inline-block relative">
                             <p id="realm_redirect_description">{{ _("Organization URL") }}</p>
-                            <input
-                              type="text" value="{% if form.subdomain.value() %}{{ form.subdomain.value() }}{% endif %}"
-                              placeholder="{{ _('your-organization') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
-                              autocomplete="off"/>
-                            <span id="realm_redirect_external_host">.{{external_host}}</span>
+                            <div class="realm-url-input-group">
+                                <input
+                                  type="text" value="{% if form.subdomain.value() %}{{ form.subdomain.value() }}{% endif %}"
+                                  placeholder="{{ _('your-organization') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
+                                  autocomplete="off"/>
+                                <span id="realm_redirect_external_host">.{{external_host}}</span>
+                            </div>
                         </div>
                         <div id="errors">
                             {% if form.subdomain.errors %}

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -152,6 +152,7 @@ html {
             text-align: center;
 
             .inline-block {
+                width: 100%;
                 text-align: center;
             }
         }
@@ -1358,24 +1359,42 @@ button#register_auth_button_gitlab {
 
 .goto-account-page {
     #realm_redirect_subdomain {
-        text-align: right;
+        text-align: left;
         position: relative;
-        padding-right: 10px;
+        border: none;
+        margin: 0; /* override the 25px 0 5px margin from .input-box */
+        width: auto;
     }
 
     #realm_redirect_external_host {
-        font-size: 20px;
-        top: 13px;
-        left: 5px;
+        font-size: 16px;
         position: relative;
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+        background-color: hsl(0deg 0% 96%);
+        border-left: 1px solid hsl(0deg 0% 87%);
+        color: hsl(0deg 0% 33%);
     }
 
     #realm_redirect_description {
-        top: 15px;
         position: relative;
         text-align: left;
         font-weight: 600;
-        margin-bottom: -5px;
+        margin-bottom: 5px;
+    }
+
+    .realm-url-input-group {
+        position: relative;
+        display: flex;
+        border: 1px solid hsl(0deg 0% 87%);
+        border-radius: 4px;
+        overflow: hidden;
+        transition: border-color 0.3s ease;
+
+        &:focus-within {
+            border-color: var(--color-border-legacy-input-focus);
+        }
     }
 
     #enter-realm-button {
@@ -1578,6 +1597,16 @@ button#register_auth_button_gitlab {
         #registration {
             padding: 0;
         }
+    }
+
+    .realm-url-input-group {
+        flex-direction: column;
+    }
+
+    #realm_redirect_external_host {
+        border-left: none !important;
+        border-top: 1px solid hsl(0deg 0% 87%);
+        padding: 8px 12px !important;
     }
 }
 


### PR DESCRIPTION
Combine the subdomain input and external host into a single unified input group on the organization login page. this change improves the space between elements and user interface.

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/Org.20login.20page/with/2467859)[#issues > Org login page](https://chat.zulip.org/#narrow/channel/9-issues/topic/Org.20login.20page/with/2467859)

**How changes were tested:**
- [x] UI testing.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before (desktop) | After (desktop) |
|--|--|
|<img width="810" height="613" alt="before_preview_1" src="https://github.com/user-attachments/assets/0fdad179-a371-4883-b70f-1ed147f5bee7" />|<img width="806" height="613" alt="Preview_2" src="https://github.com/user-attachments/assets/daf60640-6110-42ca-ada9-d6d6e0b980eb" />|

<br/>

| Before (mobile) | After (mobile) |
|--|--|
|<img width="572" height="646" alt="before_preview_2" src="https://github.com/user-attachments/assets/21a021ec-2d3d-46ea-9c12-7bce9adcccc4" />|<img width="567" height="578" alt="Preview_4" src="https://github.com/user-attachments/assets/fb02a922-621e-42b8-8281-9b6b4febcde5" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
