### PR TITLE
docs: Fix grammar mistakes across the codebase.

### DIFF
--- a/analytics/tests/test_stats_views.py
+++ b/analytics/tests/test_stats_views.py
@@ -562,7 +562,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data/realm/zulip", {"chart_name": "number_of_humans"}
         )
-        self.assert_json_error(result, "Must be an server administrator", 400)
+        self.assert_json_error(result, "Must be a server administrator", 400)
 
         user = self.example_user("hamlet")
         user.is_staff = True
@@ -588,7 +588,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data/installation", {"chart_name": "number_of_humans"}
         )
-        self.assert_json_error(result, "Must be an server administrator", 400)
+        self.assert_json_error(result, "Must be a server administrator", 400)
 
         user = self.example_user("hamlet")
         user.is_staff = True

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1585,7 +1585,7 @@ class StripeTest(StripeTestCase):
     def test_customer_minimum_licenses_for_plan(self, *mocks: Mock) -> None:
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
-        # We set set a 1 license minimum the initial upgrade.
+        # We set a 1 license minimum the initial upgrade.
         minimum_for_plan_tier = 1
         with (
             patch(

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1610,7 +1610,7 @@ class StripeTest(StripeTestCase):
     def test_customer_minimum_licenses_for_plan(self, *mocks: Mock) -> None:
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
-        # We set set a 1 license minimum the initial upgrade.
+        # We set a 1 license minimum for the initial upgrade.
         minimum_for_plan_tier = 1
         with (
             patch(

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -55,7 +55,7 @@ You can run all of the linters at once:
 $ ./tools/lint
 ```
 
-Note that will take a little time. `./tools/lint` runs many
+Note that it takes a little time. `./tools/lint` runs many
 lint checks in parallel, including:
 
 - JavaScript ([ESLint](https://eslint.org/),
@@ -308,7 +308,7 @@ assert obj.id in set([o.id for o in some_objs])
 
 You should always pass the `update_fields` keyword argument to `.save()`
 when modifying an existing Django model object. By default, `.save()` will
-overwrite every value in the column, which results in lots of race
+overwrite every field in that row, which results in lots of race
 conditions where unrelated changes made by one thread can be
 accidentally overwritten by another thread that fetched its `UserProfile`
 object before the first thread wrote out its change.

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -55,8 +55,8 @@ You can run all of the linters at once:
 $ ./tools/lint
 ```
 
-Note that will take a little time. `./tools/lint` runs many
-lint checks in parallel, including:
+But, doing that will take a little time, because `./tools/lint`
+runs many lint checks in parallel, including:
 
 - JavaScript ([ESLint](https://eslint.org/),
   [Prettier](https://prettier.io/))
@@ -307,9 +307,9 @@ assert obj.id in set([o.id for o in some_objs])
 ### Don't call user_profile.save() without `update_fields`
 
 You should always pass the `update_fields` keyword argument to `.save()`
-when modifying an existing Django model object. By default, `.save()` will
-overwrite every value in the column, which results in lots of race
-conditions where unrelated changes made by one thread can be
+when modifying an existing Django model object. By default, `.save()`
+updates all of the model object fields in the database, which results
+in lots of race conditions where unrelated changes made by one thread can be
 accidentally overwritten by another thread that fetched its `UserProfile`
 object before the first thread wrote out its change.
 

--- a/docs/processes/integration-review.md
+++ b/docs/processes/integration-review.md
@@ -174,6 +174,6 @@ Some common mistakes to watch out for:
   typically, we squash the `merge-api-changelogs` commit when there's
   only one commit in a PR touching the API, to keep the history clean).
 
-- Merging a pull request with migrations without rebasing the the work
+- Merging a pull request with migrations without rebasing the work
   and running `tools/renumber-migrations`. PRs older than a couple
   weeks are very likely to have duplicate migration numbers.

--- a/docs/processes/integration-review.md
+++ b/docs/processes/integration-review.md
@@ -184,6 +184,6 @@ Some common mistakes to watch out for:
   typically, we squash the `merge-api-changelogs` commit when there's
   only one commit in a PR touching the API, to keep the history clean).
 
-- Merging a pull request with migrations without rebasing the the work
+- Merging a pull request with migrations without rebasing the work
   and running `tools/renumber-migrations`. PRs older than a couple
   weeks are very likely to have duplicate migration numbers.

--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -54,7 +54,7 @@ This Zoom application type, introduced in Zulip 10.0, is easiest to
 set up, and is ideal for most installations that self-host Zulip. To
 [create Zoom meeting links in Zulip
 messages](https://zulip.com/help/start-a-call#start-a-call) using this
-integration, users will will need to be members of your Zoom
+integration, users will need to be members of your Zoom
 organization and use the same email address in Zulip that they have
 registered with Zoom.
 

--- a/docs/subsystems/thumbnailing.md
+++ b/docs/subsystems/thumbnailing.md
@@ -58,7 +58,7 @@ the first frame, as a 64x64 PNG image. This is currently mostly unused, but is
 intended to be part of a user preference to disable emoji animations (see
 [#13434](https://github.com/zulip/zulip/issues/13434)). Current use is limited
 to [user status](https://zulip.com/help/status-and-availability) display in
-the the buddy list. When a user uses an animated emoji as their status, the
+the buddy list. When a user uses an animated emoji as their status, the
 "still" version is used.
 
 The original emoji is stored adjacent to the thumbnailed version, enabling later

--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -236,7 +236,7 @@ More generally, you should only mock those functions you explicitly don't want t
 
 Since Python 3.3, the standard mocking library is `unittest.mock`. `unittest.mock` implements the basic mocking class `Mock`.
 It also implements `MagicMock`, which is the same as `Mock`, but contains many default magic methods (in Python,
-those are the ones starting with with a dunder `__`). From the docs:
+those are the ones starting with a dunder `__`). From the docs:
 
 > In most of these examples the Mock and MagicMock classes are interchangeable. As the MagicMock is the more capable class
 > it makes a sensible one to use by default.

--- a/docs/testing/testing-with-node.md
+++ b/docs/testing/testing-with-node.md
@@ -174,7 +174,7 @@ result.
 But often, one can write a more readable test by instead verifying
 the values of parameters in the context passed into the template
 rendering. The `mock_template` function in Zulip's testing library
-is designed to support this this.
+is designed to support this.
 
 We use `mock_template` in our unit tests to verify that the JS code is
 calling the template with the expected context data. And then we use

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -744,7 +744,7 @@ and [OpenAPI configuration](../documentation/openapi.md).
 
 In particular, if there is an API change, you should use the
 `create-api-changelog` tool to create a file for the API changelog
-entry for your your new feature. The API feature level allows the
+entry for your new feature. The API feature level allows the
 developers of mobile clients and other tools using the Zulip API to
 programmatically determine whether the Zulip server they are
 interacting with supports a given feature; see the

--- a/puppet/kandra/templates/uptrack/uptrack.conf.erb
+++ b/puppet/kandra/templates/uptrack/uptrack.conf.erb
@@ -53,7 +53,7 @@ install_on_reboot = yes
 #upgrade_on_reboot = yes
 
 # Uptrack runs in a cron job every few hours to check for and download
-# new updates. You can can configure this cron job to automatically
+# new updates. You can configure this cron job to automatically
 # install new updates as they become available.
 #
 # Enable this option to make the cron job automatically install new

--- a/starlight_help/src/components/SettingsSteps.astro
+++ b/starlight_help/src/components/SettingsSteps.astro
@@ -168,7 +168,7 @@ const {setting_type, setting_name, setting_link} = setting_link_mapping[setting_
             // The "Bots" label appears in both Personal and
             // Organization settings in the user interface, so we need special
             // text for this setting.
-            // As for the the case of "Users", it refers to the Users tab in
+            // As for the case of "Users", it refers to the Users tab in
             // organization settings. Since the users tab has multiple sub tabs
             // like active, deactivated etc., we need a way to point to them.
             setting_name === "Bots" || setting_name === "Users" ? (

--- a/starlight_help/src/components/SettingsSteps.astro
+++ b/starlight_help/src/components/SettingsSteps.astro
@@ -167,7 +167,7 @@ const {setting_type, setting_name, setting_link} = setting_link_mapping[setting_
         // The "Bots" label appears in both Personal and
         // Organization settings in the user interface, so we need special
         // text for this setting.
-        // As for the the case of "Users", it refers to the Users tab in
+        // As for the case of "Users", it refers to the Users tab in
         // organization settings. Since the users tab has multiple sub tabs
         // like active, deactivated etc., we need a way to point to them.
         setting_name === "Bots" || setting_name === "Users" ? (

--- a/starlight_help/src/content/include/_FollowedTopicWorkflows.mdx
+++ b/starlight_help/src/content/include/_FollowedTopicWorkflows.mdx
@@ -1,6 +1,6 @@
 * [Catch up](/help/follow-a-topic#catch-up-on-followed-topics) on
   followed topics at the start of the day, and whenever you want to
-  spend a few minutes checking on on the conversations that need
+  spend a few minutes checking on the conversations that need
   your attention.
 * No more stressing about missing a reply to your message in channels
   you don't regularly read. You can [automatically

--- a/templates/confirmation/redirect_to_post.html
+++ b/templates/confirmation/redirect_to_post.html
@@ -17,7 +17,7 @@ This allows us to avoid triggering the action which is being confirmed via a mer
 GET request.
 
 This largely duplicates functionality and code with confirm_preregistrationuser.html.
-We should find a way to to unify these.
+We should find a way to unify these.
 #}
 
 <form id="redirect-to-post-form" class="redirect-to-post-form"  action="{{ target_url }}" method="post">

--- a/templates/corporate/case-studies/university-of-cordoba-case-study.md
+++ b/templates/corporate/case-studies/university-of-cordoba-case-study.md
@@ -16,7 +16,7 @@ free plan was a major frustration.
 
 In search of an alternative, a faculty member reached out to request a sponsored
 Zulip Cloud Standard plan. With the request approved the very next day, the
-department moved over to Zulip starting starting in Fall 2020.
+department moved over to Zulip starting in Fall 2020.
 
 Looking back, being pushed off Slack by its search history limit ended up being
 for the best: “I think Zulip is a great tool, much better than Slack,” says

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -113,7 +113,7 @@ def generate_dev_droplet_user_data(username: str, subdomain: str, public_keys: l
     setup_zulipdev_ssh_keys = f"printf '{ssh_keys_string}' > /home/zulipdev/.ssh/authorized_keys"
 
     # We pass the hostname as username.zulipdev.org to the DigitalOcean API.
-    # But some droplets (eg on 18.04) are created with with hostname set to just username.
+    # But some droplets (eg on 18.04) are created with hostname set to just username.
     # So we fix the hostname using cloud-init.
     hostname_setup = f"hostnamectl set-hostname {subdomain}.zulipdev.org"
 

--- a/tools/oneclickapps/README.md
+++ b/tools/oneclickapps/README.md
@@ -65,7 +65,7 @@ Also pass the following as environment variables in `.github/workflows/update-on
   by invoking the script.
 - Delete the test droplet `oneclickapp-{release_version}-test` after you have completed testing
   by going to the [DigitalOcean Zulip team account](https://cloud.digitalocean.com/droplets?i=0242e0).
-  If there are other existing test droplets with the same name format but with with older release versions
+  If there are other existing test droplets with the same name format but with older release versions
   feel free to delete them as well. These droplets are also tagged with the `github-action` and `temporary`
   tags.
 

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -69,7 +69,7 @@ function get_selected_message_content_elements(): NodeListOf<HTMLElement> | unde
         .querySelectorAll(".message_content");
 }
 
-// Returns the the inner HTML of the `.message_content` element
+// Returns the inner HTML of the `.message_content` element
 // for the first or last message of a single range selection.
 // The caller is expected to only pass the first or last message
 // from a selection range, as the intermediate selected messages

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -71,7 +71,7 @@ function get_selected_message_content_elements(): NodeListOf<HTMLElement> | unde
         .querySelectorAll(".message_content");
 }
 
-// Returns the the inner HTML of the `.message_content` element
+// Returns the inner HTML of the `.message_content` element
 // for the first or last message of a single range selection.
 // The caller is expected to only pass the first or last message
 // from a selection range, as the intermediate selected messages

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -164,7 +164,7 @@ function resend_message(
 ): void {
     message_store.update_message_content(message, message.raw_content!);
     if (show_retry_spinner($row)) {
-        // retry already in in progress
+        // retry already in progress
         return;
     }
 
@@ -591,7 +591,7 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
             if (!msg_list.data.filter.can_apply_locally()) {
                 // If this message list is a search filter that we
                 // cannot apply locally, we will not have locally
-                // echoed echoed the message at all originally, and
+                // echoed the message at all originally, and
                 // must request the server now whether to add it to the view.
                 message_events_util.maybe_add_narrowed_messages(
                     msgs_to_rerender_or_add_to_narrow,

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -172,7 +172,7 @@ export function resend_message(
 ): void {
     message_store.update_message_content(message, message.raw_content!);
     if (show_retry_spinner($row)) {
-        // retry already in in progress
+        // retry already in progress
         return;
     }
 
@@ -603,7 +603,7 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
             if (!msg_list.data.filter.can_apply_locally()) {
                 // If this message list is a search filter that we
                 // cannot apply locally, we will not have locally
-                // echoed echoed the message at all originally, and
+                // echoed the message at all originally, and
                 // must request the server now whether to add it to the view.
                 message_events_util.maybe_add_narrowed_messages(
                     msgs_to_rerender_or_add_to_narrow,

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -397,7 +397,7 @@ export function create<ItemType extends {type: string}>(
             ) {
                 e.preventDefault();
                 const pill = store.pills.at(-1);
-                // We focus the pill first first, as a signal that the pill
+                // We focus the pill first, as a signal that the pill
                 // is about to be deleted. The deletion will then happen through
                 // `removePill` from the event handler on the pill.
                 if (pill) {

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -217,7 +217,7 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
                     // (`text_query`), or is not the last term in the text input, and
                     //  therefore the empty operand represents "general chat".
                     //
-                    // (2) The user has selected a topic operator, and and thus has
+                    // (2) The user has selected a topic operator, and thus has
                     // exactly `topic:` or `-topic:` written out, and it's appropriate
                     // to suggest the "general chat" operand.
                     //

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -228,7 +228,7 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
                     // (`text_query`), or is not the last term in the text input, and
                     //  therefore the empty operand represents "general chat".
                     //
-                    // (2) The user has selected a topic operator, and and thus has
+                    // (2) The user has selected a topic operator, and thus has
                     // exactly `topic:` or `-topic:` written out, and it's appropriate
                     // to suggest the "general chat" operand.
                     //

--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -85,7 +85,7 @@ function send_stream_typing_notification(
 ): void {
     const stream = stream_data.get_sub_by_id(stream_id)!;
     // If the user lost access to the stream while typing, stream might
-    // be undefined for us, in which case, we need to to return early.
+    // be undefined for us, in which case, we need to return early.
     if (stream === undefined) {
         return;
     }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -895,7 +895,7 @@
 
         /* Hide the code buttons container when the user is
            clicking on the code block other than the buttons.
-           This allows the user to select part of the the code
+           This allows the user to select part of the code
            without the buttons interfering with the selection. */
         &:active .code-buttons-container:not(:hover) {
             visibility: hidden;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -916,7 +916,7 @@
 
         /* Hide the code buttons container when the user is
            clicking on the code block other than the buttons.
-           This allows the user to select part of the the code
+           This allows the user to select part of the code
            without the buttons interfering with the selection. */
         &:active .code-buttons-container:not(:hover) {
             visibility: hidden;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -637,7 +637,7 @@ h4.stream_setting_subsection_title {
                     }
 
                     .icon-button {
-                        /* Equal to to font sizes for other icon buttons
+                        /* Equal to font sizes for other icon buttons
                         in the channel and group settings UI. */
                         font-size: calc(1.2 * var(--base-font-size-px));
                     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -592,7 +592,7 @@
                     }
 
                     .icon-button {
-                        /* Equal to to font sizes for other icon buttons
+                        /* Equal to font sizes for other icon buttons
                         in the channel and group settings UI. */
                         font-size: calc(1.2 * var(--base-font-size-px));
                     }

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -959,7 +959,7 @@ ${fence}`;
     assert.ok(message_lists.current.selected_id() !== 50);
 
     // If message text from some message is not highlighted(selected) when using the ">" hotkey
-    // to quote, then message_id passed to `respond_to_message` will be same as as the
+    // to quote, then message_id passed to `respond_to_message` will be same as the
     // id of the message having the pointer.
     const message_with_pointer = highlighted_message;
     override_rewire(compose_reply, "get_highlighted_message_ids", () => undefined);

--- a/web/tests/user_search.test.cjs
+++ b/web/tests/user_search.test.cjs
@@ -163,7 +163,7 @@ test("fetch on search", async ({override}) => {
     assert.equal(populate_call_count, 1);
 
     // Now try updating the narrow and starting a new search, before the old search
-    // is resolved. We should make two requests but only only update populate the
+    // is resolved. We should make two requests but only populate the
     // buddy list for the second fetch (the first fetch returns early).
     get_call_count = 0;
     populate_call_count = 0;

--- a/web/tests/user_search.test.cjs
+++ b/web/tests/user_search.test.cjs
@@ -163,7 +163,7 @@ test("fetch on search", async ({override}) => {
     assert.equal(populate_call_count, 1);
 
     // Now try updating the narrow and starting a new search, before the old search
-    // is resolved. We should make two requests but only only update populate the
+    // is resolved. We should make two requests but only update populate the
     // buddy list for the second fetch (the first fetch returns early).
     get_call_count = 0;
     populate_call_count = 0;

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1208,7 +1208,7 @@ def do_update_message(
             # TODO: Guest users don't see the new moved topic
             # unless breadcrumb message for new stream is
             # enabled. Excluding these users from receiving this
-            # event helps us avoid a error traceback for our
+            # event helps us avoid an error traceback for our
             # clients. We should figure out a way to inform the
             # guest users of this new topic if sending a 'message'
             # event for these messages is not an option.

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1221,7 +1221,7 @@ def do_update_message(
             # TODO: Guest users don't see the new moved topic
             # unless breadcrumb message for new stream is
             # enabled. Excluding these users from receiving this
-            # event helps us avoid a error traceback for our
+            # event helps us avoid an error traceback for our
             # clients. We should figure out a way to inform the
             # guest users of this new topic if sending a 'message'
             # event for these messages is not an option.

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -880,7 +880,7 @@ def filter_presence_idle_user_ids(user_ids: set[int]) -> list[int]:
     # Given a set of user IDs (the recipients of a message), accesses
     # the UserPresence table to determine which of these users are
     # currently idle and should potentially get email notifications
-    # (and push notifications with with
+    # (and push notifications with
     # user_profile.enable_online_push_notifications=False).
 
     if not user_ids:

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -918,7 +918,7 @@ def filter_presence_idle_user_ids(user_ids: set[int]) -> list[int]:
     # Given a set of user IDs (the recipients of a message), accesses
     # the UserPresence table to determine which of these users are
     # currently idle and should potentially get email notifications
-    # (and push notifications with with
+    # (and push notifications with
     # user_profile.enable_online_push_notifications=False).
 
     if not user_ids:

--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -114,7 +114,7 @@ def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
 def check_attachment_reference_change(
     message: Message | ScheduledMessage, rendering_result: MessageRenderingResult
 ) -> AttachmentChangeResult:
-    # For a unsaved message edit (message.* has been updated, but not
+    # For an unsaved message edit (message.* has been updated, but not
     # saved to the database), adjusts Attachment data to correspond to
     # the new content.
     prev_attachments = {a.path_id for a in message.attachment_set.all()}

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -661,7 +661,7 @@ def require_server_admin_api(
         **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if not request.user.is_staff:
-            raise JsonableError(_("Must be an server administrator"))
+            raise JsonableError(_("Must be a server administrator"))
         return view_func(request, *args, **kwargs)
 
     return _wrapped_view_func

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -30,7 +30,7 @@ class RawReactionRow(TypedDict):
 def sew_messages_and_reactions(
     messages: list[dict[str, Any]], reactions: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    """Given a iterable of messages and reactions stitch reactions
+    """Given an iterable of messages and reactions stitch reactions
     into messages.
     """
     # Add all messages with empty reaction item

--- a/zerver/lib/typed_endpoint.py
+++ b/zerver/lib/typed_endpoint.py
@@ -355,7 +355,7 @@ def parse_value_for_parameter(parameter: FuncParam[T], value: object) -> T:
         error = exc.errors()[0]
         # We require all Pydantic raised error types that we expect to be
         # explicitly handled here. The end result should either be a 400
-        # error with an translated message or an internal server error.
+        # error with a translated message or an internal server error.
         error_template = ERROR_TEMPLATES.get(error["type"])
         var_name = parameter.request_var_name + "".join(
             f"[{json.dumps(loc)}]" for loc in error["loc"]

--- a/zerver/models/prereg_users.py
+++ b/zerver/models/prereg_users.py
@@ -120,7 +120,7 @@ class PreregistrationUser(models.Model):
 
     # Used in realm import flow to allow importer (the person
     # whose email is set as PreregistrationRealm.email) to create
-    # a new user if a imported user with the matching
+    # a new user if an imported user with the matching
     # email was not found.
     is_realm_importer = models.BooleanField(default=False)
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1453,7 +1453,7 @@ paths:
                                     Not present for clients that support the `simplified_presence_events`
                                     [client capability](/api/register-queue#parameter-client_capabilities).
 
-                                    Object containing the presence data (legacy format) of of the modified
+                                    Object containing the presence data (legacy format) of the modified
                                     user.
                                   additionalProperties:
                                     type: object
@@ -24829,7 +24829,7 @@ paths:
                 can_resolve_topics_group:
                   allOf:
                     - description: |
-                        The set of users who have permission to to resolve topics in this channel
+                        The set of users who have permission to resolve topics in this channel
                         expressed as an [update to a group-setting value][update-group-setting].
 
                         [update-group-setting]: /api/group-setting-values#updating-group-setting-values

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1453,7 +1453,7 @@ paths:
                                     Not present for clients that support the `simplified_presence_events`
                                     [client capability](/api/register-queue#parameter-client_capabilities).
 
-                                    Object containing the presence data (legacy format) of of the modified
+                                    Object containing the presence data (legacy format) of the modified
                                     user.
                                   additionalProperties:
                                     type: object
@@ -25095,7 +25095,7 @@ paths:
                 can_resolve_topics_group:
                   allOf:
                     - description: |
-                        The set of users who have permission to to resolve topics in this channel
+                        The set of users who have permission to resolve topics in this channel
                         expressed as an [update to a group-setting value][update-group-setting].
 
                         [update-group-setting]: /api/group-setting-values#updating-group-setting-values

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -1571,7 +1571,7 @@ class TestRealmAuditLog(ZulipTestCase):
 
         othello = self.example_user("othello")
         old_setting_api_value = get_group_setting_value_for_api(user_group.can_mention_group)
-        # Since the old setting value was a anonymous group, we just update the
+        # Since the old setting value was an anonymous group, we just update the
         # members and subgroups of the already existing UserGroup instead of creating
         # a new UserGroup object to keep this consistent with the actual code.
         new_group = self.create_or_update_anonymous_group_for_setting(

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1138,7 +1138,7 @@ class RealmImportExportTest(ExportFile):
             all(row["is_mirror_dummy"] is False for row in realm_data["zerver_userprofile"])
         )
 
-        # Verify that the deactivated_non_consented_user did not not become a mirror dummy.
+        # Verify that the deactivated_non_consented_user did not become a mirror dummy.
         exported_deactivated_non_consented_user = next(
             user
             for user in realm_data["zerver_userprofile"]
@@ -1446,7 +1446,7 @@ class RealmImportExportTest(ExportFile):
             original_sub = model_to_dict(sub)
             exported_sub = non_consented_user_exported_subscriptions[sub.id]
             self.assertNotEqual(original_sub, exported_sub)
-            # Subscriptions of the non-consenting users get get scrubbed to replace
+            # Subscriptions of the non-consenting users get scrubbed to replace
             # "user setting"-type attributes with default values, so the #foo color
             # will be overwritten in the process.
             self.assertNotEqual(exported_sub["color"], "#foo")

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1133,7 +1133,7 @@ class RealmImportExportTest(ExportFile):
             all(row["is_mirror_dummy"] is False for row in realm_data["zerver_userprofile"])
         )
 
-        # Verify that the deactivated_non_consented_user did not not become a mirror dummy.
+        # Verify that the deactivated_non_consented_user did not become a mirror dummy.
         exported_deactivated_non_consented_user = next(
             user
             for user in realm_data["zerver_userprofile"]
@@ -1441,7 +1441,7 @@ class RealmImportExportTest(ExportFile):
             original_sub = model_to_dict(sub)
             exported_sub = non_consented_user_exported_subscriptions[sub.id]
             self.assertNotEqual(original_sub, exported_sub)
-            # Subscriptions of the non-consenting users get get scrubbed to replace
+            # Subscriptions of the non-consenting users get scrubbed to replace
             # "user setting"-type attributes with default values, so the #foo color
             # will be overwritten in the process.
             self.assertNotEqual(exported_sub["color"], "#foo")

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -2394,7 +2394,7 @@ class EditMessageTest(ZulipTestCase):
         self.assert_json_success(result)
 
     def test_remove_attachment_while_editing(self) -> None:
-        # Try editing a message and removing an linked attachment that's
+        # Try editing a message and removing a linked attachment that's
         # uploaded by us. Users should be able to detach their own attachments
         CONST_UPLOAD_PATH_PREFIX = "/user_uploads/"
         user_profile = self.example_user("hamlet")
@@ -2466,7 +2466,7 @@ class EditMessageTest(ZulipTestCase):
         self.assert_length(result_content["detached_uploads"], 0)
 
     def test_remove_another_user_attachment_while_editing(self) -> None:
-        # Try editing a message and removing an linked attachment that's
+        # Try editing a message and removing a linked attachment that's
         # uploaded by another user. Users should not be able to detach another
         # user's attachments.
 
@@ -2510,7 +2510,7 @@ class EditMessageTest(ZulipTestCase):
         self.assert_length(result_content["detached_uploads"], 0)
 
     def test_remove_another_user_deleted_attachment_while_editing(self) -> None:
-        # Try editing a message and removing an linked attachment that's been
+        # Try editing a message and removing a linked attachment that's been
         # uploaded and deleted by the original user. Users should not be able
         # to detach another user's attachments.
 

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -270,7 +270,7 @@ class ReactionMessageIDTest(ZulipTestCase):
 
     def test_inaccessible_message_id(self) -> None:
         """
-        Reacting to a inaccessible (for instance, private) message fails
+        Reacting to an inaccessible (for instance, private) message fails
         """
         pm_sender = self.example_user("hamlet")
         pm_recipient = self.example_user("othello")

--- a/zerver/tests/test_read_receipts.py
+++ b/zerver/tests/test_read_receipts.py
@@ -247,7 +247,7 @@ class TestReadReceipts(ZulipTestCase):
         self.assertFalse(cordelia.id in response_dict["user_ids"])
         self.assertTrue(othello.id in response_dict["user_ids"])
 
-        # Login as Othello and make sure Cordelia is not in in read receipts.
+        # Login as Othello and make sure Cordelia is not in read receipts.
         self.login("othello")
         result = self.client_get(f"/json/messages/{message_id}/read_receipts")
         response_dict = self.assert_json_success(result)

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -481,7 +481,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         self.subscribe(long_term_idle_user, stream_name)
         sent_message_list.append(send_fake_message("Test message 7", stream))
         # Again unsubscribe from stream and send a message.
-        # This will make sure that if initially in a unsubscribed state
+        # This will make sure that if initially in an unsubscribed state
         # a consecutive subscribe/unsubscribe doesn't misbehave.
         self.unsubscribe(long_term_idle_user, stream_name)
         send_fake_message("Test message 8", stream)
@@ -806,7 +806,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         )
 
         # Test UserMessage row is created while user is deactivated if there
-        # is a alert word in message.
+        # is an alert word in message.
         do_add_alert_words(long_term_idle_user, ["test_alert_word"])
         assert_stream_message_sent_to_idle_user("Testing test_alert_word")
 

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -515,7 +515,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         self.subscribe(long_term_idle_user, stream_name)
         sent_message_list.append(send_fake_message("Test message 7", stream))
         # Again unsubscribe from stream and send a message.
-        # This will make sure that if initially in a unsubscribed state
+        # This will make sure that if initially in an unsubscribed state
         # a consecutive subscribe/unsubscribe doesn't misbehave.
         self.unsubscribe(long_term_idle_user, stream_name)
         send_fake_message("Test message 8", stream)
@@ -840,7 +840,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         )
 
         # Test UserMessage row is created while user is deactivated if there
-        # is a alert word in message.
+        # is an alert word in message.
         do_add_alert_words(long_term_idle_user, ["test_alert_word"])
         assert_stream_message_sent_to_idle_user("Testing test_alert_word")
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3555,7 +3555,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_patch_enforces_valid_stream_name_check(self) -> None:
         """
-        Only way to force an error is with a empty string.
+        Only way to force an error is with an empty string.
         """
         user = self.example_user("hamlet")
         self.login_user(user)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3644,7 +3644,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_patch_enforces_valid_stream_name_check(self) -> None:
         """
-        Only way to force an error is with a empty string.
+        Only way to force an error is with an empty string.
         """
         user = self.example_user("hamlet")
         self.login_user(user)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1885,7 +1885,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
     def test_valid_icons(self) -> None:
         """
         A PUT request to /json/realm/icon with a valid file should return a URL
-        and actually create an realm icon.
+        and actually create a realm icon.
         """
         for fname, rfname in self.correct_files:
             with self.subTest(fname=fname):
@@ -2080,7 +2080,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
     def test_valid_logos(self) -> None:
         """
         A PUT request to /json/realm/logo with a valid file should return a URL
-        and actually create an realm logo.
+        and actually create a realm logo.
         """
         for fname, rfname in self.correct_files:
             with self.subTest(fname=fname):

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1890,7 +1890,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
     def test_valid_icons(self) -> None:
         """
         A PUT request to /json/realm/icon with a valid file should return a URL
-        and actually create an realm icon.
+        and actually create a realm icon.
         """
         for fname, rfname in self.correct_files:
             with self.subTest(fname=fname):
@@ -2085,7 +2085,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
     def test_valid_logos(self) -> None:
         """
         A PUT request to /json/realm/logo with a valid file should return a URL
-        and actually create an realm logo.
+        and actually create a realm logo.
         """
         for fname, rfname in self.correct_files:
             with self.subTest(fname=fname):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1737,7 +1737,7 @@ class UserProfileTest(ZulipTestCase):
         for onboarding_step in onboarding_steps_completed:
             OnboardingStep.objects.create(user=cordelia, onboarding_step=onboarding_step)
 
-        # Check that we didn't send an realm_user update events to
+        # Check that we didn't send a realm_user update events to
         # users; this work is happening before the user account is
         # created, so any changes will be reflected in the "add" event
         # introducing the user to clients.
@@ -1795,7 +1795,7 @@ class UserProfileTest(ZulipTestCase):
         realm_user_default.enter_sends = True
         realm_user_default.save()
 
-        # Check that we didn't send an realm_user update events to
+        # Check that we didn't send a realm_user update events to
         # users; this work is happening before the user account is
         # created, so any changes will be reflected in the "add" event
         # introducing the user to clients.
@@ -1821,7 +1821,7 @@ class UserProfileTest(ZulipTestCase):
         self.assertEqual(cross_realm_bot.email, bot.email)
         self.assertEqual(cross_realm_bot.id, bot.id)
 
-        # Pass in the ID of a cross-realm bot but with a invalid realm,
+        # Pass in the ID of a cross-realm bot but with an invalid realm,
         # note that the realm should be irrelevant here
         cross_realm_bot = get_user_by_id_in_realm_including_cross_realm(bot.id, None)
         self.assertEqual(cross_realm_bot.email, bot.email)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1738,7 +1738,7 @@ class UserProfileTest(ZulipTestCase):
         for onboarding_step in onboarding_steps_completed:
             OnboardingStep.objects.create(user=cordelia, onboarding_step=onboarding_step)
 
-        # Check that we didn't send an realm_user update events to
+        # Check that we didn't send any realm_user update events to
         # users; this work is happening before the user account is
         # created, so any changes will be reflected in the "add" event
         # introducing the user to clients.
@@ -1796,7 +1796,7 @@ class UserProfileTest(ZulipTestCase):
         realm_user_default.enter_sends = True
         realm_user_default.save()
 
-        # Check that we didn't send an realm_user update events to
+        # Check that we didn't send any realm_user update events to
         # users; this work is happening before the user account is
         # created, so any changes will be reflected in the "add" event
         # introducing the user to clients.
@@ -1822,7 +1822,7 @@ class UserProfileTest(ZulipTestCase):
         self.assertEqual(cross_realm_bot.email, bot.email)
         self.assertEqual(cross_realm_bot.id, bot.id)
 
-        # Pass in the ID of a cross-realm bot but with a invalid realm,
+        # Pass in the ID of a cross-realm bot but with an invalid realm,
         # note that the realm should be irrelevant here
         cross_realm_bot = get_user_by_id_in_realm_including_cross_realm(bot.id, None)
         self.assertEqual(cross_realm_bot.email, bot.email)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -749,7 +749,7 @@ def send_restart_events() -> None:
 
 def mark_clients_to_reload(queue_ids: Iterable[str]) -> None:
     # Build web_reload_clients, which is a sorted-by-realm-id list of
-    # website client queue-ids which were were loaded from old Tornado
+    # website client queue-ids which were loaded from old Tornado
     # instances.  We use an (ordered) dict to make removing one be
     # O(1), as well as pulling an ordered N of them to be O(N).  We
     # sort by realm_id so that restarts are rolling by realm.

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1354,7 +1354,7 @@ def realm_import_post_process(
 
             # Validate that this PreregistrationRealm object is in the
             # expected state, with no user matching the email address,
-            # and and having created this realm.
+            # and having created this realm.
             assert preregistration_realm.data_import_metadata["need_select_realm_owner"]
             assert preregistration_realm.created_realm_id == realm.id
             assert preregistration_realm.status != confirmation_settings.STATUS_USED

--- a/zerver/worker/thumbnail.py
+++ b/zerver/worker/thumbnail.py
@@ -101,7 +101,7 @@ def ensure_thumbnails(image_attachment: ImageAttachment) -> ThumbnailingResult:
         uploading_seconds = 0.0
         for thumbnail_format in needed_thumbnails:
             # This will scale to fit within the given dimensions; it
-            # may be smaller one one or more of them.
+            # may be smaller in one or more of them.
             logger.debug(
                 "Resizing to %d x %d, from %d x %d",
                 thumbnail_format.max_width,

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -2772,7 +2772,7 @@ def social_auth_finish(
             use_dummy_backend=True,
         )
         if validated_user_profile is None or validated_user_profile != user_profile:
-            # Log this as as a failure to authenticate via the social backend, since that's
+            # Log this as a failure to authenticate via the social backend, since that's
             # the correct way to think about this. ZulipDummyBackend is just an implementation
             # tool, not an actual backend a user could be authenticating through.
             log_auth_attempt(


### PR DESCRIPTION
This started as a small fix for a few typos in the code-style guide.
While rebasing, I found that most of those typos had already been
fixed upstream, so I turned it into a wider cleanup of grammar
mistakes across the codebase.

Most of the fixes are in comments, docstrings, and documentation:

- Doubled words, like "the the", "with with", and "will will".
- Wrong articles, like "a error" and "an translated".

Two changes are more visible than a comment:

- The code-style guide said "Note that will take a little time", which
  is missing its subject; it now reads "Note that it takes a little
  time". It also now says that `.save()` without `update_fields`
  overwrites every field in that row, instead of "every value in the
  column".
- The error message "Must be an server administrator" is now "a server
  administrator", and the two tests that check it are updated to match.

None of the comment or documentation changes affect how the code runs.

Picks up the documentation fixes from #38114.

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
