### PR TITLE
message_list_view: Avoid linear group search when rerendering headers.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1605,19 +1605,13 @@ export class MessageListView {
         );
     }
 
-    _rerender_header(message_group_id: string): void {
+    _rerender_header(group: MessageGroup): void {
         // Rerender the header / recipient bar of the given message group,
-        // rebuilding it from the authoritative group looked up below. This
+        // rebuilding it from the authoritative group passed in. This
         // method should only be called with rerender_messages as the
         // rerendered header may need to be updated for the "sticky_header"
         // class.
-        const group = this._find_message_group(message_group_id);
-        if (group === undefined) {
-            blueslip.error("Could not find message group for rerendering headers");
-            return;
-        }
-
-        const $header = $(`#${CSS.escape(message_group_id)}`).find(".message_header");
+        const $header = $(`#${CSS.escape(group.message_group_id)}`).find(".message_header");
 
         // TODO: It's possible that we no longer need this populate
         // call; it was introduced in an earlier version of this code
@@ -1775,9 +1769,19 @@ export class MessageListView {
         }
 
         // Now that every row is rerendered, rerender each affected bar's
-        // header once.
+        // header once. We build a lookup map here rather than calling
+        // _find_message_group in the loop, since the latter does a
+        // linear search.
+        const message_groups_by_id = new Map(
+            this._message_groups.map((group) => [group.message_group_id, group]),
+        );
         for (const message_group_id of rerendered_group_ids) {
-            this._rerender_header(message_group_id);
+            const group = message_groups_by_id.get(message_group_id);
+            if (group === undefined) {
+                blueslip.error("Could not find message group for rerendering headers");
+                continue;
+            }
+            this._rerender_header(group);
         }
 
         if (message_lists.current === this.list && narrow_state.is_message_feed_visible()) {

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -337,10 +337,12 @@ test("rerender_messages rebuilds every distinct recipient bar", () => {
         return {length: 1, parent: () => ({expectOne: () => ({attr: () => group_id})})};
     };
 
+    view._message_groups = [{message_group_id: "group-A"}, {message_group_id: "group-B"}];
+
     view._rerender_message = () => [];
     const rerendered_group_ids = [];
-    view._rerender_header = (message_group_id) => {
-        rerendered_group_ids.push(message_group_id);
+    view._rerender_header = (group) => {
+        rerendered_group_ids.push(group.message_group_id);
     };
 
     view.rerender_messages([dm1.msg, dm2.msg, dm3.msg]);


### PR DESCRIPTION
Follow-up to #39182, addressing the performance concern raised in https://github.com/zulip/zulip/pull/39182#issuecomment-4629405480.

rerender_messages called _find_message_group, a linear search over all rendered message groups, once per affected recipient bar. Since a user rename can touch every DM bar in the Combined feed, this header pass could do affected_bars x total_groups work.

Instead, build a Map from group id to group once per rerender_messages call and look groups up in it, so the header pass does a single scan of the groups no matter how many bars changed.

We deliberately do not keep a persistent hash table next to _message_groups: that list is rebuilt and spliced in several places (merging, clearing, prepending), and keeping a second structure in sync with all of them is easy to get wrong. A throwaway map built right before the loop gives the same speedup with nothing to keep in sync.

<!-- Describe your pull request here.-->


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
