### PR TITLE
stream_popover: Hide move options if time limit passed.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -375,6 +375,33 @@ async function get_message_placement_in_conversation(
     );
 }
 
+function can_move_oldest_message_in_data(
+    current_stream_id: number,
+    topic_name: string,
+    only_topic_edit: boolean,
+    move_limit_buffer: number,
+): boolean {
+    const messages_in_topic = message_util.get_loaded_messages_in_topic(
+        current_stream_id,
+        topic_name,
+    );
+    if (messages_in_topic.length > 0) {
+        messages_in_topic.sort((a, b) => a.id - b.id);
+        const oldest_message = messages_in_topic[0];
+        assert(oldest_message !== undefined);
+
+        if (only_topic_edit) {
+            return message_edit.is_topic_editable(oldest_message, move_limit_buffer);
+        }
+
+        return (
+            message_edit.is_topic_editable(oldest_message, move_limit_buffer) ||
+            message_edit.is_stream_editable(oldest_message, move_limit_buffer)
+        );
+    }
+    return true;
+}
+
 export async function build_move_topic_to_stream_popover(
     current_stream_id: number,
     topic_name: string,
@@ -397,6 +424,7 @@ export async function build_move_topic_to_stream_popover(
         only_topic_edit: boolean;
         disable_topic_input?: boolean;
         message_placement?: "first" | "intermediate" | "last";
+        can_move_oldest_message_in_data: boolean;
         stream: sub_store.StreamSubscription | undefined;
         max_topic_length: number;
     } = {
@@ -409,6 +437,7 @@ export async function build_move_topic_to_stream_popover(
         from_message_actions_popover: message !== undefined,
         only_topic_edit,
         max_topic_length: realm.max_topic_length,
+        can_move_oldest_message_in_data: true,
     };
 
     // When the modal is opened for moving the whole topic from left sidebar,
@@ -481,6 +510,13 @@ export async function build_move_topic_to_stream_popover(
         const move_limit_buffer = 5;
         args.disable_topic_input = !message_edit.is_topic_editable(message, move_limit_buffer);
         disable_stream_input = !message_edit.is_stream_editable(message, move_limit_buffer);
+
+        args.can_move_oldest_message_in_data = can_move_oldest_message_in_data(
+            current_stream_id,
+            topic_name,
+            only_topic_edit,
+            move_limit_buffer,
+        );
 
         // If message is in a search view, default to "move only this message" option,
         // same as if it were the last message in any view.

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -28,7 +28,9 @@
             <select name="propagate_mode" id="message_move_select_options" class="message_edit_topic_propagate modal_select bootstrap-focus-style">
                 <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}> {{t "Move only this message" }}</option>
                 <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}> {{t "Move this and all following messages in this topic" }}</option>
+                {{#if can_move_oldest_message_in_data}}
                 <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}> {{t "Move all messages in this topic" }}</option>
+                {{/if}}
             </select>
         </div>
         {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #25072

This PR hides the **"Move all messages in this topic"** option when the client can already determine that the user lacks permission to perform the move because of message age limits on older messages in the topic.

If any locally cached messages involved in the move are too old to be moved, this option is proactively hidden. This prevents users from initiating an action that would inevitably fail and display an error modal.

**How changes were tested:**

Manually tested the stream popover options for topics with messages exceeding the age limits to verify the option is hidden. Also verified the option remains visible for topics where messages are within the allowed age limit.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

----

### **Screenshots and screen captures:**

<!--

**When time limit has NOT passed (User has permission to move all):**

<img width="588" height="169" alt="Screenshot 2026-06-03 152647" src="https://github.com/user-attachments/assets/e179816e-e1df-434a-912a-9c5436c2d336" />

**When time limit HAS passed (User lacks permission to move all):**

<img width="588" height="165" alt="Screenshot 2026-06-03 152741" src="https://github.com/user-attachments/assets/971666ff-a81d-42f6-992a-fe6a604ba3fb" />

-->

| When time limit has NOT passed (User has permission to move all) | When time limit HAS passed (User lacks permission to move all) |
| --- | --- |
| <img width="588" height="169" alt="Screenshot 2026-06-03 152647" src="https://github.com/user-attachments/assets/e179816e-e1df-434a-912a-9c5436c2d336" /> | <img width="588" height="165" alt="Screenshot 2026-06-03 152741" src="https://github.com/user-attachments/assets/971666ff-a81d-42f6-992a-fe6a604ba3fb" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

* [x] [[Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
  (variable names, code reuse, readability, etc.).
* [x] Followed the [[AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines)](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

* [x] Explains differences from previous plans (e.g., issue description).
* [ ] Highlights technical choices and bugs encountered.
* [ ] Calls out remaining decisions and concerns.
* [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [[commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

* [x] Each commit is a coherent idea.
* [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

* [x] Visual appearance of the changes.
* [ ] Responsiveness and internationalization.
* [x] Strings and tooltips.
* [x] End-to-end functionality of buttons, interactions and flows.
* [x] Corner cases, error conditions, and easily imagined bugs.

</details>