### PR TITLE
[ai] Fix recent view channel header overlapping with conversation.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1695,6 +1695,27 @@ function set_time_column_width_css_variable(): void {
     $(":root").css("--recent-view-time-text-width", `${Math.ceil(max_width)}px`);
 }
 
+function set_channel_header_min_width_css_variable(): void {
+    if (page_params.is_node_test) {
+        return;
+    }
+    const $channel_sort_header = $(".recent-view-channel-sort-header");
+    if ($channel_sort_header.length === 0) {
+        return;
+    }
+    // Measure the "Channel" sort header's intrinsic width by cloning
+    // it into a hidden max-content wrapper inside the header cell (so
+    // it keeps the same styles). CSS floors the channel column to this
+    // width so the label never overlaps the "Conversation" header.
+    const measure_wrapper = util.make_offscreen_measurement_container();
+    measure_wrapper.append($channel_sort_header[0]!.cloneNode(true));
+    const $header_cell = $channel_sort_header.closest("th");
+    $header_cell[0]!.append(measure_wrapper);
+    const width = measure_wrapper.getBoundingClientRect().width;
+    measure_wrapper.remove();
+    $(":root").css("--recent-view-header-channel-column-min-width", `${Math.ceil(width)}px`);
+}
+
 export function update_participants_column_class(): void {
     if (!page_params.is_node_test) {
         max_avatars = Number.parseInt($(":root").css("--recent-view-max-avatars"), 10);
@@ -1738,6 +1759,9 @@ export function complete_rerender(coming_from_other_views = false): void {
         ...get_recent_view_filters_params(),
     });
     $("#recent_view_table").html(rendered_body);
+
+    // Measure the "Channel" header now that it is in the DOM.
+    set_channel_header_min_width_css_variable();
 
     // `show_selected_filters` needs to be called after the Recent
     // Conversations view has been added to the DOM, to ensure that filters

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -599,13 +599,12 @@ export function parse_youtube_start_time(url: string): number | undefined {
     return undefined;
 }
 
-// Measure the maximum rendered width of a set of candidate text
-// strings. This is used to set CSS variables for column widths
-// that need to fit their content tightly. All candidates are
-// inserted as block-level children of a single hidden container
-// sized to max-content, so only one reflow is needed.
+// Make a hidden, max-content-sized container for measuring the
+// rendered width of content without affecting the page layout.
+// Append it where the content's CSS rules apply, measure, and
+// remove it.
 /* istanbul ignore next */
-export let max_text_content_width = (candidates: string[], css_class?: string): number => {
+export function make_offscreen_measurement_container(): HTMLDivElement {
     const container = document.createElement("div");
     Object.assign(container.style, {
         position: "absolute",
@@ -615,6 +614,17 @@ export let max_text_content_width = (candidates: string[], css_class?: string): 
         left: "-9999px",
         top: "0",
     });
+    return container;
+}
+
+// Measure the maximum rendered width of a set of candidate text
+// strings. This is used to set CSS variables for column widths
+// that need to fit their content tightly. All candidates are
+// inserted as block-level children of a single hidden container
+// sized to max-content, so only one reflow is needed.
+/* istanbul ignore next */
+export let max_text_content_width = (candidates: string[], css_class?: string): number => {
+    const container = make_offscreen_measurement_container();
 
     for (const text of candidates) {
         const child = document.createElement("div");

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1237,6 +1237,13 @@
     --recent-view-body-border-width: 1px;
     --recent-view-header-border-width: 1px;
     --recent-view-row-left-padding: 0.75em; /* 12px at 16px / 1em */
+    /* How much farther right the row grid starts than the header
+       grid; the header widens its first column by this to align. */
+    --recent-view-header-channel-column-adjustment: calc(
+        var(--recent-view-row-left-padding) +
+            var(--recent-view-body-border-width) -
+            var(--recent-view-header-border-width)
+    );
     --recent-view-max-avatars: 4;
     --recent-view-participant-item-width: 1.5em; /* 24px at 16px / 1em */
     --recent-view-participant-item-padding-x: 0.0938em; /* 1.5px at 16px / 1em */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1235,6 +1235,8 @@
 
     /* Recent view */
     --recent-view-body-border-width: 1px;
+    --recent-view-header-border-width: 1px;
+    --recent-view-row-left-padding: 0.75em; /* 12px at 16px / 1em */
     --recent-view-max-avatars: 4;
     --recent-view-participant-item-width: 1.5em; /* 24px at 16px / 1em */
     --recent-view-participant-item-padding-x: 0.0938em; /* 1.5px at 16px / 1em */

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -760,8 +760,11 @@
     }
 
     &.recent-view-participants-hidden {
+        --recent-view-row-left-padding: 0.5em; /* 8px at 16px/1em */
+
         td {
-            padding: 0.375em 0.5em; /* 6px 8px at 16px/1em */
+            /* 6px 8px at 16px/1em */
+            padding: 0.375em 0.5em 0.375em var(--recent-view-row-left-padding);
         }
 
         .recent_topic_users,

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -696,10 +696,8 @@
             align-items: center;
             gap: 4px;
             cursor: pointer;
-            /* Negative margin compensates the padding so the pill hover
-               highlight doesn't push adjacent elements out of alignment. */
+            /* Padding gives the hover pill its size. */
             padding: 0.25em; /* 4px at 16px/1em */
-            margin: 0;
             border-radius: 3px;
             transition: background-color 100ms ease-in-out;
 
@@ -724,10 +722,12 @@
 
         .recent-view-channel-sort-header {
             padding-left: 1em;
-            margin-left: 0;
         }
 
         .recent-view-conversation-sort-header {
+            /* Cancel the pill padding so the label aligns with topic
+               text in rows. */
+            margin-left: -0.25em; /* -4px at 16px/1em */
             /* Prevent hover pill highlight from extending into
                the adjacent unread sort column. */
             margin-right: 0.3125em; /* 5px at 16px/1em */

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -664,26 +664,35 @@
                spans align with channel and topic text in rows. Sort
                arrows are inside the spans, so 3 columns suffice.
                1em = 16px at 16px/1em, matching the 1em (16px
-               at 16px/1em) privacy icon width in data rows. */
+               at 16px/1em) privacy icon width in data rows.
+
+               The first column is floored to the "Channel" header's
+               JS-measured width so the label never overlaps the next
+               column when channel names are short or absent. */
             display: grid;
             grid-template-columns:
-                calc(
-                    min(
-                            calc(
-                                var(--longest-subscribed-channel-name-width) +
-                                    1em + 8px
-                            ),
-                            calc(
+                max(
+                    var(--recent-view-header-channel-column-min-width, 0px),
+                    calc(
+                        min(
                                 calc(
-                                        100% -
-                                            var(
-                                                --recent-view-header-channel-column-adjustment
-                                            )
-                                    ) /
-                                    3
-                            )
-                        ) +
-                        var(--recent-view-header-channel-column-adjustment)
+                                    var(
+                                            --longest-subscribed-channel-name-width
+                                        ) +
+                                        1em + 8px
+                                ),
+                                calc(
+                                    calc(
+                                            100% -
+                                                var(
+                                                    --recent-view-header-channel-column-adjustment
+                                                )
+                                        ) /
+                                        3
+                                )
+                            ) +
+                            var(--recent-view-header-channel-column-adjustment)
+                    )
                 )
                 auto 1fr auto;
             align-items: stretch;
@@ -799,13 +808,24 @@
                 ".                 .             conversation-name .";
             width: 100%;
             /* We add 1em for the privacy icon and 8px for the flexbox
-               gap between the icon and the channel name. */
+               gap between the icon and the channel name. Floored to
+               match the header grid's "Channel" floor. */
             grid-template-columns:
-                min(
+                max(
                     calc(
-                        var(--longest-subscribed-channel-name-width) + 1em + 8px
+                        var(
+                                --recent-view-header-channel-column-min-width,
+                                0px
+                            ) -
+                            var(--recent-view-header-channel-column-adjustment)
                     ),
-                    calc(100% / 3)
+                    min(
+                        calc(
+                            var(--longest-subscribed-channel-name-width) + 1em +
+                                8px
+                        ),
+                        calc(100% / 3)
+                    )
                 )
                 auto 1fr auto;
             align-items: center;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -754,8 +754,11 @@
     }
 
     &.recent-view-participants-hidden {
+        --recent-view-row-left-padding: 0.5em; /* 8px at 16px/1em */
+
         td {
-            padding: 0.375em 0.5em; /* 6px 8px at 16px/1em */
+            /* 6px 8px at 16px/1em */
+            padding: 0.375em 0.5em 0.375em var(--recent-view-row-left-padding);
         }
 
         .recent_topic_users,

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -193,7 +193,8 @@
 
     .table_fix_head {
         padding: 0 !important;
-        border: 1px solid var(--color-border-recent-view-table);
+        border: var(--recent-view-header-border-width) solid
+            var(--color-border-recent-view-table);
         border-radius: 5px 5px 0 0;
         overflow: hidden;
     }
@@ -515,7 +516,7 @@
         /* Extra left padding to make room for the unread marker bar
            alongside the keyboard selection outline, applied to all
            rows so content aligns between read and unread rows. */
-        padding-left: 0.75em; /* 12px at 16px/1em */
+        padding-left: var(--recent-view-row-left-padding);
     }
 
     .unread_topic {
@@ -653,9 +654,10 @@
         cursor: default;
 
         .recent-view-header-wrapper {
-            /* 0.75em left padding, 1px header width */
             --recent-view-channel-row-header-minus-body: calc(
-                0.75em + var(--recent-view-body-border-width) - 1px
+                var(--recent-view-row-left-padding) +
+                    var(--recent-view-body-border-width) -
+                    var(--recent-view-header-border-width)
             );
             /* Match the row grid so "Channel" and "Conversation" sort
                spans align with channel and topic text in rows. Sort

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -690,10 +690,8 @@
             align-items: center;
             gap: 4px;
             cursor: pointer;
-            /* Negative margin compensates the padding so the pill hover
-               highlight doesn't push adjacent elements out of alignment. */
+            /* Padding gives the hover pill its size. */
             padding: 0.25em; /* 4px at 16px/1em */
-            margin: 0;
             border-radius: 3px;
             transition: background-color 100ms ease-in-out;
 
@@ -718,10 +716,12 @@
 
         .recent-view-channel-sort-header {
             padding-left: 1em;
-            margin-left: 0;
         }
 
         .recent-view-conversation-sort-header {
+            /* Cancel the pill padding so the label aligns with topic
+               text in rows. */
+            margin-left: -0.25em; /* -4px at 16px/1em */
             /* Prevent hover pill highlight from extending into
                the adjacent unread sort column. */
             margin-right: 0.3125em; /* 5px at 16px/1em */

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -654,11 +654,6 @@
         cursor: default;
 
         .recent-view-header-wrapper {
-            --recent-view-channel-row-header-minus-body: calc(
-                var(--recent-view-row-left-padding) +
-                    var(--recent-view-body-border-width) -
-                    var(--recent-view-header-border-width)
-            );
             /* Match the row grid so "Channel" and "Conversation" sort
                spans align with channel and topic text in rows. Sort
                arrows are inside the spans, so 3 columns suffice.
@@ -676,13 +671,13 @@
                                 calc(
                                         100% -
                                             var(
-                                                --recent-view-channel-row-header-minus-body
+                                                --recent-view-header-channel-column-adjustment
                                             )
                                     ) /
                                     3
                             )
                         ) +
-                        var(--recent-view-channel-row-header-minus-body)
+                        var(--recent-view-header-channel-column-adjustment)
                 )
                 auto 1fr auto;
             align-items: stretch;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -658,26 +658,35 @@
                spans align with channel and topic text in rows. Sort
                arrows are inside the spans, so 3 columns suffice.
                1em = 16px at 16px/1em, matching the 1em (16px
-               at 16px/1em) privacy icon width in data rows. */
+               at 16px/1em) privacy icon width in data rows.
+
+               The first column is floored to the "Channel" header's
+               JS-measured width so the label never overlaps the next
+               column when channel names are short or absent. */
             display: grid;
             grid-template-columns:
-                calc(
-                    min(
-                            calc(
-                                var(--longest-subscribed-channel-name-width) +
-                                    1em + 8px
-                            ),
-                            calc(
+                max(
+                    var(--recent-view-header-channel-column-min-width, 0px),
+                    calc(
+                        min(
                                 calc(
-                                        100% -
-                                            var(
-                                                --recent-view-header-channel-column-adjustment
-                                            )
-                                    ) /
-                                    3
-                            )
-                        ) +
-                        var(--recent-view-header-channel-column-adjustment)
+                                    var(
+                                            --longest-subscribed-channel-name-width
+                                        ) +
+                                        1em + 8px
+                                ),
+                                calc(
+                                    calc(
+                                            100% -
+                                                var(
+                                                    --recent-view-header-channel-column-adjustment
+                                                )
+                                        ) /
+                                        3
+                                )
+                            ) +
+                            var(--recent-view-header-channel-column-adjustment)
+                    )
                 )
                 auto 1fr auto;
             align-items: stretch;
@@ -793,13 +802,24 @@
                 ".                 .             conversation-name .";
             width: 100%;
             /* We add 1em for the privacy icon and 8px for the flexbox
-               gap between the icon and the channel name. */
+               gap between the icon and the channel name. Floored to
+               match the header grid's "Channel" floor. */
             grid-template-columns:
-                min(
+                max(
                     calc(
-                        var(--longest-subscribed-channel-name-width) + 1em + 8px
+                        var(
+                                --recent-view-header-channel-column-min-width,
+                                0px
+                            ) -
+                            var(--recent-view-header-channel-column-adjustment)
                     ),
-                    calc(100% / 3)
+                    min(
+                        calc(
+                            var(--longest-subscribed-channel-name-width) + 1em +
+                                8px
+                        ),
+                        calc(100% / 3)
+                    )
                 )
                 auto 1fr auto;
             align-items: center;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -36,6 +36,12 @@
 }
 
 #recent_view {
+    --recent-view-header-channel-column-adjustment: calc(
+        var(--recent-view-row-left-padding) +
+            var(--recent-view-body-border-width) -
+            var(--recent-view-header-border-width)
+    );
+
     display: none;
     padding-top: var(--navbar-fixed-height);
     /* Add bottom padding equal to `#bottom-whitespace`. This helps us keep #compose visible
@@ -654,11 +660,6 @@
         cursor: default;
 
         .recent-view-header-wrapper {
-            --recent-view-channel-row-header-minus-body: calc(
-                var(--recent-view-row-left-padding) +
-                    var(--recent-view-body-border-width) -
-                    var(--recent-view-header-border-width)
-            );
             /* Match the row grid so "Channel" and "Conversation" sort
                spans align with channel and topic text in rows. Sort
                arrows are inside the spans, so 3 columns suffice.
@@ -676,13 +677,13 @@
                                 calc(
                                         100% -
                                             var(
-                                                --recent-view-channel-row-header-minus-body
+                                                --recent-view-header-channel-column-adjustment
                                             )
                                     ) /
                                     3
                             )
                         ) +
-                        var(--recent-view-channel-row-header-minus-body)
+                        var(--recent-view-header-channel-column-adjustment)
                 )
                 auto 1fr auto;
             align-items: stretch;


### PR DESCRIPTION
discussion: [#issues > formating bug in recent conversations](https://chat.zulip.org/#narrow/channel/9-issues/topic/formating.20bug.20in.20recent.20conversations/with/2470060)

| before | after |
| --- | --- |
| <img width="1135" height="351" alt="image" src="https://github.com/user-attachments/assets/2ebcec02-8734-4534-bccb-5c4c6020b073" /> |  <img width="1135" height="351" alt="image" src="https://github.com/user-attachments/assets/a627fd76-1b99-4f4d-9cec-2ceb7467fd96" /> |
| <img width="1135" height="351" alt="image" src="https://github.com/user-attachments/assets/4ea252bf-1fc4-492b-8ac5-e92129388882" /> |  <img width="1135" height="351" alt="image" src="https://github.com/user-attachments/assets/f5be902f-147e-4eab-bdbc-b9e26cb77878" /> |
| conversation alignment |
| <img width="1135" height="351" alt="image" src="https://github.com/user-attachments/assets/be0838ca-7f31-4259-8707-7e0e05291480" /> |  <img width="1135" height="351" alt="image" src="https://github.com/user-attachments/assets/3a219fd1-ec12-43b3-b6b7-baef95ab18ed" /> |

---

Mostly written by me with the help of Claude.