### PR TITLE
templates: Replace decorative classless <hr /> elements with CSS borders.

### DIFF
--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -43,6 +43,13 @@
             & th {
                 font-weight: 400;
             }
+
+            & > a:last-child {
+                display: inline-block;
+                border-top: 1px solid var(--color-border-modal-bar);
+                margin-top: 20px;
+                padding-top: 20px;
+            }
         }
     }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -793,8 +793,17 @@
         padding-bottom: 10px;
     }
 
+    #prefer-html-input-group {
+        border-top: 1px solid var(--color-border-modal-bar);
+        margin-top: 20px;
+        padding-top: 20px;
+    }
+
     .stream-email-header {
         font-size: 1.125em; /* 18px at 16px/em */
+        border-top: 1px solid var(--color-border-modal-bar);
+        margin-top: 20px;
+        padding-top: 20px;
     }
 }
 
@@ -1093,6 +1102,13 @@
         /* Same bottom margin as that of input-group,
            to maintain consistent gap between fields. */
         margin-bottom: 1.25em; /* 20px at 16px/em */
+    }
+
+    .integration-url-header {
+        border-top: 1px solid var(--color-border-modal-bar);
+        margin-top: 20px;
+        padding-top: 20px;
+        font-weight: 600;
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1951,6 +1951,12 @@ label.preferences-radio-choice-label {
     margin-bottom: 20px;
 }
 
+#data-exports .tab-container {
+    border-top: 1px solid var(--color-border-modal-bar);
+    margin-top: 20px;
+    padding-top: 20px;
+}
+
 .settings-textarea,
 .modal-textarea {
     color: var(--color-text-default);

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -591,7 +591,6 @@
                 </tr>
             </table>
         </div>
-        <hr />
         <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
     </div>
 </div>

--- a/web/templates/markdown_help.hbs
+++ b/web/templates/markdown_help.hbs
@@ -24,7 +24,6 @@
                 </tbody>
             </table>
         </div>
-        <hr />
         <a href="/help/format-your-message-using-markdown" target="_blank" rel="noopener noreferrer">{{t "Detailed message formatting documentation" }}</a>
     </div>
 </div>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -208,7 +208,6 @@
                 </tbody>
             </table>
             <p>{{t "You can combine search filters as needed." }}</p>
-            <hr />
             <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
         </div>
     </div>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -29,8 +29,6 @@
     </form>
     {{/if}}
 
-    <hr/>
-
     <div class="tab-container"></div>
 
     <div class="export_section" data-export-section="data-exports">

--- a/web/templates/settings/generate_integration_url_modal.hbs
+++ b/web/templates/settings/generate_integration_url_modal.hbs
@@ -55,7 +55,6 @@
     </div>
     <div id="integrations-event-options"></div>
 </div>
-<hr />
 <p class="integration-url-header">{{t "URL for your integration"}}</p>
 <div class="integration-url">
     {{default_url_message}}

--- a/web/templates/stream_settings/copy_email_address_modal.hbs
+++ b/web/templates/stream_settings/copy_email_address_modal.hbs
@@ -6,9 +6,6 @@
         {{t "Which parts of the emails should be included in the Zulip messages?"}}
     </p>
     {{#each tags}}
-        {{#if (eq this.name "prefer-html") }}
-        <hr />
-        {{/if}}
         <div class="input-group" id="{{this.name}}-input-group">
             <label class="checkbox">
                 <input class="tag-checkbox" id="{{ this.name }}" type="checkbox"/>
@@ -17,7 +14,6 @@
             <label class="inline" for="{{this.name}}">{{this.description}}</label>
         </div>
     {{/each}}
-    <hr />
     <p class="stream-email-header">
         {{t "Channel email address:"}}
     </p>


### PR DESCRIPTION
### Context
This PR addresses part of #39359 by decoupling decorative dividers from the legacy Bootstrap `hr` rule.

### Changes
- Removed 7 classless `<hr />` elements across various templates (`keyboard_shortcuts`, `markdown_help`, `search_operators`, `data_exports_admin`, `generate_integration_url_modal`, and `copy_email_address_modal`).
- Implemented corresponding `border-top` styling using the `--color-border-modal-bar` CSS variable in `informational_overlays.css`, `settings.css`, and `modal.css` to ensure consistent theme-aware rendering (light/dark themes).

### Verification
- Verified visual parity with the previous layout across all affected overlays and modals.
- Confirmed that the new borders correctly adopt theme colors.

> Hi @laurynmm, thanks for the feedback!
> I have updated the self-review checklist to match the project template and added the before/after screenshots below to demonstrate visual parity.
> 
> 
### Before vs After Comparison

| Component | Before | After |
| :--- | :--- | :--- |
| **Keyboard Shortcuts** | <img width="200" alt="Keyboard Shortcuts Before" src="https://github.com/user-attachments/assets/c04e1a07-331e-4648-aa19-a5aca43164ff" /> | <img width="200" alt="Keyboard Shortcuts After" src="https://github.com/user-attachments/assets/815e8263-6a15-4ed8-9098-91f30b048848" /> |
| **Markdown Help** | <img width="200" alt="Markdown Help Before" src="https://github.com/user-attachments/assets/7b3f05ce-9d1e-4ab6-b88e-1ef1d0ffa722" /> | <img width="200" alt="Markdown Help After" src="https://github.com/user-attachments/assets/731dc374-57ea-4335-9a26-0ae5e1c786ba" /> |
| **Settings (Data Exports)** | <img width="200" alt="Settings (Data Exports) Before" src="https://github.com/user-attachments/assets/abf6ed87-8afd-4111-bd62-109a2e1e4ba2" /> | <img width="200" alt="Settings (Data Exports) After" src="https://github.com/user-attachments/assets/6b3ea792-0891-45fa-878d-b4d54d1d6fc4" /> |

> Please let me know if these align with the visual verification expectations.
### Self-Review Checklist
- [x] Code is clean and follows project standards.
- [x] Changes were tested in both themes.
- [x] Commit message follows project conventions.

Fixes #39359