### PR TITLE
[Backport] export: Update status of RealmExport rows while exporting.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -18,6 +18,21 @@ clients should check the `zulip_feature_level` field, present in the
 /register`](/api/register-queue) responses, to determine the API
 format used by the Zulip server that they are interacting with.
 
+## Changes in Zulip 12.1
+
+**Feature level 499**
+
+* [`GET /export/realm`](/api/get-realm-exports),
+  [`GET /events`](/api/get-events): Added an `export_from_prior_server`
+  boolean field to the export objects returned. It is `true`
+  for records that were carried across a realm import; the export
+  happened on a previous server, so its tarball is no longer stored
+  on this server. Backported change from feature level 506.
+* `DELETE /export/realm/{export_id}`: Export records with the
+  `export_from_prior_server` field set to `true` cannot be deleted, as the
+  server has no exported data to delete for them. Backported change from feature
+  level 506.
+
 ## Changes in Zulip 12.0
 
 **Feature level 498**

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -43,13 +43,16 @@ ZULIP_PATH=/root/zulip-latest
 mkdir -p "$ZULIP_PATH"
 tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1
 
+# Disable interactive prompts from apt.
+echo 'Dpkg::Options { "--force-confdef" "--force-confold" }' >/etc/apt/apt.conf.d/noninteractive
+export DEBIAN_FRONTEND=noninteractive
+
 # Do an apt upgrade to start with an up-to-date machine
-APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')
 apt-get update
 
-if ! apt-get dist-upgrade -y "${APT_OPTIONS[@]}"; then
+if ! apt-get dist-upgrade -y; then
     echo "\`apt-get dist-upgrade\`: Failure occurred while trying to perform distribution upgrade, Retrying..."
-    apt-get dist-upgrade -y "${APT_OPTIONS[@]}"
+    apt-get dist-upgrade -y
 fi
 
 os_info="$(

--- a/tools/ci/production-upgrade
+++ b/tools/ci/production-upgrade
@@ -19,6 +19,10 @@ sudo service rabbitmq-server start
 # Start the supervisor
 sudo service supervisor start
 
+# Disable interactive prompts from apt.
+echo 'Dpkg::Options { "--force-confdef" "--force-confold" }' >/etc/apt/apt.conf.d/noninteractive
+export DEBIAN_FRONTEND=noninteractive
+
 # Zulip releases before 2.1.8/3.5/4.4 have a bug in their
 # `upgrade-zulip` scripts, resulting in them exiting with status 0
 # unconditionally. We work around that by running

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 498
+API_FEATURE_LEVEL = 499
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -49,6 +49,7 @@ export const realm_export_schema = z.object({
     deleted_timestamp: z.nullable(z.number()),
     failed_timestamp: z.nullable(z.number()),
     pending: z.boolean(),
+    export_from_prior_server: z.boolean(),
     export_type: realm_export_type_schema,
 });
 type RealmExport = z.output<typeof realm_export_schema>;
@@ -126,6 +127,7 @@ export function populate_exports_table(exports: RealmExport[]): void {
                     time_failed: failed_timestamp,
                     pending: data.pending,
                     time_deleted: deleted_timestamp,
+                    export_from_prior_server: data.export_from_prior_server,
                     export_type_description:
                         settings_config.export_type_values[data.export_type].description,
                 },

--- a/web/templates/settings/admin_export_list.hbs
+++ b/web/templates/settings/admin_export_list.hbs
@@ -18,6 +18,8 @@
         <div class="export_url_spinner"></div>
         {{else if time_deleted}}
         <span class="export_status">{{t 'Deleted' }}: {{time_deleted}}</span>
+        {{else if export_from_prior_server}}
+        <span class="export_status">{{t 'Export from a prior server' }}</span>
         {{/if}}
     </td>
     <td class="actions">

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -601,6 +601,7 @@ exports.fixtures = {
                 deleted_timestamp: null,
                 failed_timestamp: null,
                 pending: true,
+                export_from_prior_server: false,
                 export_type: "public",
             },
         ],

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -520,6 +520,7 @@ class Export(BaseModel):
     deleted_timestamp: float | int | None
     failed_timestamp: float | int | None
     pending: bool
+    export_from_prior_server: bool
     export_type: RealmExportSlug
 
 

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -959,9 +959,8 @@ def get_realm_config() -> Config:
     Config(
         table="zerver_realmexport",
         model=RealmExport,
-        normal_parent=realm_config,
-        include_rows="realm_id__in",
-        exclude=["export_path"],
+        virtual_parent=realm_config,
+        custom_fetch=custom_fetch_realm_exports,
     )
 
     Config(
@@ -1725,6 +1724,21 @@ def custom_fetch_onboarding_usermessage(response: TableData, context: Context) -
             yield onboarding_usermessage_obj
 
     response["zerver_onboardingusermessage"] = rows()
+
+
+def custom_fetch_realm_exports(response: TableData, context: Context) -> None:
+    realm = context["realm"]
+
+    def rows() -> Iterator[Record]:
+        for realm_export in RealmExport.objects.filter(realm=realm).iterator():
+            realm_export_obj = model_to_dict(realm_export)
+            if realm_export_obj["status"] == RealmExport.SUCCEEDED:
+                realm_export_obj["status"] = RealmExport.EXPORT_FROM_PRIOR_SERVER
+            # Never export the export path - that's a potential data leak.
+            realm_export_obj.pop("export_path", None)
+            yield realm_export_obj
+
+    response["zerver_realmexport"] = rows()
 
 
 def fetch_usermessages(
@@ -3183,6 +3197,7 @@ def get_realm_exports_serialized(realm: Realm) -> list[dict[str, Any]]:
             deleted_timestamp=deleted_timestamp,
             failed_timestamp=failed_timestamp,
             pending=pending,
+            export_from_prior_server=export.status == RealmExport.EXPORT_FROM_PRIOR_SERVER,
             export_type=get_export_type_slug(export.type),
         )
     return sorted(exports_dict.values(), key=lambda export_dict: export_dict["id"])

--- a/zerver/migrations/0801_realmexport_backfill_export_from_prior_server_status.py
+++ b/zerver/migrations/0801_realmexport_backfill_export_from_prior_server_status.py
@@ -1,0 +1,43 @@
+from django.db import connection, migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+SUCCEEDED = 3
+EXPORT_FROM_PRIOR_SERVER = 6
+
+
+def backfill_export_from_prior_server_status(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    # RealmExport rows with SUCCEEDED status but no export_path are
+    # records carried across a realm export->import, where the tarball
+    # is not preserved. Fix them up to use EXPORT_FROM_PRIOR_SERVER status.
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            UPDATE zerver_realmexport
+            SET status = %s
+            WHERE status = %s AND export_path IS NULL
+            RETURNING id, realm_id
+            """,
+            [EXPORT_FROM_PRIOR_SERVER, SUCCEEDED],
+        )
+        for export_id, realm_id in cursor.fetchall():
+            print(
+                f"Fixed RealmExport id={export_id} realm_id={realm_id}: "
+                f"SUCCEEDED -> EXPORT_FROM_PRIOR_SERVER"
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0800_cleanup_case_mismatched_legacy_apns_tokens"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_export_from_prior_server_status,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -1481,6 +1481,7 @@ class RealmExport(models.Model):
     SUCCEEDED = 3
     FAILED = 4
     DELETED = 5
+    EXPORT_FROM_PRIOR_SERVER = 6
     status = models.PositiveSmallIntegerField(default=REQUESTED)
 
     date_requested = models.DateTimeField()

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4653,6 +4653,7 @@ paths:
                                         "deleted_timestamp": null,
                                         "failed_timestamp": 1594825444.4363360405,
                                         "pending": false,
+                                        "export_from_prior_server": false,
                                         "export_type": "public",
                                       },
                                     ],
@@ -17021,6 +17022,7 @@ paths:
                               "id": 323,
                               "failed_timestamp": null,
                               "pending": false,
+                              "export_from_prior_server": false,
                             },
                           ],
                         "msg": "",
@@ -27973,8 +27975,13 @@ components:
           description: |
             The URL to download the generated data export.
 
-            Will be `null` if the data export failed, or if it's
-            still being generated.
+            Will be `null` if the data export failed, if it's
+            still being generated, or if this export happened
+            on a previous server.
+
+            **Changes**: Starting in Zulip 12.1 (feature level 499),
+            this is also `null` for exports that happened on a previous
+            server.
         pending:
           type: boolean
           description: |
@@ -27985,6 +27992,16 @@ components:
             Depending on the size of the organization, it can take
             anywhere from seconds to an hour to generate the data
             export.
+        export_from_prior_server:
+          type: boolean
+          description: |
+            Whether this data export happened on a previous server,
+            and thus its tarball is no longer stored on this server.
+            This is `true` for records that were carried across a
+            realm import; the record is preserved for audit purposes
+            but its data is no longer available for download.
+
+            **Changes**: New in Zulip 12.1 (feature level 499).
         export_type:
           type: string
           enum:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -2011,12 +2011,16 @@ class RealmImportExportTest(ExportFile):
 
         get_user_by_delivery_email(prospero_email, imported_realm)
 
-        # Ensure RealmExport.export_path is excluded from the export and thus None after importing.
+        # Ensure RealmExport.export_path is excluded from the export and thus None after
+        # importing, and that the SUCCEEDED status was flipped to EXPORT_FROM_PRIOR_SERVER
+        # so the imported row reflects that the tarball is no longer available.
         exported_realm_exports = read_json("realm.json")["zerver_realmexport"]
         self.assert_length(exported_realm_exports, 1)
         self.assertNotIn("export_path", exported_realm_exports[0])
+        self.assertEqual(exported_realm_exports[0]["status"], RealmExport.EXPORT_FROM_PRIOR_SERVER)
         imported_realm_export = RealmExport.objects.get(realm=imported_realm)
         self.assertIsNone(imported_realm_export.export_path)
+        self.assertEqual(imported_realm_export.status, RealmExport.EXPORT_FROM_PRIOR_SERVER)
 
     def test_import_message_edit_history(self) -> None:
         realm = get_realm("zulip")
@@ -2422,7 +2426,15 @@ class RealmImportExportTest(ExportFile):
         @getter
         def get_realm_exports(r: Realm) -> set[tuple[datetime, int, int]]:
             return {
-                (rec.date_requested, rec.type, rec.status)
+                (
+                    rec.date_requested,
+                    rec.type,
+                    # SUCCEEDED rows are intentionally flipped to
+                    # EXPORT_FROM_PRIOR_SERVER during realm export.
+                    RealmExport.EXPORT_FROM_PRIOR_SERVER
+                    if rec.status == RealmExport.SUCCEEDED
+                    else rec.status,
+                )
                 for rec in RealmExport.objects.filter(realm=r)
             }
 

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -271,6 +271,39 @@ class RealmExportTest(ZulipTestCase):
             ],
         )
 
+    def test_export_from_prior_server_status_in_api(self) -> None:
+        admin = self.example_user("iago")
+        self.login_user(admin)
+
+        # A RealmExport row whose tarball is no longer stored on this
+        # server - the result of the record being carried
+        # across a realm export->import.
+        prior_server_export = RealmExport.objects.create(
+            realm=admin.realm,
+            type=RealmExport.EXPORT_PUBLIC,
+            status=RealmExport.EXPORT_FROM_PRIOR_SERVER,
+            date_requested=timezone_now(),
+            date_succeeded=timezone_now(),
+            acting_user=admin,
+            export_path=None,
+        )
+
+        result = self.client_get("/json/export/realm")
+        response_dict = self.assert_json_success(result)
+        export_dict = response_dict["exports"]
+        self.assert_length(export_dict, 1)
+        self.assertEqual(export_dict[0]["id"], prior_server_export.id)
+        self.assertIsNone(export_dict[0]["export_url"])
+        self.assertEqual(export_dict[0]["pending"], False)
+        self.assertIsNone(export_dict[0]["deleted_timestamp"])
+        self.assertIsNone(export_dict[0]["failed_timestamp"])
+        self.assertEqual(export_dict[0]["export_from_prior_server"], True)
+        self.assertEqual(export_dict[0]["acting_user_id"], admin.id)
+
+        # Trying to delete such a row reports it as already deleted.
+        result = self.client_delete(f"/json/export/realm/{prior_server_export.id}")
+        self.assert_json_error(result, "Export already deleted")
+
     def test_realm_export_rate_limited(self) -> None:
         admin = self.example_user("iago")
         self.login_user(admin)

--- a/zerver/views/realm_export.py
+++ b/zerver/views/realm_export.py
@@ -131,7 +131,7 @@ def delete_realm_export(request: HttpRequest, user: UserProfile, export_id: int)
     except RealmExport.DoesNotExist:
         raise JsonableError(_("Invalid data export ID"))
 
-    if export_row.status == RealmExport.DELETED:
+    if export_row.status in [RealmExport.DELETED, RealmExport.EXPORT_FROM_PRIOR_SERVER]:
         raise JsonableError(_("Export already deleted"))
     if export_row.status == RealmExport.FAILED:
         raise JsonableError(_("Export failed, nothing to delete"))


### PR DESCRIPTION
Backports #38862.

This has two pieces requiring special attention:
1. Backports an API change, meaning we have to use one of the reserved API level numbers for 12.x. Approach taken here is based on #31525. The following pair of commits give the example:
- Original commit: 8bacdbc895e1b03b47cea3caa063477b60de2452
- Backported commit: 94ff57a4d950459b000e62cbcdd07c5531eae42d

After merging this, we'll also want to merge this tweak to the changelog in `upstream/main` to make it match the structure of changelog changes in 8bacdbc895e1b03b47cea3caa063477b60de2452
```diff
diff --git a/api_docs/changelog.md b/api_docs/changelog.md
index ebdebedc38..c0e1293aee 100644
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -27,10 +27,12 @@ format used by the Zulip server that they are interacting with.
   boolean field to the export objects returned. It is `true`
   for records that were carried across a realm import; the export
   happened on a previous server, so its tarball is no longer stored
-  on this server.
+  on this server. This change was also backported to the Zulip 12.x
+  series, at feature level 499.
 * `DELETE /export/realm/{export_id}`: Export records with the
-  `export_from_prior_server` field set to `true` cannot be deleted, as
-  the server has no exported data to delete for them.
+  `export_from_prior_server` field set to `true` cannot be deleted, as the
+  server has no exported data to delete for them. This change was also
+  backported to the Zulip 12.x series, at feature level 499.
 
 **Feature level 505**
 
@@ -62,6 +64,19 @@ releases.
 
 ## Changes in Zulip 12.0
 
+**Feature level 499**
+
+* [`GET /export/realm`](/api/get-realm-exports),
+  [`GET /events`](/api/get-events): Added an `export_from_prior_server`
+  boolean field to the export objects returned. It is `true`
+  for records that were carried across a realm import; the export
+  happened on a previous server, so its tarball is no longer stored
+  on this server. Backported change from feature level 506.
+* `DELETE /export/realm/{export_id}`: Export records with the
+  `export_from_prior_server` field set to `true` cannot be deleted, as the
+  server has no exported data to delete for them. Backported change from feature
+  level 506.
+
 **Feature level 498**
 
 No changes; API feature level used for the Zulip 12.0 release.

```

2. This also backports a migration - but we're lucky, there have been no other new migrations in `upstream/main`! So no merge migration is needed, and we can backport as-is, new migration `0801` with `0800` as the predecessor (`12.0` included `0800`).