### PR TITLE
[ai] attachments: Handle attachment deleted during access validation.

### DIFF
--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -54,7 +54,13 @@ def remove_attachment(user_profile: UserProfile, attachment: Attachment) -> None
     attachment.delete()
 
 
-def validate_attachment_request_for_spectator_access(realm: Realm, attachment: Attachment) -> bool:
+def validate_attachment_request_for_spectator_access(
+    realm: Realm, attachment: Attachment
+) -> bool | None:
+    """Returns whether the spectator is authorized to access the
+    attachment, or None if the attachment was deleted concurrently
+    with the request.
+    """
     if attachment.realm != realm:
         return False
 
@@ -77,7 +83,11 @@ def validate_attachment_request_for_spectator_access(realm: Realm, attachment: A
                 ),
             ),
         )
-        attachment.refresh_from_db()
+
+        try:
+            attachment.refresh_from_db()
+        except Attachment.DoesNotExist:
+            return None
 
     if not attachment.is_web_public:
         return False
@@ -105,7 +115,13 @@ def validate_attachment_request(
 
     if isinstance(maybe_user_profile, AnonymousUser):
         assert realm is not None
-        return validate_attachment_request_for_spectator_access(realm, attachment), attachment
+        is_authorized = validate_attachment_request_for_spectator_access(realm, attachment)
+        if is_authorized is None:
+            # The attachment was deleted concurrently with this
+            # request; report it as not existing, just as if we
+            # had observed that initially.
+            return False, None
+        return is_authorized, attachment
 
     user_profile = maybe_user_profile
     assert isinstance(user_profile, UserProfile)
@@ -125,7 +141,13 @@ def validate_attachment_request(
                 ),
             ),
         )
-        attachment.refresh_from_db()
+        try:
+            attachment.refresh_from_db()
+        except Attachment.DoesNotExist:
+            # The attachment was deleted concurrently with this
+            # request; report it as not existing, just as if we
+            # had observed that initially.
+            return False, None
 
     if user_profile.id == attachment.owner_id:
         # If you own the file, you can access it.

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1037,6 +1037,63 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             self.assertEqual(response.getvalue(), b"zulip!")
             self.logout()
 
+    def test_file_download_authorization_attachment_deleted_concurrently(self) -> None:
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        fp = StringIO("zulip!")
+        fp.name = "zulip.txt"
+        result = self.client_post("/json/user_uploads", {"file": fp})
+        url = self.assert_json_success(result)["url"]
+        fp_path_id = re.sub(r"/user_uploads/", "", url)
+        body = f"First message ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{fp_path_id})"
+        self.send_stream_message(hamlet, "Denmark", body, "test")
+
+        # Message edits/moves invalidate the is_realm_public cache; the
+        # next access then refills it and refreshes the attachment.
+        Attachment.objects.filter(path_id=fp_path_id).update(is_realm_public=None)
+
+        # If the attachment is deleted concurrently between the initial
+        # fetch and that refresh, the attachment should be reported as
+        # not existing rather than raising an unhandled exception.
+        with mock.patch.object(Attachment, "refresh_from_db", side_effect=Attachment.DoesNotExist):
+            self.assertEqual(validate_attachment_request(hamlet, fp_path_id), (False, None))
+
+            # The call above refilled the is_realm_public cache; invalidate
+            # it again so the file-serving request also takes the refresh
+            # code path.
+            Attachment.objects.filter(path_id=fp_path_id).update(is_realm_public=None)
+            response = self.client_get(url)
+            self.assertEqual(response.status_code, 404)
+            self.assert_in_response("This file does not exist or has been deleted.", response)
+
+    def test_spectator_file_access_attachment_deleted_concurrently(self) -> None:
+        hamlet = self.example_user("hamlet")
+        self.login_user(hamlet)
+        fp = StringIO("zulip!")
+        fp.name = "zulip.txt"
+        result = self.client_post("/json/user_uploads", {"file": fp})
+        url = self.assert_json_success(result)["url"]
+        fp_path_id = re.sub(r"/user_uploads/", "", url)
+
+        self.make_stream("web-public-stream", is_web_public=True)
+        self.subscribe(hamlet, "web-public-stream")
+        body = f"First message ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{fp_path_id})"
+        self.send_stream_message(hamlet, "web-public-stream", body, "test")
+        self.logout()
+
+        # Sending the message above filled the is_web_public cache; the
+        # spectator code path only refreshes the attachment when that
+        # cache is unset, so invalidate it to exercise the refresh.
+        Attachment.objects.filter(path_id=fp_path_id).update(is_web_public=None)
+
+        # If the attachment is deleted concurrently between the initial
+        # fetch and that refresh, a spectator should get a 404 rather
+        # than an unhandled exception.
+        with mock.patch.object(Attachment, "refresh_from_db", side_effect=Attachment.DoesNotExist):
+            response = self.client_get(url)
+            self.assertEqual(response.status_code, 404)
+            self.assert_in_response("This file does not exist or has been deleted.", response)
+
     def test_serve_local(self) -> None:
         def check_xsend_links(
             name: str,


### PR DESCRIPTION
`validate_attachment_request` fetches the attachment and, when its `is_realm_public`
cache is unfilled (e.g. invalidated by a message move), refills the cache with a single
UPDATE query and then calls `refresh_from_db` to read the result. If the attachment is
deleted concurrently between the initial fetch and that refresh -- for example, its last
message was deleted, archiving the attachment -- `refresh_from_db` raises an unhandled
`Attachment.DoesNotExist`, turning into a 500 on the file-serving endpoints.

Treat this race the same as the attachment not existing at the initial fetch, returning
`(False, None)`, which the file-serving views translate into a 404.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
