### PR TITLE
[ai] Fix search by user names for multiple users not working for `dm:` operator.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -263,6 +263,20 @@ function resolve_user_id_from_operand(operand: string): number | undefined {
     );
 }
 
+// Resolve a comma-separated `dm`/`dm-including` operand to user ids, returning
+// undefined if any token cannot be resolved to a user.
+function resolve_user_ids_from_operand(operand: string): number[] | undefined {
+    const user_ids = [];
+    for (const token of operand.split(",")) {
+        const user_id = resolve_user_id_from_operand(token);
+        if (user_id === undefined) {
+            return undefined;
+        }
+        user_ids.push(user_id);
+    }
+    return user_ids;
+}
+
 function convert_single_user_id_suggestion_to_term(
     suggestion: NarrowTermSuggestion,
     canonical_operator: "sender" | "mentions",
@@ -547,15 +561,19 @@ export class Filter {
             switch (canonical_operator) {
                 case "dm":
                 case "dm-including": {
+                    // An empty operand is invalid for dm and dm-including.
+                    if (suggestion.operand === "") {
+                        return undefined;
+                    }
                     let operand: number[];
                     if (suggestion.operand.toLowerCase() === "me") {
                         operand = [people.my_current_user_id()];
                     } else {
-                        operand = people.user_ids_string_to_ids_array(suggestion.operand);
-                    }
-                    // An empty operand is invalid for dm and dm-including.
-                    if (suggestion.operand === "") {
-                        return undefined;
+                        const user_ids = resolve_user_ids_from_operand(suggestion.operand);
+                        if (user_ids === undefined) {
+                            return undefined;
+                        }
+                        operand = user_ids;
                     }
                     potential_narrow_term = {
                         operator: canonical_operator,

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -247,12 +247,28 @@ const USER_OPERATORS = new Set([
     "group-pm-with",
 ]);
 
+// Resolve a single user-operator operand token to a user id. The token can be
+// a numeric user id, a unique full name, or a `Full Name|user_id` string that
+// disambiguates duplicate names (the same form we accept for mentions). The
+// resulting id's validity as a real user is verified later by
+// `is_valid_canonical_term`.
+function resolve_user_id_from_operand(operand: string): number | undefined {
+    operand = operand.trim();
+    const numeric_user_id = Number(operand);
+    if (operand !== "" && !Number.isNaN(numeric_user_id)) {
+        return numeric_user_id;
+    }
+    return (
+        people.get_from_unique_full_name(operand)?.user_id ?? people.get_user_id_from_name(operand)
+    );
+}
+
 function convert_single_user_id_suggestion_to_term(
     suggestion: NarrowTermSuggestion,
     canonical_operator: "sender" | "mentions",
 ): NarrowCanonicalTerm | undefined {
-    const operand = Number(suggestion.operand);
-    if (Number.isNaN(operand)) {
+    const operand = resolve_user_id_from_operand(suggestion.operand);
+    if (operand === undefined) {
         return undefined;
     }
     return {

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -73,6 +73,13 @@ const annie = make_user({
     role: Role.GUEST,
 });
 
+// Multi-word names, to exercise resolving typed full names to user ids.
+const karl = make_user({
+    email: "karl@foo.com",
+    user_id: 36,
+    full_name: "Karl Stolley",
+});
+
 // Add users to `valid_user_ids`.
 const source = "server_events";
 people.add_active_user(me, source);
@@ -81,6 +88,7 @@ people.add_active_user(steve, source);
 people.add_active_user(alice, source);
 people.add_active_user(jeff, source);
 people.add_active_user(annie, source);
+people.add_active_user(karl, source);
 people.initialize_current_user(me.user_id);
 state_data.set_current_user(me);
 muted_users.add_muted_user(jeff.user_id);
@@ -2274,12 +2282,19 @@ test("convert_suggestion_to_term", () => {
         ["mentions:me", true],
         ["mentions:-1", false],
         ["mentions:invalid", false],
+        // A typed full name resolves to a user id, matching the help center
+        // docs. Quotes keep a multi-word name a single operand through the
+        // parser. A third tuple element pins down the resolved term, so a
+        // name maps to the right user id and not merely to some valid term.
+        [`sender:"${karl.full_name}"`, true, {operator: "sender", operand: karl.user_id}],
+        [`mentions:"${karl.full_name}"`, true, {operator: "mentions", operand: karl.user_id}],
     ];
-    for (const [search_term_string, expected_is_valid] of test_data) {
-        assert.equal(
-            Filter.convert_suggestion_to_term(Filter.parse(search_term_string)[0]) !== undefined,
-            expected_is_valid,
-        );
+    for (const [search_term_string, expected_is_valid, expected_term] of test_data) {
+        const term = Filter.convert_suggestion_to_term(Filter.parse(search_term_string)[0]);
+        assert.equal(term !== undefined, expected_is_valid);
+        if (expected_term !== undefined) {
+            assert.deepEqual(term, {negated: false, ...expected_term});
+        }
     }
 
     // Invalid operator.

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -80,6 +80,25 @@ const karl = make_user({
     full_name: "Karl Stolley",
 });
 
+const shubham = make_user({
+    email: "shubham@foo.com",
+    user_id: 37,
+    full_name: "Shubham Padia",
+});
+
+// Two users sharing a full name, to exercise duplicate-name handling.
+const sam_one = make_user({
+    email: "sam1@foo.com",
+    user_id: 38,
+    full_name: "Sam Park",
+});
+
+const sam_two = make_user({
+    email: "sam2@foo.com",
+    user_id: 39,
+    full_name: "Sam Park",
+});
+
 // Add users to `valid_user_ids`.
 const source = "server_events";
 people.add_active_user(me, source);
@@ -89,6 +108,9 @@ people.add_active_user(alice, source);
 people.add_active_user(jeff, source);
 people.add_active_user(annie, source);
 people.add_active_user(karl, source);
+people.add_active_user(shubham, source);
+people.add_active_user(sam_one, source);
+people.add_active_user(sam_two, source);
 people.initialize_current_user(me.user_id);
 state_data.set_current_user(me);
 muted_users.add_muted_user(jeff.user_id);
@@ -2288,6 +2310,35 @@ test("convert_suggestion_to_term", () => {
         // name maps to the right user id and not merely to some valid term.
         [`sender:"${karl.full_name}"`, true, {operator: "sender", operand: karl.user_id}],
         [`mentions:"${karl.full_name}"`, true, {operator: "mentions", operand: karl.user_id}],
+        // dm and dm-including resolve a comma-separated list of names to the
+        // corresponding user ids.
+        [`dm:"${karl.full_name}"`, true, {operator: "dm", operand: [karl.user_id]}],
+        [
+            `dm:"${karl.full_name}, ${shubham.full_name}"`,
+            true,
+            {operator: "dm", operand: [karl.user_id, shubham.user_id]},
+        ],
+        [
+            `dm-including:"${karl.full_name}, ${shubham.full_name}"`,
+            true,
+            {operator: "dm-including", operand: [karl.user_id, shubham.user_id]},
+        ],
+        // A name that matches no user is invalid.
+        ['dm:"No Such Person"', false],
+        // An ambiguous (duplicate) full name is invalid on its own...
+        [`dm:"${sam_one.full_name}"`, false],
+        // ...but the `Full Name|user_id` form disambiguates it, resolving to
+        // exactly the requested user and not the other duplicate.
+        [
+            `dm:"${sam_one.full_name}|${sam_one.user_id}"`,
+            true,
+            {operator: "dm", operand: [sam_one.user_id]},
+        ],
+        [
+            `dm:"${sam_two.full_name}|${sam_two.user_id}"`,
+            true,
+            {operator: "dm", operand: [sam_two.user_id]},
+        ],
     ];
     for (const [search_term_string, expected_is_valid, expected_term] of test_data) {
         const term = Filter.convert_suggestion_to_term(Filter.parse(search_term_string)[0]);

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -100,11 +100,29 @@ function test(label, f) {
 
 test("person_multi_word_completion", () => {
     // The help center documents searching person operators by full name,
-    // e.g. `sender:Elena García`. An unquoted multi-word name parses with a
-    // trailing `search:` term, which get_suggestions merges back into the
-    // person operand before resolving the name to a user id.
+    // e.g. `sender:Elena García` and the multi-user `dm:Bo Lin, Elena
+    // García`. An unquoted multi-word name parses with a trailing `search:`
+    // term, which get_suggestions merges back into the person operand before
+    // resolving each name to a user id.
     assert.deepEqual(get_suggestions("sender:Ted Smith"), [`sender:${ted.user_id}`]);
     assert.deepEqual(get_suggestions("mentions:Ted Smith"), [`mentions:${ted.user_id}`]);
+    assert.deepEqual(get_suggestions("dm:Ted Smith"), [`dm:${ted.user_id}`]);
+    assert.deepEqual(get_suggestions("dm-including:Ted Smith"), [`dm-including:${ted.user_id}`]);
+
+    // dm and dm-including resolve a comma-separated list of names, with or
+    // without a space after the comma.
+    assert.deepEqual(get_suggestions("dm:Ted Smith, Alice Ignore"), [
+        `dm:${ted.user_id},${alice.user_id}`,
+    ]);
+    assert.deepEqual(get_suggestions("dm:Ted Smith,Alice Ignore"), [
+        `dm:${ted.user_id},${alice.user_id}`,
+    ]);
+    assert.deepEqual(get_suggestions("dm-including:Ted Smith, Alice Ignore"), [
+        `dm-including:${ted.user_id},${alice.user_id}`,
+    ]);
+    assert.deepEqual(get_suggestions("dm-including:Ted Smith,Alice Ignore"), [
+        `dm-including:${ted.user_id},${alice.user_id}`,
+    ]);
 });
 
 test("basic_get_suggestions", ({override}) => {

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -98,6 +98,15 @@ function test(label, f) {
     });
 }
 
+test("person_multi_word_completion", () => {
+    // The help center documents searching person operators by full name,
+    // e.g. `sender:Elena García`. An unquoted multi-word name parses with a
+    // trailing `search:` term, which get_suggestions merges back into the
+    // person operand before resolving the name to a user id.
+    assert.deepEqual(get_suggestions("sender:Ted Smith"), [`sender:${ted.user_id}`]);
+    assert.deepEqual(get_suggestions("mentions:Ted Smith"), [`mentions:${ted.user_id}`]);
+});
+
 test("basic_get_suggestions", ({override}) => {
     const query = "fred";
 


### PR DESCRIPTION
Checked that following works:
* `dm: User 1, User 2`
* `dm: User 1 dm: User 2`
* `dm-including: User 1, User 2`

There are some edge cases around user names with `,` not working as expected, but I think it would be better fixed in a PR targeting all the operators instead of just this regression.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Search.20for.20group.20direct.20message.20conversations