### PR TITLE
[ai] left_sidebar: Fix direct messages zoom state desyncs.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -383,11 +383,11 @@ function zoom_in(): void {
     zoomed = true;
     previous_search_term = "";
     pre_search_scroll_position = 0;
-    ui_util.disable_left_sidebar_search();
-    update_private_messages();
     $("#left-sidebar").addClass("zoom-in");
     $("#left-sidebar").addClass("zoom-in-conversations");
     $("#direct-messages-modal").toggleClass("no-display", false);
+    ui_util.disable_left_sidebar_search();
+    update_private_messages();
 
     const $filter = $(".direct-messages-list-filter").expectOne();
     $filter.trigger("focus");

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import _ from "lodash";
 import * as z from "zod/mini";
 
+import * as blueslip from "./blueslip.ts";
 import type {Filter} from "./filter.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
@@ -36,6 +37,9 @@ let last_direct_message_count: number | undefined;
 // The direct messages section can be zoomed in to view more messages.
 // This keeps track of if we're zoomed in or not.
 let zoomed = false;
+
+// Limits reporting in update_private_messages to once per page load.
+let reported_zoomed_render_with_hidden_modal = false;
 
 // Scroll position before user started searching.
 let pre_search_scroll_position = 0;
@@ -154,6 +158,19 @@ function set_dom_to(new_dom: vdom.Tag<PMNode>, for_modal: boolean): void {
 }
 
 export function update_private_messages(): void {
+    if (
+        zoomed &&
+        !reported_zoomed_render_with_hidden_modal &&
+        $("#direct-messages-modal").hasClass("no-display")
+    ) {
+        // This render targets the zoomed modal, but the modal isn't
+        // visible, so the sidebar list the user sees will go stale.
+        // No known code path reaches this state; report it so that
+        // error reports can identify any path that does.
+        reported_zoomed_render_with_hidden_modal = true;
+        blueslip.error("Rendering zoomed DM list while its modal is hidden");
+    }
+
     const is_left_sidebar_search_active = ui_util.get_left_sidebar_search_term() !== "";
     const is_dm_section_expanded = is_left_sidebar_search_active || !private_messages_collapsed;
     if (!temporarily_collapsed) {

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -393,7 +393,7 @@ function zoom_in(): void {
     $filter.trigger("focus");
 }
 
-function zoom_out(): void {
+export function zoom_out(): void {
     if (!zoomed) {
         return;
     }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -628,6 +628,11 @@ export function dispatch_normal_event(event) {
                         activity_ui.redraw_user(event.person.user_id);
                     }
 
+                    // The user may already appear in direct message
+                    // conversations, previously rendered with a
+                    // placeholder user record.
+                    pm_list.update_private_messages();
+
                     if (!event.person.is_bot) {
                         settings_exports.update_export_consent_data_and_redraw({
                             user_id: event.person.user_id,
@@ -651,6 +656,7 @@ export function dispatch_normal_event(event) {
                         user_id,
                         people.INACCESSIBLE_USER_NAME,
                     );
+                    pm_list.update_private_messages();
                     break;
                 }
                 default:

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -163,7 +163,7 @@ function zoom_in(stream_id: number): void {
     }
 
     zoomed_in = true;
-    $("#direct-messages-modal").toggleClass("no-display", true);
+    pm_list.zoom_out();
     popovers.hide_all();
     pm_list.close();
     zoom_in_topics(stream_id);

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -970,6 +970,7 @@ run_test("add_realm_user_redraw_logic", ({override}) => {
 
     override(settings_account, "maybe_update_deactivate_account_button", noop);
     override(settings_exports, "update_export_consent_data_and_redraw", noop);
+    override(pm_list, "update_private_messages", noop);
 
     const check_should_redraw_new_user_stub = make_stub();
     // make_stub().f returns true by default, so it's already doing what we want.
@@ -989,8 +990,11 @@ run_test("realm_user", ({override}) => {
     override(settings_account, "maybe_update_deactivate_account_button", noop);
     override(activity_ui, "check_should_redraw_new_user", noop);
     override(settings_exports, "update_export_consent_data_and_redraw", noop);
+    const pm_list_stub = make_stub();
+    override(pm_list, "update_private_messages", pm_list_stub.f);
     let event = event_fixtures.realm_user__add;
     dispatch({...event});
+    assert.equal(pm_list_stub.num_calls, 1);
     const added_person = people.get_by_user_id(event.person.user_id);
     // sanity check a few individual fields
     assert.equal(added_person.full_name, "Test User");
@@ -1027,7 +1031,10 @@ run_test("realm_user", ({override}) => {
 
     override(settings_data, "user_can_access_all_other_users", () => false);
     event = event_fixtures.realm_user__remove;
+    // The second and third update_private_messages calls are from
+    // dispatching realm_user__add_bot above and this remove event.
     dispatch(event);
+    assert.equal(pm_list_stub.num_calls, 3);
     const removed_person = people.get_by_user_id(event.person.user_id);
     assert.equal(removed_person.full_name, "translated: Unknown user");
 });

--- a/web/tests/example4.test.cjs
+++ b/web/tests/example4.test.cjs
@@ -99,6 +99,7 @@ run_test("add users with event", ({override}) => {
     // Keep reading to see how overriding works!
     override(settings_bots, "redraw_all_bots_list", noop);
     override(activity_ui, "check_should_redraw_new_user", noop);
+    override(pm_list, "update_private_messages", noop);
     // Let's simulate dispatching our event!
     server_events_dispatch.dispatch_normal_event(event);
 
@@ -109,10 +110,10 @@ run_test("add users with event", ({override}) => {
 /*
 
    It's actually a little surprising that adding a user does
-   not have side effects beyond the people object and the bots list.
-   I guess we don't immediately update the buddy list, but that's
-   because the buddy list gets updated on the next server
-   fetch.
+   not have side effects beyond the people object, the bots list,
+   and the direct messages list. I guess we don't immediately
+   update the buddy list, but that's because the buddy list gets
+   updated on the next server fetch.
 
    Let's try an update next.  To make this work, we will want
    to override some more of our stubs.


### PR DESCRIPTION
Related report (not confirmed fixed by this PR — see below):
[#issues > Ordering of topics to include unread first](https://chat.zulip.org/#narrow/channel/9-issues/topic/Ordering.20of.20topics.20to.20include.20unread.20first/with/2462695)

When `pm_list`'s internal `zoomed` flag is set while the zoomed "more
conversations" modal is hidden, every direct messages list render targets
the hidden modal container: the sidebar rows the user sees freeze, while
the header unread badge (updated separately via `set_count`) stays live.
This matches the symptoms and screenshots in the report above, including
that zooming in and out of "more conversations" repairs the list.

This commit series:
1. Makes `stream_list`'s topics zoom exit the DM zoom properly (via a new
   `pm_list.zoom_out()` export) instead of just hiding its modal, which
   left the `zoomed` flag set. Reachable by pressing the browser back
   button to a channel narrow saved with `show_more_topics` while the DM
   zoom is open; reproduced in the dev environment.
2. Reorders `pm_list.zoom_in()` to show the modal before rendering its
   contents, so an exception during rendering leaves a visible modal with
   a working close button rather than an invisible stuck zoom state. No
   visual change when rendering succeeds: no paint can occur between
   these synchronous DOM updates.
3. Adds a blueslip report when a render targets a hidden zoomed modal.
   The two commits above fix the ways we know of to reach that state; we
   have **not** organically reproduced the exact state in the original
   report, so this probe exists to identify any remaining path from error
   report breadcrumbs.
4. Re-renders the DM list on `realm_user` add/remove events. Conversations
   whose participant is known only via a placeholder user record are
   classified as including a deactivated user (and hidden when read);
   previously nothing re-rendered the list when the real user data
   arrived.

**Open questions:**
- Should the probe in commit 3 also recover (call `zoom_out()`) instead of
  only reporting? Reporting-only is harmless on false positives; recovery
  fixes the user's frozen sidebar immediately but force-closes the zoom if
  the check ever misfires.
- Commit 4 re-renders unconditionally, matching neighboring handlers
  (user_status, full-name updates). A `pm_conversations.recent.has_user()`
  guard is possible if per-event work is a concern; note that
  `is_partner()` is not a correct guard, since `partners` isn't populated
  from the register payload.

**How changes were tested:**

- [x] Manual: browser-back to a `show_more_topics` history entry while the
      DM zoom is open exits the DM zoom cleanly (previously: DM modal
      replaced silently, then Escape left an empty sidebar modal overlay)
- [x] Manual: normal "more conversations" zoom in/out behavior unchanged


**Screenshots and screen captures:**

Before (reaches broken zoomed DM state):

<img width="2810" height="2098" alt="Kapture 2026-06-10 at 13 49 08" src="https://github.com/user-attachments/assets/f748a9fd-abb5-4675-947b-f98a95ba42a1" />

After (fixed):

<img width="2810" height="2098" alt="Kapture 2026-06-10 at 13 47 22" src="https://github.com/user-attachments/assets/16a037ef-e0bc-493d-a850-a9f61815fd2e" />
