### PR TITLE
api-docs: Document  `/bots/{bot_id}` endpoint

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -519,7 +519,8 @@ element to plain escaped text.
 
 **Feature level 447**
 
-* `PATCH /bots/{bot_id}`: Added `short_name` parameter to support updating bot's email.
+* [`PATCH /bots/{bot_id}`](/api/update-bot): Added `short_name` parameter to
+  support updating bot's email.
 
 **Feature level 446**
 
@@ -1280,11 +1281,11 @@ No changes; feature level used for Zulip 10.0 release.
 
 **Feature level 359**
 
-* `PATCH /bots/{bot_user_id}`: Previously, changing the owner of a bot
-  unsubscribed the bot from any channels that the new owner was not
-  subscribed to. This behavior was removed in favor of documenting the
-  security trade-off associated with giving bots read access to
-  sensitive channel content.
+* [`PATCH /bots/{bot_user_id}`](/api/update-bot): Previously, changing
+  the owner of a bot unsubscribed the bot from any channels that the new
+  owner was not subscribed to. This behavior was removed in favor of
+  documenting the security trade-off associated with giving bots read
+  access to sensitive channel content.
 
 **Feature level 358**
 
@@ -3528,9 +3529,9 @@ user's profile.
 
 **Feature level 130**
 
-* `PATCH /bots/{bot_user_id}`: Added support for changing a bot's role
-  via this endpoint. Previously, this could only be done via [`PATCH
-  /users/{user_id}`](/api/update-user).
+* [`PATCH /bots/{bot_user_id}`](/api/update-bot): Added support for
+  changing a bot's role via this endpoint. Previously, this could
+  only be done via [`PATCH /users/{user_id}`](/api/update-user).
 
 **Feature level 129**
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -123,6 +123,11 @@
 * [Add alert words](/api/add-alert-words)
 * [Remove alert words](/api/remove-alert-words)
 * [Regenerate your API key](/api/regenerate-api-key)
+
+## Bot users
+
+* [Update a bot](/api/update-bot)
+* [Deactivate a bot](/api/deactivate-bot)
 * [Get a bot's API key](/api/get-bot-api-key)
 * [Regenerate a bot's API key](/api/regenerate-bot-api-key)
 

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -459,6 +459,21 @@ def regenerate_bot_api_key_test() -> dict[str, object]:
     return {"bot_id": bot.id}
 
 
+@openapi_param_value_generator(["/bots/{bot_id}:delete"])
+def deactivate_bot() -> dict[str, object]:
+    iago = helpers.example_user("iago")
+    bot = do_create_user(
+        email="deactivate-bot-test@zulip.com",
+        password=None,
+        full_name="Bot to be deactivated",
+        realm=get_realm("zulip"),
+        bot_type=UserProfile.DEFAULT_BOT,
+        bot_owner=iago,
+        acting_user=None,
+    )
+    return {"bot_id": bot.id}
+
+
 @openapi_param_value_generator(["/thumbnail/status/{realm_id_str}/{filename}:get"])
 def check_thumbnail_status_for_uploaded_file() -> dict[str, object]:
     realm_id = ""

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -359,6 +359,10 @@ def generate_curl_example(
     ):
         properties = content["multipart/form-data"]["schema"]["properties"]
         for key, property in properties.items():
+            if include is not None and key not in include:
+                continue
+            if exclude is not None and key in exclude:
+                continue
             lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
 
     for i in range(1, len(lines) - 1):

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -26,6 +26,7 @@ OPENAPI_SPEC_PATH = os.path.abspath(
 # has documentation but not with this particular method.
 EXCLUDE_UNDOCUMENTED_ENDPOINTS = {
     ("/users", "patch"),
+    ("/bots/{bot_id}", "post"),
 }
 # Consists of endpoints with some documentation remaining.
 # These are skipped but return true as the validator cannot exclude objects

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -821,6 +821,29 @@ def regenerate_api_key(client: Client) -> None:
     client.session = None
 
 
+@openapi_test_function("/bots/{bot_id}:patch")
+def update_bot(client: Client) -> None:
+    bot_id = 17
+    new_owner_id = 10
+    ensure_users([bot_id, new_owner_id], ["default-bot", "hamlet"])
+
+    # {code_example|start}
+    # Update a bot's full name, role, and owner, given the bot's ID.
+    request = {
+        "full_name": "NewBotName",
+        "role": 400,
+        "bot_owner_id": new_owner_id,
+    }
+    result = client.call_endpoint(
+        url=f"/bots/{bot_id}",
+        method="PATCH",
+        request=request,
+    )
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/bots/{bot_id}", "patch", "200")
+
+
 @openapi_test_function("/bots/{bot_id}/api_key:get")
 def get_bot_api_key(client: Client) -> None:
     bot_id = 17
@@ -2235,6 +2258,10 @@ def test_users(client: Client, owner_client: Client) -> None:
     remove_device(client)
 
 
+def test_user_bots(client: Client) -> None:
+    update_bot(client)
+
+
 def test_streams(client: Client, nonadmin_client: Client) -> None:
     add_subscriptions(client)
     add_channel(client)
@@ -2332,6 +2359,7 @@ def test_the_api(
     # `regenerate_api_key`, since they are needed for curl tests.
     test_api_key_endpoints(client)
     test_users(client, owner_client)
+    test_user_bots(client)
     test_streams(client, nonadmin_client)
     test_messages(client, nonadmin_client)
     test_queues(client)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -26843,11 +26843,323 @@ paths:
                       }
                     description: |
                       An example JSON response when the channel folder ID is invalid:
+  /bots/{bot_id}:
+    patch:
+      operationId: update-bot
+      summary: Update a bot
+      tags: ["bot_users"]
+      description: |
+        Administrative endpoint to update the details of a bot user in the organization.
+
+        Only the bot's owner or an administrator can edit the details of a bot user.
+
+        Supports editing details shared by all types of bot users (such as full name,
+        avatar and role), as well as details that are unique to specific bot types.
+
+      x-curl-examples-parameters:
+        oneOf:
+          - type: include
+            parameters:
+              enum:
+                - full_name
+                - role
+                - bot_owner_id
+      x-parameter-description: |
+        To update the bot's avatar, the new avatar image must be sent as
+        the `file` part of a `multipart/form-data` request body. Only one
+        file may be included per request.
+
+        You can include any of the parameters above in the same multipart request.
+      parameters:
+        - $ref: "#/components/parameters/BotId"
+      requestBody:
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                full_name:
+                  description: |
+                    The bot's new full name.
+                  type: string
+                  example: NewBotName
+                short_name:
+                  description: |
+                    The bot's new short name.
+
+                    A bot's short name is used to construct the bot's "email address",
+                    which is used for [Zulip's API authentication](/api/http-headers#the-authorization-header).
+
+                    **Changes**: New in Zulip 12.0 (feature level 447).
+                  type: string
+                  example: new-bot
+                role:
+                  description: |
+                    New [role](/api/roles-and-permissions) for the bot.
+                    Roles are encoded as:
+
+                    - Organization owner: 100
+                    - Organization administrator: 200
+                    - Organization moderator: 300
+                    - Member: 400
+                    - Guest: 600
+
+                    Only organization owners can add or remove the owner
+                    role.
+
+                    **Changes**: New in Zulip 6.0 (feature level 130). In
+                    previous versions, a bot's role could only be changed via
+                    [`PATCH /users/{user_id}`](/api/update-user).
+                  type: integer
+                  example: 400
+                bot_owner_id:
+                  description: |
+                    User ID of the bot's new owner. The new owner must be an
+                    active, non-bot user in the organization.
+
+                    **Changes**: Prior to Zulip 10.0 (feature level 359),
+                    changing a bot's owner also unsubscribed the bot from
+                    any channels that the new owner was not subscribed to.
+                  type: integer
+                  example: 8
+                config_data:
+                  description: |
+                    Only applies to incoming webhook and embedded bot users.
+
+                    A dictionary of string key/value pairs, which describe the configuration
+                    for the bot. These are usually details like API keys, and are unique to
+                    the integration/bot.
+
+                    This parameter performs a partial update. Each key in
+                    the dictionary is inserted or overwritten in the bot's
+                    stored configuration, and keys that are not present in
+                    the request are left unchanged.
+
+                    There is no way to delete a configured key through
+                    this endpoint. Sending an empty string for a key's value
+                    stores an empty string.
+                  type: object
+                  example: {"api_key": "12345678"}
+                service_payload_url:
+                  description: |
+                    Only applies to outgoing webhook bots.
+
+                    The new URL to which the bot's
+                    [outgoing webhook](/api/outgoing-webhook-payload) requests should
+                    be sent.
+                  type: string
+                  example: https://example.com/bots/foo
+                service_interface:
+                  description: |
+                    Only applies to outgoing webhook bots.
+
+                    The interface type for the bot's
+                    [outgoing webhook payload](/api/outgoing-webhook-payload):
+
+                    - `1`: Generic
+                    - `2`: Slack-compatible
+                  type: integer
+                  enum: [1, 2]
+                  default: 1
+                  example: 1
+                default_sending_stream:
+                  description: |
+                    The name of the channel that the bot will send messages to
+                    by default.
+
+                    Pass the empty string to clear the default sending channel.
+                  type: string
+                  example: Denmark
+                default_events_register_stream:
+                  description: |
+                    The default channel for which the bot receives
+                    [`POST /register`](/api/register-queue) and
+                    [`GET /events`](/api/get-events) data.
+
+                    Pass the empty string to clear the default events-register channel.
+                  type: string
+                  example: Denmark
+                default_all_public_streams:
+                  description: |
+                    Whether the bot can send messages to all channels by default.
+                  type: boolean
+                  example: true
+            encoding:
+              role:
+                contentType: application/json
+              bot_owner_id:
+                contentType: application/json
+              config_data:
+                contentType: application/json
+              service_payload_url:
+                contentType: application/json
+              service_interface:
+                contentType: application/json
+              default_all_public_streams:
+                contentType: application/json
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  example: /path/to/img.png
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      full_name:
+                        type: string
+                        description: |
+                          The bot's full name after the update.
+                      avatar_url:
+                        type: string
+                        description: |
+                          The URL of the bot's avatar after the update.
+                      service_interface:
+                        type: integer
+                        description: |
+                          The `service_interface` value submitted in the request,
+                          or `1` if the request did not include this field.
+                      service_payload_url:
+                        type: string
+                        nullable: true
+                        description: |
+                          The `service_payload_url` value submitted in the request, or `null`
+                          if the request did not modify this field.
+                      config_data:
+                        type: object
+                        nullable: true
+                        additionalProperties:
+                          type: string
+                          description: |
+                            `{key}`: The stored string value for this configuration key.
+                        description: |
+                          The configuration data submitted in the request,
+                          or `null` if the request did not modify this field.
+
+                          This does not necessarily reflect the entire bot's `config_data`,
+                          only the updated values.
+                      default_sending_stream:
+                        type: string
+                        nullable: true
+                        description: |
+                          The name of the bot's default sending channel, or
+                          `null` if the bot does not have one.
+                      default_events_register_stream:
+                        type: string
+                        nullable: true
+                        description: |
+                          The default channel for which the bot receives events/register data,
+                          or `null` if the bot does not have one.
+                      default_all_public_streams:
+                        type: boolean
+                        description: |
+                          Whether the bot can send messages to all channels by default.
+                      bot_owner:
+                        type: string
+                        description: |
+                          The email address of the bot's owner.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "full_name": "NewBotName",
+                        "avatar_url": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1",
+                        "service_interface": 1,
+                        "service_payload_url": null,
+                        "config_data": null,
+                        "default_sending_stream": null,
+                        "default_events_register_stream": null,
+                        "default_all_public_streams": false,
+                        "bot_owner": "iago@zulip.com",
+                      }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "No such bot",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response when the bot ID is invalid
+                          or refers to a user who is not a bot:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Email address already in use",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response when changing `short_name`
+                          would result in a duplicate bot email address:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Failed to change owner, bots can't own other bots",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response when the requested new
+                          `bot_owner_id` refers to a bot user:
+    delete:
+      operationId: deactivate-bot
+      summary: Deactivate a bot
+      tags: ["bot_users"]
+      description: |
+        Administrative endpoint to deactivate a bot user given the
+        bot's user ID.
+
+        Only the bot's owner or an administrator can deactivate
+        a bot.
+      parameters:
+        - $ref: "#/components/parameters/BotId"
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "No such bot",
+                        "result": "error",
+                      }
+                    description: |
+                      An example JSON response when the bot ID is invalid
+                      or refers to a user who is not a bot:
   /bots/{bot_id}/api_key:
     get:
       operationId: get-bot-api-key
       summary: Get a bot's API key
-      tags: ["users"]
+      tags: ["bot_users"]
       description: |
         Fetch the API key for a bot user. Only the bot's owner and
         organization administrators have access to a bot's API key.
@@ -26898,7 +27210,7 @@ paths:
     post:
       operationId: regenerate-bot-api-key
       summary: Regenerate a bot's API key
-      tags: ["users"]
+      tags: ["bot_users"]
       description: |
         Generate a new API key for a bot user. Only the bot's owner and
         organization administrators have access to a bot's API key.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -745,6 +745,44 @@ class TestCurlExampleGeneration(ZulipTestCase):
         },
     }
 
+    spec_mock_using_multipart_form_data = {
+        "security": [{"basicAuth": []}],
+        "paths": {
+            "/endpoint": {
+                "post": {
+                    "description": "Upload some files.",
+                    "parameters": [],
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "file_a": {
+                                            "type": "string",
+                                            "format": "binary",
+                                            "example": "/path/to/a.png",
+                                        },
+                                        "file_b": {
+                                            "type": "string",
+                                            "format": "binary",
+                                            "example": "/path/to/b.png",
+                                        },
+                                        "file_c": {
+                                            "type": "string",
+                                            "format": "binary",
+                                            "example": "/path/to/c.png",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
     def curl_example(self, endpoint: str, method: str, *args: Any, **kwargs: Any) -> list[str]:
         return generate_curl_example(endpoint, method, "http://localhost:9991/api", *args, **kwargs)
 
@@ -899,6 +937,46 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "    --data-urlencode num_before=4 \\",
             "    --data-urlencode num_after=8 \\",
             '    --data-urlencode \'narrow=[{"operand": "Denmark", "operator": "channel"}]\'',
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+    @patch("zerver.openapi.openapi.OpenAPISpec.openapi")
+    def test_generate_and_render_curl_example_multipart_with_includes(
+        self, spec_mock: MagicMock
+    ) -> None:
+        spec_mock.return_value = self.spec_mock_using_multipart_form_data
+        generated_curl_example = self.curl_example(
+            "/endpoint",
+            "POST",
+            include=["file_a", "file_b"],
+        )
+        expected_curl_example = [
+            "```curl",
+            "curl -sSX POST http://localhost:9991/api/v1/endpoint \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    -F file_a=@/path/to/a.png \\",
+            "    -F file_b=@/path/to/b.png",
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+    @patch("zerver.openapi.openapi.OpenAPISpec.openapi")
+    def test_generate_and_render_curl_example_multipart_with_excludes(
+        self, spec_mock: MagicMock
+    ) -> None:
+        spec_mock.return_value = self.spec_mock_using_multipart_form_data
+        generated_curl_example = self.curl_example(
+            "/endpoint",
+            "POST",
+            exclude=["file_b"],
+        )
+        expected_curl_example = [
+            "```curl",
+            "curl -sSX POST http://localhost:9991/api/v1/endpoint \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    -F file_a=@/path/to/a.png \\",
+            "    -F file_c=@/path/to/c.png",
             "```",
         ]
         self.assertEqual(generated_curl_example, expected_curl_example)

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -228,7 +228,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         #### These "organization settings" endpoint have modest value to document:
         "/realm",
         "/bots",
-        "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
         "/realm/profile_fields/{field_id}",
         "/realm/icon",
@@ -1007,6 +1006,7 @@ class OpenAPIAttributesTest(ZulipTestCase):
             "reminders",
             "navigation_views",
             "bots",
+            "bot_users",
         ]
         paths = OpenAPISpec(OPENAPI_SPEC_PATH).openapi()["paths"]
         for path, path_item in paths.items():


### PR DESCRIPTION
`PATCH /bots/{bot_id}` (update a bot) and `DELETE /bots/{bot_id}` (deactivate a bot) were both already implemented but completely undocumented in `zerver/openapi/zulip.yaml`. 
  
This PR also patches a small infrastructure issues uncovered along the way: `generate_curl_example` already filters urlencoded fields via `x-curl-examples-parameters`, but it was emitting `-F` flags for every multipart property unconditionally. The PATCH endpoint advertises both body types (urlencoded for normal fields, multipart for avatar uploads), so the filter had to apply to both branches.


**Screenshots and screen captures:**

<img width="885" height="777" alt="image" src="https://github.com/user-attachments/assets/2bc7e252-3ee8-4c6c-9dcf-07fb862d8d5c" />


<img width="885" height="956" alt="image" src="https://github.com/user-attachments/assets/bfd36e80-2d7d-4c9b-bda9-d9aa7588b780" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
