### PR TITLE
dark_theme: Use variable for animated button icon color

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -255,7 +255,7 @@
 
     .color_animated_button {
         .zulip-icon {
-            color: hsl(0deg 0% 100%);
+            color: var(--color-animated-button-text);
         }
     }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Fixes part of #39354.

This replaces the hardcoded `hsl(0deg 0% 100%)` color for the animated button icon in `dark_theme.css` with the existing `--color-animated-button-text` variable.

The variable's dark-theme value matches the previous hardcoded color, so there are no
visual changes.

**How changes were tested:**
Manually tested the "Log in to view image" button in both light and dark
theme.

**Screenshots and screen captures:**

| | Before | After |
|---|---|---|
| **Light theme — full view** | <img width="2880" height="1480" alt="before-light-full" src="https://github.com/user-attachments/assets/a522a1f4-0081-4961-93e5-d19f613f5e61" /> | <img width="2880" height="1480" alt="after-light-full" src="https://github.com/user-attachments/assets/980f17b3-f9c2-48b8-83ef-16930fdea439" /> |
| **Light theme — zoomed** | <img width="1882" height="282" alt="before-light-zoomed" src="https://github.com/user-attachments/assets/adada543-db36-49a6-8f2c-e8b5d711cf0f" /> | <img width="1882" height="282" alt="after-light-zoomed" src="https://github.com/user-attachments/assets/bfc9f7ec-af1a-463c-8540-39722ad7ccc9" /> |
| **Light theme — closer crop** | <img width="346" height="88" alt="before-light-more zoomed" src="https://github.com/user-attachments/assets/12a1fa16-cd99-422e-bd0a-f20e837cfe0e" /> | <img width="346" height="88" alt="after-light-more zoomed" src="https://github.com/user-attachments/assets/496fbdd6-c125-4d1f-836a-834e8ec655a7" /> |
| **Dark theme — full view** | <img width="2880" height="1480" alt="before-dark-full" src="https://github.com/user-attachments/assets/ca40787f-ba6e-4050-9417-6774b1a27322" /> | <img width="2880" height="1480" alt="after-dark-full" src="https://github.com/user-attachments/assets/275fefa0-dbf7-4d3f-81a7-f67964614b11" /> |
| **Dark theme — zoomed** | <img width="1882" height="282" alt="before-dark-zoomed" src="https://github.com/user-attachments/assets/cc3d0f19-1286-48e6-8b69-5fd2543c27bd" /> | <img width="1882" height="282" alt="after-dark-zoomed" src="https://github.com/user-attachments/assets/fb2f2a14-e7e5-4b01-8ef4-0a4192631fe2" /> |
| **Dark theme — closer crop** | <img width="346" height="88" alt="before-dark-more zoomed" src="https://github.com/user-attachments/assets/c75682f4-55d3-4c54-a342-3f08316f0f95" /> | <img width="346" height="88" alt="after-dark-more zoomed" src="https://github.com/user-attachments/assets/1b6815c2-c725-4c73-a5c9-c5b5656ee356" /> |


<details>
<summary>Variable usage across the codebase</summary>

```git grep -n "color-animated-button"```
`web/styles/app_components.css:561:    .color-animated-button-text {
web/styles/app_components.css:562:        color: var(--color-animated-button-text);
web/styles/app_components.css:570:        .color-animated-button-text {
web/styles/app_components.css:580:    .color-animated-button-text {
web/styles/app_variables.css:1185:    --color-animated-button-text: light-dark(
web/styles/dark_theme.css:258:            color: var(--color-animated-button-text);
web/templates/login_to_view_image_button.hbs:4:        <span class="color-animated-button-text">{{t "Log in to view image" }}</span>`
</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>