### PR TITLE
settings: Live-update the user list style preview.

### DIFF
--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -349,6 +349,14 @@ export function report_user_list_style_change(settings_panel: SettingsPanel): vo
     }
 }
 
+export function update_user_list_style_preview_name(full_name: string): void {
+    $(".user_list_style_values .preview .user-name").text(full_name);
+}
+
+export function update_user_list_style_preview_avatar(avatar_url: string): void {
+    $(".user_list_style_values .preview .user-profile-picture img").attr("src", avatar_url);
+}
+
 export function update_page(property: UserSettingsProperty): void {
     if (!overlays.settings_open()) {
         return;

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -26,6 +26,7 @@ import * as settings_exports from "./settings_exports.ts";
 import * as settings_linkifiers from "./settings_linkifiers.ts";
 import * as settings_org from "./settings_org.ts";
 import * as settings_panel_menu from "./settings_panel_menu.ts";
+import * as settings_preferences from "./settings_preferences.ts";
 import * as settings_profile_fields from "./settings_profile_fields.ts";
 import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults.ts";
 import * as settings_streams from "./settings_streams.ts";
@@ -113,6 +114,7 @@ export const update_person = function update(event: UserUpdate): void {
         if (people.is_my_user_id(event.user_id)) {
             current_user.full_name = event.full_name;
             settings_account.update_full_name(event.full_name);
+            settings_preferences.update_user_list_style_preview_name(event.full_name);
         }
         if (user.is_bot && bot_data.get(event.user_id) !== undefined) {
             bot_data.update(event.user_id, {user_id: event.user_id, full_name: event.full_name});
@@ -199,6 +201,9 @@ export const update_person = function update(event: UserUpdate): void {
             } else {
                 $("#user-avatar-source").hide();
             }
+            settings_preferences.update_user_list_style_preview_avatar(
+                people.small_avatar_url_for_person(user),
+            );
         }
 
         message_live_update.update_avatar(user.user_id, event.avatar_url);

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -22,6 +22,10 @@ const settings_account = mock_esm("../src/settings_account", {
     add_or_remove_owner_from_role_dropdown() {},
     update_user_own_role_dropdown_state() {},
 });
+const settings_preferences = mock_esm("../src/settings_preferences", {
+    update_user_list_style_preview_name() {},
+    update_user_list_style_preview_avatar() {},
+});
 const settings_bots = mock_esm("../src/settings_bots", {
     redraw_your_bots_list() {},
     toggle_bot_config_download_container() {},
@@ -216,10 +220,16 @@ run_test("updates", ({override}) => {
     assert.ok(!current_user.is_guest);
     assert.ok(!current_user.is_admin);
 
+    let user_list_style_preview_name;
+    settings_preferences.update_user_list_style_preview_name = (full_name_arg) => {
+        user_list_style_preview_name = full_name_arg;
+    };
+
     user_events.update_person({user_id: me.user_id, full_name: "Me V2"});
     assert.equal(people.my_full_name(), "Me V2");
     assert.equal(user_id, me.user_id);
     assert.equal(full_name, "Me V2");
+    assert.equal(user_list_style_preview_name, "Me V2");
 
     user_events.update_person({user_id: isaac.user_id, new_email: "newton@example.com"});
     person = people.get_by_user_id(isaac.user_id);
@@ -240,6 +250,10 @@ run_test("updates", ({override}) => {
     buddy_data.insert_or_move = (user_ids_arg) => {
         inserted_or_moved_user_ids = user_ids_arg;
     };
+    let user_list_style_preview_avatar_url;
+    settings_preferences.update_user_list_style_preview_avatar = (avatar_url_arg) => {
+        user_list_style_preview_avatar_url = avatar_url_arg;
+    };
 
     user_events.update_person({user_id: isaac.user_id, full_name: "Sir Isaac"});
     person = people.get_by_email(isaac.email);
@@ -247,6 +261,9 @@ run_test("updates", ({override}) => {
     assert.equal(person.is_admin, true);
     assert.equal(user_id, isaac.user_id);
     assert.equal(full_name, "Sir Isaac");
+    // The user list style preview shows the current user's name, so
+    // renaming someone else must not update it.
+    assert.equal(user_list_style_preview_name, "Me V2");
 
     person = people.get_by_email(isaac.email);
     assert.equal(person.delivery_email, null);
@@ -267,6 +284,9 @@ run_test("updates", ({override}) => {
     assert.equal(user_id, isaac.user_id);
     assert.equal(person.avatar_url, avatar_url);
     assert.deepEqual(inserted_or_moved_user_ids, [isaac.user_id]);
+    // The user list style preview shows the current user's avatar, so
+    // another user's avatar change must not update it.
+    assert.equal(user_list_style_preview_avatar_url, undefined);
 
     user_events.update_person({user_id: me.user_id, avatar_url: "http://gravatar.com/789456"});
     person = people.get_by_email(me.email);
@@ -274,6 +294,7 @@ run_test("updates", ({override}) => {
     assert.equal(user_id, me.user_id);
     assert.equal(person.avatar_url, avatar_url);
     assert.deepEqual(inserted_or_moved_user_ids, [me.user_id]);
+    assert.equal(user_list_style_preview_avatar_url, "http://gravatar.com/789456");
 
     user_events.update_person({user_id: me.user_id, timezone: "UTC"});
     person = people.get_by_email(me.email);


### PR DESCRIPTION
The "User list style" previews, both in personal preferences and in the realm-level default user settings panel, render the current user's name and avatar when the settings overlay is built, and were left stale when the user changed their name or avatar while the overlay remained open.

Reported in
https://chat.zulip.org/#narrow/channel/9-issues/topic/Updating.20name.20in.20settings.20dialog/near/2475959.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before (name):
<img width="1180" height="802" alt="list_style_before" src="https://github.com/user-attachments/assets/f1c7a0f4-8734-4516-a6f3-0ac02282ab7c" />
After (name):
<img width="1180" height="802" alt="list_style_after" src="https://github.com/user-attachments/assets/53c014c9-aa48-459e-ad34-acd1d7945e77" />

Before (profile pic):
<img width="1180" height="802" alt="list_style_before_profile_pic" src="https://github.com/user-attachments/assets/e6eba200-353d-498a-a521-1cb08e679dc1" /> 
After (profile pic):
<img width="1180" height="802" alt="list_style_after_profile_pic" src="https://github.com/user-attachments/assets/22f6e554-cab6-4502-8379-6bb04a9aa3b1" /> 



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
