### PR TITLE
Fix undefined while quoting single message

### DIFF
--- a/web/src/message_fetch_raw_content.ts
+++ b/web/src/message_fetch_raw_content.ts
@@ -3,7 +3,6 @@ import assert from "minimalistic-assert";
 import * as channel from "./channel.ts";
 import * as message_fetch from "./message_fetch.ts";
 import * as message_store from "./message_store.ts";
-import {the} from "./util.ts";
 
 export function get_raw_content_for_messages(info: {
     message_ids: number[];
@@ -67,14 +66,26 @@ export function get_raw_content_for_single_message(info: {
     timeout_ms?: number;
 }): void {
     const {message_id, on_success, on_error, timeout_ms} = info;
-    get_raw_content_for_messages({
-        message_ids: [message_id],
-        timeout_ms,
-        on_success(raw_content_arr) {
-            on_success(the(raw_content_arr));
+    const message = message_store.get(message_id);
+    assert(message !== undefined);
+    if (message.raw_content) {
+        on_success(message.raw_content);
+        return;
+    }
+
+    // The single-message endpoint handles messages that the user has
+    // access to, but are not in the user's message history, e.g.,
+    // private channel messages with shared history sent prior to the
+    // user being subscribed to the channel.
+    channel.get({
+        url: "/json/messages/" + message_id,
+        data: {allow_empty_topic_name: true, apply_markdown: false},
+        success(raw_data) {
+            const data = message_store.single_message_content_schema.parse(raw_data);
+            message_store.maybe_update_raw_content(message_id, data.message.content);
+            on_success(data.message.content);
         },
-        on_error() {
-            on_error();
-        },
+        timeout: timeout_ms,
+        error: on_error,
     });
 }

--- a/web/tests/message_fetch_raw_content.test.cjs
+++ b/web/tests/message_fetch_raw_content.test.cjs
@@ -172,11 +172,11 @@ run_test("get_raw_content_for_single_message", ({override}) => {
     assert.equal(success_call_args, msg_1.raw_content);
 
     // Case: The network request succeeds.
+    let channel_get_args;
     override(channel, "get", (args) => {
+        channel_get_args = args;
         args.success({
-            messages: [
-                {id: 2, content_type: "text/x-markdown", content: "Fetched markdown content"},
-            ],
+            message: {content_type: "text/x-markdown", content: "Fetched markdown content"},
         });
     });
 
@@ -188,10 +188,37 @@ run_test("get_raw_content_for_single_message", ({override}) => {
         },
     });
     assert.ok(success_called);
+    // Uses the single-message endpoint, not the batch endpoint, so that
+    // messages from unsubscribed channels can be fetched.
+    assert.equal(channel_get_args.url, "/json/messages/2");
     assert.equal(success_call_args, "Fetched markdown content");
     assert.equal(success_call_args, msg_2.raw_content);
 
+    // Case: Message from an unsubscribed channel. The fetch should
+    // succeed, but raw_content should not be cached.
+    success_called = false;
+    override(channel, "get", (args) => {
+        channel_get_args = args;
+        args.success({
+            message: {content_type: "text/x-markdown", content: "Unsubscribed content"},
+        });
+    });
+
+    message_fetch_raw_content.get_raw_content_for_single_message({
+        message_id: 3,
+        on_success(args) {
+            success_called = true;
+            success_call_args = args;
+        },
+    });
+    assert.ok(success_called);
+    assert.equal(channel_get_args.url, "/json/messages/3");
+    assert.equal(success_call_args, "Unsubscribed content");
+    // raw_content is not cached for messages from unsubscribed channels.
+    assert.equal(msg_3.raw_content, undefined);
+
     // Case: The network request fails/times out.
+    error_called = false;
     override(channel, "get", (args) => {
         args.error();
     });

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8656,7 +8656,7 @@ paths:
       summary: Get messages
       tags: ["messages"]
       description: |
-        This endpoint is the primary way to fetch a messages. It is used by all official
+        This endpoint is the primary way to fetch messages. It is used by all official
         Zulip clients (e.g. the web, desktop, mobile, and terminal clients) as well as
         many bots, API clients, backup scripts, etc.
 


### PR DESCRIPTION
Partial fix for [#issues > Quoting shows undefined](https://chat.zulip.org/#narrow/channel/9-issues/topic/Quoting.20shows.20undefined/with/2461025)

Ref comment: https://github.com/zulip/zulip/pull/39377#issuecomment-4613457664

tested by quoting/forwarding messages from subscribed and unsubscribed public channels.
And by quoting/forwarding messages from private channels with shared history.