### PR TITLE
[ai] auth: Honor pending email invitations when invitations are required

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -271,6 +271,7 @@ class HomepageForm(forms.Form):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.realm = kwargs.pop("realm", None)
         self.from_multiuse_invite = kwargs.pop("from_multiuse_invite", False)
+        self.has_pending_invitation = kwargs.pop("has_pending_invitation", False)
         self.require_password_backend = kwargs.pop("require_password_backend", False)
         self.invited_as = kwargs.pop("invited_as", None)
         super().__init__(*args, **kwargs)
@@ -292,7 +293,7 @@ class HomepageForm(forms.Form):
             )
 
         if not from_multiuse_invite:
-            if realm.invite_required:
+            if realm.invite_required and not self.has_pending_invitation:
                 raise ValidationError(
                     _(
                         "Please request an invite for {email} from the organization administrator."

--- a/zerver/models/prereg_users.py
+++ b/zerver/models/prereg_users.py
@@ -138,18 +138,27 @@ class PreregistrationUser(models.Model):
 
 def filter_to_valid_prereg_users(
     query: QuerySet[PreregistrationUser],
+    invitations_only: bool = False,
 ) -> QuerySet[PreregistrationUser]:
     """
-    If invite_expires_in_days is specified, we return only those PreregistrationUser
-    objects that were created at most that many days in the past.
+    Filters out PreregistrationUser objects that have been used or
+    revoked, or whose confirmation link has expired.
     """
     used_value = confirmation_settings.STATUS_USED
     revoked_value = confirmation_settings.STATUS_REVOKED
 
     query = query.exclude(status__in=[used_value, revoked_value])
-    return query.filter(
-        Q(confirmation__expiry_date=None) | Q(confirmation__expiry_date__gte=timezone_now())
+
+    confirmation_q = Q(confirmation__expiry_date=None) | Q(
+        confirmation__expiry_date__gte=timezone_now()
     )
+    if invitations_only:
+        # Imported here to avoid a circular import.
+        from confirmation.models import Confirmation
+
+        confirmation_q &= Q(confirmation__type=Confirmation.INVITATION)
+
+    return query.filter(confirmation_q)
 
 
 class MultiuseInvite(models.Model):

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -49,7 +49,7 @@ from typing_extensions import override
 from confirmation.models import Confirmation, create_confirmation_link
 from zerver.actions.create_realm import do_create_realm
 from zerver.actions.create_user import do_create_user, do_reactivate_user
-from zerver.actions.invites import do_invite_users
+from zerver.actions.invites import do_invite_users, do_revoke_user_invite
 from zerver.actions.realm_settings import (
     do_deactivate_realm,
     do_reactivate_realm,
@@ -1597,6 +1597,105 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.stage_two_of_registration(
             result, realm, subdomain, email, name, name, self.BACKEND_CLASS.full_name_validated
         )
+
+    @override_settings(TERMS_OF_SERVICE_VERSION=None)
+    def test_social_auth_registration_invitation_exists_invite_required(self) -> None:
+        """
+        A user with a pending email invitation can sign up via a social
+        backend even when the organization requires invitations to join.
+        """
+        email = "newuser@zulip.com"
+        name = "Full Name"
+        subdomain = "zulip"
+        realm = get_realm("zulip")
+        do_set_realm_property(realm, "invite_required", True, acting_user=None)
+
+        iago = self.example_user("iago")
+        with self.captureOnCommitCallbacks(execute=True):
+            do_invite_users(
+                iago,
+                [Invitee(full_name=name, email=email)],
+                [],
+                include_realm_default_subscriptions=True,
+                invite_expires_in_minutes=2 * 24 * 60,
+            )
+
+        account_data_dict = self.get_account_data_dict(email=email, name=name)
+        result = self.social_auth_test(
+            account_data_dict, expect_choose_email_screen=True, subdomain=subdomain, is_signup=True
+        )
+        self.stage_two_of_registration(
+            result, realm, subdomain, email, name, name, self.BACKEND_CLASS.full_name_validated
+        )
+
+    @override_settings(TERMS_OF_SERVICE_VERSION=None)
+    def test_social_auth_registration_invite_required_invalid_invitations(self) -> None:
+        """
+        In an organization requiring invitations, PreregistrationUser rows
+        that aren't valid pending invitations to this realm do not permit
+        signup.
+        """
+        email = "newuser@zulip.com"
+        name = "Full Name"
+        subdomain = "zulip"
+        realm = get_realm("zulip")
+        do_set_realm_property(realm, "invite_required", True, acting_user=None)
+        iago = self.example_user("iago")
+
+        def invite(referred_by: UserProfile) -> PreregistrationUser:
+            with self.captureOnCommitCallbacks(execute=True):
+                do_invite_users(
+                    referred_by,
+                    [Invitee(full_name=name, email=email)],
+                    [],
+                    include_realm_default_subscriptions=True,
+                    invite_expires_in_minutes=2 * 24 * 60,
+                )
+            return PreregistrationUser.objects.get(email=email, referred_by=referred_by)
+
+        def leftover_signup_attempt() -> None:
+            # Left over from the user's own earlier signup attempt, made
+            # while the organization permitted signups; such rows have
+            # referred_by unset.
+            prereg_user = PreregistrationUser.objects.create(
+                email=email, realm=realm, password_required=False
+            )
+            create_confirmation_link(prereg_user, Confirmation.USER_REGISTRATION)
+
+        def revoked_invitation() -> None:
+            do_revoke_user_invite(invite(iago), acting_user=iago)
+
+        def expired_invitation() -> None:
+            with time_machine.travel(timezone_now() - timedelta(days=3), tick=False):
+                invite(iago)
+
+        def invitation_in_another_realm() -> None:
+            invite(self.lear_user("cordelia"))
+
+        for setup in [
+            leftover_signup_attempt,
+            revoked_invitation,
+            expired_invitation,
+            invitation_in_another_realm,
+        ]:
+            with self.subTest(setup.__name__):
+                setup()
+                account_data_dict = self.get_account_data_dict(email=email, name=name)
+                result = self.social_auth_test(
+                    account_data_dict,
+                    expect_choose_email_screen=True,
+                    subdomain=subdomain,
+                    is_signup=True,
+                )
+                result = self.client_get(result["Location"])
+                self.assertEqual(result.status_code, 200)
+                self.assert_in_success_response(
+                    [f"Please request an invite for {email} from the organization administrator."],
+                    result,
+                )
+                with self.assertRaises(UserProfile.DoesNotExist):
+                    get_user_by_delivery_email(email, realm)
+                PreregistrationUser.objects.filter(email=email).delete()
 
     @override_settings(TERMS_OF_SERVICE_VERSION=None)
     def test_social_auth_with_invalid_multiuse_invite(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -264,6 +264,22 @@ def maybe_send_to_registration(
     else:
         invited_as = PreregistrationUser.INVITE_AS["MEMBER"]
 
+    try:
+        # If there's an existing, valid PreregistrationUser for this
+        # user, we want to fetch it since some values from it will be used
+        # as defaults for creating the signed up user.
+        existing_prereg_user = filter_to_valid_prereg_users(
+            PreregistrationUser.objects.filter(email__iexact=email, realm=realm)
+        ).latest("invited_at")
+    except PreregistrationUser.DoesNotExist:
+        existing_prereg_user = None
+
+    if multiuse_obj is None and existing_prereg_user is not None:
+        # When the user is not signing up via a multiuse invite link,
+        # the existing PreregistrationUser tells us the role they were
+        # intended to have, when they were invited.
+        invited_as = existing_prereg_user.invited_as
+
     form = HomepageForm(
         {"email": email},
         realm=realm,
@@ -276,19 +292,10 @@ def maybe_send_to_registration(
         # Confirmation objects, and then send the user to account
         # creation or confirm-continue-registration depending on
         # is_signup.
-        try:
-            # If there's an existing, valid PreregistrationUser for this
-            # user, we want to fetch it since some values from it will be used
-            # as defaults for creating the signed up user.
-            existing_prereg_user = filter_to_valid_prereg_users(
-                PreregistrationUser.objects.filter(email__iexact=email, realm=realm)
-            ).latest("invited_at")
-        except PreregistrationUser.DoesNotExist:
-            existing_prereg_user = None
-
+        #
         # full_name data passed here as argument should take precedence
-        # over the defaults with which the existing PreregistrationUser that we've just fetched
-        # was created.
+        # over the defaults with which the existing PreregistrationUser
+        # fetched above was created.
         prereg_user = create_preregistration_user(
             email,
             realm,
@@ -316,7 +323,6 @@ def maybe_send_to_registration(
             include_realm_default_subscriptions = (
                 existing_prereg_user.include_realm_default_subscriptions
             )
-            invited_as = existing_prereg_user.invited_as
 
         if streams_to_subscribe:
             prereg_user.streams.set(streams_to_subscribe)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -280,15 +280,22 @@ def maybe_send_to_registration(
         # intended to have, when they were invited.
         invited_as = existing_prereg_user.invited_as
 
-    # A valid email invitation for this user permits them to sign up
-    # even if the organization requires invitations to join. Only
-    # invitations have referred_by set; PreregistrationUser rows
-    # created by the user's own earlier signup attempts do not, and
-    # must not bypass the invite_required check.
+    # A valid pending email invitation for this user permits them to
+    # sign up even if the organization requires invitations to join;
+    # PreregistrationUser rows left over from the user's own earlier
+    # signup attempts are not invitations, and must not bypass the
+    # invite_required check.
     has_pending_invitation = filter_to_valid_prereg_users(
         PreregistrationUser.objects.filter(
-            email__iexact=email, realm=realm, referred_by__isnull=False
-        )
+            email__iexact=email,
+            realm=realm,
+            # Only invitations have referred_by set. This condition is
+            # redundant with invitations_only below; we keep both as
+            # defense in depth to ensure we only look at the intended
+            # PreregistrationUser set.
+            referred_by__isnull=False,
+        ),
+        invitations_only=True,
     ).exists()
 
     form = HomepageForm(

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -280,10 +280,22 @@ def maybe_send_to_registration(
         # intended to have, when they were invited.
         invited_as = existing_prereg_user.invited_as
 
+    # A valid email invitation for this user permits them to sign up
+    # even if the organization requires invitations to join. Only
+    # invitations have referred_by set; PreregistrationUser rows
+    # created by the user's own earlier signup attempts do not, and
+    # must not bypass the invite_required check.
+    has_pending_invitation = filter_to_valid_prereg_users(
+        PreregistrationUser.objects.filter(
+            email__iexact=email, realm=realm, referred_by__isnull=False
+        )
+    ).exists()
+
     form = HomepageForm(
         {"email": email},
         realm=realm,
         from_multiuse_invite=from_multiuse_invite,
+        has_pending_invitation=has_pending_invitation,
         invited_as=role or invited_as,
     )
     if form.is_valid():


### PR DESCRIPTION
Fixes: the second issue identified while investigating the report in
[#production help > ✔ Clear entries from zerver_preregistrationuser table](https://chat.zulip.org/#narrow/channel/31-production-help/topic/.E2.9C.94.20Clear.20entries.20from.20zerver_preregistrationuser.20table/with/2472555)
 — in an organization with **Invitations are required for joining
this organization** enabled, a user whom an administrator had invited *by email*
was still rejected with "Please request an invite for {email} from the organization
administrator." when signing up via an external authentication method (e.g. SAML).
`maybe_send_to_registration` only credited multiuse invite links; pending email
invitations were invisible to the `HomepageForm` `invite_required` check.

This is a dead end in practice for servers whose authentication backends give the
user no way to complete the email-based registration flow that the invitation link
itself drives (e.g. SAML-only servers, or the LDAP+SAML setups affected by the
companion PR for the registration bounce bug).

**Commits:**

1. `auth: Check spare licenses against the invited role during signup.` — prep:
   moves the existing `PreregistrationUser` lookup before form validation and
   passes the role the account will actually be created with into `HomepageForm`,
   so the `BILLING_ENABLED` spare-license check evaluates the right role (e.g. an
   invited guest can sign up when only guest licenses remain).

2. `auth: Honor pending email invitations when invitations are required.` — treats
   a valid pending email invitation as satisfying `invite_required`.

**Security analysis:** the invitation check is restricted to `PreregistrationUser`
rows with `referred_by` set — only `do_invite_users` (i.e. a member with invite
permission) creates such rows. Rows the user can cause to be created themselves
(signup attempts via `maybe_send_to_registration` or `prepare_activation_url`)
never set `referred_by`, so leftover signup-attempt rows cannot bypass
`invite_required`. Revoked and expired invitations are excluded via
`filter_to_valid_prereg_users`, and invitations to a different realm don't match
the realm-scoped query. All four of these non-qualifying cases are covered by a
parameterized regression test. The email comparison is `iexact` against the
externally-verified email, scoped to the request's realm.

**Open question:** the same wart exists in the plain email flow — typing an
invited address into `/register` on an `invite_required` realm is also rejected,
even with a pending invitation. That case is less severe (the user can use the
link in the invitation email), and honoring it there would need extra plumbing to
carry the invitation's stream/group defaults through `prepare_activation_url`, so
it is left for a follow-up.

**How changes were tested:**

- [x] New test `test_social_auth_registration_invitation_exists_invite_required`
      (runs for every social backend), verified to fail without the fix
- [x] New parameterized negative test covering rows that must not bypass
      `invite_required`: leftover non-invitation `PreregistrationUser` rows,
      revoked invitations, expired invitations, and invitations to a different
      realm
- [x] `./tools/test-backend zerver.tests.test_auth_backends zerver.tests.test_signup`
      against both the final state (694 tests) and the prep commit standalone
      (678 tests)
- [x] `./tools/lint zerver/views/auth.py zerver/forms.py zerver/tests/test_auth_backends.py`
- [x] Adversarial review of the access-control reasoning by a second pass
      (`referred_by` provenance; revocation, expiry, and cross-realm exclusion)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>