### PR TITLE
Recent view / Inbox misc fixes.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1022,6 +1022,7 @@
     --focus-ring-outline-offset-in-views: calc(
         -1 * var(--focus-ring-width-in-views)
     );
+    --unread-count-focus-outline-radius-in-views: 0.5em; /* 8px at 16px/1em */
     --color-background-search: light-dark(hsl(0deg 0% 100%), hsl(0deg 0% 17%));
     --color-background-search-collapsed: light-dark(
         hsl(0deg 0% 100%),

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -947,6 +947,11 @@
     }
 }
 
+#inbox-view .inbox-container #inbox-pane #inbox-expand-all-button {
+    --color-outline-button-focus: var(--color-outline-focus);
+    --outline-offset-button-focus: var(--focus-ring-outline-offset-in-views);
+}
+
 #inbox-animation-extra-content-blocker {
     background: var(--color-background-inbox);
 }

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -900,18 +900,11 @@
     }
 
     /* Focus ring drawn as a pseudo-element on the inner badge,
-       with `5px` of breathing room outside the badge and `5px`
-       corners on the ring so it visually matches the action
-       button and state-marker rings, which paint at 3px effective
-       (5px `border-radius` minus 2px `outline-offset`) but on
-       smaller (~26×26) wrappers. Using straight `5px` corners on
-       this larger (~26×28) ring keeps the perceived corner
-       roundness consistent with the inbox's other focus
-       indicators. A wrapper-sized outline (the previous
-       implementation) leaves a wide gap between the ring and
-       the badge fill that reads as a second concentric outline;
-       the deliberate 5px gap here reads as padding around a
-       single badge instead. */
+       with `5px` of breathing room outside the badge. A
+       wrapper-sized outline (the previous implementation) leaves a
+       wide gap between the ring and the badge fill that reads as a
+       second concentric outline; the deliberate 5px gap here reads
+       as padding around a single badge instead. */
     .unread-count-focus-outline {
         &:focus-visible {
             outline: none;
@@ -929,7 +922,9 @@
                     position: absolute;
                     inset: -0.3125em; /* -5px at 16px/1em */
                     border: var(--focus-ring-outline);
-                    border-radius: 0.3125em; /* 5px at 16px/1em */
+                    border-radius: var(
+                        --unread-count-focus-outline-radius-in-views
+                    );
                     pointer-events: none;
                 }
             }

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -19,7 +19,6 @@
         .unread_count {
             opacity: 1;
             outline: 0 solid var(--color-background-unread-counter);
-            transition: outline-width 0.1s ease;
 
             &:hover {
                 outline-width: var(--focus-ring-width-in-views);

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -1048,7 +1048,7 @@
         position: absolute;
         inset: -0.3125em; /* -5px at 16px/1em */
         border: var(--focus-ring-outline);
-        border-radius: 0.3125em; /* 5px at 16px/1em */
+        border-radius: var(--unread-count-focus-outline-radius-in-views);
         pointer-events: none;
     }
 }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -341,7 +341,6 @@
         align-self: center;
         opacity: 1;
         outline: 0 solid var(--color-background-unread-counter);
-        transition: outline-width 0.1s ease;
 
         &:hover {
             outline-width: var(--focus-ring-width-in-views);


### PR DESCRIPTION
Followup on https://github.com/zulip/zulip/pull/39105#issuecomment-4548400027

| before | after |
| --- | --- |
| <img width="1350" height="572" alt="image" src="https://github.com/user-attachments/assets/ea04c5a0-1a0f-4375-9f5e-3304b3d12030" /> |  <img width="731" height="360" alt="image" src="https://github.com/user-attachments/assets/9daa32ca-d7c3-48a3-9eed-eddf61539d12" /> |
| <img width="731" height="360" alt="image" src="https://github.com/user-attachments/assets/9598e01f-b73a-4f79-bf62-18475ca22a26" /> | <img width="731" height="360" alt="image" src="https://github.com/user-attachments/assets/17b05279-3ca9-4c50-84d0-9b2c88fa5b6c" /> |
| <img width="731" height="360" alt="image" src="https://github.com/user-attachments/assets/b506af3d-d338-4c98-a534-87f67513b0a8" /> | <img width="731" height="360" alt="image" src="https://github.com/user-attachments/assets/5145592d-05c1-4d30-90cf-d9123dbbd446" /> |

Unread count transition fix:
Before:
<img width="800" height="338" alt="inconsistent-outlines" src="https://github.com/user-attachments/assets/5530000f-c338-4d36-8798-2b45b2e9cb4e" />


After:


https://github.com/user-attachments/assets/772aa9a2-aec1-45a5-afc6-585d7beee534




---

Used claude for commiting but mostly written by me.
