### PR TITLE
[ai] click_handlers: Guard sidebar dragstart blur against non-elements.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -1024,7 +1024,12 @@ export function initialize(): void {
 
     // disable the draggability for left-sidebar components
     $("#stream_filters, #left-sidebar-navigation-list").on("dragstart", (e) => {
-        e.target.blur();
+        // e.target is the innermost node where the drag started, which is
+        // not necessarily an element with a blur() method; for instance,
+        // dragging a text selection makes it a Text node.
+        if (e.target instanceof HTMLElement) {
+            e.target.blur();
+        }
         return false;
     });
 


### PR DESCRIPTION
The left-sidebar dragstart handler calls e.target.blur() to drop the focus outline Chrome draws when a drag begins. But e.target is the innermost node where the drag started, which need not be an element with a blur() method: dragging a text selection (e.g. an accidentally selected channel name) makes it a Text node, throwing "e.target.blur is not a function".

Only call blur() when e.target is an HTMLElement. A Text node can never hold focus or show a focus outline, so there is nothing to clear in the skipped case; focusable sidebar controls are all HTMLElements and still get blurred.

https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/TypeError.3A.20e.2Etarget.2Eblur.20is.20not.20a.20function/near/2471801

---

from claude:

### Reproducer

1. In the **left sidebar**, pick a channel name in the channel list (the `#stream_filters` region) — e.g. a channel called `general`.
2. **Double-click the channel name** to select its text (the word should highlight). Double-click selects the word, which is the easiest way to get a text selection without navigating.
   - If double-click navigates/opens the channel instead of selecting, click-and-drag across the text once to highlight it, then release.
3. Now **press on the highlighted text and drag it** a few pixels (a normal text-drag gesture, as if dragging the selected word elsewhere).
4. As the drag starts, the console logs:
   ```
   Uncaught TypeError: e.target.blur is not a function
       at HTMLDivElement.<anonymous> (click_handlers.ts:1027)
   ```

The same works on the **Views list** (`#left-sidebar-navigation-list` — "Combined feed", "Mentions", etc.): select the label text and drag it.

### Why this triggers it
- Dragging a *text selection* dispatches `dragstart` with `e.target` set to the underlying `Text` node.
- `Text` inherits from `Node`, which has no `.blur()` (unlike `HTMLElement`/`SVGElement`), so `e.target.blur()` throws.
- This matches the handler's own comment about users *"involuntarily drag[ging] something"* — an accidental text selection + drag in the sidebar.
