### PR TITLE
Search typeahead code correctness

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -144,7 +144,6 @@ function narrow_to_search_contents_with_search_bar_open(): void {
     if ($(".navbar-search.expanded").length === 0) {
         open_search_bar_and_close_narrow_description();
         focus_search_input_at_end();
-        search_typeahead.lookup(false);
         search_input_has_changed = true;
     }
 }

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -229,9 +229,16 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
             return get_search_bar_text() !== "";
         },
         hideAfterSelect(): boolean {
-            const search_bar_text = get_search_bar_text();
-            const text_terms = Filter.parse(search_bar_text);
-            return text_terms.at(-1)?.operator === "search";
+            const last_term = Filter.parse(get_search_bar_text()).at(-1);
+            // An empty search bar means the selected term was complete
+            // and has been converted to a pill, so hide the typeahead.
+            if (last_term === undefined) {
+                return true;
+            }
+            // Keep the typeahead open when only a bare operator was
+            // selected (e.g. "channel:") so the user can continue
+            // typing the operand.
+            return last_term.operand !== "";
         },
         matcher(_query: string) {
             return () => true;

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -215,6 +215,27 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             assert.equal(opts.updater(`channel:${verona_stream_id}`), "");
             assert.ok(input_pill_displayed);
         }
+
+        {
+            /* Test hideAfterSelect */
+            // An empty search bar means the selected term became a pill,
+            // so the typeahead should hide.
+            $search_query_box.text("");
+            assert.ok(opts.hideAfterSelect());
+
+            // A bare operator still needs an operand, so keep the
+            // typeahead open.
+            $search_query_box.text("channel:");
+            assert.ok(!opts.hideAfterSelect());
+
+            // A complete operator term is done, so hide the typeahead.
+            $search_query_box.text("channel:Verona");
+            assert.ok(opts.hideAfterSelect());
+
+            // A plain search term is also complete, so hide.
+            $search_query_box.text("ver");
+            assert.ok(opts.hideAfterSelect());
+        }
     }
 
     $search_query_box.text("test string");


### PR DESCRIPTION
When a search suggestion is selected, the typeahead should reopen only if the user picked a bare operator (like "channel:") that still needs an operand; otherwise the term is complete and the dropdown should stay closed. 

- `hideAfterSelect` previously returned true only for search operators. So it returned false even after a complete operator term such as `channel:general` was selected.
- After a narrow we reopen the search bar to keep it visible, but we also called `search_typeahead.lookup(false)`, (which is called to reopen the typeahead dropdown), something we don't want after a narrow.

Note: This is a code-correctness cleanup rather than a behavior change: a separate bug(1) in the bootstrap typeahead module already keeps the typeahead from reopening after a narrow today, so the wrong `hideAfterSelect` return value and stray `lookup` call has no user visible effect either way.

(1) `select()` method in bootstrap module returns `lookup(true)` if `hideAfterSelect` is false.

Discussion: [#design > typeahead: close upon selecting a search pill? @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/typeahead.3A.20close.20upon.20selecting.20a.20search.20pill.3F/near/2467961)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/1be3d6c4-692f-4619-a7bc-4831fed1f261" />|<video src="https://github.com/user-attachments/assets/507b5697-6653-400a-a85b-b00c5a94df0f" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
