### PR TITLE
mattermost: Do not use convert_html_to_text

### DIFF
--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -33,7 +33,6 @@ from zerver.data_import.import_util import (
     build_stream_subscriptions,
     build_user_profile,
     build_zerver_realm,
-    convert_html_to_text,
     create_converted_data_files,
     get_attachment_path_and_content,
     get_domain_name_for_import,
@@ -541,12 +540,6 @@ def process_raw_message_batch(
             content=raw_message["content"],
             mention_user_ids=mention_user_ids,
         )
-
-        try:
-            content = convert_html_to_text(content)
-        except Exception:  # nocoverage
-            logging.warning("Error converting HTML to text for message: '%s'; continuing", content)
-            logging.warning(str(raw_message))
 
         date_sent = raw_message["date_sent"]
         sender_user_id = raw_message["sender_id"]


### PR DESCRIPTION
html2text is used in the background and it alters the content of messages significantly.
markdownify has the same problem.

Any non-convertable html tag gets removed from the message by html2text. For example, if a message contains `</rant>` or `<username>` (used by chat-bridging software) and gets passed through html2text those two invalid html tags disappear.

Also this speeds up the converter considerably.
For example, now it converts ~350k messages in about 55secs on a 4 core machine whereas it has taken hours before.

I went through the commit history of `mattermost.py` and it was never explained why html2text was used in the first place.

Mattermost makes it possible to use a subset of html tags to format messages but formatting gets irrelevant if message content gets altered.
We used matterbridge and it prepended `<username>` to every message posted on a to-MM-bridged chat.
So without this <username> string it is impossible to tell by whom this message was posted.

**How changes were tested:**

I ran `./manage.py convert_mattermost_data` with a mattermost export of roughly ~350k messages from the last ~12 years.

And it was done without errors in about 55 seconds.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines). I wrote this myself.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
