### PR TITLE
webhooks/stripe: Update Stripe integration.

### DIFF
--- a/zerver/webhooks/stripe/fixtures/charge_dispute_closed_with_pi.json
+++ b/zerver/webhooks/stripe/fixtures/charge_dispute_closed_with_pi.json
@@ -1,0 +1,107 @@
+{
+  "id": "evt_1TbGFuJEe0yY0QKrzGIDyOUL",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779783749,
+  "data": {
+    "object": {
+      "id": "du_1TbG46JEe0yY0QKr8P0G3pa3",
+      "object": "dispute",
+      "amount": 2200,
+      "balance_transaction": "txn_1TbG47JEe0yY0QKrI4W6EK83",
+      "balance_transactions": [
+        {
+          "available_on": 1780358400,
+          "created": 1779783019,
+          "net": -3700,
+          "currency": "usd",
+          "source": "du_1TbG46JEe0yY0QKr8P0G3pa3",
+          "reporting_category": "dispute",
+          "fee_details": [
+            {
+              "application": null,
+              "amount": 1500,
+              "type": "stripe_fee",
+              "description": "Dispute fee",
+              "currency": "usd"
+            }
+          ],
+          "amount": -2200,
+          "status": "pending",
+          "balance_type": "payments",
+          "object": "balance_transaction",
+          "id": "txn_1TbG47JEe0yY0QKrI4W6EK83",
+          "exchange_rate": null,
+          "type": "adjustment",
+          "description": "Chargeback withdrawal for ch_3TbG44JEe0yY0QKr0aPnlMSQ",
+          "fee": 1500
+        }
+      ],
+      "charge": "ch_3TbG44JEe0yY0QKr0aPnlMSQ",
+      "created": 1779783018,
+      "currency": "usd",
+      "enhanced_eligibility_types": [],
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": "45678",
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": "customer@example.com",
+        "customer_name": "xyz",
+        "customer_purchase_ip": "192.0.2.1",
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "enhanced_evidence": {},
+        "product_description": "dwdwqde",
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": null
+      },
+      "evidence_details": {
+        "due_by": 1780531199,
+        "enhanced_eligibility": {},
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "is_charge_refundable": false,
+      "livemode": false,
+      "metadata": {},
+      "payment_intent": "pi_3TbG44JEe0yY0QKr0OnHpigY",
+      "payment_method_details": {
+        "card": {
+          "brand": "visa",
+          "case_type": "chargeback",
+          "network_reason_code": "13.1"
+        },
+        "type": "card"
+      },
+      "reason": "product_not_received",
+      "status": "lost"
+    },
+    "previous_attributes": {
+      "status": "needs_response"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_Ss0fvx4GaEU6Rq",
+    "idempotency_key": "4e25d3da-6908-4f3e-a569-e800c65af574"
+  },
+  "type": "charge.dispute.closed"
+}

--- a/zerver/webhooks/stripe/fixtures/charge_dispute_created_with_pi.json
+++ b/zerver/webhooks/stripe/fixtures/charge_dispute_created_with_pi.json
@@ -1,0 +1,104 @@
+{
+  "id": "evt_1TbG48JEe0yY0QKrrgcor0DZ",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779783019,
+  "data": {
+    "object": {
+      "id": "du_1TbG46JEe0yY0QKr8P0G3pa3",
+      "object": "dispute",
+      "amount": 2200,
+      "balance_transaction": "txn_1TbG47JEe0yY0QKrI4W6EK83",
+      "balance_transactions": [
+        {
+          "available_on": 1780358400,
+          "created": 1779783019,
+          "net": -3700,
+          "currency": "usd",
+          "source": "du_1TbG46JEe0yY0QKr8P0G3pa3",
+          "reporting_category": "dispute",
+          "fee_details": [
+            {
+              "application": null,
+              "amount": 1500,
+              "type": "stripe_fee",
+              "description": "Dispute fee",
+              "currency": "usd"
+            }
+          ],
+          "amount": -2200,
+          "status": "pending",
+          "balance_type": "payments",
+          "object": "balance_transaction",
+          "id": "txn_1TbG47JEe0yY0QKrI4W6EK83",
+          "exchange_rate": null,
+          "type": "adjustment",
+          "description": "Chargeback withdrawal for ch_3TbG44JEe0yY0QKr0aPnlMSQ",
+          "fee": 1500
+        }
+      ],
+      "charge": "ch_3TbG44JEe0yY0QKr0aPnlMSQ",
+      "created": 1779783018,
+      "currency": "usd",
+      "enhanced_eligibility_types": [],
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": null,
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": null,
+        "customer_name": null,
+        "customer_purchase_ip": null,
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "enhanced_evidence": {},
+        "product_description": null,
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": null
+      },
+      "evidence_details": {
+        "due_by": 1780531199,
+        "enhanced_eligibility": {},
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "is_charge_refundable": false,
+      "livemode": false,
+      "metadata": {},
+      "payment_intent": "pi_3TbG44JEe0yY0QKr0OnHpigY",
+      "payment_method_details": {
+        "card": {
+          "brand": "visa",
+          "case_type": "chargeback",
+          "network_reason_code": "13.1"
+        },
+        "type": "card"
+      },
+      "reason": "product_not_received",
+      "status": "needs_response"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_yAUasv124PD79B",
+    "idempotency_key": "2fed1e18-ac4c-4f3a-8aae-03f03fdcff9b"
+  },
+  "type": "charge.dispute.created"
+}

--- a/zerver/webhooks/stripe/fixtures/charge_failed_with_pi.json
+++ b/zerver/webhooks/stripe/fixtures/charge_failed_with_pi.json
@@ -1,0 +1,128 @@
+{
+  "id": "evt_3TbGfyJEe0yY0QKr08P0MBRO",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779785366,
+  "data": {
+    "object": {
+      "id": "ch_3TbGfyJEe0yY0QKr0Nh9uVjd",
+      "object": "charge",
+      "amount": 2200,
+      "amount_captured": 0,
+      "amount_refunded": 0,
+      "application": null,
+      "application_fee": null,
+      "application_fee_amount": null,
+      "balance_transaction": null,
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": "89999",
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null,
+        "tax_id": null
+      },
+      "calculated_statement_descriptor": "KARNATAKATE2W",
+      "captured": false,
+      "created": 1779785366,
+      "currency": "usd",
+      "customer": null,
+      "description": "dwfwdqf",
+      "destination": null,
+      "dispute": null,
+      "disputed": false,
+      "failure_balance_transaction": null,
+      "failure_code": "card_declined",
+      "failure_message": "Your card was declined.",
+      "fraud_details": {},
+      "livemode": false,
+      "metadata": {},
+      "on_behalf_of": null,
+      "order": null,
+      "outcome": {
+        "advice_code": "try_again_later",
+        "network_advice_code": null,
+        "network_decline_code": "01",
+        "network_status": "declined_by_network",
+        "reason": "generic_decline",
+        "risk_level": "normal",
+        "risk_score": 9,
+        "seller_message": "The bank did not return any further details with this decline.",
+        "type": "issuer_declined"
+      },
+      "paid": false,
+      "payment_intent": "pi_3TbGfyJEe0yY0QKr0V9PBbP9",
+      "payment_method": "pm_1TbGfxJEe0yY0QKr6Adq5Ky8",
+      "payment_method_details": {
+        "card": {
+          "amount_authorized": null,
+          "authorization_code": "267232",
+          "brand": "visa",
+          "checks": {
+            "address_line1_check": null,
+            "address_postal_code_check": "pass",
+            "cvc_check": "pass"
+          },
+          "country": "US",
+          "ds_transaction_id": null,
+          "exp_month": 12,
+          "exp_year": 2034,
+          "extended_authorization": {
+            "status": "disabled"
+          },
+          "fingerprint": "exampleFingerpr2",
+          "funding": "credit",
+          "incremental_authorization": {
+            "status": "unavailable"
+          },
+          "installments": null,
+          "last4": "0002",
+          "mandate": null,
+          "multicapture": {
+            "status": "unavailable"
+          },
+          "network": "visa",
+          "network_token": {
+            "used": false
+          },
+          "network_transaction_id": "100116825454997",
+          "overcapture": {
+            "maximum_amount_capturable": 2200,
+            "status": "unavailable"
+          },
+          "regulated_status": "unregulated",
+          "three_d_secure": null,
+          "wallet": null
+        },
+        "type": "card"
+      },
+      "radar_options": {},
+      "receipt_email": null,
+      "receipt_number": null,
+      "receipt_url": null,
+      "refunded": false,
+      "review": null,
+      "shipping": null,
+      "source": null,
+      "source_transfer": null,
+      "statement_descriptor": "Karnatakate2w",
+      "statement_descriptor_suffix": null,
+      "status": "failed",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_UylpYEOXaAFBkb",
+    "idempotency_key": "9ff3c174-0cdd-4212-873d-7237de717995"
+  },
+  "type": "charge.failed"
+}

--- a/zerver/webhooks/stripe/fixtures/charge_succeeded_with_pi.json
+++ b/zerver/webhooks/stripe/fixtures/charge_succeeded_with_pi.json
@@ -1,0 +1,128 @@
+{
+  "id": "evt_3TbGBUJEe0yY0QKr1eTEBGsV",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779783477,
+  "data": {
+    "object": {
+      "id": "ch_3TbGBUJEe0yY0QKr18Sf1VVH",
+      "object": "charge",
+      "amount": 22200,
+      "amount_captured": 22200,
+      "amount_refunded": 0,
+      "application": null,
+      "application_fee": null,
+      "application_fee_amount": null,
+      "balance_transaction": "txn_3TbGBUJEe0yY0QKr1CDjmSO5",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": "89000",
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null,
+        "tax_id": null
+      },
+      "calculated_statement_descriptor": "DVSCVSVCS",
+      "captured": true,
+      "created": 1779783476,
+      "currency": "usd",
+      "customer": null,
+      "description": "dfdfvds",
+      "destination": null,
+      "dispute": null,
+      "disputed": false,
+      "failure_balance_transaction": null,
+      "failure_code": null,
+      "failure_message": null,
+      "fraud_details": {},
+      "livemode": false,
+      "metadata": {},
+      "on_behalf_of": null,
+      "order": null,
+      "outcome": {
+        "advice_code": null,
+        "network_advice_code": null,
+        "network_decline_code": null,
+        "network_status": "approved_by_network",
+        "reason": null,
+        "risk_level": "normal",
+        "risk_score": 47,
+        "seller_message": "Payment complete.",
+        "type": "authorized"
+      },
+      "paid": true,
+      "payment_intent": "pi_3TbGBUJEe0yY0QKr1NhtlhQp",
+      "payment_method": "pm_1TbGBTJEe0yY0QKrnlc9x8bY",
+      "payment_method_details": {
+        "card": {
+          "amount_authorized": 22200,
+          "authorization_code": "659476",
+          "brand": "visa",
+          "checks": {
+            "address_line1_check": null,
+            "address_postal_code_check": "pass",
+            "cvc_check": "pass"
+          },
+          "country": "US",
+          "ds_transaction_id": null,
+          "exp_month": 12,
+          "exp_year": 2034,
+          "extended_authorization": {
+            "status": "disabled"
+          },
+          "fingerprint": "exampleFingerpr1",
+          "funding": "credit",
+          "incremental_authorization": {
+            "status": "unavailable"
+          },
+          "installments": null,
+          "last4": "0002",
+          "mandate": null,
+          "multicapture": {
+            "status": "unavailable"
+          },
+          "network": "visa",
+          "network_token": {
+            "used": false
+          },
+          "network_transaction_id": "122547268103849",
+          "overcapture": {
+            "maximum_amount_capturable": 22200,
+            "status": "unavailable"
+          },
+          "regulated_status": "unregulated",
+          "three_d_secure": null,
+          "wallet": null
+        },
+        "type": "card"
+      },
+      "radar_options": {},
+      "receipt_email": null,
+      "receipt_number": null,
+      "receipt_url": "https://pay.stripe.com/receipts/payment/exampleReceiptToken",
+      "refunded": false,
+      "review": null,
+      "shipping": null,
+      "source": null,
+      "source_transfer": null,
+      "statement_descriptor": "dvscvsvcs",
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_iNHOyacAIM38T3",
+    "idempotency_key": "c154b458-e07d-4672-962c-aab59cd23443"
+  },
+  "type": "charge.succeeded"
+}

--- a/zerver/webhooks/stripe/fixtures/customer_subscription_created_with_collection_method.json
+++ b/zerver/webhooks/stripe/fixtures/customer_subscription_created_with_collection_method.json
@@ -1,0 +1,182 @@
+{
+  "id": "evt_1TbGh9JEe0yY0QKrWXxtlSFi",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779785439,
+  "data": {
+    "object": {
+      "id": "sub_1TbGh3JEe0yY0QKrmHd5I4l8",
+      "object": "subscription",
+      "application": null,
+      "application_fee_percent": null,
+      "automatic_tax": {
+        "disabled_reason": null,
+        "enabled": false,
+        "liability": null
+      },
+      "billing_cycle_anchor": 1779785433,
+      "billing_cycle_anchor_config": null,
+      "billing_mode": {
+        "flexible": {
+          "proration_discounts": "included"
+        },
+        "type": "flexible",
+        "updated_at": 1779785433
+      },
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "cancellation_details": {
+        "comment": null,
+        "feedback": null,
+        "reason": null
+      },
+      "collection_method": "charge_automatically",
+      "created": 1779785433,
+      "currency": "usd",
+      "customer": "cus_UZ11RVzkmLf6Cf",
+      "customer_account": null,
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "description": null,
+      "discounts": [],
+      "ended_at": null,
+      "invoice_settings": {
+        "account_tax_ids": null,
+        "issuer": {
+          "type": "self"
+        }
+      },
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_UaRaMpdva0xGKZ",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1779785433,
+            "current_period_end": 1782463833,
+            "current_period_start": 1779785433,
+            "discounts": [],
+            "metadata": {},
+            "plan": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "plan",
+              "active": true,
+              "amount": 12100,
+              "amount_decimal": "12100",
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {},
+              "meter": null,
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "custom_unit_amount": null,
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {},
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "recurring": {
+                "interval": "month",
+                "interval_count": 1,
+                "meter": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tax_behavior": "unspecified",
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 12100,
+              "unit_amount_decimal": "12100"
+            },
+            "quantity": 1,
+            "subscription": "sub_1TbGh3JEe0yY0QKrmHd5I4l8",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_1TbGh3JEe0yY0QKrmHd5I4l8"
+      },
+      "latest_invoice": "in_1TbGh3JEe0yY0QKrev3GM1LF",
+      "livemode": false,
+      "managed_payments": {
+        "enabled": false
+      },
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "on_behalf_of": null,
+      "pause_collection": null,
+      "payment_settings": {
+        "payment_method_options": null,
+        "payment_method_types": null,
+        "save_default_payment_method": "off"
+      },
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+        "object": "plan",
+        "active": true,
+        "amount": 12100,
+        "amount_decimal": "12100",
+        "billing_scheme": "per_unit",
+        "created": 1779456689,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {},
+        "meter": null,
+        "nickname": null,
+        "product": "prod_UZ1DpExTQfai36",
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1779785433,
+      "status": "active",
+      "test_clock": null,
+      "transfer_data": null,
+      "trial_end": null,
+      "trial_settings": {
+        "end_behavior": {
+          "missing_payment_method": "create_invoice"
+        }
+      },
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_zmo4VwbMJZNxoR",
+    "idempotency_key": "b919fbfa-0f4b-4c0f-bddd-caecb61630c7"
+  },
+  "type": "customer.subscription.created"
+}

--- a/zerver/webhooks/stripe/fixtures/customer_subscription_deleted_with_collection_method.json
+++ b/zerver/webhooks/stripe/fixtures/customer_subscription_deleted_with_collection_method.json
@@ -1,0 +1,182 @@
+{
+  "id": "evt_1TbGjLJEe0yY0QKrJVg6cuyY",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779785575,
+  "data": {
+    "object": {
+      "id": "sub_1TbGh3JEe0yY0QKrmHd5I4l8",
+      "object": "subscription",
+      "application": null,
+      "application_fee_percent": null,
+      "automatic_tax": {
+        "disabled_reason": null,
+        "enabled": false,
+        "liability": null
+      },
+      "billing_cycle_anchor": 1779785433,
+      "billing_cycle_anchor_config": null,
+      "billing_mode": {
+        "flexible": {
+          "proration_discounts": "included"
+        },
+        "type": "flexible",
+        "updated_at": 1779785433
+      },
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": 1779785575,
+      "cancellation_details": {
+        "comment": null,
+        "feedback": null,
+        "reason": "cancellation_requested"
+      },
+      "collection_method": "charge_automatically",
+      "created": 1779785433,
+      "currency": "usd",
+      "customer": "cus_UZ11RVzkmLf6Cf",
+      "customer_account": null,
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "description": null,
+      "discounts": [],
+      "ended_at": 1779785575,
+      "invoice_settings": {
+        "account_tax_ids": null,
+        "issuer": {
+          "type": "self"
+        }
+      },
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_UaRaMpdva0xGKZ",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1779785433,
+            "current_period_end": 1782463833,
+            "current_period_start": 1779785433,
+            "discounts": [],
+            "metadata": {},
+            "plan": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "plan",
+              "active": true,
+              "amount": 12100,
+              "amount_decimal": "12100",
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {},
+              "meter": null,
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "custom_unit_amount": null,
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {},
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "recurring": {
+                "interval": "month",
+                "interval_count": 1,
+                "meter": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tax_behavior": "unspecified",
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 12100,
+              "unit_amount_decimal": "12100"
+            },
+            "quantity": 1,
+            "subscription": "sub_1TbGh3JEe0yY0QKrmHd5I4l8",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_1TbGh3JEe0yY0QKrmHd5I4l8"
+      },
+      "latest_invoice": "in_1TbGh3JEe0yY0QKrev3GM1LF",
+      "livemode": false,
+      "managed_payments": {
+        "enabled": false
+      },
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "on_behalf_of": null,
+      "pause_collection": null,
+      "payment_settings": {
+        "payment_method_options": null,
+        "payment_method_types": null,
+        "save_default_payment_method": "off"
+      },
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+        "object": "plan",
+        "active": true,
+        "amount": 12100,
+        "amount_decimal": "12100",
+        "billing_scheme": "per_unit",
+        "created": 1779456689,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {},
+        "meter": null,
+        "nickname": null,
+        "product": "prod_UZ1DpExTQfai36",
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1779785433,
+      "status": "canceled",
+      "test_clock": null,
+      "transfer_data": null,
+      "trial_end": null,
+      "trial_settings": {
+        "end_behavior": {
+          "missing_payment_method": "create_invoice"
+        }
+      },
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_PqR8tYwVux7o6H",
+    "idempotency_key": null
+  },
+  "type": "customer.subscription.deleted"
+}

--- a/zerver/webhooks/stripe/fixtures/customer_subscription_trial_will_end_with_collection_method.json
+++ b/zerver/webhooks/stripe/fixtures/customer_subscription_trial_will_end_with_collection_method.json
@@ -1,0 +1,182 @@
+{
+  "id": "evt_1TbGl4JEe0yY0QKrTkegvQtJ",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779785681,
+  "data": {
+    "object": {
+      "id": "sub_1TZtDLJEe0yY0QKroHU9hRvx",
+      "object": "subscription",
+      "application": null,
+      "application_fee_percent": null,
+      "automatic_tax": {
+        "disabled_reason": null,
+        "enabled": false,
+        "liability": null
+      },
+      "billing_cycle_anchor": 1779872032,
+      "billing_cycle_anchor_config": null,
+      "billing_mode": {
+        "flexible": {
+          "proration_discounts": "included"
+        },
+        "type": "flexible",
+        "updated_at": 1779456851
+      },
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "cancellation_details": {
+        "comment": null,
+        "feedback": null,
+        "reason": null
+      },
+      "collection_method": "charge_automatically",
+      "created": 1779456851,
+      "currency": "usd",
+      "customer": "cus_UZ11RVzkmLf6Cf",
+      "customer_account": null,
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": "card_1TZtDIJEe0yY0QKrvFxlx22i",
+      "default_tax_rates": [],
+      "description": null,
+      "discounts": [],
+      "ended_at": null,
+      "invoice_settings": {
+        "account_tax_ids": null,
+        "issuer": {
+          "type": "self"
+        }
+      },
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_UZ1FcKhj7HyQiA",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1779456852,
+            "current_period_end": 1779872032,
+            "current_period_start": 1779785647,
+            "discounts": [],
+            "metadata": {},
+            "plan": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "plan",
+              "active": true,
+              "amount": 12100,
+              "amount_decimal": "12100",
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {},
+              "meter": null,
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "custom_unit_amount": null,
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {},
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "recurring": {
+                "interval": "month",
+                "interval_count": 1,
+                "meter": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tax_behavior": "unspecified",
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 12100,
+              "unit_amount_decimal": "12100"
+            },
+            "quantity": 1,
+            "subscription": "sub_1TZtDLJEe0yY0QKroHU9hRvx",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_1TZtDLJEe0yY0QKroHU9hRvx"
+      },
+      "latest_invoice": "in_1TbGkVJEe0yY0QKrU2nXFauO",
+      "livemode": false,
+      "managed_payments": {
+        "enabled": false
+      },
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "on_behalf_of": null,
+      "pause_collection": null,
+      "payment_settings": {
+        "payment_method_options": null,
+        "payment_method_types": null,
+        "save_default_payment_method": "off"
+      },
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+        "object": "plan",
+        "active": true,
+        "amount": 12100,
+        "amount_decimal": "12100",
+        "billing_scheme": "per_unit",
+        "created": 1779456689,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {},
+        "meter": null,
+        "nickname": null,
+        "product": "prod_UZ1DpExTQfai36",
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1779456851,
+      "status": "trialing",
+      "test_clock": null,
+      "transfer_data": null,
+      "trial_end": 1779872032,
+      "trial_settings": {
+        "end_behavior": {
+          "missing_payment_method": "create_invoice"
+        }
+      },
+      "trial_start": 1779785647
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": null,
+    "idempotency_key": null
+  },
+  "type": "customer.subscription.trial_will_end"
+}

--- a/zerver/webhooks/stripe/fixtures/customer_subscription_updated_with_collection_method.json
+++ b/zerver/webhooks/stripe/fixtures/customer_subscription_updated_with_collection_method.json
@@ -1,0 +1,254 @@
+{
+  "id": "evt_1TbGkWJEe0yY0QKrVdOxWpbv",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1779785648,
+  "data": {
+    "object": {
+      "id": "sub_1TZtDLJEe0yY0QKroHU9hRvx",
+      "object": "subscription",
+      "application": null,
+      "application_fee_percent": null,
+      "automatic_tax": {
+        "disabled_reason": null,
+        "enabled": false,
+        "liability": null
+      },
+      "billing_cycle_anchor": 1779872032,
+      "billing_cycle_anchor_config": null,
+      "billing_mode": {
+        "flexible": {
+          "proration_discounts": "included"
+        },
+        "type": "flexible",
+        "updated_at": 1779456851
+      },
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "cancellation_details": {
+        "comment": null,
+        "feedback": null,
+        "reason": null
+      },
+      "collection_method": "charge_automatically",
+      "created": 1779456851,
+      "currency": "usd",
+      "customer": "cus_UZ11RVzkmLf6Cf",
+      "customer_account": null,
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": "card_1TZtDIJEe0yY0QKrvFxlx22i",
+      "default_tax_rates": [],
+      "description": null,
+      "discounts": [],
+      "ended_at": null,
+      "invoice_settings": {
+        "account_tax_ids": null,
+        "issuer": {
+          "type": "self"
+        }
+      },
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_UZ1FcKhj7HyQiA",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1779456852,
+            "current_period_end": 1779872032,
+            "current_period_start": 1779785647,
+            "discounts": [],
+            "metadata": {},
+            "plan": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "plan",
+              "active": true,
+              "amount": 12100,
+              "amount_decimal": "12100",
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {},
+              "meter": null,
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "custom_unit_amount": null,
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {},
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "recurring": {
+                "interval": "month",
+                "interval_count": 1,
+                "meter": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tax_behavior": "unspecified",
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 12100,
+              "unit_amount_decimal": "12100"
+            },
+            "quantity": 1,
+            "subscription": "sub_1TZtDLJEe0yY0QKroHU9hRvx",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_1TZtDLJEe0yY0QKroHU9hRvx"
+      },
+      "latest_invoice": "in_1TbGkVJEe0yY0QKrU2nXFauO",
+      "livemode": false,
+      "managed_payments": {
+        "enabled": false
+      },
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "on_behalf_of": null,
+      "pause_collection": null,
+      "payment_settings": {
+        "payment_method_options": null,
+        "payment_method_types": null,
+        "save_default_payment_method": "off"
+      },
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+        "object": "plan",
+        "active": true,
+        "amount": 12100,
+        "amount_decimal": "12100",
+        "billing_scheme": "per_unit",
+        "created": 1779456689,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {},
+        "meter": null,
+        "nickname": null,
+        "product": "prod_UZ1DpExTQfai36",
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1779456851,
+      "status": "trialing",
+      "test_clock": null,
+      "transfer_data": null,
+      "trial_end": 1779872032,
+      "trial_settings": {
+        "end_behavior": {
+          "missing_payment_method": "create_invoice"
+        }
+      },
+      "trial_start": 1779785647
+    },
+    "previous_attributes": {
+      "billing_cycle_anchor": 1779456851,
+      "items": {
+        "data": [
+          {
+            "id": "si_UZ1FcKhj7HyQiA",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1779456852,
+            "current_period_end": 1782135251,
+            "current_period_start": 1779456851,
+            "discounts": [],
+            "metadata": {},
+            "plan": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "plan",
+              "active": true,
+              "amount": 12100,
+              "amount_decimal": "12100",
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {},
+              "meter": null,
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1TZtAjJEe0yY0QKr27Tj0mDA",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1779456689,
+              "currency": "usd",
+              "custom_unit_amount": null,
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {},
+              "nickname": null,
+              "product": "prod_UZ1DpExTQfai36",
+              "recurring": {
+                "interval": "month",
+                "interval_count": 1,
+                "meter": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tax_behavior": "unspecified",
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 12100,
+              "unit_amount_decimal": "12100"
+            },
+            "quantity": 1,
+            "subscription": "sub_1TZtDLJEe0yY0QKroHU9hRvx",
+            "tax_rates": []
+          }
+        ]
+      },
+      "latest_invoice": "in_1TZtDLJEe0yY0QKrk8merGGy",
+      "status": "active",
+      "trial_end": null,
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_YWhm3Hsc5864Ke",
+    "idempotency_key": "fd0dbe18-9cd7-4d92-a4e4-3cb266611dbb"
+  },
+  "type": "customer.subscription.updated"
+}

--- a/zerver/webhooks/stripe/fixtures/invoiceitem_created_with_invoice.json
+++ b/zerver/webhooks/stripe/fixtures/invoiceitem_created_with_invoice.json
@@ -1,0 +1,50 @@
+{
+  "id": "evt_1Tcef5JEe0yY0QKryPb86CKZ",
+  "object": "event",
+  "api_version": "2026-04-22.dahlia",
+  "created": 1780115895,
+  "data": {
+    "object": {
+      "id": "ii_1Tcef5JEe0yY0QKr36usPoJ3",
+      "object": "invoiceitem",
+      "amount": 12100,
+      "currency": "usd",
+      "customer": "cus_UZ11RVzkmLf6Cf",
+      "customer_account": null,
+      "date": 1780115895,
+      "description": "wqre",
+      "discountable": true,
+      "discounts": [
+        "di_1Tcef5JEe0yY0QKruIQEK0rH"
+      ],
+      "invoice": "in_1TceefJEe0yY0QKrKgc29TeP",
+      "livemode": false,
+      "metadata": {},
+      "parent": null,
+      "period": {
+        "end": 1780115895,
+        "start": 1780115895
+      },
+      "pricing": {
+        "price_details": {
+          "price": "price_1TZtH5JEe0yY0QKrNgCWDrCD",
+          "product": "prod_UZ1DpExTQfai36"
+        },
+        "type": "price_details",
+        "unit_amount_decimal": "12100"
+      },
+      "proration": false,
+      "quantity": 1,
+      "quantity_decimal": "1",
+      "tax_rates": [],
+      "test_clock": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_Zhi6MOREJYJVRf",
+    "idempotency_key": "f3cef8ff-591d-4993-a20a-e53e75d6e570"
+  },
+  "type": "invoiceitem.created"
+}

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -1,6 +1,8 @@
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import orjson
+
 from zerver.lib.test_classes import WebhookTestCase
 
 
@@ -23,6 +25,23 @@ class StripeHookTests(WebhookTestCase):
             expected_topic_name,
             expected_message,
             content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_charge_dispute_created_pdp_prefix(self) -> None:
+        self.subscribe(self.test_user, self.channel_name)
+        payload = orjson.loads(self.get_body("charge_dispute_created"))
+        payload["data"]["object"]["id"] = "pdp_00000000000000"
+        msg = self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            orjson.dumps(payload).decode(),
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name="disputes",
+            content="[Dispute](https://dashboard.stripe.com/disputes/pdp_00000000000000) created. Current status: needs response.",
         )
 
     def test_charge_failed(self) -> None:

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -17,6 +17,15 @@ class StripeHookTests(WebhookTestCase):
             content_type="application/x-www-form-urlencoded",
         )
 
+    def test_charge_dispute_closed_with_pi(self) -> None:
+        expected_topic_name = "disputes"
+        expected_message = "[Dispute](https://dashboard.stripe.com/payments/pi_3TbG44JEe0yY0QKr0OnHpigY) closed. Current status: lost."
+        self.check_webhook(
+            "charge_dispute_closed_with_pi",
+            expected_topic_name,
+            expected_message,
+        )
+
     def test_charge_dispute_created(self) -> None:
         expected_topic_name = "disputes"
         expected_message = "[Dispute](https://dashboard.stripe.com/payments/ch_00000000000000) created. Current status: needs response."
@@ -44,6 +53,15 @@ class StripeHookTests(WebhookTestCase):
             content="[Dispute](https://dashboard.stripe.com/payments/ch_00000000000000) created. Current status: needs response.",
         )
 
+    def test_charge_dispute_created_with_pi(self) -> None:
+        expected_topic_name = "disputes"
+        expected_message = "[Dispute](https://dashboard.stripe.com/payments/pi_3TbG44JEe0yY0QKr0OnHpigY) created. Current status: needs response."
+        self.check_webhook(
+            "charge_dispute_created_with_pi",
+            expected_topic_name,
+            expected_message,
+        )
+
     def test_charge_failed(self) -> None:
         expected_topic_name = "charges"
         expected_message = (
@@ -54,6 +72,15 @@ class StripeHookTests(WebhookTestCase):
             expected_topic_name,
             expected_message,
             content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_charge_failed_with_pi(self) -> None:
+        expected_topic_name = "charges"
+        expected_message = "[Charge](https://dashboard.stripe.com/payments/pi_3TbGfyJEe0yY0QKr0V9PBbP9) for $22.00 failed. Failure code: card_declined"
+        self.check_webhook(
+            "charge_failed_with_pi",
+            expected_topic_name,
+            expected_message,
         )
 
     # Credit card charge
@@ -76,6 +103,15 @@ class StripeHookTests(WebhookTestCase):
             expected_topic_name,
             expected_message,
             content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_charge_succeeded_with_pi(self) -> None:
+        expected_topic_name = "charges"
+        expected_message = "[Charge](https://dashboard.stripe.com/payments/pi_3TbGBUJEe0yY0QKr1NhtlhQp) for $222.00 succeeded"
+        self.check_webhook(
+            "charge_succeeded_with_pi",
+            expected_topic_name,
+            expected_message,
         )
 
     def test_customer_created(self) -> None:
@@ -259,12 +295,12 @@ Amount due: 0.00 INR
 
     def test_refund_event(self) -> None:
         expected_topic_name = "refunds"
-        expected_message = "A refund for a [charge](https://dashboard.stripe.com/payments/ch_1Gib61HLwdCOCoR71rnkccye) of 300000.00 INR was updated."
+        expected_message = "A refund for a [charge](https://dashboard.stripe.com/payments/pi_1Gib60HLwdCOCoR7KJbTO3U7) of 300000.00 INR was updated."
         self.check_webhook("refund_event", expected_topic_name, expected_message)
 
     def test_pseudo_refund_event(self) -> None:
         expected_topic_name = "refunds"
-        expected_message = "A refund for a [payment](https://dashboard.stripe.com/payments/py_abcde12345ABCDG) of 12.34 EUR was updated."
+        expected_message = "A refund for a [payment](https://dashboard.stripe.com/payments/pi_abcd1234ABCDH) of 12.34 EUR was updated."
         self.check_webhook("pseudo_refund_event", expected_topic_name, expected_message)
 
     @patch("zerver.webhooks.stripe.view.check_send_webhook_message")

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -162,6 +162,19 @@ Billing method: send invoice"""
             content_type="application/x-www-form-urlencoded",
         )
 
+    def test_customer_subscription_created_with_collection_method(self) -> None:
+        expected_topic_name = "cus_UZ11RVzkmLf6Cf"
+        expected_message = """\
+[Subscription](https://dashboard.stripe.com/subscriptions/sub_1TbGh3JEe0yY0QKrmHd5I4l8) created
+Plan: https://dashboard.stripe.com/plans/price_1TZtAjJEe0yY0QKr27Tj0mDA
+Quantity: 1
+Billing method: charge automatically"""
+        self.check_webhook(
+            "customer_subscription_created_with_collection_method",
+            expected_topic_name,
+            expected_message,
+        )
+
     def test_customer_subscription_created_no_nickname(self) -> None:
         expected_topic_name = "cus_00000000000000"
         expected_message = """\
@@ -188,6 +201,15 @@ Billing method: send invoice"""
             content_type="application/x-www-form-urlencoded",
         )
 
+    def test_customer_subscription_deleted_with_collection_method(self) -> None:
+        expected_topic_name = "cus_UZ11RVzkmLf6Cf"
+        expected_message = "[Subscription](https://dashboard.stripe.com/subscriptions/sub_1TbGh3JEe0yY0QKrmHd5I4l8) deleted"
+        self.check_webhook(
+            "customer_subscription_deleted_with_collection_method",
+            expected_topic_name,
+            expected_message,
+        )
+
     def test_customer_subscription_updated(self) -> None:
         expected_topic_name = "cus_00000000000000"
         expected_message = """\
@@ -206,6 +228,20 @@ Billing method: send invoice"""
             content_type="application/x-www-form-urlencoded",
         )
 
+    def test_customer_subscription_updated_with_collection_method(self) -> None:
+        expected_topic_name = "cus_UZ11RVzkmLf6Cf"
+        expected_message = """\
+[Subscription](https://dashboard.stripe.com/subscriptions/sub_1TZtDLJEe0yY0QKroHU9hRvx) updated
+* Billing cycle anchor is now <time:2026-05-27T08:53:52+00:00>
+* Status is now trialing
+* Trial end is now <time:2026-05-27T08:53:52+00:00>
+* Trial start is now <time:2026-05-26T08:54:07+00:00>"""
+        self.check_webhook(
+            "customer_subscription_updated_with_collection_method",
+            expected_topic_name,
+            expected_message,
+        )
+
     def test_customer_subscription_trial_will_end(self) -> None:
         expected_topic_name = "cus_00000000000000"
         expected_message = "[Subscription](https://dashboard.stripe.com/subscriptions/sub_00000000000000) trial will end in 3 days"
@@ -217,6 +253,16 @@ Billing method: send invoice"""
                 expected_topic_name,
                 expected_message,
                 content_type="application/x-www-form-urlencoded",
+            )
+
+    def test_customer_subscription_trial_will_end_with_collection_method(self) -> None:
+        expected_topic_name = "cus_UZ11RVzkmLf6Cf"
+        expected_message = "[Subscription](https://dashboard.stripe.com/subscriptions/sub_1TZtDLJEe0yY0QKroHU9hRvx) trial will end in 3 days"
+        with mock.patch("time.time", return_value=1779872032 - 3 * 3600 * 24 + 100):
+            self.check_webhook(
+                "customer_subscription_trial_will_end_with_collection_method",
+                expected_topic_name,
+                expected_message,
             )
 
     def test_customer_updated__account_balance(self) -> None:

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -341,13 +341,30 @@ Amount due: 0.00 INR
 
     def test_refund_event(self) -> None:
         expected_topic_name = "refunds"
-        expected_message = "A refund for a [charge](https://dashboard.stripe.com/payments/pi_1Gib60HLwdCOCoR7KJbTO3U7) of 300000.00 INR was updated."
+        expected_message = "A refund for a [charge](https://dashboard.stripe.com/payments/pi_1Gib60HLwdCOCoR7KJbTO3U7) of 300000.00 INR failed."
         self.check_webhook("refund_event", expected_topic_name, expected_message)
 
     def test_pseudo_refund_event(self) -> None:
         expected_topic_name = "refunds"
-        expected_message = "A refund for a [payment](https://dashboard.stripe.com/payments/pi_abcd1234ABCDH) of 12.34 EUR was updated."
+        expected_message = "A refund for a [payment](https://dashboard.stripe.com/payments/pi_abcd1234ABCDH) of 12.34 EUR succeeded."
         self.check_webhook("pseudo_refund_event", expected_topic_name, expected_message)
+
+    def test_refund_event_requires_action(self) -> None:
+        self.subscribe(self.test_user, self.channel_name)
+        payload = orjson.loads(self.get_body("refund_event"))
+        payload["data"]["object"]["status"] = "requires_action"
+        msg = self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            orjson.dumps(payload).decode(),
+            content_type="application/json",
+        )
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name="refunds",
+            content="A refund for a [charge](https://dashboard.stripe.com/payments/pi_1Gib60HLwdCOCoR7KJbTO3U7) of 300000.00 INR requires action.",
+        )
 
     @patch("zerver.webhooks.stripe.view.check_send_webhook_message")
     def test_account_updated_without_previous_attributes_ignore(

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -9,7 +9,7 @@ from zerver.lib.test_classes import WebhookTestCase
 class StripeHookTests(WebhookTestCase):
     def test_charge_dispute_closed(self) -> None:
         expected_topic_name = "disputes"
-        expected_message = "[Dispute](https://dashboard.stripe.com/disputes/dp_00000000000000) closed. Current status: won."
+        expected_message = "[Dispute](https://dashboard.stripe.com/payments/ch_00000000000000) closed. Current status: won."
         self.check_webhook(
             "charge_dispute_closed",
             expected_topic_name,
@@ -19,7 +19,7 @@ class StripeHookTests(WebhookTestCase):
 
     def test_charge_dispute_created(self) -> None:
         expected_topic_name = "disputes"
-        expected_message = "[Dispute](https://dashboard.stripe.com/disputes/dp_00000000000000) created. Current status: needs response."
+        expected_message = "[Dispute](https://dashboard.stripe.com/payments/ch_00000000000000) created. Current status: needs response."
         self.check_webhook(
             "charge_dispute_created",
             expected_topic_name,
@@ -41,13 +41,13 @@ class StripeHookTests(WebhookTestCase):
             message=msg,
             channel_name=self.channel_name,
             topic_name="disputes",
-            content="[Dispute](https://dashboard.stripe.com/disputes/pdp_00000000000000) created. Current status: needs response.",
+            content="[Dispute](https://dashboard.stripe.com/payments/ch_00000000000000) created. Current status: needs response.",
         )
 
     def test_charge_failed(self) -> None:
         expected_topic_name = "charges"
         expected_message = (
-            "[Charge](https://dashboard.stripe.com/charges/ch_00000000000000) for 1.00 AUD failed"
+            "[Charge](https://dashboard.stripe.com/payments/ch_00000000000000) for 1.00 AUD failed"
         )
         self.check_webhook(
             "charge_failed",
@@ -59,7 +59,7 @@ class StripeHookTests(WebhookTestCase):
     # Credit card charge
     def test_charge_succeeded__card(self) -> None:
         expected_topic_name = "cus_00000000000000"
-        expected_message = "[Charge](https://dashboard.stripe.com/charges/ch_000000000000000000000000) for 1.00 AUD succeeded"
+        expected_message = "[Charge](https://dashboard.stripe.com/payments/ch_000000000000000000000000) for 1.00 AUD succeeded"
         self.check_webhook(
             "charge_succeeded__card",
             expected_topic_name,
@@ -229,9 +229,19 @@ Amount due: 0.00 INR
 
     def test_invoiceitem_created(self) -> None:
         expected_topic_name = "cus_00000000000000"
-        expected_message = "[Invoice item](https://dashboard.stripe.com/invoiceitems/ii_00000000000000) created for 10.00 CAD"
+        expected_message = "Invoice item created for 10.00 CAD"
         self.check_webhook(
             "invoiceitem_created",
+            expected_topic_name,
+            expected_message,
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_invoiceitem_created_with_intent(self) -> None:
+        expected_topic_name = "cus_UZ11RVzkmLf6Cf"
+        expected_message = "[Invoice item](https://dashboard.stripe.com/invoices/in_1TceefJEe0yY0QKrKgc29TeP) created for $121.00"
+        self.check_webhook(
+            "invoiceitem_created_with_invoice",
             expected_topic_name,
             expected_message,
             content_type="application/x-www-form-urlencoded",
@@ -249,12 +259,12 @@ Amount due: 0.00 INR
 
     def test_refund_event(self) -> None:
         expected_topic_name = "refunds"
-        expected_message = "A [refund](https://dashboard.stripe.com/refunds/re_1Gib6ZHLwdCOCoR7VrzCnXlj) for a [charge](https://dashboard.stripe.com/charges/ch_1Gib61HLwdCOCoR71rnkccye) of 300000.00 INR was updated."
+        expected_message = "A refund for a [charge](https://dashboard.stripe.com/payments/ch_1Gib61HLwdCOCoR71rnkccye) of 300000.00 INR was updated."
         self.check_webhook("refund_event", expected_topic_name, expected_message)
 
     def test_pseudo_refund_event(self) -> None:
         expected_topic_name = "refunds"
-        expected_message = "A [refund](https://dashboard.stripe.com/refunds/pyr_abcde12345ABCDF) for a [payment](https://dashboard.stripe.com/payments/py_abcde12345ABCDG) of 12.34 EUR was updated."
+        expected_message = "A refund for a [payment](https://dashboard.stripe.com/payments/py_abcde12345ABCDG) of 12.34 EUR was updated."
         self.check_webhook("pseudo_refund_event", expected_topic_name, expected_message)
 
     @patch("zerver.webhooks.stripe.view.check_send_webhook_message")

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -83,6 +83,10 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         topic_name = customer_id
     body = None
 
+    def charge_object_type(charge_id: str) -> str:
+        # Legacy ACH-style charges report object_type "charge" but use a "py_" id prefix.
+        return "payment" if charge_id.startswith("py_") else "charge"
+
     def update_string(blacklist: Sequence[str] = []) -> str:
         assert "previous_attributes" in payload["data"]
         previous_attributes = set(payload["data"]["previous_attributes"].keys()).difference(
@@ -100,7 +104,10 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
 
     def default_body(update_blacklist: Sequence[str] = []) -> str:
         body = "{resource} {verbed}".format(
-            resource=linkified_id(object_["id"].tame(check_string)), verbed=event.replace("_", " ")
+            resource=linkified_id(
+                object_["id"].tame(check_string), object_["object"].tame(check_string)
+            ),
+            verbed=event.replace("_", " "),
         )
         if event == "updated":
             return body + update_string(blacklist=update_blacklist)
@@ -126,8 +133,10 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         if resource == "charge":
             if not topic_name:  # only in legacy fixtures
                 topic_name = "charges"
+            object_id = object_["id"].tame(check_string)
+            charge_type = charge_object_type(object_id)
             body = "{resource} for {amount} {verbed}".format(
-                resource=linkified_id(object_["id"].tame(check_string)),
+                resource=linkified_id(object_id, charge_type),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
                 ),
@@ -142,9 +151,15 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
             )
         if resource == "refund":
             topic_name = "refunds"
+            charge_id = object_["charge"].tame(check_string)
+            charge_type = charge_object_type(charge_id)
             body = "A {resource} for a {charge} of {amount} was updated.".format(
-                resource=linkified_id(object_["id"].tame(check_string), lower=True),
-                charge=linkified_id(object_["charge"].tame(check_string), lower=True),
+                resource=linkified_id(
+                    object_["id"].tame(check_string),
+                    object_["object"].tame(check_string),
+                    lower=True,
+                ),
+                charge=linkified_id(charge_id, charge_type, lower=True),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
                 ),
@@ -314,44 +329,42 @@ def amount_string(amount: int, currency: str) -> str:
     return decimal_amount + f" {currency.upper()}"
 
 
-def linkified_id(object_id: str, lower: bool = False) -> str:
+def linkified_id(object_id: str, object_type: str, lower: bool = False) -> str:
     names_and_urls: dict[str, tuple[str, str | None]] = {
         # Core resources
-        "ch": ("Charge", "charges"),
-        "cus": ("Customer", "customers"),
-        "dp": ("Dispute", "disputes"),
-        "du": ("Dispute", "disputes"),
+        "charge": ("Charge", "charges"),
+        "customer": ("Customer", "customers"),
+        "dispute": ("Dispute", "disputes"),
         "file": ("File", "files"),
-        "link": ("File link", "file_links"),
-        "pi": ("Payment intent", "payment_intents"),
-        "po": ("Payout", "payouts"),
-        "prod": ("Product", "products"),
-        "re": ("Refund", "refunds"),
-        "tok": ("Token", "tokens"),
+        "file_link": ("File link", "file_links"),
+        "payment_intent": ("Payment intent", "payment_intents"),
+        "payout": ("Payout", "payouts"),
+        "product": ("Product", "products"),
+        "refund": ("Refund", "refunds"),
+        "token": ("Token", "tokens"),
         # Payment methods
         # payment methods have URL prefixes like /customers/cus_id/sources
-        "ba": ("Bank account", None),
+        "bank_account": ("Bank account", None),
         "card": ("Card", None),
-        "src": ("Source", None),
+        "source": ("Source", None),
         # Billing
         # coupons have a configurable id, but the URL prefix is /coupons
         # discounts don't have a URL, I think
-        "in": ("Invoice", "invoices"),
-        "ii": ("Invoice item", "invoiceitems"),
+        "invoice": ("Invoice", "invoices"),
+        "invoiceitem": ("Invoice item", "invoiceitems"),
         # products are covered in core resources
         # plans have a configurable id, though by default they are created with this pattern
         # 'plan': ('Plan', 'plans'),
-        "sub": ("Subscription", "subscriptions"),
-        "si": ("Subscription item", "subscription_items"),
+        "subscription": ("Subscription", "subscriptions"),
+        "subscription_item": ("Subscription item", "subscription_items"),
         # I think usage records have URL prefixes like /subscription_items/si_id/usage_record_summaries
-        "mbur": ("Usage record", None),
+        "usage_record": ("Usage record", None),
         # Undocumented :|
-        "py": ("Payment", "payments"),
-        "pyr": ("Refund", "refunds"),  # Pseudo refunds. Not fully tested.
+        "payment": ("Payment", "payments"),
         # Connect, Fraud, Orders, etc not implemented
     }
-    name, url_prefix = names_and_urls[object_id.split("_", 1)[0]]
-    if lower:  # nocoverage
+    name, url_prefix = names_and_urls[object_type]
+    if lower:
         name = name.lower()
     if url_prefix is None:  # nocoverage
         return name

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -87,6 +87,11 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         # Legacy ACH-style charges report object_type "charge" but use a "py_" id prefix.
         return "payment" if charge_id.startswith("py_") else "charge"
 
+    def get_payment_intent_id() -> str | None:
+        # Legacy payment related events don't have a `payment_intent` field in the payload
+        # or have it as null but newer ones do.
+        return object_.get("payment_intent").tame(check_none_or(check_string))
+
     def update_string(blacklist: Sequence[str] = []) -> str:
         assert "previous_attributes" in payload["data"]
         previous_attributes = set(payload["data"]["previous_attributes"].keys()).difference(
@@ -107,7 +112,7 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         object_id: str | None
         match object_type:
             case "dispute":
-                object_id = object_["charge"].tame(check_string)
+                object_id = get_payment_intent_id() or object_["charge"].tame(check_string)
             case "invoiceitem":
                 # Older `invoiceitem.created` event has invoice field as null.
                 object_id = object_["invoice"].tame(check_none_or(check_string))
@@ -144,7 +149,7 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
             object_id = object_["id"].tame(check_string)
             charge_type = charge_object_type(object_id)
             body = "{resource} for {amount} {verbed}".format(
-                resource=linkified_id(object_id, charge_type),
+                resource=linkified_id(get_payment_intent_id() or object_id, charge_type),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
                 ),
@@ -164,7 +169,7 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
             charge_type = charge_object_type(charge_id)
             body = "A {resource} for a {charge} of {amount} was updated.".format(
                 resource=object_["object"].tame(check_string),
-                charge=linkified_id(charge_id, charge_type, lower=True),
+                charge=linkified_id(get_payment_intent_id() or charge_id, charge_type, lower=True),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
                 ),

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -167,12 +167,15 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
             # Refunds have no dedicated dashboard URL, so we link to the parent charge.
             charge_id = object_["charge"].tame(check_string)
             charge_type = charge_object_type(charge_id)
-            body = "A {resource} for a {charge} of {amount} was updated.".format(
+            body = "A {resource} for a {charge} of {amount} {status}.".format(
                 resource=object_["object"].tame(check_string),
                 charge=linkified_id(get_payment_intent_id() or charge_id, charge_type, lower=True),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
                 ),
+                # status is one of "pending", "succeeded", "failed",
+                # "canceled", or "requires_action".
+                status=object_["status"].tame(check_string).replace("_", " "),
             )
     if category == "checkout_beta":  # nocoverage
         # Not sure what this is

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -329,7 +329,7 @@ def amount_string(amount: int, currency: str) -> str:
     return decimal_amount + f" {currency.upper()}"
 
 
-def linkified_id(object_id: str, object_type: str, lower: bool = False) -> str:
+def linkified_id(object_id: str | None, object_type: str, lower: bool = False) -> str:
     names_and_urls: dict[str, tuple[str, str | None]] = {
         # Core resources
         "charge": ("Charge", "charges"),
@@ -366,7 +366,7 @@ def linkified_id(object_id: str, object_type: str, lower: bool = False) -> str:
     name, url_prefix = names_and_urls[object_type]
     if lower:
         name = name.lower()
-    if url_prefix is None:  # nocoverage
+    if url_prefix is None or object_id is None:  # nocoverage
         return name
     return f"[{name}](https://dashboard.stripe.com/{url_prefix}/{object_id})"
 

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -203,7 +203,9 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         if resource == "source":  # nocoverage
             body = default_body()
         if resource == "subscription":
-            body = default_body()
+            # `items` and `latest_invoice` appear in modern `previous_attributes`
+            # but render as noisy object dumps, so omit them from the update list.
+            body = default_body(update_blacklist=["items", "latest_invoice"])
             if event == "trial_will_end":
                 DAY = 60 * 60 * 24  # seconds in a day
                 # Basically always three: https://stripe.com/docs/api/python#event_types
@@ -224,10 +226,16 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
                         )
                 if object_["quantity"]:
                     body += "\nQuantity: {}".format(object_["quantity"].tame(check_int))
-                if "billing" in object_:  # nocoverage
-                    body += "\nBilling method: {}".format(
-                        object_["billing"].tame(check_string).replace("_", " ")
-                    )
+                # `billing` was renamed to `collection_method` but older payloads
+                # still send the former.
+                if "billing" in object_:
+                    billing_method = object_["billing"].tame(check_string)
+                elif "collection_method" in object_:
+                    billing_method = object_["collection_method"].tame(check_string)
+                else:  # nocoverage
+                    billing_method = None
+                if billing_method is not None:
+                    body += "\nBilling method: {}".format(billing_method.replace("_", " "))
     if category == "file":  # nocoverage
         topic_name = "files"
         body = default_body() + " ({purpose}). \nTitle: {title}".format(

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -103,10 +103,18 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
         )
 
     def default_body(update_blacklist: Sequence[str] = []) -> str:
+        object_type = object_["object"].tame(check_string)
+        object_id: str | None
+        match object_type:
+            case "dispute":
+                object_id = object_["charge"].tame(check_string)
+            case "invoiceitem":
+                # Older `invoiceitem.created` event has invoice field as null.
+                object_id = object_["invoice"].tame(check_none_or(check_string))
+            case _:
+                object_id = object_["id"].tame(check_string)
         body = "{resource} {verbed}".format(
-            resource=linkified_id(
-                object_["id"].tame(check_string), object_["object"].tame(check_string)
-            ),
+            resource=linkified_id(object_id, object_type),
             verbed=event.replace("_", " "),
         )
         if event == "updated":
@@ -151,14 +159,11 @@ def topic_and_body(payload: WildValue) -> tuple[str, str]:
             )
         if resource == "refund":
             topic_name = "refunds"
+            # Refunds have no dedicated dashboard URL, so we link to the parent charge.
             charge_id = object_["charge"].tame(check_string)
             charge_type = charge_object_type(charge_id)
             body = "A {resource} for a {charge} of {amount} was updated.".format(
-                resource=linkified_id(
-                    object_["id"].tame(check_string),
-                    object_["object"].tame(check_string),
-                    lower=True,
-                ),
+                resource=object_["object"].tame(check_string),
                 charge=linkified_id(charge_id, charge_type, lower=True),
                 amount=amount_string(
                     object_["amount"].tame(check_int), object_["currency"].tame(check_string)
@@ -332,32 +337,47 @@ def amount_string(amount: int, currency: str) -> str:
 def linkified_id(object_id: str | None, object_type: str, lower: bool = False) -> str:
     names_and_urls: dict[str, tuple[str, str | None]] = {
         # Core resources
-        "charge": ("Charge", "charges"),
+        # `charge` no longer has a dedicated `/charges/<id>` page and modern
+        # Stripe surfaces charges under their parent payment intent at
+        # `/payments/<payment_intent_id>`. Older payloads omit
+        # `payment_intent`, but `/payments/<charge_id>` redirects correctly
+        # to the charge's parent payment intent page.
+        "charge": ("Charge", "payments"),
         "customer": ("Customer", "customers"),
-        "dispute": ("Dispute", "disputes"),
+        # dispute doesn't have a dedicated URL,
+        # but can be visualized in the parent payment's page.
+        "dispute": ("Dispute", "payments"),
         "file": ("File", "files"),
         "file_link": ("File link", "file_links"),
         "payment_intent": ("Payment intent", "payment_intents"),
         "payout": ("Payout", "payouts"),
         "product": ("Product", "products"),
-        "refund": ("Refund", "refunds"),
+        # refund doesn't have a dedicated URL,
+        # but can be visualized in the parent payment's page.
+        # The current refund events path does not use this object
+        # as they already reference the parent charge,
+        # not removing it from here for potential future use.
+        "refund": ("Refund", "payments"),
         "token": ("Token", "tokens"),
         # Payment methods
         # payment methods have URL prefixes like /customers/cus_id/sources
         "bank_account": ("Bank account", None),
         "card": ("Card", None),
+        # source object is deprecated but still functional (https://docs.stripe.com/api/sources).
         "source": ("Source", None),
         # Billing
         # coupons have a configurable id, but the URL prefix is /coupons
         # discounts don't have a URL, I think
         "invoice": ("Invoice", "invoices"),
-        "invoiceitem": ("Invoice item", "invoiceitems"),
+        # invoice items don't have a dedicated URL,
+        # but are visualized in the parent invoice's page.
+        "invoiceitem": ("Invoice item", "invoices"),
         # products are covered in core resources
         # plans have a configurable id, though by default they are created with this pattern
         # 'plan': ('Plan', 'plans'),
         "subscription": ("Subscription", "subscriptions"),
         "subscription_item": ("Subscription item", "subscription_items"),
-        # I think usage records have URL prefixes like /subscription_items/si_id/usage_record_summaries
+        # Legacy usage-based billing API, no flat dashboard URL (https://docs.stripe.com/api/usage_records?api-version=2024-10-28.acacia).
         "usage_record": ("Usage record", None),
         # Undocumented :|
         "payment": ("Payment", "payments"),
@@ -366,7 +386,7 @@ def linkified_id(object_id: str | None, object_type: str, lower: bool = False) -
     name, url_prefix = names_and_urls[object_type]
     if lower:
         name = name.lower()
-    if url_prefix is None or object_id is None:  # nocoverage
+    if url_prefix is None or object_id is None:
         return name
     return f"[{name}](https://dashboard.stripe.com/{url_prefix}/{object_id})"
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR is a follow up of https://github.com/zulip/zulip/pull/39398, updating some of the depricated fields and legacy URLs while keeping it backward compatible(most of the Stripe Updates are).


**How changes were tested:**
I have used [Stripe's Developer Dashboard](https://docs.stripe.com/development/dashboard) to trigger events and verify fixtures and the sequence of events.

* commit 1 (https://github.com/zulip/zulip/commit/4ea02ca11f9bc2f94a9335affa83ca7402cbece0): Belongs to the mentioned PR will rebase this once that gets merged.
* commit 2 (https://github.com/zulip/zulip/commit/1333a0579b3954e926f18df261d28a97ce145ed8): Prep commit for commit 3 to allow `linkified_id` to accept null `object_id` values.
* commit 3 (https://github.com/zulip/zulip/commit/362c7a8e08b156579f6b3a1f989d4a90f43653d8): Used the test dashbaord to verify the display path of the resources and update with the same. I have verified and updated the paths of the resources(`charge`, `customer`, `dispute`, `invoice`, `invoiceitem`, `refund`, and `subscription`) being used only and the other here are dead code so did not  update those paths.
* commit 4 (https://github.com/zulip/zulip/commit/d3596c9829f0a100392222ebabd2e0c1eb01634f): Refactors the code to use [payment_intent](https://docs.stripe.com/api/payment_intents) ids whenever present and is not null ( which is not for older versions) to prevent redirects, also add the updated fixtures with pi field.
* commit 5 (https://github.com/zulip/zulip/commit/16562f73766214e23e48f329f003bbf7b7810171): Stripe had [renamed `billing` field to `collection_method` ](https://docs.stripe.com/changelog/2019-10-17/renames-billing-attribute) so add the updated fixtures and use `collection_method` for newer versions and also keeping it backward compatible to support `billing` as well for older versions.
* commit 6(https://github.com/zulip/zulip/commit/5a33ecbed765dd84c7a6e6081413b1136a724b58): Prior `charge.refund.updated` event just diplayed the message as "was updated", but this could be enhanced be using the [status](https://docs.stripe.com/api/refunds/object#refund_object-status) field that is present in fixtures.
Also a thing to note here that Stripe [suggests](https://docs.stripe.com/api/events/types#event_types-charge.refund.updated) to use standalone [`refund`](https://docs.stripe.com/api/events/types#event_types-refund.created) events for getting info about all refund events. But I did observe that whenever we create a refund; even in the latest API version `refund.created` and `refund.succeded` event is always accompanied by `charge.refund.updated`. Since we can't remove `charge.refund.updated` and adding standalone events would be noisy, so updated `charge.refund.updated` event to include status in the messages.

<!-- If the PR makes UI changes, you must include screenshots. -->

**Screenshots and screen captures:**
<img width="1148" height="184" alt="image" src="https://github.com/user-attachments/assets/adfbd94b-a083-4020-9765-092c9f63f56f" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
