### PR TITLE
postgresql: Raise locked-memory limit for io_uring rings.

### DIFF
--- a/puppet/zulip/files/postgresql/postgresql@.service.d/zulip.conf
+++ b/puppet/zulip/files/postgresql/postgresql@.service.d/zulip.conf
@@ -1,0 +1,8 @@
+# This file is managed by Zulip's Puppet configuration.
+#
+# Linux 6.14+ charges (per-user) the rings from io_uring against to
+# RLIMIT_MEMLOCK, which is by default limited to 8MiB; the default
+# Zulip PostgreSQL configuration needs ~13MiB.  Set a limit sizably
+# above that.
+[Service]
+LimitMEMLOCK=256M

--- a/puppet/zulip/manifests/profile/postgresql.pp
+++ b/puppet/zulip/manifests/profile/postgresql.pp
@@ -2,6 +2,7 @@
 class zulip::profile::postgresql(Boolean $start = true) {
   include zulip::profile::base
   include zulip::postgresql_base
+  include zulip::systemd_daemon_reload
 
   $version = $zulip::postgresql_common::version
 
@@ -68,6 +69,25 @@ class zulip::profile::postgresql(Boolean $start = true) {
     fail("PostgreSQL ${version} not supported")
   }
 
+  # PostgreSQL 18's io_method = io_uring requires a larger
+  # RLIMIT_MEMLOCK than systemd's default on Linux 6.14 and newer
+  if $facts['os']['family'] == 'Debian' {
+    file { '/etc/systemd/system/postgresql@.service.d':
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
+    file { '/etc/systemd/system/postgresql@.service.d/zulip.conf':
+      ensure => file,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      source => 'puppet:///modules/zulip/postgresql/postgresql@.service.d/zulip.conf',
+      notify => [Exec['reload systemd'], Service['postgresql']],
+    }
+  }
+
   if $replication_primary != undef and $replication_user != undef {
     # The presence of a standby.signal file triggers replication
     file { "${zulip::postgresql_base::postgresql_datadir}/standby.signal":
@@ -90,7 +110,7 @@ class zulip::profile::postgresql(Boolean $start = true) {
   }
   service { 'postgresql':
     ensure    => $start,
-    require   => $require,
+    require   => $require + [Exec['reload systemd']],
     subscribe => [ File[$postgresql_conf_file] ],
   }
 }

--- a/puppet/zulip/manifests/systemd_daemon_reload.pp
+++ b/puppet/zulip/manifests/systemd_daemon_reload.pp
@@ -1,6 +1,9 @@
 class zulip::systemd_daemon_reload {
   exec { 'reload systemd':
-    command     => 'sh -c "! command -v systemctl > /dev/null || systemctl daemon-reload"',
+    # /run/systemd/system only exists if systemd is the running init
+    # system (see sd_booted(3)), as opposed to merely installed, as may
+    # be the case in containers.
+    command     => 'sh -c "! test -d /run/systemd/system || systemctl daemon-reload"',
     refreshonly => true,
   }
 }


### PR DESCRIPTION
Since f0cc982e52a6, PostgreSQL 18 uses io_uring when available. PostgreSQL creates an io_uring instance for each of the `max_connections = 1000` possible backends.  Linux 6.14 and newer charge that usage (8-13MiB at our default PostgreSQL settings) against RLIMIT_MEMLOCK.  Unfortunately, the systemd default is only 8MiB; on such kernels (e.g. Ubuntu 26.04), PostgreSQL 18 fails to start with:

    FATAL: could not setup io_uring queue: Cannot allocate memory

Raise the limit to 256MiB.  This accommodates io_uring usage even at the maximum configurable io_max_concurrency (~100MiB), times two clusters running concurrently during pg_upgradecluster (since the kernel counts locked memory per-user, not per-process).

Installations on older kernels (e.g. Ubuntu 24.04's Linux 6.8) pin the same memory without accounting it, so they start fine today but would fail after a kernel upgrade; applying the higher limit fixes them preemptively.

-----

[#production help > ubuntu-26-04-postgres-io-method](https://chat.zulip.org/#narrow/channel/31-production-help/topic/ubuntu-26-04-postgres-io-method/with/2468065)
