### PR TITLE
users: Remove get_users_involved_in_dms_with_target_users.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -96,7 +96,6 @@ from zerver.lib.users import (
     get_inaccessible_user_ids,
     get_subscribers_of_target_user_subscriptions,
     get_user_ids_who_can_access_user,
-    get_users_involved_in_dms_with_target_users,
     user_access_restricted_in_realm,
 )
 from zerver.lib.validator import check_widget_content
@@ -1706,7 +1705,6 @@ def get_recipients_for_user_creation_events(
             recipients_for_user_creation_events[sender].add(user_profiles[0].id)
         return recipients_for_user_creation_events
 
-    users_involved_in_dms = get_users_involved_in_dms_with_target_users(guest_recipients, realm)
     subscribers_of_guest_recipient_subscriptions = get_subscribers_of_target_user_subscriptions(
         guest_recipients
     )
@@ -1716,15 +1714,11 @@ def get_recipients_for_user_creation_events(
             if user.id == recipient_user.id or user.is_bot:
                 continue
 
-            if (
-                user.id not in users_involved_in_dms[recipient_user.id]
-                and user.id not in subscribers_of_guest_recipient_subscriptions[recipient_user.id]
-            ):
+            if user.id not in subscribers_of_guest_recipient_subscriptions[recipient_user.id]:
                 recipients_for_user_creation_events[user].add(recipient_user.id)
 
         if (
             not sender.is_bot
-            and sender.id not in users_involved_in_dms[recipient_user.id]
             and sender.id not in subscribers_of_guest_recipient_subscriptions[recipient_user.id]
         ):
             recipients_for_user_creation_events[sender].add(recipient_user.id)

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -100,7 +100,6 @@ from zerver.lib.users import (
     check_can_access_user,
     get_subscribers_of_target_user_subscriptions,
     get_user_ids_who_can_access_user,
-    get_users_involved_in_dms_with_target_users,
     user_access_restricted_in_realm,
 )
 from zerver.lib.validator import check_widget_content
@@ -1796,11 +1795,10 @@ def get_recipients_for_user_creation_events(
     ).exists():
         return recipients_for_user_creation_events
 
-    # TODO: The following 2 functions execute 4 queries.
-    # While this is only for a new DirectMessageGroup,
-    # it's still worth optimizing, also because these functions
-    # are called in other code paths.
-    users_involved_in_dms = get_users_involved_in_dms_with_target_users(guest_recipients, realm)
+    # TODO: get_subscribers_of_target_user_subscriptions
+    # executes 2 queries. While this is only for a new DirectMessageGroup,
+    # it's still worth optimizing, also because it's called
+    # in other code paths.
     subscribers_of_guest_recipient_subscriptions = get_subscribers_of_target_user_subscriptions(
         guest_recipients
     )
@@ -1810,15 +1808,11 @@ def get_recipients_for_user_creation_events(
             if user.id == recipient_user.id or user.is_bot:
                 continue
 
-            if (
-                user.id not in users_involved_in_dms[recipient_user.id]
-                and user.id not in subscribers_of_guest_recipient_subscriptions[recipient_user.id]
-            ):
+            if user.id not in subscribers_of_guest_recipient_subscriptions[recipient_user.id]:
                 recipients_for_user_creation_events[user].add(recipient_user.id)
 
         if (
             not sender.is_bot
-            and sender.id not in users_involved_in_dms[recipient_user.id]
             and sender.id not in subscribers_of_guest_recipient_subscriptions[recipient_user.id]
         ):
             recipients_for_user_creation_events[sender].add(recipient_user.id)

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -60,7 +60,6 @@ from zerver.lib.user_groups import (
 from zerver.lib.users import (
     all_users_accessible_by_everyone_in_realm,
     get_subscribers_of_target_user_subscriptions,
-    get_users_involved_in_dms_with_target_users,
 )
 from zerver.models import (
     ArchivedAttachment,
@@ -699,8 +698,6 @@ def send_user_creation_events_on_adding_subscriptions(
     altered_users = list(altered_streams_dict.keys())
     non_guest_user_ids = active_non_guest_user_ids(realm.id)
 
-    users_involved_in_dms = get_users_involved_in_dms_with_target_users(altered_users, realm)
-
     altered_stream_ids = altered_user_dict.keys()
     subscribers_dict = get_users_for_streams(set(altered_stream_ids))
 
@@ -720,10 +717,7 @@ def send_user_creation_events_on_adding_subscriptions(
             subscribers_in_altered_streams |= subscriber_ids_dict[stream_id]
 
         users_already_with_access_to_altered_user = (
-            set(non_guest_user_ids)
-            | subscribers_of_altered_user_subscriptions[user.id]
-            | users_involved_in_dms[user.id]
-            | {user.id}
+            set(non_guest_user_ids) | subscribers_of_altered_user_subscriptions[user.id] | {user.id}
         )
 
         users_to_receive_creation_event = (
@@ -735,11 +729,9 @@ def send_user_creation_events_on_adding_subscriptions(
         if user.is_guest:
             # If the altered user is a guest, then the user may receive
             # user creation events for subscribers of the new stream.
-            users_already_accessible_to_altered_user = (
-                subscribers_of_altered_user_subscriptions[user.id]
-                | users_involved_in_dms[user.id]
-                | {user.id}
-            )
+            users_already_accessible_to_altered_user = subscribers_of_altered_user_subscriptions[
+                user.id
+            ] | {user.id}
 
             new_accessible_user_ids = (
                 subscribers_in_altered_streams - users_already_accessible_to_altered_user
@@ -1019,7 +1011,6 @@ def send_user_remove_events_on_removing_subscriptions(
     for stream_ids in altered_user_dict.values():
         altered_stream_ids |= stream_ids
 
-    users_involved_in_dms = get_users_involved_in_dms_with_target_users(altered_users, realm)
     subscribers_of_altered_user_subscriptions = get_subscribers_of_target_user_subscriptions(
         altered_users
     )
@@ -1034,10 +1025,7 @@ def send_user_remove_events_on_removing_subscriptions(
             users_in_unsubscribed_streams |= subscribers_dict[stream_id]
 
         users_who_can_access_altered_user = (
-            set(non_guest_user_ids)
-            | subscribers_of_altered_user_subscriptions[user.id]
-            | users_involved_in_dms[user.id]
-            | {user.id}
+            set(non_guest_user_ids) | subscribers_of_altered_user_subscriptions[user.id] | {user.id}
         )
 
         subscribers_without_access_to_altered_user = (
@@ -1056,9 +1044,7 @@ def send_user_remove_events_on_removing_subscriptions(
 
         if user.is_guest:
             users_inaccessible_to_altered_user = users_in_unsubscribed_streams - (
-                subscribers_of_altered_user_subscriptions[user.id]
-                | users_involved_in_dms[user.id]
-                | {user.id}
+                subscribers_of_altered_user_subscriptions[user.id] | {user.id}
             )
 
             for user_id in users_inaccessible_to_altered_user:

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -60,7 +60,6 @@ from zerver.lib.user_groups import (
 from zerver.lib.users import (
     all_users_accessible_by_everyone_in_realm,
     get_subscribers_of_target_user_subscriptions,
-    get_users_involved_in_dms_with_target_users,
 )
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
@@ -701,8 +700,6 @@ def send_user_creation_events_on_adding_subscriptions(
     altered_users = list(altered_streams_dict.keys())
     non_guest_user_ids = active_non_guest_user_ids(realm.id)
 
-    users_involved_in_dms = get_users_involved_in_dms_with_target_users(altered_users, realm)
-
     altered_stream_ids = altered_user_dict.keys()
     subscribers_dict = get_users_for_streams(set(altered_stream_ids))
 
@@ -722,10 +719,7 @@ def send_user_creation_events_on_adding_subscriptions(
             subscribers_in_altered_streams |= subscriber_ids_dict[stream_id]
 
         users_already_with_access_to_altered_user = (
-            set(non_guest_user_ids)
-            | subscribers_of_altered_user_subscriptions[user.id]
-            | users_involved_in_dms[user.id]
-            | {user.id}
+            set(non_guest_user_ids) | subscribers_of_altered_user_subscriptions[user.id] | {user.id}
         )
 
         users_to_receive_creation_event = (
@@ -737,11 +731,9 @@ def send_user_creation_events_on_adding_subscriptions(
         if user.is_guest:
             # If the altered user is a guest, then the user may receive
             # user creation events for subscribers of the new stream.
-            users_already_accessible_to_altered_user = (
-                subscribers_of_altered_user_subscriptions[user.id]
-                | users_involved_in_dms[user.id]
-                | {user.id}
-            )
+            users_already_accessible_to_altered_user = subscribers_of_altered_user_subscriptions[
+                user.id
+            ] | {user.id}
 
             new_accessible_user_ids = (
                 subscribers_in_altered_streams - users_already_accessible_to_altered_user
@@ -1027,7 +1019,6 @@ def send_user_remove_events_on_removing_subscriptions(
     for stream_ids in altered_user_dict.values():
         altered_stream_ids |= stream_ids
 
-    users_involved_in_dms = get_users_involved_in_dms_with_target_users(altered_users, realm)
     subscribers_of_altered_user_subscriptions = get_subscribers_of_target_user_subscriptions(
         altered_users
     )
@@ -1042,10 +1033,7 @@ def send_user_remove_events_on_removing_subscriptions(
             users_in_unsubscribed_streams |= subscribers_dict[stream_id]
 
         users_who_can_access_altered_user = (
-            set(non_guest_user_ids)
-            | subscribers_of_altered_user_subscriptions[user.id]
-            | users_involved_in_dms[user.id]
-            | {user.id}
+            set(non_guest_user_ids) | subscribers_of_altered_user_subscriptions[user.id] | {user.id}
         )
 
         subscribers_without_access_to_altered_user = (
@@ -1064,9 +1052,7 @@ def send_user_remove_events_on_removing_subscriptions(
 
         if user.is_guest:
             users_inaccessible_to_altered_user = users_in_unsubscribed_streams - (
-                subscribers_of_altered_user_subscriptions[user.id]
-                | users_involved_in_dms[user.id]
-                | {user.id}
+                subscribers_of_altered_user_subscriptions[user.id] | {user.id}
             )
 
             for user_id in users_inaccessible_to_altered_user:

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -55,7 +55,6 @@ from zerver.lib.user_groups import (
 from zerver.lib.users import (
     get_active_bots_owned_by_user,
     get_user_ids_who_can_access_user,
-    get_users_involved_in_dms_with_target_users,
     user_access_restricted_in_realm,
 )
 from zerver.models import (
@@ -384,7 +383,6 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
         return
 
     non_guest_user_ids = active_non_guest_user_ids(realm.id)
-    users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users([user_profile], realm)
 
     # This code path is parallel to
     # get_subscribers_of_target_user_subscriptions, but can't reuse it
@@ -411,9 +409,7 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
             peer_stream_subscribers.add(user_id)
 
     users_with_access_to_deactivated_user = (
-        set(non_guest_user_ids)
-        | users_involved_in_dms_dict[user_profile.id]
-        | peer_direct_message_group_subscribers
+        set(non_guest_user_ids) | peer_direct_message_group_subscribers
     )
     if users_with_access_to_deactivated_user:
         send_event_on_commit(

--- a/zerver/lib/presence.py
+++ b/zerver/lib/presence.py
@@ -198,7 +198,7 @@ def get_presence_dict_by_realm(
         requesting_user_profile
     ):
         assert requesting_user_profile is not None
-        accessible_user_ids = get_accessible_user_ids(realm, requesting_user_profile)
+        accessible_user_ids = get_accessible_user_ids(requesting_user_profile)
         query = query.filter(user_profile_id__in=accessible_user_ids)
 
     presence_rows = list(

--- a/zerver/lib/user_status.py
+++ b/zerver/lib/user_status.py
@@ -66,7 +66,7 @@ def get_all_users_status_dict(realm: Realm, user_profile: UserProfile) -> dict[s
     )
 
     if not check_user_can_access_all_users(user_profile):
-        accessible_user_ids = get_accessible_user_ids(realm, user_profile)
+        accessible_user_ids = get_accessible_user_ids(user_profile)
         query = query.filter(user_profile_id__in=accessible_user_ids)
 
     rows = query.values(

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -834,6 +834,7 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 def get_subscribers_of_target_user_subscriptions(
     target_users: list[UserProfile], include_deactivated_users_for_dm_groups: bool = False
 ) -> dict[int, set[int]]:
+    """Get all users involved in stream and direct message groups with target_users."""
     target_user_ids = [user.id for user in target_users]
     target_user_subscriptions = (
         Subscription.objects.filter(

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -28,8 +28,6 @@ from zerver.lib.user_groups import user_has_permission_for_group_setting
 from zerver.models import (
     CustomProfileField,
     CustomProfileFieldValue,
-    DirectMessageGroup,
-    Message,
     Realm,
     Recipient,
     Service,
@@ -824,13 +822,11 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
     active_non_guest_user_ids_in_realm = active_non_guest_user_ids(realm.id)
 
     users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions([target_user])
-    users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users([target_user], realm)
 
     user_ids_who_can_access_target_user = (
         {target_user.id}
         | set(active_non_guest_user_ids_in_realm)
         | users_sharing_any_subscription[target_user.id]
-        | users_involved_in_dms_dict[target_user.id]
     )
     return list(user_ids_who_can_access_target_user)
 
@@ -895,46 +891,6 @@ def get_subscribers_of_target_user_subscriptions(
             )
 
     return users_subbed_to_target_user_subscriptions_dict
-
-
-def get_users_involved_in_dms_with_target_users(
-    target_users: list[UserProfile], realm: Realm, include_deactivated_users: bool = False
-) -> dict[int, set[int]]:
-    # Find DM partners via 1:1 DM groups with message history.
-    # Push the message-existence check into the subscription query
-    # as a subquery, so we only fetch DMGs that actually have messages.
-    target_dmg_subs = Subscription.objects.filter(
-        user_profile_id__in=[user.id for user in target_users],
-        recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
-        recipient__type_id__in=DirectMessageGroup.objects.filter(
-            group_size__lte=2,
-        ),
-        recipient_id__in=Message.objects.filter(realm=realm).values("recipient_id"),
-    ).values_list("user_profile_id", "recipient_id")
-
-    dmg_to_targets: dict[int, set[int]] = defaultdict(set)
-    for target_id, recipient_id in target_dmg_subs:
-        dmg_to_targets[recipient_id].add(target_id)
-
-    if not dmg_to_targets:
-        return defaultdict(set)
-
-    # Now that we know the set of relevant recipients, and which of
-    # users we care about are in each, we pull the full subscription
-    # set to map user -> recipient -> full list of other users
-    partner_query = Subscription.objects.filter(
-        recipient_id__in=dmg_to_targets.keys(),
-    )
-    if not include_deactivated_users:
-        partner_query = partner_query.filter(is_user_active=True)
-
-    direct_message_participants_dict: dict[int, set[int]] = defaultdict(set)
-    for recipient_id, user_id in partner_query.values_list("recipient_id", "user_profile_id"):
-        for target_id in dmg_to_targets[recipient_id]:
-            if user_id != target_id:
-                direct_message_participants_dict[target_id].add(user_id)
-
-    return direct_message_participants_dict
 
 
 def user_profile_to_user_row(user_profile: UserProfile) -> RawUserDict:
@@ -1020,17 +976,12 @@ def get_accessible_user_ids(
     subscribers_dict_of_target_user_subscriptions = get_subscribers_of_target_user_subscriptions(
         [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
     )
-    users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users(
-        [user_profile], realm, include_deactivated_users=include_deactivated_users
-    )
 
     # This does not include bots, because either the caller
     # wants only human users or it handles bots separately.
-    accessible_user_ids = (
-        {user_profile.id}
-        | subscribers_dict_of_target_user_subscriptions[user_profile.id]
-        | users_involved_in_dms_dict[user_profile.id]
-    )
+    accessible_user_ids = {user_profile.id} | subscribers_dict_of_target_user_subscriptions[
+        user_profile.id
+    ]
 
     return list(accessible_user_ids)
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -28,8 +28,6 @@ from zerver.lib.user_groups import user_has_permission_for_group_setting
 from zerver.models import (
     CustomProfileField,
     CustomProfileFieldValue,
-    DirectMessageGroup,
-    Message,
     Realm,
     Recipient,
     Service,
@@ -837,13 +835,11 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
     active_non_guest_user_ids_in_realm = active_non_guest_user_ids(realm.id)
 
     users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions([target_user])
-    users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users([target_user], realm)
 
     user_ids_who_can_access_target_user = (
         {target_user.id}
         | set(active_non_guest_user_ids_in_realm)
         | users_sharing_any_subscription[target_user.id]
-        | users_involved_in_dms_dict[target_user.id]
     )
     return list(user_ids_who_can_access_target_user)
 
@@ -908,46 +904,6 @@ def get_subscribers_of_target_user_subscriptions(
             )
 
     return users_subbed_to_target_user_subscriptions_dict
-
-
-def get_users_involved_in_dms_with_target_users(
-    target_users: list[UserProfile], realm: Realm, include_deactivated_users: bool = False
-) -> dict[int, set[int]]:
-    # Find DM partners via 1:1 DM groups with message history.
-    # Push the message-existence check into the subscription query
-    # as a subquery, so we only fetch DMGs that actually have messages.
-    target_dmg_subs = Subscription.objects.filter(
-        user_profile_id__in=[user.id for user in target_users],
-        recipient__type=Recipient.DIRECT_MESSAGE_GROUP,
-        recipient__type_id__in=DirectMessageGroup.objects.filter(
-            group_size__lte=2,
-        ),
-        recipient_id__in=Message.objects.filter(realm=realm).values("recipient_id"),
-    ).values_list("user_profile_id", "recipient_id")
-
-    dmg_to_targets: dict[int, set[int]] = defaultdict(set)
-    for target_id, recipient_id in target_dmg_subs:
-        dmg_to_targets[recipient_id].add(target_id)
-
-    if not dmg_to_targets:
-        return defaultdict(set)
-
-    # Now that we know the set of relevant recipients, and which of
-    # users we care about are in each, we pull the full subscription
-    # set to map user -> recipient -> full list of other users
-    partner_query = Subscription.objects.filter(
-        recipient_id__in=dmg_to_targets.keys(),
-    )
-    if not include_deactivated_users:
-        partner_query = partner_query.filter(is_user_active=True)
-
-    direct_message_participants_dict: dict[int, set[int]] = defaultdict(set)
-    for recipient_id, user_id in partner_query.values_list("recipient_id", "user_profile_id"):
-        for target_id in dmg_to_targets[recipient_id]:
-            if user_id != target_id:
-                direct_message_participants_dict[target_id].add(user_id)
-
-    return direct_message_participants_dict
 
 
 def user_profile_to_user_row(user_profile: UserProfile) -> RawUserDict:
@@ -1028,22 +984,17 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
 
 
 def get_accessible_user_ids(
-    realm: Realm, user_profile: UserProfile, include_deactivated_users: bool = False
+    user_profile: UserProfile, include_deactivated_users: bool = False
 ) -> set[int]:
     subscribers_dict_of_target_user_subscriptions = get_subscribers_of_target_user_subscriptions(
         [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
     )
-    users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users(
-        [user_profile], realm, include_deactivated_users=include_deactivated_users
-    )
 
     # This does not include bots, because either the caller
     # wants only human users or it handles bots separately.
-    accessible_user_ids = (
-        {user_profile.id}
-        | subscribers_dict_of_target_user_subscriptions[user_profile.id]
-        | users_involved_in_dms_dict[user_profile.id]
-    )
+    accessible_user_ids = {user_profile.id} | subscribers_dict_of_target_user_subscriptions[
+        user_profile.id
+    ]
 
     return accessible_user_ids
 
@@ -1061,9 +1012,7 @@ def get_user_dicts_in_realm(
         return (all_user_dicts, [])
 
     assert user_profile is not None
-    accessible_user_ids = get_accessible_user_ids(
-        realm, user_profile, include_deactivated_users=True
-    )
+    accessible_user_ids = get_accessible_user_ids(user_profile, include_deactivated_users=True)
 
     accessible_user_dicts: list[RawUserDict] = []
     inaccessible_user_dicts: list[APIUserDict] = []

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -847,6 +847,7 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 def get_subscribers_of_target_user_subscriptions(
     target_users: list[UserProfile], include_deactivated_users_for_dm_groups: bool = False
 ) -> dict[int, set[int]]:
+    """Get all users involved in stream and direct message groups with target_users."""
     target_user_ids = [user.id for user in target_users]
     target_user_subscriptions = (
         Subscription.objects.filter(

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1029,7 +1029,7 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
 
 def get_accessible_user_ids(
     realm: Realm, user_profile: UserProfile, include_deactivated_users: bool = False
-) -> list[int]:
+) -> set[int]:
     subscribers_dict_of_target_user_subscriptions = get_subscribers_of_target_user_subscriptions(
         [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
     )
@@ -1045,7 +1045,7 @@ def get_accessible_user_ids(
         | users_involved_in_dms_dict[user_profile.id]
     )
 
-    return list(accessible_user_ids)
+    return accessible_user_ids
 
 
 def get_user_dicts_in_realm(

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -3059,7 +3059,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
         # A normal user sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(30):
+        with self.assert_database_query_count(28):
             self.send_group_direct_message(iago, recipients)
 
         # A normal user sends a message
@@ -3072,16 +3072,13 @@ class PersonalMessageSendTest(ZulipTestCase):
         self.subscribe(polonius, "Verona")
 
         # polonius and prospero have already exchanged 1:1 DM
-        # via set_up_db_for_testing_user_access,
-        # and we need this interaction because:
-        # 1- It's very common for the message recipients
+        # via set_up_db_for_testing_user_access;
+        # it's very common for a message recipients
         # to have 1:1 DM partners.
-        # 2- This triggers 2 queries by get_users_involved_in_dms_with_target_users,
-        # so we can capture that.
 
         # A guest with limited user access sends the first message
         # to a new DirectMessageGroup.
-        with self.assert_database_query_count(32):
+        with self.assert_database_query_count(30):
             self.send_group_direct_message(polonius, recipients)
 
         # A guest with limited user access sends a message

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -64,10 +64,10 @@ from zerver.lib.users import (
     access_user_by_id,
     access_user_by_id_including_cross_realm,
     check_can_access_user,
+    get_accessible_user_ids,
     get_accounts_for_email,
     get_cross_realm_dicts,
     get_inaccessible_user_ids,
-    get_users_involved_in_dms_with_target_users,
     user_ids_to_users,
 )
 from zerver.lib.utils import assert_is_not_none
@@ -3588,7 +3588,7 @@ class GetProfileTest(ZulipTestCase):
         self.set_up_db_for_testing_user_access()
 
         self.login("polonius")
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(7):
             result = orjson.loads(self.client_get("/json/users").content)
         accessible_users = result["members"]
         # The user can access 3 bot users and 7 human users.
@@ -3624,6 +3624,45 @@ class GetProfileTest(ZulipTestCase):
             accessible_user_ids, {polonius.id, iago.id, prospero.id, aaron.id, zoe.id, shiva.id}
         )
 
+    def test_get_accessible_user_ids(self) -> None:
+        realm = get_realm("zulip")
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        prospero = self.example_user("prospero")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        shiva = self.example_user("shiva")
+        polonius = self.example_user("polonius")
+
+        self.set_up_db_for_testing_user_access()
+
+        # Polonius can access:
+        # - hamlet and iago, common stream.
+        # - prospero and shiva, 1:1 Direct message with polonius.
+        # - aaron and zoe, common Direct message group.
+        self.assertEqual(
+            set(get_accessible_user_ids(realm, polonius)),
+            {polonius.id, prospero.id, zoe.id, shiva.id, aaron.id, hamlet.id, iago.id},
+        )
+
+        do_deactivate_user(shiva, acting_user=None)
+        do_deactivate_user(aaron, acting_user=None)
+        do_deactivate_user(hamlet, acting_user=None)
+
+        # By default, all deactivated partners are
+        # excluded. Active users remain accessible.
+        self.assertEqual(
+            set(get_accessible_user_ids(realm, polonius)),
+            {polonius.id, prospero.id, zoe.id, iago.id},
+        )
+
+        # The deactivated Direct message partners can be
+        # accessible using include_deactivated_users flag.
+        self.assertEqual(
+            set(get_accessible_user_ids(realm, polonius, include_deactivated_users=True)),
+            {polonius.id, prospero.id, zoe.id, shiva.id, aaron.id, iago.id},
+        )
+
     def test_get_user_dicts_with_ids(self) -> None:
         cordelia = self.example_user("cordelia")
         desdemona = self.example_user("desdemona")
@@ -3643,7 +3682,7 @@ class GetProfileTest(ZulipTestCase):
         accessible_user_ids_subset = [hamlet.id, iago.id, aaron.id, zoe.id, webhook_bot.id]
         inaccessible_user_ids_subset = [cordelia.id, desdemona.id]
         user_ids_to_fetch = accessible_user_ids_subset + inaccessible_user_ids_subset
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(7):
             result = orjson.loads(
                 self.client_get(
                     "/json/users", {"user_ids": orjson.dumps(user_ids_to_fetch).decode()}
@@ -3712,7 +3751,7 @@ class GetProfileTest(ZulipTestCase):
             result = self.client_get(f"/json/users/{user.id}")
             self.assert_json_error(result, "Insufficient permission")
 
-        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(9):
+        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(7):
             result = self.client_get("/json/users")
         self.assert_json_success(result)
 
@@ -3781,69 +3820,6 @@ class GetProfileTest(ZulipTestCase):
 
         # no personal messages history between desdemona and polonius
         self.assertFalse(check_can_access_user(desdemona, polonius))
-
-    def test_get_users_involved_in_dms_excludes_deactivated_users(self) -> None:
-        hamlet = self.example_user("hamlet")
-        othello = self.example_user("othello")
-        cordelia = self.example_user("cordelia")
-        realm = hamlet.realm
-
-        self.send_personal_message(hamlet, othello, "Hello othello!")
-        self.send_personal_message(hamlet, cordelia, "Hello cordelia!")
-        self.send_personal_message(othello, hamlet, "Hello back from othello!")
-
-        # Before deactivation, both users should be in DM participants
-        users_involved_before = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertIn(othello.id, users_involved_before[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_before[hamlet.id])
-
-        do_deactivate_user(othello, acting_user=None)
-
-        # After deactivation with include_deactivated_users=False,
-        # othello should be excluded
-        users_involved_after = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertNotIn(othello.id, users_involved_after[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_after[hamlet.id])
-
-        # With include_deactivated_users=True, othello should be included
-        users_involved_with_deactivated = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=True
-        )
-        self.assertIn(othello.id, users_involved_with_deactivated[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_with_deactivated[hamlet.id])
-
-    def test_get_users_involved_in_dms_with_dm_group_recipients(self) -> None:
-        hamlet = self.example_user("hamlet")
-        othello = self.example_user("othello")
-        cordelia = self.example_user("cordelia")
-        realm = hamlet.realm
-
-        self.send_personal_message(hamlet, othello, "Hello othello!")
-        self.send_personal_message(hamlet, cordelia, "Hello cordelia!")
-
-        users_involved = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertIn(othello.id, users_involved[hamlet.id])
-        self.assertIn(cordelia.id, users_involved[hamlet.id])
-
-        do_deactivate_user(othello, acting_user=None)
-
-        users_involved_after = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertNotIn(othello.id, users_involved_after[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_after[hamlet.id])
-
-        users_involved_with_deactivated = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=True
-        )
-        self.assertIn(othello.id, users_involved_with_deactivated[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_with_deactivated[hamlet.id])
 
     def test_get_users_for_spectators(self) -> None:
         # Checks that spectators can fetch users data.

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -65,10 +65,10 @@ from zerver.lib.users import (
     access_user_by_id,
     access_user_by_id_including_cross_realm,
     check_can_access_user,
+    get_accessible_user_ids,
     get_accounts_for_email,
     get_cross_realm_dicts,
     get_inaccessible_user_ids,
-    get_users_involved_in_dms_with_target_users,
     user_ids_to_users,
 )
 from zerver.lib.utils import assert_is_not_none
@@ -3591,7 +3591,7 @@ class GetProfileTest(ZulipTestCase):
         self.set_up_db_for_testing_user_access()
 
         self.login("polonius")
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(7):
             result = orjson.loads(self.client_get("/json/users").content)
         accessible_users = result["members"]
         # The user can access 3 bot users and 7 human users.
@@ -3627,6 +3627,44 @@ class GetProfileTest(ZulipTestCase):
             accessible_user_ids, {polonius.id, iago.id, prospero.id, aaron.id, zoe.id, shiva.id}
         )
 
+    def test_get_accessible_user_ids(self) -> None:
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        prospero = self.example_user("prospero")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        shiva = self.example_user("shiva")
+        polonius = self.example_user("polonius")
+
+        self.set_up_db_for_testing_user_access()
+
+        # Polonius can access:
+        # - hamlet and iago, common stream.
+        # - prospero and shiva, 1:1 Direct message with polonius.
+        # - aaron and zoe, common Direct message group.
+        self.assertEqual(
+            get_accessible_user_ids(polonius),
+            {polonius.id, prospero.id, zoe.id, shiva.id, aaron.id, hamlet.id, iago.id},
+        )
+
+        do_deactivate_user(shiva, acting_user=None)
+        do_deactivate_user(aaron, acting_user=None)
+        do_deactivate_user(hamlet, acting_user=None)
+
+        # By default, all deactivated partners are
+        # excluded. Active users remain accessible.
+        self.assertEqual(
+            get_accessible_user_ids(polonius),
+            {polonius.id, prospero.id, zoe.id, iago.id},
+        )
+
+        # The deactivated Direct message partners can be
+        # accessible using include_deactivated_users flag.
+        self.assertEqual(
+            get_accessible_user_ids(polonius, include_deactivated_users=True),
+            {polonius.id, prospero.id, zoe.id, shiva.id, aaron.id, iago.id},
+        )
+
     def test_get_user_dicts_with_ids(self) -> None:
         cordelia = self.example_user("cordelia")
         desdemona = self.example_user("desdemona")
@@ -3646,7 +3684,7 @@ class GetProfileTest(ZulipTestCase):
         accessible_user_ids_subset = [hamlet.id, iago.id, aaron.id, zoe.id, webhook_bot.id]
         inaccessible_user_ids_subset = [cordelia.id, desdemona.id]
         user_ids_to_fetch = accessible_user_ids_subset + inaccessible_user_ids_subset
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(7):
             result = orjson.loads(
                 self.client_get(
                     "/json/users", {"user_ids": orjson.dumps(user_ids_to_fetch).decode()}
@@ -3715,7 +3753,7 @@ class GetProfileTest(ZulipTestCase):
             result = self.client_get(f"/json/users/{user.id}")
             self.assert_json_error(result, "Insufficient permission")
 
-        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(9):
+        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(7):
             result = self.client_get("/json/users")
         self.assert_json_success(result)
 
@@ -3810,69 +3848,6 @@ class GetProfileTest(ZulipTestCase):
         # already have very limited access to users.
         hamlet = self.example_user("hamlet")
         self.assertTrue(check_can_access_user(hamlet, None))
-
-    def test_get_users_involved_in_dms_excludes_deactivated_users(self) -> None:
-        hamlet = self.example_user("hamlet")
-        othello = self.example_user("othello")
-        cordelia = self.example_user("cordelia")
-        realm = hamlet.realm
-
-        self.send_personal_message(hamlet, othello, "Hello othello!")
-        self.send_personal_message(hamlet, cordelia, "Hello cordelia!")
-        self.send_personal_message(othello, hamlet, "Hello back from othello!")
-
-        # Before deactivation, both users should be in DM participants
-        users_involved_before = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertIn(othello.id, users_involved_before[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_before[hamlet.id])
-
-        do_deactivate_user(othello, acting_user=None)
-
-        # After deactivation with include_deactivated_users=False,
-        # othello should be excluded
-        users_involved_after = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertNotIn(othello.id, users_involved_after[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_after[hamlet.id])
-
-        # With include_deactivated_users=True, othello should be included
-        users_involved_with_deactivated = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=True
-        )
-        self.assertIn(othello.id, users_involved_with_deactivated[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_with_deactivated[hamlet.id])
-
-    def test_get_users_involved_in_dms_with_dm_group_recipients(self) -> None:
-        hamlet = self.example_user("hamlet")
-        othello = self.example_user("othello")
-        cordelia = self.example_user("cordelia")
-        realm = hamlet.realm
-
-        self.send_personal_message(hamlet, othello, "Hello othello!")
-        self.send_personal_message(hamlet, cordelia, "Hello cordelia!")
-
-        users_involved = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertIn(othello.id, users_involved[hamlet.id])
-        self.assertIn(cordelia.id, users_involved[hamlet.id])
-
-        do_deactivate_user(othello, acting_user=None)
-
-        users_involved_after = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=False
-        )
-        self.assertNotIn(othello.id, users_involved_after[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_after[hamlet.id])
-
-        users_involved_with_deactivated = get_users_involved_in_dms_with_target_users(
-            [hamlet], realm, include_deactivated_users=True
-        )
-        self.assertIn(othello.id, users_involved_with_deactivated[hamlet.id])
-        self.assertIn(cordelia.id, users_involved_with_deactivated[hamlet.id])
 
     def test_get_users_for_spectators(self) -> None:
         # Checks that spectators can fetch users data.


### PR DESCRIPTION
Fixes part of #27835.

`get_users_involved_in_dms_with_target_users` was previously needed when recipient type was different for 1:1 DM but that is no longer the case. Now, the whole result of this function is already included in the result of `get_subscribers_of_target_user_subscriptions`

## Performance gains:
Saving 2 db round trips. 

This also optimizes the following events where that function was called:
- `send_user_creation_events_on_adding_subscriptions`
- `send_user_remove_events_on_removing_subscriptions`
- `send_events_for_user_deactivation`

