### PR TITLE
Fix `close_search_bar_and_open_narrow_description()`

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -516,6 +516,9 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     hide(): this {
+        if (!this.shown) {
+            return this;
+        }
         this.shown = false;
         if (this.non_tippy_parent_element) {
             this.$container.hide();

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -162,7 +162,7 @@ function build_message_view_header(filter: Filter | undefined): void {
     } else {
         const context = get_message_view_header_context(filter);
         append_and_display_title_area(context);
-        search.close_search_bar_and_open_narrow_description();
+        search.close_search();
     }
 }
 

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -418,7 +418,7 @@ export let exit_search = (opts: {keep_search_narrow_open: boolean}): void => {
     const filter = narrow_state.filter();
     if (!filter || filter.is_common_narrow()) {
         // for common narrows, we change the UI (and don't redirect)
-        close_search_bar_and_open_narrow_description();
+        close_search();
     } else if (opts.keep_search_narrow_open) {
         // If the user is in a search narrow and we don't want to redirect,
         // we just keep the search bar open and don't do anything.
@@ -448,12 +448,20 @@ export function rewire_open_search_bar_and_close_narrow_description(
     open_search_bar_and_close_narrow_description = value;
 }
 
-export function close_search_bar_and_open_narrow_description(): void {
-    // Hide the dropdown before closing the search bar. We do this
-    // to avoid being in a situation where the typeahead gets narrow
-    // in width as the search bar closes, which doesn't look great.
-    $("#searchbox_form .dropdown-menu").hide();
+// Close the search UI by hiding the active typeahead instance,
+// collapsing the search bar, and restoring the narrow description
+// header if it was previously hidden.
+export function close_search(): void {
+    search_typeahead?.hide();
+    // closeInputFieldOnHide may have already closed the bar via
+    // close_search_bar_and_open_narrow_description during the hide() call
+    // above. Close it if the bar is still open.
+    if ($(".navbar-search").hasClass("expanded")) {
+        close_search_bar_and_open_narrow_description();
+    }
+}
 
+export function close_search_bar_and_open_narrow_description(): void {
     if (search_pill_widget !== null) {
         search_pill_widget.clear(true);
     }

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -34,6 +34,7 @@ set_global("getSelection", () => ({
 }));
 
 let typeahead_forced_open = false;
+let search_typeahead;
 
 const verona = make_stream({
     subscribed: true,
@@ -84,11 +85,16 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
         assert.equal(opts.helpOnEmptyStrings, true);
         assert.equal(opts.matcher("")(), true);
 
-        return {
+        search_typeahead = {
+            shown: false,
             lookup() {
                 typeahead_forced_open = true;
             },
+            hide() {
+                this.shown = false;
+            },
         };
+        return search_typeahead;
     });
 
     search.initialize({
@@ -311,6 +317,16 @@ run_test("initiate_search", ({override_rewire}) => {
     assert.ok(typeahead_forced_open);
     assert.ok(search_bar_opened);
     assert.equal($("#search_query").text(), "");
+});
+
+run_test("close_search", () => {
+    search_typeahead.shown = true;
+    $(".navbar-search").addClass("expanded");
+
+    search.close_search();
+
+    assert.equal(search_typeahead.shown, false);
+    assert.ok(!$(".navbar-search").hasClass("expanded"));
 });
 
 run_test("create_item_from_search_string with invalid string", () => {


### PR DESCRIPTION
Currently, when closing the search bar, we hide the dropdown element directly rather than via `search_typeahead.hide()`, to avoid a visual artifact(see note) as the bar collapses. This leaves `typeahead.shown = true` while the element is DOM-hidden.

note: Commit cb04ae1f958ce4c5adc03e00cdb66995bdc5a892 introduced `$("#searchbox_form .dropdown-menu").hide();` to fix a bug found in https://github.com/zulip/zulip/pull/24345#issuecomment-1575687133 (point 6)

Instead, we add `close_search()`, which hides the typeahead instance, closes the search bar, and restores the narrow description header. This ensures the `typeahead.shown` state is updated correctly while preserving the existing search bar closing behavior.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|without `$("#searchbox_form .dropdown-menu").hide();` introduced in cb04ae1f958ce4c5adc03e00cdb66995bdc5a892|After (current PR changes)|
|-|-|
|<video src="https://github.com/user-attachments/assets/940e7598-d5e7-4abe-9102-50ed92e1975a" />|<video src="https://github.com/user-attachments/assets/13247607-ad0e-477c-9e4f-132af5b68dcb" />|
||<video src="https://github.com/user-attachments/assets/f3a1a42d-e7e7-4d87-854d-7346009d6a0a" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
