### PR TITLE
web/styles: Fix alignment and rotation axis of slow-send spinner.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -842,7 +842,7 @@ strong {
 .messagebox-content .slow-send-spinner {
     display: block;
     font-size: 0.8571em; /* 12px at 14px/em */
-    text-align: right;
+    margin-left: auto;
     opacity: 0.8;
     color: var(--color-text-default);
     animation: rotate 1s infinite linear;


### PR DESCRIPTION
Fixes #38753

### Problem
The `.slow-send-spinner` was using `text-align: right;` combined with `display: block;`. This caused the element's layout box to stretch wide across its container, forcing the CSS keyframe `rotate` animation to calculate a skewed transform-origin. As a result, the loading icon would visibly wobble on an eccentric axis instead of spinning smoothly in place.

### Solution
- Removed `text-align: right;` from `.messagebox-content .slow-send-spinner`.
- Applied `margin-left: auto;` to cleanly collapse the Grid/Block element's bounding box to the exact visual width of the spinner icon itself (14px). 

This allows the default center `transform-origin` to correctly resolve to the spinner's absolute center point, ensuring a perfectly stable and clean rotational axis loop on slow connections.

### Testing
- **Visual Verification (Attached):** 
    * **Before:** *(Unable to capture a local video/screenshot. Due to severe WSL/Webpack caching issues on my local dev server, the browser aggressively holds onto the fixed CSS file and refuses to serve the reverted code. The original bug behavior and layout wobble can be tracked in the main issue #38753).*
    
   * **After:** video demonstrating the stable center-axis rotation of the spinner.

https://github.com/user-attachments/assets/e0a9b8b8-76b3-4555-95a5-80b0c4eb388a



Screenshots :-
<img width="89" height="108" alt="Screenshot 2026-06-10 160220" src="https://github.com/user-attachments/assets/c0354870-d28f-4ba5-b55a-229bd321d630" />
<img width="93" height="104" alt="Screenshot 2026-06-10 160236" src="https://github.com/user-attachments/assets/b3a44d43-029b-4559-a043-b01a1d1ed4ed" />
<img width="94" height="111" alt="Screenshot 2026-06-10 160252" src="https://github.com/user-attachments/assets/ce9259a2-35de-4ea5-9d0c-e44f938c2a8d" />

- **Linting:** Passed local frontend linter tests (`./tools/lint web/styles/zulip.css`) with no Stylelint errors.
<img width="1308" height="195" alt="image" src="https://github.com/user-attachments/assets/e6f55bf7-0c70-4938-92da-021fa8e89ff1" />

### Open Questions / Risks
* **None.** The fix is contained entirely within the CSS layout for this specific spinner class. The attached video verifies the visual behavior, though maintainers are welcome to double-check the interaction on an artificially throttled network connection if desired!

### Self-Review Checklist
- [x] My PR description follows the structural problem, solution, testing, and risks guidelines.
- [x] My commit message follows the required `web/styles:` component prefix convention.
- [x] The target issue is explicitly linked using the closing keyword (`Fixes #38753`).
- [x] I have run the frontend linter tests locally and verified they pass with zero errors.
- [x] I have provided the requested "after" screenshots/videos of the visual fix.
- [ ] I have provided the requested "before" screenshots/videos of the visual fix.

