### PR TITLE
EmoticonTranslations: Avoid bundling 3700 unused emoji images

### DIFF
--- a/starlight_help/src/components/EmoticonTranslations.astro
+++ b/starlight_help/src/components/EmoticonTranslations.astro
@@ -1,13 +1,8 @@
 ---
-import EmojiCodes from "../../../static/generated/emoji/emoji_codes.json";
+import {getCollection} from "astro:content";
 
-const nameToCodePoint: Record<string, string> = EmojiCodes.name_to_codepoint;
-const emojiImageUrls: Record<string, {src: string}> = import.meta.glob(
-    "../../../static/generated/emoji/images-google-64/*.png",
-    {
-        eager: true,
-        import: "default",
-    },
+const emoticons = (await getCollection("emoticons")).toSorted(
+    (a, b) => a.data.order - b.data.order,
 );
 
 const rowHTML = (emoticon: string, emoji: string, imageSrc: string) => `
@@ -17,13 +12,8 @@ const rowHTML = (emoticon: string, emoji: string, imageSrc: string) => `
 </tr>
 `;
 let body = "";
-const emoticonConversions: Record<string, string> =
-    EmojiCodes.emoticon_conversions;
-for (const name of Object.keys(emoticonConversions)) {
-    const emoticon: string = emoticonConversions[name]!;
-    const codepoint = nameToCodePoint[emoticon.slice(1, -1)]!;
-    const imagePath = `../../../static/generated/emoji/images-google-64/${codepoint}.png`;
-    body += rowHTML(name, emoticon, emojiImageUrls[imagePath]!.src);
+for (const entry of emoticons) {
+    body += rowHTML(entry.id, entry.data.emoji, entry.data.image.src);
 }
 ---
 

--- a/starlight_help/src/content.config.ts
+++ b/starlight_help/src/content.config.ts
@@ -1,7 +1,27 @@
 import {docsLoader} from "@astrojs/starlight/loaders";
 import {docsSchema} from "@astrojs/starlight/schema";
+import {z} from "astro/zod";
 import {defineCollection} from "astro:content";
+
+import EmojiCodes from "../../static/generated/emoji/emoji_codes.json";
+
+const emoticonConversions: Record<string, string> = EmojiCodes.emoticon_conversions;
+const nameToCodePoint: Record<string, string> = EmojiCodes.name_to_codepoint;
+
+// Using image() in the schema means Astro bundles only the few emoji used for
+// emoticons, rather than the thousands import.meta.glob would copy.
+const emoticons = defineCollection({
+    loader: () =>
+        Object.entries(emoticonConversions).map(([emoticon, emoji], order) => ({
+            id: emoticon,
+            order,
+            emoji,
+            image: `../../static/generated/emoji/images-google-64/${nameToCodePoint[emoji.slice(1, -1)]}.png`,
+        })),
+    schema: ({image}) => z.object({order: z.int(), emoji: z.string(), image: image()}),
+});
 
 export const collections = {
     docs: defineCollection({loader: docsLoader(), schema: docsSchema()}),
+    emoticons,
 };


### PR DESCRIPTION
The directory-wide `import.meta.glob` in `EmoticonTranslations` matched every emoji PNG, so Astro bundled some 3700 unused images into `dist/_astro`.  Instead, derive the dozen emoticon-translation entries from `emoji_codes.json` in a [content collection](https://docs.astro.build/en/guides/content-collections/), using the [`image()`](https://docs.astro.build/en/guides/images/#images-in-content-collections) schema helper so only the referenced emoji are bundled.

- Cc @shubham-padia (#37828).