### PR TITLE
scheduled_messages: Lock the row when editing to avoid duplicate send.

### DIFF
--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -172,9 +172,12 @@ def edit_scheduled_message(
     deliver_at: datetime | None,
     realm: Realm,
 ) -> None:
-    scheduled_message_object = access_scheduled_message(sender, scheduled_message_id)
+    scheduled_message_object = access_scheduled_message(
+        sender, scheduled_message_id, lock_message=True
+    )
 
-    # Handles the race between us initiating this transaction and user sending us the edit request.
+    # We locked the row above, so a concurrent delivery has already
+    # committed and this guard reliably observes its delivered=True.
     if scheduled_message_object.delivered is True:
         raise JsonableError(_("Scheduled message was already sent"))
 

--- a/zerver/lib/scheduled_messages.py
+++ b/zerver/lib/scheduled_messages.py
@@ -10,10 +10,18 @@ from zerver.models.scheduled_jobs import (
 
 
 def access_scheduled_message(
-    user_profile: UserProfile, scheduled_message_id: int
+    user_profile: UserProfile,
+    scheduled_message_id: int,
+    lock_message: bool = False,
 ) -> ScheduledMessage:
+    base_query = ScheduledMessage.objects.all()
+    if lock_message:
+        # Callers that are going to modify the row should take this lock
+        # to avoid racing with an in-progress delivery. Only pass
+        # lock_message from within a @transaction.atomic block.
+        base_query = base_query.select_for_update(no_key=True)
     try:
-        return ScheduledMessage.objects.get(
+        return base_query.get(
             id=scheduled_message_id, sender=user_profile, delivery_type=ScheduledMessage.SEND_LATER
         )
     except ScheduledMessage.DoesNotExist:


### PR DESCRIPTION
edit_scheduled_message read the ScheduledMessage with an unlocked SELECT, while try_deliver_one_scheduled_message locks the row with select_for_update(no_key=True) before sending. Under READ COMMITTED the unlocked read could observe the pre-delivery snapshot (delivered=False), pass the "already sent" guard, and then save() the whole stale object back, overwriting the worker's committed delivered=True and delivered_message_id. The next worker pass would re-match the row and deliver the message a second time, while the edit silently "succeeded" on an already-sent message.

Take the same FOR NO KEY UPDATE lock in the edit path by threading a lock_message argument through access_scheduled_message, mirroring access_message. An edit that races a delivery now blocks until the worker commits and then reads delivered=True, so the existing guard reliably rejects it. The other callers (delete and the failure notification) are unaffected: a delete is already serialized by the DELETE row lock, and the notification runs inside the worker's own locked transaction.

---

Found as part of Claude audit.