### PR TITLE
compose: clarify warning when linking to a private channel

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -2,11 +2,10 @@ import assert from "node:assert/strict";
 
 import type {Page} from "puppeteer";
 
+import {GENERIC_BOT_TYPE, OUTGOING_WEBHOOK_BOT_TYPE} from "../src/bot_type_values.ts";
+
 import * as common from "./lib/common.ts";
 import {test_credentials} from "./lib/common.ts";
-
-const OUTGOING_WEBHOOK_BOT_TYPE = "3";
-const GENERIC_BOT_TYPE = "1";
 
 const zuliprc_regex =
     /^data:application\/octet-stream;charset=utf-8,\[api]\nemail=.+\nkey=.+\nsite=.+\n$/;

--- a/web/src/bot_type_values.ts
+++ b/web/src/bot_type_values.ts
@@ -1,8 +1,9 @@
 // Bot type integer values from the API.
-export const GENERIC_BOT_TYPE = 1;
+export const GENERIC_BOT_TYPE_INT = 1;
 export const INCOMING_WEBHOOK_BOT_TYPE_INT = 2;
 export const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
 
 // String forms used as HTML form values.
+export const GENERIC_BOT_TYPE = "1";
 export const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 export const EMBEDDED_BOT_TYPE = "4";

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -296,10 +296,12 @@ export async function warn_if_private_stream_is_linked(
     );
 
     if (!existing_stream_warnings.includes(linked_stream.stream_id)) {
+        const audience_channel = stream_data.get_sub_by_id(stream_id)!;
         const new_row_html = render_private_stream_warning({
             stream_id: linked_stream.stream_id,
             banner_type: compose_banner.WARNING,
             channel_name: linked_stream.name,
+            audience_channel_name: audience_channel.name,
             classname: compose_banner.CLASSNAMES.private_stream_warning,
         });
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -12,7 +12,7 @@ import type {Bot} from "./bot_data.ts";
 import * as bot_helper from "./bot_helper.ts";
 import {
     EMBEDDED_BOT_TYPE,
-    GENERIC_BOT_TYPE,
+    GENERIC_BOT_TYPE_INT,
     INCOMING_WEBHOOK_BOT_TYPE_INT,
     OUTGOING_WEBHOOK_BOT_TYPE,
     OUTGOING_WEBHOOK_BOT_TYPE_INT,
@@ -455,7 +455,7 @@ function bot_info(bot_user_id: number): BotInfo {
             : {
                   bot_owner_id: null,
               }),
-        show_download_zuliprc_button: is_bot_owner && bot_user.bot_type === GENERIC_BOT_TYPE,
+        show_download_zuliprc_button: is_bot_owner && bot_user.bot_type === GENERIC_BOT_TYPE_INT,
         show_generate_integration_url_button:
             can_modify_bot && bot_user.bot_type === INCOMING_WEBHOOK_BOT_TYPE_INT,
     };

--- a/web/templates/compose_banner/private_stream_warning.hbs
+++ b/web/templates/compose_banner/private_stream_warning.hbs
@@ -1,5 +1,9 @@
 {{#> compose_banner . }}
     <p class="banner_message">
-        {{#tr}}Warning: <strong>#{channel_name}</strong> is a private channel.{{/tr}}
+        {{#tr}}
+            Warning: Not all subscribers of <z-audience-channel></z-audience-channel> can view <z-channel></z-channel>, a private channel.
+            {{#*inline "z-audience-channel"}}<strong>#{{audience_channel_name}}</strong>{{/inline}}
+            {{#*inline "z-channel"}}<strong>#{{channel_name}}</strong>{{/inline}}
+        {{/tr}}
     </p>
 {{/compose_banner}}

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -617,7 +617,8 @@ test_ui("warn_if_private_stream_is_linked", async ({mock_template}) => {
     let banner_rendered = false;
     mock_template("compose_banner/private_stream_warning.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.private_stream_warning);
-        assert.equal(data.channel_name, "Denmark");
+        assert.equal(data.channel_name, "secret");
+        assert.equal(data.audience_channel_name, "Denmark");
         banner_rendered = true;
         return "<banner-stub>";
     });
@@ -644,7 +645,7 @@ test_ui("warn_if_private_stream_is_linked", async ({mock_template}) => {
     compose_state.set_selected_recipient_id(denmark.stream_id);
     const secret_stream = {
         invite_only: true,
-        name: "Denmark",
+        name: "secret",
         stream_id: 22,
     };
     stream_data.add_sub_for_tests(secret_stream);

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -21,7 +21,7 @@ const {page_params} = require("./lib/zpage_params.cjs");
 
 const channel = mock_esm("../src/channel");
 
-const {GENERIC_BOT_TYPE, INCOMING_WEBHOOK_BOT_TYPE_INT} = zrequire("bot_type_values");
+const {GENERIC_BOT_TYPE_INT, INCOMING_WEBHOOK_BOT_TYPE_INT} = zrequire("bot_type_values");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const {set_current_user, set_realm} = zrequire("state_data");
@@ -544,7 +544,7 @@ test("is_subscriber_subset", async () => {
         email: "generic@zulip.com",
         full_name: "Generic Bot",
         user_id: 106,
-        bot_type: GENERIC_BOT_TYPE,
+        bot_type: GENERIC_BOT_TYPE_INT,
     });
     people.add_active_user(generic_bot);
 


### PR DESCRIPTION
Two follow-up changes from PR #39026 review threads:
1. `bot_type_values`: normalize int/string naming, migrate e2e test
Renames `GENERIC_BOT_TYPE` → `GENERIC_BOT_TYPE_INT` in `bot_type_values.ts` so the `_INT` suffix consistently marks the int form across all bot types (matching `INCOMING_WEBHOOK_BOT_TYPE_INT` and `OUTGOING_WEBHOOK_BOT_TYPE_INT`). Adds the string form `GENERIC_BOT_TYPE = "1"`, and migrates `web/e2e-tests/settings.test.ts` to import both string-form constants from `bot_type_values.ts` instead of defining them locally.
This file was missed in #39026 because it needed the string-form `GENERIC_BOT_TYPE` which didn't exist in `bot_type_values.ts` until this PR.

2. `compose`: clarify warning when linking to a private channel
Updates the warning banner from the concise:
**Warning: #channel-name is a private channel.**
to the more explicit:
**Warning: Not all subscribers of #this-channel can view #linked-channel, a private channel.**

Discussed in the [#feedback](https://chat.zulip.org/#narrow/channel/137-feedback/topic/Private.20channel.20compose.20banner.20when.20linking.2E) thread.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
1. New banner wording when linking a private channel.
<img width="1029" height="236" alt="image" src="https://github.com/user-attachments/assets/688ba058-835b-47d8-b303-acedc2057e24" />
2. No banner when linking a private channel from itself.
<img width="1037" height="180" alt="image" src="https://github.com/user-attachments/assets/61238f57-06dc-4c0b-90f8-32cc11f3fafd" />
3. No banner when linking a private channel from a DM.
<img width="1032" height="185" alt="image" src="https://github.com/user-attachments/assets/546bb515-deb3-460c-9638-147686a0373b" />
4. No banner when linking a public channel.
<img width="1021" height="181" alt="image" src="https://github.com/user-attachments/assets/d9714a63-66bb-4d4e-aab8-69929654af43" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
