### PR TITLE
[ai] Wait for audit log update from free trial users instead of trying to process an invoice.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -2508,7 +2508,11 @@ class BillingSession(ABC):
                 # Check if user has already paid for the plan by invoice.
                 if not plan.charge_automatically:
                     last_sent_invoice = Invoice.objects.filter(plan=plan).order_by("-id").first()
-                    if last_sent_invoice and last_sent_invoice.status == Invoice.PAID:
+                    # An invoice-billed, free trial plan should have an invoice
+                    # created when it was created (see process_initial_upgrade).
+                    if last_sent_invoice is None:
+                        raise BillingError(f"Invoice-billed free trial has no invoice: {plan}.")
+                    if last_sent_invoice.status == Invoice.PAID:
                         # This will create invoice for any additional licenses that user has at the time of
                         # switching from free trial to paid plan since they already paid for the plan's this billing cycle.
                         is_renewal = False

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -5922,9 +5922,13 @@ def check_remote_server_audit_log_data(
                 plan, billing_session, next_invoice_date, last_audit_log_update
             )
 
-        # We still process free trial plans so that we can directly downgrade them.
-        if plan.is_free_trial() and not plan.charge_automatically:  # nocoverage
-            return True
+        # Process free trial plans that are billed by invoice if the sent
+        # invoice has not been paid, so that they can be automatically
+        # downgraded.
+        if plan.is_free_trial() and not plan.charge_automatically:
+            last_sent_invoice = Invoice.objects.filter(plan=plan).order_by("-id").first()
+            if last_sent_invoice is None or last_sent_invoice.status != Invoice.PAID:
+                return True
 
         # We don't have current audit log data from the remote server,
         # so we don't have enough information to invoice the plan.

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1787,6 +1787,37 @@ class StripeTest(StripeTestCase):
             # No additional ledger entries are created.
             self.assertEqual(before_ledger_count, after_ledger_count)
 
+    def test_make_end_of_cycle_updates_errors_without_free_trial_invoice(self) -> None:
+        realm = get_realm("zulip")
+        customer = Customer.objects.create(realm=realm, stripe_customer_id="cus_123")
+        free_trial_end_date = self.now + timedelta(days=30)
+        plan = CustomerPlan.objects.create(
+            customer=customer,
+            tier=CustomerPlan.TIER_CLOUD_STANDARD,
+            status=CustomerPlan.FREE_TRIAL,
+            # Billed by invoice rather than charged automatically.
+            charge_automatically=False,
+            billing_cycle_anchor=self.now,
+            billing_schedule=CustomerPlan.BILLING_SCHEDULE_ANNUAL,
+            price_per_license=8000,
+            next_invoice_date=free_trial_end_date,
+        )
+        LicenseLedger.objects.create(
+            plan=plan,
+            is_renewal=True,
+            event_time=self.now,
+            licenses=10,
+            licenses_at_next_renewal=10,
+        )
+        # No Invoice object exists for the plan.
+        billing_session = RealmBillingSession(realm=realm)
+        with self.assertRaises(BillingError) as billing_context:
+            billing_session.make_end_of_cycle_updates_if_needed(plan, free_trial_end_date)
+        self.assertEqual(
+            f"Invoice-billed free trial has no invoice: {plan}.",
+            billing_context.exception.error_description,
+        )
+
     @mock_stripe(tested_timestamp_fields=["created"])
     def test_free_trial_upgrade_by_invoice_with_additional_users_after_payment(
         self, *mocks: Mock

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -50,6 +50,7 @@ from corporate.lib.stripe import (
     UpdatePlanRequest,
     add_months,
     catch_stripe_errors,
+    check_remote_server_audit_log_data,
     compute_plan_parameters,
     customer_has_credit_card_as_default_payment_method,
     customer_has_last_n_invoices_open,
@@ -7026,6 +7027,74 @@ class TestRemoteServerBillingSession(StripeTestCase):
     #     customer = billing_session.update_or_create_stripe_customer()
     #     assert customer.stripe_customer_id
     #     # Confirm audit log, etc.
+
+    def test_check_audit_log_data_for_free_trial_billed_by_invoice(self) -> None:
+        remote_server = RemoteZulipServer.objects.create(
+            uuid=str(uuid.uuid4()),
+            api_key="magic_secret_api_key",
+            hostname="demo.example.com",
+            contact_email="email@example.com",
+            last_audit_log_update=timezone_now() - timedelta(days=5),
+        )
+        billing_session = RemoteServerBillingSession(remote_server)
+        customer = Customer.objects.create(
+            remote_server=remote_server, stripe_customer_id="cus_12345"
+        )
+        plan = CustomerPlan.objects.create(
+            customer=customer,
+            tier=CustomerPlan.TIER_SELF_HOSTED_BASIC,
+            status=CustomerPlan.FREE_TRIAL,
+            # Billed by invoice rather than charged automatically.
+            charge_automatically=False,
+            billing_cycle_anchor=timezone_now() - timedelta(days=30),
+            billing_schedule=CustomerPlan.BILLING_SCHEDULE_MONTHLY,
+            price_per_license=350,
+            # Audit log data above is stale relative to this date.
+            next_invoice_date=timezone_now(),
+        )
+
+        from django.core.mail import outbox
+
+        # Unpaid free trial: notify Zulip support, and return true to
+        # not defer invoicing the plan so that it can be downgraded.
+        Invoice.objects.create(
+            customer=customer,
+            plan=plan,
+            stripe_invoice_id="stripe_invoice_id_unpaid",
+            status=Invoice.SENT,
+        )
+        self.assertTrue(check_remote_server_audit_log_data(remote_server, plan, billing_session))
+        plan.refresh_from_db()
+        self.assertTrue(plan.stale_audit_log_data_email_sent)
+        self.assert_length(outbox, 1)
+        message = outbox[-1]
+        self.assertEqual(message.to, ["sales@zulip.com"])
+        self.assertEqual(
+            message.subject,
+            f"Stale audit log data for {billing_session.billing_entity_display_name}'s plan",
+        )
+
+        plan.stale_audit_log_data_email_sent = False
+        plan.save(update_fields=["stale_audit_log_data_email_sent"])
+
+        # Paid free trial: notify Zulip support, and return false to
+        # defer invoicing the plan until audit log data is fresh.
+        Invoice.objects.create(
+            customer=customer,
+            plan=plan,
+            stripe_invoice_id="stripe_invoice_id_paid",
+            status=Invoice.PAID,
+        )
+        self.assertFalse(check_remote_server_audit_log_data(remote_server, plan, billing_session))
+        plan.refresh_from_db()
+        self.assertTrue(plan.stale_audit_log_data_email_sent)
+        self.assert_length(outbox, 2)
+        message = outbox[-1]
+        self.assertEqual(message.to, ["sales@zulip.com"])
+        self.assertEqual(
+            message.subject,
+            f"Stale audit log data for {billing_session.billing_entity_display_name}'s plan",
+        )
 
 
 class TestSupportBillingHelpers(StripeTestCase):


### PR DESCRIPTION
Fixes error when we try to process free trial customer on manual billing with stale audit log.

Also, fixed the logic that if a free trial customer has no invoice, it is an error in our billing logic, so that should throw an error.