### PR TITLE
api docs: Document DELETE /export/realm/{export_id}.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -63,10 +63,10 @@ format used by the Zulip server that they are interacting with.
   happened on a previous server, so its tarball is no longer stored
   on this server. This change was also backported to the Zulip 12.x
   series, at feature level 499.
-* `DELETE /export/realm/{export_id}`: Export records with the
-  `export_from_prior_server` field set to `true` cannot be deleted, as the
-  server has no exported data to delete for them. This change was also
-  backported to the Zulip 12.x series, at feature level 499.
+* [`DELETE /export/realm/{export_id}`](/api/delete-realm-export): Export
+  records with the `export_from_prior_server` field set to `true` cannot
+  be deleted, as the server has no exported data to delete for them. This
+  change was also backported to the Zulip 12.x series, at feature level 499.
 
 **Feature level 505**
 
@@ -114,10 +114,10 @@ releases.
   for records that were carried across a realm import; the export
   happened on a previous server, so its tarball is no longer stored
   on this server. Backported change from feature level 506.
-* `DELETE /export/realm/{export_id}`: Export records with the
-  `export_from_prior_server` field set to `true` cannot be deleted, as the
-  server has no exported data to delete for them. Backported change from feature
-  level 506.
+* [`DELETE /export/realm/{export_id}`](/api/delete-realm-export): Export
+  records with the `export_from_prior_server` field set to `true` cannot
+  be deleted, as the server has no exported data to delete for them.
+  Backported change from feature level 506.
 
 ## Changes in Zulip 12.0
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -52,10 +52,10 @@ format used by the Zulip server that they are interacting with.
   happened on a previous server, so its tarball is no longer stored
   on this server. This change was also backported to the Zulip 12.x
   series, at feature level 499.
-* `DELETE /export/realm/{export_id}`: Export records with the
-  `export_from_prior_server` field set to `true` cannot be deleted, as the
-  server has no exported data to delete for them. This change was also
-  backported to the Zulip 12.x series, at feature level 499.
+* [`DELETE /export/realm/{export_id}`](/api/delete-realm-export): Export
+  records with the `export_from_prior_server` field set to `true` cannot
+  be deleted, as the server has no exported data to delete for them. This
+  change was also backported to the Zulip 12.x series, at feature level 499.
 
 **Feature level 505**
 
@@ -103,10 +103,10 @@ releases.
   for records that were carried across a realm import; the export
   happened on a previous server, so its tarball is no longer stored
   on this server. Backported change from feature level 506.
-* `DELETE /export/realm/{export_id}`: Export records with the
-  `export_from_prior_server` field set to `true` cannot be deleted, as the
-  server has no exported data to delete for them. Backported change from feature
-  level 506.
+* [`DELETE /export/realm/{export_id}`](/api/delete-realm-export): Export
+  records with the `export_from_prior_server` field set to `true` cannot
+  be deleted, as the server has no exported data to delete for them.
+  Backported change from feature level 506.
 
 ## Changes in Zulip 12.0
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -159,6 +159,7 @@
 * [Get all data exports](/api/get-realm-exports)
 * [Create a data export](/api/export-realm)
 * [Get data export consent state](/api/get-realm-export-consents)
+* [Delete a data export](/api/delete-realm-export)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 
 ## Real-time events

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -159,6 +159,7 @@
 * [Get all data exports](/api/get-realm-exports)
 * [Create a data export](/api/export-realm)
 * [Get data export consent state](/api/get-realm-export-consents)
+* [Delete a data export](/api/delete-realm-export)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate an organization](/api/deactivate-realm)
 

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -27,7 +27,7 @@ from zerver.lib.test_helpers import read_test_image_file
 from zerver.lib.upload import upload_message_attachment
 from zerver.models import Client, Message, NamedUserGroup, UserPresence
 from zerver.models.channel_folders import ChannelFolder
-from zerver.models.realms import get_realm
+from zerver.models.realms import RealmExport, get_realm
 from zerver.models.users import UserProfile, get_user
 from zerver.openapi.openapi import Parameter
 
@@ -523,3 +523,17 @@ def remove_bot_storage_bot_auth() -> dict[str, object]:
     set_bot_storage(bot, [("foo", "bar")])
     AUTHENTICATION_LINE[0] = f"{bot.email}:{bot.api_key}"
     return {}
+
+
+@openapi_param_value_generator(["/export/realm/{export_id}:delete"])
+def delete_realm_export() -> dict[str, object]:
+    export = RealmExport.objects.create(
+        realm=get_realm("zulip"),
+        type=RealmExport.EXPORT_PUBLIC,
+        status=RealmExport.SUCCEEDED,
+        date_requested=timezone_now(),
+        date_started=timezone_now(),
+        date_succeeded=timezone_now(),
+        export_path="/dummy",
+    )
+    return {"export_id": export.id}

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -756,13 +756,14 @@ def get_realm_exports(client: Client) -> None:
 
 
 @openapi_test_function("/export/realm:post")
-def export_realm(client: Client) -> None:
+def export_realm(client: Client) -> int:
     # {code_example|start}
     # Create a public data export of the organization.
     result = client.call_endpoint(url="/export/realm", method="POST")
     # {code_example|end}
     assert_success_response(result)
     validate_against_openapi_schema(result, "/export/realm", "post", "200")
+    return result["id"]
 
 
 @openapi_test_function("/export/realm/consents:get")
@@ -773,6 +774,16 @@ def get_realm_export_consents(client: Client) -> None:
     # {code_example|end}
     assert_success_response(result)
     validate_against_openapi_schema(result, "/export/realm/consents", "get", "200")
+
+
+@openapi_test_function("/export/realm/{export_id}:delete")
+def delete_realm_export(client: Client, export_id: int) -> None:
+    # {code_example|start}
+    # Delete a completed public or standard data export.
+    result = client.call_endpoint(url=f"/export/realm/{export_id}", method="DELETE")
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/export/realm/{export_id}", "delete", "200")
 
 
 @openapi_test_function("/users/me:get")
@@ -2289,9 +2300,10 @@ def test_server_organizations(client: Client) -> None:
     get_realm_profile_fields(client)
     reorder_realm_profile_fields(client)
     create_realm_profile_field(client)
-    export_realm(client)
+    export_id = export_realm(client)
     get_realm_exports(client)
     get_realm_export_consents(client)
+    delete_realm_export(client, export_id)
 
 
 def test_errors(client: Client) -> None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4630,9 +4630,10 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
-                                Event sent to the user who requested a
+                                Event sent to organization administrators when the
+                                status of a public or standard
                                 [data export](/help/export-your-organization)
-                                when the status of the data export changes.
+                                in the organization changes.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17319,6 +17319,67 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /export/realm/{export_id}:
+    delete:
+      operationId: delete-realm-export
+      summary: Delete a data export
+      tags: ["server_and_organizations"]
+      x-requires-administrator: true
+      description: |
+        Delete a completed public or standard [data export][export-data]
+        of the organization.
+
+        Data exports that happened on a previous server (i.e., an export
+        with `"export_from_prior_server": true` in the
+        [`GET /export/realm`](/api/get-realm-exports#response) response)
+        cannot be deleted using this endpoint, since their tarball is no
+        longer stored on this server; attempting to do so fails with
+        the same error as for an export that has already been deleted.
+
+        This endpoint's success response does not describe the resulting
+        state of the organization's data exports. Clients should rely
+        on the [`realm_export` event](/api/get-events#realm_export),
+        which every organization administrator receives whenever a
+        data export's state changes, for the current state of an
+        organization's data exports.
+
+        **Changes**: Prior to Zulip 13.0 (feature level 506), data
+        exports without a tarball stored on this server had no
+        dedicated status, so attempting to delete one resulted in an
+        unexpected error. Starting at that feature level, such a
+        delete attempt instead fails cleanly, as described above. This
+        change was also backported to the Zulip 12.x series, at
+        feature level 499.
+
+        New in Zulip 2.1.
+
+        [export-data]: /help/export-your-organization#export-data-in-an-importable-format
+      parameters:
+        - name: export_id
+          in: path
+          description: The ID of the data export to be deleted.
+          required: true
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - description: |
+                      A typical failed JSON response for an invalid data export ID.
+                    example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "Invalid data export ID",
+                        "result": "error",
+                      }
   /export/realm:
     get:
       operationId: get-realm-exports

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17165,6 +17165,67 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /export/realm/{export_id}:
+    delete:
+      operationId: delete-realm-export
+      summary: Delete a data export
+      tags: ["server_and_organizations"]
+      x-requires-administrator: true
+      description: |
+        Delete a completed public or standard [data export][export-data]
+        of the organization.
+
+        Data exports that happened on a previous server (that is, with
+        `export_from_prior_server` set to `true` in the
+        [`GET /export/realm`](/api/get-realm-exports) response) cannot
+        be deleted using this endpoint, since their tarball is no
+        longer stored on this server; attempting to do so fails with
+        the same error as for an export that has already been deleted.
+
+        This endpoint's success response does not describe the
+        resulting state of the organization's data exports. Clients
+        should rely on the `realm_export` event (see
+        [`GET /events`](/api/get-events)), which every organization
+        administrator receives whenever a data export's state changes,
+        to find out the current state of a deleted export.
+
+        **Changes**: In Zulip 13.0 (feature level 506), attempting to
+        delete a data export that happened on a previous server began
+        returning the clean error described above. Prior to this
+        change, since data exports without a tarball stored on this
+        server had no dedicated status, attempting to delete one
+        resulted in an unexpected error. This change was also
+        backported to the Zulip 12.x series, at feature level 499.
+
+        New in Zulip 2.1.
+
+        [export-data]: /help/export-your-organization#export-data-in-an-importable-format
+      parameters:
+        - name: export_id
+          in: path
+          description: The ID of the data export to be deleted.
+          required: true
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - description: |
+                      A typical failed JSON response for an invalid data export ID.
+                    example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "Invalid data export ID",
+                        "result": "error",
+                      }
   /export/realm:
     get:
       operationId: get-realm-exports

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17441,16 +17441,32 @@ paths:
       tags: ["server_and_organizations"]
       x-requires-administrator: true
       description: |
-        Create a public or a standard [data export][export-data] of the organization.
-
         !!! warn ""
 
             **Note**: If you're the administrator of a self-hosted installation,
             you may be looking for the documentation on [server data export and
             import][data-export] or [server backups][backups].
 
-        **Changes**: Prior to Zulip 10.0 (feature level 304), only
-        public data exports could be created using this endpoint.
+        Create a public or a standard [data export][export-data] of the
+        organization.
+
+        This endpoint only queues the data export; it does not wait for
+        the export to complete, which depending on the size of the
+        organization can take anywhere from seconds to an hour.
+        Therefore, this endpoint's success response does not describe
+        the outcome of the export.
+
+        To find out the outcome of the export, clients should rely on the
+        [`realm_export` event](/api/get-events#realm_export), which is
+        which is sent to every organization administrator immediately
+        when the export is requested, and again once it completes or
+        fails. Additionally, when the export succeeds, the user who
+        requested it will receive a direct message from the Notification
+        Bot with a link to the organization's data exports panel, where
+        the export can be downloaded.
+
+        **Changes**: Prior to Zulip 10.0 (feature level 304), only public
+        data exports could be created using this endpoint.
 
         New in Zulip 2.1.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17499,7 +17499,7 @@ paths:
                     `2` being replaced by `full_with_consent`. The option `full_without_consent`
                     was added for full exports without member consent.
 
-                    **Changes**: New in Zulip 10.0 (feature level 304). Previously,
+                    New in Zulip 10.0 (feature level 304). Previously,
                     all export requests were public data exports.
                   type: string
                   enum:
@@ -28459,7 +28459,7 @@ components:
             `2` being replaced by `full_with_consent`. The option `full_without_consent`
             was added for full exports without member consent.
 
-            **Changes**: New in Zulip 10.0 (feature level 304). Previously,
+            New in Zulip 10.0 (feature level 304). Previously,
             the export type was not included in these objects because only
             public data exports could be created or listed via the API or UI.
     UserGroup:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17295,6 +17295,19 @@ paths:
             you may be looking for the documentation on [server data export and
             import][data-export] or [server backups][backups].
 
+        This endpoint only queues the data export; it does not wait for
+        the export to complete, which depending on the size of the
+        organization can take anywhere from seconds to an hour. This
+        endpoint's success response does not describe the outcome of
+        the export. To find out the outcome, clients should rely on
+        the `realm_export` event (see [`GET /events`](/api/get-events)),
+        which is sent to every organization administrator immediately
+        when the export is requested, and again once it completes or
+        fails. Additionally, once the export succeeds, the user who
+        requested it gets a direct message from the notification bot
+        linking to the organization's data exports settings, where
+        the export can be downloaded.
+
         **Changes**: Prior to Zulip 10.0 (feature level 304), only
         public data exports could be created using this endpoint.
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -215,8 +215,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         ## This one isn't really representable
         # "/user_uploads/{realm_id_str}/{filename}",
         #### These realm administration settings are valuable to document:
-        # Delete a data export.
-        "/export/realm/{export_id}",
         # Default stream groups are an unfinished feature and therefore
         # shouldn't be added to the documentation until that's completed.
         "/default_stream_groups/create",


### PR DESCRIPTION
Picks up #38517 (originally by @mostafabahaa25, preserved as co-author on the commit), incorporating @laurynmm's review feedback from her [review](https://github.com/zulip/zulip/pull/38517#pullrequestreview-3389700765) and adding a Python example, now possible after #39032 enabled successful realm exports in the test runner.

This was the last undocumented endpoint in the realm administration data exports group; the other three (`GET /export/realm`, `POST /export/realm`, `GET /export/realm/consents`) are already documented.

Fixes: the missing OpenAPI documentation for `DELETE /export/realm/{export_id}`, ensuring realm administrators have testable API instructions for deleting completed data exports.

**How changes were tested:**

- [x] `./tools/lint`
- [x] `./tools/test-backend zerver.tests.test_openapi`
- [x] `./tools/test-api`
- [x] Rendered `/api/delete-realm-export` in `./tools/run-dev` and visually verified all the changes.

<details>
<summary>**Screenshots and screen captures:**</summary>

The Sidebar:
<img width="327" height="115" alt="image" src="https://github.com/user-attachments/assets/7d14129d-0269-4f77-be8d-dcd4deead80a" />

The rendered documentation page: delete-realm-export
<img width="602" height="1245" alt="image" src="https://github.com/user-attachments/assets/b97197f4-74f5-413a-9a6b-7e4894662f59" />

The rendered documentation page: export-realm


</details>
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
