### PR TITLE
[ai] narrow_banner: Use plural error for multiple invalid dm-including users.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -482,13 +482,12 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             for (const user of people_in_dms.values()) {
                 if (user === undefined) {
                     return {
-                        // We intentionally give the same non-specific
-                        // error message as the single user case,
+                        // We don't pinpoint which user is invalid,
                         // since we don't display API email addresses
                         // or user IDs typically in UI errors, and we
                         // don't have any other handle as to which
                         // user this was supposed to be.
-                        title: $t({defaultMessage: "This user does not exist!"}),
+                        title: $t({defaultMessage: "One or more of these users do not exist!"}),
                     };
                 }
                 valid_people_in_dms.push(user);

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -117,6 +117,28 @@ function empty_search_query_banner(current_filter: Filter): NarrowBannerData {
     return {title: NO_SEARCH_RESULTS_TITLE};
 }
 
+// Returns a banner describing why direct messages to these users are
+// not allowed, or undefined if they are permitted.
+function dm_permission_error_banner(user_ids_string: string): NarrowBannerData | undefined {
+    const direct_message_error_string =
+        compose_validate.check_dm_permissions_and_get_error_string(user_ids_string);
+    if (direct_message_error_string === "") {
+        return undefined;
+    }
+    return {
+        title: direct_message_error_string,
+        html: $t_html(
+            {
+                defaultMessage: "<z-link>Learn more.</z-link>",
+            },
+            {
+                "z-link": (content_html) =>
+                    `<a target="_blank" rel="noopener noreferrer" href="/help/restrict-direct-messages">${content_html.join("")}</a>`,
+            },
+        ),
+    };
+}
+
 export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerData {
     const default_banner = {
         title: $t({defaultMessage: "There are no messages here."}),
@@ -368,21 +390,9 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             const user_ids = first_term.operand;
             assert(user_ids?.[0] !== undefined);
             const user_ids_string = util.sorted_ids(user_ids).join(",");
-            const direct_message_error_string =
-                compose_validate.check_dm_permissions_and_get_error_string(user_ids_string);
-            if (direct_message_error_string) {
-                return {
-                    title: direct_message_error_string,
-                    html: $t_html(
-                        {
-                            defaultMessage: "<z-link>Learn more.</z-link>",
-                        },
-                        {
-                            "z-link": (content_html) =>
-                                `<a target="_blank" rel="noopener noreferrer" href="/help/restrict-direct-messages">${content_html.join("")}</a>`,
-                        },
-                    ),
-                };
+            const dm_permission_error = dm_permission_error_banner(user_ids_string);
+            if (dm_permission_error) {
+                return dm_permission_error;
             }
             if (user_ids.length === 1) {
                 const user_id = user_ids[0];
@@ -493,21 +503,9 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                 valid_people_in_dms.push(user);
             }
             const person_id_string = valid_people_in_dms.map((user) => user.user_id).join(",");
-            const direct_message_error_string =
-                compose_validate.check_dm_permissions_and_get_error_string(person_id_string);
-            if (direct_message_error_string) {
-                return {
-                    title: direct_message_error_string,
-                    html: $t_html(
-                        {
-                            defaultMessage: "<z-link>Learn more.</z-link>",
-                        },
-                        {
-                            "z-link": (content_html) =>
-                                `<a target="_blank" rel="noopener noreferrer" href="/help/restrict-direct-messages">${content_html.join("")}</a>`,
-                        },
-                    ),
-                };
+            const dm_permission_error = dm_permission_error_banner(person_id_string);
+            if (dm_permission_error) {
+                return dm_permission_error;
             }
             if (
                 valid_people_in_dms.length === 1 &&

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -515,7 +515,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: This user does not exist!"),
+        empty_narrow_html("translated: One or more of these users do not exist!"),
     );
 
     current_filter = set_filter([["dm-including", [alice.user_id]]]);


### PR DESCRIPTION
When narrowing to a `dm-including` filter with more than one recipient where at least one user is invalid, we now show "One or more of these users do not exist!" rather than the singular "This user does not exist!". This matches the existing behavior of the `dm` case and is more accurate, while still avoiding pinpointing which specific user is invalid (we don't surface API email addresses or user IDs in these errors).

This is a follow-up to the review discussion in
https://github.com/zulip/zulip/pull/35888#discussion_r3342439968.

