### PR TITLE
video-calls: Fix parsing of JITSI_SERVER_URL.

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -5,7 +5,7 @@ import sys
 import time
 from copy import deepcopy
 from typing import Any, Final, Literal
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 from scripts.lib.zulip_tools import get_tornado_ports
 from zerver.lib.db import TimeTrackingConnection, TimeTrackingCursor
@@ -43,6 +43,7 @@ from .configured_settings import (
     EXTRA_INSTALLED_APPS,
     GOOGLE_OAUTH2_CLIENT_ID,
     IS_DEV_DROPLET,
+    JITSI_SERVER_URL,
     LOCAL_UPLOADS_DIR,
     MEMCACHED_LOCATION,
     MEMCACHED_USERNAME,
@@ -526,6 +527,23 @@ if LOCAL_UPLOADS_DIR is None and S3_REGION is None:
     S3_REGION = boto3.client("s3").meta.region_name
 
 DROPBOX_APP_KEY = get_secret("dropbox_app_key")
+
+# Parse JITSI_SERVER_URL string and if no URL scheme is present,
+# default to "https".
+if JITSI_SERVER_URL is not None:
+    split_url = urlsplit(JITSI_SERVER_URL)
+    if split_url.scheme == "":
+        if split_url.netloc == "":
+            # Parsing the URL returned no scheme or netloc,
+            # e.g., "jitsi.example.com", so prepend the
+            # default "https" scheme along with the "://"
+            # character pattern.
+            JITSI_SERVER_URL = f"https://{JITSI_SERVER_URL}"
+        else:
+            # Parsing the URL did return a netloc, e.g.,
+            # "example.com/jitsi", so replace the empty
+            # scheme with "https" and unsplit the URL.
+            JITSI_SERVER_URL = split_url._replace(scheme="https").geturl()
 
 BIG_BLUE_BUTTON_SECRET = get_secret("big_blue_button_secret")
 


### PR DESCRIPTION
Bare hostnames used to be supported for `JITSI_SERVER_URL`, e.g., "jitsi.example.com". In `computed_settings.py`, if `JITSI_SERVER_URL` is not `None`, we parse the string and set "https" as the default scheme if it isn't present.

Fixes #39230.

**Notes**:
- After parsing the `JITSI_SERVER_URL`, if there is no `scheme` and no `netloc`, then we prepend "https://" to `JITSI_SERVER_URL`. An example of this is a string like "jitis.example.com", which is all parsed as `path` in `urlsplit`.
  - `urllib.urlsplit` doc: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit
- After parting the `JITSI_SERVER_URL`, if there is no `scheme`, but there is a value for `netloc`, then we use `_replace` to add the "https" `scheme` and get the URL from the split URL components. An example of this is a string like "example.com/jitsi", which has `example.com` as the `neloc` and `/jitsi` as the `path`.
- These changes dosn't address this https://github.com/zulip/zulip/pull/37829#issuecomment-4350953272.

---

**Screenshots and screen captures:**

*`JITSI_SERVER_URL = "jitsi.example.com"`*:

| Before | After | After compose |
| --- | --- | --- |
| <img width="988" height="322" alt="Screenshot From 2026-05-27 18-11-18" src="https://github.com/user-attachments/assets/4d0a34c7-d4c4-4a05-bedf-81db9a72b3ae" /> | <img width="846" height="388" alt="Screenshot From 2026-05-27 18-10-50" src="https://github.com/user-attachments/assets/a3f30f4d-6edd-44eb-8c7a-a9e866c185da" /> | <img width="1406" height="282" alt="Screenshot From 2026-05-27 18-13-02" src="https://github.com/user-attachments/assets/2760c725-813e-4b5a-b348-fb3d63bab729" />


*`JITSI_SERVER_URL = "example.com/jitsi"`*:

| Before | After | After compose |
| --- | --- | --- |
| <img width="988" height="322" alt="Screenshot From 2026-05-27 18-11-46" src="https://github.com/user-attachments/assets/6ddc783f-4aec-455d-a93f-e6f9e2d53191" /> | <img width="846" height="388" alt="Screenshot From 2026-05-27 18-09-19" src="https://github.com/user-attachments/assets/af410981-9dd7-461b-bf9a-534e99be9c06" /> | <img width="1406" height="282" alt="Screenshot From 2026-05-27 18-13-24" src="https://github.com/user-attachments/assets/2ba3ed73-c031-44b9-bc29-24a8810bed04" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
