### PR TITLE
search: reject incompatible search pills

### DIFF
--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -11,7 +11,11 @@ import * as input_pill from "./input_pill.ts";
 import type {InputPill, InputPillContainer} from "./input_pill.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
-import {type Suggestion, search_term_description_html} from "./search_suggestion.ts";
+import {
+    type Suggestion,
+    is_search_term_compatible,
+    search_term_description_html,
+} from "./search_suggestion.ts";
 import type {NarrowCanonicalTerm, NarrowTermSuggestion} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as user_status from "./user_status.ts";
@@ -38,6 +42,35 @@ export type SearchUserPillContext = {
 
 type SearchPill = ({type: "generic_operator"} & NarrowCanonicalTerm) | SearchUserPill;
 
+function search_pill_to_term(item: SearchPill): NarrowCanonicalTerm {
+    switch (item.operator) {
+        case "dm":
+        case "dm-including":
+            assert(item.type === "search_user");
+            return {
+                operator: item.operator,
+                operand: item.users.map((user) => user.user_id),
+                negated: item.negated,
+            };
+
+        case "sender":
+        case "mentions":
+            assert(item.type === "search_user");
+            return {
+                operator: item.operator,
+                operand: item.users[0]!.user_id,
+                negated: item.negated,
+            };
+
+        default:
+            return {
+                operator: item.operator,
+                operand: item.operand,
+                negated: item.negated,
+            };
+    }
+}
+
 export type SearchPillWidget = InputPillContainer<SearchPill>;
 
 type PillRenderData =
@@ -52,18 +85,27 @@ type PillRenderData =
           })
     | SearchUserPill;
 
-export function create_item_from_search_string(search_string: string): SearchPill | undefined {
+export function create_item_from_search_string(
+    search_string: string,
+    existing_items: SearchPill[] = [],
+): SearchPill | undefined {
     const search_term = util.the(Filter.parse(search_string));
     const potential_narrow_term = Filter.convert_suggestion_to_term(search_term);
 
-    if (potential_narrow_term) {
-        return {
-            type: "generic_operator",
-            ...potential_narrow_term,
-        };
+    if (potential_narrow_term === undefined) {
+        return undefined;
     }
 
-    return undefined;
+    const existing_terms = existing_items.map((item) => search_pill_to_term(item));
+
+    if (!is_search_term_compatible(potential_narrow_term, existing_terms)) {
+        return undefined;
+    }
+
+    return {
+        type: "generic_operator",
+        ...potential_narrow_term,
+    };
 }
 
 export function get_search_string_from_item(item: SearchPill): string {
@@ -466,6 +508,7 @@ export function set_search_bar_contents(
     const invalid_inputs = [];
     const search_operator_strings = [];
     const added_pills_as_input_strings = new Set(); // to prevent duplicating terms
+    const added_terms: NarrowCanonicalTerm[] = [];
 
     for (const term of search_terms) {
         const input = Filter.unparse([term]);
@@ -499,6 +542,11 @@ export function set_search_bar_contents(
             continue;
         }
 
+        if (!is_search_term_compatible(narrow_term, added_terms)) {
+            invalid_inputs.push(input);
+            continue;
+        }
+
         switch (term.operator) {
             case "dm":
             case "dm-including":
@@ -508,6 +556,7 @@ export function set_search_bar_contents(
                 const users = user_ids.map((user_id) => people.get_by_user_id(user_id));
                 append_user_pill(users, pill_widget, term.operator, term.negated ?? false);
                 added_pills_as_input_strings.add(input);
+                added_terms.push(narrow_term);
                 break;
             }
             case "search":
@@ -517,6 +566,7 @@ export function set_search_bar_contents(
             default:
                 pill_widget.appendValue(input);
                 added_pills_as_input_strings.add(input);
+                added_terms.push(narrow_term);
                 break;
         }
     }
@@ -535,30 +585,5 @@ export function set_search_bar_contents(
 export function get_current_search_pill_terms(
     pill_widget: SearchPillWidget,
 ): NarrowCanonicalTerm[] {
-    return pill_widget.items().map((item) => {
-        switch (item.operator) {
-            case "dm":
-            case "dm-including":
-                assert(item.type === "search_user");
-                return {
-                    operator: item.operator,
-                    operand: item.users.map((user) => user.user_id),
-                    negated: item.negated,
-                };
-            case "sender":
-            case "mentions":
-                assert(item.type === "search_user");
-                return {
-                    operator: item.operator,
-                    operand: item.users[0]!.user_id,
-                    negated: item.negated,
-                };
-            default:
-                return {
-                    operator: item.operator,
-                    operand: item.operand,
-                    negated: item.negated,
-                };
-        }
-    });
+    return pill_widget.items().map((item) => search_pill_to_term(item));
 }

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -29,7 +29,7 @@ type ChannelTopicEntry = {
     topic: string;
 };
 
-type TermPattern = Omit<NarrowTerm, "operand"> & Partial<Pick<NarrowTerm, "operand">>;
+export type TermPattern = Omit<NarrowTerm, "operand"> & Partial<Pick<NarrowTerm, "operand">>;
 
 const common_incompatible_patterns: TermPattern[] = [
     {operator: "is", operand: "dm"},
@@ -195,6 +195,62 @@ function filter_suggestions_by_criteria(
     );
 }
 
+function search_filter_from_term(term: NarrowCanonicalTerm): SearchFilter {
+    if (term.operator === "channels") {
+        if (
+            term.operand === "public" ||
+            term.operand === "web-public" ||
+            term.operand === "archived"
+        ) {
+            return `channels:${term.operand}` as SearchFilter;
+        }
+
+        return "channels";
+    }
+
+    if (term.operator === "is") {
+        if (term.operand === "resolved") {
+            return term.negated ? "-is:resolved" : "is:resolved";
+        }
+
+        if (
+            term.operand === "dm" ||
+            term.operand === "starred" ||
+            term.operand === "mentioned" ||
+            term.operand === "followed" ||
+            term.operand === "alerted" ||
+            term.operand === "unread" ||
+            term.operand === "muted"
+        ) {
+            return `is:${term.operand}` as SearchFilter;
+        }
+
+        return "is";
+    }
+
+    if (term.operator === "has") {
+        if (
+            term.operand === "link" ||
+            term.operand === "image" ||
+            term.operand === "attachment" ||
+            term.operand === "reaction"
+        ) {
+            return `has:${term.operand}` as SearchFilter;
+        }
+
+        return "has";
+    }
+
+    return term.operator;
+}
+
+export function is_search_term_compatible(
+    term: NarrowCanonicalTerm,
+    existing_terms: NarrowCanonicalTerm[],
+): boolean {
+    const search_filter = search_filter_from_term(term);
+    return !match_criteria(existing_terms, incompatible_patterns[search_filter]);
+}
 function check_validity(
     last_operator: NarrowCanonicalOperator,
     terms: NarrowCanonicalTerm[],

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -152,6 +152,52 @@ test("get_suggestions deduplication", () => {
     assert.deepEqual(suggestions, expected);
 });
 
+test("incompatible_search_terms", () => {
+    const channel_term = {
+        operator: "channel",
+        operand: "66",
+        negated: false,
+    };
+
+    const dm_term = {
+        operator: "dm",
+        operand: [bob.user_id],
+        negated: false,
+    };
+
+    const topic_term = {
+        operator: "topic",
+        operand: "test",
+        negated: false,
+    };
+
+    const is_dm_term = {
+        operator: "is",
+        operand: "dm",
+        negated: false,
+    };
+
+    const has_link_term = {
+        operator: "has",
+        operand: "link",
+        negated: false,
+    };
+
+    const is_starred_term = {
+        operator: "is",
+        operand: "starred",
+        negated: false,
+    };
+
+    assert.equal(search.is_search_term_compatible(channel_term, [dm_term]), false);
+    assert.equal(search.is_search_term_compatible(dm_term, [channel_term]), false);
+    assert.equal(search.is_search_term_compatible(topic_term, [dm_term]), false);
+    assert.equal(search.is_search_term_compatible(is_dm_term, [channel_term]), false);
+
+    assert.equal(search.is_search_term_compatible(has_link_term, [channel_term]), true);
+    assert.equal(search.is_search_term_compatible(is_starred_term, [dm_term]), true);
+});
+
 test("get_is_suggestions_for_spectator", () => {
     page_params.is_spectator = true;
 


### PR DESCRIPTION
## Summary

Fixes #39400

This PR prevents incompatible search pills from being added to the search bar.

## Changes

- Added a reusable compatibility helper around the existing incompatible search patterns.
- Reused the incompatibility rules during search pill creation.
- Updated search pill creation to reject incompatible pills.
- Updated search bar rebuilding logic to reject incompatible terms.
- Added tests for incompatible search terms:
  - channel + dm
  - dm + channel
  - topic + dm
  - is:dm + channel
- Verified compatible pills still remain allowed.

## Testing

I verified the changed files and checked that the expected compatibility logic and tests are present.

I could not run Zulip's JS test command locally because my macOS environment is not provisioned with Zulip's Vagrant/Docker development environment yet. Running ./tools/provision directly on macOS fails with:

```txt
/etc/os-release: No such file or directory
```

I will run:

```bash
tools/test-js-with-node web/tests/search_suggestion.test.cjs
tools/run-dev eslint web/src/search_suggestion.ts web/src/search_pill.ts web/tests/search_suggestion.test.cjs
```

after setting up the recommended Zulip dev environment.