### PR TITLE
api-docs: Update changelog to reflect the backport of feature level 506.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -48,7 +48,8 @@ format used by the Zulip server that they are interacting with.
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events):
   The `require_e2ee_push_notifications` realm setting, when enabled,
   now completely disables legacy push notifications rather than sending
-  them with redacted content.
+  them with redacted content. This change was also backported to the Zulip
+  12.x series, at feature level 500.
 
 **Feature level 503**
 
@@ -59,10 +60,17 @@ format used by the Zulip server that they are interacting with.
 
 No changes; start of Zulip 13.0 development branch.
 
-Feature levels 500-501 reserved for future use in 12.x maintenance
+Feature level 501 reserved for future use in 12.x maintenance
 releases.
 
 ## Changes in Zulip 12.1
+
+**Feature level 500**
+
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events):
+  The `require_e2ee_push_notifications` realm setting, when enabled,
+  now completely disables legacy push notifications rather than sending
+  them with redacted content. Backported change from feature level 504.
 
 **Feature level 499**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5922,7 +5922,7 @@ paths:
                                         sent. Only updated version of clients (which support E2EE
                                         push notifications) will receive push notifications.
 
-                                        **Changes**: In Zulip 13.0 (feature level 504), this
+                                        **Changes**: In Zulip 12.1 (feature levels 500-501, and 504+), this
                                         setting now completely disables legacy push notifications
                                         rather than sending them with redacted content.
 
@@ -20638,7 +20638,7 @@ paths:
                           sent. Only updated version of clients (which support E2EE
                           push notifications) will receive push notifications.
 
-                          **Changes**: In Zulip 13.0 (feature level 504), this
+                          **Changes**: In Zulip 12.1 (feature levels 500-501, and 504+), this
                           setting now completely disables legacy push notifications
                           rather than sending them with redacted content.
 


### PR DESCRIPTION
Equivalent to #39443

Now that the API change has been backported in
b47139bb0c62eff722a4bbce26c02805ed9604ca,
we update the changelog to reflect this fact.
Analogous commit to
6dc2c93ad2b699658b4cbae93f0e0a811be6f095

