### PR TITLE
[ai] registration: Don't require LDAP auth for externally-verified users.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1461,7 +1461,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
             self.assert_in_response("Enter your account details to complete registration.", result)
 
             # Verify that the user is asked for name but not password
-            self.assert_not_in_success_response(["id_password"], result)
+            self.assert_not_in_success_response(["id_password", "ldap-password"], result)
             self.assert_in_success_response(["id_full_name"], result)
             if expect_full_name_prepopulated:
                 # Verify the name field gets correctly pre-populated:
@@ -1966,6 +1966,54 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
                 name,
                 ldap_name,
                 skip_registration_form=True,
+            )
+
+    @override_settings(TERMS_OF_SERVICE_VERSION="1.0")
+    def test_social_auth_with_ldap_auth_registration_user_in_ldap_with_form(self) -> None:
+        """
+        Like test_social_auth_with_ldap_auth_registration_user_in_ldap, but with
+        a Terms of Service version set, so that
+        the registration form is displayed instead of being skipped. The form
+        should not prompt the user for their LDAP password, since their
+        identity was already verified by the social backend and any password
+        entered would be ignored.
+        """
+        self.init_default_ldap_database()
+        email = "newuser_email@zulip.com"
+        name = "Social Fullname"
+        # The name of this user in the LDAP directory, which is expected
+        # to take precedence over the name provided by the social backend.
+        ldap_name = "New LDAP fullname"
+        realm = get_realm("zulip")
+        subdomain = "zulip"
+        ldap_user_attr_map = {"full_name": "cn"}
+
+        backend_path = f"zproject.backends.{self.BACKEND_CLASS.__name__}"
+        with self.settings(
+            POPULATE_PROFILE_VIA_LDAP=True,
+            LDAP_EMAIL_ATTR="mail",
+            AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
+            AUTHENTICATION_BACKENDS=(
+                backend_path,
+                "zproject.backends.ZulipLDAPAuthBackend",
+                "zproject.backends.ZulipDummyBackend",
+            ),
+        ):
+            account_data_dict = self.get_account_data_dict(email=email, name=name)
+            result = self.social_auth_test(
+                account_data_dict,
+                expect_choose_email_screen=True,
+                subdomain=subdomain,
+                is_signup=True,
+            )
+            self.stage_two_of_registration(
+                result,
+                realm,
+                subdomain,
+                email,
+                name,
+                ldap_name,
+                skip_registration_form=False,
             )
 
     def test_social_auth_complete(self) -> None:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1920,6 +1920,54 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
             ],
         )
 
+    @override_settings(TERMS_OF_SERVICE_VERSION=None)
+    def test_social_auth_with_ldap_auth_registration_user_in_ldap(self) -> None:
+        """
+        This test checks that in configurations that use the LDAP authentication
+        backend and a social backend, a user who exists in the LDAP directory
+        can create an account via the social backend, with their identity
+        having been verified by the social backend.
+        """
+        self.init_default_ldap_database()
+        email = "newuser_email@zulip.com"
+        name = "Social Fullname"
+        # The name of this user in the LDAP directory, which is expected
+        # to take precedence over the name provided by the social backend.
+        ldap_name = "New LDAP fullname"
+        realm = get_realm("zulip")
+        subdomain = "zulip"
+        ldap_user_attr_map = {"full_name": "cn"}
+
+        backend_path = f"zproject.backends.{self.BACKEND_CLASS.__name__}"
+        with self.settings(
+            POPULATE_PROFILE_VIA_LDAP=True,
+            LDAP_EMAIL_ATTR="mail",
+            AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
+            AUTHENTICATION_BACKENDS=(
+                backend_path,
+                "zproject.backends.ZulipLDAPAuthBackend",
+                "zproject.backends.ZulipDummyBackend",
+            ),
+        ):
+            account_data_dict = self.get_account_data_dict(email=email, name=name)
+            result = self.social_auth_test(
+                account_data_dict,
+                expect_choose_email_screen=True,
+                subdomain=subdomain,
+                is_signup=True,
+            )
+            # The full name is populated from LDAP, so the registration form
+            # is skipped and the account is created directly.
+            self.stage_two_of_registration(
+                result,
+                realm,
+                subdomain,
+                email,
+                name,
+                ldap_name,
+                skip_registration_form=True,
+            )
+
     def test_social_auth_complete(self) -> None:
         def mock_process_error(backend: BaseOAuth2, data: Mapping[str, object]) -> None:
             raise AuthFailed(backend, "Not found")

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -584,7 +584,13 @@ def registration_helper(
                     # requires that LDAP accounts enter their LDAP
                     # password to register, or ZulipLDAPUserPopulator,
                     # which just populates UserProfile fields (no auth).
-                    require_ldap_password = isinstance(backend, ZulipLDAPAuthBackend)
+                    #
+                    # If the user is signing up via an external auth method,
+                    # their identity has already been verified and password_required
+                    # is set to False.
+                    require_ldap_password = (
+                        isinstance(backend, ZulipLDAPAuthBackend) and password_required
+                    )
                     break
 
         initial_data = {}

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -743,49 +743,46 @@ def registration_helper(
                 # with LDAP and we need to carefully decide whether they should be permitted to proceed
                 # with account creation anyway or be stopped. There are three scenarios to consider:
                 #
-                # 1. EmailAuthBackend is enabled for the realm. That explicitly means that a user
+                # 1. The user came here through one of the ExternalAuthMethods. Their identity has
+                #    already been verified by the external authentication method, so LDAP password
+                #    verification is not applicable and account creation can proceed.
+                # 2. EmailAuthBackend is enabled for the realm. That explicitly means that a user
                 #    with a valid confirmation link should be able to create an account, because
                 #    they were invited or organization permissions allowed sign up.
-                # 2. EmailAuthBackend is disabled - that means the organization wants to be authenticating
-                #    users with an external source (LDAP or one of the ExternalAuthMethods). If the user
-                #    came here through one of the ExternalAuthMethods, their identity can be considered
-                #    verified and account creation can proceed.
                 # 3. EmailAuthBackend is disabled and the user did not come here through an ExternalAuthMethod.
                 #    That means they came here by entering their email address on the registration page
                 #    and clicking the confirmation link received. That means their identity needs to be
                 #    verified with LDAP - and that has just failed above. Thus the account should NOT be
                 #    created.
                 #
-                if email_auth_enabled(realm):
-                    can_use_different_backend = True
                 # We can identify the user came here through an ExternalAuthMethod by password_required
                 # being set to False on the PreregistrationUser object.
-                elif len(get_external_method_dicts(realm)) > 0 and not password_required:
-                    can_use_different_backend = True
-                else:
-                    can_use_different_backend = False
-
-                if settings.LDAP_APPEND_DOMAIN:
-                    # In LDAP_APPEND_DOMAIN configurations, we don't allow making a non-LDAP account
-                    # if the email matches the ldap domain.
-                    can_use_different_backend = can_use_different_backend and (
-                        not email_belongs_to_ldap(realm, email)
-                    )
-                if return_data.get("no_matching_ldap_user") and can_use_different_backend:
-                    # If both the LDAP and Email or Social auth backends are
-                    # enabled, and there's no matching user in the LDAP
-                    # directory then the intent is to create a user in the
-                    # realm with their email outside the LDAP organization
-                    # (with e.g. a password stored in the Zulip database,
-                    # not LDAP).  So we fall through and create the new
-                    # account.
+                if len(get_external_method_dicts(realm)) > 0 and not password_required:
+                    # Scenario 1: fall through and create the new account.
                     pass
                 else:
-                    # TODO: This probably isn't going to give a
-                    # user-friendly error message, but it doesn't
-                    # particularly matter, because the registration form
-                    # is hidden for most users.
-                    return HttpResponseRedirect(reverse("login", query={"email": email}))
+                    can_use_different_backend = email_auth_enabled(realm)
+                    if settings.LDAP_APPEND_DOMAIN:
+                        # In LDAP_APPEND_DOMAIN configurations, we don't allow making a non-LDAP account
+                        # if the email matches the ldap domain.
+                        can_use_different_backend = can_use_different_backend and (
+                            not email_belongs_to_ldap(realm, email)
+                        )
+                    if return_data.get("no_matching_ldap_user") and can_use_different_backend:
+                        # Scenario 2: If both the LDAP and Email auth backends are
+                        # enabled, and there's no matching user in the LDAP
+                        # directory then the intent is to create a user in the
+                        # realm with their email outside the LDAP organization
+                        # (with e.g. a password stored in the Zulip database,
+                        # not LDAP).  So we fall through and create the new
+                        # account.
+                        pass
+                    else:
+                        # TODO: This probably isn't going to give a
+                        # user-friendly error message, but it doesn't
+                        # particularly matter, because the registration form
+                        # is hidden for most users.
+                        return HttpResponseRedirect(reverse("login", query={"email": email}))
             else:
                 assert isinstance(user, UserProfile)
                 user_profile = user


### PR DESCRIPTION
Fixes: a silent signup dead-loop on servers with both `ZulipLDAPAuthBackend` and an
external authentication method (e.g. SAML) enabled, reported in [#production help > Clear entries from zerver_preregistrationuser table](https://chat.zulip.org/#narrow/channel/31-production-help/topic/Clear.20entries.20from.20zerver_preregistrationuser.20table/with/2472555).

A new user who exists in the LDAP directory and signs up via SAML reaches
`registration_helper` with `password=None` (their identity was verified by the IdP, so
no password is collected). The LDAP `authenticate()` call rejects the empty password
without setting `no_matching_ldap_user`, and the security gate added around
CVE-2023-28623 only permits falling through to account creation when the user is
*absent* from LDAP. Result: a silent 302 back to the login page — no account, no
user-facing error, nothing above DEBUG in the logs, and one stray `PreregistrationUser`
row per attempt. Broken since Zulip Server 2.1.0.

The fix implements what scenario 2 of the existing security comment (from the
CVE-2023-28623 fix) already describes: if the user's identity was verified by an
external authentication method (identified by `password_required=False` on the
`PreregistrationUser`, the same signal the CVE fix uses), account creation proceeds
without LDAP password verification.

**Security analysis:**
- The CVE-2023-28623 protection is unchanged: email-confirmation-only signups
  (`password_required=True`) still cannot bypass LDAP when `EmailAuthBackend` is
  disabled; the existing regression test for the CVE still passes.
- One deliberate behavior change beyond the reported bug: an externally-verified user
  whose email matches `LDAP_APPEND_DOMAIN` but who is missing from LDAP can now also
  complete signup. This matches the behavior of a server with the external method
  enabled and no LDAP backend — the `LDAP_APPEND_DOMAIN` clamp's stated purpose
  ("don't allow making a non-LDAP account") targets password-based accounts created
  via email confirmation, and SSO signups create accounts with unusable passwords.
  Flagging for review in case LDAP-as-authoritative-deprovisioning-source is a
  property we want to preserve here.

**Possible follow-up (not in this PR):** `maybe_send_to_registration` rejects SAML
signup with "Please request an invite…" when `invite_required` is set, even if a valid
*email* invitation is pending for that address (it only honors multiuse invite links).

**How changes were tested:**

- [x] New test `test_social_auth_with_ldap_auth_registration_user_in_ldap`, which
      fails on `main` (`UserProfile.DoesNotExist`) and passes with this change
- [x] `./tools/test-backend zerver.tests.test_auth_backends zerver.tests.test_signup`
      (686 tests, including the CVE-2023-28623 regression test)
- [x] `./tools/lint zerver/views/registration.py zerver/tests/test_auth_backends.py`

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
