### PR TITLE
docs: Fix incorrect display server info for keypress visualizers.

### DIFF
--- a/docs/contributing/presenting-visual-changes.md
+++ b/docs/contributing/presenting-visual-changes.md
@@ -386,5 +386,5 @@ You can check out the following tools for capturing screenshots and videos/GIFs.
 
 #### Linux
 
-- [hibiki](https://github.com/linuxmobile/hibiki), for X11.
-- [screenkey](https://gitlab.com/screenkey/screenkey), for Wayland.
+- [hibiki](https://github.com/linuxmobile/hibiki), for Wayland.
+- [screenkey](https://gitlab.com/screenkey/screenkey), for X11.


### PR DESCRIPTION
| Before | After |
|-----|-----|
| <img width="1920" height="1031" alt="image" src="https://github.com/user-attachments/assets/8c6df1aa-191b-4047-8ef3-990a525ee5ac" />| <img width="1920" height="1031" alt="image" src="https://github.com/user-attachments/assets/2305e175-dbfd-4a36-87d9-c7e84a8dd4b3" /> |

Fixes:[#documentation > keyboard interactions in PR screencasts @ 💬](https://chat.zulip.org/#narrow/channel/19-documentation/topic/keyboard.20interactions.20in.20PR.20screencasts/near/2473600)