### PR TITLE
api-docs: Document PATCH and DELETE /realm/profile_fields/{field_id}.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -321,9 +321,10 @@ No changes; API feature level used for the Zulip 12.0 release.
 **Feature level 476**
 
 * [`POST /realm/profile_fields`](/api/create-custom-profile-field),
-  [`GET /realm/profile_fields`](/api/get-custom-profile-fields) The
-  `display_in_profile_summary` parameter can now be set to true for the
-  `Paragraph` field type.
+  [`GET /realm/profile_fields`](/api/get-custom-profile-fields),
+  [`PATCH /realm/profile_fields/{field_id}`](/api/update-custom-profile-field)
+  The `display_in_profile_summary` parameter can now be set to true for
+  the `Paragraph` field type.
 
 **Feature level 475**
 
@@ -2042,9 +2043,11 @@ No changes; feature level used for Zulip 10.0 release.
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
   [`POST /realm/profile_fields`](/api/create-custom-profile-field),
-  [`GET /realm/profile_fields`](/api/get-custom-profile-fields): Added a new
-  parameter `editable_by_user` to custom profile field objects, which indicates whether
-  regular users can edit the value of the profile field on their own account.
+  [`GET /realm/profile_fields`](/api/get-custom-profile-fields),
+  [`PATCH /realm/profile_fields/{field_id}`](/api/update-custom-profile-field):
+  Added a new parameter `editable_by_user` to custom profile field objects,
+  which indicates whether regular users can edit the value of the profile
+  field on their own account.
 
 **Feature level 295**
 
@@ -2521,10 +2524,11 @@ No changes; feature level used for Zulip 9.0 release.
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
   [`POST /realm/profile_fields`](/api/create-custom-profile-field),
-  [`GET /realm/profile_fields`](/api/get-custom-profile-fields): Added a new
-  parameter `required`, on custom profile field objects, indicating whether an
-  organization administrator has configured the field as something users should
-  be required to provide.
+  [`GET /realm/profile_fields`](/api/get-custom-profile-fields),
+  [`PATCH /realm/profile_fields/{field_id}`](/api/update-custom-profile-field):
+  Added a new parameter `required`, on custom profile field objects,
+  indicating whether an organization administrator has configured the
+  field as something users should be required to provide.
 
 **Feature level 243**
 
@@ -3435,10 +3439,11 @@ No changes; feature level used for Zulip 6.0 release.
 **Feature level 146**
 
 * [`POST /realm/profile_fields`](/api/create-custom-profile-field),
-[`GET /realm/profile_fields`](/api/get-custom-profile-fields): Added a
-new parameter `display_in_profile_summary`, which clients use to
-decide whether to display the field in a small/summary section of the
-user's profile.
+[`GET /realm/profile_fields`](/api/get-custom-profile-fields),
+[`PATCH /realm/profile_fields/{field_id}`](/api/update-custom-profile-field):
+Added a new parameter `display_in_profile_summary`, which clients use
+to decide whether to display the field in a small/summary section of
+the user's profile.
 
 **Feature level 145**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -2455,9 +2455,10 @@ No changes; feature level used for Zulip 9.0 release.
 
 **Feature level 252**
 
-* `PATCH /realm/profile_fields/{field_id}`: `name`, `hint`, `display_in_profile_summary`,
-  `required` and `field_data` fields are now optional during an update. Previously we
-  required the clients to populate the fields in the PATCH request even if there was
+* [`PATCH /realm/profile_fields/{field_id}`](/api/update-custom-profile-field):
+  `name`, `hint`, `display_in_profile_summary`, `required` and `field_data`
+  fields are now optional during an update. Previously we required the
+  clients to populate the fields in the PATCH request even if there was
   no change to those fields' values.
 
 **Feature level 251**

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -151,6 +151,8 @@
 * [Get all custom profile fields](/api/get-custom-profile-fields)
 * [Reorder custom profile fields](/api/reorder-custom-profile-fields)
 * [Create a custom profile field](/api/create-custom-profile-field)
+* [Update a custom profile field](/api/update-custom-profile-field)
+* [Delete a custom profile field](/api/delete-custom-profile-field)
 * [Update realm-level defaults of user settings](/api/update-realm-user-settings-defaults)
 * [Get allowed domains](/api/get-realm-domains)
 * [Add an allowed domain](/api/add-realm-domain)

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -266,7 +266,7 @@ example:
 
     --custom-headers='{"X-Custom-Header": "value"}'
 
-The format is a JSON dictionary, so make sure that the header names do
+The format is a JSON object, so make sure that the header names do
 not contain any spaces in them and that you use the precise quoting
 approach shown above.
 
@@ -289,7 +289,7 @@ By having Zulip open in one browsre tab and this tool in another, you can
 quickly tweak your webhook code and send sample messages for different
 test fixtures.
 
-Custom HTTP headers must be entered as a JSON dictionary, if you want to
+Custom HTTP headers must be entered as a JSON object, if you want to
 use any. Feel free to use 4-spaces as tabs for indentation if you'd like.
 
 ## Step 5: Create automated tests

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -313,7 +313,7 @@ example:
 
     --custom-headers='{"X-Custom-Header": "value"}'
 
-The format is a JSON dictionary, so make sure that the header names do
+The format is a JSON object, so make sure that the header names do
 not contain any spaces in them and that you use the precise quoting
 approach shown above.
 
@@ -336,7 +336,7 @@ By having Zulip open in one browser tab and this tool in another, you can
 quickly tweak your webhook code and send sample messages for different
 test fixtures.
 
-Custom HTTP headers must be entered as a JSON dictionary, if you want to
+Custom HTTP headers must be entered as a JSON object, if you want to
 use any. Feel free to use 4-spaces as tabs for indentation if you'd like.
 
 ### Testing with the third-party service

--- a/starlight_help/src/content/docs/outgoing-webhooks.mdx
+++ b/starlight_help/src/content/docs/outgoing-webhooks.mdx
@@ -66,7 +66,7 @@ of two possible formats, described below.
 ### Example response payloads
 
 If the bot code wants to opt out of responding, it can explicitly
-encode a JSON dictionary that contains `response_not_required` set
+encode a JSON object that contains `response_not_required` set
 to `True`, so that no response message is sent to the user.  (This
 is helpful to distinguish deliberate non-responses from bugs.)
 

--- a/zerver/management/commands/send_webhook_fixture_message.py
+++ b/zerver/management/commands/send_webhook_fixture_message.py
@@ -26,7 +26,7 @@ command line option.
 Example:
     --custom-headers='{"X-Custom-Header": "value"}'
 
-The format is a JSON dictionary, so make sure that the header names do
+The format is a JSON object, so make sure that the header names do
 not contain any spaces in them and that you use the precise quoting
 approach shown above.
 """

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -14,6 +14,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.channel_folders import check_add_channel_folder
 from zerver.actions.create_user import do_create_user
+from zerver.actions.custom_profile_fields import try_add_realm_custom_profile_field
 from zerver.actions.presence import update_user_presence
 from zerver.actions.reactions import do_add_reaction
 from zerver.actions.realm_domains import do_add_realm_domain
@@ -24,8 +25,9 @@ from zerver.lib.events import do_events_register
 from zerver.lib.initial_password import initial_password
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import read_test_image_file
+from zerver.lib.types import ProfileFieldData
 from zerver.lib.upload import upload_message_attachment
-from zerver.models import Client, Message, NamedUserGroup, UserPresence
+from zerver.models import Client, CustomProfileField, Message, NamedUserGroup, UserPresence
 from zerver.models.channel_folders import ChannelFolder
 from zerver.models.realms import get_realm
 from zerver.models.users import UserProfile, get_user
@@ -356,6 +358,36 @@ def remove_realm_playground() -> dict[str, object]:
     )
     return {
         "playground_id": playground_id,
+    }
+
+
+@openapi_param_value_generator(["/realm/profile_fields/{field_id}:patch"])
+def update_custom_profile_field() -> dict[str, object]:
+    # A dropdown field, so that the documented field_data example validates.
+    field_data: ProfileFieldData = {
+        "0": {"text": "Vim", "order": "1"},
+        "1": {"text": "Emacs", "order": "2"},
+    }
+    field = try_add_realm_custom_profile_field(
+        get_realm("zulip"),
+        "Favorite IDE",
+        CustomProfileField.DROPDOWN,
+        field_data=field_data,
+    )
+    return {
+        "field_id": field.id,
+    }
+
+
+@openapi_param_value_generator(["/realm/profile_fields/{field_id}:delete"])
+def delete_custom_profile_field() -> dict[str, object]:
+    field = try_add_realm_custom_profile_field(
+        get_realm("zulip"),
+        "Field to delete",
+        CustomProfileField.SHORT_TEXT,
+    )
+    return {
+        "field_id": field.id,
     }
 
 

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -14,6 +14,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.channel_folders import check_add_channel_folder
 from zerver.actions.create_user import do_create_user
+from zerver.actions.custom_profile_fields import try_add_realm_custom_profile_field
 from zerver.actions.presence import update_user_presence
 from zerver.actions.reactions import do_add_reaction
 from zerver.actions.realm_domains import do_add_realm_domain
@@ -24,8 +25,9 @@ from zerver.lib.events import do_events_register
 from zerver.lib.initial_password import initial_password
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import read_test_image_file
+from zerver.lib.types import ProfileFieldData
 from zerver.lib.upload import upload_message_attachment
-from zerver.models import Client, Message, NamedUserGroup, UserPresence
+from zerver.models import Client, CustomProfileField, Message, NamedUserGroup, UserPresence
 from zerver.models.channel_folders import ChannelFolder
 from zerver.models.realms import RealmExport, get_realm
 from zerver.models.users import UserProfile, get_user
@@ -356,6 +358,36 @@ def remove_realm_playground() -> dict[str, object]:
     )
     return {
         "playground_id": playground_id,
+    }
+
+
+@openapi_param_value_generator(["/realm/profile_fields/{field_id}:patch"])
+def update_custom_profile_field() -> dict[str, object]:
+    # A dropdown field, so that the documented field_data example validates.
+    field_data: ProfileFieldData = {
+        "0": {"text": "Vim", "order": "1"},
+        "1": {"text": "Emacs", "order": "2"},
+    }
+    field = try_add_realm_custom_profile_field(
+        get_realm("zulip"),
+        "Favorite IDE",
+        CustomProfileField.DROPDOWN,
+        field_data=field_data,
+    )
+    return {
+        "field_id": field.id,
+    }
+
+
+@openapi_param_value_generator(["/realm/profile_fields/{field_id}:delete"])
+def delete_custom_profile_field() -> dict[str, object]:
+    field = try_add_realm_custom_profile_field(
+        get_realm("zulip"),
+        "Field to delete",
+        CustomProfileField.SHORT_TEXT,
+    )
+    return {
+        "field_id": field.id,
     }
 
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -661,7 +661,7 @@ def reorder_realm_profile_fields(client: Client) -> None:
 
 
 @openapi_test_function("/realm/profile_fields:post")
-def create_realm_profile_field(client: Client) -> None:
+def create_realm_profile_field(client: Client) -> int:
     # {code_example|start}
     # Create a custom profile field in the user's organization.
     request = {"name": "Phone", "hint": "Contact no.", "field_type": 1}
@@ -669,6 +669,30 @@ def create_realm_profile_field(client: Client) -> None:
     # {code_example|end}
     assert_success_response(result)
     validate_against_openapi_schema(result, "/realm/profile_fields", "post", "200")
+    return result["id"]
+
+
+@openapi_test_function("/realm/profile_fields/{field_id}:patch")
+def update_realm_profile_field(client: Client, field_id: int) -> None:
+    # {code_example|start}
+    # Update a custom profile field in the user's organization.
+    request = {"name": "Cell", "hint": "Contact number."}
+    result = client.call_endpoint(
+        url=f"/realm/profile_fields/{field_id}", method="PATCH", request=request
+    )
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/realm/profile_fields/{field_id}", "patch", "200")
+
+
+@openapi_test_function("/realm/profile_fields/{field_id}:delete")
+def delete_realm_profile_field(client: Client, field_id: int) -> None:
+    # {code_example|start}
+    # Delete a custom profile field in the user's organization.
+    result = client.call_endpoint(url=f"/realm/profile_fields/{field_id}", method="DELETE")
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/realm/profile_fields/{field_id}", "delete", "200")
 
 
 @openapi_test_function("/realm/filters:post")
@@ -2288,7 +2312,9 @@ def test_server_organizations(client: Client) -> None:
     delete_custom_emoji(client)
     get_realm_profile_fields(client)
     reorder_realm_profile_fields(client)
-    create_realm_profile_field(client)
+    profile_field_id = create_realm_profile_field(client)
+    update_realm_profile_field(client, profile_field_id)
+    delete_realm_profile_field(client, profile_field_id)
     export_realm(client)
     get_realm_exports(client)
     get_realm_export_consents(client)

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -661,7 +661,7 @@ def reorder_realm_profile_fields(client: Client) -> None:
 
 
 @openapi_test_function("/realm/profile_fields:post")
-def create_realm_profile_field(client: Client) -> None:
+def create_realm_profile_field(client: Client) -> int:
     # {code_example|start}
     # Create a custom profile field in the user's organization.
     request = {"name": "Phone", "hint": "Contact no.", "field_type": 1}
@@ -669,6 +669,30 @@ def create_realm_profile_field(client: Client) -> None:
     # {code_example|end}
     assert_success_response(result)
     validate_against_openapi_schema(result, "/realm/profile_fields", "post", "200")
+    return result["id"]
+
+
+@openapi_test_function("/realm/profile_fields/{field_id}:patch")
+def update_realm_profile_field(client: Client, field_id: int) -> None:
+    # {code_example|start}
+    # Update a custom profile field in the user's organization.
+    request = {"name": "Cell", "hint": "Contact number."}
+    result = client.call_endpoint(
+        url=f"/realm/profile_fields/{field_id}", method="PATCH", request=request
+    )
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/realm/profile_fields/{field_id}", "patch", "200")
+
+
+@openapi_test_function("/realm/profile_fields/{field_id}:delete")
+def delete_realm_profile_field(client: Client, field_id: int) -> None:
+    # {code_example|start}
+    # Delete a custom profile field in the user's organization.
+    result = client.call_endpoint(url=f"/realm/profile_fields/{field_id}", method="DELETE")
+    # {code_example|end}
+    assert_success_response(result)
+    validate_against_openapi_schema(result, "/realm/profile_fields/{field_id}", "delete", "200")
 
 
 @openapi_test_function("/realm/filters:post")
@@ -2299,7 +2323,9 @@ def test_server_organizations(client: Client) -> None:
     delete_custom_emoji(client)
     get_realm_profile_fields(client)
     reorder_realm_profile_fields(client)
-    create_realm_profile_field(client)
+    profile_field_id = create_realm_profile_field(client)
+    update_realm_profile_field(client, profile_field_id)
+    delete_realm_profile_field(client, profile_field_id)
     export_id = export_realm(client)
     get_realm_exports(client)
     get_realm_export_consents(client)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15275,6 +15275,162 @@ paths:
                         description: |
                           The ID for the custom profile field.
                     example: {"result": "success", "msg": "", "id": 9}
+  /realm/profile_fields/{field_id}:
+    patch:
+      operationId: update-custom-profile-field
+      summary: Update a custom profile field
+      tags: ["server_and_organizations"]
+      x-requires-administrator: true
+      description: |
+        Update the configuration of a
+        [custom profile field](/help/custom-profile-fields) in the user's
+        organization.
+
+        Only the parameters that are passed are modified; any parameter that
+        is omitted is left unchanged. A field's type cannot be changed after
+        it is created.
+
+        The `name`, `hint`, and `field_data` of a custom profile field using
+        one of Zulip's default external account providers (e.g., GitHub,
+        Twitter) cannot be changed; only its `display_in_profile_summary`,
+        `required`, `editable_by_user`, and `use_for_user_matching`
+        properties can be updated.
+
+        At most 2 fields can have `display_in_profile_summary` set to
+        `true` in an organization. In the web application, the checkbox
+        for this option is disabled for other fields once two are already
+        selected, with a tooltip explaining the limit.
+
+        **Changes**: Before Zulip 9.0 (feature level 252), the `name`, `hint`,
+        `field_data`, `display_in_profile_summary` and `required` parameters
+        were all required in every request, even when their values were
+        unchanged.
+      parameters:
+        - $ref: "#/components/parameters/CustomProfileFieldId"
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: |
+                    The name of the custom profile field, which appears both in
+                    the user-facing settings UI for configuring the custom profile
+                    fields and in the UI displaying a user's profile.
+                  type: string
+                  example: "Programming language"
+                hint:
+                  $ref: "#/components/schemas/CustomProfileFieldHintSchema"
+                field_data:
+                  $ref: "#/components/schemas/CustomProfileFieldDataSchema"
+                display_in_profile_summary:
+                  $ref: "#/components/schemas/CustomProfileFieldDisplayInProfileSummarySchema"
+                required:
+                  $ref: "#/components/schemas/CustomProfileFieldRequiredSchema"
+                editable_by_user:
+                  $ref: "#/components/schemas/CustomProfileFieldEditableByUserSchema"
+                use_for_user_matching:
+                  $ref: "#/components/schemas/CustomProfileFieldUseForUserMatchingSchema"
+            encoding:
+              field_data:
+                contentType: application/json
+              display_in_profile_summary:
+                contentType: application/json
+              required:
+                contentType: application/json
+              editable_by_user:
+                contentType: application/json
+              use_for_user_matching:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Field id 4 not found.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when there is no custom profile
+                          field with the requested ID:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "A field with that label already exists.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when another custom profile field
+                          already uses the requested name:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Only 2 custom profile fields can be displayed in the profile summary.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when setting
+                          `display_in_profile_summary` to `true` would exceed the
+                          organization's limit of 2 such fields:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Default custom field cannot be updated.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when attempting to change the
+                          `name`, `hint`, or `field_data` of a default external account field:
+    delete:
+      operationId: delete-custom-profile-field
+      summary: Delete a custom profile field
+      tags: ["server_and_organizations"]
+      x-requires-administrator: true
+      description: |
+        Delete a [custom profile field](/help/custom-profile-fields) in the
+        user's organization.
+
+        Deleting a custom profile field also removes the values configured for
+        that field from every user's profile. In the web application, the
+        number of affected users is shown in the delete confirmation modal
+        before the field is removed.
+      parameters:
+        - $ref: "#/components/parameters/CustomProfileFieldId"
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "Field id 4 not found.",
+                        "result": "error",
+                      }
+                    description: |
+                      A typical failed JSON response for when there is no custom profile
+                      field with the requested ID:
   /realm/user_settings_defaults:
     patch:
       operationId: update-realm-user-settings-defaults
@@ -27910,6 +28066,10 @@ components:
         dropdown UI for individual users to select an option.
 
         The interface for field type 7 is not yet stabilized.
+
+        See [profile field types](/help/custom-profile-fields#profile-field-types)
+        or the [`field_type` parameter](/api/create-custom-profile-field#parameter-field_type)
+        for what each field type number means.
       type: object
       example:
         {
@@ -31414,4 +31574,13 @@ components:
       schema:
         type: integer
       example: 17
+      required: true
+    CustomProfileFieldId:
+      name: field_id
+      in: path
+      description: |
+        The ID of the target custom profile field.
+      schema:
+        type: integer
+      example: 4
       required: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15207,9 +15207,9 @@ paths:
               properties:
                 name:
                   description: |
-                    The name of the custom profile field, which will appear both in
-                    user-facing settings UI for configuring custom profile fields and
-                    in UI displaying a user's profile.
+                    The name of the custom profile field, which appears both in
+                    the user-facing settings UI for configuring the custom profile
+                    fields and in the UI displaying a user's profile.
                   type: string
                   example: "Favorite programming language"
                 hint:
@@ -15254,7 +15254,7 @@ paths:
                     }
                 display_in_profile_summary:
                   description: |
-                    Whether clients should display this profile field in a summary section of a
+                    Whether clients should display this profile field in the summary section of a
                     user's profile (or in a more easily accessible "small profile").
 
                     At most 2 profile fields may have this property be true in a given

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27990,7 +27990,7 @@ components:
             Field types 3 (Dropdown) and 7 (External account) support storing
             additional configuration for the field type in the `field_data` attribute.
 
-            For field type 3 (Dropdown), this attribute is a JSON dictionary
+            For field type 3 (Dropdown), this attribute is a JSON object
             defining the choices and the order they will be displayed in the
             dropdown UI for individual users to select an option.
 
@@ -28061,7 +28061,7 @@ components:
         Field types 3 (Dropdown) and 7 (External account) support storing
         additional configuration for the field type in the `field_data` attribute.
 
-        For field type 3 (Dropdown), this attribute is a JSON dictionary
+        For field type 3 (Dropdown), this attribute is a JSON object
         defining the choices and the order they will be displayed in the
         dropdown UI for individual users to select an option.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15454,6 +15454,164 @@ paths:
                         description: |
                           The ID for the custom profile field.
                     example: {"result": "success", "msg": "", "id": 9}
+  /realm/profile_fields/{field_id}:
+    patch:
+      operationId: update-custom-profile-field
+      summary: Update a custom profile field
+      tags: ["server_and_organizations"]
+      x-requires-administrator: true
+      description: |
+        Update the configuration of a
+        [custom profile field](/help/custom-profile-fields) in the user's
+        organization.
+
+        The [type](/api/create-custom-profile-field#parameter-field_type)
+        of a custom profile field cannot be changed.
+
+        At most, 2 custom profile fields can have
+        [`display_in_profile_summary`](/api/update-custom-profile-field#parameter-display_in_profile_summary)
+        set to `true` in an organization.
+
+        For custom profile fields with type 7 (External account) that use
+        one of Zulip's configured default external account providers
+        (e.g., GitHub, LinkedIn, etc.), the field's
+        [`name`](/api/update-custom-profile-field#parameter-name),
+        [`hint`](/api/update-custom-profile-field#parameter-hint), and
+        [`field_data`](/api/update-custom-profile-field#parameter-field_data)
+        cannot be changed, and attempting to do so will return an error.
+
+        **Changes**: Before Zulip 9.0 (feature level 252), the `name`,
+        `hint`, `field_data`, `required` and `display_in_profile_summary`
+        parameters were all required in every request, even when their
+        values were unchanged.
+      parameters:
+        - $ref: "#/components/parameters/CustomProfileFieldId"
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: |
+                    The name of the custom profile field, which appears both in
+                    the user-facing settings UI for configuring the custom profile
+                    fields and in the UI displaying a user's profile.
+                  type: string
+                  example: "Programming language"
+                hint:
+                  $ref: "#/components/schemas/CustomProfileFieldHintSchema"
+                field_data:
+                  $ref: "#/components/schemas/CustomProfileFieldDataSchema"
+                display_in_profile_summary:
+                  $ref: "#/components/schemas/CustomProfileFieldDisplayInProfileSummarySchema"
+                required:
+                  $ref: "#/components/schemas/CustomProfileFieldRequiredSchema"
+                editable_by_user:
+                  $ref: "#/components/schemas/CustomProfileFieldEditableByUserSchema"
+                use_for_user_matching:
+                  $ref: "#/components/schemas/CustomProfileFieldUseForUserMatchingSchema"
+            encoding:
+              field_data:
+                contentType: application/json
+              display_in_profile_summary:
+                contentType: application/json
+              required:
+                contentType: application/json
+              editable_by_user:
+                contentType: application/json
+              use_for_user_matching:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Field id 4 not found.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when there is no custom profile
+                          field with the requested ID:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "A field with that label already exists.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when another custom profile field
+                          already uses the requested name:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Only 2 custom profile fields can be displayed in the profile summary.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when setting
+                          `display_in_profile_summary` to `true` would exceed the
+                          organization's limit of 2 such fields:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Default custom field cannot be updated.",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when attempting to change the
+                          `name`, `hint`, or `field_data` of a default external account field:
+    delete:
+      operationId: delete-custom-profile-field
+      summary: Delete a custom profile field
+      tags: ["server_and_organizations"]
+      x-requires-administrator: true
+      description: |
+        Delete a [custom profile field](/help/custom-profile-fields) in
+        the user's organization.
+
+        This will also permanently delete any value configured for the
+        custom profile field from every user profile in the database.
+        Therefore, it's recommended that clients warn the active user of
+        the related data removal before submitting the request, e.g.,
+        notify them of how many users will have their profile data
+        deleted as a result of deleting the custom profile field.
+      parameters:
+        - $ref: "#/components/parameters/CustomProfileFieldId"
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "Field id 4 not found.",
+                        "result": "error",
+                      }
+                    description: |
+                      A typical failed JSON response for when there is no custom profile
+                      field with the requested ID:
   /realm/user_settings_defaults:
     patch:
       operationId: update-realm-user-settings-defaults
@@ -28185,6 +28343,10 @@ components:
         dropdown UI for individual users to select an option.
 
         The interface for field type 7 is not yet stabilized.
+
+        See [profile field types](/help/custom-profile-fields#profile-field-types)
+        or the [`field_type` parameter](/api/create-custom-profile-field#parameter-field_type)
+        for what each field type number means.
       type: object
       example:
         {
@@ -31712,4 +31874,13 @@ components:
       schema:
         type: integer
       example: 17
+      required: true
+    CustomProfileFieldId:
+      name: field_id
+      in: path
+      description: |
+        The ID of the target custom profile field.
+      schema:
+        type: integer
+      example: 4
       required: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15391,12 +15391,6 @@ paths:
                     fields and in the UI displaying a user's profile.
                   type: string
                   example: "Favorite programming language"
-                hint:
-                  description: |
-                    The help text to be displayed for the custom profile field in user-facing
-                    settings UI for configuring custom profile fields.
-                  type: string
-                  example: "Your favorite programming language."
                 field_type:
                   description: |
                     The field type can be any of the supported custom profile field types. See the
@@ -15415,72 +15409,18 @@ paths:
                     **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
                   type: integer
                   example: 3
+                hint:
+                  $ref: "#/components/schemas/CustomProfileFieldHintSchema"
                 field_data:
-                  description: |
-                    Field types 3 (Dropdown) and 7 (External account) support storing
-                    additional configuration for the field type in the `field_data` attribute.
-
-                    For field type 3 (Dropdown), this attribute is a JSON dictionary
-                    defining the choices and the order they will be displayed in the
-                    dropdown UI for individual users to select an option.
-
-                    The interface for field type 7 is not yet stabilized.
-                  type: object
-                  example:
-                    {
-                      "python": {"text": "Python", "order": "1"},
-                      "java": {"text": "Java", "order": "2"},
-                    }
+                  $ref: "#/components/schemas/CustomProfileFieldDataSchema"
                 display_in_profile_summary:
-                  description: |
-                    Whether clients should display this profile field in the summary section of a
-                    user's profile (or in a more easily accessible "small profile").
-
-                    At most 2 profile fields may have this property be true in a given
-                    organization.
-
-                    The "Users" profile field is not supported, but that is likely to
-                    be temporary.
-
-                    **Changes**: Before Zulip 12.0 (feature level 476), the
-                    "Paragraph" field type was not supported.
-
-                    New in Zulip 6.0 (feature level 146).
-                  type: boolean
-                  example: true
+                  $ref: "#/components/schemas/CustomProfileFieldDisplayInProfileSummarySchema"
                 required:
-                  description: |
-                    Whether an organization administrator has configured this profile field as
-                    required.
-
-                    Because the required property is mutable, clients cannot assume that a required
-                    custom profile field has a value. The Zulip web application displays a prominent
-                    banner to any user who has not set a value for a required field.
-
-                    **Changes**: New in Zulip 9.0 (feature level 244).
-                  type: boolean
-                  example: true
+                  $ref: "#/components/schemas/CustomProfileFieldRequiredSchema"
                 editable_by_user:
-                  description: |
-                    Whether regular users can edit this profile field on their own account.
-
-                    Note that organization administrators can edit custom profile fields for any user
-                    regardless of this setting.
-
-                    **Changes**: New in Zulip 10.0 (feature level 296).
-                  type: boolean
-                  example: true
+                  $ref: "#/components/schemas/CustomProfileFieldEditableByUserSchema"
                 use_for_user_matching:
-                  description: |
-                    Whether this custom profile field should be used to match users in typeahead
-                    suggestions. Only allowed for Short Text and External Account
-                    [profile field types](/help/custom-profile-fields#profile-field-types).
-
-                    This field is only included when its value is `true`.
-
-                    **Changes**: New in Zulip 12.0 (feature level 455).
-                  type: boolean
-                  example: false
+                  $ref: "#/components/schemas/CustomProfileFieldUseForUserMatchingSchema"
               required:
                 - field_type
             encoding:
@@ -28229,6 +28169,78 @@ components:
         - hint
         - required
         - editable_by_user
+    CustomProfileFieldHintSchema:
+      description: |
+        The help text to be displayed for the custom profile field in user-facing
+        settings UI for configuring custom profile fields.
+      type: string
+      example: "Your favorite programming language."
+    CustomProfileFieldDataSchema:
+      description: |
+        Field types 3 (Dropdown) and 7 (External account) support storing
+        additional configuration for the field type in the `field_data` attribute.
+
+        For field type 3 (Dropdown), this attribute is a JSON dictionary
+        defining the choices and the order they will be displayed in the
+        dropdown UI for individual users to select an option.
+
+        The interface for field type 7 is not yet stabilized.
+      type: object
+      example:
+        {
+          "python": {"text": "Python", "order": "1"},
+          "java": {"text": "Java", "order": "2"},
+        }
+    CustomProfileFieldDisplayInProfileSummarySchema:
+      description: |
+        Whether clients should display this profile field in the summary section of a
+        user's profile (or in a more easily accessible "small profile").
+
+        At most 2 profile fields may have this property be true in a given
+        organization.
+
+        The "Users" profile field is not supported, but that is likely to
+        be temporary.
+
+        **Changes**: Before Zulip 12.0 (feature level 476), the
+        "Paragraph" field type was not supported.
+
+        New in Zulip 6.0 (feature level 146).
+      type: boolean
+      example: true
+    CustomProfileFieldRequiredSchema:
+      description: |
+        Whether an organization administrator has configured this profile field as
+        required.
+
+        Because the required property is mutable, clients cannot assume that a required
+        custom profile field has a value. The Zulip web application displays a prominent
+        banner to any user who has not set a value for a required field.
+
+        **Changes**: New in Zulip 9.0 (feature level 244).
+      type: boolean
+      example: true
+    CustomProfileFieldEditableByUserSchema:
+      description: |
+        Whether regular users can edit this profile field on their own account.
+
+        Note that organization administrators can edit custom profile fields for any user
+        regardless of this setting.
+
+        **Changes**: New in Zulip 10.0 (feature level 296).
+      type: boolean
+      example: true
+    CustomProfileFieldUseForUserMatchingSchema:
+      description: |
+        Whether this custom profile field should be used to match users in typeahead
+        suggestions. Only allowed for Short Text and External Account
+        [profile field types](/help/custom-profile-fields#profile-field-types).
+
+        This field is only included when its value is `true`.
+
+        **Changes**: New in Zulip 12.0 (feature level 455).
+      type: boolean
+      example: false
     OnboardingStep:
       type: object
       additionalProperties: false

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15212,12 +15212,6 @@ paths:
                     fields and in the UI displaying a user's profile.
                   type: string
                   example: "Favorite programming language"
-                hint:
-                  description: |
-                    The help text to be displayed for the custom profile field in user-facing
-                    settings UI for configuring custom profile fields.
-                  type: string
-                  example: "Your favorite programming language."
                 field_type:
                   description: |
                     The field type can be any of the supported custom profile field types. See the
@@ -15236,72 +15230,18 @@ paths:
                     **Changes**: Field type `8` added in Zulip 6.0 (feature level 151).
                   type: integer
                   example: 3
+                hint:
+                  $ref: "#/components/schemas/CustomProfileFieldHintSchema"
                 field_data:
-                  description: |
-                    Field types 3 (Dropdown) and 7 (External account) support storing
-                    additional configuration for the field type in the `field_data` attribute.
-
-                    For field type 3 (Dropdown), this attribute is a JSON dictionary
-                    defining the choices and the order they will be displayed in the
-                    dropdown UI for individual users to select an option.
-
-                    The interface for field type 7 is not yet stabilized.
-                  type: object
-                  example:
-                    {
-                      "python": {"text": "Python", "order": "1"},
-                      "java": {"text": "Java", "order": "2"},
-                    }
+                  $ref: "#/components/schemas/CustomProfileFieldDataSchema"
                 display_in_profile_summary:
-                  description: |
-                    Whether clients should display this profile field in the summary section of a
-                    user's profile (or in a more easily accessible "small profile").
-
-                    At most 2 profile fields may have this property be true in a given
-                    organization.
-
-                    The "Users" profile field is not supported, but that is likely to
-                    be temporary.
-
-                    **Changes**: Before Zulip 12.0 (feature level 476), the
-                    "Paragraph" field type was not supported.
-
-                    New in Zulip 6.0 (feature level 146).
-                  type: boolean
-                  example: true
+                  $ref: "#/components/schemas/CustomProfileFieldDisplayInProfileSummarySchema"
                 required:
-                  description: |
-                    Whether an organization administrator has configured this profile field as
-                    required.
-
-                    Because the required property is mutable, clients cannot assume that a required
-                    custom profile field has a value. The Zulip web application displays a prominent
-                    banner to any user who has not set a value for a required field.
-
-                    **Changes**: New in Zulip 9.0 (feature level 244).
-                  type: boolean
-                  example: true
+                  $ref: "#/components/schemas/CustomProfileFieldRequiredSchema"
                 editable_by_user:
-                  description: |
-                    Whether regular users can edit this profile field on their own account.
-
-                    Note that organization administrators can edit custom profile fields for any user
-                    regardless of this setting.
-
-                    **Changes**: New in Zulip 10.0 (feature level 296).
-                  type: boolean
-                  example: true
+                  $ref: "#/components/schemas/CustomProfileFieldEditableByUserSchema"
                 use_for_user_matching:
-                  description: |
-                    Whether this custom profile field should be used to match users in typeahead
-                    suggestions. Only allowed for Short Text and External Account
-                    [profile field types](/help/custom-profile-fields#profile-field-types).
-
-                    This field is only included when its value is `true`.
-
-                    **Changes**: New in Zulip 12.0 (feature level 455).
-                  type: boolean
-                  example: false
+                  $ref: "#/components/schemas/CustomProfileFieldUseForUserMatchingSchema"
               required:
                 - field_type
             encoding:
@@ -27954,6 +27894,78 @@ components:
         - hint
         - required
         - editable_by_user
+    CustomProfileFieldHintSchema:
+      description: |
+        The help text to be displayed for the custom profile field in user-facing
+        settings UI for configuring custom profile fields.
+      type: string
+      example: "Your favorite programming language."
+    CustomProfileFieldDataSchema:
+      description: |
+        Field types 3 (Dropdown) and 7 (External account) support storing
+        additional configuration for the field type in the `field_data` attribute.
+
+        For field type 3 (Dropdown), this attribute is a JSON dictionary
+        defining the choices and the order they will be displayed in the
+        dropdown UI for individual users to select an option.
+
+        The interface for field type 7 is not yet stabilized.
+      type: object
+      example:
+        {
+          "python": {"text": "Python", "order": "1"},
+          "java": {"text": "Java", "order": "2"},
+        }
+    CustomProfileFieldDisplayInProfileSummarySchema:
+      description: |
+        Whether clients should display this profile field in the summary section of a
+        user's profile (or in a more easily accessible "small profile").
+
+        At most 2 profile fields may have this property be true in a given
+        organization.
+
+        The "Users" profile field is not supported, but that is likely to
+        be temporary.
+
+        **Changes**: Before Zulip 12.0 (feature level 476), the
+        "Paragraph" field type was not supported.
+
+        New in Zulip 6.0 (feature level 146).
+      type: boolean
+      example: true
+    CustomProfileFieldRequiredSchema:
+      description: |
+        Whether an organization administrator has configured this profile field as
+        required.
+
+        Because the required property is mutable, clients cannot assume that a required
+        custom profile field has a value. The Zulip web application displays a prominent
+        banner to any user who has not set a value for a required field.
+
+        **Changes**: New in Zulip 9.0 (feature level 244).
+      type: boolean
+      example: true
+    CustomProfileFieldEditableByUserSchema:
+      description: |
+        Whether regular users can edit this profile field on their own account.
+
+        Note that organization administrators can edit custom profile fields for any user
+        regardless of this setting.
+
+        **Changes**: New in Zulip 10.0 (feature level 296).
+      type: boolean
+      example: true
+    CustomProfileFieldUseForUserMatchingSchema:
+      description: |
+        Whether this custom profile field should be used to match users in typeahead
+        suggestions. Only allowed for Short Text and External Account
+        [profile field types](/help/custom-profile-fields#profile-field-types).
+
+        This field is only included when its value is `true`.
+
+        **Changes**: New in Zulip 12.0 (feature level 455).
+      type: boolean
+      example: false
     OnboardingStep:
       type: object
       additionalProperties: false

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15263,8 +15263,6 @@ paths:
                     The "Users" profile field is not supported, but that is likely to
                     be temporary.
 
-                    [profile-field-types]: /help/custom-profile-fields#profile-field-types
-
                     **Changes**: Before Zulip 12.0 (feature level 476), the
                     "Paragraph" field type was not supported.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15386,9 +15386,9 @@ paths:
               properties:
                 name:
                   description: |
-                    The name of the custom profile field, which will appear both in
-                    user-facing settings UI for configuring custom profile fields and
-                    in UI displaying a user's profile.
+                    The name of the custom profile field, which appears both in
+                    the user-facing settings UI for configuring the custom profile
+                    fields and in the UI displaying a user's profile.
                   type: string
                   example: "Favorite programming language"
                 hint:
@@ -15433,7 +15433,7 @@ paths:
                     }
                 display_in_profile_summary:
                   description: |
-                    Whether clients should display this profile field in a summary section of a
+                    Whether clients should display this profile field in the summary section of a
                     user's profile (or in a more easily accessible "small profile").
 
                     At most 2 profile fields may have this property be true in a given

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -28267,7 +28267,7 @@ components:
             Field types 3 (Dropdown) and 7 (External account) support storing
             additional configuration for the field type in the `field_data` attribute.
 
-            For field type 3 (Dropdown), this attribute is a JSON dictionary
+            For field type 3 (Dropdown), this attribute is a JSON object
             defining the choices and the order they will be displayed in the
             dropdown UI for individual users to select an option.
 
@@ -28338,7 +28338,7 @@ components:
         Field types 3 (Dropdown) and 7 (External account) support storing
         additional configuration for the field type in the `field_data` attribute.
 
-        For field type 3 (Dropdown), this attribute is a JSON dictionary
+        For field type 3 (Dropdown), this attribute is a JSON object
         defining the choices and the order they will be displayed in the
         dropdown UI for individual users to select an option.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15442,8 +15442,6 @@ paths:
                     The "Users" profile field is not supported, but that is likely to
                     be temporary.
 
-                    [profile-field-types]: /help/custom-profile-fields#profile-field-types
-
                     **Changes**: Before Zulip 12.0 (feature level 476), the
                     "Paragraph" field type was not supported.
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -230,7 +230,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots",
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
-        "/realm/profile_fields/{field_id}",
         "/realm/icon",
         "/realm/logo",
         "/realm/deactivate",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -228,7 +228,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots",
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
-        "/realm/profile_fields/{field_id}",
         "/realm/icon",
         "/realm/logo",
         "/realm/subdomain/{subdomain}",


### PR DESCRIPTION
Documents the `PATCH` and `DELETE` methods of `/realm/profile_fields/{field_id}`, the endpoints for updating and deleting a custom profile field.

A few decisions worth flagging for review:

- For `PATCH`, all body parameters are optional; the `**Changes**` note records feature level 252, when `name`, `hint`, `field_data`, `display_in_profile_summary` and `required` became optional in an update request. `field_type` is intentionally not documented, since a field's type cannot be changed after creation.
- No new feature level is added, since this documents pre-existing behavior rather than changing the API.
- Documenting these endpoints enrolls them in the generated-curl-example test, so the PR registers curl-example value generators for both methods that create a custom profile field and return its ID. The `PATCH` generator creates a dropdown field so the documented `field_data` example validates, and the `PATCH` `name`example avoids colliding with the `create` endpoint's example field.


Fixes: Documents the previously-undocumented `PATCH`/`DELETE` `/realm/profile_fields/{field_id}` endpoints.

**How changes were tested:**

- `./tools/test-backend zerver.tests.test_openapi` (21 tests)
- `./tools/test-backend zerver.tests.test_custom_profile_data` (38 tests)
- `./tools/test-api`
- `./tools/lint zerver/openapi/zulip.yaml api_docs/include/rest-endpoints.md zerver/tests/test_openapi.py`
- Rendered both pages on a local dev server and verified the admin badge, parameter tables, curl examples, and error-response descriptions.

<details>
<summary>Screenshots and screen captures:</summary>

The sidebar:
<img width="327" height="173" alt="image" src="https://github.com/user-attachments/assets/764f8b6a-030c-4014-8e5c-7f01ec1e1126" />

The rendered documentation page, `PATCH /realm/profile_fields/{field_id}`
<img width="1400" height="3844" alt="update-custom-profile-field-curl-tab" src="https://github.com/user-attachments/assets/fdac55a3-122b-4741-a2ea-1bdb98e2faf9" />

The rendered documentation page, `DELETE /realm/profile_fields/{field_id}`
<img width="1400" height="1322" alt="delete-custom-profile-field-curl-tab" src="https://github.com/user-attachments/assets/9cdd135b-6f4b-4644-89c8-46c7884202b6" />

</details>
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
