### PR TITLE
jira: Preserve formatting inside code blocks

### DIFF
--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from zerver.actions.custom_profile_fields import try_add_realm_default_custom_profile_field
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.models.realms import get_realm
+from zerver.webhooks.jira.view import convert_jira_markup
 
 
 class JiraHookTests(WebhookTestCase):
@@ -164,3 +165,11 @@ Leonardo Franchi [Administrator] created [TEST-4: Test Created Assignee](https:/
         expected_topic_name = "SP-1: Add support for newer format Jira issue comment events"
         expected_message = f"""@_**{hamlet.full_name}|{hamlet.id}** commented on [SP-1: Add support for newer format Jira issue comment events](https://f20171170.atlassian.net/browse/SP-1)\n``` quote\nThis is a comment that likes to **exercise** a lot of _different_ `conventions` that `jira uses`.\r\n\r\n~~~\n\r\nthis code is not highlighted, but monospaced\r\n\n~~~\r\n\r\n~~~\n\r\ndef python():\r\n    print "likes to be formatted"\r\n\n~~~\r\n\r\n[http://www.google.com](http://www.google.com) is a bare link, and [Google](http://www.google.com) is given a title.\r\n\r\nThanks!\r\n\r\n~~~ quote\n\r\nSomeone said somewhere\r\n\n~~~!\n**Niloth**\n@_**{hamlet.full_name}|{hamlet.id}**\n```"""
         self.check_webhook("comment_created", expected_topic_name, expected_message)
+
+    def test_convert_jira_markup_preserves_code_block_content(self) -> None:
+        content = "Here is some sample text.\n{code}\n*not bold*\n{{literal}}\n{code}\nAnd bold *yes*."
+        result = convert_jira_markup(content, self.test_user.realm)
+        self.assertEqual(
+            result,
+            "Here is some sample text.\n~~~\n*not bold*\n{{literal}}\n~~~\nAnd bold **yes**."
+        )

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -54,6 +54,22 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
     # Attempt to do some simplistic conversion of Jira
     # formatting to Markdown, for consumption in Zulip
 
+    # Preserve raw content inside {code} and {noformat} blocks so that
+    # markup such as *bold* or {{monospace}} is not transformed inside
+    # literal code blocks.
+    preserved_blocks: dict[str, str] = {}
+
+    def preserve_raw_block(match: re.Match[str]) -> str:
+        placeholder = f"__JIRA_RAW_BLOCK_{len(preserved_blocks)}__"
+        preserved_blocks[placeholder] = f"~~~\n{match.group(1)}\n~~~"
+        return placeholder
+
+    noformat_re = re.compile(r"{noformat}(.*?){noformat}", re.DOTALL)
+    content = re.sub(noformat_re, preserve_raw_block, content)
+
+    code_re = re.compile(r"{code[^\n]*}(.*?){code}", re.DOTALL)
+    content = re.sub(code_re, preserve_raw_block, content)
+
     # Jira uses *word* for bold, we use **word**
     content = re.sub(r"\*([^\*]+)\*", r"**\1**", content)
 
@@ -66,15 +82,6 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
     # Wrapping a block of code in {quote}stuff{quote} also block-quotes it
     quote_re = re.compile(r"{quote}(.*?){quote}", re.DOTALL)
     content = re.sub(quote_re, r"~~~ quote\n\1\n~~~", content)
-
-    # {noformat}stuff{noformat} blocks are just code blocks with no
-    # syntax highlighting
-    noformat_re = re.compile(r"{noformat}(.*?){noformat}", re.DOTALL)
-    content = re.sub(noformat_re, r"~~~\n\1\n~~~", content)
-
-    # Code blocks are delineated by {code[: lang]} {code}
-    code_re = re.compile(r"{code[^\n]*}(.*?){code}", re.DOTALL)
-    content = re.sub(code_re, r"~~~\n\1\n~~~", content)
 
     # Links are of form: [https://www.google.com] or [Link Title|https://www.google.com]
     # In order to support both forms, we don't match a | in bare links
@@ -97,6 +104,9 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
             replacement = f"**{username}**"
 
         content = content.replace(f"[~{username}]", replacement)
+
+    for placeholder, replacement in preserved_blocks.items():
+        content = content.replace(placeholder, replacement)
 
     return content
 


### PR DESCRIPTION
This PR fixes an issue in Jira markup conversion where inline formatting rules were incorrectly applied inside Jira {code} and {noformat} blocks.

Previously, content such as *not bold* inside Jira code blocks was converted into Markdown bold formatting during webhook processing. The fix preserves literal content inside Jira code/noformat blocks by temporarily extracting these blocks before applying inline formatting conversions and restoring them afterward.

A regression test has also been added to ensure code block contents remain unchanged while normal Jira formatting conversion still works correctly.

**How changes were tested:**

* Ran Jira webhook backend test suite:
  ./tools/test-backend zerver.webhooks.jira.tests.JiraHookTests
* Verified formatting behavior for Jira {code} and {noformat} blocks manually.
