### PR TITLE
message_edit: Show message edit button while saving changes.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -70,7 +70,7 @@ import * as util from "./util.ts";
 export const currently_editing_messages = new Map<number, JQuery<HTMLTextAreaElement>>();
 const resized_edit_box_height = new Map<number, number>();
 let currently_topic_editing_message_ids: number[] = [];
-const currently_echoing_messages = new Map<number, EchoedMessageData>();
+export const currently_echoing_messages = new Map<number, EchoedMessageData>();
 
 type EchoedMessageData = {
     raw_content: string;
@@ -183,9 +183,10 @@ export function is_message_editable_ignoring_permissions(message: Message): bool
     }
 
     // Messages where we're currently locally echoing an edit not yet acknowledged
-    // by the server.
+    // by the server are shown in the message edit box, but with "Save"
+    // disabled.
     if (currently_echoing_messages.has(message.id)) {
-        return false;
+        return true;
     }
     return true;
 }
@@ -409,9 +410,14 @@ function handle_message_edit_enter(
     if (composebox_typeahead.should_enter_send(e)) {
         const $row = $message_edit_content.closest(".message_row");
         const $message_edit_save_button = $row.find(".message_edit_save");
-        if ($message_edit_save_button.prop("disabled")) {
-            // In cases when the save button is disabled
-            // we need to disable save on pressing Enter
+        const $message_edit_save_container = $row.find(".message_edit_save_container");
+        if (
+            $message_edit_save_button.prop("disabled") ||
+            !$message_edit_save_container.hasClass("hide")
+        ) {
+            // In cases when the save button is disabled,
+            // or the save button is hidden to show the saving
+            // indicator, we need to disable save on pressing Enter
             // Prevent default to avoid new-line on pressing
             // Enter inside the textarea in this case
             e.preventDefault();
@@ -424,6 +430,12 @@ function handle_message_edit_enter(
     } else {
         composebox_typeahead.handle_enter($message_edit_content, e);
         return;
+    }
+}
+export function handle_message_edit_event(message_id: number): void {
+    currently_echoing_messages.delete(message_id);
+    if (!currently_editing_messages.has(message_id)) {
+        end_message_edit(message_id);
     }
 }
 
@@ -628,12 +640,14 @@ function edit_message($row: JQuery, raw_content: string): void {
     }
 
     const is_editable = is_content_editable(message, seconds_left_buffer);
+    const currently_echoing = currently_echoing_messages.has(message.id);
 
     const $form = $(
         render_message_edit_form({
             message_id: message.id,
             is_editable,
             content: raw_content,
+            is_echoing: currently_echoing,
             file_upload_enabled,
             giphy_enabled: gif_state.is_giphy_enabled(),
             tenor_enabled: gif_state.is_tenor_enabled(),
@@ -1393,7 +1407,6 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
         success(res) {
             if (edit_locally_echoed) {
                 delete message.local_edit_timestamp;
-                currently_echoing_messages.delete(message_id);
             }
 
             // Ordinarily, in a code path like this, we'd make
@@ -1492,8 +1505,11 @@ export function maybe_show_edit($row: JQuery, id: number): void {
     }
 
     if (currently_editing_messages.has(id)) {
-        const $message_edit_content = currently_editing_messages.get(id);
-        edit_message($row, $message_edit_content?.val() ?? "");
+        const message_edit_content = currently_editing_messages.get(id)?.val();
+        start_edit_with_content($row, message_edit_content ?? "");
+        if ($row.hasClass("show_preview")) {
+            show_preview_area($row);
+        }
     }
 }
 

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -474,8 +474,9 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 anchor_message.is_me_message = event.is_me_message;
             }
 
-            // mark the current message edit attempt as complete.
-            message_edit.end_message_edit(event.message_id);
+            // mark the current message edit attempt as complete if the
+            // message edit box is hidden.
+            message_edit.handle_message_edit_event(event.message_id);
 
             // Save the content edit to the front end anchor_message.edit_history
             // before topic edits to ensure that combined topic / content

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1714,8 +1714,13 @@ export class MessageListView {
         if (message_content_edited) {
             $rendered_msg.addClass("fade-in-message");
         }
-        this._post_process($rendered_msg);
+        if ($row.hasClass("preview_mode")) {
+            // We'll render the preview area after we've
+            // rendered the message edit content in this new row.
+            $rendered_msg.addClass("show_preview");
+        }
         $row.replaceWith($rendered_msg);
+        this._post_process($rendered_msg);
 
         // If this list not currently displayed, we don't need to select the message.
         if (was_selected && this.list === message_lists.current) {
@@ -1811,6 +1816,7 @@ export class MessageListView {
             this.update_sticky_recipient_headers();
             maybe_restore_focus_to_message_edit_form();
         }
+        autosize.update(this.$list.find(".message_edit_content"));
     }
 
     append(

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -867,6 +867,27 @@
     }
 }
 
+.message-edit-saving {
+    /* Use grid overlay so the spinner is centered while
+       the hidden "Saving" text holds the button width. */
+    display: grid;
+    grid-template: "button-display";
+}
+
+.message-edit-saving .fa-circle-o-notch {
+    display: inline-block;
+    grid-area: button-display;
+    justify-self: center;
+    z-index: 1;
+    animation: rotate 1s infinite linear;
+}
+
+.message-edit-saving .message-edit-saving-text {
+    visibility: hidden;
+    grid-area: button-display;
+    z-index: 0;
+}
+
 .message_edit_cancel,
 .message_edit_close {
     color: var(--color-exit-button-text);

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -19,20 +19,28 @@
                 <div class="controls edit-controls">
                     <div class="message-edit-buttons-and-timer">
                         {{#if is_editable}}
-                            <div class="message_edit_save_container">
-                                <button type="button" class="message-actions-button message_edit_save">
-                                    <img class="loader" alt="" src="" />
-                                    <span>{{t "Save" }}</span>
-                                </button>
-                            </div>
-                            <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
-                            <span class="tippy-zulip-tooltip message-limit-indicator" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
-                            <div class="message-edit-timer">
-                                <span class="message_edit_countdown_timer
-                                  tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
-                            </div>
+                        <div class="message-edit-saving-container tippy-zulip-tooltip {{#unless is_echoing}}hide{{/unless}}"
+                          data-tippy-content="{{t 'Saving previous changes.' }}">
+                            <button type="button" class="message-actions-button message-edit-saving saving" disabled>
+                                <span class="fa fa-circle-o-notch"></span>
+                                <span class="message-edit-saving-text">{{t "Saving" }}</span>
+                            </button>
+                        </div>
+
+                        <div class="message_edit_save_container {{#if is_echoing}}hide{{/if}}">
+                            <button type="button" class="message-actions-button message_edit_save">
+                                <img class="loader" alt="" src="" />
+                                <span>{{t "Save" }}</span>
+                            </button>
+                        </div>
+                        <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
+                        <span class="tippy-zulip-tooltip message-limit-indicator" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
+                        <div class="message-edit-timer">
+                            <span class="message_edit_countdown_timer
+                              tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
+                        </div>
                         {{else}}
-                            <button type="button" class="message-actions-button message_edit_close"><span>{{t "Close" }}</span></button>
+                        <button type="button" class="message-actions-button message_edit_close"><span>{{t "Close" }}</span></button>
                         {{/if}}
                     </div>
                     {{#if is_editable}}

--- a/web/tests/message_events.test.cjs
+++ b/web/tests/message_events.test.cjs
@@ -120,7 +120,7 @@ run_test("update_messages", ({override, override_rewire}) => {
     };
 
     const side_effects = [
-        [message_edit, "end_message_edit"],
+        [message_edit, "handle_message_edit_event"],
         [message_notifications, "received_messages"],
         [unread_ui, "update_unread_counts"],
         [stream_list, "update_streams_sidebar"],
@@ -139,7 +139,14 @@ run_test("update_messages", ({override, override_rewire}) => {
     const $modal = $.create("micromodal").addClass("modal--open");
     $message_edit_history_modal.set_parents_result(".micromodal", $modal);
 
+    const $row = $.create("<stub message row>");
+    const $message_edit = $.create("<stub message edit>");
+    $message_edit.addClass("hide");
+    $message_edit.length = 1;
+    $row.set_find_results(".message_edit", $message_edit);
+
     // TEST THIS:
+    override(message_edit, "currently_echoing_messages", new Map());
     message_events.update_messages(events);
 
     assert.ok(!unread.unread_mentions_counter.has(original_message.id));


### PR DESCRIPTION
Previously, when a message is edited and saved, when the window is closed during local echo, we would show an option to view the source, despite the edit is not saved and we are waiting for the server response.

This commit rather continues to show the edit button in such a state, with the edit window showing a spinner instead of the "save" button.

If the success response for the previous edit comes while the current edit is in progress, we retain the latest edit state (even after rerendering) so that the user doesn't lose their changes. The "save" button too, is now enabled again.
Same is the case for a failure response.

**How changes were tested:**
We can test this by adding `time.sleep(10)` in function`update_message_backend` in `zerver/views/message_edit.py`

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1120" height="225" alt="image" src="https://github.com/user-attachments/assets/9b898985-cc92-4294-9edf-adb1b84e242f" />

https://github.com/user-attachments/assets/6ecee299-38f2-4889-808f-78685f0427cb


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
