### PR TITLE
rocketchat: Use uploadDate as date_created for realm emoji.

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -7,10 +7,11 @@ import subprocess
 from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
 from collections.abc import Set as AbstractSet
+from datetime import datetime
 from dataclasses import dataclass
 from email.errors import HeaderDefect
 from email.headerregistry import Address
-from typing import Any, Generic, Protocol, TypeAlias, TypeVar
+from typing import Any, Generic, Optional, Protocol, TypeAlias, TypeVar
 from urllib.parse import SplitResult
 
 import orjson
@@ -738,15 +739,22 @@ def download_and_export_upload_file(
         shutil.copyfileobj(response.raw, upload_file)
 
 
-def build_realm_emoji(realm_id: int, name: str, id: int, file_name: str) -> ZerverFieldsT:
-    return model_to_dict(
-        RealmEmoji(
-            realm_id=realm_id,
-            name=name,
-            id=id,
-            file_name=file_name,
-        ),
+def build_realm_emoji(
+    realm_id: int,
+    name: str,
+    id: int,
+    file_name: str,
+    date_created: Optional[datetime] = None,
+) -> ZerverFieldsT:
+    realmemoji = RealmEmoji(
+        realm_id=realm_id,
+        name=name,
+        id=id,
+        file_name=file_name,
     )
+    if date_created is not None:
+        realmemoji.date_created = date_created
+    return model_to_dict(realmemoji)
 
 
 def get_emojis(

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -399,7 +399,7 @@ def build_custom_emoji(
     zerver_realmemoji: list[ZerverFieldsT] = []
     emoji_records: list[ZerverFieldsT] = []
 
-    # Map emoji file_id to emoji file data
+            # Map emoji file_id to emoji file data and uploadDate
     emoji_file_data = defaultdict(list)
     object_id_to_filename = {}
             filename_to_upload_date: dict[str, Any] = {}

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -402,9 +402,11 @@ def build_custom_emoji(
     # Map emoji file_id to emoji file data
     emoji_file_data = defaultdict(list)
     object_id_to_filename = {}
+            filename_to_upload_date: dict[str, Any] = {}
     for emoji_file in custom_emoji_data["file"]:
         if isinstance(emoji_file["_id"], bson.objectid.ObjectId):  # nocoverage
             object_id_to_filename[str(emoji_file["_id"])] = emoji_file["filename"]
+                            filename_to_upload_date[emoji_file["filename"]] = emoji_file.get("uploadDate")  # nocoverage
     for emoji_chunk in sorted(custom_emoji_data["chunk"], key=lambda c: c["n"]):
         file_id = str(emoji_chunk["files_id"])
         emoji_file_data[object_id_to_filename.get(file_id, file_id)].append(emoji_chunk["data"])
@@ -441,6 +443,7 @@ def build_custom_emoji(
                 name=alias,
                 id=NEXT_ID("realmemoji"),
                 file_name=emoji_filename,
+                    date_created=filename_to_upload_date.get(emoji_filename),
             )
             zerver_realmemoji.append(realmemoji)
 


### PR DESCRIPTION
Currently, when importing realm emoji from Rocket.Chat, the
`date_created` field on `RealmEmoji` records is set to the time of
import ("now"), rather than when the emoji was originally created.

Rocket.Chat's `custom_emoji.files.bson` export file includes an
`uploadDate` field per emoji file, which is the original upload
timestamp. This PR threads that date through to `build_realm_emoji`
so that imported emoji have an accurate `date_created`.

Fixes #39061.