### PR TITLE
api_docs: Improve aspect-ratio based image preview sizing recommendations.

### DIFF
--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -351,6 +351,11 @@ equally to both formats.
   spinner. This attribute encodes the dimensions of the original
   image as `{width}x{height}`. These dimensions are for the image as
   rendered, _after_ any EXIF rotation and mirroring has been applied.
+- When there's a run of consecutive images (Markdown images or
+  link-derived previews) not interspersed with text, clients may group
+  them together to show them side-by-side in a "gallery" block to make
+  good use of horizontal space, even if the images have line breaks
+  in between.
 - If the client would like to control the thumbnail resolution used,
   it can replace the final section of the URL (`840x560.webp` in the
   example above) with the `name` of its preferred format from the set

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -331,10 +331,12 @@ Transcoded images presented in Markdown image syntax are structured like this:
   src="/user_uploads/thumbnail/path/to/example.heic/840x560.webp">
 ```
 
-### Recommended client processing of image previews
+### Recommended client processing of inline images and image previews
 
-Clients are recommended to do the following when processing image
-previews:
+Clients are recommended to do the following when processing images,
+whether they appear as link-derived image previews or as images
+written with Markdown image syntax. Except where noted, these apply
+equally to both formats.
 
 - Images should be sized from their aspect ratio: choose a maximum
   height and derive the width from the aspect ratio (for very wide
@@ -357,8 +359,10 @@ previews:
   response. Clients should not make any assumptions about what format
   the server will use as the "default" thumbnail resolution, as it may
   change over time.
-- Download button type elements should provide the original image
-  (encoded via the `href` of the containing `a` tag).
+- Download button type elements should provide the original image. For
+  link-derived previews, this is the `href` of the containing `a` tag;
+  for images written with Markdown image syntax, it is the
+  `data-original-src` attribute.
 - The content-type of the original image is provided on a
   `data-original-content-type` attribute, so clients can decide if
   they are capable of rendering the original image.

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -336,13 +336,19 @@ Transcoded images presented in Markdown image syntax are structured like this:
 Clients are recommended to do the following when processing image
 previews:
 
-- Clients that would like to use the image's aspect ratio to lay out
-  one or more images in the message feed may use the
-  `data-original-dimensions` attribute, which is present even if the
-  image is a placeholder spinner.  This attribute encodes the
-  dimensions of the original image as `{width}x{height}`.  These
-  dimensions are for the image as rendered, _after_ any EXIF rotation
-  and mirroring has been applied.
+- Images should be sized from their aspect ratio: choose a maximum
+  height and derive the width from the aspect ratio (for very wide
+  images, constrain the width to the space available instead), rather
+  than rendering them inside a fixed-size container. This maximum
+  height may be scaled using the organization's
+  `realm_media_preview_size` policy, from the `register` response
+  (new in Zulip 12.0). Images smaller than the maximum height should
+  be rendered at their original size, rather than scaled up.
+- The aspect ratio is derived from the `data-original-dimensions`
+  attribute, which is present even if the image is a placeholder
+  spinner. This attribute encodes the dimensions of the original
+  image as `{width}x{height}`. These dimensions are for the image as
+  rendered, _after_ any EXIF rotation and mirroring has been applied.
 - If the client would like to control the thumbnail resolution used,
   it can replace the final section of the URL (`840x560.webp` in the
   example above) with the `name` of its preferred format from the set


### PR DESCRIPTION
This PR updates the "Recommended client processing of image previews" section of the docs by adding the fixed height approach used by the web client to support the image thumbnail sizing setting.

As discussed in [#mobile > Gallery image containers have fixed size @ 💬](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Gallery.20image.20containers.20have.20fixed.20size/near/2472007), the docs do not specify the approach required for implementing `media_preview_size` based setting. The relevant web PRs that necessitate this change are: #34208, #34564 and #37931.

The changes regarding "dinky" images and gallerification are not included as they do not have a basis in backend endpoints and are left to the discretion of the clients.

**Screenshots and screen captures:**

|Before|After|
|----|----|
|<img width="1000" height="625" alt="Screenshot 2026-06-05 at 22-58-34 Message formatting Zulip API documentation" src="https://github.com/user-attachments/assets/101080a0-4607-4ac8-91a0-d89a18be8741" />|<img width="1000" height="625" alt="Screenshot 2026-06-05 at 22-58-57 Message formatting Zulip API documentation" src="https://github.com/user-attachments/assets/0b6e368e-f958-401b-8d10-82cc6f8797dd" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
