### PR TITLE
user profile: Support back-button navigation between tabs.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -586,3 +586,7 @@ export function get_link_hash(link: string): string {
         return "";
     }
 }
+
+export function user_profile_url(user_id: number, tab_key = "profile"): string {
+    return `#user/${user_id}/${tab_key}`;
+}

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -401,6 +401,20 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
             return;
         }
 
+        if (base === "user") {
+            const user_id = Number.parseInt(hash_parser.get_current_hash_section(), 10);
+            if (people.is_known_user_id(user_id)) {
+                const tab_segment = hash_parser.get_current_nth_hash_section(2) ?? "profile";
+                const tab_key = tab_segment;
+                if (user_profile.get_user_id_if_user_profile_modal_open() === user_id) {
+                    user_profile.update_user_profile_tab(tab_key);
+                } else {
+                    user_profile.show_user_profile(user_id, tab_key);
+                }
+            }
+            return;
+        }
+
         // TODO: handle other cases like internal settings
         //       changes.
         return;
@@ -546,10 +560,16 @@ function do_hashchange_overlay(old_hash: string | undefined): void {
         if (!people.is_known_user_id(user_id)) {
             user_profile.show_user_profile_access_error_modal();
         } else {
-            user_profile.show_user_profile(user_id);
+            const tab_segment = hash_parser.get_current_nth_hash_section(2) ?? "profile";
+            const tab_key = tab_segment;
+            if (user_profile.get_user_id_if_user_profile_modal_open() === user_id) {
+                user_profile.update_user_profile_tab(tab_key);
+            } else {
+                user_profile.show_user_profile(user_id, tab_key);
+            }
         }
-        return;
     }
+    return;
 }
 
 function hashchanged(
@@ -582,6 +602,13 @@ function hashchanged(
 
     if (hash_parser.is_overlay_hash(current_hash)) {
         browser_history.state.changing_hash = true;
+        // If navigating between user profile tabs while modal is open,
+        // just switch the tab without closing and reopening the modal.
+        if (hash_parser.get_hash_category(current_hash) === "user") {
+            do_hashchange_overlay(old_hash);
+            browser_history.state.changing_hash = false;
+            return undefined;
+        }
         modals.close_active_if_any();
         do_hashchange_overlay(old_hash);
         browser_history.state.changing_hash = false;

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -706,7 +706,7 @@ export function handle_edit_form($tbody: JQuery): void {
             return;
         }
 
-        user_profile.show_user_profile(user_id, "manage-profile-tab");
+        user_profile.show_user_profile(user_id, "manage");
     });
 }
 

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -10,7 +10,6 @@ import render_user_card_popover_for_deleted_user from "../templates/popovers/use
 import render_user_card_popover_for_unknown_user from "../templates/popovers/user_card/user_card_popover_for_unknown_user.hbs";
 
 import * as blueslip from "./blueslip.ts";
-import * as browser_history from "./browser_history.ts";
 import * as buddy_data from "./buddy_data.ts";
 import * as channel from "./channel.ts";
 import * as compose_actions from "./compose_actions.ts";
@@ -850,7 +849,7 @@ function register_click_handlers(): void {
         if (is_overlay_hash(current_hash)) {
             user_profile.show_user_profile(user_id);
         } else {
-            browser_history.go_to_location(`user/${user_id}`);
+            user_profile.show_user_profile(user_id);
         }
         e.stopPropagation();
         e.preventDefault();
@@ -1006,7 +1005,7 @@ function register_click_handlers(): void {
     $("body").on("click", ".sidebar-popover-manage-user", function () {
         hide_all();
         const user_id = elem_to_user_id($(this).parents("ul"));
-        user_profile.show_user_profile(user_id, "manage-profile-tab");
+        user_profile.show_user_profile(user_id, "manage");
     });
 
     $("body").on("click", ".edit-your-profile", () => {

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -850,7 +850,7 @@ function register_click_handlers(): void {
         if (is_overlay_hash(current_hash)) {
             user_profile.show_user_profile(user_id);
         } else {
-            browser_history.go_to_location(`user/${user_id}`);
+            browser_history.go_to_location(hash_util.user_profile_url(user_id));
         }
         e.stopPropagation();
         e.preventDefault();
@@ -1006,7 +1006,7 @@ function register_click_handlers(): void {
     $("body").on("click", ".sidebar-popover-manage-user", function () {
         hide_all();
         const user_id = elem_to_user_id($(this).parents("ul"));
-        user_profile.show_user_profile(user_id, "manage-profile-tab");
+        user_profile.show_user_profile(user_id, "manage");
     });
 
     $("body").on("click", ".edit-your-profile", () => {

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -37,7 +37,7 @@ import * as custom_profile_fields_ui from "./custom_profile_fields_ui.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import type {DropdownWidget, DropdownWidgetOptions} from "./dropdown_widget.ts";
-import {get_current_hash_category} from "./hash_parser.ts";
+import {get_current_hash_category, is_overlay_hash} from "./hash_parser.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {InputPillContainer} from "./input_pill.ts";
@@ -555,18 +555,21 @@ export function hide_user_profile(): void {
 }
 
 function on_user_profile_hide(): void {
-    const base = get_current_hash_category();
     // After closing the user profile, if the hash consists of `#user`
     // it means that it acts as an overlay rather than a modal (when
     // no other overlay is in the background). Hence, we also need to
     // update the hash when we close it.
-    if (base === "user") {
+    if (get_current_hash_category() === "user") {
         browser_history.exit_overlay();
     }
 }
 
 function show_manage_user_tab(target: string): void {
     toggler.goto(target);
+}
+
+export function update_user_profile_tab(tab_key: string): void {
+    toggler.goto(tab_key);
 }
 
 function initialize_user_type_fields(user: User): void {
@@ -738,6 +741,20 @@ export function show_user_profile(user_id: number, default_tab_key = "profile"):
     }
 
     $("#user-profile-modal-holder").html(render_user_profile_modal(args));
+
+    if (get_current_hash_category() === "user") {
+        // Hash is already #user/ID (no tab) from a click handler — replace it
+        // in history so we don't create an extra back-button step.
+        window.history.replaceState(
+            null,
+            "",
+            browser_history.get_full_url(hash_util.user_profile_url(user_id, default_tab_key)),
+        );
+    } else if (!is_overlay_hash(window.location.hash)) {
+        browser_history.set_hash_before_overlay(window.location.hash);
+        browser_history.update(hash_util.user_profile_url(user_id, default_tab_key));
+    }
+
     modals.open("user-profile-modal", {autoremove: true, on_hide: on_user_profile_hide});
     $(".tabcontent").hide();
     $("#user-profile-modal .dialog_submit_button").prop("disabled", true);
@@ -746,7 +763,11 @@ export function show_user_profile(user_id: number, default_tab_key = "profile"):
 
     if (default_tab_key === "channels") {
         default_tab = 1;
-    } else if (default_tab_key === "manage") {
+    } else if (default_tab_key === "manage" && can_manage_profile) {
+        // Guard: the manage tab is only appended to opts.values when
+        // can_manage_profile is true. Without this check, direct navigation
+        // to #user/ID/manage by a non-admin passes selected=3 to the toggler
+        // with only 3 entries (indices 0-2), causing an out-of-range error.
         default_tab = 3;
     }
 
@@ -760,6 +781,9 @@ export function show_user_profile(user_id: number, default_tab_key = "profile"):
             {label: $t({defaultMessage: "User groups"}), key: "groups"},
         ],
         callback(_name: string | undefined, key: string) {
+            if (get_current_hash_category() === "user") {
+                browser_history.update(hash_util.user_profile_url(user.user_id, key));
+            }
             $(".tabcontent").hide();
             $(`#user-profile-modal [data-tab-key='${CSS.escape(key)}']`).show();
             $("#user-profile-modal").removeClass("prevent-user-modal-content-scrolling");

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -680,7 +680,7 @@ function add_user_to_groups(group_ids: number[], user_id: number, $alert_box: JQ
     add_user_to_next_group();
 }
 
-export function show_user_profile(user_id: number, default_tab_key = "profile-tab"): void {
+export function show_user_profile(user_id: number, default_tab_key = "profile"): void {
     const user = people.get_by_user_id(user_id);
     // Reset these widgets so that they are created again for the opened modal.
     user_streams_list_widget = undefined;
@@ -744,9 +744,9 @@ export function show_user_profile(user_id: number, default_tab_key = "profile-ta
 
     let default_tab = 0;
 
-    if (default_tab_key === "user-profile-streams-tab") {
+    if (default_tab_key === "channels") {
         default_tab = 1;
-    } else if (default_tab_key === "manage-profile-tab") {
+    } else if (default_tab_key === "manage") {
         default_tab = 3;
     }
 
@@ -755,35 +755,35 @@ export function show_user_profile(user_id: number, default_tab_key = "profile-ta
         selected: default_tab,
         child_wants_focus: true,
         values: [
-            {label: $t({defaultMessage: "Profile"}), key: "profile-tab"},
-            {label: $t({defaultMessage: "Channels"}), key: "user-profile-streams-tab"},
-            {label: $t({defaultMessage: "User groups"}), key: "user-profile-groups-tab"},
+            {label: $t({defaultMessage: "Profile"}), key: "profile"},
+            {label: $t({defaultMessage: "Channels"}), key: "channels"},
+            {label: $t({defaultMessage: "User groups"}), key: "groups"},
         ],
         callback(_name: string | undefined, key: string) {
             $(".tabcontent").hide();
-            $(`#${CSS.escape(key)}`).show();
+            $(`#user-profile-modal [data-tab-key='${CSS.escape(key)}']`).show();
             $("#user-profile-modal").removeClass("prevent-user-modal-content-scrolling");
             $("#user-profile-modal .manage-profile-tab-footer").removeClass(
                 "manage-profile-tab-active",
             );
             switch (key) {
-                case "profile-tab":
+                case "profile":
                     if (!has_initialized_user_type_fields) {
                         initialize_user_type_fields(user);
                         has_initialized_user_type_fields = true;
                     }
                     break;
-                case "user-profile-groups-tab": {
+                case "groups": {
                     render_or_update_user_groups_tab(user);
                     $("#user-profile-modal").addClass("prevent-user-modal-content-scrolling");
                     break;
                 }
-                case "user-profile-streams-tab": {
+                case "channels": {
                     void render_or_update_user_streams_tab(user);
                     $("#user-profile-modal").addClass("prevent-user-modal-content-scrolling");
                     break;
                 }
-                case "manage-profile-tab":
+                case "manage":
                     render_manage_profile_content(user);
                     break;
             }
@@ -802,7 +802,7 @@ export function show_user_profile(user_id: number, default_tab_key = "profile-ta
               : $t({defaultMessage: "Manage user"});
         const manage_profile_tab = {
             label: manage_profile_label,
-            key: "manage-profile-tab",
+            key: "manage",
         };
         opts.values.push(manage_profile_tab);
     }
@@ -1655,7 +1655,7 @@ export function initialize(): void {
         "click",
         "#user-profile-name-heading .user-profile-update-user-tab-button",
         (e) => {
-            show_manage_user_tab("manage-profile-tab");
+            show_manage_user_tab("manage");
             e.stopPropagation();
             e.preventDefault();
         },

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -37,7 +37,7 @@ import * as custom_profile_fields_ui from "./custom_profile_fields_ui.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import type {DropdownWidget, DropdownWidgetOptions} from "./dropdown_widget.ts";
-import {get_current_hash_category} from "./hash_parser.ts";
+import {get_current_hash_category, is_overlay_hash} from "./hash_parser.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {InputPillContainer} from "./input_pill.ts";
@@ -555,18 +555,21 @@ export function hide_user_profile(): void {
 }
 
 function on_user_profile_hide(): void {
-    const base = get_current_hash_category();
     // After closing the user profile, if the hash consists of `#user`
     // it means that it acts as an overlay rather than a modal (when
     // no other overlay is in the background). Hence, we also need to
     // update the hash when we close it.
-    if (base === "user") {
+    if (get_current_hash_category() === "user") {
         browser_history.exit_overlay();
     }
 }
 
 function show_manage_user_tab(target: string): void {
     toggler.goto(target);
+}
+
+export function update_user_profile_tab(tab_key: string): void {
+    toggler.goto(tab_key);
 }
 
 function initialize_user_type_fields(user: User): void {
@@ -738,6 +741,17 @@ export function show_user_profile(user_id: number, default_tab_key = "profile"):
     }
 
     $("#user-profile-modal-holder").html(render_user_profile_modal(args));
+
+    // Whether this profile view should behave as its own overlay (owning
+    // the URL hash) rather than as a modal on top of another overlay.
+    // The toggler callback below is the single place that acts on this,
+    // for both the initial tab and subsequent tab switches.
+    const should_own_hash =
+        get_current_hash_category() === "user" || !is_overlay_hash(window.location.hash);
+    if (should_own_hash && get_current_hash_category() !== "user") {
+        browser_history.set_hash_before_overlay(window.location.hash);
+    }
+
     modals.open("user-profile-modal", {autoremove: true, on_hide: on_user_profile_hide});
     $(".tabcontent").hide();
     $("#user-profile-modal .dialog_submit_button").prop("disabled", true);
@@ -746,11 +760,23 @@ export function show_user_profile(user_id: number, default_tab_key = "profile"):
 
     if (default_tab_key === "channels") {
         default_tab = 1;
-    } else if (default_tab_key === "manage") {
+    } else if (default_tab_key === "manage" && can_manage_profile) {
+        // Guard: the manage tab is only appended to opts.values when
+        // can_manage_profile is true. Without this check, direct navigation
+        // to #user/ID/manage by a non-admin passes selected=3 to the toggler
+        // with only 3 entries (indices 0-2), causing an out-of-range error.
         default_tab = 3;
     }
 
     let has_initialized_user_type_fields = false;
+    // Tracks whether the toggler's callback is firing for the tab it was
+    // constructed with, as opposed to a later tab switch. The initial call
+    // can disagree with the URL (e.g. #user/ID/manage opened by a user who
+    // can't manage the profile falls back to the profile tab), in which
+    // case we must correct the URL in place rather than push a new history
+    // entry, or the back button would bounce to the stale tab instead of
+    // closing the modal.
+    let is_initial_tab_selection = true;
     const opts = {
         selected: default_tab,
         child_wants_focus: true,
@@ -760,6 +786,19 @@ export function show_user_profile(user_id: number, default_tab_key = "profile"):
             {label: $t({defaultMessage: "User groups"}), key: "groups"},
         ],
         callback(_name: string | undefined, key: string) {
+            if (should_own_hash) {
+                const new_hash = hash_util.user_profile_url(user.user_id, key);
+                if (
+                    is_initial_tab_selection &&
+                    get_current_hash_category() === "user" &&
+                    window.location.hash !== new_hash
+                ) {
+                    window.history.replaceState(null, "", browser_history.get_full_url(new_hash));
+                } else {
+                    browser_history.update(new_hash);
+                }
+            }
+            is_initial_tab_selection = false;
             $(".tabcontent").hide();
             $(`#user-profile-modal [data-tab-key='${CSS.escape(key)}']`).show();
             $("#user-profile-modal").removeClass("prevent-user-modal-content-scrolling");

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -46,7 +46,7 @@
             </div>
             <main class="modal__content" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                 <div class="tab-data">
-                    <div class="tabcontent active" id="profile-tab">
+                    <div class="tabcontent active" id="profile-tab" data-tab-key="profile">
                         <div class="top">
                             <div class="col-wrap col-left">
                                 <div id="default-section">
@@ -122,7 +122,7 @@
                         </div>
                     </div>
 
-                    <div class="tabcontent" id="user-profile-streams-tab">
+                    <div class="tabcontent" id="user-profile-streams-tab" data-tab-key="channels">
                         <div class="stream_list_info banner-wrapper"></div>
                         <div class="stream-list-top-section">
                             <div class="header-section">
@@ -151,7 +151,7 @@
                         </div>
                     </div>
 
-                    <div class="tabcontent" id="user-profile-groups-tab">
+                    <div class="tabcontent" id="user-profile-groups-tab" data-tab-key="groups">
                         <div class="user-profile-group-list-alert banner-wrapper"></div>
                         <div class="group-list-top-section">
                             <div class="header-section">
@@ -189,7 +189,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="tabcontent" id="manage-profile-tab"></div>
+                    <div class="tabcontent" id="manage-profile-tab" data-tab-key="manage"></div>
                 </div>
             </main>
             <footer class="modal__footer manage-profile-tab-footer">


### PR DESCRIPTION
The user profile modal had no URL state for its tabs, so the browser back button would close the modal entirely instead of navigating between tabs.

Update the URL hash to #user/<id>/<tab> when the user profile modal opens or the active tab changes, so the browser back button can navigate between tabs and close the modal correctly. 

Use browser_history.update() instead of set_hash() so that tab changes fire hashchange events on back/forward navigation. Handle this in do_hashchange_overlay to switch tabs without closing and reopening the modal.

Fixes: #38156

This PR addresses the same issue as #38251, which currently has merge conflicts and pending change requests. It also addresses the issues raised by the maintainer, including the URL change when opening the modal from the settings overlay.

The approach here is more focused: 
- and tab changes call browser_history.update() directly in the toggler callback.

**How changes were tested:**

Tested manually in the browser:
- Open modal from a narrow : URL updates to #user/<id>/profile
- Switch tabs : URL updates accordingly
- Press back: navigates between tabs, then closes modal
- Close with X: URL returns to previous hash
- Paste #user/<id>/manage directly: modal opens on correct tab
- Open modal from settings: URL does not change

**Screenshots and screen captures:**

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

[BeforeBackButton.webm](https://github.com/user-attachments/assets/05a0c330-fd6c-4586-93e3-5674e39cd803)

</td>
<td>

[AfterBackButton.webm](https://github.com/user-attachments/assets/cbec8a91-c233-491b-8c30-b2298240b21c)

</td>
</tr>
</table>

<details>
<summary>Self-review checklist</summary>

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
