### PR TITLE
Add UI for viewing invitation details

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -129,6 +129,8 @@
 ## Invitations
 
 * [Get all invitations](/api/get-invites)
+* [Get email invitation details](/api/get-email-invite-details)
+* [Get reusable invitation link details](/api/get-multiuse-invite-details)
 * [Send invitations](/api/send-invites)
 * [Create a reusable invitation link](/api/create-invite-link)
 * [Resend an email invitation](/api/resend-email-invite)

--- a/api_docs/unmerged.d/ZF-d7fd0d.md
+++ b/api_docs/unmerged.d/ZF-d7fd0d.md
@@ -1,0 +1,7 @@
+* [`GET /invites/{invite_id}`](/api/get-email-invite-details): New endpoint that
+  returns details for a single email invitation, including the `stream_ids` and
+  `group_ids` of the channels and groups the invitee will be subscribed to.
+* [`GET /invites/multiuse/{invite_id}`](/api/get-multiuse-invite-details): New
+  endpoint that returns details for a single reusable invitation link, including
+  the `stream_ids` and `group_ids` of the channels and groups the invitee will
+  be subscribed to.

--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -4,6 +4,8 @@ import * as z from "zod/mini";
 import render_settings_resend_invite_modal from "../templates/confirm_dialog/confirm_resend_invite.hbs";
 import render_settings_revoke_invite_modal from "../templates/confirm_dialog/confirm_revoke_invite.hbs";
 import render_admin_invites_list from "../templates/settings/admin_invites_list.hbs";
+import render_view_invitation_modal from "../templates/settings/view_invitation_modal.hbs";
+import render_view_invitation_modal_content from "../templates/settings/view_invitation_modal_content.hbs";
 
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
@@ -12,12 +14,16 @@ import * as dialog_widget from "./dialog_widget.ts";
 import {$t_html} from "./i18n.ts";
 import * as ListWidget from "./list_widget.ts";
 import * as loading from "./loading.ts";
+import * as modals from "./modals.ts";
 import * as people from "./people.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
 import {current_user} from "./state_data.ts";
+import * as stream_data from "./stream_data.ts";
+import * as stream_settings_data from "./stream_settings_data.ts";
 import * as timerender from "./timerender.ts";
 import * as ui_report from "./ui_report.ts";
+import * as user_groups from "./user_groups.ts";
 import * as util from "./util.ts";
 
 export const invite_schema = z.intersection(
@@ -51,6 +57,15 @@ type Invite = z.output<typeof invite_schema> & {
     notify_referrer_on_join?: boolean;
 };
 
+const invite_details_schema = z.intersection(
+    invite_schema,
+    z.object({
+        welcome_message_custom_text: z.nullable(z.string()),
+        stream_ids: z.array(z.number()),
+        group_ids: z.array(z.number()),
+    }),
+);
+
 const meta = {
     loaded: false,
 };
@@ -66,6 +81,176 @@ function failed_listing_invites(xhr: JQuery.jqXHR): void {
         xhr,
         $("#invites-field-status"),
     );
+}
+
+function launch_revoke_invite_dialog({
+    $row,
+    invite_id,
+    is_multiuse,
+    email,
+    referred_by,
+}: {
+    $row: JQuery;
+    invite_id: string;
+    is_multiuse: string;
+    email: string;
+    referred_by: string;
+}): void {
+    const is_multiuse_bool = is_multiuse === "true";
+    const modal_content_html = render_settings_revoke_invite_modal({
+        is_multiuse: is_multiuse_bool,
+        email,
+        referred_by,
+    });
+    confirm_dialog.launch({
+        modal_title_html: is_multiuse_bool
+            ? $t_html({defaultMessage: "Revoke invitation link"})
+            : $t_html({defaultMessage: "Revoke invitation to {email}"}, {email}),
+        modal_content_html,
+        id: "revoke_invite_modal",
+        is_compact: true,
+        close_on_submit: false,
+        loading_spinner: true,
+        on_click() {
+            do_revoke_invite({$row, invite_id, is_multiuse});
+        },
+    });
+    $(".dialog_submit_button").attr("data-invite-id", invite_id);
+    $(".dialog_submit_button").attr("data-is-multiuse", is_multiuse);
+}
+
+function launch_resend_invite_dialog({
+    $row,
+    invite_id,
+    email,
+}: {
+    $row: JQuery;
+    invite_id: string;
+    email: string;
+}): void {
+    const modal_content_html = render_settings_resend_invite_modal({email});
+    confirm_dialog.launch({
+        modal_title_html: $t_html({defaultMessage: "Resend invitation?"}),
+        modal_content_html,
+        id: "resend_invite_modal",
+        close_on_submit: false,
+        loading_spinner: true,
+        on_click() {
+            do_resend_invite({$row, invite_id});
+        },
+    });
+    $(".dialog_submit_button").attr("data-invite-id", invite_id);
+}
+
+function open_invite_details_modal({
+    $row,
+    invite_id,
+    is_multiuse,
+}: {
+    $row: JQuery;
+    invite_id: string;
+    is_multiuse: string;
+}): void {
+    $("body").append($(render_view_invitation_modal({})));
+    modals.open("invite-details-modal", {
+        autoremove: true,
+        on_shown() {
+            const url =
+                is_multiuse === "true"
+                    ? "/json/invites/multiuse/" + invite_id
+                    : "/json/invites/" + invite_id;
+
+            loading.make_indicator($("#invite-details-modal .invite-details-loading-indicator"), {
+                abs_positioned: true,
+            });
+
+            void channel.get({
+                url,
+                timeout: 10 * 1000,
+                success(raw_data) {
+                    const data = z.object({invite: invite_details_schema}).parse(raw_data);
+                    const invite = data.invite;
+                    const stream_ids = [...invite.stream_ids];
+                    stream_settings_data.sort_for_stream_settings(stream_ids, "by-stream-name");
+                    const streams = stream_ids
+                        .map((id) => stream_data.get_sub_by_id(id))
+                        .filter((s) => s !== undefined);
+                    const groups = invite.group_ids
+                        .map((id) => user_groups.maybe_get_user_group_from_id(id))
+                        .filter((g) => g !== undefined)
+                        .toSorted((a, b) => util.strcmp(a.name, b.name));
+                    const referrer_name = current_user.is_admin
+                        ? people.get_full_name(invite.invited_by_user_id)
+                        : "";
+
+                    const ctx = {
+                        is_multiuse: invite.is_multiuse,
+                        invitee_display: invite.is_multiuse ? invite.link_url : invite.email,
+                        invited_by_user_id: invite.invited_by_user_id,
+                        is_admin: current_user.is_admin,
+                        referrer_name,
+                        invited_as_text: settings_config.user_role_map.get(invite.invited_as),
+                        invited_at: timerender.absolute_time(invite.invited * 1000),
+                        expires_at:
+                            invite.expiry_date !== null
+                                ? timerender.absolute_time(invite.expiry_date * 1000)
+                                : null,
+                        streams,
+                        has_streams: streams.length > 0,
+                        welcome_message_custom_text: invite.welcome_message_custom_text,
+                        groups,
+                        has_groups: groups.length > 0,
+                    };
+
+                    loading.destroy_indicator(
+                        $("#invite-details-modal .invite-details-loading-indicator"),
+                    );
+                    $("#invite-details-content").html(render_view_invitation_modal_content(ctx));
+
+                    const invite_id_str = invite.id.toString();
+                    const is_multiuse_str = invite.is_multiuse.toString();
+
+                    if (!invite.is_multiuse) {
+                        $("#invite-details-resend-btn").removeClass("hide");
+                    }
+
+                    $("#invite-details-modal .revoke").prop("disabled", false);
+                    $("#invite-details-modal .revoke").on("click", () => {
+                        modals.close("invite-details-modal");
+                        launch_revoke_invite_dialog({
+                            $row,
+                            invite_id: invite_id_str,
+                            is_multiuse: is_multiuse_str,
+                            email: invite.is_multiuse ? "" : invite.email,
+                            referred_by: referrer_name,
+                        });
+                    });
+
+                    if (!invite.is_multiuse) {
+                        $("#invite-details-modal .resend").on("click", () => {
+                            modals.close("invite-details-modal");
+                            launch_resend_invite_dialog({
+                                $row,
+                                invite_id: invite_id_str,
+                                email: invite.email,
+                            });
+                        });
+                    }
+                },
+                error(xhr) {
+                    loading.destroy_indicator(
+                        $("#invite-details-modal .invite-details-loading-indicator"),
+                    );
+                    ui_report.error(
+                        $t_html({defaultMessage: "Error fetching invitation details."}),
+                        xhr,
+                        $("#invites-field-status"),
+                    );
+                    modals.close("invite-details-modal");
+                },
+            });
+        },
+    });
 }
 
 function add_invited_as_text(invites: Invite[]): void {
@@ -273,29 +458,7 @@ export function on_load_success(
         const referred_by = $row.find(".referred_by").text();
         const invite_id = $(this).closest("tr").attr("data-invite-id")!;
         const is_multiuse = $(this).closest("tr").attr("data-is-multiuse")!;
-        const ctx = {
-            is_multiuse: is_multiuse === "true",
-            email,
-            referred_by,
-        };
-        const modal_content_html = render_settings_revoke_invite_modal(ctx);
-
-        confirm_dialog.launch({
-            modal_title_html: ctx.is_multiuse
-                ? $t_html({defaultMessage: "Revoke invitation link"})
-                : $t_html({defaultMessage: "Revoke invitation to {email}"}, {email}),
-            modal_content_html,
-            is_compact: true,
-            id: "revoke_invite_modal",
-            close_on_submit: false,
-            loading_spinner: true,
-            on_click() {
-                do_revoke_invite({$row, invite_id, is_multiuse});
-            },
-        });
-
-        $(".dialog_submit_button").attr("data-invite-id", invite_id);
-        $(".dialog_submit_button").attr("data-is-multiuse", is_multiuse);
+        launch_revoke_invite_dialog({$row, invite_id, is_multiuse, email, referred_by});
     });
 
     $(".admin_invites_table").on("click", ".resend", function (this: HTMLElement, e) {
@@ -303,24 +466,19 @@ export function on_load_success(
         // will not show up because of a call to `close_active` in `settings.ts`.
         e.preventDefault();
         e.stopPropagation();
-
         const $row = $(this).closest(".invite_row");
         const email = $row.find(".email").text();
         const invite_id = $(this).closest("tr").attr("data-invite-id")!;
-        const modal_content_html = render_settings_resend_invite_modal({email});
+        launch_resend_invite_dialog({$row, invite_id, email});
+    });
 
-        confirm_dialog.launch({
-            modal_title_html: $t_html({defaultMessage: "Resend invitation?"}),
-            modal_content_html,
-            id: "resend_invite_modal",
-            close_on_submit: false,
-            loading_spinner: true,
-            on_click() {
-                do_resend_invite({$row, invite_id});
-            },
-        });
-
-        $(".dialog_submit_button").attr("data-invite-id", invite_id);
+    $(".admin_invites_table").on("click", ".view-invite-details", function (this: HTMLElement, e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const $row = $(this).closest(".invite_row");
+        const invite_id = $(this).closest("tr").attr("data-invite-id")!;
+        const is_multiuse = $(this).closest("tr").attr("data-is-multiuse")!;
+        open_invite_details_modal({$row, invite_id, is_multiuse});
     });
 }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -241,21 +241,25 @@
 
 /* Modal-specific CSS belongs below this point. */
 
-#user-profile-modal {
-    .modal__container {
-        height: var(--user-profile-modal-height);
-    }
-
+#user-profile-modal,
+#invite-details-modal {
     .name {
         color: var(--color-user-profile-field-name);
         font-weight: 600;
-        margin-right: 10px;
+        /* 10px at 14px/1em */
+        margin-right: 0.7143em;
         overflow-wrap: break-word;
     }
 
     .value {
         vertical-align: top;
         overflow-wrap: anywhere;
+    }
+}
+
+#user-profile-modal {
+    .modal__container {
+        height: var(--user-profile-modal-height);
     }
 
     #exit-sign {
@@ -929,8 +933,11 @@
     box-shadow: var(--invalid-input-box-shadow);
 }
 
-.email_change_container .settings-field-hint {
+.settings-field-hint {
     color: var(--color-text-settings-field-hint);
+}
+
+.email_change_container .settings-field-hint {
     font-size: 0.9em;
 }
 
@@ -1264,3 +1271,24 @@ ul.modal-options-list {
 /* ==============================================================
  * END MODAL MARGIN OVERRIDES
  * ============================================================== */
+
+#invite-details-modal {
+    .invite-details-loading-indicator {
+        justify-self: center;
+    }
+
+    #invite-details-default-section {
+        .default-field {
+            /* 10px at 14px/1em */
+            margin-bottom: 0.7143em;
+        }
+    }
+
+    .invite-details-stream-list,
+    .invite-details-group-list {
+        /* Override browser default list styles. */
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+}

--- a/web/templates/settings/admin_invites_list.hbs
+++ b/web/templates/settings/admin_invites_list.hbs
@@ -1,5 +1,5 @@
 {{#with invite}}
-<tr class="invite_row" data-invite-id="{{id}}" data-is-multiuse="{{#unless is_multiuse}}false{{else}}true{{/unless}}">
+<tr class="invite_row" data-invite-id="{{id}}" data-is-multiuse="{{#if is_multiuse}}true{{else}}false{{/if}}">
     <td>
         {{#if is_multiuse}}
         <span class="email">
@@ -32,6 +32,14 @@
         <span>{{invited_as_text}}</span>
     </td>
     <td class="actions">
+        {{> ../components/icon_button
+          icon="eye"
+          intent="neutral"
+          custom_classes="view-invite-details tippy-zulip-delayed-tooltip"
+          aria-label=(t "View details")
+          data-tippy-content=(t "View details")
+          disabled=disable_buttons
+          }}
         {{> ../components/icon_button
           icon="trash"
           intent="danger"

--- a/web/templates/settings/view_invitation_modal.hbs
+++ b/web/templates/settings/view_invitation_modal.hbs
@@ -1,0 +1,41 @@
+<div class="micromodal" id="invite-details-modal" aria-hidden="true">
+    <div class="modal__overlay" tabindex="-1">
+        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="invite-details-modal-title">
+            <div class="modal__header">
+                <div class="modal__header-content">
+                    <h1 class="modal__title" id="invite-details-modal-title">{{t "Manage invitation"}}</h1>
+                </div>
+                {{> ../components/icon_button
+                  icon="close"
+                  intent="neutral"
+                  custom_classes="modal__close"
+                  aria-label=(t "Close modal")
+                  data-micromodal-close=true
+                  }}
+            </div>
+            <main class="modal__content" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                <div class="invite-details-loading-indicator"></div>
+                <div id="invite-details-content"></div>
+            </main>
+            <footer class="modal__footer">
+                <span id="invite-details-resend-btn" class="hide">
+                    {{> ../components/icon_button
+                      icon="send-dm"
+                      intent="neutral"
+                      custom_classes="resend tippy-zulip-delayed-tooltip"
+                      aria-label=(t "Resend")
+                      data-tippy-content=(t "Resend")
+                      }}
+                </span>
+                {{> ../components/icon_button
+                  icon="trash"
+                  intent="danger"
+                  custom_classes="revoke tippy-zulip-delayed-tooltip"
+                  aria-label=(t "Revoke")
+                  data-tippy-content=(t "Revoke")
+                  disabled=true
+                  }}
+            </footer>
+        </div>
+    </div>
+</div>

--- a/web/templates/settings/view_invitation_modal_content.hbs
+++ b/web/templates/settings/view_invitation_modal_content.hbs
@@ -1,0 +1,76 @@
+<div id="invite-details-default-section">
+    {{#if is_multiuse}}
+    <div class="default-field">
+        <div class="name">{{t "Invitee"}}</div>
+        <div class="value">
+            <a href="{{invitee_display}}" target="_blank" rel="noopener noreferrer">
+                {{t "Invite link"}}
+            </a>
+        </div>
+    </div>
+    {{else}}
+    <div class="default-field">
+        <div class="name">{{t "Invitee"}}</div>
+        <div class="value">{{invitee_display}}</div>
+    </div>
+    {{/if}}
+    <div class="default-field">
+        <div class="name">{{t "Invited as"}}</div>
+        <div class="value">{{invited_as_text}}</div>
+    </div>
+    {{#if is_admin}}
+    <div class="default-field">
+        <div class="name">{{t "Invited by"}}</div>
+        <span class="referred_by panel_user_list">
+            {{> ../user_display_only_pill display_value=referrer_name user_id=invited_by_user_id is_active=true}}
+        </span>
+    </div>
+    {{/if}}
+    <div class="default-field">
+        <div class="name">{{t "Invited at"}}</div>
+        <div class="value">{{invited_at}}</div>
+    </div>
+    {{#if expires_at}}
+    <div class="default-field">
+        <div class="name">{{t "Expires at"}}</div>
+        <div class="value">{{expires_at}}</div>
+    </div>
+    {{/if}}
+    {{#if welcome_message_custom_text}}
+    <div class="default-field">
+        <div class="name">{{t "Welcome message"}}</div>
+        <div class="value">{{welcome_message_custom_text}}</div>
+    </div>
+    {{/if}}
+    <div class="default-field">
+        <div class="name">{{t "Channels they will join"}}</div>
+        {{#if has_streams}}
+        <ul class="invite-details-stream-list">
+            {{#each streams}}
+                <li>
+                    {{> ../decorated_channel_name stream=this inline_with_text=true show_colored_icon=true}}
+                </li>
+            {{/each}}
+        </ul>
+        {{else}}
+        <div class="value">{{t "None"}}</div>
+        {{/if}}
+        <div class="settings-field-hint">
+            {{t "This list shows only channels you have access to."}}
+        </div>
+    </div>
+    <div class="default-field">
+        <div class="name">{{t "Groups they will join"}}</div>
+        {{#if has_groups}}
+        <ul class="invite-details-group-list">
+            {{#each groups}}
+                <li>
+                    {{> ../user_group_display_only_pill group_id=id display_value=name}}
+                </li>
+            {{/each}}
+        </ul>
+        {{else}}
+        <div class="value">{{t "None"}}</div>
+        {{/if}}
+    </div>
+</div>

--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -3,7 +3,7 @@ from collections.abc import Collection, Sequence
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from email.utils import format_datetime as email_format_datetime
-from typing import Any
+from typing import Any, TypedDict
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -23,6 +23,7 @@ from confirmation.models import (
     create_confirmation_object,
 )
 from zerver.context_processors import common_context
+from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.email_validation import (
     get_existing_user_errors,
     get_realm_email_validator,
@@ -32,8 +33,10 @@ from zerver.lib.exceptions import InvitationError
 from zerver.lib.invites import notify_invites_changed
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.send_email import FromAddress, clear_scheduled_invitation_emails, send_future_email
+from zerver.lib.streams import get_metadata_access_streams
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.types import Invitee
+from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
     Message,
@@ -47,6 +50,33 @@ from zerver.models import (
 )
 from zerver.models.prereg_users import filter_to_valid_prereg_users
 from zerver.models.realm_audit_logs import AuditLogEventType
+
+
+class EmailInviteDetailsDict(TypedDict):
+    email: str
+    invited_by_user_id: int
+    invited: int
+    expiry_date: int | None
+    id: int
+    invited_as: int
+    is_multiuse: bool
+    notify_referrer_on_join: bool
+    welcome_message_custom_text: str | None
+    stream_ids: list[int]
+    group_ids: list[int]
+
+
+class MultiuseInviteDetailsDict(TypedDict):
+    link_url: str
+    invited_by_user_id: int
+    invited: int
+    expiry_date: int | None
+    id: int
+    invited_as: int
+    is_multiuse: bool
+    welcome_message_custom_text: str | None
+    stream_ids: list[int]
+    group_ids: list[int]
 
 
 def estimate_recent_invites(realms: Collection[Realm] | QuerySet[Realm], *, days: int) -> int:
@@ -340,6 +370,34 @@ class MultiuseInviteData:
     is_multiuse: bool
 
 
+def _build_prereg_invite_data(invitee: PreregistrationUser) -> PreregistrationInviteData:
+    assert invitee.referred_by is not None
+    return PreregistrationInviteData(
+        email=invitee.email,
+        invited_by_user_id=invitee.referred_by.id,
+        invited=datetime_to_timestamp(invitee.invited_at),
+        expiry_date=get_invitation_expiry_date(invitee.confirmation.get()),
+        id=invitee.id,
+        invited_as=invitee.invited_as,
+        is_multiuse=False,
+        notify_referrer_on_join=invitee.notify_referrer_on_join,
+    )
+
+
+def _build_multiuse_invite_data(
+    invite: MultiuseInvite, confirmation_obj: Confirmation
+) -> MultiuseInviteData:
+    return MultiuseInviteData(
+        invited_by_user_id=invite.referred_by.id,
+        invited=datetime_to_timestamp(confirmation_obj.date_sent),
+        expiry_date=get_invitation_expiry_date(confirmation_obj),
+        id=invite.id,
+        link_url=confirmation_url_for(confirmation_obj),
+        invited_as=invite.invited_as,
+        is_multiuse=True,
+    )
+
+
 def do_get_invites_controlled_by_user(user_profile: UserProfile) -> list[dict[str, Any]]:
     """
     Returns a list of dicts representing invitations that can be controlled by user_profile.
@@ -355,22 +413,9 @@ def do_get_invites_controlled_by_user(user_profile: UserProfile) -> list[dict[st
             PreregistrationUser.objects.filter(referred_by=user_profile)
         )
 
-    invites: list[PreregistrationInviteData | MultiuseInviteData] = []
-
-    for invitee in prereg_users:
-        assert invitee.referred_by is not None
-        invites.append(
-            PreregistrationInviteData(
-                email=invitee.email,
-                invited_by_user_id=invitee.referred_by.id,
-                invited=datetime_to_timestamp(invitee.invited_at),
-                expiry_date=get_invitation_expiry_date(invitee.confirmation.get()),
-                id=invitee.id,
-                invited_as=invitee.invited_as,
-                is_multiuse=False,
-                notify_referrer_on_join=invitee.notify_referrer_on_join,
-            )
-        )
+    invites: list[PreregistrationInviteData | MultiuseInviteData] = [
+        _build_prereg_invite_data(invitee) for invitee in prereg_users
+    ]
 
     if user_profile.is_realm_admin:
         multiuse_invite_ids = (
@@ -401,18 +446,81 @@ def do_get_invites_controlled_by_user(user_profile: UserProfile) -> list[dict[st
         assert invite is not None
 
         assert invite.status != confirmation_settings.STATUS_REVOKED
-        invites.append(
-            MultiuseInviteData(
-                invited_by_user_id=invite.referred_by.id,
-                invited=datetime_to_timestamp(confirmation_obj.date_sent),
-                expiry_date=get_invitation_expiry_date(confirmation_obj),
-                id=invite.id,
-                link_url=confirmation_url_for(confirmation_obj),
-                invited_as=invite.invited_as,
-                is_multiuse=True,
-            )
-        )
+        invites.append(_build_multiuse_invite_data(invite, confirmation_obj))
     return [asdict(invite) for invite in invites]
+
+
+def get_accessible_stream_ids_for_invite(
+    stream_ids: Collection[int], user_profile: UserProfile
+) -> list[int]:
+    """Filter stream_ids down to those user_profile currently has metadata
+    access to, so the invite details endpoints don't leak the existence of
+    private channels to viewers who can't otherwise see them."""
+    streams = Stream.objects.filter(id__in=stream_ids)
+    accessible_streams = get_metadata_access_streams(
+        user_profile, streams, UserGroupMembershipDetails(user_recursive_group_ids=None)
+    )
+    return sorted(stream.id for stream in accessible_streams)
+
+
+def get_invite_details_dict(
+    prereg_user: PreregistrationUser, user_profile: UserProfile
+) -> EmailInviteDetailsDict:
+    """Return email invite details including stream IDs and group IDs."""
+    base = _build_prereg_invite_data(prereg_user)
+    explicit_stream_ids = set(prereg_user.streams.values_list("id", flat=True))
+    if prereg_user.include_realm_default_subscriptions:
+        all_stream_ids = explicit_stream_ids | get_default_stream_ids_for_realm(
+            user_profile.realm.id
+        )
+    else:
+        all_stream_ids = explicit_stream_ids
+    stream_ids = get_accessible_stream_ids_for_invite(all_stream_ids, user_profile)
+    group_ids = list(prereg_user.groups.values_list("id", flat=True))
+    return {
+        "email": base.email,
+        "invited_by_user_id": base.invited_by_user_id,
+        "invited": base.invited,
+        "expiry_date": base.expiry_date,
+        "id": base.id,
+        "invited_as": base.invited_as,
+        "is_multiuse": base.is_multiuse,
+        "notify_referrer_on_join": base.notify_referrer_on_join,
+        "welcome_message_custom_text": prereg_user.welcome_message_custom_text,
+        "stream_ids": stream_ids,
+        "group_ids": group_ids,
+    }
+
+
+def get_multiuse_invite_details_dict(
+    invite: MultiuseInvite, user_profile: UserProfile
+) -> MultiuseInviteDetailsDict:
+    """Return multiuse invite details including stream IDs and group IDs."""
+    confirmation_obj = Confirmation.objects.get(
+        type=Confirmation.MULTIUSE_INVITE,
+        content_type=ContentType.objects.get_for_model(MultiuseInvite),
+        object_id=invite.id,
+    )
+    base = _build_multiuse_invite_data(invite, confirmation_obj)
+    explicit_stream_ids = set(invite.streams.values_list("id", flat=True))
+    if invite.include_realm_default_subscriptions:
+        all_stream_ids = explicit_stream_ids | get_default_stream_ids_for_realm(invite.realm_id)
+    else:
+        all_stream_ids = explicit_stream_ids
+    stream_ids = get_accessible_stream_ids_for_invite(all_stream_ids, user_profile)
+    group_ids = list(invite.groups.values_list("id", flat=True))
+    return {
+        "link_url": base.link_url,
+        "invited_by_user_id": base.invited_by_user_id,
+        "invited": base.invited,
+        "expiry_date": base.expiry_date,
+        "id": base.id,
+        "invited_as": base.invited_as,
+        "is_multiuse": base.is_multiuse,
+        "welcome_message_custom_text": invite.welcome_message_custom_text,
+        "stream_ids": stream_ids,
+        "group_ids": group_ids,
+    }
 
 
 @transaction.atomic(durable=True)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17824,6 +17824,84 @@ paths:
                           An example JSON error response for when the user doesn't have permission
                           to subscribe other users to channels and `stream_ids` is not empty.
   /invites/{invite_id}:
+    get:
+      operationId: get-email-invite-details
+      summary: Get email invitation details
+      tags: ["invites"]
+      description: |
+        Fetch details for a single pending email
+        [invitation](/help/invite-new-users#send-email-invitations), including
+        the channels and groups the invitee will be subscribed to.
+
+        A user can only fetch details for [invitations that they can
+        manage](/help/invite-new-users#manage-pending-invitations).
+
+        **Changes**: New in Zulip 13.0 (feature level ZF-d7fd0d).
+      parameters:
+        - name: invite_id
+          in: path
+          description: |
+            The ID of the email invitation to fetch.
+          schema:
+            type: integer
+          example: 1
+          required: true
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      invite:
+                        allOf:
+                          - $ref: "#/components/schemas/Invite"
+                          - type: object
+                            description: |
+                              An email invitation object with full details, including the
+                              channels and groups the invitee will be subscribed to upon
+                              accepting the invitation.
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "invite":
+                          {
+                            "email": "example@zulip.com",
+                            "invited_by_user_id": 11,
+                            "invited": 1726339239,
+                            "expiry_date": 1727203239,
+                            "id": 1,
+                            "invited_as": 400,
+                            "is_multiuse": false,
+                            "notify_referrer_on_join": true,
+                            "welcome_message_custom_text": null,
+                            "stream_ids": [14, 3, 13, 10, 2],
+                            "group_ids": [],
+                          },
+                      }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "No such invitation",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for an invalid email invitation ID.
     delete:
       operationId: revoke-email-invite
       summary: Revoke an email invitation
@@ -17862,6 +17940,94 @@ paths:
                         description: |
                           A typical failed JSON response for an invalid email invitation ID:
   /invites/multiuse/{invite_id}:
+    get:
+      operationId: get-multiuse-invite-details
+      summary: Get reusable invitation link details
+      tags: ["invites"]
+      description: |
+        Fetch details for a single pending [reusable invitation
+        link](/help/invite-new-users#create-a-reusable-invitation-link),
+        including the channels and groups the invitee will be subscribed to.
+
+        A user can only fetch details for [invitations that they can
+        manage](/help/invite-new-users#manage-pending-invitations).
+
+        **Changes**: New in Zulip 13.0 (feature level ZF-d7fd0d).
+      parameters:
+        - name: invite_id
+          in: path
+          description: |
+            The ID of the reusable invitation link to fetch.
+          schema:
+            type: integer
+          example: 1
+          required: true
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      invite:
+                        allOf:
+                          - $ref: "#/components/schemas/Invite"
+                          - type: object
+                            description: |
+                              A reusable invitation link object with full details, including the
+                              channels and groups the invitee will be subscribed to upon
+                              accepting the invitation.
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "invite":
+                          {
+                            "link_url": "https://example.zulipchat.com/join/yddhtzk4jgl7rsmazc5fyyyy/",
+                            "invited_by_user_id": 11,
+                            "invited": 1726339239,
+                            "expiry_date": 1727203239,
+                            "id": 1,
+                            "invited_as": 400,
+                            "is_multiuse": true,
+                            "welcome_message_custom_text": null,
+                            "stream_ids": [1, 2, 3, 13, 14],
+                            "group_ids": [],
+                          },
+                      }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "No such invitation",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for an invalid invitation link ID.
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Invitation has already been revoked",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          A typical failed JSON response for when the invitation link
+                          has already been revoked.
     delete:
       operationId: revoke-invite-link
       summary: Revoke a reusable invitation link
@@ -28472,6 +28638,38 @@ components:
           description: |
             A boolean specifying whether the [invitation](/help/invite-new-users) is a
             reusable invitation link or an email invitation.
+        stream_ids:
+          type: array
+          items:
+            type: integer
+          description: |
+            IDs of the channels the invitee will be subscribed to upon accepting
+            the invitation. Only present in responses from
+            [`GET /invites/{invite_id}`](/api/get-email-invite-details) and
+            [`GET /invites/multiuse/{invite_id}`](/api/get-multiuse-invite-details).
+
+            **Changes**: New in Zulip 13.0 (feature level ZF-d7fd0d).
+        group_ids:
+          type: array
+          items:
+            type: integer
+          description: |
+            IDs of the [user groups](/api/get-user-groups) the invitee will be
+            added to upon accepting the invitation. Only present in responses from
+            [`GET /invites/{invite_id}`](/api/get-email-invite-details) and
+            [`GET /invites/multiuse/{invite_id}`](/api/get-multiuse-invite-details).
+
+            **Changes**: New in Zulip 13.0 (feature level ZF-d7fd0d).
+        welcome_message_custom_text:
+          type: string
+          nullable: true
+          description: |
+            A custom welcome message included in the invitation email, or `null`
+            if no custom message was set. Only present in responses from
+            [`GET /invites/{invite_id}`](/api/get-email-invite-details) and
+            [`GET /invites/multiuse/{invite_id}`](/api/get-multiuse-invite-details).
+
+            **Changes**: New in Zulip 13.0 (feature level ZF-d7fd0d).
     InviteExpirationParameter:
       description: |
         The number of minutes before the invitation will expire. If `null`, the

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -38,6 +38,7 @@ from zerver.actions.invites import (
     do_invite_users,
     do_revoke_multi_use_invite,
     do_revoke_user_invite,
+    get_multiuse_invite_details_dict,
     too_many_recent_realm_invites,
 )
 from zerver.actions.realm_settings import (
@@ -2668,6 +2669,268 @@ class InvitationsTestCase(InviteUserBase):
         prereg_user.refresh_from_db()
         self.assertEqual(prereg_user.status, confirmation_settings.STATUS_REVOKED)
         self.assertTrue(Confirmation.objects.filter(id=confirmation.id).exists())
+
+    def test_get_email_invite_details(self) -> None:
+        """
+        GET /json/invites/{invite_id} returns invite details including
+        stream_ids and group_ids for the invitation.
+        """
+        self.login("iago")
+        zulip_realm = get_realm("zulip")
+        invitee_email = "test-invite-details@zulip.com"
+
+        # Invite with default realm subscriptions.
+        self.assert_json_success(
+            self.invite(
+                invitee_email, [], realm=zulip_realm, include_realm_default_subscriptions=True
+            )
+        )
+        prereg_user = PreregistrationUser.objects.get(email=invitee_email)
+
+        result = self.client_get(f"/json/invites/{prereg_user.id}")
+        self.assert_json_success(result)
+        invite = result.json()["invite"]
+        self.assertEqual(invite["email"], invitee_email)
+        self.assertFalse(invite["is_multiuse"])
+        self.assert_length(
+            invite["stream_ids"],
+            len(get_slim_realm_default_streams(zulip_realm.id)),
+        )
+        self.assertEqual(invite["group_ids"], [])
+
+        # Non-existent invite ID returns an error.
+        result = self.client_get(f"/json/invites/{prereg_user.id + 9999}")
+        self.assert_json_error(result, "No such invitation")
+
+        # A revoked invite is not accessible.
+        do_revoke_user_invite(prereg_user, acting_user=self.example_user("iago"))
+        result = self.client_get(f"/json/invites/{prereg_user.id}")
+        self.assert_json_error(result, "Invitation already used or deactivated.")
+
+        # Invite from a different realm is not accessible.
+        mit_realm = get_realm("zephyr")
+        other_realm_prereg = PreregistrationUser.objects.create(
+            referred_by=self.mit_user("sipbtest"), realm=mit_realm
+        )
+        result = self.client_get(f"/json/invites/{other_realm_prereg.id}")
+        self.assert_json_error(result, "No such invitation")
+
+    def test_get_email_invite_details_with_streams(self) -> None:
+        """
+        GET /json/invites/{invite_id} returns only the explicitly specified
+        stream_ids when not using realm default subscriptions.
+        """
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        invitee_email = "test-invite-streams@zulip.com"
+        zulip_realm = get_realm("zulip")
+
+        self.assert_json_success(self.invite(invitee_email, ["Denmark"], realm=zulip_realm))
+        prereg_user = PreregistrationUser.objects.get(email=invitee_email, referred_by=user_profile)
+
+        # The creator can access their own invitation.
+        result = self.api_get(user_profile, f"/api/v1/invites/{prereg_user.id}")
+        self.assert_json_success(result)
+        invite = result.json()["invite"]
+        self.assert_length(invite["stream_ids"], 1)
+
+        # Another non-admin member cannot access someone else's invitation.
+        result = self.api_get(self.example_user("othello"), f"/api/v1/invites/{prereg_user.id}")
+        self.assert_json_error(result, "Must be an organization administrator")
+
+    def test_get_email_invite_details_excludes_inaccessible_private_streams(self) -> None:
+        """
+        GET /json/invites/{invite_id} omits private channel IDs that the
+        requesting user no longer has metadata access to, even if the
+        channel was included when the invite was created.
+        """
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        private_stream_name = "Secret invite stream"
+        self.make_stream(private_stream_name, invite_only=True)
+        self.subscribe(user_profile, private_stream_name)
+
+        invitee_email = "test-invite-hidden-stream@zulip.com"
+        self.assert_json_success(self.invite(invitee_email, [private_stream_name, "Denmark"]))
+        prereg_user = PreregistrationUser.objects.get(email=invitee_email, referred_by=user_profile)
+
+        # While still subscribed, the referrer can see both channels.
+        result = self.api_get(user_profile, f"/api/v1/invites/{prereg_user.id}")
+        self.assert_json_success(result)
+        self.assert_length(result.json()["invite"]["stream_ids"], 2)
+
+        # After leaving the private channel, its ID is no longer exposed.
+        self.unsubscribe(user_profile, private_stream_name)
+        result = self.api_get(user_profile, f"/api/v1/invites/{prereg_user.id}")
+        self.assert_json_success(result)
+        self.assertEqual(result.json()["invite"]["stream_ids"], [self.get_stream_id("Denmark")])
+
+    def test_get_email_invite_details_owner_permission(self) -> None:
+        """
+        GET /json/invites/{invite_id} requires owner permission when the
+        invite is for an owner role.
+        """
+        self.login("desdemona")
+        owner = self.example_user("desdemona")
+        zulip_realm = get_realm("zulip")
+        invitee_email = "test-owner-invite@zulip.com"
+        self.assert_json_success(
+            self.invite(
+                invitee_email,
+                [],
+                invite_as=PreregistrationUser.INVITE_AS["REALM_OWNER"],
+                realm=zulip_realm,
+                include_realm_default_subscriptions=True,
+            )
+        )
+        prereg_user = PreregistrationUser.objects.get(email=invitee_email)
+
+        # Admin (non-owner) cannot access owner invitation.
+        result = self.api_get(self.example_user("iago"), f"/api/v1/invites/{prereg_user.id}")
+        self.assert_json_error(result, "Must be an organization owner")
+
+        # Owner can access their own owner invitation.
+        result = self.api_get(owner, f"/api/v1/invites/{prereg_user.id}")
+        self.assert_json_success(result)
+        self.assert_length(
+            result.json()["invite"]["stream_ids"],
+            len(get_slim_realm_default_streams(zulip_realm.id)),
+        )
+
+    def test_get_multiuse_invite_details(self) -> None:
+        """
+        GET /json/invites/multiuse/{invite_id} returns invite details
+        including stream_ids and group_ids.
+        """
+        self.login("iago")
+        zulip_realm = get_realm("zulip")
+
+        # Multiuse invite with explicit streams.
+        streams = [get_stream("Denmark", zulip_realm), get_stream("Scotland", zulip_realm)]
+        invite_expires_in_minutes = 2 * 24 * 60
+        do_create_multiuse_invite_link(
+            self.example_user("iago"),
+            PreregistrationUser.INVITE_AS["MEMBER"],
+            invite_expires_in_minutes,
+            include_realm_default_subscriptions=False,
+            streams=streams,
+        )
+        invite_id = do_get_invites_controlled_by_user(self.example_user("iago"))[0]["id"]
+        multiuse_invite = MultiuseInvite.objects.get(id=invite_id)
+
+        result = self.client_get(f"/json/invites/multiuse/{multiuse_invite.id}")
+        self.assert_json_success(result)
+        invite = result.json()["invite"]
+        self.assertTrue(invite["is_multiuse"])
+        self.assert_length(invite["stream_ids"], 2)
+        self.assertEqual(invite["group_ids"], [])
+        self.assertIn("link_url", invite)
+
+        # Invite with realm default subscriptions uses default stream IDs.
+        do_create_multiuse_invite_link(
+            self.example_user("iago"),
+            PreregistrationUser.INVITE_AS["MEMBER"],
+            invite_expires_in_minutes,
+            include_realm_default_subscriptions=True,
+            streams=[],
+        )
+        all_invites = do_get_invites_controlled_by_user(self.example_user("iago"))
+        default_streams_invite_id = next(inv["id"] for inv in all_invites if inv["id"] != invite_id)
+        default_streams_invite = MultiuseInvite.objects.get(id=default_streams_invite_id)
+
+        result = self.client_get(f"/json/invites/multiuse/{default_streams_invite.id}")
+        self.assert_json_success(result)
+        self.assert_length(
+            result.json()["invite"]["stream_ids"],
+            len(get_slim_realm_default_streams(zulip_realm.id)),
+        )
+
+        # Non-existent ID returns error.
+        non_existent_id = MultiuseInvite.objects.count() + 9999
+        result = self.client_get(f"/json/invites/multiuse/{non_existent_id}")
+        self.assert_json_error(result, "No such invitation")
+
+        # Invite from another realm is inaccessible.
+        mit_realm = get_realm("zephyr")
+        other_realm_invite = MultiuseInvite.objects.create(
+            referred_by=self.mit_user("sipbtest"), realm=mit_realm
+        )
+        create_confirmation_link(
+            other_realm_invite,
+            Confirmation.MULTIUSE_INVITE,
+            validity_in_minutes=invite_expires_in_minutes,
+        )
+        result = self.client_get(f"/json/invites/multiuse/{other_realm_invite.id}")
+        self.assert_json_error(result, "No such invitation")
+
+    def test_get_multiuse_invite_details_revoked(self) -> None:
+        """
+        GET /json/invites/multiuse/{invite_id} returns an error for
+        already-revoked invitation links.
+        """
+        self.login("desdemona")
+        zulip_realm = get_realm("zulip")
+        multiuse_invite = MultiuseInvite.objects.create(
+            referred_by=self.example_user("desdemona"),
+            realm=zulip_realm,
+            invited_as=PreregistrationUser.INVITE_AS["REALM_OWNER"],
+        )
+        create_confirmation_link(
+            multiuse_invite, Confirmation.MULTIUSE_INVITE, validity_in_minutes=2 * 24 * 60
+        )
+
+        # Admin cannot see owner-level invite.
+        self.login("iago")
+        result = self.client_get(f"/json/invites/multiuse/{multiuse_invite.id}")
+        self.assert_json_error(result, "Must be an organization owner")
+
+        # Owner can see it, then revoke it, then it's no longer accessible.
+        self.login("desdemona")
+        result = self.client_get(f"/json/invites/multiuse/{multiuse_invite.id}")
+        self.assert_json_success(result)
+
+        do_revoke_multi_use_invite(multiuse_invite)
+        result = self.client_get(f"/json/invites/multiuse/{multiuse_invite.id}")
+        self.assert_json_error(result, "Invitation has already been revoked")
+
+    def test_get_multiuse_invite_details_dict(self) -> None:
+        """
+        get_multiuse_invite_details_dict returns the correct stream_ids for
+        invites with explicit streams and for invites using realm defaults.
+        """
+        user_profile = self.example_user("iago")
+        zulip_realm = user_profile.realm
+        streams = [get_stream(name, zulip_realm) for name in ["Denmark", "Scotland"]]
+        invite_expires_in_minutes = 2 * 24 * 60
+
+        do_create_multiuse_invite_link(
+            user_profile,
+            PreregistrationUser.INVITE_AS["MEMBER"],
+            invite_expires_in_minutes,
+            include_realm_default_subscriptions=False,
+            streams=streams,
+        )
+        do_create_multiuse_invite_link(
+            user_profile,
+            PreregistrationUser.INVITE_AS["MEMBER"],
+            invite_expires_in_minutes,
+            include_realm_default_subscriptions=True,
+            streams=[],
+        )
+
+        all_invites = do_get_invites_controlled_by_user(user_profile)
+        invite_one_id = all_invites[0]["id"]
+        invite_two_id = all_invites[1]["id"]
+
+        stream_ids_one = get_multiuse_invite_details_dict(
+            MultiuseInvite.objects.get(id=invite_one_id), user_profile
+        )["stream_ids"]
+        stream_ids_two = get_multiuse_invite_details_dict(
+            MultiuseInvite.objects.get(id=invite_two_id), user_profile
+        )["stream_ids"]
+
+        self.assert_length(stream_ids_one, 2)
+        self.assert_length(stream_ids_two, len(get_slim_realm_default_streams(zulip_realm.id)))
 
     def test_delete_multiuse_invite(self) -> None:
         """

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -16,6 +16,8 @@ from zerver.actions.invites import (
     do_revoke_multi_use_invite,
     do_revoke_user_invite,
     do_send_user_invite_email,
+    get_invite_details_dict,
+    get_multiuse_invite_details_dict,
 )
 from zerver.decorator import require_human_non_guest_user
 from zerver.lib.exceptions import InvitationError, JsonableError, OrganizationOwnerRequiredError
@@ -229,6 +231,26 @@ def get_invitees_set(invitee_emails_raw: str) -> set[Invitee]:
 def get_user_invites(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     all_users = do_get_invites_controlled_by_user(user_profile)
     return json_success(request, data={"invites": all_users})
+
+
+@require_human_non_guest_user
+@typed_endpoint
+def get_email_invite_details(
+    request: HttpRequest, user_profile: UserProfile, *, invite_id: PathOnly[int]
+) -> HttpResponse:
+    prereg_user = access_invite_by_id(user_profile, invite_id)
+    invite = get_invite_details_dict(prereg_user, user_profile)
+    return json_success(request, data={"invite": invite})
+
+
+@require_human_non_guest_user
+@typed_endpoint
+def get_multiuse_invite_details(
+    request: HttpRequest, user_profile: UserProfile, *, invite_id: PathOnly[int]
+) -> HttpResponse:
+    invite = access_multiuse_invite_by_id(user_profile, invite_id)
+    invite_details = get_multiuse_invite_details_dict(invite, user_profile)
+    return json_success(request, data={"invite": invite_details})
 
 
 @require_human_non_guest_user

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -63,6 +63,8 @@ from zerver.views.health import health
 from zerver.views.home import accounts_accept_terms, desktop_home, doc_permalinks_view, home
 from zerver.views.invite import (
     generate_multiuse_invite_backend,
+    get_email_invite_details,
+    get_multiuse_invite_details,
     get_user_invites,
     invite_users_backend,
     resend_user_invite_email,
@@ -372,12 +374,15 @@ v1_api_and_json_patterns = [
     rest_path("bots/<int:bot_id>", PATCH=patch_bot_backend, DELETE=deactivate_bot_backend),
     # invites -> zerver.views.invite
     rest_path("invites", GET=get_user_invites, POST=invite_users_backend),
-    rest_path("invites/<int:invite_id>", DELETE=revoke_user_invite),
+    rest_path("invites/<int:invite_id>", GET=get_email_invite_details, DELETE=revoke_user_invite),
     rest_path("invites/<int:invite_id>/resend", POST=resend_user_invite_email),
     # invites/multiuse -> zerver.views.invite
     rest_path("invites/multiuse", POST=generate_multiuse_invite_backend),
-    # invites/multiuse -> zerver.views.invite
-    rest_path("invites/multiuse/<int:invite_id>", DELETE=revoke_multiuse_invite),
+    rest_path(
+        "invites/multiuse/<int:invite_id>",
+        GET=get_multiuse_invite_details,
+        DELETE=revoke_multiuse_invite,
+    ),
     # mark messages as read (in bulk)
     rest_path("mark_all_as_read", POST=mark_all_as_read),
     rest_path("mark_stream_as_read", POST=mark_stream_as_read),


### PR DESCRIPTION
Previously, the invitations table gave no way to inspect the full details of an invitation — channels and groups the invitee would join were invisible. This PR adds a "Manage invitation" modal that surfaces all metadata and provides Revoke / Resend actions in one place.

## Changes

Two new read-only endpoints — `GET /invites/{invite_id}` and `GET /invites/multiuse/{invite_id}` — returning stream IDs, group names, role, inviter, and timestamps for a single invitation. Acces control reuses the existing `access_invite_by_id` /
`access_multiuse_invite_by_id` helpers.

A "View details" eye-icon button in the Actions column opens the modal, which shows the invitee, role, invited-by pill (admins only), timestamps, and the channels/groups they will join. The footer has Revoke (trash) and Resend (paper-plane) icon buttons that delegate to the existing confirm-dialog helpers.

Fixes: #31244 

## Screenshots

Place where it is located

<img width="1172" height="995" alt="image" src="https://github.com/user-attachments/assets/619b1acb-7945-4029-9a61-2e9ad85ce5a9" />

Icon to open the model (eye icon)

<img width="168" height="161" alt="image" src="https://github.com/user-attachments/assets/2534bdc7-2c72-4837-99e0-8c37e706823c" />

Model

<img width="687" height="747" alt="image" src="https://github.com/user-attachments/assets/a1303fb2-3e0a-419a-9c5f-0665dbf0432b" />

<img width="687" height="747" alt="image" src="https://github.com/user-attachments/assets/c040fbef-05c8-4603-b444-5444a5c8a68a" />



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
