### PR TITLE
style: Fix keyboard focus styling for invite organization link

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -610,11 +610,27 @@
     margin-top: calc(25px - (var(--legacy-body-line-height-unitless) * 1em));
     margin-bottom: var(--sidebar-bottom-spacing);
 
+    &:has(:focus-visible) {
+        /* Apply focus and active styles to the parent container so the
+        entire invite-user row receives keyboard focus indication,
+        matching the behavior of other interactive sidebar rows.
+        We use :has with :focus-visible so that mouse-clicks
+        do not trigger the outline. */
+        outline: 2px solid var(--color-outline-focus);
+        outline-offset: -2px;
+        background-color: var(--color-background-hover-narrow-filter);
+    }
+
     .invite-user-link {
         /* TODO: We should eventually change the grid to use the correct
            --right-sidebar-presence-circle-width with left spacing, and
            share that left spacing value here. */
         padding-left: calc(var(--right-sidebar-toggle-width-offset) + 0.3em);
+        text-decoration: none;
+
+        &:focus {
+            outline: none;
+        }
     }
 }
 


### PR DESCRIPTION
### Description
Fixed keyboard (Tab) focus styling of the "Invite to Organization" link in the right sidebar to match the existing focus style used by action-heading links at the bottom of the left sidebar.

The fix applies focus indication on the parent container (.invite-user-shortcut) using :has(.invite-user-link:focus-visible), so the entire row receives the highlight — matching how other interactive sidebar rows behave.

Fixes: #39172

**How changes were tested:**

* Launched the Zulip dev environment on local machine (localhost:9991)
* Traversed UI with Tab key to verify focus ring appears correctly on the "Invite to Organization" link in the right sidebar
* Confirmed the entire row gets highlighted with outline: 2px solid var(--color-outline-focus) and background-color on focus,
matching the left sidebar's behavior
* Verified text-decoration: none suppresses the unwanted underline during focus
* Verified mouse clicks do not trigger the focus ring (handled by :focus-visible scoping)
* Tested in both Light and Dark themes

**Screenshots and screen captures:**

| Theme | Before | After |
| --- | --- | --- |
| **Light Theme** |<img width="359" height="57" alt="DS08im3tBj" src="https://github.com/user-attachments/assets/42c030e0-29dc-402a-a825-757c134bf7c7" />|<img width="359" height="57" alt="OKgEX6OFqe" src="https://github.com/user-attachments/assets/b4037c0c-2ea5-4513-94c7-7f4111c4aba7" />|
| **Dark Theme** |<img width="359" height="57" alt="0gipZ4UUQL" src="https://github.com/user-attachments/assets/69370613-396b-43d5-860d-876ec80a2d18" />|<img width="359" height="57" alt="chrome_gs6E5Rbpo5" src="https://github.com/user-attachments/assets/131ecd4e-b233-4e6a-8a97-7f57b5ea238c" />|

**Video demo (Light + Dark):** 

https://github.com/user-attachments/assets/5fdadf86-f39a-4a3a-b4ad-fc1e32af2610



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
(variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>