### PR TITLE
search: Remove dead `openInputFieldOnKeyUp` code.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -99,20 +99,13 @@
  *   Since it's in the right part of the DOM, we don't need to do
  *   the manual positioning in the show() function.
  *
- * 11. Add `openInputFieldOnKeyUp` option:
- *
- *   If the typeahead isn't shown yet, the `lookup` call in the keyup
- *   handler will open it. Here we make a callback to the input field
- *   before we open the lookahead in case it needs to make UI changes first
- *   (e.g. widening the search bar).
- *
- * 12. Add `closeInputFieldOnHide` option:
+ * 11. Add `closeInputFieldOnHide` option:
  *
  *   Some input fields like search have visual changes that need to happen
  *   when the typeahead hides. This callback function is called in `hide()`
  *   and allows those extra UI changes to happen.
  *
- *  13. Allow option to remove custom logic for tab keypresses:
+ *  12. Allow option to remove custom logic for tab keypresses:
  *
  *   Sometimes tab is treated similarly to the escape or enter key, with
  *   custom functionality, which also prevents propagation to default tab
@@ -120,15 +113,15 @@
  *   turned off so that tab only does one thing while focus is in the
  *   typeahead -- move focus to the next element.
  *
- * 14. Don't act on blurs that change focus within the `non_tippy_parent_element`:
+ * 13. Don't act on blurs that change focus within the `non_tippy_parent_element`:
  *
  *   This allows us to have things like a close button, and be able
  *   to move focus there without the typeahead closing.
  *
- * 15. To position typeaheads, we use Tippyjs except for typeaheads that are
+ * 14. To position typeaheads, we use Tippyjs except for typeaheads that are
  *    appended to a `non_tippy_parent_element`.
  *
- * 16. Add `requireHighlight` and `shouldHighlightFirstResult` options:
+ * 15. Add `requireHighlight` and `shouldHighlightFirstResult` options:
  *
  *   Allow none of the typeahead options to be highlighted, which lets
  *   the user remove highlight by going navigating (with the keyboard)
@@ -141,18 +134,18 @@
  *   `shouldHighlightFirstResult` relatedly lets us decide whether
  *   the first result should be highlighted when the typeahead opens.
  *
- * 17. Add `updateElementContent` option.
+ * 16. Add `updateElementContent` option.
  *
  *   This is useful for complicated typeaheads that have custom logic
  *   for setting their element's contents after an item is selected.
  *
- * 18. Add `hideAfterSelect` option, default true.
+ * 17. Add `hideAfterSelect` option, default true.
  *
  *   This is useful for custom situations where we want to trigger the
  *   typeahead to do a lookup after selecting an option, when the user
  *   is making multiple related selections in a row.
  *
- * 19. Add `hideOnEmptyAfterBackspace` option, default false.
+ * 18. Add `hideOnEmptyAfterBackspace` option, default false.
  *
  *   This allows us to prevent the typeahead menu from being displayed
  *   when a pill is deleted using the backspace key.
@@ -249,7 +242,6 @@ export class Typeahead<ItemType extends string | object> {
     select_on_escape_condition: () => boolean;
     // Used to clear tooltip instances attached to typeahead container.
     clear_typeahead_tooltip: (() => void) | undefined;
-    openInputFieldOnKeyUp: (() => void) | undefined;
     closeInputFieldOnHide: (() => void) | undefined;
     helpOnEmptyStrings: boolean;
     tabIsEnter: boolean;
@@ -305,7 +297,6 @@ export class Typeahead<ItemType extends string | object> {
         this.stopAdvance = options.stopAdvance ?? false;
         this.select_on_escape_condition = options.select_on_escape_condition ?? (() => false);
         this.advanceKeys = options.advanceKeys ?? [];
-        this.openInputFieldOnKeyUp = options.openInputFieldOnKeyUp;
         this.closeInputFieldOnHide = options.closeInputFieldOnHide;
         this.tabIsEnter = options.tabIsEnter ?? true;
         this.helpOnEmptyStrings = options.helpOnEmptyStrings ?? false;
@@ -843,13 +834,6 @@ export class Typeahead<ItemType extends string | object> {
                 ) {
                     return;
                 }
-                if (this.openInputFieldOnKeyUp !== undefined && !this.shown) {
-                    // If the typeahead isn't shown yet, the `lookup` call will open it.
-                    // Here we make a callback to the input field before we open the
-                    // lookahead in case it needs to make UI changes first (e.g. widening
-                    // the search bar).
-                    this.openInputFieldOnKeyUp();
-                }
                 if (e.key === "Backspace") {
                     this.lookup(this.hideOnEmptyAfterBackspace);
                     return;
@@ -967,7 +951,6 @@ type TypeaheadOptions<ItemType> = {
     matcher?: (query: string) => (item: ItemType) => boolean;
     on_escape?: () => void;
     clear_typeahead_tooltip?: () => void;
-    openInputFieldOnKeyUp?: () => void;
     option_label?: (matching_items: ItemType[], item: ItemType) => string | false;
     non_tippy_parent_element?: string;
     sorter: (items: ItemType[], query: string) => ItemType[];

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -269,11 +269,6 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
             exit_search({keep_search_narrow_open: false});
         },
         tabIsEnter: true,
-        openInputFieldOnKeyUp(): void {
-            if ($(".navbar-search.expanded").length === 0) {
-                open_search_bar_and_close_narrow_description();
-            }
-        },
         // This is here so that we can close the search bar
         // when a user opens it and immediately changes their
         // mind and clicks away.


### PR DESCRIPTION
`openInputFieldOnKeyUp` in the search typeahead was used to open the search input when the user started typing while the search box was closed.
In commit 75dab825feac0abc051f59e0e75488b7e8aa0b74, we removed the ability to type into closed search box, making this code path unreachable.
We remove this option altogether from bootstrap_typeahead module.

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
