### PR TITLE
markdown: Add hl_lines support to fenced code blocks.

### DIFF
--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -132,6 +132,9 @@ FENCE_RE = re.compile(
 CODE_WRAP = "<pre><code{}>{}\n</code></pre>"
 LANG_TAG = ' class="{}"'
 
+# Highlight-lines directive in a fenced code header, e.g. ```python hl_lines="1 3"
+HL_LINES_RE = re.compile(r"""hl_lines=(?P<quot>"|')(?P<hl_lines>.*?)(?P=quot)""")
+
 
 def validate_curl_content(lines: list[str]) -> None:
     error_msg = """
@@ -253,7 +256,12 @@ def generic_handler(
     elif lang == "spoiler":
         return SpoilerHandler(processor, output, fence, header)
     else:
-        return CodeHandler(processor, output, fence, lang, run_content_validators)
+        hl_lines = None
+        if header is not None:
+            hl_match = HL_LINES_RE.search(header)
+            if hl_match is not None:
+                hl_lines = parse_hl_lines(hl_match.group("hl_lines"))
+        return CodeHandler(processor, output, fence, lang, run_content_validators, hl_lines)
 
 
 def check_for_new_fence(
@@ -305,9 +313,11 @@ class CodeHandler(ZulipBaseHandler):
         fence: str,
         lang: str | None,
         run_content_validators: bool = False,
+        hl_lines: list[int] | None = None,
     ) -> None:
         self.lang = lang
         self.run_content_validators = run_content_validators
+        self.hl_lines = hl_lines
         super().__init__(processor, output, fence)
 
     @override
@@ -320,7 +330,7 @@ class CodeHandler(ZulipBaseHandler):
 
     @override
     def format_text(self, text: str) -> str:
-        return self.processor.format_code(self.lang, text)
+        return self.processor.format_code(self.lang, text, self.hl_lines)
 
 
 class QuoteHandler(ZulipBaseHandler):
@@ -471,7 +481,7 @@ class FencedBlockPreprocessor(Preprocessor):
             output.append("")
         return output
 
-    def format_code(self, lang: str | None, text: str) -> str:
+    def format_code(self, lang: str | None, text: str, hl_lines: list[int] | None = None) -> str:
         if lang:
             langclass = LANG_TAG.format(lang)
         else:
@@ -497,6 +507,7 @@ class FencedBlockPreprocessor(Preprocessor):
                 style=self.codehilite_conf["pygments_style"][0],
                 use_pygments=self.codehilite_conf["use_pygments"][0],
                 lang=lang or None,
+                hl_lines=hl_lines or [],
                 noclasses=self.codehilite_conf["noclasses"][0],
                 # By default, the Pygments PHP lexers won't highlight
                 # code without a `<?php` marker at the start of the

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -83,8 +83,9 @@ class SimulatedFencedBlockPreprocessor(FencedBlockPreprocessor):
     # Simulate code formatting.
 
     @override
-    def format_code(self, lang: str | None, code: str) -> str:
-        return (lang or "") + ":" + code
+    def format_code(self, lang: str | None, code: str, hl_lines: list[int] | None = None) -> str:
+        hl = f"[hl={hl_lines}]" if hl_lines else ""
+        return (lang or "") + ":" + hl + code
 
     @override
     def placeholder(self, s: str) -> str:
@@ -3893,6 +3894,15 @@ class MarkdownErrorTests(ZulipTestCase):
         self.assertIn("print('pygments fallback test')", rendered_html)
         mocked_hilite.assert_called()
         self.assertIn("Failed to highlight fenced code block", log.output[0])
+
+    def test_fenced_code_hl_lines(self) -> None:
+        """hl_lines in a code fence header highlights the requested lines."""
+        markdown_text = '```python hl_lines="2"\nfirst = 1\nsecond = 2\nthird = 3\n```'
+        rendered_html = markdown_convert(
+            markdown_text,
+            self.example_user("hamlet"),
+        ).rendered_content
+        self.assertIn('class="hll"', rendered_html)
 
 
 class TestHtmlToMarkdown(ZulipTestCase):


### PR DESCRIPTION
Fixes #2036.

Code fences can now highlight specific lines with an `hl_lines` attribute in the fence header:

    ```python hl_lines="1 3"
    first = 1
    second = 2
    third = 3
    ```

### Approach

The highlighted lines are read from the existing `header` capture group and passed to Pygments via `parse_hl_lines`, so `FENCE_RE` is left unchanged. That avoids the regex-ambiguity objection that stalled the earlier attempt (#16984), which parsed `hl_lines` inside `FENCE_RE` itself.

This builds on that PR's groundwork: the decision not to support ranges (a range like `1-3` could expand a huge span into a DoS-sized list of ints), the test approach, and the CSS direction. The `.codehilite .hll` styles for both the light and dark themes already exist in `web/styles/pygments.css`, so no CSS change is needed here.

### Testing

Added an end-to-end test asserting an `hl_lines` fence renders the `hll` line-highlight span. `./tools/test-backend zerver.tests.test_markdown` passes (139 tests), including the exact-output fenced-code tests, so a plain code block renders identically to before.
