### PR TITLE
policies: Bump Australia's digital age of consent from 15 to 16

### DIFF
--- a/templates/corporate/policies/age-of-consent.md
+++ b/templates/corporate/policies/age-of-consent.md
@@ -50,7 +50,7 @@ is higher than our minimal requirement of 13 years of age.
 
 ## Pacific
 
-* Australia: 15
+* Australia: 16
 * Indonesia: 18
 * Malaysia: 18
 * Philippines: 18


### PR DESCRIPTION
Notable commit messages:

    policies: Bump Australia's digital age of consent from 15 to 16
    
    Source:
      https://www.esafety.gov.au/about-us/industry-regulation/social-media-age-restrictions/assessment
    
    This was flagged individually; I haven't audited the full list.