### PR TITLE
github: Handle webhook payloads missing the sender field.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -321,6 +321,26 @@ class GitHubWebhookTest(WebhookTestCase):
         expected_message = ":cross_mark: baxterthehacker closed without merge [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
         self.check_webhook("pull_request__closed", TOPIC_PR, expected_message)
 
+    def test_pull_request_closed_msg_without_sender(self) -> None:
+        expected_message = ":cross_mark: Unknown closed without merge [PR #1](https://github.com/baxterthehacker/public-repo/pull/1)."
+        self.subscribe(self.test_user, self.channel_name)
+        payload = orjson.loads(self.get_body("pull_request__closed"))
+        del payload["sender"]
+        self.send_webhook_payload(
+            self.test_user,
+            self.url,
+            payload,
+            HTTP_X_GITHUB_EVENT="pull_request",
+            content_type="application/json",
+        )
+        msg = self.get_last_message()
+        self.assert_channel_message(
+            message=msg,
+            channel_name=self.channel_name,
+            topic_name=TOPIC_PR,
+            content=expected_message,
+        )
+
     def test_pull_request_closed_msg_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic_name = "notifications"

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -1010,7 +1010,12 @@ def get_user_mention(helper: Helper, github_username: str) -> str:
 
 
 def get_sender_name(helper: Helper) -> str:
-    return get_user_mention(helper, helper.payload["sender"]["login"].tame(check_string))
+    payload = helper.payload
+    if "sender" not in payload:
+        # GitHub documents "sender" as required, but very rarely omits it
+        # (e.g. an event attributed from a deleted account).
+        return "Unknown"
+    return get_user_mention(helper, payload["sender"]["login"].tame(check_string))
 
 
 def get_sender_url(payload: WildValue) -> str:


### PR DESCRIPTION
GitHub documents the top-level "sender" object as required on the events we handle, but in rare cases it is absent an event attributed to a deleted account (the pull request author shows up as the "ghost" user). In such cases message delivery raises an uncaught ValidationError that is logged as a server error and returned to GitHub as a 500.
This PR adds a defensive check for the `sender` field and if it is missing than added a fallback value as `Unknown`.

[Note that the explanation for why sender is missing is based on the available evidence and remains speculative. We do not have documentation from GitHub confirming this behavior. The information we have is that the request was generated by GitHub (User-Agent: GitHub-Hookshot), it was a pull_request/closed event, and the pull request author had a deleted account and appeared as the ghost user.]


<!-- Describe your pull request here.-->

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/127-integrations/topic/GitHub.20webhook/with/2471791)[#integrations > GitHub webhook](https://chat.zulip.org/#narrow/channel/127-integrations/topic/GitHub.20webhook/with/2471791)

**How changes were tested:**
Added test `test_pull_request_closed_msg_without_sender` and all tests pass

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1141" height="161" alt="image" src="https://github.com/user-attachments/assets/8e25397a-e2ca-4fc6-96d0-4629f944c5ec" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
