### PR TITLE
[ai] slack_import: Make self-serve Slack imports safe under duplicate subdomains.

### DIFF
--- a/templates/zerver/slack_import.html
+++ b/templates/zerver/slack_import.html
@@ -35,6 +35,11 @@
                     </div>
                 </div>
                 {% else %}
+                {% if slack_import_error %}
+                <div class="input-box">
+                    <p id="slack-import-error" class="help-inline text-error">{{ slack_import_error }}</p>
+                </div>
+                {% endif %}
                 <form method="post" class="form-inline" action="{{ url('import_realm_from_slack') }}">
                     {{ csrf_input }}
                     <div class="input-box no-validation">

--- a/templates/zerver/slack_import.html
+++ b/templates/zerver/slack_import.html
@@ -39,7 +39,12 @@
                 <div class="input-box">
                     <p id="slack-import-error" class="help-inline text-error">{{ slack_import_error }}</p>
                 </div>
-                {% endif %}
+                <div class="input-box">
+                    <button type="button" id="slack-import-start-over" class="register-button">
+                        {{ _("Start over") }}
+                    </button>
+                </div>
+                {% else %}
                 <form method="post" class="form-inline" action="{{ url('import_realm_from_slack') }}">
                     {{ csrf_input }}
                     <div class="input-box no-validation">
@@ -125,6 +130,7 @@
                 </form>
                 {% endif %}
                 {% endif %}
+                {% endif %}
             </div>
             {% if poll_for_import_completion %}
             <div id="bottom-hint-slack-import-page">
@@ -136,7 +142,7 @@
                     {% endtrans %}
                 </span>
             </div>
-            {% else %}
+            {% elif not slack_import_error %}
             <form method="post" class="hidden" id="cancel-slack-import-form" action="{{ url('import_realm_from_slack') }}">
                 {{ csrf_input }}
                 <input type='hidden' name='key' value="{{ key }}" />

--- a/web/src/portico/slack-import.ts
+++ b/web/src/portico/slack-import.ts
@@ -125,6 +125,10 @@ $(() => {
         $("#cancel-slack-import-form").trigger("submit");
     });
 
+    $("#slack-import-start-over").on("click", () => {
+        window.location.assign("/new/");
+    });
+
     $("#slack-access-token").on("input", () => {
         $("#update-slack-access-token").show();
     });

--- a/zerver/actions/data_import.py
+++ b/zerver/actions/data_import.py
@@ -47,6 +47,20 @@ def import_slack_data(event: dict[str, Any]) -> None:
 
     preregistration_realm = PreregistrationRealm.objects.get(id=event["preregistration_realm_id"])
     string_id = preregistration_realm.string_id
+
+    if Realm.objects.filter(string_id=string_id).exists():
+        # The subdomain is already taken -- e.g. by an earlier or
+        # concurrent import of the same subdomain that won the race to
+        # create the realm (string_id is unique). Importing would fail
+        # on that unique constraint, and we must not touch the existing
+        # realm, so abort before the expensive conversion work and
+        # surface the conflict to the user.
+        logger.error("(%s) Aborting Slack import: subdomain is already in use", string_id)
+        preregistration_realm.data_import_metadata["is_import_work_queued"] = False
+        preregistration_realm.data_import_metadata["subdomain_unavailable"] = True
+        preregistration_realm.save(update_fields=["data_import_metadata"])
+        return
+
     output_dir = tempfile.mkdtemp(
         prefix=f"import-{preregistration_realm.id}-converted-",
         dir=settings.IMPORT_TMPFILE_DIRECTORY,

--- a/zerver/actions/data_import.py
+++ b/zerver/actions/data_import.py
@@ -21,7 +21,7 @@ from zerver.lib.exceptions import SlackImportInvalidFileError
 from zerver.lib.import_realm import do_import_realm
 from zerver.lib.upload import save_attachment_contents
 from zerver.models.prereg_users import PreregistrationRealm
-from zerver.models.realms import Realm
+from zerver.models.realms import Realm, get_realm
 from zerver.models.users import RealmUserDefault, UserProfile, get_user_by_delivery_email
 
 logger = logging.getLogger("zulip.registration")
@@ -49,18 +49,44 @@ def import_slack_data(event: dict[str, Any]) -> None:
     preregistration_realm = PreregistrationRealm.objects.get(id=event["preregistration_realm_id"])
     string_id = preregistration_realm.string_id
 
-    if Realm.objects.filter(string_id=string_id).exists():
-        # The subdomain is already taken -- e.g. by an earlier or
-        # concurrent import of the same subdomain that won the race to
-        # create the realm (string_id is unique). Importing would fail
-        # on that unique constraint, and we must not touch the existing
-        # realm, so abort before the expensive conversion work and
-        # surface the conflict to the user.
-        logger.error("(%s) Aborting Slack import: subdomain is already in use", string_id)
-        preregistration_realm.data_import_metadata["is_import_work_queued"] = False
-        preregistration_realm.data_import_metadata["subdomain_unavailable"] = True
-        preregistration_realm.save(update_fields=["data_import_metadata"])
+    if preregistration_realm.created_realm is not None:
+        # A prior delivery of this event already finished the import. The
+        # worker can die after a successful import but before the event is
+        # acked, which redelivers the event; there is nothing left to do.
+        logger.info("(%s) Slack import already completed; skipping redelivery", string_id)
         return
+
+    try:
+        existing_realm: Realm | None = get_realm(string_id)
+    except Realm.DoesNotExist:
+        existing_realm = None
+    if existing_realm is not None:
+        if preregistration_realm.data_import_metadata.get("import_created_realm_id") == (
+            existing_realm.id
+        ):
+            # A prior attempt of *this* import created the realm and then the
+            # worker died before finishing, and the event was redelivered.
+            # The realm is our own half-imported orphan, so delete it and
+            # re-import below, rather than treating it as a foreign conflict.
+            logger.warning(
+                "(%s) Cleaning up our own orphaned realm from a prior import attempt", string_id
+            )
+            with transaction.atomic(durable=True):
+                orphan = Realm.objects.select_for_update(no_key=False).get(id=existing_realm.id)
+                assert orphan.date_created >= timezone_now() - timedelta(hours=24)
+                do_delete_all_realm_attachments(orphan)
+                orphan.delete()
+        else:
+            # The subdomain is taken by an earlier or concurrent import of the
+            # same subdomain that won the race to create the realm (string_id
+            # is unique). Importing would fail on that unique constraint, and
+            # we must not touch the other import's realm, so abort before the
+            # expensive conversion work and surface the conflict to the user.
+            logger.error("(%s) Aborting Slack import: subdomain is already in use", string_id)
+            preregistration_realm.data_import_metadata["is_import_work_queued"] = False
+            preregistration_realm.data_import_metadata["subdomain_unavailable"] = True
+            preregistration_realm.save(update_fields=["data_import_metadata"])
+            return
 
     output_dir = tempfile.mkdtemp(
         prefix=f"import-{preregistration_realm.id}-converted-",
@@ -103,7 +129,15 @@ def import_slack_data(event: dict[str, Any]) -> None:
                 message_count,
             )
 
-            realm = do_import_realm(output_dir, string_id)
+            def record_created_realm(new_realm: Realm) -> None:
+                # Stamp the registration with the realm it owns, atomically
+                # with the realm's creation, so a redelivered import (after a
+                # crash) can recognize and clean up its own half-imported realm
+                # instead of mistaking it for a foreign conflict.
+                preregistration_realm.data_import_metadata["import_created_realm_id"] = new_realm.id
+                preregistration_realm.save(update_fields=["data_import_metadata"])
+
+            realm = do_import_realm(output_dir, string_id, on_realm_created=record_created_realm)
             logger.info("(%s) Completed import, performing post-import steps", string_id)
             realm.org_type = preregistration_realm.org_type
             realm.default_language = preregistration_realm.default_language

--- a/zerver/actions/data_import.py
+++ b/zerver/actions/data_import.py
@@ -3,10 +3,12 @@ import logging
 import os
 import shutil
 import tempfile
+from datetime import timedelta
 from typing import Any
 
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
+from django.utils.timezone import now as timezone_now
 
 from confirmation import settings as confirmation_settings
 from zerver.actions.create_realm import get_email_address_visibility_default
@@ -22,6 +24,20 @@ from zerver.models.realms import Realm
 from zerver.models.users import RealmUserDefault, UserProfile, get_user_by_delivery_email
 
 logger = logging.getLogger("zulip.registration")
+
+
+def is_string_id_unique_violation(e: BaseException) -> bool:
+    """True when e is the IntegrityError from violating the unique constraint
+    on Realm.string_id -- i.e. the subdomain is already taken by another
+    realm. Other IntegrityErrors (e.g. genuine bugs elsewhere in the import)
+    return False, so they get the normal failure handling rather than being
+    mistaken for a taken subdomain."""
+    if not isinstance(e, IntegrityError):
+        return False
+    # Django wraps the underlying psycopg2 error as __cause__; its
+    # diagnostics carry the Postgres constraint name.
+    diag = getattr(e.__cause__, "diag", None)
+    return getattr(diag, "constraint_name", None) == "zerver_realm_string_id_key"
 
 
 def import_slack_data(event: dict[str, Any]) -> None:
@@ -121,18 +137,44 @@ def import_slack_data(event: dict[str, Any]) -> None:
     except Exception as e:
         logger.exception(e)
         try:
-            # Clean up the realm if the import failed
             preregistration_realm.created_realm = None
             preregistration_realm.data_import_metadata["is_import_work_queued"] = False
             if type(e) is SlackImportInvalidFileError:
                 # Store the error to be displayed to the user.
                 preregistration_realm.data_import_metadata["invalid_file_error_message"] = str(e)
+
+            # do_import_realm creates the realm with this string_id. If a
+            # concurrent or earlier import of the same subdomain won the
+            # race to create it, our realm insert violates the unique
+            # constraint on Realm.string_id and do_import_realm raises that
+            # IntegrityError. The existing realm belongs to the other
+            # import, so we must not clean it up: deleting it would destroy
+            # their data and can deadlock against their in-progress work on
+            # zerver_userprofile. We record the conflict for the status poll
+            # to surface instead.
+            subdomain_taken = is_string_id_unique_violation(e)
+            if subdomain_taken:
+                preregistration_realm.data_import_metadata["subdomain_unavailable"] = True
             preregistration_realm.save()
 
-            with transaction.atomic(durable=True):
-                realm = Realm.objects.select_for_update(no_key=False).get(string_id=string_id)
-                do_delete_all_realm_attachments(realm)
-                realm.delete()
+            # For any other failure -- including IntegrityErrors from
+            # genuine bugs on some other constraint -- delete the realm
+            # this import created, if it got that far. A failure before
+            # do_import_realm creates the realm (e.g. an invalid-file error
+            # during conversion) leaves no such realm, so the get() below
+            # raises Realm.DoesNotExist, which we swallow. Otherwise the
+            # realm with this string_id is the (possibly half-imported) one
+            # we created. The age assertion is a last line of defense
+            # against a bug ever pointing this deletion at an established
+            # realm; a Slack import's realm is created at conversion time,
+            # so it is always far younger than a day by the time we get
+            # here.
+            if not subdomain_taken:
+                with transaction.atomic(durable=True):
+                    realm = Realm.objects.select_for_update(no_key=False).get(string_id=string_id)
+                    assert realm.date_created >= timezone_now() - timedelta(hours=24)
+                    do_delete_all_realm_attachments(realm)
+                    realm.delete()
         except Realm.DoesNotExist:
             pass
         raise

--- a/zerver/actions/data_import.py
+++ b/zerver/actions/data_import.py
@@ -12,6 +12,7 @@ from django.utils.timezone import now as timezone_now
 
 from confirmation import settings as confirmation_settings
 from zerver.actions.create_realm import get_email_address_visibility_default
+from zerver.actions.create_user import do_reactivate_user
 from zerver.actions.realm_settings import do_delete_all_realm_attachments
 from zerver.actions.users import do_change_user_role
 from zerver.context_processors import is_realm_import_enabled
@@ -124,12 +125,24 @@ def import_slack_data(event: dict[str, Any]) -> None:
 
             # Try finding the user who imported this realm and make them owner.
             try:
-                importing_user = get_user_by_delivery_email(preregistration_realm.email, realm)
-                assert (
-                    importing_user.is_active
-                    and not importing_user.is_bot
-                    and not importing_user.is_mirror_dummy
+                importing_user: UserProfile | None = get_user_by_delivery_email(
+                    preregistration_realm.email, realm
                 )
+            except UserProfile.DoesNotExist:
+                importing_user = None
+
+            if importing_user is None or importing_user.is_bot or importing_user.is_mirror_dummy:
+                # The email address that the importing user validated
+                # with Zulip either does not appear in the data export,
+                # or maps to an account that cannot own the
+                # organization (a bot or a placeholder/mirror-dummy
+                # account). Prompt them to pick which account is theirs.
+                preregistration_realm.data_import_metadata["need_select_realm_owner"] = True
+            else:
+                if not importing_user.is_active:
+                    # The importer's account was deactivated in the
+                    # export; reactivate it so they can own the realm.
+                    do_reactivate_user(importing_user, acting_user=None)
                 if importing_user.role != UserProfile.ROLE_REALM_OWNER:
                     do_change_user_role(
                         importing_user,
@@ -138,11 +151,6 @@ def import_slack_data(event: dict[str, Any]) -> None:
                         notify=False,
                     )
                 preregistration_realm.status = confirmation_settings.STATUS_USED
-            except UserProfile.DoesNotExist:
-                # If the email address that the importing user
-                # validated with Zulip does not appear in the data
-                # export, we will prompt them which account is theirs.
-                preregistration_realm.data_import_metadata["need_select_realm_owner"] = True
 
             preregistration_realm.created_realm = realm
             preregistration_realm.data_import_metadata["is_import_work_queued"] = False

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1826,32 +1826,44 @@ def do_convert_directory(
     logging.info("Zulip data dump created at %s", output_dir)
 
 
+class SlackTokenValidationError(Exception):
+    """Raised by check_slack_token_access when a Slack token fails validation.
+    The message never includes the token itself, so it is safe to surface to
+    users -- e.g. on the self-serve import page or to a webhook's bot owner."""
+
+
 def check_slack_token_access(token: str, required_scopes: set[str]) -> None:
     if token.startswith("xoxp-"):
         logging.info("This is a Slack user token, which grants all rights the user has!")
     elif not required_scopes:
         raise ValueError("required_scopes shouldn't be empty!")
     elif token.startswith("xoxb-"):
-        data = requests.get(
-            "https://slack.com/api/api.test", headers={"Authorization": f"Bearer {token}"}
-        )
+        try:
+            data = requests.get(
+                "https://slack.com/api/api.test", headers={"Authorization": f"Bearer {token}"}
+            )
+        except requests.RequestException as e:
+            logging.info("Slack token validation request failed: %s", e)
+            raise SlackTokenValidationError(
+                "Could not reach Slack to validate the token. Please try again."
+            )
         if data.status_code != 200:
-            raise ValueError(
-                f"Failed to fetch data (HTTP status {data.status_code}) for Slack token: {token}"
+            raise SlackTokenValidationError(
+                f"Failed to validate the token with Slack (HTTP status {data.status_code})."
             )
         if not data.json()["ok"]:
             error = data.json()["error"]
             if error != "missing_scope":
                 logging.info("Slack token is invalid: %s", error)
-                raise ValueError(f"Invalid token: {token}")
+                raise SlackTokenValidationError("Invalid token.")
         has_scopes = set(data.headers.get("x-oauth-scopes", "").split(","))
         missing_scopes = required_scopes - has_scopes
         if missing_scopes:
-            raise ValueError(
+            raise SlackTokenValidationError(
                 f"Slack token is missing the following required scopes: {sorted(missing_scopes)}"
             )
     else:
-        raise Exception("Invalid token. Valid tokens start with xoxb-.")
+        raise SlackTokenValidationError("Invalid token. Valid tokens start with xoxb-.")
 
 
 def get_slack_api_data(

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import os
 import shutil
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -1345,7 +1346,18 @@ def disable_restricted_authentication_methods(data: ImportedTableData) -> None:
 # Because the Python object => JSON conversion process is not fully
 # faithful, we have to use a set of fixers (e.g. on DateTime objects
 # and foreign keys) to do the import correctly.
-def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Realm:
+def do_import_realm(
+    import_dir: Path,
+    subdomain: str,
+    processes: int = 1,
+    *,
+    on_realm_created: Callable[[Realm], None] | None = None,
+) -> Realm:
+    # on_realm_created, if given, is called with the freshly-created (still
+    # deactivated) Realm inside the same durable transaction that creates it.
+    # The self-serve Slack import uses this to record which realm an import
+    # owns, atomically with its creation, so a redelivered import can later
+    # recognize and clean up its own half-imported realm.
     logging.info("Importing realm dump %s", import_dir)
     if not os.path.exists(import_dir):
         raise Exception("Missing import directory!")
@@ -1456,6 +1468,9 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
                 setattr(realm, setting_name + "_id", -1)
 
         realm.save()
+
+        if on_realm_created is not None:
+            on_realm_created(realm)
 
         if "zerver_presencesequence" in data:
             re_map_foreign_keys(data, "zerver_presencesequence", "realm", related_table="realm")

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -21,7 +21,7 @@ from django.utils.timezone import now as timezone_now
 from requests.models import PreparedRequest
 
 from confirmation import settings as confirmation_settings
-from confirmation.models import Confirmation, get_object_from_key
+from confirmation.models import Confirmation, create_confirmation_link, get_object_from_key
 from zerver.actions.create_realm import do_create_realm, get_email_address_visibility_default
 from zerver.actions.create_user import do_create_user
 from zerver.actions.data_import import import_slack_data
@@ -3107,6 +3107,37 @@ To Do
         self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
         # The conflict is recorded so the status poll can surface it.
         self.assertTrue(prereg_realm.data_import_metadata["subdomain_unavailable"])
+
+    def test_realm_import_status_failed_import_does_not_use_other_realm(self) -> None:
+        # A failed import must report its own failure, even when a
+        # different registration's realm happens to share the
+        # subdomain. Otherwise the failed import's status poll would
+        # read the other realm and report misleading progress (or even
+        # "Done").
+        other_realm = do_create_realm(string_id="shared-subdomain", name="Other realm")
+        self.assertFalse(other_realm.deactivated)
+
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="shared-subdomain",
+            name="Test Realm",
+            email="test@example.com",
+            data_import_metadata={
+                "import_from": "slack",
+                "is_import_work_queued": False,
+                "subdomain_unavailable": True,
+            },
+        )
+        confirmation_key = create_confirmation_link(
+            prereg_realm,
+            Confirmation.NEW_REALM_USER_REGISTRATION,
+            no_associated_realm_object=True,
+        ).split("/")[-1]
+
+        result = self.client_get(f"/json/realm/import/status/{confirmation_key}")
+        response_dict = self.assert_json_success(result)
+        self.assertIn("no longer available", response_dict["status"])
+        # The other realm must not be reported as this import's result.
+        self.assertNotIn("Done", response_dict["status"])
 
     @responses.activate
     def test_cancel_realm_import(self) -> None:

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -3241,6 +3241,38 @@ To Do
         # The other realm must not be reported as this import's result.
         self.assertNotIn("Done", response_dict["status"])
 
+    def test_realm_import_status_clears_stale_subdomain_unavailable_flag(self) -> None:
+        # If the import that won the race for the subdomain later failed and
+        # freed it, this import's stored subdomain_unavailable flag is stale.
+        # The status poll must clear the flag and report this import's own
+        # failure, rather than telling the user the URL is still taken.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="freed-subdomain",
+            name="Test Realm",
+            email="freed@example.com",
+            data_import_metadata={
+                "import_from": "slack",
+                "is_import_work_queued": False,
+                "subdomain_unavailable": True,
+            },
+        )
+        self.assertFalse(Realm.objects.filter(string_id="freed-subdomain").exists())
+        confirmation_key = create_confirmation_link(
+            prereg_realm,
+            Confirmation.NEW_REALM_USER_REGISTRATION,
+            no_associated_realm_object=True,
+        ).split("/")[-1]
+
+        result = self.client_get(f"/json/realm/import/status/{confirmation_key}")
+        response_dict = self.assert_json_success(result)
+        # The freed subdomain is not reported as taken; this import's own
+        # failure surfaces instead.
+        self.assertNotIn("no longer available", response_dict["status"])
+        self.assertEqual(response_dict["status"], "unexpected_import_failure")
+        # The stale flag has been cleared from the stored metadata.
+        prereg_realm.refresh_from_db()
+        self.assertNotIn("subdomain_unavailable", prereg_realm.data_import_metadata)
+
     def test_start_slack_import_without_uploaded_file_renders_page(self) -> None:
         # POSTing "start import" before the export file finished uploading must
         # re-render the import page, not 500 on an assertion.

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -3241,6 +3241,70 @@ To Do
         # The other realm must not be reported as this import's result.
         self.assertNotIn("Done", response_dict["status"])
 
+    def test_start_slack_import_without_uploaded_file_renders_page(self) -> None:
+        # POSTing "start import" before the export file finished uploading must
+        # re-render the import page, not 500 on an assertion.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="start-no-file",
+            name="Test Realm",
+            email="nofile@zulip.com",
+            data_import_metadata={"import_from": "slack", "slack_access_token": "xoxb-token"},
+        )
+        confirmation_key = create_confirmation_link(
+            prereg_realm,
+            Confirmation.NEW_REALM_USER_REGISTRATION,
+            no_associated_realm_object=True,
+        ).split("/")[-1]
+
+        with mock.patch(
+            "zerver.views.registration.queue_json_publish_rollback_unsafe"
+        ) as queue_mock:
+            result = self.client_post(
+                "/new/import/slack/",
+                {"key": confirmation_key, "start_slack_import": "true"},
+            )
+
+        self.assertEqual(result.status_code, 200)
+        queue_mock.assert_not_called()
+        prereg_realm.refresh_from_db()
+        self.assertIsNot(prereg_realm.data_import_metadata.get("is_import_work_queued"), True)
+
+    def test_start_slack_import_with_taken_subdomain_shows_error(self) -> None:
+        # Starting an import for a subdomain that has since been taken -- e.g.
+        # a concurrent import of the same subdomain finished first -- must show
+        # a clear error rather than enqueueing a doomed import.
+        do_create_realm(string_id="taken-subdomain", name="Existing realm")
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="taken-subdomain",
+            name="Test Realm",
+            email="taken@zulip.com",
+            data_import_metadata={
+                "import_from": "slack",
+                "slack_access_token": "xoxb-token",
+                "uploaded_import_file_name": "export.zip",
+            },
+        )
+        confirmation_key = create_confirmation_link(
+            prereg_realm,
+            Confirmation.NEW_REALM_USER_REGISTRATION,
+            no_associated_realm_object=True,
+        ).split("/")[-1]
+
+        with mock.patch(
+            "zerver.views.registration.queue_json_publish_rollback_unsafe"
+        ) as queue_mock:
+            result = self.client_post(
+                "/new/import/slack/",
+                {"key": confirmation_key, "start_slack_import": "true"},
+            )
+
+        self.assertEqual(result.status_code, 200)
+        self.assert_in_response("no longer available", result)
+        queue_mock.assert_not_called()
+        prereg_realm.refresh_from_db()
+        self.assertIsNone(prereg_realm.created_realm)
+        self.assertIsNot(prereg_realm.data_import_metadata.get("is_import_work_queued"), True)
+
     @responses.activate
     def test_cancel_realm_import(self) -> None:
         # Choose import from slack

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -3445,6 +3445,9 @@ To Do
 
         self.assertEqual(result.status_code, 200)
         self.assert_in_response("no longer available", result)
+        # The page offers a clear way out and hides the now-useless import form.
+        self.assert_in_response("Start over", result)
+        self.assert_not_in_success_response(["Slack bot user OAuth token"], result)
         queue_mock.assert_not_called()
         prereg_realm.refresh_from_db()
         self.assertIsNone(prereg_realm.created_realm)
@@ -3472,6 +3475,9 @@ To Do
         result = self.client_post("/new/import/slack/", {"key": confirmation_key})
         self.assertEqual(result.status_code, 200)
         self.assert_in_response("no longer available", result)
+        # The page offers a clear way out and hides the now-useless import form.
+        self.assert_in_response("Start over", result)
+        self.assert_not_in_success_response(["Slack bot user OAuth token"], result)
 
     @responses.activate
     def test_cancel_realm_import(self) -> None:

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -46,6 +46,7 @@ from zerver.data_import.slack import (
     MessageConversionResult,
     SlackBotEmail,
     SlackBotNotFoundError,
+    SlackTokenValidationError,
     channel_message_to_zerver_message,
     channels_to_zerver_stream,
     check_slack_token_access,
@@ -450,9 +451,12 @@ class SlackImporter(ZulipTestCase):
         )
 
         def exception_for(token: str, required_scopes: set[str] = SLACK_IMPORT_TOKEN_SCOPES) -> str:
-            with self.assertRaises(Exception) as invalid:
+            with self.assertRaises(SlackTokenValidationError) as invalid:
                 check_slack_token_access(token, required_scopes)
-            return invalid.exception.args[0]
+            message = invalid.exception.args[0]
+            # The user-facing message must never leak the token.
+            self.assertNotIn(token, message)
+            return message
 
         self.assertEqual(
             exception_for("xoxq-unknown"),
@@ -462,12 +466,12 @@ class SlackImporter(ZulipTestCase):
         with self.assertLogs(level="INFO"):
             self.assertEqual(
                 exception_for("xoxb-invalid-token"),
-                "Invalid token: xoxb-invalid-token",
+                "Invalid token.",
             )
 
         self.assertEqual(
             exception_for("xoxb-broken-request"),
-            "Failed to fetch data (HTTP status 400) for Slack token: xoxb-broken-request",
+            "Failed to validate the token with Slack (HTTP status 400).",
         )
 
         self.assertEqual(
@@ -479,10 +483,10 @@ class SlackImporter(ZulipTestCase):
             "Slack token is missing the following required scopes: ['team:read', 'users:read', 'users:read.email']",
         )
 
-        self.assertEqual(
-            exception_for("xoxb-valid-token", set()),
-            "required_scopes shouldn't be empty!",
-        )
+        # An empty required_scopes is a caller bug, not a token problem.
+        with self.assertRaises(ValueError) as empty_scopes:
+            check_slack_token_access("xoxb-valid-token", set())
+        self.assertEqual(empty_scopes.exception.args[0], "required_scopes shouldn't be empty!")
 
         check_slack_token_access("xoxb-valid-token", required_scopes=SLACK_IMPORT_TOKEN_SCOPES)
 
@@ -2477,7 +2481,7 @@ To Do
         assert confirmation_key is not None
 
         # Check that the we show an error message if the token is invalid.
-        mock_check_slack_token_access.side_effect = ValueError("Invalid slack token")
+        mock_check_slack_token_access.side_effect = SlackTokenValidationError("Invalid slack token")
         result = self.client_post(
             "/new/import/slack/",
             {

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -3305,6 +3305,29 @@ To Do
         self.assertIsNone(prereg_realm.created_realm)
         self.assertIsNot(prereg_realm.data_import_metadata.get("is_import_work_queued"), True)
 
+    def test_slack_import_page_warns_when_subdomain_taken(self) -> None:
+        # When the subdomain is already taken (e.g. a concurrent import of the
+        # same subdomain got there first), the import setup page itself shows
+        # the error, rather than leaving the user filling out a form for an
+        # import that can't succeed.
+        do_create_realm(string_id="taken-subdomain-2", name="Existing realm")
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="taken-subdomain-2",
+            name="Test Realm",
+            email="taken2@zulip.com",
+            data_import_metadata={"import_from": "slack", "slack_access_token": "xoxb-token"},
+        )
+        confirmation_key = create_confirmation_link(
+            prereg_realm,
+            Confirmation.NEW_REALM_USER_REGISTRATION,
+            no_associated_realm_object=True,
+        ).split("/")[-1]
+
+        # Render the setup page (no start_slack_import).
+        result = self.client_post("/new/import/slack/", {"key": confirmation_key})
+        self.assertEqual(result.status_code, 200)
+        self.assert_in_response("no longer available", result)
+
     @responses.activate
     def test_cancel_realm_import(self) -> None:
         # Choose import from slack

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -5,6 +5,7 @@ import tempfile
 import zipfile
 from collections.abc import Iterator
 from io import BytesIO
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 from unittest.mock import ANY
@@ -14,6 +15,7 @@ import orjson
 import responses
 from attr import dataclass
 from django.conf import settings
+from django.db import IntegrityError
 from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
 from requests.models import PreparedRequest
@@ -166,6 +168,26 @@ def request_callback(request: PreparedRequest) -> tuple[int, dict[str, str], byt
     except KeyError:
         return team_not_found
     return (200, {}, orjson.dumps({"ok": True, "team": {"id": team_id, "domain": team_domain}}))
+
+
+class FakeUniqueViolationError(Exception):
+    """Stand-in for the psycopg2 UniqueViolation that Django exposes as
+    IntegrityError.__cause__, carrying the diagnostics (diag.constraint_name)
+    that import_slack_data inspects."""
+
+    def __init__(self, message: str, constraint_name: str) -> None:
+        super().__init__(message)
+        self.diag = SimpleNamespace(constraint_name=constraint_name)
+
+
+def slack_import_integrity_error(constraint_name: str) -> IntegrityError:
+    """Build the IntegrityError Django raises when an INSERT violates a unique
+    constraint, so import_slack_data can recognize a taken subdomain from the
+    constraint name."""
+    message = f'duplicate key value violates unique constraint "{constraint_name}"'
+    error = IntegrityError(message)
+    error.__cause__ = FakeUniqueViolationError(message, constraint_name)
+    return error
 
 
 class SlackImporter(ZulipTestCase):
@@ -2929,6 +2951,112 @@ To Do
         self.assertIsNone(prereg_realm.created_realm)
         self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
         self.assertFalse(Realm.objects.filter(string_id=prereg_realm.string_id).exists())
+
+    @mock.patch("zerver.actions.data_import.do_import_realm")
+    @mock.patch("zerver.actions.data_import.do_convert_zipfile")
+    @mock.patch("zerver.actions.data_import.save_attachment_contents")
+    def test_import_slack_data_failure_keeps_concurrently_created_realm(
+        self,
+        mock_save_attachment_contents: mock.Mock,
+        mock_do_convert_zipfile: mock.Mock,
+        mock_do_import_realm: mock.Mock,
+    ) -> None:
+        # A concurrent import of the same subdomain wins the race to create
+        # the realm while this import runs; do_import_realm then fails with an
+        # IntegrityError on the unique string_id. This import created nothing,
+        # so it must not delete the concurrently created realm -- doing so
+        # would destroy that realm's data and can deadlock against its
+        # in-progress work.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="test-realm",
+            name="Test Realm",
+            email="test@example.com",
+            data_import_metadata={"import_from": "slack"},
+        )
+
+        def create_realm_then_conflict(*args: object, **kwargs: object) -> Realm:
+            other_realm = do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+            UserProfile.objects.create(
+                realm=other_realm,
+                delivery_email="someone@example.com",
+                email="someone@example.com",
+            )
+            raise slack_import_integrity_error("zerver_realm_string_id_key")
+
+        mock_do_import_realm.side_effect = create_realm_then_conflict
+        event = {
+            "preregistration_realm_id": prereg_realm.id,
+            "filename": "import/test/slack.zip",
+            "slack_access_token": "xoxb-valid-token",
+        }
+
+        with (
+            self.assertLogs("zulip.registration", "ERROR") as logs,
+            self.assertRaises(IntegrityError),
+        ):
+            import_slack_data(event)
+        self.assertIn("zerver_realm_string_id_key", logs.output[0])
+
+        # The concurrently created realm and its data must be untouched.
+        other_realm = Realm.objects.get(string_id=prereg_realm.string_id)
+        self.assertTrue(
+            UserProfile.objects.filter(
+                realm=other_realm, delivery_email="someone@example.com"
+            ).exists()
+        )
+        prereg_realm.refresh_from_db()
+        self.assertIsNone(prereg_realm.created_realm)
+        self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
+        # The conflict is recorded so the status poll can surface it.
+        self.assertTrue(prereg_realm.data_import_metadata["subdomain_unavailable"])
+
+    @mock.patch("zerver.actions.data_import.do_import_realm")
+    @mock.patch("zerver.actions.data_import.do_convert_zipfile")
+    @mock.patch("zerver.actions.data_import.save_attachment_contents")
+    def test_import_slack_data_failure_unrelated_integrity_error(
+        self,
+        mock_save_attachment_contents: mock.Mock,
+        mock_do_convert_zipfile: mock.Mock,
+        mock_do_import_realm: mock.Mock,
+    ) -> None:
+        # An IntegrityError that is not the unique violation on Realm.string_id
+        # -- e.g. a genuine bug in the import code hitting some other constraint
+        # -- must be treated like any other failure: the half-imported realm
+        # this import created is cleaned up, and the subdomain is not reported
+        # as unavailable.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="test-realm",
+            name="Test Realm",
+            email="test@example.com",
+            data_import_metadata={"import_from": "slack"},
+        )
+
+        def create_realm_then_unrelated_conflict(*args: object, **kwargs: object) -> Realm:
+            do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+            raise slack_import_integrity_error("zerver_useractivityinterval_uniq")
+
+        mock_do_import_realm.side_effect = create_realm_then_unrelated_conflict
+        event = {
+            "preregistration_realm_id": prereg_realm.id,
+            "filename": "import/test/slack.zip",
+            "slack_access_token": "xoxb-valid-token",
+        }
+
+        with (
+            self.assertLogs("zulip.registration", "ERROR") as logs,
+            self.assertRaises(IntegrityError),
+        ):
+            import_slack_data(event)
+        self.assertIn("zerver_useractivityinterval_uniq", logs.output[0])
+
+        prereg_realm.refresh_from_db()
+        self.assertIsNone(prereg_realm.created_realm)
+        self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
+        # The realm this import created is cleaned up, since this is not a
+        # subdomain conflict.
+        self.assertFalse(Realm.objects.filter(string_id=prereg_realm.string_id).exists())
+        # A non-string_id error must not be reported as a taken subdomain.
+        self.assertNotIn("subdomain_unavailable", prereg_realm.data_import_metadata)
 
     @responses.activate
     def test_cancel_realm_import(self) -> None:

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -2753,7 +2753,9 @@ To Do
         mock_do_convert_zipfile.assert_called_once_with(
             mock.ANY, mock.ANY, event["slack_access_token"]
         )
-        mock_do_import_realm.assert_called_once_with(mock.ANY, prereg_realm.string_id)
+        mock_do_import_realm.assert_called_once_with(
+            mock.ANY, prereg_realm.string_id, on_realm_created=mock.ANY
+        )
 
         prereg_realm.refresh_from_db()
         self.assertEqual(prereg_realm.status, 1)  # STATUS_USED
@@ -2919,7 +2921,9 @@ To Do
         mock_do_convert_zipfile.assert_called_once_with(
             mock.ANY, mock.ANY, event["slack_access_token"]
         )
-        mock_do_import_realm.assert_called_once_with(mock.ANY, prereg_realm.string_id)
+        mock_do_import_realm.assert_called_once_with(
+            mock.ANY, prereg_realm.string_id, on_realm_created=mock.ANY
+        )
 
         prereg_realm.refresh_from_db()
         self.assertTrue(prereg_realm.data_import_metadata.get("need_select_realm_owner"))
@@ -3213,6 +3217,111 @@ To Do
         self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
         # The conflict is recorded so the status poll can surface it.
         self.assertTrue(prereg_realm.data_import_metadata["subdomain_unavailable"])
+
+    @mock.patch("zerver.actions.data_import.do_import_realm")
+    @mock.patch("zerver.actions.data_import.do_convert_zipfile")
+    @mock.patch("zerver.actions.data_import.save_attachment_contents")
+    def test_import_slack_data_recovers_own_orphaned_realm_on_redelivery(
+        self,
+        mock_save_attachment_contents: mock.Mock,
+        mock_do_convert_zipfile: mock.Mock,
+        mock_do_import_realm: mock.Mock,
+    ) -> None:
+        # do_import_realm durably commits the realm partway through, so a
+        # worker that dies before finishing leaves a half-imported realm; the
+        # event is then redelivered. On redelivery the import must recognize
+        # the realm as its own (via the import_created_realm_id stamp) and
+        # clean it up and re-import, rather than treating it as a foreign
+        # conflict and orphaning the realm forever.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="test-realm",
+            name="Test Realm",
+            email="test@example.com",
+            data_import_metadata={"import_from": "slack", "is_import_work_queued": True},
+        )
+        # The orphan left behind by the crashed prior attempt, stamped as ours.
+        orphan = do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+        orphan_user = UserProfile.objects.create(
+            realm=orphan,
+            delivery_email="someone@example.com",
+            email="someone@example.com",
+        )
+        prereg_realm.data_import_metadata["import_created_realm_id"] = orphan.id
+        prereg_realm.save(update_fields=["data_import_metadata"])
+
+        def reimport(*args: object, on_realm_created: object = None, **kwargs: object) -> Realm:
+            new_realm = do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+            assert callable(on_realm_created)
+            on_realm_created(new_realm)
+            return new_realm
+
+        mock_do_import_realm.side_effect = reimport
+        event = {
+            "preregistration_realm_id": prereg_realm.id,
+            "filename": "import/test/slack.zip",
+            "slack_access_token": "xoxb-valid-token",
+        }
+
+        with self.assertLogs("zulip.registration", "INFO") as logs:
+            import_slack_data(event)
+        self.assertIn(
+            "WARNING:zulip.registration:"
+            "(test-realm) Cleaning up our own orphaned realm from a prior import attempt",
+            logs.output,
+        )
+
+        # The orphan and its data are gone, and a fresh realm was imported in
+        # its place.
+        self.assertFalse(Realm.objects.filter(id=orphan.id).exists())
+        self.assertFalse(UserProfile.objects.filter(id=orphan_user.id).exists())
+        mock_do_import_realm.assert_called_once()
+        new_realm = Realm.objects.get(string_id=prereg_realm.string_id)
+        self.assertNotEqual(new_realm.id, orphan.id)
+        prereg_realm.refresh_from_db()
+        self.assertEqual(prereg_realm.created_realm_id, new_realm.id)
+        self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
+
+    @mock.patch("zerver.actions.data_import.do_import_realm")
+    @mock.patch("zerver.actions.data_import.do_convert_zipfile")
+    @mock.patch("zerver.actions.data_import.save_attachment_contents")
+    def test_import_slack_data_skips_redelivery_after_success(
+        self,
+        mock_save_attachment_contents: mock.Mock,
+        mock_do_convert_zipfile: mock.Mock,
+        mock_do_import_realm: mock.Mock,
+    ) -> None:
+        # If a successful import's event is redelivered (the worker died after
+        # the import finished but before acking), the import must be a no-op
+        # rather than re-running and clobbering the created realm.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="test-realm",
+            name="Test Realm",
+            email="test@example.com",
+            data_import_metadata={"import_from": "slack"},
+        )
+        created_realm = do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+        prereg_realm.created_realm = created_realm
+        prereg_realm.save(update_fields=["created_realm"])
+        event = {
+            "preregistration_realm_id": prereg_realm.id,
+            "filename": "import/test/slack.zip",
+            "slack_access_token": "xoxb-valid-token",
+        }
+
+        with self.assertLogs("zulip.registration", "INFO") as logs:
+            import_slack_data(event)
+        self.assertEqual(
+            logs.output,
+            [
+                "INFO:zulip.registration:"
+                "(test-realm) Slack import already completed; skipping redelivery"
+            ],
+        )
+
+        mock_save_attachment_contents.assert_not_called()
+        mock_do_convert_zipfile.assert_not_called()
+        mock_do_import_realm.assert_not_called()
+        self.assertTrue(Realm.objects.filter(id=created_realm.id).exists())
 
     def test_realm_import_status_failed_import_does_not_use_other_realm(self) -> None:
         # A failed import must report its own failure, even when a

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -2539,38 +2539,36 @@ To Do
 
         # We don't want to test to whole realm import process here but only that
         # realm import calls are made with correct arguments and different cases
-        # are handled well.
-        realm = do_create_realm(
-            string_id=prereg_realm.string_id,
-            name=prereg_realm.name,
-        )
+        # are handled well. do_import_realm creates the realm (and its users) as
+        # part of the import, so mock it to do so here -- matching production,
+        # where no realm with this subdomain exists until the import creates it.
+        def fake_do_import_realm(*args: object, **kwargs: object) -> Realm:
+            realm = do_create_realm(
+                string_id=prereg_realm.string_id,
+                name=prereg_realm.name,
+            )
+            do_create_user("email1", "password", realm, "full_name", acting_user=None)
+            do_create_user(
+                "bot_email",
+                "password",
+                realm,
+                "bot_full_name",
+                bot_type=UserProfile.DEFAULT_BOT,
+                acting_user=None,
+            )
+            self.assertEqual(
+                get_email_address_visibility_default(realm.org_type),
+                UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            )
+            return realm
 
-        test_user = do_create_user("email1", "password", realm, "full_name", acting_user=None)
-        test_bot_user = do_create_user(
-            "bot_email",
-            "password",
-            realm,
-            "bot_full_name",
-            bot_type=UserProfile.DEFAULT_BOT,
-            acting_user=None,
-        )
-        self.assertEqual(
-            get_email_address_visibility_default(realm.org_type),
-            UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS,
-        )
-        self.assertEqual(
-            test_user.email_address_visibility, UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS
-        )
-        self.assertEqual(
-            test_bot_user.email_address_visibility, UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE
-        )
         with (
             mock.patch(
                 "zerver.actions.data_import.save_attachment_contents"
             ) as mocked_save_attachment,
             mock.patch("zerver.actions.data_import.do_convert_zipfile") as mocked_convert_zipfile,
             mock.patch(
-                "zerver.actions.data_import.do_import_realm", return_value=realm
+                "zerver.actions.data_import.do_import_realm", side_effect=fake_do_import_realm
             ) as mocked_import_realm,
         ):
             from zerver.lib.queue import queue_json_publish_rollback_unsafe
@@ -2587,20 +2585,21 @@ To Do
         self.assertTrue(mocked_save_attachment.called)
         self.assertTrue(mocked_convert_zipfile.called)
         self.assertTrue(mocked_import_realm.called)
-        realm.refresh_from_db()
+        realm = Realm.objects.get(string_id=prereg_realm.string_id)
         self.assertEqual(realm.org_type, prereg_realm.org_type)
         self.assertEqual(realm.default_language, prereg_realm.default_language)
         prereg_realm.refresh_from_db()
         self.assertTrue(prereg_realm.data_import_metadata["need_select_realm_owner"])
 
-        # Check that imported users have user provided email visibility setting.
-        test_user.refresh_from_db()
+        # Check that imported non-bot users have the importer-provided email
+        # visibility setting.
+        test_user = UserProfile.objects.get(realm=realm, delivery_email="email1")
         self.assertEqual(
             test_user.email_address_visibility,
             importer_set_email_address_visibility,
         )
         # Check that bots were not impacted by this setting.
-        test_bot_user.refresh_from_db()
+        test_bot_user = UserProfile.objects.get(realm=realm, delivery_email="bot_email")
         self.assertEqual(
             test_bot_user.email_address_visibility, UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE
         )
@@ -2698,16 +2697,22 @@ To Do
             email="test_import_slack_data_user@example.com",
             data_import_metadata={"import_from": "slack"},
         )
-        mock_realm = do_create_realm(
-            string_id=prereg_realm.string_id,
-            name=prereg_realm.name,
-        )
-        mock_do_import_realm.return_value = mock_realm
 
-        importing_user = UserProfile.objects.create(
-            realm=mock_realm,
-            delivery_email=prereg_realm.email,
-        )
+        # do_import_realm creates the realm (with the importing user) during
+        # the import; mock it to do so, matching production where the realm
+        # does not exist until the import creates it.
+        def fake_do_import_realm(*args: object, **kwargs: object) -> Realm:
+            realm = do_create_realm(
+                string_id=prereg_realm.string_id,
+                name=prereg_realm.name,
+            )
+            UserProfile.objects.create(
+                realm=realm,
+                delivery_email=prereg_realm.email,
+            )
+            return realm
+
+        mock_do_import_realm.side_effect = fake_do_import_realm
 
         event = {
             "preregistration_realm_id": prereg_realm.id,
@@ -2725,12 +2730,14 @@ To Do
 
         prereg_realm.refresh_from_db()
         self.assertEqual(prereg_realm.status, 1)  # STATUS_USED
-        self.assertEqual(prereg_realm.created_realm, mock_realm)
+        realm = prereg_realm.created_realm
+        assert realm is not None
+        self.assertEqual(realm.string_id, prereg_realm.string_id)
         self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
         self.assertFalse(prereg_realm.data_import_metadata.get("need_select_realm_owner"))
 
         # Check that the importing user was made the realm owner
-        importing_user.refresh_from_db()
+        importing_user = UserProfile.objects.get(realm=realm, delivery_email=prereg_realm.email)
         self.assertEqual(importing_user.role, UserProfile.ROLE_REALM_OWNER)
 
     @mock.patch("zerver.actions.data_import.do_import_realm")
@@ -2760,11 +2767,17 @@ To Do
         confirmation_key = find_key_by_email(email)
         assert confirmation_key is not None
         prereg_realm = PreregistrationRealm.objects.get(email=email)
-        mock_realm = do_create_realm(
-            string_id=prereg_realm.string_id,
-            name=prereg_realm.name,
-        )
-        mock_do_import_realm.return_value = mock_realm
+
+        # do_import_realm creates the realm during the import; mock it to do
+        # so, matching production where the realm does not exist until the
+        # import creates it.
+        def fake_do_import_realm(*args: object, **kwargs: object) -> Realm:
+            return do_create_realm(
+                string_id=prereg_realm.string_id,
+                name=prereg_realm.name,
+            )
+
+        mock_do_import_realm.side_effect = fake_do_import_realm
 
         event = {
             "preregistration_realm_id": prereg_realm.id,
@@ -2833,7 +2846,8 @@ To Do
 
         prereg_realm.refresh_from_db()
         self.assertEqual(prereg_realm.status, confirmation_settings.STATUS_USED)
-        self.assertEqual(prereg_realm.created_realm, mock_realm)
+        assert prereg_realm.created_realm is not None
+        self.assertEqual(prereg_realm.created_realm.string_id, prereg_realm.string_id)
         self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
         self.assertFalse(prereg_realm.data_import_metadata.get("need_select_realm_owner"))
         self.assertIsNone(prereg_realm.data_import_metadata.get("user_activation_url"))
@@ -2884,18 +2898,21 @@ To Do
         mock_do_convert_zipfile: mock.Mock,
         mock_do_import_realm: mock.Mock,
     ) -> None:
+        # If do_import_realm durably creates the realm and then fails during a
+        # later step, the failure handler must delete the half-imported realm
+        # that this import created.
         prereg_realm = PreregistrationRealm.objects.create(
             string_id="test-realm",
             name="Test Realm",
             email="test@example.com",
             data_import_metadata={"import_from": "slack"},
         )
-        do_create_realm(
-            string_id=prereg_realm.string_id,
-            name=prereg_realm.name,
-        )
-        self.assertTrue(Realm.objects.filter(string_id=prereg_realm.string_id).exists())
-        mock_do_import_realm.side_effect = AssertionError("Import failed")
+
+        def create_realm_then_fail(*args: object, **kwargs: object) -> Realm:
+            do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+            raise AssertionError("Import failed")
+
+        mock_do_import_realm.side_effect = create_realm_then_fail
         event = {
             "preregistration_realm_id": prereg_realm.id,
             "filename": "import/test/slack.zip",

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -3058,6 +3058,56 @@ To Do
         # A non-string_id error must not be reported as a taken subdomain.
         self.assertNotIn("subdomain_unavailable", prereg_realm.data_import_metadata)
 
+    @mock.patch("zerver.actions.data_import.do_import_realm")
+    @mock.patch("zerver.actions.data_import.do_convert_zipfile")
+    @mock.patch("zerver.actions.data_import.save_attachment_contents")
+    def test_import_slack_data_aborts_when_subdomain_taken(
+        self,
+        mock_save_attachment_contents: mock.Mock,
+        mock_do_convert_zipfile: mock.Mock,
+        mock_do_import_realm: mock.Mock,
+    ) -> None:
+        # If a realm with this subdomain already exists when the import job
+        # starts -- e.g. an earlier import of the same subdomain finished
+        # first -- abort without attempting the (doomed) import and without
+        # touching the existing realm.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="test-realm",
+            name="Test Realm",
+            email="test@example.com",
+            data_import_metadata={"import_from": "slack", "is_import_work_queued": True},
+        )
+        other_realm = do_create_realm(
+            string_id=prereg_realm.string_id,
+            name=prereg_realm.name,
+        )
+        other_user = UserProfile.objects.create(
+            realm=other_realm,
+            delivery_email="someone@example.com",
+            email="someone@example.com",
+        )
+        event = {
+            "preregistration_realm_id": prereg_realm.id,
+            "filename": "import/test/slack.zip",
+            "slack_access_token": "xoxb-valid-token",
+        }
+
+        with self.assertLogs("zulip.registration", "ERROR") as logs:
+            import_slack_data(event)
+        self.assertIn("subdomain is already in use", logs.output[0])
+
+        # The import was not attempted, and the existing realm is untouched.
+        mock_save_attachment_contents.assert_not_called()
+        mock_do_convert_zipfile.assert_not_called()
+        mock_do_import_realm.assert_not_called()
+        self.assertTrue(Realm.objects.filter(id=other_realm.id).exists())
+        self.assertTrue(UserProfile.objects.filter(id=other_user.id).exists())
+        prereg_realm.refresh_from_db()
+        self.assertIsNone(prereg_realm.created_realm)
+        self.assertFalse(prereg_realm.data_import_metadata["is_import_work_queued"])
+        # The conflict is recorded so the status poll can surface it.
+        self.assertTrue(prereg_realm.data_import_metadata["subdomain_unavailable"])
+
     @responses.activate
     def test_cancel_realm_import(self) -> None:
         # Choose import from slack

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -25,6 +25,7 @@ from confirmation.models import Confirmation, create_confirmation_link, get_obje
 from zerver.actions.create_realm import do_create_realm, get_email_address_visibility_default
 from zerver.actions.create_user import do_create_user
 from zerver.actions.data_import import import_slack_data
+from zerver.actions.users import do_deactivate_user
 from zerver.data_import.import_util import (
     UploadFileRequest,
     UploadRecordData,
@@ -2761,6 +2762,107 @@ To Do
         # Check that the importing user was made the realm owner
         importing_user = UserProfile.objects.get(realm=realm, delivery_email=prereg_realm.email)
         self.assertEqual(importing_user.role, UserProfile.ROLE_REALM_OWNER)
+
+    @mock.patch("zerver.actions.data_import.do_import_realm")
+    @mock.patch("zerver.actions.data_import.do_convert_zipfile")
+    @mock.patch("zerver.actions.data_import.save_attachment_contents")
+    def test_import_slack_data_reactivates_deactivated_importing_user(
+        self,
+        mock_save_attachment_contents: mock.Mock,
+        mock_do_convert_zipfile: mock.Mock,
+        mock_do_import_realm: mock.Mock,
+    ) -> None:
+        # If the importing user's account was deactivated in the export, the
+        # import must not fail at the end (throwing away the imported realm);
+        # instead reactivate the account and make it the realm owner.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="test-realm-inactive-owner",
+            name="Test Realm",
+            email="importer@example.com",
+            data_import_metadata={"import_from": "slack"},
+        )
+
+        def fake_do_import_realm(*args: object, **kwargs: object) -> Realm:
+            realm = do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+            importing_user = do_create_user(
+                prereg_realm.email,
+                "password",
+                realm,
+                "Importing user",
+                acting_user=None,
+            )
+            do_deactivate_user(importing_user, acting_user=None)
+            return realm
+
+        mock_do_import_realm.side_effect = fake_do_import_realm
+        event = {
+            "preregistration_realm_id": prereg_realm.id,
+            "filename": "import/test/slack.zip",
+            "slack_access_token": "xoxb-valid-token",
+        }
+
+        import_slack_data(event)
+
+        prereg_realm.refresh_from_db()
+        realm = prereg_realm.created_realm
+        assert realm is not None
+        # The imported realm is preserved and its owner reactivated.
+        self.assertEqual(prereg_realm.status, confirmation_settings.STATUS_USED)
+        self.assertFalse(prereg_realm.data_import_metadata.get("need_select_realm_owner"))
+        importing_user = UserProfile.objects.get(realm=realm, delivery_email=prereg_realm.email)
+        self.assertTrue(importing_user.is_active)
+        self.assertEqual(importing_user.role, UserProfile.ROLE_REALM_OWNER)
+
+    @mock.patch("zerver.actions.data_import.do_import_realm")
+    @mock.patch("zerver.actions.data_import.do_convert_zipfile")
+    @mock.patch("zerver.actions.data_import.save_attachment_contents")
+    def test_import_slack_data_importing_user_is_bot_prompts_owner_selection(
+        self,
+        mock_save_attachment_contents: mock.Mock,
+        mock_do_convert_zipfile: mock.Mock,
+        mock_do_import_realm: mock.Mock,
+    ) -> None:
+        # If the importer's email maps to a bot account, it cannot own the
+        # realm; fall back to the "select your account" flow rather than
+        # crashing and discarding the imported realm.
+        prereg_realm = PreregistrationRealm.objects.create(
+            string_id="test-realm-bot-owner",
+            name="Test Realm",
+            email="bot-importer@example.com",
+            data_import_metadata={"import_from": "slack"},
+        )
+
+        def fake_do_import_realm(*args: object, **kwargs: object) -> Realm:
+            realm = do_create_realm(string_id=prereg_realm.string_id, name=prereg_realm.name)
+            owner = do_create_user(
+                "human-owner@example.com", "password", realm, "Human", acting_user=None
+            )
+            do_create_user(
+                prereg_realm.email,
+                "password",
+                realm,
+                "Bot account",
+                bot_type=UserProfile.DEFAULT_BOT,
+                bot_owner=owner,
+                acting_user=None,
+            )
+            return realm
+
+        mock_do_import_realm.side_effect = fake_do_import_realm
+        event = {
+            "preregistration_realm_id": prereg_realm.id,
+            "filename": "import/test/slack.zip",
+            "slack_access_token": "xoxb-valid-token",
+        }
+
+        import_slack_data(event)
+
+        prereg_realm.refresh_from_db()
+        realm = prereg_realm.created_realm
+        assert realm is not None
+        # The realm is preserved; the user is asked to select an owner.
+        self.assertTrue(prereg_realm.data_import_metadata["need_select_realm_owner"])
+        self.assertNotEqual(prereg_realm.status, confirmation_settings.STATUS_USED)
 
     @mock.patch("zerver.actions.data_import.do_import_realm")
     @mock.patch("zerver.actions.data_import.do_convert_zipfile")

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -404,10 +404,35 @@ def registration_helper(
 
         if start_slack_import:
             assert is_realm_import_enabled()
-            assert prereg_realm.data_import_metadata.get("slack_access_token") is not None
-            assert prereg_realm.data_import_metadata.get("uploaded_import_file_name") is not None
-            assert prereg_realm.data_import_metadata.get("is_import_work_queued") is not True
+            # check_prereg_key guarantees this: a prereg whose import already
+            # created a realm only validates with need_select_realm_owner set,
+            # which is handled above.
             assert prereg_realm.created_realm is None
+
+            if Realm.objects.filter(string_id=prereg_realm.string_id).exists():
+                # The subdomain was taken since registration -- e.g. a
+                # concurrent import of the same subdomain finished first.
+                # Importing would fail on the unique string_id, so don't
+                # start a doomed import; tell the user to start over with a
+                # different URL.
+                return render_slack_import_page(
+                    request,
+                    prereg_realm,
+                    key,
+                    slack_import_error=_(
+                        "This organization URL is no longer available. "
+                        "Please start over and choose a different URL."
+                    ),
+                )
+
+            if (
+                prereg_realm.data_import_metadata.get("slack_access_token") is None
+                or prereg_realm.data_import_metadata.get("uploaded_import_file_name") is None
+            ):
+                # The Slack token and export file must be provided before the
+                # import can start. The UI gates this, but re-render the page
+                # rather than erroring if the form is somehow submitted early.
+                return render_slack_import_page(request, prereg_realm, key)
 
             prereg_realm.data_import_metadata["email_address_visibility"] = email_address_visibility
             prereg_realm.save(update_fields=["data_import_metadata"])

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -309,6 +309,17 @@ def render_slack_import_page(
     return TemplateResponse(request, "zerver/slack_import.html", context)
 
 
+def check_for_slack_import_subdomain_unavailable_error(
+    prereg_realm: PreregistrationRealm,
+) -> str | None:
+    if Realm.objects.filter(string_id=prereg_realm.string_id).exists():
+        return _(
+            "This organization URL is no longer available. "
+            "Please start over and choose a different URL."
+        )
+    return None
+
+
 @never_cache
 @require_post
 def import_realm_from_slack(*args: Any, **kwargs: Any) -> HttpResponse:
@@ -409,20 +420,17 @@ def registration_helper(
             # which is handled above.
             assert prereg_realm.created_realm is None
 
-            if Realm.objects.filter(string_id=prereg_realm.string_id).exists():
+            subdomain_unavailable_error = check_for_slack_import_subdomain_unavailable_error(
+                prereg_realm
+            )
+            if subdomain_unavailable_error is not None:
                 # The subdomain was taken since registration -- e.g. a
                 # concurrent import of the same subdomain finished first.
                 # Importing would fail on the unique string_id, so don't
                 # start a doomed import; tell the user to start over with a
                 # different URL.
                 return render_slack_import_page(
-                    request,
-                    prereg_realm,
-                    key,
-                    slack_import_error=_(
-                        "This organization URL is no longer available. "
-                        "Please start over and choose a different URL."
-                    ),
+                    request, prereg_realm, key, slack_import_error=subdomain_unavailable_error
                 )
 
             if (
@@ -463,6 +471,13 @@ def registration_helper(
         elif prereg_realm.data_import_metadata.get("import_from") == "slack":
             assert is_realm_import_enabled()
 
+            # Warn up front if the subdomain has been taken (e.g. by a
+            # concurrent import of the same subdomain) so the user isn't left
+            # filling out the form for an import that can't succeed.
+            subdomain_unavailable_error = check_for_slack_import_subdomain_unavailable_error(
+                prereg_realm
+            )
+
             saved_slack_access_token = prereg_realm.data_import_metadata.get("slack_access_token")
             if slack_access_token is not None and slack_access_token != saved_slack_access_token:
                 # Verify slack token access.
@@ -481,13 +496,16 @@ def registration_helper(
                         request,
                         prereg_realm,
                         key,
+                        slack_import_error=subdomain_unavailable_error or "",
                         slack_access_token_validation_error=str(e),
                     )
 
                 prereg_realm.data_import_metadata["slack_access_token"] = slack_access_token
                 prereg_realm.save(update_fields=["data_import_metadata"])
 
-            return render_slack_import_page(request, prereg_realm, key)
+            return render_slack_import_page(
+                request, prereg_realm, key, slack_import_error=subdomain_unavailable_error or ""
+            )
 
         password_required = True
         role = UserProfile.ROLE_REALM_OWNER

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1221,21 +1221,27 @@ def realm_import_status(
     # happens to share the subdomain.
     if preregistration_realm.created_realm is None:
         if metadata.get("subdomain_unavailable"):
-            # Another import already registered this subdomain. Send the
-            # user back to registration to choose a different one.
-            return json_success(
-                request,
-                {
-                    "status": _(
-                        "This organization URL is no longer available. "
-                        "Please choose a different URL."
-                    ),
-                    "redirect": reverse(
-                        "get_prereg_key_and_redirect", kwargs={"confirmation_key": confirmation_key}
-                    ),
-                },
-            )
-        elif metadata.get("invalid_file_error_message"):
+            if Realm.objects.filter(string_id=preregistration_realm.string_id).exists():
+                # A realm still holds this subdomain. Send the user back to
+                # registration to choose a different one.
+                return json_success(
+                    request,
+                    {
+                        "status": _(
+                            "This organization URL is no longer available. "
+                            "Please choose a different URL."
+                        ),
+                        "redirect": reverse(
+                            "get_prereg_key_and_redirect",
+                            kwargs={"confirmation_key": confirmation_key},
+                        ),
+                    },
+                )
+            # The subdomain has since been freed, so the stored flag is stale;
+            # clear it and report this import's own failure below.
+            del metadata["subdomain_unavailable"]
+            preregistration_realm.save(update_fields=["data_import_metadata"])
+        if metadata.get("invalid_file_error_message"):
             # Redirect user the file upload page if we have an error message to display.
             return json_success(
                 request,

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -276,6 +276,39 @@ def accounts_register(*args: Any, **kwargs: Any) -> HttpResponse:
     return registration_helper(*args, **kwargs)
 
 
+def render_slack_import_page(
+    request: HttpRequest,
+    prereg_realm: PreregistrationRealm,
+    key: str,
+    *,
+    slack_import_error: str = "",
+    slack_access_token_validation_error: str = "",
+) -> HttpResponse:
+    # Set text of `EMAIL_ADDRESS_VISIBILITY_EVERYONE` to "Everyone" so that it
+    # doesn't overflow the select box in the slack import page.
+    email_address_visibility_options = []
+    for visibility_id, name in RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP.items():
+        if visibility_id == RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_EVERYONE:
+            name = gettext_lazy("Everyone")
+        email_address_visibility_options.append((visibility_id, name))
+
+    metadata = prereg_realm.data_import_metadata
+    context: dict[str, Any] = {
+        "key": key,
+        "max_file_size": settings.MAX_WEB_DATA_IMPORT_SIZE_MB,
+        "email_address_visibility_options": email_address_visibility_options,
+        "email_address_visibility_default": get_email_address_visibility_default(
+            prereg_realm.org_type
+        ),
+        "slack_access_token": metadata.get("slack_access_token"),
+        "uploaded_import_file_name": metadata.get("uploaded_import_file_name"),
+        "invalid_file_error_message": metadata.get("invalid_file_error_message", ""),
+        "slack_access_token_validation_error": slack_access_token_validation_error,
+        "slack_import_error": slack_import_error,
+    }
+    return TemplateResponse(request, "zerver/slack_import.html", context)
+
+
 @never_cache
 @require_post
 def import_realm_from_slack(*args: Any, **kwargs: Any) -> HttpResponse:
@@ -403,67 +436,33 @@ def registration_helper(
             )
 
         elif prereg_realm.data_import_metadata.get("import_from") == "slack":
-            # Set text of `EMAIL_ADDRESS_VISIBILITY_EVERYONE` to "Everyone" so that it doesn't overflow the
-            # select box in the slack import page.
-            email_address_visibility_options = []
-
-            for id, name in RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP.items():
-                if id == RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_EVERYONE:
-                    name = gettext_lazy("Everyone")
-                email_address_visibility_options.append((id, name))
-
             assert is_realm_import_enabled()
-            context: dict[str, Any] = {
-                "key": key,
-                "max_file_size": settings.MAX_WEB_DATA_IMPORT_SIZE_MB,
-                "email_address_visibility_options": email_address_visibility_options,
-                "email_address_visibility_default": get_email_address_visibility_default(
-                    prereg_realm.org_type
-                ),
-            }
 
             saved_slack_access_token = prereg_realm.data_import_metadata.get("slack_access_token")
-            if saved_slack_access_token or slack_access_token is not None:
-                if (
-                    slack_access_token is not None
-                    and slack_access_token != saved_slack_access_token
-                ):
-                    # Verify slack token access.
-                    from zerver.data_import.slack import (
-                        SLACK_IMPORT_TOKEN_SCOPES,
-                        check_slack_token_access,
+            if slack_access_token is not None and slack_access_token != saved_slack_access_token:
+                # Verify slack token access.
+                from zerver.data_import.slack import (
+                    SLACK_IMPORT_TOKEN_SCOPES,
+                    check_slack_token_access,
+                )
+
+                try:
+                    check_slack_token_access(slack_access_token, SLACK_IMPORT_TOKEN_SCOPES)
+                except Exception as e:
+                    logger.info(
+                        "(%s) Slack token failed validation: %s", prereg_realm.string_id, str(e)
+                    )
+                    return render_slack_import_page(
+                        request,
+                        prereg_realm,
+                        key,
+                        slack_access_token_validation_error=str(e),
                     )
 
-                    try:
-                        check_slack_token_access(slack_access_token, SLACK_IMPORT_TOKEN_SCOPES)
-                    except Exception as e:
-                        context["slack_access_token_validation_error"] = str(e)
-                        logger.info(
-                            "(%s) Slack token failed validation: %s", prereg_realm.string_id, str(e)
-                        )
-                        return TemplateResponse(
-                            request,
-                            "zerver/slack_import.html",
-                            context,
-                        )
+                prereg_realm.data_import_metadata["slack_access_token"] = slack_access_token
+                prereg_realm.save(update_fields=["data_import_metadata"])
 
-                    saved_slack_access_token = slack_access_token
-                    prereg_realm.data_import_metadata["slack_access_token"] = slack_access_token
-                    prereg_realm.save(update_fields=["data_import_metadata"])
-
-                context["slack_access_token"] = saved_slack_access_token
-                context["uploaded_import_file_name"] = prereg_realm.data_import_metadata.get(
-                    "uploaded_import_file_name"
-                )
-                context["invalid_file_error_message"] = prereg_realm.data_import_metadata.get(
-                    "invalid_file_error_message", ""
-                )
-
-            return TemplateResponse(
-                request,
-                "zerver/slack_import.html",
-                context,
-            )
+            return render_slack_import_page(request, prereg_realm, key)
 
         password_required = True
         role = UserProfile.ROLE_REALM_OWNER

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1124,13 +1124,25 @@ def realm_import_status(
         raise JsonableError(_("Unauthenticated"))
 
     assert isinstance(preregistration_realm, PreregistrationRealm)
-    try:
-        realm = Realm.objects.get(string_id=preregistration_realm.string_id)
-    except Realm.DoesNotExist:
-        # TODO: Either store the path to the temporary conversion directory on
-        # preregistration_realm.data_import_metadata, or have the conversion
-        # process support writing updates to this for a better progress indicator.
-        if preregistration_realm.data_import_metadata.get("is_import_work_queued"):
+    metadata = preregistration_realm.data_import_metadata
+
+    if metadata.get("is_import_work_queued"):
+        # This preregistration's import job is still running; report its
+        # progress. We find the realm being imported by its subdomain;
+        # in the rare case that a concurrent import of the same
+        # subdomain is further along, the progress shown may briefly
+        # reflect that import, but this resolves once this job finishes.
+        #
+        # TODO: The progress below is inferred from the observed state of
+        # the Realm (whether it exists yet, is still deactivated, has
+        # messages or attachments). A cleaner design would have
+        # import_slack_data record explicit status strings on
+        # data_import_metadata as it advances ("queued", "converting",
+        # "importing converted data", "finalizing") so this endpoint reads
+        # the status directly instead of reverse-engineering it.
+        try:
+            realm = Realm.objects.get(string_id=preregistration_realm.string_id)
+        except Realm.DoesNotExist:
             return json_success(
                 request,
                 {
@@ -1141,24 +1153,64 @@ def realm_import_status(
                     )
                 },
             )
-        elif preregistration_realm.data_import_metadata.get("invalid_file_error_message"):
+
+        if realm.deactivated:
+            # These "if" cases are in the inverse order than they're done
+            # in the import process, so we get the latest step that it's
+            # on.
+            if Message.objects.filter(realm_id=realm.id).exists():
+                return json_success(request, {"status": _("Importing messages…")})
+            try:
+                next(all_message_attachments(prefix=f"{realm.id}/"))
+                return json_success(request, {"status": _("Importing attachment data…")})
+            except StopIteration:
+                pass
+            return json_success(request, {"status": _("Importing converted Slack data…")})
+
+        # The realm has been reactivated, but the import job is still
+        # running its post-import steps.
+        return json_success(request, {"status": _("Finalizing import…")})
+
+    # The import job is no longer running. A successful import always
+    # links preregistration_realm.created_realm, so if it is unset the
+    # import failed. We deliberately key on this preregistration's own
+    # created_realm rather than a subdomain lookup, so that a failed
+    # import isn't reported using a different registration's realm that
+    # happens to share the subdomain.
+    if preregistration_realm.created_realm is None:
+        if metadata.get("subdomain_unavailable"):
+            # Another import already registered this subdomain. Send the
+            # user back to registration to choose a different one.
+            return json_success(
+                request,
+                {
+                    "status": _(
+                        "This organization URL is no longer available. "
+                        "Please choose a different URL."
+                    ),
+                    "redirect": reverse(
+                        "get_prereg_key_and_redirect", kwargs={"confirmation_key": confirmation_key}
+                    ),
+                },
+            )
+        elif metadata.get("invalid_file_error_message"):
             # Redirect user the file upload page if we have an error message to display.
-            result = {
-                "status": preregistration_realm.data_import_metadata.get(
-                    "invalid_file_error_message"
-                ),
-                "redirect": reverse(
-                    "get_prereg_key_and_redirect", kwargs={"confirmation_key": confirmation_key}
-                ),
-            }
-            return json_success(request, result)
+            return json_success(
+                request,
+                {
+                    "status": metadata.get("invalid_file_error_message"),
+                    "redirect": reverse(
+                        "get_prereg_key_and_redirect", kwargs={"confirmation_key": confirmation_key}
+                    ),
+                },
+            )
         else:
             # The import failed due to an unexpected reason. Ask user to email
             # support with the import file so that we can do the import manually
             # and investigate the failure.
             # If there was an error during import, it would have already been logged by Sentry.
             # We don't have access to the exception here.
-            preregistration_realm.data_import_metadata["unexpected_import_failure"] = True
+            metadata["unexpected_import_failure"] = True
             preregistration_realm.save(update_fields=["data_import_metadata"])
             return json_success(
                 request,
@@ -1167,26 +1219,10 @@ def realm_import_status(
                 },
             )
 
-    if realm.deactivated:
-        # These "if" cases are in the inverse order than they're done
-        # in the import process, so we get the latest step that it's
-        # on.
-        if Message.objects.filter(realm_id=realm.id).exists():
-            return json_success(request, {"status": _("Importing messages…")})
-        try:
-            next(all_message_attachments(prefix=f"{realm.id}/"))
-            return json_success(request, {"status": _("Importing attachment data…")})
-        except StopIteration:
-            pass
-        return json_success(request, {"status": _("Importing converted Slack data…")})
+    # The import succeeded; created_realm is this preregistration's own realm.
+    realm = preregistration_realm.created_realm
+    need_select_realm_owner = metadata.get("need_select_realm_owner", False)
 
-    need_select_realm_owner = preregistration_realm.data_import_metadata.get(
-        "need_select_realm_owner", False
-    )
-    if not need_select_realm_owner and preregistration_realm.created_realm is None:
-        return json_success(request, {"status": _("Finalizing import…")})
-
-    # We have a non-deactivated realm and it's linked to the prereg key
     result = {"status": _("Done!")}
     if not need_select_realm_owner:
         importing_user = get_user_by_delivery_email(preregistration_realm.email, realm)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -483,12 +483,13 @@ def registration_helper(
                 # Verify slack token access.
                 from zerver.data_import.slack import (
                     SLACK_IMPORT_TOKEN_SCOPES,
+                    SlackTokenValidationError,
                     check_slack_token_access,
                 )
 
                 try:
                     check_slack_token_access(slack_access_token, SLACK_IMPORT_TOKEN_SCOPES)
-                except Exception as e:
+                except SlackTokenValidationError as e:
                     logger.info(
                         "(%s) Slack token failed validation: %s", prereg_realm.string_id, str(e)
                     )


### PR DESCRIPTION
Fixes a cluster of Sentry-reported crashes and UX gaps in the self-serve
Slack import flow, all rooted in two registrations being able to target the
same subdomain (`string_id` is unique only on `Realm`, not on
`PreregistrationRealm`).

**Fixed:**
- A failed import no longer deletes a *concurrent* import's realm — this was destroying another import's data and deadlocking on `zerver_userprofile`.
- An import for an already-taken subdomain now aborts *before* the expensive download/conversion, instead of doing all that work only to fail.
- Import status is now reported from the registration's **own** realm, so a second registration sharing a subdomain isn't shown the wrong realm's progress (or "Done").
- A fully successful import is no longer discarded when the importing user is inactive/a bot/a mirror-dummy: an inactive importer is reactivated and made owner; otherwise the user is asked to pick their account.
- "Start import" no longer returns a 500 when the export file hasn't finished uploading; the preconditions degrade gracefully.
- Starting an import for a taken subdomain shows a clear "this URL is no longer available" message instead of enqueueing a doomed job.
- The second importer is warned on page load (not just on "Start") that the subdomain is already being taken.
- The import error message now wraps within the form column instead of stretching the box.

<img width="471" height="826" alt="image" src="https://github.com/user-attachments/assets/bd323161-d09e-42ba-a7fc-d3ce3f39863a" />

