### PR TITLE
api-docs: Update changelog to reflect the backport of feature level 506.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -27,10 +27,12 @@ format used by the Zulip server that they are interacting with.
   boolean field to the export objects returned. It is `true`
   for records that were carried across a realm import; the export
   happened on a previous server, so its tarball is no longer stored
-  on this server.
+  on this server. This change was also backported to the Zulip 12.x
+  series, at feature level 499.
 * `DELETE /export/realm/{export_id}`: Export records with the
-  `export_from_prior_server` field set to `true` cannot be deleted, as
-  the server has no exported data to delete for them.
+  `export_from_prior_server` field set to `true` cannot be deleted, as the
+  server has no exported data to delete for them. This change was also
+  backported to the Zulip 12.x series, at feature level 499.
 
 **Feature level 505**
 
@@ -57,8 +59,23 @@ format used by the Zulip server that they are interacting with.
 
 No changes; start of Zulip 13.0 development branch.
 
-Feature levels 499-501 reserved for future use in 12.x maintenance
+Feature levels 500-501 reserved for future use in 12.x maintenance
 releases.
+
+## Changes in Zulip 12.1
+
+**Feature level 499**
+
+* [`GET /export/realm`](/api/get-realm-exports),
+  [`GET /events`](/api/get-events): Added an `export_from_prior_server`
+  boolean field to the export objects returned. It is `true`
+  for records that were carried across a realm import; the export
+  happened on a previous server, so its tarball is no longer stored
+  on this server. Backported change from feature level 506.
+* `DELETE /export/realm/{export_id}`: Export records with the
+  `export_from_prior_server` field set to `true` cannot be deleted, as the
+  server has no exported data to delete for them. Backported change from feature
+  level 506.
 
 ## Changes in Zulip 12.0
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27976,8 +27976,8 @@ components:
             still being generated, or if this export happened
             on a previous server.
 
-            **Changes**: Starting in Zulip 13.0 (feature level 506),
-            this is also `null` for exports that happened on a previous
+            **Changes**: Starting in Zulip 12.1 (feature levels 499-501, and
+            506+), this is also `null` for exports that happened on a previous
             server.
         pending:
           type: boolean
@@ -27998,7 +27998,7 @@ components:
             realm import; the record is preserved for audit purposes
             but its data is no longer available for download.
 
-            **Changes**: New in Zulip 13.0 (feature level 506).
+            **Changes**: New in Zulip 12.1 (feature levels 499-501, and 506+).
         export_type:
           type: string
           enum:


### PR DESCRIPTION
Now that the API change has been backported in
0d4e27f7ea88099a72b0cee7d32f6080706c5c0e,
we update the changelog to reflect this fact and bring the structure in line with 8bacdbc895e1b03b47cea3caa063477b60de2452.

This is just the diff mentioned in #39442.