### PR TITLE
configure-rabbitmq: Fix rabbitmqctl typo that broke non-default vhosts.

### DIFF
--- a/scripts/setup/configure-rabbitmq
+++ b/scripts/setup/configure-rabbitmq
@@ -25,6 +25,6 @@ rabbitmqctl delete_user guest || true
 rabbitmqctl add_user "$RABBITMQ_USERNAME" "$RABBITMQ_PASSWORD"
 rabbitmqctl set_user_tags "$RABBITMQ_USERNAME" administrator
 if ! rabbitmqctl list_vhosts --no-table-headers --quiet | grep -qx "$RABBITMQ_VHOST"; then
-    rabbitmqcql add_vhost "$RABBITMQ_VHOST"
+    rabbitmqctl add_vhost "$RABBITMQ_VHOST"
 fi
 rabbitmqctl set_permissions -p "$RABBITMQ_VHOST" "$RABBITMQ_USERNAME" '.*' '.*' '.*'


### PR DESCRIPTION
The add_vhost call was misspelled "rabbitmqcql", which exits 127 (command not found) and, under set -eu, aborts the whole install/upgrade run. The branch only executes when RABBITMQ_VHOST is not the default "/" (the default vhost already exists, so the grep test skips the branch), which is why the typo went unnoticed since it was introduced.
