### PR TITLE
[ai] restore-backup: Read terminate-psql-sessions script as root.

### DIFF
--- a/scripts/setup/restore-backup
+++ b/scripts/setup/restore-backup
@@ -99,6 +99,15 @@ def restore_backup(tarball_file: IO[bytes], keep_settings: bool, keep_zulipconf:
         db_dir = os.path.join(tmp, "zulip-backup", "database")
         os.setresuid(0, 0, 0)
         run(["chown", "-R", POSTGRES_PWENT.pw_name, "--", tmp])
+        # Open the terminate-psql-sessions script while still running
+        # as root, since the postgres user may lack permission to read
+        # it -- e.g. because /home/zulip is not world-readable, which
+        # is the default for home directories on Debian 13 and Ubuntu
+        # 21.04 and newer.
+        terminate_psql_sessions_fd = os.open(
+            os.path.join(settings.DEPLOY_ROOT, "scripts", "setup", "terminate-psql-sessions"),
+            os.O_RDONLY,
+        )
         os.setresuid(POSTGRES_PWENT.pw_uid, POSTGRES_PWENT.pw_uid, 0)
 
         postgresql_env = dict(os.environ)
@@ -111,12 +120,11 @@ def restore_backup(tarball_file: IO[bytes], keep_settings: bool, keep_zulipconf:
                 postgresql_env["PGPASSWORD"] = db["PASSWORD"]
 
         run(
-            [
-                os.path.join(settings.DEPLOY_ROOT, "scripts", "setup", "terminate-psql-sessions"),
-                db["NAME"],
-            ],
+            ["bash", "-s", "-", db["NAME"]],
+            stdin=terminate_psql_sessions_fd,
             env=postgresql_env,
         )
+        os.close(terminate_psql_sessions_fd)
         run(["dropdb", "--if-exists", "--", db["NAME"]], cwd="/", env=postgresql_env)
         run(
             ["createdb", "--owner=zulip", "--template=template0", "--", db["NAME"]],


### PR DESCRIPTION
Fixes: #39470

On Debian 13 (and Ubuntu 21.04+), shadow's `/etc/login.defs` enables
`HOME_MODE` (0700 / 0750 respectively), so the installer's
`useradd -m zulip` creates a `/home/zulip` that the `postgres` user
cannot traverse. `restore-backup` drops to the postgres user (for
peer authentication) and then executes
`{DEPLOY_ROOT}/scripts/setup/terminate-psql-sessions`, which fails
with `PermissionError: [Errno 13]`.

This is the same failure `create-database` had, fixed in e3835554a7
(#15646) by feeding the script to `bash` via stdin; `restore-backup`
was the one remaining caller that execs it as postgres directly. The
fix here mirrors that approach: open the script while still running
as root (a raw fd, so the privilege-drop sequencing stays flat and
explicit), and pass it as stdin to `bash -s`.

Nothing else needs another user to traverse `/home/zulip`: nginx
workers run as the zulip user, and `process_fts_updates` is installed
into `/usr/local/bin` — which is why affected installs otherwise run
fine and only restores onto fresh machines fail.

**Testing:**
- [x] Reproduced the EACCES by exec'ing `terminate-psql-sessions`
      under a mode-0700 directory with euid postgres (matches the
      tracebacks in #39470 and #24016)
- [x] Verified the fix mechanism end-to-end as the postgres user
      against a running PostgreSQL: root-opened fd + `bash -s -
      <dbname>` executes the script successfully with the directory
      unreadable to postgres
- [x] Verified `HOME_MODE 0700` is enabled in Debian 13's
      src:shadow login.defs (commented out in Debian 12), and
      empirically that `useradd -m` yields 0750 on Ubuntu 22.04
- [x] `./tools/lint scripts/setup/restore-backup`

**Open questions:**
- Restores onto fresh Ubuntu ≥21.04 hosts have presumably been
  broken the same way since 2021 (0750 home, postgres not in the
  zulip group); #39470 is just the first clean report, since #24016
  was confounded by the reporter's own `chmod -R 700`.

**Self-review checklist** (applicable items):
- [x] Self-reviewed the changes for clarity and correctness
- [x] Each commit is a coherent, minimal idea and passes lint
- [x] Clear, greppable names; comments explain "why"
- [ ] Automated tests — not applicable; `scripts/` install/restore
      tooling has no test harness, verified manually as above
