### PR TITLE
tusd: Route self-serve import uploads by key even when authenticated.

### DIFF
--- a/web/src/portico/slack-import.ts
+++ b/web/src/portico/slack-import.ts
@@ -22,7 +22,10 @@ $(() => {
                 maxFileSize: max_file_upload_size_mib * 1024 * 1024,
             },
             meta: {
-                key,
+                // The tusd hook handler routes uploads carrying this
+                // metadata field to the pending realm registration,
+                // rather than treating them as ordinary attachments.
+                realm_import_registration_key: key,
             },
             locale: {
                 strings: {

--- a/zerver/tests/test_tusd.py
+++ b/zerver/tests/test_tusd.py
@@ -109,7 +109,17 @@ class TusdHooksTest(ZulipTestCase):
 
 
 class TusdPreCreateTest(ZulipTestCase):
-    def request(self, key: str = "") -> TusHook:
+    def request(self, key: str | None = None) -> TusHook:
+        # Only realm-import uploads carry a registration key in their
+        # metadata; ordinary attachment uploads have no such field.
+        meta_data = {
+            "filename": "zulip.txt",
+            "filetype": "text/plain",
+            "name": "zulip.txt",
+            "type": "text/plain",
+        }
+        if key is not None:
+            meta_data["realm_import_registration_key"] = key
         return TusHook(
             type="pre-create",
             event=TusEvent(
@@ -120,13 +130,7 @@ class TusdPreCreateTest(ZulipTestCase):
                     id="",
                     is_final=False,
                     is_partial=False,
-                    meta_data={
-                        "filename": "zulip.txt",
-                        "filetype": "text/plain",
-                        "name": "zulip.txt",
-                        "type": "text/plain",
-                        "key": key,
-                    },
+                    meta_data=meta_data,
                     offset=0,
                     partial_uploads=None,
                     size=1234,
@@ -154,6 +158,23 @@ class TusdPreCreateTest(ZulipTestCase):
         result = self.client_post(
             "/api/internal/tusd",
             self.request().model_dump(),
+            content_type="application/json",
+        )
+        self.assertEqual(result.status_code, 200)
+        result_json = result.json()
+        self.assertEqual(result_json["HttpResponse"]["StatusCode"], 401)
+        self.assertEqual(
+            orjson.loads(result_json["HttpResponse"]["Body"]), {"message": "Unauthenticated upload"}
+        )
+        self.assertEqual(result_json["RejectUpload"], True)
+
+    def test_unauthed_invalid_key_rejected(self) -> None:
+        # An upload claiming to be for a realm import, but carrying an
+        # invalid confirmation key, is rejected rather than being routed
+        # to the realm-import handlers.
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request(key="a" * 24).model_dump(),
             content_type="application/json",
         )
         self.assertEqual(result.status_code, 200)
@@ -347,7 +368,7 @@ class TusdPreCreateTest(ZulipTestCase):
                 "filetype": "text/plain",
                 "name": "zulip.zip",
                 "type": "text/plain",
-                "key": confirmation_key,
+                "realm_import_registration_key": confirmation_key,
             },
             is_final=False,
             is_partial=False,
@@ -375,6 +396,74 @@ class TusdPreCreateTest(ZulipTestCase):
         )
 
         self.assertEqual(result.status_code, 200)
+        prereg_realm.refresh_from_db()
+        self.assertTrue(
+            prereg_realm.data_import_metadata["uploaded_import_file_name"].endswith(filename)
+        )
+
+    def test_realm_import_data_upload_while_logged_in(self) -> None:
+        # A user who is signed in to an existing organization while creating a
+        # new one via Slack import must still have the upload routed to the
+        # registration by its key, rather than treated as an ordinary
+        # attachment just because the request happens to be authenticated.
+        email = "ete-slack-import@zulip.com"
+        self.submit_realm_creation_form(
+            email,
+            realm_subdomain="ete-slack-import",
+            realm_name="Slack import end to end",
+            import_from="slack",
+        )
+        prereg_realm = PreregistrationRealm.objects.get(email=email)
+        confirmation_key = find_key_by_email(email)
+        assert confirmation_key is not None
+
+        self.login("hamlet")
+
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request(key=confirmation_key).model_dump(),
+            content_type="application/json",
+        )
+        self.assertEqual(result.status_code, 200)
+        filename = f"import/{prereg_realm.id}/slack.zip"
+        self.assertTrue(result.json()["ChangeFileInfo"]["ID"].endswith(filename))
+
+        info = TusUpload(
+            id=filename,
+            size=len("zulip!"),
+            offset=0,
+            size_is_deferred=False,
+            meta_data={
+                "filename": filename,
+                "filetype": "text/plain",
+                "name": "zulip.zip",
+                "type": "text/plain",
+                "realm_import_registration_key": confirmation_key,
+            },
+            is_final=False,
+            is_partial=False,
+            partial_uploads=None,
+            storage=None,
+        )
+        request = TusHook(
+            type="pre-finish",
+            event=TusEvent(
+                upload=info,
+                http_request=TusHTTPRequest(
+                    method="PATCH",
+                    uri=f"/api/v1/tus/{info.id}",
+                    remote_addr="12.34.56.78",
+                    header={},
+                ),
+            ),
+        )
+        result = self.client_post(
+            "/api/internal/tusd",
+            request.model_dump(),
+            content_type="application/json",
+        )
+        self.assertEqual(result.status_code, 200)
+
         prereg_realm.refresh_from_db()
         self.assertTrue(
             prereg_realm.data_import_metadata["uploaded_import_file_name"].endswith(filename)

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -320,6 +320,40 @@ def handle_tusd_hook(
         raise AccessDeniedError
 
     hook_name = payload.type
+
+    # A self-serve realm-import upload carries the registration's
+    # confirmation key in its metadata. Route those to the preregistration
+    # handlers based on that key, regardless of whether the request also
+    # happens to be authenticated -- e.g. when the user is signed in to an
+    # existing organization -- so the upload is recorded against the prereg
+    # rather than stored as an ordinary attachment.
+    realm_import_registration_key = payload.event.upload.meta_data.get(
+        "realm_import_registration_key"
+    )
+    if realm_import_registration_key is not None:
+        try:
+            prereg_object = get_object_from_key(
+                realm_import_registration_key,
+                [Confirmation.NEW_REALM_USER_REGISTRATION],
+                mark_object_used=False,
+            )
+        except ConfirmationKeyError:
+            return reject_upload("Unauthenticated upload", 401)
+
+        assert isinstance(prereg_object, PreregistrationRealm)
+        assert prereg_object.created_realm is None
+
+        if hook_name == "pre-create":
+            return handle_preregistration_pre_create_hook(
+                request, prereg_object, payload.event.upload
+            )
+        elif hook_name == "pre-finish":
+            return handle_preregistration_pre_finish_hook(
+                request, prereg_object, payload.event.upload
+            )
+        else:  # nocoverage
+            return HttpResponseNotFound()
+
     maybe_user = authenticate_user(request)
     if maybe_user.is_authenticated:
         # Authenticated requests are file upload requests
@@ -332,23 +366,4 @@ def handle_tusd_hook(
         else:
             return HttpResponseNotFound()
 
-    # Check if unauthenticated requests are for realm creation
-    key = payload.event.upload.meta_data.get("key")
-    if key is None:
-        return reject_upload("Unauthenticated upload", 401)
-    try:
-        prereg_object = get_object_from_key(
-            key, [Confirmation.NEW_REALM_USER_REGISTRATION], mark_object_used=False
-        )
-    except ConfirmationKeyError:
-        return reject_upload("Unauthenticated upload", 401)
-
-    assert isinstance(prereg_object, PreregistrationRealm)
-    assert prereg_object.created_realm is None
-
-    if hook_name == "pre-create":
-        return handle_preregistration_pre_create_hook(request, prereg_object, payload.event.upload)
-    elif hook_name == "pre-finish":
-        return handle_preregistration_pre_finish_hook(request, prereg_object, payload.event.upload)
-    else:  # nocoverage
-        return HttpResponseNotFound()
+    return reject_upload("Unauthenticated upload", 401)


### PR DESCRIPTION
See https://github.com/zulip/zulip/pull/39451#issuecomment-4646336047