### PR TITLE
integrations: Notify on Linear project and project-update events.

### DIFF
--- a/zerver/webhooks/linear/doc.md
+++ b/zerver/webhooks/linear/doc.md
@@ -23,6 +23,14 @@ Get Linear notifications in Zulip!
 
 {!event-filtering-additional-feature.md!}
 
+The integration sends notifications for the following Linear event
+types:
+
+* **Issues** and sub-issues: created, updated, and removed.
+* **Comments** on issues: created, updated, and removed.
+* **Projects**: created, updated, and removed.
+* **Project updates** (project status posts): created, edited, and removed.
+
 ### Related documentation
 
 - [Linear webhook events documentation][linear-webhooks]

--- a/zerver/webhooks/linear/fixtures/projectUpdate_auto_update_after_create.json
+++ b/zerver/webhooks/linear/fixtures/projectUpdate_auto_update_after_create.json
@@ -1,5 +1,5 @@
 {
-    "action": "create",
+    "action": "update",
     "actor": {
         "id": "e825c109-f691-4716-a85f-b68a2626531c",
         "name": "Dhruv Shetty",
@@ -7,34 +7,37 @@
         "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
         "type": "user"
     },
-    "createdAt": "2026-05-26T07:50:10.584Z",
+    "createdAt": "2026-06-01T18:23:31.692Z",
     "data": {
-        "id": "af46c665-4220-4be6-9fcc-9460717f8134",
-        "createdAt": "2026-05-26T07:50:10.584Z",
-        "updatedAt": "2026-05-26T07:50:10.584Z",
+        "id": "a2ad5ab3-4d3a-4381-b587-99f83b886b8e",
+        "createdAt": "2026-06-01T18:02:04.554Z",
+        "updatedAt": "2026-06-01T18:02:04.554Z",
         "frequencyResolution": "weekly",
-        "name": "Project-Zulip",
-        "description": "This is a project for zulip",
-        "slugId": "a98782de01a9",
+        "name": "Zulip-terminal",
+        "description": "",
+        "slugId": "5bfd1327f54b",
         "color": "#bec2c8",
         "statusId": "3f1ad536-fcf2-4c64-af47-ee92e9272900",
         "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
-        "startDate": null,
+        "startDate": "2026-06-01",
         "startDateResolution": null,
-        "targetDate": null,
+        "targetDate": "2026-06-03",
         "targetDateResolution": null,
-        "sortOrder": -82.95,
-        "prioritySortOrder": 0,
+        "sortOrder": 2906.87,
+        "prioritySortOrder": -138.43,
         "priority": 0,
+        "lastUpdateId": "bd310e45-6cf9-4452-9fa0-6b73d2b3d9b9",
+        "health": "atRisk",
+        "healthUpdatedAt": "2026-06-01T18:23:31.644Z",
         "issueCountHistory": [],
         "completedIssueCountHistory": [],
         "scopeHistory": [],
         "completedScopeHistory": [],
         "inProgressScopeHistory": [],
         "labelIds": [],
-        "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9",
+        "url": "https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b",
         "teamIds": [
-            "3f2043ea-4f81-4feb-a970-743c92028a07"
+            "b36906f3-70ef-40a7-8c0e-12d97e4d5ab4"
         ],
         "memberIds": [],
         "milestones": [],
@@ -45,11 +48,16 @@
             "name": "Backlog",
             "type": "backlog"
         },
-        "content": "Description for the project."
+        "content": null
     },
-    "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9",
+    "updatedFrom": {
+        "health": null,
+        "lastUpdateId": null,
+        "healthUpdatedAt": null
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b",
     "type": "Project",
     "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
-    "webhookTimestamp": 1779781812825,
+    "webhookTimestamp": 1780338211942,
     "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
 }

--- a/zerver/webhooks/linear/fixtures/projectUpdate_auto_update_after_edit.json
+++ b/zerver/webhooks/linear/fixtures/projectUpdate_auto_update_after_edit.json
@@ -1,0 +1,70 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-30T08:07:17.117Z",
+    "data": {
+        "id": "b0cfc985-0196-4ef5-925f-11c3d7aa8d14",
+        "createdAt": "2026-05-28T18:22:43.480Z",
+        "updatedAt": "2026-05-30T08:05:51.321Z",
+        "frequencyResolution": "weekly",
+        "name": "Project Zulip",
+        "description": "",
+        "slugId": "c65c2156ca87",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-21",
+        "startDateResolution": null,
+        "targetDate": "2026-05-22",
+        "targetDateResolution": null,
+        "sortOrder": 916.31,
+        "prioritySortOrder": -470.02,
+        "priority": 0,
+        "lastUpdateId": "4a0814c9-2d39-4c2e-8cbb-947c1bfc61cd",
+        "health": "offTrack",
+        "healthUpdatedAt": "2026-05-28T18:28:25.827Z",
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+        "teamIds": [
+            "b36906f3-70ef-40a7-8c0e-12d97e4d5ab4"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the description "
+    },
+    "updatedFrom": {
+        "health": "atRisk"
+    },
+    "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1780128437659,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/projectUpdate_create.json
+++ b/zerver/webhooks/linear/fixtures/projectUpdate_create.json
@@ -1,0 +1,39 @@
+{
+    "action": "create",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-06-01T18:23:31.644Z",
+    "data": {
+        "id": "bd310e45-6cf9-4452-9fa0-6b73d2b3d9b9",
+        "createdAt": "2026-06-01T18:23:31.644Z",
+        "updatedAt": "2026-06-01T18:23:31.644Z",
+        "body": "This is a project status update\n**Imported User**[7:03 AM](<http://localhost:9991/#narrow/channel/10-design/topic/.E2.9C.94.20NEW.20router.20wasn.27t.20de-duping.20slowly/near/88>)\n\nExisting robust and atomic methodologies use suffix trees to evaluate trainable theory. The basic tenet of this approach is the development of checksums. Despite the fact that conventional wisdom states that this obstacle is regularly overcame by the deployment of the World Wide Web, we believe that a different approach is necessary.",
+        "reactionData": [],
+        "bodyData": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"This is a project status update\"},{\"type\":\"hard_break\"},{\"type\":\"text\",\"marks\":[{\"type\":\"strong\"}],\"text\":\"Imported User\"},{\"type\":\"text\",\"marks\":[{\"type\":\"link\",\"attrs\":{\"href\":\"http://localhost:9991/#narrow/channel/10-design/topic/.E2.9C.94.20NEW.20router.20wasn.27t.20de-duping.20slowly/near/88\"}}],\"text\":\"7:03 AM\"}]},{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Existing robust and atomic methodologies use suffix trees to evaluate trainable theory. The basic tenet of this approach is the development of checksums. Despite the fact that conventional wisdom states that this obstacle is regularly overcame by the deployment of the World Wide Web, we believe that a different approach is necessary.\"}]}]}",
+        "slugId": "bd310e45",
+        "projectId": "a2ad5ab3-4d3a-4381-b587-99f83b886b8e",
+        "health": "atRisk",
+        "userId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "project": {
+            "id": "a2ad5ab3-4d3a-4381-b587-99f83b886b8e",
+            "name": "Zulip-terminal",
+            "url": "https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b"
+        },
+        "user": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        }
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b/activity#project-update-bd310e45",
+    "type": "ProjectUpdate",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1780338211948,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/projectUpdate_remove.json
+++ b/zerver/webhooks/linear/fixtures/projectUpdate_remove.json
@@ -1,0 +1,39 @@
+{
+    "action": "remove",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-26T08:20:00.000Z",
+    "data": {
+        "id": "c17d574a-1f5f-45d3-ae98-ecd48fac03e5",
+        "createdAt": "2026-05-26T07:54:58.550Z",
+        "updatedAt": "2026-05-26T08:20:00.000Z",
+        "body": "Update: blocker resolved, still on track for end of month.",
+        "reactionData": [],
+        "bodyData": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Update: blocker resolved, still on track for end of month.\"}]}]}",
+        "slugId": "c17d574a",
+        "projectId": "af46c665-4220-4be6-9fcc-9460717f8134",
+        "health": "onTrack",
+        "userId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "project": {
+            "id": "af46c665-4220-4be6-9fcc-9460717f8134",
+            "name": "Project-Zulip",
+            "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9"
+        },
+        "user": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        }
+    },
+    "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9/activity#project-update-c17d574a",
+    "type": "ProjectUpdate",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779783600000,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/projectUpdate_update.json
+++ b/zerver/webhooks/linear/fixtures/projectUpdate_update.json
@@ -1,0 +1,44 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-30T08:07:17.110Z",
+    "data": {
+        "id": "4a0814c9-2d39-4c2e-8cbb-947c1bfc61cd",
+        "createdAt": "2026-05-28T18:28:25.827Z",
+        "updatedAt": "2026-05-30T08:07:17.109Z",
+        "body": "There is a risk",
+        "reactionData": [],
+        "bodyData": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"There is a risk\"}]}]}",
+        "slugId": "4a0814c9",
+        "projectId": "b0cfc985-0196-4ef5-925f-11c3d7aa8d14",
+        "health": "offTrack",
+        "userId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "project": {
+            "id": "b0cfc985-0196-4ef5-925f-11c3d7aa8d14",
+            "name": "Project Zulip",
+            "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87"
+        },
+        "user": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "diffMarkdown": "**Priority**: Medium"
+    },
+    "updatedFrom": {
+        "health": "atRisk",
+        "updatedAt": "2026-05-28T18:28:27.463Z"
+    },
+    "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87/activity#project-update-4a0814c9",
+    "type": "ProjectUpdate",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1780128437657,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_auto_update_after_create.json
+++ b/zerver/webhooks/linear/fixtures/project_auto_update_after_create.json
@@ -1,0 +1,86 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T05:53:50.732Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T05:53:50.732Z",
+        "archivedAt": null,
+        "updateReminderFrequencyInWeeks": null,
+        "updateReminderFrequency": null,
+        "frequencyResolution": "weekly",
+        "updateRemindersDay": null,
+        "updateRemindersHour": null,
+        "name": "Zulip-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "icon": null,
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "projectUpdateRemindersPausedUntilAt": null,
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-05-30",
+        "targetDateResolution": null,
+        "startedAt": null,
+        "completedAt": null,
+        "canceledAt": null,
+        "autoArchivedAt": null,
+        "trashed": null,
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "convertedFromIssueId": null,
+        "lastAppliedTemplateId": null,
+        "priority": 1,
+        "lastUpdateId": null,
+        "healthUpdatedAt": null,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {},
+    "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779947631572,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_create_complex.json
+++ b/zerver/webhooks/linear/fixtures/project_create_complex.json
@@ -1,0 +1,69 @@
+{
+    "action": "create",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T05:53:50.732Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T05:53:50.732Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-05-30",
+        "targetDateResolution": null,
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 1,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the project description."
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779947631560,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_create_without_description.json
+++ b/zerver/webhooks/linear/fixtures/project_create_without_description.json
@@ -7,15 +7,15 @@
         "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
         "type": "user"
     },
-    "createdAt": "2026-05-26T07:50:10.584Z",
+    "createdAt": "2026-06-01T17:55:01.650Z",
     "data": {
-        "id": "af46c665-4220-4be6-9fcc-9460717f8134",
-        "createdAt": "2026-05-26T07:50:10.584Z",
-        "updatedAt": "2026-05-26T07:50:10.584Z",
+        "id": "74198d0d-e127-488d-a2ad-bd4742fea109",
+        "createdAt": "2026-06-01T17:55:01.650Z",
+        "updatedAt": "2026-06-01T17:55:01.650Z",
         "frequencyResolution": "weekly",
-        "name": "Project-Zulip",
-        "description": "This is a project for zulip",
-        "slugId": "a98782de01a9",
+        "name": "Project-Manhattan",
+        "description": "",
+        "slugId": "9719af1a1893",
         "color": "#bec2c8",
         "statusId": "3f1ad536-fcf2-4c64-af47-ee92e9272900",
         "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
@@ -23,8 +23,8 @@
         "startDateResolution": null,
         "targetDate": null,
         "targetDateResolution": null,
-        "sortOrder": -82.95,
-        "prioritySortOrder": 0,
+        "sortOrder": 1837.96,
+        "prioritySortOrder": -259.06,
         "priority": 0,
         "issueCountHistory": [],
         "completedIssueCountHistory": [],
@@ -32,9 +32,9 @@
         "completedScopeHistory": [],
         "inProgressScopeHistory": [],
         "labelIds": [],
-        "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9",
+        "url": "https://linear.app/zulipdhruv/project/project-manhattan-9719af1a1893",
         "teamIds": [
-            "3f2043ea-4f81-4feb-a970-743c92028a07"
+            "b36906f3-70ef-40a7-8c0e-12d97e4d5ab4"
         ],
         "memberIds": [],
         "milestones": [],
@@ -45,11 +45,11 @@
             "name": "Backlog",
             "type": "backlog"
         },
-        "content": "Description for the project."
+        "content": null
     },
-    "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9",
+    "url": "https://linear.app/zulipdhruv/project/project-manhattan-9719af1a1893",
     "type": "Project",
     "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
-    "webhookTimestamp": 1779781812825,
+    "webhookTimestamp": 1780336502056,
     "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
 }

--- a/zerver/webhooks/linear/fixtures/project_create_without_description_with_dates.json
+++ b/zerver/webhooks/linear/fixtures/project_create_without_description_with_dates.json
@@ -7,24 +7,24 @@
         "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
         "type": "user"
     },
-    "createdAt": "2026-05-26T07:50:10.584Z",
+    "createdAt": "2026-06-01T18:02:04.554Z",
     "data": {
-        "id": "af46c665-4220-4be6-9fcc-9460717f8134",
-        "createdAt": "2026-05-26T07:50:10.584Z",
-        "updatedAt": "2026-05-26T07:50:10.584Z",
+        "id": "a2ad5ab3-4d3a-4381-b587-99f83b886b8e",
+        "createdAt": "2026-06-01T18:02:04.554Z",
+        "updatedAt": "2026-06-01T18:02:04.554Z",
         "frequencyResolution": "weekly",
-        "name": "Project-Zulip",
-        "description": "This is a project for zulip",
-        "slugId": "a98782de01a9",
+        "name": "Zulip-terminal",
+        "description": "",
+        "slugId": "5bfd1327f54b",
         "color": "#bec2c8",
         "statusId": "3f1ad536-fcf2-4c64-af47-ee92e9272900",
         "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
-        "startDate": null,
+        "startDate": "2026-06-01",
         "startDateResolution": null,
-        "targetDate": null,
+        "targetDate": "2026-06-03",
         "targetDateResolution": null,
-        "sortOrder": -82.95,
-        "prioritySortOrder": 0,
+        "sortOrder": 2906.87,
+        "prioritySortOrder": -138.43,
         "priority": 0,
         "issueCountHistory": [],
         "completedIssueCountHistory": [],
@@ -32,9 +32,9 @@
         "completedScopeHistory": [],
         "inProgressScopeHistory": [],
         "labelIds": [],
-        "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9",
+        "url": "https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b",
         "teamIds": [
-            "3f2043ea-4f81-4feb-a970-743c92028a07"
+            "b36906f3-70ef-40a7-8c0e-12d97e4d5ab4"
         ],
         "memberIds": [],
         "milestones": [],
@@ -45,11 +45,11 @@
             "name": "Backlog",
             "type": "backlog"
         },
-        "content": "Description for the project."
+        "content": null
     },
-    "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9",
+    "url": "https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b",
     "type": "Project",
     "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
-    "webhookTimestamp": 1779781812825,
+    "webhookTimestamp": 1780336925169,
     "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
 }

--- a/zerver/webhooks/linear/fixtures/project_remove.json
+++ b/zerver/webhooks/linear/fixtures/project_remove.json
@@ -1,0 +1,26 @@
+{
+    "action": "remove",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-26T08:00:00.000Z",
+    "data": {
+        "id": "af46c665-4220-4be6-9fcc-9460717f8134",
+        "createdAt": "2026-05-26T07:50:10.584Z",
+        "updatedAt": "2026-05-26T08:00:00.000Z",
+        "name": "Project-Zulip",
+        "slugId": "a98782de01a9",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ]
+    },
+    "url": "https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779782400000,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_description.json
+++ b/zerver/webhooks/linear/fixtures/project_update_description.json
@@ -1,0 +1,89 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T10:07:28.765Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T10:07:28.757Z",
+        "archivedAt": null,
+        "updateReminderFrequencyInWeeks": null,
+        "updateReminderFrequency": null,
+        "frequencyResolution": "weekly",
+        "updateRemindersDay": null,
+        "updateRemindersHour": null,
+        "name": "Zulip-Test-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "icon": null,
+        "color": "#bec2c8",
+        "statusId": "82e50c50-04c3-424a-89ea-abd832530d1c",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "projectUpdateRemindersPausedUntilAt": null,
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-05-29",
+        "targetDateResolution": null,
+        "startedAt": "2026-05-28T09:59:40.255Z",
+        "completedAt": null,
+        "canceledAt": null,
+        "autoArchivedAt": null,
+        "trashed": null,
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "convertedFromIssueId": null,
+        "lastAppliedTemplateId": null,
+        "priority": 2,
+        "lastUpdateId": null,
+        "healthUpdatedAt": null,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "82e50c50-04c3-424a-89ea-abd832530d1c",
+            "color": "#F2C94C",
+            "name": "In Progress",
+            "type": "started"
+        },
+        "content": "This is the new Project Description"
+    },
+    "updatedFrom": {
+        "updatedAt": "2026-05-28T10:07:28.757Z",
+        "content": "This is the project description."
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779962849004,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_lead_cleared.json
+++ b/zerver/webhooks/linear/fixtures/project_update_lead_cleared.json
@@ -1,0 +1,66 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T06:58:05.857Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T06:58:05.856Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-06-02",
+        "targetDateResolution": null,
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 2,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {
+        "updatedAt": "2026-05-28T06:28:04.058Z",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c"
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779951486427,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_lead_set.json
+++ b/zerver/webhooks/linear/fixtures/project_update_lead_set.json
@@ -1,0 +1,74 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T10:00:33.556Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T10:00:33.554Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Test-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "82e50c50-04c3-424a-89ea-abd832530d1c",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-06-02",
+        "targetDateResolution": null,
+        "startedAt": "2026-05-28T09:59:40.255Z",
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 2,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "82e50c50-04c3-424a-89ea-abd832530d1c",
+            "color": "#F2C94C",
+            "name": "In Progress",
+            "type": "started"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {
+        "leadId": null,
+        "updatedAt": "2026-05-28T09:59:40.256Z"
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779962434093,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_priority.json
+++ b/zerver/webhooks/linear/fixtures/project_update_priority.json
@@ -1,0 +1,73 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T06:09:48.713Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T06:09:48.712Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-05-30",
+        "targetDateResolution": null,
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 2,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {
+        "priority": 1,
+        "updatedAt": "2026-05-28T05:53:50.732Z"
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779948589012,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_priority_cleared.json
+++ b/zerver/webhooks/linear/fixtures/project_update_priority_cleared.json
@@ -1,0 +1,71 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-30T08:05:51.322Z",
+    "data": {
+        "id": "b0cfc985-0196-4ef5-925f-11c3d7aa8d14",
+        "createdAt": "2026-05-28T18:22:43.480Z",
+        "updatedAt": "2026-05-30T08:05:51.321Z",
+        "frequencyResolution": "weekly",
+        "name": "Project Zulip",
+        "description": "",
+        "slugId": "c65c2156ca87",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-21",
+        "startDateResolution": null,
+        "targetDate": "2026-05-22",
+        "targetDateResolution": null,
+        "sortOrder": 916.31,
+        "prioritySortOrder": -470.02,
+        "priority": 0,
+        "lastUpdateId": "4a0814c9-2d39-4c2e-8cbb-947c1bfc61cd",
+        "health": "atRisk",
+        "healthUpdatedAt": "2026-05-28T18:28:25.827Z",
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+        "teamIds": [
+            "b36906f3-70ef-40a7-8c0e-12d97e4d5ab4"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the description "
+    },
+    "updatedFrom": {
+        "priority": 3,
+        "updatedAt": "2026-05-28T18:27:43.114Z"
+    },
+    "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1780128351862,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_rename.json
+++ b/zerver/webhooks/linear/fixtures/project_update_rename.json
@@ -1,0 +1,66 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T09:59:12.782Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T09:59:12.781Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Test-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-06-02",
+        "targetDateResolution": null,
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 2,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {
+        "name": "Zulip-Project",
+        "updatedAt": "2026-05-28T06:58:05.856Z"
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779962353030,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_status.json
+++ b/zerver/webhooks/linear/fixtures/project_update_status.json
@@ -1,0 +1,68 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T09:59:40.257Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T09:59:40.256Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Test-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "82e50c50-04c3-424a-89ea-abd832530d1c",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-06-02",
+        "targetDateResolution": null,
+        "startedAt": "2026-05-28T09:59:40.255Z",
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 2,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "status": {
+            "id": "82e50c50-04c3-424a-89ea-abd832530d1c",
+            "color": "#F2C94C",
+            "name": "In Progress",
+            "type": "started"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "startedAt": null,
+        "updatedAt": "2026-05-28T09:59:12.781Z"
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779962381554,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_target_date.json
+++ b/zerver/webhooks/linear/fixtures/project_update_target_date.json
@@ -1,0 +1,73 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T06:28:04.058Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T06:28:04.058Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-06-02",
+        "targetDateResolution": null,
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 2,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {
+        "updatedAt": "2026-05-28T06:09:48.712Z",
+        "targetDate": "2026-05-30"
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779949684623,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_target_date_cleared.json
+++ b/zerver/webhooks/linear/fixtures/project_update_target_date_cleared.json
@@ -1,0 +1,71 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-30T08:09:02.389Z",
+    "data": {
+        "id": "b0cfc985-0196-4ef5-925f-11c3d7aa8d14",
+        "createdAt": "2026-05-28T18:22:43.480Z",
+        "updatedAt": "2026-05-30T08:09:02.388Z",
+        "frequencyResolution": "weekly",
+        "name": "Project Zulip",
+        "description": "",
+        "slugId": "c65c2156ca87",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-21",
+        "startDateResolution": null,
+        "targetDate": null,
+        "targetDateResolution": null,
+        "sortOrder": 916.31,
+        "prioritySortOrder": -470.02,
+        "priority": 0,
+        "lastUpdateId": "4a0814c9-2d39-4c2e-8cbb-947c1bfc61cd",
+        "health": "offTrack",
+        "healthUpdatedAt": "2026-05-28T18:28:25.827Z",
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+        "teamIds": [
+            "b36906f3-70ef-40a7-8c0e-12d97e4d5ab4"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the description "
+    },
+    "updatedFrom": {
+        "updatedAt": "2026-05-30T08:05:51.321Z",
+        "targetDate": "2026-05-22"
+    },
+    "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1780128543140,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_target_date_preponed.json
+++ b/zerver/webhooks/linear/fixtures/project_update_target_date_preponed.json
@@ -1,0 +1,74 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-28T10:01:08.850Z",
+    "data": {
+        "id": "e65b2421-bad1-4075-bfd4-24be439c83f9",
+        "createdAt": "2026-05-28T05:53:50.732Z",
+        "updatedAt": "2026-05-28T10:01:08.848Z",
+        "frequencyResolution": "weekly",
+        "name": "Zulip-Test-Project",
+        "description": "Summary for the Project",
+        "slugId": "532c1333013b",
+        "color": "#bec2c8",
+        "statusId": "82e50c50-04c3-424a-89ea-abd832530d1c",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-28",
+        "startDateResolution": null,
+        "targetDate": "2026-05-29",
+        "targetDateResolution": null,
+        "startedAt": "2026-05-28T09:59:40.255Z",
+        "sortOrder": -48.27,
+        "prioritySortOrder": -1032,
+        "priority": 2,
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+        "teamIds": [
+            "3f2043ea-4f81-4feb-a970-743c92028a07"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [
+            {
+                "id": "17cd9287-8bee-4581-9a52-202e1fb8e990",
+                "name": "Phase 1"
+            }
+        ],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "82e50c50-04c3-424a-89ea-abd832530d1c",
+            "color": "#F2C94C",
+            "name": "In Progress",
+            "type": "started"
+        },
+        "content": "This is the project description."
+    },
+    "updatedFrom": {
+        "updatedAt": "2026-05-28T10:00:33.554Z",
+        "targetDate": "2026-06-02"
+    },
+    "url": "https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1779962469265,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/fixtures/project_update_target_date_set.json
+++ b/zerver/webhooks/linear/fixtures/project_update_target_date_set.json
@@ -1,0 +1,71 @@
+{
+    "action": "update",
+    "actor": {
+        "id": "e825c109-f691-4716-a85f-b68a2626531c",
+        "name": "Dhruv Shetty",
+        "email": "dhruvshetty2203@gmail.com",
+        "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203",
+        "type": "user"
+    },
+    "createdAt": "2026-05-30T08:09:43.300Z",
+    "data": {
+        "id": "b0cfc985-0196-4ef5-925f-11c3d7aa8d14",
+        "createdAt": "2026-05-28T18:22:43.480Z",
+        "updatedAt": "2026-05-30T08:09:43.300Z",
+        "frequencyResolution": "weekly",
+        "name": "Project Zulip",
+        "description": "",
+        "slugId": "c65c2156ca87",
+        "color": "#bec2c8",
+        "statusId": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+        "creatorId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "leadId": "e825c109-f691-4716-a85f-b68a2626531c",
+        "startDate": "2026-05-21",
+        "startDateResolution": null,
+        "targetDate": "2026-05-30",
+        "targetDateResolution": null,
+        "sortOrder": 916.31,
+        "prioritySortOrder": -470.02,
+        "priority": 0,
+        "lastUpdateId": "4a0814c9-2d39-4c2e-8cbb-947c1bfc61cd",
+        "health": "offTrack",
+        "healthUpdatedAt": "2026-05-28T18:28:25.827Z",
+        "issueCountHistory": [],
+        "completedIssueCountHistory": [],
+        "scopeHistory": [],
+        "completedScopeHistory": [],
+        "inProgressScopeHistory": [],
+        "labelIds": [],
+        "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+        "teamIds": [
+            "b36906f3-70ef-40a7-8c0e-12d97e4d5ab4"
+        ],
+        "memberIds": [
+            "e825c109-f691-4716-a85f-b68a2626531c"
+        ],
+        "milestones": [],
+        "initiatives": [],
+        "lead": {
+            "id": "e825c109-f691-4716-a85f-b68a2626531c",
+            "name": "Dhruv Shetty",
+            "email": "dhruvshetty2203@gmail.com",
+            "url": "https://linear.app/zulipdhruv/profiles/dhruvshetty2203"
+        },
+        "status": {
+            "id": "2bd9226f-7d3a-4987-bea7-190e37029ccc",
+            "color": "#D7D8DB",
+            "name": "Planned",
+            "type": "planned"
+        },
+        "content": "This is the description "
+    },
+    "updatedFrom": {
+        "updatedAt": "2026-05-30T08:09:02.388Z",
+        "targetDate": null
+    },
+    "url": "https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87",
+    "type": "Project",
+    "organizationId": "498d97b2-c819-42cc-8d65-7bffd494ed23",
+    "webhookTimestamp": 1780128584448,
+    "webhookId": "a9d5653b-3026-4030-9c0e-ac964e3bb507"
+}

--- a/zerver/webhooks/linear/tests.py
+++ b/zerver/webhooks/linear/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from zerver.lib.test_classes import WebhookTestCase
 
 
@@ -72,10 +74,123 @@ class LinearHookTests(WebhookTestCase):
         self.check_webhook("issue_update", expected_topic_name, expected_message)
 
     def test_project_create(self) -> None:
-        payload = self.get_body("project_create")
-        result = self.client_post(
-            self.url,
-            payload,
-            content_type="application/json",
+        expected_topic_name = "Project: Project-Zulip"
+        expected_message = "Dhruv Shetty created project [Project-Zulip](https://linear.app/zulipdhruv/project/project-zulip-a98782de01a9):\n~~~ quote\nThis is a project for zulip\n~~~\n**Status:** Backlog"
+        self.check_webhook("project_create", expected_topic_name, expected_message)
+
+    def test_project_create_complex(self) -> None:
+        expected_topic_name = "Project: Zulip-Project"
+        expected_message = "Dhruv Shetty created project [Zulip-Project](https://linear.app/zulipdhruv/project/zulip-project-532c1333013b):\n~~~ quote\nSummary for the Project\n**Start date:** 2026-05-28 – **Target date:** 2026-05-30\n~~~\n**Status:** Planned · **Lead:** Dhruv Shetty · **Priority:** Urgent\n- **Milestone:** Phase 1"
+        self.check_webhook("project_create_complex", expected_topic_name, expected_message)
+
+    def test_project_create_without_description(self) -> None:
+        expected_topic_name = "Project: Project-Manhattan"
+        expected_message = "Dhruv Shetty created project [Project-Manhattan](https://linear.app/zulipdhruv/project/project-manhattan-9719af1a1893)\n**Status:** Backlog"
+        self.check_webhook(
+            "project_create_without_description", expected_topic_name, expected_message
         )
+
+    def test_project_create_without_description_with_dates(self) -> None:
+        expected_topic_name = "Project: Zulip-terminal"
+        expected_message = "Dhruv Shetty created project [Zulip-terminal](https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b)\n**Status:** Backlog\n- **Start date:** 2026-06-01\n- **Target date:** 2026-06-03"
+        self.check_webhook(
+            "project_create_without_description_with_dates", expected_topic_name, expected_message
+        )
+
+    def test_project_update_priority(self) -> None:
+        expected_topic_name = "Project: Zulip-Project"
+        expected_message = "Dhruv Shetty updated project [Zulip-Project](https://linear.app/zulipdhruv/project/zulip-project-532c1333013b).\nPriority is now set to High."
+        self.check_webhook("project_update_priority", expected_topic_name, expected_message)
+
+    def test_project_update_target_date(self) -> None:
+        expected_topic_name = "Project: Zulip-Project"
+        expected_message = "Dhruv Shetty updated project [Zulip-Project](https://linear.app/zulipdhruv/project/zulip-project-532c1333013b).\nTarget date is postponed to 2026-06-02."
+        self.check_webhook("project_update_target_date", expected_topic_name, expected_message)
+
+    def test_project_update_rename(self) -> None:
+        expected_topic_name = "Project: Zulip-Test-Project"
+        expected_message = "Dhruv Shetty updated project [Zulip-Test-Project](https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b).\nRenamed to Zulip-Test-Project."
+        self.check_webhook("project_update_rename", expected_topic_name, expected_message)
+
+    def test_project_update_status(self) -> None:
+        expected_topic_name = "Project: Zulip-Test-Project"
+        expected_message = "Dhruv Shetty updated project [Zulip-Test-Project](https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b).\nProject status is now In Progress."
+        self.check_webhook("project_update_status", expected_topic_name, expected_message)
+
+    def test_project_update_lead_set(self) -> None:
+        expected_topic_name = "Project: Zulip-Test-Project"
+        expected_message = "Dhruv Shetty updated project [Zulip-Test-Project](https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b).\nDhruv Shetty is now the project lead."
+        self.check_webhook("project_update_lead_set", expected_topic_name, expected_message)
+
+    def test_project_update_target_date_preponed(self) -> None:
+        expected_topic_name = "Project: Zulip-Test-Project"
+        expected_message = "Dhruv Shetty updated project [Zulip-Test-Project](https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b).\nTarget date is preponed to 2026-05-29."
+        self.check_webhook(
+            "project_update_target_date_preponed", expected_topic_name, expected_message
+        )
+
+    def test_project_update_target_date_set(self) -> None:
+        expected_topic_name = "Project: Project Zulip"
+        expected_message = "Dhruv Shetty updated project [Project Zulip](https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87).\nTarget date is set to 2026-05-30."
+        self.check_webhook("project_update_target_date_set", expected_topic_name, expected_message)
+
+    def test_project_update_description(self) -> None:
+        expected_topic_name = "Project: Zulip-Test-Project"
+        expected_message = "Dhruv Shetty updated project [Zulip-Test-Project](https://linear.app/zulipdhruv/project/zulip-test-project-532c1333013b).\nDescription is updated."
+        self.check_webhook("project_update_description", expected_topic_name, expected_message)
+
+    def test_project_remove(self) -> None:
+        expected_topic_name = "Project: Project-Zulip"
+        expected_message = "Dhruv Shetty removed project **Project-Zulip**."
+        self.check_webhook("project_remove", expected_topic_name, expected_message)
+
+    def test_projectUpdate_create(self) -> None:
+        expected_topic_name = "Project: Zulip-terminal"
+        expected_message = "Dhruv Shetty [posted](https://linear.app/zulipdhruv/project/zulip-terminal-5bfd1327f54b/activity#project-update-bd310e45) a status update on **Zulip-terminal** (health: At Risk):\n~~~ quote\nThis is a project status update\n**Imported User**[7:03 AM](<http://localhost:9991/#narrow/channel/10-design/topic/.E2.9C.94.20NEW.20router.20wasn.27t.20de-duping.20slowly/near/88>)\n\nExisting robust and atomic methodologies use suffix trees to evaluate trainable theory. The basic tenet of this approach is the development of checksums. Despite the fact that conventional wisdom states that this obstacle is regularly overcame by the deployment of the World Wide Web, we believe that a different approach is necessary.\n~~~"
+        self.check_webhook("projectUpdate_create", expected_topic_name, expected_message)
+
+    def test_projectUpdate_update(self) -> None:
+        expected_topic_name = "Project: Project Zulip"
+        expected_message = "Dhruv Shetty [edited](https://linear.app/zulipdhruv/project/project-zulip-c65c2156ca87/activity#project-update-4a0814c9) a status update on **Project Zulip** (health: Off Track):\n~~~ quote\nThere is a risk\n~~~\n\n**Priority**: Medium"
+        self.check_webhook("projectUpdate_update", expected_topic_name, expected_message)
+
+    def test_projectUpdate_remove(self) -> None:
+        expected_topic_name = "Project: Project-Zulip"
+        expected_message = "Dhruv Shetty removed a status update on **Project-Zulip**."
+        self.check_webhook("projectUpdate_remove", expected_topic_name, expected_message)
+
+    def test_projectUpdate_auto_update_after_create_is_suppressed(self) -> None:
+        # Linear's auto-fire after a ProjectUpdate post (lastUpdateId in
+        # updatedFrom) must not produce a duplicate Zulip message.
+        with patch("zerver.webhooks.linear.view.check_send_webhook_message") as m:
+            result = self.client_post(
+                self.url,
+                self.get_body("projectUpdate_auto_update_after_create"),
+                content_type="application/json",
+            )
+        self.assertFalse(m.called)
+        self.assert_json_success(result)
+
+    def test_projectUpdate_auto_update_after_edit_is_suppressed(self) -> None:
+        # Linear's auto-fire after editing a ProjectUpdate (health-only in
+        # updatedFrom) must not produce a duplicate Zulip message.
+        with patch("zerver.webhooks.linear.view.check_send_webhook_message") as m:
+            result = self.client_post(
+                self.url,
+                self.get_body("projectUpdate_auto_update_after_edit"),
+                content_type="application/json",
+            )
+        self.assertFalse(m.called)
+        self.assert_json_success(result)
+
+    def test_project_auto_update_after_create_is_suppressed(self) -> None:
+        # Linear's auto-fire after Project.create (empty updatedFrom) must
+        # not produce a Zulip message.
+        with patch("zerver.webhooks.linear.view.check_send_webhook_message") as m:
+            result = self.client_post(
+                self.url,
+                self.get_body("project_auto_update_after_create"),
+                content_type="application/json",
+            )
+        self.assertFalse(m.called)
         self.assert_json_success(result)

--- a/zerver/webhooks/linear/view.py
+++ b/zerver/webhooks/linear/view.py
@@ -6,7 +6,7 @@ from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_int, check_string
+from zerver.lib.validator import WildValue, check_int, check_none_or, check_string
 from zerver.lib.webhooks.common import OptionalUserSpecifiedTopicStr, check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -17,6 +17,26 @@ ISSUE_CREATE_OR_UPDATE_TEMPLATE = "[{type}]({url}) was {action} in team {team_na
 ISSUE_REMOVE_TEMPLATE = "This issue has been removed from team {team_name}."
 COMMENT_CREATE_OR_UPDATE_TEMPLATE = "{user} [{action}]({url}) on issue **{issue_title}**:"
 COMMENT_REMOVE_TEMPLATE = "{user} has removed a comment."
+PROJECT_CREATE_TEMPLATE = "{actor} created project [{name}]({url})"
+PROJECT_UPDATE_TEMPLATE = "{actor} updated project [{name}]({url})"
+PROJECT_REMOVE_TEMPLATE = "{actor} removed project **{name}**."
+PROJECT_UPDATE_CREATE_OR_EDIT_TEMPLATE = (
+    "{user} [{action}]({url}) a status update on **{project_name}** (health: {health}):"
+)
+PROJECT_UPDATE_REMOVE_TEMPLATE = "{user} removed a status update on **{project_name}**."
+
+PROJECT_HEALTH_LABELS = {
+    "onTrack": "On Track",
+    "atRisk": "At Risk",
+    "offTrack": "Off Track",
+}
+
+PROJECT_PRIORITY_LABELS = {
+    1: "Urgent",
+    2: "High",
+    3: "Medium",
+    4: "Low",
+}
 
 
 def get_issue_created_or_updated_message(event: str, payload: WildValue, action: str) -> str:
@@ -97,13 +117,207 @@ def get_comment_message(payload: WildValue, event: str) -> str:
     )
 
 
+def get_actor_name(payload: WildValue) -> str:
+    return payload["actor"]["name"].tame(check_string)
+
+
+def get_project_inline_fields(payload: WildValue) -> list[str]:
+    # The project's at-a-glance identity, rendered as a single bold-labeled
+    # line below the create message.
+    fields = []
+    data = payload["data"]
+
+    status = data.get("status")
+    if status:
+        fields.append(f"**Status:** {status['name'].tame(check_string)}")
+
+    lead = data.get("lead")
+    if lead:
+        fields.append(f"**Lead:** {lead['name'].tame(check_string)}")
+
+    if "priority" in data:
+        priority = data["priority"].tame(check_int)
+        if priority in PROJECT_PRIORITY_LABELS:
+            fields.append(f"**Priority:** {PROJECT_PRIORITY_LABELS[priority]}")
+
+    return fields
+
+
+def get_project_date_fields(payload: WildValue) -> list[str]:
+    data = payload["data"]
+    dates = []
+    for date_field, label in (("startDate", "Start date"), ("targetDate", "Target date")):
+        if date_field in data:
+            value = data[date_field].tame(check_none_or(check_string))
+            if value:
+                dates.append(f"**{label}:** {value}")
+    return dates
+
+
+def get_project_milestone_fields(payload: WildValue) -> list[str]:
+    data = payload["data"]
+    if "milestones" in data:
+        milestone_names = [m["name"].tame(check_string) for m in data["milestones"]]
+        if milestone_names:
+            label = "Milestone" if len(milestone_names) == 1 else "Milestones"
+            return [f"**{label}:** {', '.join(milestone_names)}"]
+    return []
+
+
+# Linear's API name "content" is what users edit as the project description;
+# the separate "description" field is a short summary that rarely changes.
+PROJECT_UPDATE_CHANGE_FIELDS = (
+    "name",
+    "statusId",
+    "leadId",
+    "priority",
+    "startDate",
+    "targetDate",
+    "content",
+)
+
+
+def get_project_update_changes(payload: WildValue) -> list[str]:
+    changes = []
+    data = payload["data"]
+    updated_from = payload["updatedFrom"]
+
+    for key in PROJECT_UPDATE_CHANGE_FIELDS:
+        if key not in updated_from:
+            continue
+
+        if key == "name":
+            changes.append(f"renamed to {data['name'].tame(check_string)}")
+        elif key == "statusId":
+            status = data.get("status")
+            if status:
+                changes.append(f"project status is now {status['name'].tame(check_string)}")
+        elif key == "leadId":
+            lead = data.get("lead")
+            if lead:
+                changes.append(f"{lead['name'].tame(check_string)} is now the project lead")
+        elif key == "priority":
+            new_priority = data["priority"].tame(check_int)
+            if new_priority in PROJECT_PRIORITY_LABELS:
+                changes.append(f"priority is now set to {PROJECT_PRIORITY_LABELS[new_priority]}")
+        elif key in ("startDate", "targetDate"):
+            label = "target date" if key == "targetDate" else "start date"
+            new_value = data[key].tame(check_none_or(check_string))
+            if new_value is not None:
+                old_value = updated_from[key].tame(check_none_or(check_string))
+                if old_value is None:
+                    changes.append(f"{label} is set to {new_value}")
+                elif new_value < old_value:
+                    changes.append(f"{label} is preponed to {new_value}")
+                else:
+                    changes.append(f"{label} is postponed to {new_value}")
+        elif key == "content":
+            changes.append("description is updated")
+
+    return changes
+
+
+def get_project_create_or_update_body(payload: WildValue, action: str) -> str:
+    actor = get_actor_name(payload)
+    name = payload["data"]["name"].tame(check_string)
+    url = payload["url"].tame(check_string)
+
+    if action != "create":
+        # changes is non-empty: content-free updates were filtered in get_event_type.
+        message = PROJECT_UPDATE_TEMPLATE.format(actor=actor, name=name, url=url)
+        sentence = ", ".join(get_project_update_changes(payload))
+        sentence = sentence[0].upper() + sentence[1:]
+        return f"{message}.\n{sentence}."
+
+    message = PROJECT_CREATE_TEMPLATE.format(actor=actor, name=name, url=url)
+    description = (
+        payload["data"]["description"].tame(check_string)
+        if "description" in payload["data"]
+        else ""
+    )
+    inline_fields = get_project_inline_fields(payload)
+    dates = get_project_date_fields(payload)
+    bullets = get_project_milestone_fields(payload)
+
+    # The schedule lives inside the description quote when there is one;
+    # otherwise the dates drop down to bullets alongside the milestones.
+    if description:
+        quote = description
+        if dates:
+            quote += "\n" + " – ".join(dates)
+        message += f":{CONTENT_MESSAGE_TEMPLATE.format(message=quote)}"
+    else:
+        bullets = dates + bullets
+
+    lines = []
+    if inline_fields:
+        lines.append(" · ".join(inline_fields))
+    lines.extend(f"- {bullet}" for bullet in bullets)
+
+    if not lines:  # nocoverage
+        # A project always carries at least a status, so this is defensive.
+        if not description:
+            message += "."
+        return message
+
+    fields = "\n".join(lines)
+    if description:
+        # The quote template already ends with a newline, so the fields
+        # follow the closing fence directly.
+        return message + fields
+    return f"{message}\n{fields}"
+
+
+def get_project_remove_body(payload: WildValue) -> str:
+    return PROJECT_REMOVE_TEMPLATE.format(
+        actor=get_actor_name(payload),
+        name=payload["data"]["name"].tame(check_string),
+    )
+
+
+def get_project_message(payload: WildValue, event: str) -> str:
+    action = payload["action"].tame(check_string)
+    if action == "remove":
+        return get_project_remove_body(payload)
+
+    return get_project_create_or_update_body(payload, "create" if action == "create" else "update")
+
+
+def get_project_update_message(payload: WildValue, event: str) -> str:
+    action = payload["action"].tame(check_string)
+    user = payload["data"]["user"]["name"].tame(check_string)
+    project_name = payload["data"]["project"]["name"].tame(check_string)
+
+    if action == "remove":
+        return PROJECT_UPDATE_REMOVE_TEMPLATE.format(user=user, project_name=project_name)
+
+    health = payload["data"]["health"].tame(check_string)
+    message = PROJECT_UPDATE_CREATE_OR_EDIT_TEMPLATE.format(
+        user=user,
+        action="posted" if action == "create" else "edited",
+        url=payload["url"].tame(check_string),
+        project_name=project_name,
+        health=PROJECT_HEALTH_LABELS.get(health, health),
+    )
+    message += CONTENT_MESSAGE_TEMPLATE.format(message=payload["data"]["body"].tame(check_string))
+
+    if "diffMarkdown" in payload["data"]:
+        diff_markdown = payload["data"]["diffMarkdown"].tame(check_none_or(check_string))
+        if diff_markdown:
+            message += f"\n{diff_markdown}"
+
+    return message
+
+
 EVENT_FUNCTION_MAPPER: dict[str, Callable[[WildValue, str], str]] = {
     "issue": get_issue_or_sub_issue_message,
     "sub_issue": get_issue_or_sub_issue_message,
     "comment": get_comment_message,
+    "project": get_project_message,
+    "project_update": get_project_update_message,
 }
 
-IGNORED_EVENTS = ["IssueLabel", "Project", "ProjectUpdate", "Cycle", "Reaction"]
+IGNORED_EVENTS = ["IssueLabel", "Cycle", "Reaction"]
 
 ALL_EVENT_TYPES = list(EVENT_FUNCTION_MAPPER.keys())
 
@@ -143,6 +357,12 @@ def get_topic(user_specified_topic: str | None, event: str, payload: WildValue) 
     elif event == "issue":
         title = payload["data"]["title"].tame(check_string)
         return f"Issue: {title}"
+    elif event == "project":
+        name = payload["data"]["name"].tame(check_string)
+        return f"Project: {name}"
+    elif event == "project_update":
+        name = payload["data"]["project"]["name"].tame(check_string)
+        return f"Project: {name}"
 
     raise UnsupportedWebhookEventTypeError(event)
 
@@ -155,7 +375,20 @@ def get_event_type(payload: WildValue) -> str | None:
         return "issue" if not has_parent_id else "sub_issue"
     elif event_type == "Comment":
         return "comment"
-    elif event_type in IGNORED_EVENTS:
+    elif event_type == "Project":
+        # Suppress Project.update events that wouldn't produce a renderable
+        # message: Linear's auto-fire after a ProjectUpdate post (lastUpdateId
+        # in updatedFrom), and any update whose changes are all clears/noise
+        # (we only notify on adds/replaces, not removes).
+        if "updatedFrom" in payload:
+            if "lastUpdateId" in payload["updatedFrom"]:
+                return None
+            if not get_project_update_changes(payload):
+                return None
+        return "project"
+    elif event_type == "ProjectUpdate":
+        return "project_update"
+    elif event_type in IGNORED_EVENTS:  # nocoverage
         return None
 
     # This happens when a new event type is added to Linear and we


### PR DESCRIPTION
Extends the Linear webhook integration to notify on **Project** and **ProjectUpdate** (project status posts) events. 

- **Project**: create / update / remove. Updates render specific change clauses.
- **ProjectUpdate**: posted / edited / removed, with the health label inline and Linear's optional `diffMarkdown`  summary appended.
- Suppresses Linear's two content-free auto-fires that would otherwise produce duplicate notifications: the `Project.update` emitted right after `Project.create` (empty `updatedFrom`) and the one emitted alongside every
  `ProjectUpdate` post (identified by `lastUpdateId` in `updatedFrom`).

All test fixtures are real captured webhook payloads.



Fixes part of #23118

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="921" height="719" alt="Screenshot From 2026-06-02 02-16-53" src="https://github.com/user-attachments/assets/90cec1c8-d52c-49b2-a455-1cae3b9c15ad" />
Project Create Event

<img width="918" height="383" alt="Screenshot From 2026-06-02 02-24-58" src="https://github.com/user-attachments/assets/715beccb-561c-4bfe-ba82-80fd4bdadfa6" />

ProjectUpdate Event

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x]  Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
