### PR TITLE
retry_backoff: Explicitly import from correct module.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -27,6 +27,7 @@ import {message_render_response_schema} from "./message_store.ts";
 import * as people from "./people.ts";
 import {postprocess_content} from "./postprocess_content.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as rtl from "./rtl.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
@@ -1554,7 +1555,7 @@ async function poll_thumbnail_status(
         }
 
         if (pending_thumbnail_paths.size > 0) {
-            const retry_delay_secs = util.get_retry_backoff_seconds(undefined, attempt, true);
+            const retry_delay_secs = get_retry_backoff_seconds(undefined, attempt, true);
             thumbnail_poll_timeout = setTimeout(() => {
                 void poll_thumbnail_status(
                     $preview_container,

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -25,12 +25,12 @@ import {page_params} from "./page_params.ts";
 import * as popup_banners from "./popup_banners.ts";
 import {recent_view_messages_data} from "./recent_view_messages_data.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import {narrow_operator_schema} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_list from "./stream_list.ts";
 import * as unread_ops from "./unread_ops.ts";
-import * as util from "./util.ts";
 
 export const message_ids_response_schema = z.object({
     found_newest: z.boolean(),
@@ -489,7 +489,7 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
                 return;
             }
 
-            const delay_secs = util.get_retry_backoff_seconds(xhr, attempt, true);
+            const delay_secs = get_retry_backoff_seconds(xhr, attempt, true);
             popup_banners.open_connection_error_popup_banner({
                 caller: "message_fetch",
                 retry_delay_secs: delay_secs,

--- a/web/src/onboarding_steps.ts
+++ b/web/src/onboarding_steps.ts
@@ -10,6 +10,7 @@ import * as dialog_widget from "./dialog_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type * as message_view from "./message_view.ts";
 import * as people from "./people.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import type {StateData, onboarding_step_schema} from "./state_data.ts";
 import * as util from "./util.ts";
 
@@ -49,7 +50,7 @@ export function post_onboarding_step_as_read(
                 return;
             }
 
-            const retry_delay_secs = util.get_retry_backoff_seconds(xhr, attempt);
+            const retry_delay_secs = get_retry_backoff_seconds(xhr, attempt);
             setTimeout(() => {
                 post_onboarding_step_as_read(
                     onboarding_step_name,

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -7,8 +7,8 @@ import {LazySet} from "./lazy_set.ts";
 import {page_params} from "./page_params.ts";
 import type {User} from "./people.ts";
 import * as people from "./people.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as sub_store from "./sub_store.ts";
-import * as util from "./util.ts";
 
 // Maps stream_id to the number of subscribers in that stream.
 // Note: These counts can sometimes be wrong due to races on the backend,
@@ -87,7 +87,7 @@ export async function fetch_stream_subscribers_with_retry(
     // Failed request, retry.
     if (subscribers === null) {
         num_attempts += 1;
-        const retry_delay_secs = util.get_retry_backoff_seconds(undefined, num_attempts);
+        const retry_delay_secs = get_retry_backoff_seconds(undefined, num_attempts);
         await new Promise((resolve) => setTimeout(resolve, retry_delay_secs * 1000));
         return fetch_stream_subscribers_with_retry(stream_id, num_attempts);
     }
@@ -565,7 +565,7 @@ export async function fetch_subscriptions_for_user(user_id: number): Promise<voi
             // Failed request, so try again (unless we've reached the retry limit)
             else if (result === null) {
                 num_attempts += 1;
-                const retry_delay_secs = util.get_retry_backoff_seconds(undefined, num_attempts);
+                const retry_delay_secs = get_retry_backoff_seconds(undefined, num_attempts);
                 await new Promise((resolve) => setTimeout(resolve, retry_delay_secs * 1000));
                 continue;
             }

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -12,6 +12,7 @@ import * as message_user_ids from "./message_user_ids.ts";
 import * as muted_users from "./muted_users.ts";
 import {page_params} from "./page_params.ts";
 import * as reload_state from "./reload_state.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as server_events_state from "./server_events_state.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
@@ -1961,7 +1962,7 @@ async function start_fetch_for_requested_users(): Promise<void> {
             break;
         } catch (error) {
             // Retry on error.
-            const retry_delay_secs = util.get_retry_backoff_seconds(undefined, num_attempts);
+            const retry_delay_secs = get_retry_backoff_seconds(undefined, num_attempts);
 
             // Since users are in `valid_user_ids`, we expect
             // the fetch to eventually succeed, so we log a warning

--- a/web/src/reload.ts
+++ b/web/src/reload.ts
@@ -15,6 +15,7 @@ import {page_params} from "./page_params.ts";
 import * as popup_banners from "./popup_banners.ts";
 import type {ReloadingReason} from "./popup_banners.ts";
 import * as reload_state from "./reload_state.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as util from "./util.ts";
 
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
@@ -332,7 +333,7 @@ export function initiate({
         },
         error(xhr) {
             server_reachable_check_failures += 1;
-            const retry_delay_secs = util.get_retry_backoff_seconds(
+            const retry_delay_secs = get_retry_backoff_seconds(
                 xhr,
                 server_reachable_check_failures,
             );

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -10,11 +10,11 @@ import {page_params} from "./page_params.ts";
 import * as popup_banners from "./popup_banners.ts";
 import * as reload from "./reload.ts";
 import * as reload_state from "./reload_state.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as sent_messages from "./sent_messages.ts";
 import * as server_events_dispatch from "./server_events_dispatch.js";
 import {mark_first_events_response_received, queue_id} from "./server_events_state.ts";
 import {server_message_schema} from "./server_message.ts";
-import * as util from "./util.ts";
 import * as watchdog from "./watchdog.ts";
 
 // Docs: https://zulip.readthedocs.io/en/latest/subsystems/events-system.html
@@ -205,7 +205,7 @@ function get_events({dont_block = false} = {}) {
             get_events_timeout = setTimeout(get_events, 0);
         },
         error(xhr, error_type) {
-            const retry_delay_secs = util.get_retry_backoff_seconds(xhr, get_events_failures);
+            const retry_delay_secs = get_retry_backoff_seconds(xhr, get_events_failures);
             try {
                 get_events_xhr = undefined;
                 // If we're old enough that our message queue has been

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -2,8 +2,8 @@ import assert from "minimalistic-assert";
 import * as z from "zod/mini";
 
 import * as channel from "./channel.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
-import * as util from "./util.ts";
 
 const stream_topic_history_response_schema = z.object({
     topics: z.array(
@@ -40,7 +40,7 @@ function fetch_channel_history_with_retry(stream_id: number, attempt = 1): void 
             pending_on_success_callbacks.delete(stream_id);
         },
         error(xhr) {
-            const retry_delay_secs = util.get_retry_backoff_seconds(xhr, attempt);
+            const retry_delay_secs = get_retry_backoff_seconds(xhr, attempt);
             setTimeout(() => {
                 fetch_channel_history_with_retry(stream_id, attempt + 1);
             }, retry_delay_secs * 1000);

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -111,6 +111,7 @@ import * as recent_view_ui from "./recent_view_ui.ts";
 import * as reload_setup from "./reload_setup.ts";
 import * as reminders_overlay_ui from "./reminders_overlay_ui.ts";
 import * as resize_handler from "./resize_handler.ts";
+import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import * as saved_snippets from "./saved_snippets.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui.ts";
@@ -893,7 +894,7 @@ $(() => {
                 error(xhr) {
                     register_failures += 1;
                     if (register_failures <= 5) {
-                        const retry_delay_secs = util.get_retry_backoff_seconds(
+                        const retry_delay_secs = get_retry_backoff_seconds(
                             xhr,
                             register_failures,
                             false,

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -546,8 +546,6 @@ export function is_topic_name_considered_empty(topic: string): boolean {
     return false;
 }
 
-export {get_retry_backoff_seconds, rewire_get_retry_backoff_seconds} from "./retry_backoff.ts";
-
 export async function sha256_hash(text: string): Promise<string | undefined> {
     // The Web Crypto API is only available in secure contexts (HTTPS or localhost).
     if (!window.isSecureContext) {

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -32,11 +32,11 @@ set_global("setTimeout", (func) => {
 
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
+const retry_backoff = zrequire("retry_backoff");
 const settings_config = zrequire("../src/settings_config.ts");
 const {set_current_user, set_realm} = zrequire("state_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
-const util = zrequire("util");
 
 const current_user = {};
 set_current_user(current_user);
@@ -1736,7 +1736,7 @@ run_test("fetch_users retry", async ({override, override_rewire}) => {
     });
 
     // Math.round will be `0`.
-    override_rewire(util, "get_retry_backoff_seconds", () => retry_count / 1000);
+    override_rewire(retry_backoff, "get_retry_backoff_seconds", () => retry_count / 1000);
     // Check that we retry the request after a failed attempt.
     blueslip.expect(
         "warn",
@@ -1979,7 +1979,7 @@ run_test("fetch_users corner case", async ({override, override_rewire}) => {
         }
     });
 
-    override_rewire(util, "get_retry_backoff_seconds", () => 0);
+    override_rewire(retry_backoff, "get_retry_backoff_seconds", () => 0);
     // Check that we retry the request after a failed attempt.
     blueslip.expect(
         "warn",

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -17,6 +17,7 @@ set_realm(realm);
 
 set_global("document", {});
 const util = zrequire("util");
+const {get_retry_backoff_seconds} = zrequire("retry_backoff");
 
 initialize_user_settings({user_settings: {}});
 
@@ -590,31 +591,31 @@ run_test("get_retry_backoff_seconds", () => {
 
     // Shorter backoff scale
     // First retry should be between 1-2 seconds.
-    let backoff = util.get_retry_backoff_seconds(xhr_500_error, 1, true);
+    let backoff = get_retry_backoff_seconds(xhr_500_error, 1, true);
     assert.ok(backoff >= 1);
     assert.ok(backoff < 3);
     // 100th retry should be between 16-32 seconds.
-    backoff = util.get_retry_backoff_seconds(xhr_500_error, 100, true);
+    backoff = get_retry_backoff_seconds(xhr_500_error, 100, true);
     assert.ok(backoff >= 16);
     assert.ok(backoff <= 32);
 
     // Longer backoff scale
     // First retry should be between 1-2 seconds.
-    backoff = util.get_retry_backoff_seconds(xhr_500_error, 1);
+    backoff = get_retry_backoff_seconds(xhr_500_error, 1);
     assert.ok(backoff >= 1);
     assert.ok(backoff <= 3);
     // 100th retry should be between 45-90 seconds.
-    backoff = util.get_retry_backoff_seconds(xhr_500_error, 100);
+    backoff = get_retry_backoff_seconds(xhr_500_error, 100);
     assert.ok(backoff >= 45);
     assert.ok(backoff <= 90);
 
     // Slower backoff scale
     // First retry should be between 2-4 seconds.
-    backoff = util.get_retry_backoff_seconds(xhr_500_error, 1, false, true);
+    backoff = get_retry_backoff_seconds(xhr_500_error, 1, false, true);
     assert.ok(backoff >= 2);
     assert.ok(backoff <= 4);
     // 100th retry should be between 45-90 seconds.
-    backoff = util.get_retry_backoff_seconds(xhr_500_error, 100, false, true);
+    backoff = get_retry_backoff_seconds(xhr_500_error, 100, false, true);
     assert.ok(backoff >= 45);
     assert.ok(backoff <= 90);
 
@@ -628,10 +629,10 @@ run_test("get_retry_backoff_seconds", () => {
         },
     };
     // First retry should be greater than the retry-after value.
-    backoff = util.get_retry_backoff_seconds(xhr_rate_limit_error, 1);
+    backoff = get_retry_backoff_seconds(xhr_rate_limit_error, 1);
     assert.ok(backoff >= 28.706807374954224);
     // 100th retry should be between 45-90 seconds.
-    backoff = util.get_retry_backoff_seconds(xhr_rate_limit_error, 100);
+    backoff = get_retry_backoff_seconds(xhr_rate_limit_error, 100);
     assert.ok(backoff >= 45);
     assert.ok(backoff <= 90);
 });


### PR DESCRIPTION
This PR is intended to correct Webpack build failures owing to stale references to the `util` module and an `export...from` syntax introduced by Claude/#39261.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>