### PR TITLE
Stop manually translating the /integration page.

### DIFF
--- a/templates/zerver/integrations/catalog.html
+++ b/templates/zerver/integrations/catalog.html
@@ -19,16 +19,14 @@
                 <div class="integration-main-text">
                     <header>
                         <h1 class="portico-page-heading">
-                            {% trans %}Over {{integrations_count_display}} native integrations.{% endtrans %}
+                            Over {{ integrations_count_display }} native integrations.
                         </h1>
                     </header>
                     <p class="portico-page-subheading">
-                        {% trans %}
                         And hundreds more through
                         <a href="/integrations/zapier">Zapier</a>
                         and
                         <a href="/integrations/ifttt">IFTTT</a>.
-                        {% endtrans %}
                     </p>
                 </div>
 
@@ -36,12 +34,12 @@
                     <div class="searchbar">
                         <div class="searchbar-reset">
                             <i class="zulip-icon zulip-icon-search" aria-hidden="true"></i>
-                            <input type="text" class="search_input" placeholder="{{ _('Search integrations') }}"/>
+                            <input type="text" class="search_input" placeholder="Search integrations"/>
                         </div>
                     </div>
                 </div>
 
-                {% set dropdown_label = _('Filter by category') %}
+                {% set dropdown_label = 'Filter by category' %}
                 {% if selected_category_slug != 'all' %}
                 {% set dropdown_label = categories_dict.get(selected_category_slug, dropdown_label) %}
                 {% endif %}
@@ -52,46 +50,46 @@
                     </div>
                     <div class="dropdown-list">
                         <a href="/integrations/" class="integration-category {% if selected_category_slug == 'all' %}selected{% endif %}" data-category="all">
-                            {% trans %}All{% endtrans %}
+                            All
                         </a>
                         {% for category in categories_dict.keys() %}
                         <a href="/integrations/category/{{ category }}" class="integration-category {% if selected_category_slug == category %}selected{% endif %}" data-category="{{ category }}">
                             {{ categories_dict[category] }}
                         </a>
                         {% endfor %}
-                        <h3 class="heading">{% trans %}Custom integrations{% endtrans %}</h3>
+                        <h3 class="heading">Custom integrations</h3>
                         <a href="https://zulip.readthedocs.io/en/latest/webhooks/incoming-webhooks-overview.html">
-                            {% trans %}Incoming webhooks{% endtrans %}
+                            Incoming webhooks
                         </a>
                         <a href="/help/writing-bots">
-                            {% trans %}Interactive bots{% endtrans %}
+                            Interactive bots
                         </a>
                         <a href="/api/rest">
-                            {% trans %}REST API{% endtrans %}
+                            REST API
                         </a>
                     </div>
                 </div>
 
                 <div class="catalog">
                     <div class="integration-categories-sidebar">
-                        <h3>{% trans %}Categories{% endtrans %}</h3>
+                        <h3>Categories</h3>
                         <a href="/integrations/" data-category="all" class="integration-category {% if selected_category_slug == 'all' %}selected{% endif %}">
-                            {% trans %}All{% endtrans %}
+                            All
                         </a>
                         {% for category in categories_dict.keys() %}
                         <a href="/integrations/category/{{ category }}" data-category="{{ category }}" class="integration-category {% if selected_category_slug == category %}selected{% endif %}">
                             {{ categories_dict[category] }}
                         </a>
                         {% endfor %}
-                        <h3>{% trans %}Custom integrations{% endtrans %}</h3>
+                        <h3>Custom integrations</h3>
                         <a href="https://zulip.readthedocs.io/en/latest/webhooks/incoming-webhooks-overview.html">
-                            {% trans %}Incoming webhooks{% endtrans %}
+                            Incoming webhooks
                         </a>
                         <a href="/help/writing-bots">
-                            {% trans %}Interactive bots{% endtrans %}
+                            Interactive bots
                         </a>
                         <a href="/api/rest">
-                            {% trans %}REST API{% endtrans %}
+                            REST API
                         </a>
                     </div>
 

--- a/templates/zerver/integrations/doc.html
+++ b/templates/zerver/integrations/doc.html
@@ -31,7 +31,7 @@
                         {% endif %}
                         {{ integration_macros.render_integration_lozenge(selected_integration, is_doc_view=true) }}
                         <a href="/integrations/{% if return_category_slug != 'all' %}category/{{ return_category_slug }}{% endif %}" id="integration-list-link">
-                            <i class="zulip-icon zulip-icon-arrow-left" aria-hidden="true"></i><span class="integrations-back-label-long">{% trans %}Back to list{% endtrans %}</span><span class="integrations-back-label-short">{% trans %}Back{% endtrans %}</span>
+                            <i class="zulip-icon zulip-icon-arrow-left" aria-hidden="true"></i><span class="integrations-back-label-long">Back to list</span><span class="integrations-back-label-short">Back</span>
                         </a>
                     </div>
 

--- a/templates/zerver/integrations/macros.html
+++ b/templates/zerver/integrations/macros.html
@@ -6,12 +6,12 @@
         <img class="integration-logo" src="{{ integration.logo_url }}"
           alt="{{ integration.display_name }} logo"/>
         {% if integration.secondary_line_text %}
-        <h3 class="integration-name with-secondary">{{ integration.display_name }}</h3>
+        <h3 class="integration-name with-secondary" translate="no">{{ integration.display_name }}</h3>
         <h4 class="integration-secondary-line-text">
             {{ integration.secondary_line_text }}
         </h4>
         {% else %}
-        <h3 class="integration-name">{{ integration.display_name }}</h3>
+        <h3 class="integration-name" translate="no">{{ integration.display_name }}</h3>
         {% endif %}
         <h4 class="integration-category">{{ integration.categories[0] }}</h4>
     </div>

--- a/templates/zerver/integrations/macros.html
+++ b/templates/zerver/integrations/macros.html
@@ -1,7 +1,7 @@
 {% macro render_integration_lozenge(integration, is_doc_view=false) -%}
     <div
       class="integration-lozenge{% if is_doc_view %} without-category{% endif %} integration-{{ integration.name }}"
-      data-categories='{{ integration.get_translated_categories()|tojson }}'
+      data-categories='{{ integration.categories|tojson }}'
       data-name="{{ integration.name }}">
         <img class="integration-logo" src="{{ integration.logo_url }}"
           alt="{{ integration.display_name }} logo"/>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -586,6 +586,7 @@ html_rules: list["Rule"] = [
         },
         "exclude": {
             "templates/corporate",
+            "templates/zerver/integrations/catalog.html",
             # We have URL template and Pygments language name as placeholders
             # in the below template which we don't want to be translatable.
             "web/templates/settings/playground_settings_admin.hbs",

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -8,9 +8,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpRequest, HttpResponseBase
 from django.urls import URLPattern, path
 from django.utils.module_loading import import_string
-from django.utils.translation import gettext_lazy
 from django.views.decorators.csrf import csrf_exempt
-from django_stubs_ext import StrPromise
 from typing_extensions import override
 
 from zerver.lib.storage import static_path
@@ -36,24 +34,23 @@ Over time, we expect this registry to grow additional convenience
 features for writing and configuring integrations efficiently.
 """
 
-
-CATEGORIES: dict[str, StrPromise] = {
-    "meta-integration": gettext_lazy("Integration frameworks"),
-    "bots": gettext_lazy("Interactive bots"),
-    "video-calling": gettext_lazy("Video calling"),
-    "continuous-integration": gettext_lazy("Continuous integration"),
-    "customer-support": gettext_lazy("Customer support"),
-    "deployment": gettext_lazy("Deployment"),
-    "entertainment": gettext_lazy("Entertainment"),
-    "communication": gettext_lazy("Communication"),
-    "financial": gettext_lazy("Financial"),
-    "hr": gettext_lazy("Human resources"),
-    "marketing": gettext_lazy("Marketing"),
-    "misc": gettext_lazy("Miscellaneous"),
-    "monitoring": gettext_lazy("Monitoring"),
-    "project-management": gettext_lazy("Project management"),
-    "productivity": gettext_lazy("Productivity"),
-    "version-control": gettext_lazy("Version control"),
+CATEGORIES: dict[str, str] = {
+    "meta-integration": "Integration frameworks",
+    "bots": "Interactive bots",
+    "video-calling": "Video calling",
+    "continuous-integration": "Continuous integration",
+    "customer-support": "Customer support",
+    "deployment": "Deployment",
+    "entertainment": "Entertainment",
+    "communication": "Communication",
+    "financial": "Financial",
+    "hr": "Human resources",
+    "marketing": "Marketing",
+    "misc": "Miscellaneous",
+    "monitoring": "Monitoring",
+    "project-management": "Project management",
+    "productivity": "Productivity",
+    "version-control": "Version control",
 }
 
 # Can also be computed from INTEGRATIONS by removing entries from
@@ -241,9 +238,6 @@ class Integration:
     def get_bot_avatar_path(self) -> str:
         name = os.path.splitext(os.path.basename(self.logo_path))[0]
         return self.DEFAULT_BOT_AVATAR_PATH.format(name=name)
-
-    def get_translated_categories(self) -> list[str]:
-        return [str(category) for category in self.categories]
 
 
 class BotIntegration(Integration):

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -422,9 +422,9 @@ def add_catalog_integrations_context(request: HttpRequest, category_slug: str) -
 
 
 def get_categories_for_integration(integration: Integration) -> list[tuple[str, str]]:
-    display_to_slug = {str(display): slug for slug, display in CATEGORIES.items()}
+    display_to_slug = {display: slug for slug, display in CATEGORIES.items()}
     result = []
-    for display_name in integration.get_translated_categories():
+    for display_name in integration.categories:
         slug = display_to_slug.get(display_name)
         assert slug is not None
         result.append((slug, display_name))


### PR DESCRIPTION
This removes the translated strings from the integrations templates and makes `CATEGORIES` hold plain strings, so these pages emit plain English and leave any translating to the browser.

**Reason**: The /integrations catalog and doc pages are documentation-style pages , they have a large amount of content that is updated frequently, much like the help center and API documentation, which we do not translate and instead leave to browser-based translation.

**Screenshots and screen captures:**

<!-- Desktop /integrations/, narrow /integrations/, /integrations/category/bots, /integrations/github,
     and a before/after pair at /ja/integrations/ (server Japanese on main → English on this branch). -->


Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/101-design/topic/.2Fintegrations.20and.20.2Fcommunities.20design.20update.20.2338913/with/2471992)[#design > /integrations and /communities design update #38913](https://chat.zulip.org/#narrow/channel/101-design/topic/.2Fintegrations.20and.20.2Fcommunities.20design.20update.20.2338913/with/2471992)

**How changes were tested:**
Tried using the browsers "translate this page" and also visited the `/lang/integration` .
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Screenshots and screen captures:</summary>
<img width="1920" height="1080" alt="Screenshot From 2026-06-03 13-42-04" src="https://github.com/user-attachments/assets/64dbb096-e424-45b9-b643-a021b5a7a7f2" />
<img width="1920" height="1080" alt="Screenshot From 2026-06-03 13-42-16" src="https://github.com/user-attachments/assets/3e6754e2-4c95-4b33-b788-2006b6ec1905" />
<img width="1920" height="1080" alt="Screenshot From 2026-06-03 14-11-05" src="https://github.com/user-attachments/assets/ea874d81-c10d-4dbf-875d-f302b74ad14d" />
<img width="1920" height="1080" alt="Screenshot From 2026-06-03 14-11-35" src="https://github.com/user-attachments/assets/5e3875bb-c0f3-4e23-92f0-e069027fd82f" />
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

