### PR TITLE
File preview add pdf

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "handlebars": "^4.7.2",
     "handlebars-loader": "^1.7.1",
     "highlight.js": "^11.11.0",
+    "pdfjs-dist": "^5.6.205",
     "html-webpack-plugin": "^5.3.2",
     "intl-messageformat": "^11.0.7",
     "is-url": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ga-gtag": "^1.0.1",
     "handlebars": "^4.7.2",
     "handlebars-loader": "^1.7.1",
+    "highlight.js": "^11.11.0",
     "html-webpack-plugin": "^5.3.2",
     "intl-messageformat": "^11.0.7",
     "is-url": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       handlebars-loader:
         specifier: ^1.7.1
         version: 1.7.3(handlebars@4.7.9(patch_hash=53ad8d748fa2ca3a7a0502c46f2ed1236eef8162efec84c06849dc83ad9e28e9))
+      highlight.js:
+        specifier: ^11.11.0
+        version: 11.11.1
       html-webpack-plugin:
         specifier: ^5.3.2
         version: 5.6.7(webpack@5.106.2)
@@ -5638,6 +5641,10 @@ packages:
 
   heap@0.2.7:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
@@ -16011,6 +16018,8 @@ snapshots:
   he@1.2.0: {}
 
   heap@0.2.7: {}
+
+  highlight.js@11.11.1: {}
 
   hookified@1.15.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       panzoom:
         specifier: ^9.4.2
         version: 9.4.4
+      pdfjs-dist:
+        specifier: ^5.6.205
+        version: 5.7.284
       plotly.js:
         specifier: ^3.0.0
         version: 3.5.1(mapbox-gl@1.13.3)
@@ -2389,6 +2392,81 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -7342,6 +7420,10 @@ packages:
     resolution: {integrity: sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==}
     hasBin: true
 
+  pdfjs-dist@5.7.284:
+    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -11986,6 +12068,54 @@ snapshots:
       - supports-color
 
   '@mixmark-io/domino@2.2.0': {}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@noble/hashes@1.4.0': {}
 
@@ -18154,6 +18284,10 @@ snapshots:
     dependencies:
       ieee754: 1.2.1
       resolve-protobuf-schema: 2.1.0
+
+  pdfjs-dist@5.7.284:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   pend@1.2.0: {}
 

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -20,6 +20,19 @@ location /static/ {
     # Set a nonexistent path, so we just serve the nice Django 404 page.
     error_page 404 /django_static_404.html;
 
+    # pdf.js and other ESM assets ship .mjs web-worker files. The system
+    # /etc/nginx/mime.types has no .mjs entry, so without this they are
+    # served as application/octet-stream and rejected by the browser's
+    # strict module-script MIME check. Set the type with default_type in
+    # a .mjs-only location rather than a types {} block, which would
+    # discard the inherited MIME map for every other static asset. This
+    # precedes the immutable-hash location and reuses its headers, since
+    # these hashed worker files are equally safe to cache aggressively.
+    location ~ \.mjs$ {
+        default_type text/javascript;
+        include /etc/nginx/zulip-include/immutable_headers;
+    }
+
     # These files are hashed and thus immutable; cache them aggressively.
     # Django adds 12 hex digits; Webpack adds 20.
     location ~ '\.[0-9a-f]{12}\.|[./][0-9a-f]{20}\.' {

--- a/web/src/attachment_navigator.ts
+++ b/web/src/attachment_navigator.ts
@@ -1,11 +1,26 @@
 import $ from "jquery";
 
-import * as file_attachment_preview from "./file_attachment_preview.ts";
-import * as lightbox from "./lightbox.ts";
 import * as overlays from "./overlays.ts";
 
 // Unified attachment type — represents any navigable attachment in the message list.
 export type AttachmentType = "image" | "video" | "file" | "unsupported";
+
+// Renderers for the different viewers we can navigate to. These are
+// registered by file_attachment_preview at startup so that this module
+// doesn't import file_attachment_preview or lightbox directly, which
+// would create an import cycle (both of those import this module).
+type NavigationRenderers = {
+    should_preview: (url: string) => boolean;
+    open_file_preview: (url: string, filename: string) => void;
+    open_download_only: (url: string, filename: string) => void;
+    open_media_lightbox: ($el: JQuery<HTMLImageElement | HTMLMediaElement>) => void;
+};
+
+let renderers: NavigationRenderers | undefined;
+
+export function register_navigation_renderers(r: NavigationRenderers): void {
+    renderers = r;
+}
 
 export type Attachment = {
     type: AttachmentType;
@@ -44,10 +59,10 @@ export function collect_attachments(): Attachment[] {
         const $row = $(this);
 
         // Collect inline images
-        $row.find(
+        $row.find<HTMLImageElement>(
             ".message-media-inline-image img, .message-media-preview-image img",
         ).each(function () {
-            const $img = $(this as HTMLImageElement);
+            const $img = $(this);
             const $anchor = $img.parent("a");
             const url = $anchor.attr("href") ?? $img.attr("src") ?? "";
             const title = $anchor.attr("aria-label") ?? url.split("/").pop() ?? "image";
@@ -60,8 +75,8 @@ export function collect_attachments(): Attachment[] {
         });
 
         // Collect inline videos
-        $row.find(".message_inline_video video").each(function () {
-            const $video = $(this as HTMLMediaElement);
+        $row.find<HTMLMediaElement>(".message_inline_video video").each(function () {
+            const $video = $(this);
             const url = $video.attr("src") ?? "";
             const filename = url.split("/").pop() ?? "video";
             attachments.push({
@@ -107,9 +122,7 @@ export function collect_attachments(): Attachment[] {
             }
 
             attachments.push({
-                type: file_attachment_preview.should_preview(href)
-                    ? "file"
-                    : "unsupported",
+                type: renderers?.should_preview(href) ? "file" : "unsupported",
                 url: href,
                 filename,
             });
@@ -170,6 +183,10 @@ function navigate_to(index: number): void {
         index = 0;
     }
 
+    if (renderers === undefined) {
+        return;
+    }
+
     const target = attachment_list[index]!;
     current_index = index;
 
@@ -185,24 +202,16 @@ function navigate_to(index: number): void {
     // Open the appropriate viewer for the target attachment
     switch (target.type) {
         case "image":
-            if (target.$element && target.$element.length > 0) {
-                lightbox.handle_inline_media_element_click(
-                    target.$element as JQuery<HTMLImageElement>,
-                );
-            }
-            break;
         case "video":
             if (target.$element && target.$element.length > 0) {
-                lightbox.handle_inline_media_element_click(
-                    target.$element as JQuery<HTMLMediaElement>,
-                );
+                renderers.open_media_lightbox(target.$element);
             }
             break;
         case "file":
-            void file_attachment_preview.open_preview(target.url, target.filename);
+            renderers.open_file_preview(target.url, target.filename);
             break;
         case "unsupported":
-            void file_attachment_preview.open_download_only(target.url, target.filename);
+            renderers.open_download_only(target.url, target.filename);
             break;
     }
 }

--- a/web/src/attachment_navigator.ts
+++ b/web/src/attachment_navigator.ts
@@ -1,0 +1,228 @@
+import $ from "jquery";
+
+import * as file_attachment_preview from "./file_attachment_preview.ts";
+import * as lightbox from "./lightbox.ts";
+import * as overlays from "./overlays.ts";
+
+// Unified attachment type — represents any navigable attachment in the message list.
+export type AttachmentType = "image" | "video" | "file" | "unsupported";
+
+export type Attachment = {
+    type: AttachmentType;
+    url: string;
+    filename: string;
+    // For images/videos, the DOM element needed to open the lightbox.
+    $element?: JQuery<HTMLImageElement | HTMLMediaElement>;
+};
+
+let attachment_list: Attachment[] = [];
+let current_index = -1;
+// When true, start_navigation() preserves the current index instead of re-searching.
+// Set by navigate_to() to avoid findIndex returning the wrong match for duplicate URLs.
+let skip_next_search = false;
+
+function get_extension(filename: string): string {
+    const dot_index = filename.lastIndexOf(".");
+    if (dot_index === -1) {
+        return "";
+    }
+    return filename.slice(dot_index + 1).toLowerCase();
+}
+
+// Collect all attachments from the focused message list in DOM order.
+export function collect_attachments(): Attachment[] {
+    const attachments: Attachment[] = [];
+
+    // Walk through all messages in DOM order and collect attachments
+    const $message_list = $(".focused-message-list");
+    if ($message_list.length === 0) {
+        return attachments;
+    }
+
+    // Find all message rows and collect their attachments in order
+    $message_list.find(".message_row").each(function () {
+        const $row = $(this);
+
+        // Collect inline images
+        $row.find(
+            ".message-media-inline-image img, .message-media-preview-image img",
+        ).each(function () {
+            const $img = $(this as HTMLImageElement);
+            const $anchor = $img.parent("a");
+            const url = $anchor.attr("href") ?? $img.attr("src") ?? "";
+            const title = $anchor.attr("aria-label") ?? url.split("/").pop() ?? "image";
+            attachments.push({
+                type: "image",
+                url,
+                filename: title,
+                $element: $img,
+            });
+        });
+
+        // Collect inline videos
+        $row.find(".message_inline_video video").each(function () {
+            const $video = $(this as HTMLMediaElement);
+            const url = $video.attr("src") ?? "";
+            const filename = url.split("/").pop() ?? "video";
+            attachments.push({
+                type: "video",
+                url,
+                filename,
+                $element: $video,
+            });
+        });
+
+        // Collect file attachments (links to /user_uploads/)
+        $row.find('a[href^="/user_uploads/"]').each(function () {
+            const $link = $(this);
+            const href = $link.attr("href") ?? "";
+
+            // Skip links that are inside image/video containers (already captured above)
+            if (
+                $link.closest(
+                    ".message-media-inline-image, .message-media-preview-image, .message_inline_video",
+                ).length > 0
+            ) {
+                return;
+            }
+
+            const filename = decodeURIComponent(href.slice(href.lastIndexOf("/") + 1));
+            const ext = get_extension(filename);
+
+            // Skip image/video extensions since those render inline
+            const image_exts = new Set([
+                "jpg",
+                "jpeg",
+                "png",
+                "gif",
+                "webp",
+                "svg",
+                "bmp",
+                "ico",
+                "heic",
+            ]);
+            const video_exts = new Set(["mp4", "webm", "ogg", "mov"]);
+            if (image_exts.has(ext) || video_exts.has(ext)) {
+                return;
+            }
+
+            attachments.push({
+                type: file_attachment_preview.should_preview(href)
+                    ? "file"
+                    : "unsupported",
+                url: href,
+                filename,
+            });
+        });
+    });
+
+    return attachments;
+}
+
+// Set up navigation for the current attachment being viewed.
+export function start_navigation(url: string): void {
+    // If navigating internally (via prev/next), we already know the index.
+    // Skip the URL search to avoid matching the wrong duplicate.
+    if (skip_next_search) {
+        skip_next_search = false;
+        return;
+    }
+
+    attachment_list = collect_attachments();
+
+    // Find the current attachment by matching URL
+    current_index = attachment_list.findIndex(
+        (a) => a.url === url || a.url === decodeURIComponent(url),
+    );
+
+    if (current_index === -1) {
+        // If we can't find it, try matching by filename
+        const filename = decodeURIComponent(url.slice(url.lastIndexOf("/") + 1));
+        current_index = attachment_list.findIndex((a) => a.filename === filename);
+    }
+}
+
+export function get_total(): number {
+    return attachment_list.length;
+}
+
+export function get_current_index(): number {
+    return current_index;
+}
+
+export function has_prev(): boolean {
+    return attachment_list.length > 1;
+}
+
+export function has_next(): boolean {
+    return attachment_list.length > 1;
+}
+
+function navigate_to(index: number): void {
+    if (attachment_list.length === 0) {
+        return;
+    }
+
+    // Wrap around
+    if (index < 0) {
+        index = attachment_list.length - 1;
+    } else if (index >= attachment_list.length) {
+        index = 0;
+    }
+
+    const target = attachment_list[index]!;
+    current_index = index;
+
+    // Tell start_navigation() not to re-search — we already know the index.
+    // This prevents findIndex from matching a duplicate URL/filename.
+    skip_next_search = true;
+
+    // Close the current overlay
+    if (overlays.any_active()) {
+        overlays.close_active();
+    }
+
+    // Open the appropriate viewer for the target attachment
+    switch (target.type) {
+        case "image":
+            if (target.$element && target.$element.length > 0) {
+                lightbox.handle_inline_media_element_click(
+                    target.$element as JQuery<HTMLImageElement>,
+                );
+            }
+            break;
+        case "video":
+            if (target.$element && target.$element.length > 0) {
+                lightbox.handle_inline_media_element_click(
+                    target.$element as JQuery<HTMLMediaElement>,
+                );
+            }
+            break;
+        case "file":
+            void file_attachment_preview.open_preview(target.url, target.filename);
+            break;
+        case "unsupported":
+            void file_attachment_preview.open_download_only(target.url, target.filename);
+            break;
+    }
+}
+
+export function prev(): void {
+    if (current_index === -1 || attachment_list.length <= 1) {
+        return;
+    }
+    navigate_to(current_index - 1);
+}
+
+export function next(): void {
+    if (current_index === -1 || attachment_list.length <= 1) {
+        return;
+    }
+    navigate_to(current_index + 1);
+}
+
+export function clear(): void {
+    attachment_list = [];
+    current_index = -1;
+    skip_next_search = false;
+}

--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -50,6 +50,7 @@ import "../../styles/left_sidebar.css";
 import "../../styles/right_sidebar.css";
 import "../../styles/lightbox.css";
 import "../../styles/box_resize.css";
+import "../../styles/file_attachment_preview.css";
 import "../../styles/popovers.css";
 import "../../styles/recent_view.css";
 import "../../styles/typing_notifications.css";

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -15,6 +15,7 @@ import * as compose_actions from "./compose_actions.ts";
 import * as compose_reply from "./compose_reply.ts";
 import * as compose_state from "./compose_state.ts";
 import * as emoji_picker from "./emoji_picker.ts";
+import * as file_attachment_preview from "./file_attachment_preview.ts";
 import * as flatpickr from "./flatpickr.ts";
 import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
@@ -40,7 +41,6 @@ import * as spectators from "./spectators.ts";
 import * as starred_messages_ui from "./starred_messages_ui.ts";
 import * as stream_list from "./stream_list.ts";
 import * as stream_popover from "./stream_popover.ts";
-import * as file_attachment_preview from "./file_attachment_preview.ts";
 import * as topic_list from "./topic_list.ts";
 import * as ui_util from "./ui_util.ts";
 import {parse_html} from "./ui_util.ts";
@@ -400,7 +400,7 @@ export function initialize(): void {
             href &&
             href.startsWith("/user_uploads/") &&
             // Don't intercept image/video links handled by lightbox
-            !$(this).closest(".message_inline_image, .message_inline_video").length
+            $(this).closest(".message_inline_image, .message_inline_video").length === 0
         ) {
             e.preventDefault();
             e.stopPropagation();
@@ -408,7 +408,7 @@ export function initialize(): void {
             if (file_attachment_preview.should_preview(href)) {
                 void file_attachment_preview.open_preview(href, filename);
             } else {
-                void file_attachment_preview.open_download_only(href, filename);
+                file_attachment_preview.open_download_only(href, filename);
             }
         }
     });

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -40,6 +40,7 @@ import * as spectators from "./spectators.ts";
 import * as starred_messages_ui from "./starred_messages_ui.ts";
 import * as stream_list from "./stream_list.ts";
 import * as stream_popover from "./stream_popover.ts";
+import * as file_attachment_preview from "./file_attachment_preview.ts";
 import * as topic_list from "./topic_list.ts";
 import * as ui_util from "./ui_util.ts";
 import {parse_html} from "./ui_util.ts";
@@ -390,6 +391,23 @@ export function initialize(): void {
         const $row = $(this).closest(".message_row");
         message_edit.end_message_row_edit($row);
         e.stopPropagation();
+    });
+    // Intercept clicks on user_uploads links for text attachment preview.
+    // This must be registered before the generic <a> blur handler below.
+    $("body").on("click", "a[href]", function (this: HTMLAnchorElement, e) {
+        const href = this.getAttribute("href");
+        if (
+            href &&
+            href.startsWith("/user_uploads/") &&
+            // Don't intercept image/video links handled by lightbox
+            !$(this).closest(".message_inline_image, .message_inline_video").length &&
+            file_attachment_preview.should_preview(href)
+        ) {
+            e.preventDefault();
+            e.stopPropagation();
+            const filename = decodeURIComponent(href.slice(href.lastIndexOf("/") + 1));
+            void file_attachment_preview.open_preview(href, filename);
+        }
     });
     $("body").on("click", "a", function () {
         if (document.activeElement === this) {

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -392,7 +392,7 @@ export function initialize(): void {
         message_edit.end_message_row_edit($row);
         e.stopPropagation();
     });
-    // Intercept clicks on user_uploads links for text attachment preview.
+    // Intercept clicks on user_uploads links for file attachment preview.
     // This must be registered before the generic <a> blur handler below.
     $("body").on("click", "a[href]", function (this: HTMLAnchorElement, e) {
         const href = this.getAttribute("href");
@@ -400,13 +400,16 @@ export function initialize(): void {
             href &&
             href.startsWith("/user_uploads/") &&
             // Don't intercept image/video links handled by lightbox
-            !$(this).closest(".message_inline_image, .message_inline_video").length &&
-            file_attachment_preview.should_preview(href)
+            !$(this).closest(".message_inline_image, .message_inline_video").length
         ) {
             e.preventDefault();
             e.stopPropagation();
             const filename = decodeURIComponent(href.slice(href.lastIndexOf("/") + 1));
-            void file_attachment_preview.open_preview(href, filename);
+            if (file_attachment_preview.should_preview(href)) {
+                void file_attachment_preview.open_preview(href, filename);
+            } else {
+                void file_attachment_preview.open_download_only(href, filename);
+            }
         }
     });
     $("body").on("click", "a", function () {

--- a/web/src/file_attachment_preview.ts
+++ b/web/src/file_attachment_preview.ts
@@ -8,8 +8,10 @@ import * as attachment_navigator from "./attachment_navigator.ts";
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
 import {$t} from "./i18n.ts";
+import * as lightbox from "./lightbox.ts";
 import {message_render_response_schema} from "./message_store.ts";
 import * as overlays from "./overlays.ts";
+import type * as pdf_preview from "./pdf_preview.ts";
 import {user_settings} from "./user_settings.ts";
 
 hljs.registerLanguage("matlab", matlab);
@@ -107,7 +109,12 @@ function get_extra_extensions(): Set<string> {
     if (!raw) {
         return new Set();
     }
-    return new Set(raw.split(",").map((ext) => ext.trim().toLowerCase()).filter(Boolean));
+    return new Set(
+        raw
+            .split(",")
+            .map((ext) => ext.trim().toLowerCase())
+            .filter(Boolean),
+    );
 }
 
 export function should_preview(url: string): boolean {
@@ -132,8 +139,7 @@ function get_download_url(url: string): string {
             parsed.pathname.startsWith("/user_uploads/")
         ) {
             parsed.pathname =
-                "/user_uploads/download/" +
-                parsed.pathname.slice("/user_uploads/".length);
+                "/user_uploads/download/" + parsed.pathname.slice("/user_uploads/".length);
             return parsed.href;
         }
     } catch {
@@ -180,36 +186,50 @@ function parse_csv(text: string): string[][] {
     let current_field = "";
     let in_quotes = false;
 
-    for (let i = 0; i < text.length; i++) {
+    for (let i = 0; i < text.length; i += 1) {
         const ch = text[i];
         if (in_quotes) {
             if (ch === '"') {
                 if (i + 1 < text.length && text[i + 1] === '"') {
                     current_field += '"';
-                    i++;
+                    i += 1;
                 } else {
                     in_quotes = false;
                 }
             } else {
                 current_field += ch;
             }
-        } else if (ch === '"') {
-            in_quotes = true;
-        } else if (ch === ",") {
-            current_row.push(current_field);
-            current_field = "";
-        } else if (ch === "\n" || ch === "\r") {
-            if (ch === "\r" && i + 1 < text.length && text[i + 1] === "\n") {
-                i++;
-            }
-            current_row.push(current_field);
-            current_field = "";
-            if (current_row.some((f) => f.length > 0)) {
-                rows.push(current_row);
-            }
-            current_row = [];
         } else {
-            current_field += ch;
+            switch (ch) {
+                case '"': {
+                    in_quotes = true;
+
+                    break;
+                }
+                case ",": {
+                    current_row.push(current_field);
+                    current_field = "";
+
+                    break;
+                }
+                case "\n":
+                case "\r": {
+                    if (ch === "\r" && i + 1 < text.length && text[i + 1] === "\n") {
+                        i += 1;
+                    }
+                    current_row.push(current_field);
+                    current_field = "";
+                    if (current_row.some((f) => f.length > 0)) {
+                        rows.push(current_row);
+                    }
+                    current_row = [];
+
+                    break;
+                }
+                default: {
+                    current_field += ch;
+                }
+            }
         }
     }
     current_row.push(current_field);
@@ -228,14 +248,15 @@ function render_csv_table(text: string): string {
     const header = rows[0]!;
     const body_rows = rows.slice(1);
 
-    let html = '<div class="file-preview-csv-wrapper"><table class="file-preview-csv-table"><thead><tr>';
+    let html =
+        '<div class="file-preview-csv-wrapper"><table class="file-preview-csv-table"><thead><tr>';
     for (const cell of header) {
         html += `<th>${escape_html(cell)}</th>`;
     }
     html += "</tr></thead><tbody>";
     for (const row of body_rows) {
         html += "<tr>";
-        for (let i = 0; i < header.length; i++) {
+        for (let i = 0; i < header.length; i += 1) {
             html += `<td>${escape_html(row[i] ?? "")}</td>`;
         }
         html += "</tr>";
@@ -247,15 +268,13 @@ function render_csv_table(text: string): string {
 // PDF state for multi-page navigation — managed by the dynamically
 // imported pdf_preview module.  We keep a local reference for the
 // click handlers that need synchronous access to the state.
-let pdf_preview_mod: typeof import("./pdf_preview.ts") | null = null;
+let pdf_preview_mod: typeof pdf_preview | null = null;
 
 // Lazy-load the PDF preview module (and its pdfjs-dist dependency).
 // Isolated into its own module so that pdfjs-dist (ESM-only) doesn't
 // prevent the CJS test runner from loading this file.
-async function load_pdf_preview(): Promise<typeof import("./pdf_preview.ts")> {
-    if (!pdf_preview_mod) {
-        pdf_preview_mod = await import("./pdf_preview.ts");
-    }
+async function load_pdf_preview(): Promise<typeof pdf_preview> {
+    pdf_preview_mod ??= await import("./pdf_preview.ts");
     return pdf_preview_mod;
 }
 
@@ -416,7 +435,10 @@ export function open_download_only(url: string, filename: string): void {
     update_nav_arrows();
 
     show_error(
-        $t({defaultMessage: "No preview available for this file type. Use the Download button to save it."}),
+        $t({
+            defaultMessage:
+                "No preview available for this file type. Use the Download button to save it.",
+        }),
     );
 }
 
@@ -425,6 +447,18 @@ export function initialize(): void {
         return;
     }
     is_initialized = true;
+
+    // Register the viewers that attachment_navigator drives, so that it
+    // doesn't need to import this module or lightbox directly (which
+    // would create an import cycle).
+    attachment_navigator.register_navigation_renderers({
+        should_preview,
+        open_file_preview(url, filename) {
+            void open_preview(url, filename);
+        },
+        open_download_only,
+        open_media_lightbox: lightbox.handle_inline_media_element_click,
+    });
 
     const rendered = render_file_attachment_preview();
     $("body").append($(rendered));
@@ -437,11 +471,11 @@ export function initialize(): void {
         overlays.close_overlay(OVERLAY_NAME);
     });
 
-    $overlay.on("click", ".file-preview-download", function () {
+    $overlay.on("click", ".file-preview-download", function (this: HTMLElement) {
         this.blur();
     });
 
-    $overlay.on("click", ".file-preview-error-download", function () {
+    $overlay.on("click", ".file-preview-error-download", function (this: HTMLElement) {
         this.blur();
     });
 

--- a/web/src/file_attachment_preview.ts
+++ b/web/src/file_attachment_preview.ts
@@ -1,0 +1,376 @@
+import hljs from "highlight.js/lib/common";
+import matlab from "highlight.js/lib/languages/matlab";
+import $ from "jquery";
+
+import render_file_attachment_preview from "../templates/file_attachment_preview.hbs";
+
+import * as blueslip from "./blueslip.ts";
+import * as channel from "./channel.ts";
+import {$t} from "./i18n.ts";
+import {message_render_response_schema} from "./message_store.ts";
+import * as overlays from "./overlays.ts";
+import {user_settings} from "./user_settings.ts";
+
+hljs.registerLanguage("matlab", matlab);
+
+// Map file extensions to highlight.js language names.
+// Extensions not listed here will use highlightAuto().
+const EXT_TO_HLJS_LANGUAGE: Record<string, string> = {
+    py: "python",
+    js: "javascript",
+    mjs: "javascript",
+    cjs: "javascript",
+    ts: "typescript",
+    tsx: "typescript",
+    jsx: "javascript",
+    rb: "ruby",
+    rs: "rust",
+    go: "go",
+    java: "java",
+    kt: "kotlin",
+    kts: "kotlin",
+    c: "c",
+    h: "c",
+    cpp: "cpp",
+    cc: "cpp",
+    cxx: "cpp",
+    hpp: "cpp",
+    hh: "cpp",
+    cs: "csharp",
+    swift: "swift",
+    m: "matlab",
+    r: "r",
+    pl: "perl",
+    pm: "perl",
+    php: "php",
+    lua: "lua",
+    sh: "bash",
+    bash: "bash",
+    zsh: "bash",
+    sql: "sql",
+    json: "json",
+    yaml: "yaml",
+    yml: "yaml",
+    xml: "xml",
+    html: "xml",
+    htm: "xml",
+    css: "css",
+    scss: "scss",
+    less: "less",
+    makefile: "makefile",
+    mk: "makefile",
+    diff: "diff",
+    patch: "diff",
+    ini: "ini",
+    toml: "ini",
+    cfg: "ini",
+    graphql: "graphql",
+    gql: "graphql",
+    vb: "vbnet",
+    wasm: "wasm",
+    objc: "objectivec",
+};
+
+// Built-in set of extensions that are always previewable.
+// Includes txt, md, csv, plus all extensions with known syntax highlighting.
+const BUILT_IN_PREVIEW_EXTENSIONS = new Set([
+    "txt",
+    "md",
+    "csv",
+    ...Object.keys(EXT_TO_HLJS_LANGUAGE),
+]);
+
+const MAX_PREVIEW_SIZE = 256 * 1024; // 256 KB
+const OVERLAY_NAME = "file-attachment-preview";
+
+let is_initialized = false;
+
+function get_extension(filename: string): string {
+    const dot_index = filename.lastIndexOf(".");
+    if (dot_index === -1) {
+        return "";
+    }
+    return filename.slice(dot_index + 1).toLowerCase();
+}
+
+function get_extra_extensions(): Set<string> {
+    const raw = user_settings.file_preview_extensions;
+    if (!raw) {
+        return new Set();
+    }
+    return new Set(raw.split(",").map((ext) => ext.trim().toLowerCase()).filter(Boolean));
+}
+
+export function should_preview(url: string): boolean {
+    const raw = user_settings.file_preview_extensions;
+    // "none" disables all previews
+    if (raw === "none") {
+        return false;
+    }
+    const filename = decodeURIComponent(url.slice(url.lastIndexOf("/") + 1));
+    const ext = get_extension(filename);
+    if (!ext) {
+        return false;
+    }
+    return BUILT_IN_PREVIEW_EXTENSIONS.has(ext) || get_extra_extensions().has(ext);
+}
+
+function get_download_url(url: string): string {
+    try {
+        const parsed = new URL(url, window.location.href);
+        if (
+            parsed.origin === window.location.origin &&
+            parsed.pathname.startsWith("/user_uploads/")
+        ) {
+            parsed.pathname =
+                "/user_uploads/download/" +
+                parsed.pathname.slice("/user_uploads/".length);
+            return parsed.href;
+        }
+    } catch {
+        // Fall through to return original URL
+    }
+    return url;
+}
+
+function show_loading(): void {
+    const $overlay = $(`#${CSS.escape(OVERLAY_NAME)}-overlay`);
+    $overlay.find(".file-preview-loading").addClass("show");
+    $overlay.find(".file-preview-rendered").removeClass("show");
+    $overlay.find(".file-preview-error").removeClass("show");
+}
+
+function show_rendered(html: string, is_markdown: boolean): void {
+    const $overlay = $(`#${CSS.escape(OVERLAY_NAME)}-overlay`);
+    const $rendered = $overlay.find(".file-preview-rendered");
+    $rendered.html(html);
+    $rendered.toggleClass("rendered-markdown", is_markdown);
+    $overlay.find(".file-preview-loading").removeClass("show");
+    $rendered.addClass("show");
+    $overlay.find(".file-preview-error").removeClass("show");
+}
+
+function show_error(message: string): void {
+    const $overlay = $(`#${CSS.escape(OVERLAY_NAME)}-overlay`);
+    $overlay.find(".file-preview-loading").removeClass("show");
+    $overlay.find(".file-preview-rendered").removeClass("show");
+    const $error = $overlay.find(".file-preview-error");
+    $error.find(".file-preview-error-message").text(message);
+    $error.addClass("show");
+}
+
+function escape_html(text: string): string {
+    const div = document.createElement("div");
+    div.append(document.createTextNode(text));
+    return div.innerHTML;
+}
+
+function parse_csv(text: string): string[][] {
+    const rows: string[][] = [];
+    let current_row: string[] = [];
+    let current_field = "";
+    let in_quotes = false;
+
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (in_quotes) {
+            if (ch === '"') {
+                if (i + 1 < text.length && text[i + 1] === '"') {
+                    current_field += '"';
+                    i++;
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                current_field += ch;
+            }
+        } else if (ch === '"') {
+            in_quotes = true;
+        } else if (ch === ",") {
+            current_row.push(current_field);
+            current_field = "";
+        } else if (ch === "\n" || ch === "\r") {
+            if (ch === "\r" && i + 1 < text.length && text[i + 1] === "\n") {
+                i++;
+            }
+            current_row.push(current_field);
+            current_field = "";
+            if (current_row.some((f) => f.length > 0)) {
+                rows.push(current_row);
+            }
+            current_row = [];
+        } else {
+            current_field += ch;
+        }
+    }
+    current_row.push(current_field);
+    if (current_row.some((f) => f.length > 0)) {
+        rows.push(current_row);
+    }
+    return rows;
+}
+
+function render_csv_table(text: string): string {
+    const rows = parse_csv(text);
+    if (rows.length === 0) {
+        return `<pre><code>${escape_html(text)}</code></pre>`;
+    }
+
+    const header = rows[0];
+    const body_rows = rows.slice(1);
+
+    let html = '<div class="file-preview-csv-wrapper"><table class="file-preview-csv-table"><thead><tr>';
+    for (const cell of header) {
+        html += `<th>${escape_html(cell)}</th>`;
+    }
+    html += "</tr></thead><tbody>";
+    for (const row of body_rows) {
+        html += "<tr>";
+        for (let i = 0; i < header.length; i++) {
+            html += `<td>${escape_html(row[i] ?? "")}</td>`;
+        }
+        html += "</tr>";
+    }
+    html += "</tbody></table></div>";
+    return html;
+}
+
+function render_markdown_via_server(text: string): void {
+    // Use Zulip's server-side markdown renderer for accurate preview.
+    void channel.post({
+        url: "/json/messages/render",
+        data: {content: text},
+        success(response_data) {
+            const data = message_render_response_schema.parse(response_data);
+            show_rendered(data.rendered, true);
+        },
+        error() {
+            blueslip.warn("Server markdown render failed, using fallback");
+            show_rendered(`<pre><code>${escape_html(text)}</code></pre>`, false);
+        },
+    });
+}
+
+function render_content(text: string, ext: string): void {
+    if (ext === "md") {
+        render_markdown_via_server(text);
+        return;
+    }
+
+    if (ext === "csv") {
+        show_rendered(render_csv_table(text), false);
+        return;
+    }
+
+    // Try syntax highlighting for known source code extensions
+    const language = EXT_TO_HLJS_LANGUAGE[ext];
+    if (language) {
+        const highlighted = hljs.highlight(text, {language});
+        show_rendered(
+            `<pre><code class="hljs language-${language}">${highlighted.value}</code></pre>`,
+            false,
+        );
+        return;
+    }
+
+    // Default: plain text in <pre>
+    show_rendered(`<pre><code>${escape_html(text)}</code></pre>`, false);
+}
+
+export async function open_preview(url: string, filename: string): Promise<void> {
+    if (overlays.any_active()) {
+        overlays.close_active();
+    }
+
+    const download_url = get_download_url(url);
+    const ext = get_extension(filename);
+
+    const $overlay = $(`#${CSS.escape(OVERLAY_NAME)}-overlay`);
+    $overlay.find(".file-preview-filename").text(filename);
+    $overlay.find(".file-preview-download").attr("href", download_url);
+    $overlay.find(".file-preview-error-download").attr("href", download_url);
+
+    overlays.open_overlay({
+        name: OVERLAY_NAME,
+        $overlay,
+        on_close() {
+            $overlay.find(".file-preview-rendered").empty().removeClass("show rendered-markdown");
+            $overlay.find(".file-preview-loading").removeClass("show");
+            $overlay.find(".file-preview-error").removeClass("show");
+        },
+    });
+
+    show_loading();
+
+    try {
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            show_error(
+                $t(
+                    {defaultMessage: "Could not load file (HTTP {status})"},
+                    {status: response.status},
+                ),
+            );
+            return;
+        }
+
+        const content_length = response.headers.get("Content-Length");
+        if (content_length && Number.parseInt(content_length, 10) > MAX_PREVIEW_SIZE) {
+            show_error($t({defaultMessage: "File is too large to preview (max 256 KB)."}));
+            return;
+        }
+
+        const buffer = await response.arrayBuffer();
+
+        if (buffer.byteLength > MAX_PREVIEW_SIZE) {
+            show_error($t({defaultMessage: "File is too large to preview (max 256 KB)."}));
+            return;
+        }
+
+        let text: string;
+        try {
+            const decoder = new TextDecoder("utf-8", {fatal: true});
+            text = decoder.decode(buffer);
+        } catch {
+            show_error(
+                $t({
+                    defaultMessage:
+                        "This file appears to contain binary content and cannot be previewed.",
+                }),
+            );
+            return;
+        }
+
+        render_content(text, ext);
+    } catch (error) {
+        blueslip.warn("Error loading text attachment preview", {error});
+        show_error($t({defaultMessage: "An error occurred while loading the preview."}));
+    }
+}
+
+export function initialize(): void {
+    if (is_initialized) {
+        return;
+    }
+    is_initialized = true;
+
+    const rendered = render_file_attachment_preview();
+    $("body").append($(rendered));
+
+    const $overlay = $(`#${CSS.escape(OVERLAY_NAME)}-overlay`);
+
+    $overlay.on("click", ".file-preview-close", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        overlays.close_overlay(OVERLAY_NAME);
+    });
+
+    $overlay.on("click", ".file-preview-download", function () {
+        this.blur();
+    });
+
+    $overlay.on("click", ".file-preview-error-download", function () {
+        this.blur();
+    });
+}

--- a/web/src/file_attachment_preview.ts
+++ b/web/src/file_attachment_preview.ts
@@ -73,11 +73,12 @@ const EXT_TO_HLJS_LANGUAGE: Record<string, string> = {
 };
 
 // Built-in set of extensions that are always previewable.
-// Includes txt, md, csv, plus all extensions with known syntax highlighting.
+// Includes txt, md, csv, pdf, plus all extensions with known syntax highlighting.
 const BUILT_IN_PREVIEW_EXTENSIONS = new Set([
     "txt",
     "md",
     "csv",
+    "pdf",
     ...Object.keys(EXT_TO_HLJS_LANGUAGE),
 ]);
 
@@ -243,6 +244,21 @@ function render_csv_table(text: string): string {
     return html;
 }
 
+// PDF state for multi-page navigation — managed by the dynamically
+// imported pdf_preview module.  We keep a local reference for the
+// click handlers that need synchronous access to the state.
+let pdf_preview_mod: typeof import("./pdf_preview.ts") | null = null;
+
+// Lazy-load the PDF preview module (and its pdfjs-dist dependency).
+// Isolated into its own module so that pdfjs-dist (ESM-only) doesn't
+// prevent the CJS test runner from loading this file.
+async function load_pdf_preview(): Promise<typeof import("./pdf_preview.ts")> {
+    if (!pdf_preview_mod) {
+        pdf_preview_mod = await import("./pdf_preview.ts");
+    }
+    return pdf_preview_mod;
+}
+
 function render_markdown_via_server(text: string): void {
     // Use Zulip's server-side markdown renderer for accurate preview.
     void channel.post({
@@ -307,6 +323,7 @@ export async function open_preview(url: string, filename: string): Promise<void>
             $overlay.find(".file-preview-rendered").empty().removeClass("show rendered-markdown");
             $overlay.find(".file-preview-loading").removeClass("show");
             $overlay.find(".file-preview-error").removeClass("show");
+            pdf_preview_mod?.clear_pdf_state();
         },
     });
 
@@ -315,6 +332,13 @@ export async function open_preview(url: string, filename: string): Promise<void>
     update_nav_arrows();
 
     show_loading();
+
+    // PDF files rendered via pdf.js (secure canvas rendering, no iframe)
+    if (ext === "pdf") {
+        const pdf_mod = await load_pdf_preview();
+        await pdf_mod.show_pdf(url, $overlay, show_error);
+        return;
+    }
 
     try {
         const response = await fetch(url);
@@ -384,6 +408,7 @@ export function open_download_only(url: string, filename: string): void {
             $overlay.find(".file-preview-rendered").empty().removeClass("show rendered-markdown");
             $overlay.find(".file-preview-loading").removeClass("show");
             $overlay.find(".file-preview-error").removeClass("show");
+            pdf_preview_mod?.clear_pdf_state();
         },
     });
 
@@ -418,6 +443,23 @@ export function initialize(): void {
 
     $overlay.on("click", ".file-preview-error-download", function () {
         this.blur();
+    });
+
+    // PDF page navigation handlers
+    $overlay.on("click", ".file-preview-pdf-prev", (e) => {
+        e.preventDefault();
+        const state = pdf_preview_mod?.get_pdf_state();
+        if (state && state.current_page > 1) {
+            void pdf_preview_mod!.render_pdf_page(state.current_page - 1, $overlay, show_error);
+        }
+    });
+
+    $overlay.on("click", ".file-preview-pdf-next", (e) => {
+        e.preventDefault();
+        const state = pdf_preview_mod?.get_pdf_state();
+        if (state && state.current_page < state.total_pages) {
+            void pdf_preview_mod!.render_pdf_page(state.current_page + 1, $overlay, show_error);
+        }
     });
 
     // Attachment navigation handlers

--- a/web/src/file_attachment_preview.ts
+++ b/web/src/file_attachment_preview.ts
@@ -4,6 +4,7 @@ import $ from "jquery";
 
 import render_file_attachment_preview from "../templates/file_attachment_preview.hbs";
 
+import * as attachment_navigator from "./attachment_navigator.ts";
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
 import {$t} from "./i18n.ts";
@@ -84,6 +85,13 @@ const MAX_PREVIEW_SIZE = 256 * 1024; // 256 KB
 const OVERLAY_NAME = "file-attachment-preview";
 
 let is_initialized = false;
+
+function update_nav_arrows(): void {
+    const $overlay = $(`#${CSS.escape(OVERLAY_NAME)}-overlay`);
+    const show_arrows = attachment_navigator.get_total() > 1;
+    $overlay.find(".file-preview-nav-prev").toggleClass("visible", show_arrows);
+    $overlay.find(".file-preview-nav-next").toggleClass("visible", show_arrows);
+}
 
 function get_extension(filename: string): string {
     const dot_index = filename.lastIndexOf(".");
@@ -216,7 +224,7 @@ function render_csv_table(text: string): string {
         return `<pre><code>${escape_html(text)}</code></pre>`;
     }
 
-    const header = rows[0];
+    const header = rows[0]!;
     const body_rows = rows.slice(1);
 
     let html = '<div class="file-preview-csv-wrapper"><table class="file-preview-csv-table"><thead><tr>';
@@ -273,7 +281,9 @@ function render_content(text: string, ext: string): void {
         return;
     }
 
-    // Default: plain text in <pre>
+    // For unknown extensions, show as plain text only if in the
+    // allowed set (built-in or user-configured extras). Otherwise
+    // the file should not have reached here — show a download prompt.
     show_rendered(`<pre><code>${escape_html(text)}</code></pre>`, false);
 }
 
@@ -299,6 +309,10 @@ export async function open_preview(url: string, filename: string): Promise<void>
             $overlay.find(".file-preview-error").removeClass("show");
         },
     });
+
+    // Set up attachment navigation
+    attachment_navigator.start_navigation(url);
+    update_nav_arrows();
 
     show_loading();
 
@@ -349,6 +363,38 @@ export async function open_preview(url: string, filename: string): Promise<void>
     }
 }
 
+// Open the overlay for a file type that cannot be previewed.
+// Shows only the filename and download button, with navigation arrows.
+export function open_download_only(url: string, filename: string): void {
+    if (overlays.any_active()) {
+        overlays.close_active();
+    }
+
+    const download_url = get_download_url(url);
+
+    const $overlay = $(`#${CSS.escape(OVERLAY_NAME)}-overlay`);
+    $overlay.find(".file-preview-filename").text(filename);
+    $overlay.find(".file-preview-download").attr("href", download_url);
+    $overlay.find(".file-preview-error-download").attr("href", download_url);
+
+    overlays.open_overlay({
+        name: OVERLAY_NAME,
+        $overlay,
+        on_close() {
+            $overlay.find(".file-preview-rendered").empty().removeClass("show rendered-markdown");
+            $overlay.find(".file-preview-loading").removeClass("show");
+            $overlay.find(".file-preview-error").removeClass("show");
+        },
+    });
+
+    attachment_navigator.start_navigation(url);
+    update_nav_arrows();
+
+    show_error(
+        $t({defaultMessage: "No preview available for this file type. Use the Download button to save it."}),
+    );
+}
+
 export function initialize(): void {
     if (is_initialized) {
         return;
@@ -373,4 +419,26 @@ export function initialize(): void {
     $overlay.on("click", ".file-preview-error-download", function () {
         this.blur();
     });
+
+    // Attachment navigation handlers
+    $overlay.on("click", ".file-preview-nav-prev", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        attachment_navigator.prev();
+    });
+
+    $overlay.on("click", ".file-preview-nav-next", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        attachment_navigator.next();
+    });
+}
+
+// Export for use by hotkey.ts
+export function prev(): void {
+    attachment_navigator.prev();
+}
+
+export function next(): void {
+    attachment_navigator.next();
 }

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -23,6 +23,7 @@ import * as drafts_overlay_ui from "./drafts_overlay_ui.ts";
 import * as emoji from "./emoji.ts";
 import * as emoji_picker from "./emoji_picker.ts";
 import * as feedback_widget from "./feedback_widget.ts";
+import * as file_attachment_preview from "./file_attachment_preview.ts";
 import * as gear_menu from "./gear_menu.ts";
 import * as gif_picker_ui from "./gif_picker_ui.ts";
 import * as hash_util from "./hash_util.ts";
@@ -1103,6 +1104,9 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         if (overlays.lightbox_open()) {
             lightbox.prev();
             return true;
+        } else if (overlays.file_preview_open()) {
+            file_attachment_preview.prev();
+            return true;
         } else if (overlays.streams_open()) {
             stream_settings_ui.toggle_view(event_name);
             return true;
@@ -1118,6 +1122,9 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
     if (event_name === "right_arrow") {
         if (overlays.lightbox_open()) {
             lightbox.next();
+            return true;
+        } else if (overlays.file_preview_open()) {
+            file_attachment_preview.next();
             return true;
         } else if (overlays.streams_open()) {
             stream_settings_ui.toggle_view(event_name);

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -5,6 +5,7 @@ import type {PanZoom} from "panzoom";
 
 import render_lightbox_overlay from "../templates/lightbox_overlay.hbs";
 
+import * as attachment_navigator from "./attachment_navigator.ts";
 import * as blueslip from "./blueslip.ts";
 import * as message_store from "./message_store.ts";
 import * as overlays from "./overlays.ts";
@@ -411,6 +412,9 @@ export function build_open_media_function(
             on_close,
         });
 
+        // Start unified attachment navigation
+        attachment_navigator.start_navigation(payload.url);
+
         popovers.hide_all();
         is_open = true;
     };
@@ -622,14 +626,41 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
 }
 
 export function prev(): void {
+    // Use the unified attachment navigator for cross-type navigation
+    if (attachment_navigator.get_total() > 1) {
+        attachment_navigator.prev();
+        return;
+    }
     $(".image-list .image.selected").prev().trigger("click");
 }
 
 export function next(): void {
+    // Use the unified attachment navigator for cross-type navigation
+    if (attachment_navigator.get_total() > 1) {
+        attachment_navigator.next();
+        return;
+    }
     $(".image-list .image.selected").next().trigger("click");
 }
 
 function update_arrow_visibility(): void {
+    const nav_has_multiple = attachment_navigator.get_total() > 1;
+    if (nav_has_multiple) {
+        // When using the unified navigator, always show arrows (wrapping enabled)
+        $("#lightbox_overlay .center .arrow[data-direction='prev']").toggleClass(
+            "invisible",
+            false,
+        );
+        $("#lightbox_overlay .center .arrow[data-direction='next']").toggleClass(
+            "invisible",
+            false,
+        );
+        // Show side nav arrows too
+        $("#lightbox_overlay .lightbox-nav-prev").addClass("visible");
+        $("#lightbox_overlay .lightbox-nav-next").addClass("visible");
+        return;
+    }
+
     const $selected = $(".image-list .image.selected");
     const has_prev = $selected.prev(".image").length > 0;
     const has_next = $selected.next(".image").length > 0;
@@ -641,6 +672,10 @@ function update_arrow_visibility(): void {
         "invisible",
         !has_next,
     );
+    // Show side arrows when there are multiple lightbox images
+    const show_side = has_prev || has_next;
+    $("#lightbox_overlay .lightbox-nav-prev").toggleClass("visible", show_side);
+    $("#lightbox_overlay .lightbox-nav-next").toggleClass("visible", show_side);
 }
 
 function remove_video_players(): void {
@@ -802,6 +837,18 @@ export function initialize(): void {
     $("#lightbox_overlay").on("click", ".center .arrow", function () {
         const direction = $(this).attr("data-direction");
 
+        if (direction === "next") {
+            next();
+        } else if (direction === "prev") {
+            prev();
+        }
+    });
+
+    // Side navigation arrows (matching file preview style)
+    $("#lightbox_overlay").on("click", ".lightbox-side-nav", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const direction = $(this).attr("data-direction");
         if (direction === "next") {
             next();
         } else if (direction === "prev") {

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -686,7 +686,7 @@ function remove_video_players(): void {
 }
 
 export function handle_inline_media_element_click(
-    $media: JQuery<HTMLMediaElement> | JQuery<HTMLImageElement>,
+    $media: JQuery<HTMLMediaElement | HTMLImageElement>,
     hide_navigation_arrows = false,
 ): void {
     set_selected_media_element($media);

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -66,6 +66,10 @@ export function lightbox_open(): boolean {
     return open_overlay_name === "lightbox";
 }
 
+export function file_preview_open(): boolean {
+    return open_overlay_name === "file-attachment-preview";
+}
+
 export function drafts_open(): boolean {
     return open_overlay_name === "drafts";
 }

--- a/web/src/pdf_preview.ts
+++ b/web/src/pdf_preview.ts
@@ -1,0 +1,153 @@
+// Separate module for PDF rendering via pdf.js.
+// Isolated to keep pdfjs-dist (ESM-only) out of the main
+// file_attachment_preview module, which must be loadable by
+// the CJS test runner.
+
+import {GlobalWorkerOptions, getDocument} from "pdfjs-dist";
+
+import * as blueslip from "./blueslip.ts";
+import {$t} from "./i18n.ts";
+
+// Configure pdf.js worker — webpack resolves the URL via import.meta.url
+GlobalWorkerOptions.workerSrc = new URL(
+    "pdfjs-dist/build/pdf.worker.min.mjs",
+    import.meta.url,
+).href;
+
+// PDF state for multi-page navigation
+let pdf_state: {
+    total_pages: number;
+    current_page: number;
+    url: string;
+    scale: number;
+} | null = null;
+
+export function get_pdf_state(): typeof pdf_state {
+    return pdf_state;
+}
+
+export function clear_pdf_state(): void {
+    pdf_state = null;
+}
+
+export async function render_pdf_page(
+    page_number: number,
+    $overlay: JQuery,
+    show_error: (msg: string) => void,
+): Promise<void> {
+    if (!pdf_state) {
+        return;
+    }
+    const $rendered = $overlay.find(".file-preview-rendered");
+
+    try {
+        const pdf = await getDocument(pdf_state.url).promise;
+        const page = await pdf.getPage(page_number);
+
+        // Calculate scale to fit the container width
+        const $container = $rendered.find(".file-preview-pdf-container");
+        const container_width = Math.max($container.width() ?? 800, 400);
+        const viewport_unscaled = page.getViewport({scale: 1});
+        const fit_scale = (container_width - 40) / viewport_unscaled.width;
+        // Apply user zoom and device pixel ratio for crisp rendering
+        const dpr = window.devicePixelRatio || 1;
+        const scale = Math.min(fit_scale, 2.0) * pdf_state.scale * dpr;
+        const viewport = page.getViewport({scale});
+
+        const canvas = $rendered.find<HTMLCanvasElement>(".file-preview-pdf-canvas")[0]!;
+
+        // Set canvas pixel dimensions to the scaled viewport
+        canvas.width = Math.floor(viewport.width);
+        canvas.height = Math.floor(viewport.height);
+        // Set CSS dimensions to display at the logical (non-DPR) size
+        canvas.style.width = `${Math.floor(viewport.width / dpr)}px`;
+        canvas.style.height = `${Math.floor(viewport.height / dpr)}px`;
+
+        await page.render({canvas, viewport}).promise;
+
+        // Update page indicator
+        pdf_state.current_page = page_number;
+        $rendered
+            .find(".file-preview-pdf-page-indicator")
+            .text(`${page_number} / ${pdf_state.total_pages}`);
+
+        // Update button states
+        $rendered
+            .find(".file-preview-pdf-prev")
+            .prop("disabled", page_number <= 1);
+        $rendered
+            .find(".file-preview-pdf-next")
+            .prop("disabled", page_number >= pdf_state.total_pages);
+
+        pdf.destroy();
+    } catch (error) {
+        blueslip.warn("Error rendering PDF page", {error: String(error)});
+        show_error($t({defaultMessage: "An error occurred while rendering the PDF."}));
+    }
+}
+
+export async function show_pdf(
+    url: string,
+    $overlay: JQuery,
+    show_error: (msg: string) => void,
+): Promise<void> {
+    const $rendered = $overlay.find(".file-preview-rendered");
+
+    try {
+        const pdf = await getDocument(url).promise;
+        const total_pages = pdf.numPages;
+
+        pdf_state = {
+            total_pages,
+            current_page: 1,
+            url,
+            scale: 1.0,
+        };
+
+        // Build PDF viewer UI with page navigation
+        let controls_html = "";
+        if (total_pages > 1) {
+            controls_html = `
+                <div class="file-preview-pdf-controls">
+                    <button class="file-preview-pdf-prev" disabled>&lsaquo;</button>
+                    <span class="file-preview-pdf-page-indicator">1 / ${total_pages}</span>
+                    <button class="file-preview-pdf-next" ${total_pages <= 1 ? "disabled" : ""}>&rsaquo;</button>
+                </div>`;
+        }
+
+        $rendered.html(
+            `<div class="file-preview-pdf-container">
+                ${controls_html}
+                <div class="file-preview-pdf-canvas-wrapper">
+                    <canvas class="file-preview-pdf-canvas"></canvas>
+                </div>
+            </div>`,
+        );
+
+        $overlay.find(".file-preview-loading").removeClass("show");
+        $rendered.addClass("show");
+        $overlay.find(".file-preview-error").removeClass("show");
+
+        // Render the first page directly using the already-loaded document
+        const page = await pdf.getPage(1);
+        const $container = $rendered.find(".file-preview-pdf-container");
+        const container_width = Math.max($container.width() ?? 800, 400);
+        const viewport_unscaled = page.getViewport({scale: 1});
+        const fit_scale = (container_width - 40) / viewport_unscaled.width;
+        const dpr = window.devicePixelRatio || 1;
+        const scale = Math.min(fit_scale, 2.0) * dpr;
+        const viewport = page.getViewport({scale});
+
+        const canvas = $rendered.find<HTMLCanvasElement>(".file-preview-pdf-canvas")[0]!;
+        canvas.width = Math.floor(viewport.width);
+        canvas.height = Math.floor(viewport.height);
+        canvas.style.width = `${Math.floor(viewport.width / dpr)}px`;
+        canvas.style.height = `${Math.floor(viewport.height / dpr)}px`;
+
+        await page.render({canvas, viewport}).promise;
+        pdf.destroy();
+    } catch (error) {
+        blueslip.warn("Error loading PDF", {error: String(error)});
+        show_error($t({defaultMessage: "Could not load PDF. The file may be corrupted."}));
+    }
+}

--- a/web/src/pdf_preview.ts
+++ b/web/src/pdf_preview.ts
@@ -51,7 +51,7 @@ export async function render_pdf_page(
         const fit_scale = (container_width - 40) / viewport_unscaled.width;
         // Apply user zoom and device pixel ratio for crisp rendering
         const dpr = window.devicePixelRatio || 1;
-        const scale = Math.min(fit_scale, 2.0) * pdf_state.scale * dpr;
+        const scale = Math.min(fit_scale, 2) * pdf_state.scale * dpr;
         const viewport = page.getViewport({scale});
 
         const canvas = $rendered.find<HTMLCanvasElement>(".file-preview-pdf-canvas")[0]!;
@@ -72,14 +72,12 @@ export async function render_pdf_page(
             .text(`${page_number} / ${pdf_state.total_pages}`);
 
         // Update button states
-        $rendered
-            .find(".file-preview-pdf-prev")
-            .prop("disabled", page_number <= 1);
+        $rendered.find(".file-preview-pdf-prev").prop("disabled", page_number <= 1);
         $rendered
             .find(".file-preview-pdf-next")
             .prop("disabled", page_number >= pdf_state.total_pages);
 
-        pdf.destroy();
+        void pdf.destroy();
     } catch (error) {
         blueslip.warn("Error rendering PDF page", {error: String(error)});
         show_error($t({defaultMessage: "An error occurred while rendering the PDF."}));
@@ -101,7 +99,7 @@ export async function show_pdf(
             total_pages,
             current_page: 1,
             url,
-            scale: 1.0,
+            scale: 1,
         };
 
         // Build PDF viewer UI with page navigation
@@ -135,7 +133,7 @@ export async function show_pdf(
         const viewport_unscaled = page.getViewport({scale: 1});
         const fit_scale = (container_width - 40) / viewport_unscaled.width;
         const dpr = window.devicePixelRatio || 1;
-        const scale = Math.min(fit_scale, 2.0) * dpr;
+        const scale = Math.min(fit_scale, 2) * dpr;
         const viewport = page.getViewport({scale});
 
         const canvas = $rendered.find<HTMLCanvasElement>(".file-preview-pdf-canvas")[0]!;
@@ -145,7 +143,7 @@ export async function show_pdf(
         canvas.style.height = `${Math.floor(viewport.height / dpr)}px`;
 
         await page.render({canvas, viewport}).promise;
-        pdf.destroy();
+        void pdf.destroy();
     } catch (error) {
         blueslip.warn("Error loading PDF", {error: String(error)});
         show_error($t({defaultMessage: "Could not load PDF. The file may be corrupted."}));

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -106,16 +106,11 @@ export function postprocess_content(html: string): string {
                 // Add a download icon button next to the attachment link
                 // so users can download without opening the preview.
                 const download_pathname =
-                    "/user_uploads/download/" +
-                    url.pathname.slice("/user_uploads/".length);
+                    "/user_uploads/download/" + url.pathname.slice("/user_uploads/".length);
                 const download_url = new URL(download_pathname, url.origin);
 
                 // Only add if not already present (idempotent)
-                if (
-                    !elt.nextElementSibling?.classList.contains(
-                        "attachment-download-icon",
-                    )
-                ) {
+                if (!elt.nextElementSibling?.classList.contains("attachment-download-icon")) {
                     assert(inertDocument !== undefined);
                     const download_link = inertDocument.createElement("a");
                     download_link.classList.add(

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -102,6 +102,39 @@ export function postprocess_content(html: string): string {
                         ),
                     },
                 );
+
+                // Add a download icon button next to the attachment link
+                // so users can download without opening the preview.
+                const download_pathname =
+                    "/user_uploads/download/" +
+                    url.pathname.slice("/user_uploads/".length);
+                const download_url = new URL(download_pathname, url.origin);
+
+                // Only add if not already present (idempotent)
+                if (
+                    !elt.nextElementSibling?.classList.contains(
+                        "attachment-download-icon",
+                    )
+                ) {
+                    assert(inertDocument !== undefined);
+                    const download_link = inertDocument.createElement("a");
+                    download_link.classList.add(
+                        "attachment-download-icon",
+                        "icon-button",
+                        "icon-button-square",
+                        "icon-button-neutral",
+                    );
+                    download_link.setAttribute("href", download_url.toString());
+                    download_link.setAttribute("download", "");
+                    download_link.setAttribute("aria-label", $t({defaultMessage: "Download"}));
+                    download_link.setAttribute("title", title);
+
+                    const icon = inertDocument.createElement("i");
+                    icon.classList.add("zulip-icon", "zulip-icon-download");
+                    download_link.append(icon);
+
+                    elt.after(download_link);
+                }
             } else {
                 title = url.toString();
                 legacy_title = href;

--- a/web/src/realm_user_settings_defaults.ts
+++ b/web/src/realm_user_settings_defaults.ts
@@ -66,6 +66,7 @@ export const realm_default_settings_schema = z.object({
     web_mark_read_on_scroll_policy: z.number(),
     web_navigate_to_sent_message: z.boolean(),
     web_stream_unreads_count_display_policy: z.number(),
+    file_preview_extensions: z.string(),
     wildcard_mentions_notify: z.boolean(),
 });
 export type RealmDefaultSettings = z.infer<typeof realm_default_settings_schema>;

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -957,6 +957,7 @@ export function dispatch_normal_event(event) {
                 "receives_typing_notifications",
                 "resolved_topic_notice_auto_read_policy",
                 "starred_message_counts",
+                "file_preview_extensions",
                 "timezone",
                 "translate_emoticons",
                 "twenty_four_hour_time",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -705,6 +705,7 @@ export const preferences_settings_labels = {
     web_navigate_to_sent_message: $t({
         defaultMessage: "Automatically go to conversation where you sent a message",
     }),
+    file_preview_extensions: $t({defaultMessage: "Additional text preview extensions"}),
 };
 
 export const notification_settings_labels = {

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -191,6 +191,19 @@ export function set_up(settings_panel: SettingsPanel): void {
         change_display_setting(data, $status_element);
     });
 
+    $container.on(
+        "change",
+        "input[name='file_preview_extensions']",
+        function (this: HTMLElement, e) {
+            const $input_elem = $(e.currentTarget);
+            const data = {file_preview_extensions: $input_elem.val() as string};
+            const $status_element = $input_elem
+                .closest(".subsection-parent")
+                .find(".alert-notification");
+            change_display_setting(data, $status_element);
+        },
+    );
+
     $container.find(".info-density-button").on("click", function (this: HTMLElement, e) {
         e.preventDefault();
         const changed_property = z

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -196,7 +196,9 @@ export function set_up(settings_panel: SettingsPanel): void {
         "input[name='file_preview_extensions']",
         function (this: HTMLElement, e) {
             const $input_elem = $(e.currentTarget);
-            const data = {file_preview_extensions: $input_elem.val() as string};
+            const setting_value = settings_components.get_input_element_value(this);
+            assert(typeof setting_value === "string");
+            const data = {file_preview_extensions: setting_value};
             const $status_element = $input_elem
                 .closest(".subsection-parent")
                 .find(".alert-notification");

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -132,6 +132,7 @@ import * as sidebar_ui from "./sidebar_ui.ts";
 import * as spoilers from "./spoilers.ts";
 import * as starred_messages from "./starred_messages.ts";
 import * as starred_messages_ui from "./starred_messages_ui.ts";
+import * as file_attachment_preview from "./file_attachment_preview.ts";
 import {
     current_user,
     realm,
@@ -630,6 +631,7 @@ export async function initialize_everything(state_data) {
     condense.initialize();
     spoilers.initialize();
     lightbox.initialize();
+    file_attachment_preview.initialize();
     sidebar_ui.initialize();
     user_profile.initialize();
     stream_popover.initialize();

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -50,6 +50,7 @@ import * as emoji from "./emoji.ts";
 import * as emoji_picker from "./emoji_picker.ts";
 import * as emojisets from "./emojisets.ts";
 import * as fenced_code from "./fenced_code.ts";
+import * as file_attachment_preview from "./file_attachment_preview.ts";
 import * as gear_menu from "./gear_menu.ts";
 import * as gif_picker_ui from "./gif_picker_ui.ts";
 import * as gif_state from "./gif_state.ts";
@@ -132,7 +133,6 @@ import * as sidebar_ui from "./sidebar_ui.ts";
 import * as spoilers from "./spoilers.ts";
 import * as starred_messages from "./starred_messages.ts";
 import * as starred_messages_ui from "./starred_messages_ui.ts";
-import * as file_attachment_preview from "./file_attachment_preview.ts";
 import {
     current_user,
     realm,

--- a/web/src/user_settings.ts
+++ b/web/src/user_settings.ts
@@ -69,6 +69,7 @@ export const user_settings_schema = z.object({
     send_read_receipts: z.boolean(),
     send_stream_typing_notifications: z.boolean(),
     starred_message_counts: z.boolean(),
+    file_preview_extensions: z.string(),
     timezone: z.string(),
     translate_emoticons: z.boolean(),
     twenty_four_hour_time: z.boolean(),

--- a/web/styles/file_attachment_preview.css
+++ b/web/styles/file_attachment_preview.css
@@ -1,0 +1,514 @@
+/* Light-mode styles for rendered markdown, code, and CSV within the preview overlay */
+%file-preview-light-theme {
+    #file-attachment-preview-overlay {
+        .file-preview-rendered {
+            color: hsl(0deg 0% 20%);
+
+            /* Source code / plain text pre block */
+            pre {
+                background-color: hsl(0deg 0% 100%);
+                border-color: hsl(0deg 0% 85%);
+                color: hsl(210deg 12% 16%);
+            }
+
+            /* highlight.js token colors (GitHub Light theme) */
+            .hljs {
+                background: hsl(0deg 0% 100%);
+                color: hsl(210deg 12% 16%);
+            }
+
+            .hljs-comment,
+            .hljs-quote {
+                color: hsl(210deg 10% 47%);
+                font-style: italic;
+            }
+
+            .hljs-keyword,
+            .hljs-selector-tag,
+            .hljs-type {
+                color: hsl(349deg 74% 42%);
+            }
+
+            .hljs-string,
+            .hljs-doctag,
+            .hljs-regexp {
+                color: hsl(219deg 96% 19%);
+            }
+
+            .hljs-number,
+            .hljs-literal,
+            .hljs-built_in,
+            .hljs-attr {
+                color: hsl(217deg 100% 39%);
+            }
+
+            .hljs-title,
+            .hljs-section {
+                color: hsl(271deg 61% 50%);
+            }
+
+            .hljs-variable {
+                color: hsl(22deg 82% 46%);
+            }
+
+            .hljs-meta {
+                color: hsl(44deg 74% 26%);
+            }
+
+            .hljs-addition {
+                color: hsl(137deg 69% 24%);
+                background-color: hsl(137deg 50% 92%);
+            }
+
+            .hljs-deletion {
+                color: hsl(349deg 74% 42%);
+                background-color: hsl(349deg 50% 95%);
+            }
+
+            &.rendered-markdown {
+                background-color: hsl(0deg 0% 100%);
+
+                h1,
+                h2,
+                h3,
+                h4,
+                h5,
+                h6 {
+                    color: hsl(0deg 0% 13%);
+                }
+
+                a {
+                    color: hsl(200deg 100% 40%);
+                }
+
+                blockquote {
+                    border-left-color: hsl(0deg 0% 80%);
+                    color: hsl(0deg 0% 40%);
+                }
+
+                code {
+                    background-color: hsl(0deg 0% 95%);
+                    color: hsl(210deg 12% 16%);
+                }
+
+                pre {
+                    background-color: hsl(0deg 0% 96%);
+                    border-color: hsl(0deg 0% 87%);
+
+                    code {
+                        background-color: transparent;
+                    }
+                }
+            }
+        }
+
+        .file-preview-csv-wrapper {
+            border-color: hsl(0deg 0% 0% / 15%);
+            background-color: hsl(0deg 0% 100%);
+        }
+
+        .file-preview-csv-table {
+            th {
+                background-color: hsl(0deg 0% 93%);
+                color: hsl(0deg 0% 20%);
+            }
+
+            td {
+                color: hsl(0deg 0% 20%);
+            }
+
+            th,
+            td {
+                border-bottom-color: hsl(0deg 0% 85%);
+            }
+
+            tbody tr:nth-child(even) {
+                background-color: hsl(0deg 0% 96%);
+            }
+
+            tbody tr:hover {
+                background-color: hsl(200deg 50% 92%);
+            }
+        }
+    }
+}
+
+/* Dark-mode styles for rendered markdown, code, and CSV within the preview overlay */
+%file-preview-dark-theme {
+    #file-attachment-preview-overlay {
+        .file-preview-rendered {
+            color: hsl(0deg 0% 93%);
+
+            /* Source code / plain text pre block */
+            pre {
+                background-color: hsl(227deg 40% 12%);
+                border-color: hsl(0deg 0% 100% / 10%);
+                color: hsl(212deg 19% 77%);
+            }
+
+            /* highlight.js token colors (GitHub Dark Dimmed theme) */
+            .hljs {
+                background: hsl(227deg 40% 12%);
+                color: hsl(212deg 19% 77%);
+            }
+
+            .hljs-comment,
+            .hljs-quote {
+                color: hsl(210deg 10% 49%);
+                font-style: italic;
+            }
+
+            .hljs-keyword,
+            .hljs-selector-tag,
+            .hljs-type {
+                color: hsl(4deg 84% 67%);
+            }
+
+            .hljs-string,
+            .hljs-doctag,
+            .hljs-regexp {
+                color: hsl(207deg 100% 79%);
+            }
+
+            .hljs-number,
+            .hljs-literal,
+            .hljs-built_in,
+            .hljs-attr {
+                color: hsl(207deg 100% 79%);
+            }
+
+            .hljs-title,
+            .hljs-section {
+                color: hsl(271deg 82% 72%);
+            }
+
+            .hljs-variable {
+                color: hsl(26deg 100% 69%);
+            }
+
+            .hljs-meta {
+                color: hsl(44deg 100% 73%);
+            }
+
+            .hljs-addition {
+                color: hsl(137deg 62% 55%);
+                background-color: hsl(137deg 60% 14%);
+            }
+
+            .hljs-deletion {
+                color: hsl(4deg 84% 67%);
+                background-color: hsl(4deg 60% 17%);
+            }
+
+            &.rendered-markdown {
+                background-color: hsl(227deg 30% 14%);
+
+                h1,
+                h2,
+                h3,
+                h4,
+                h5,
+                h6 {
+                    color: hsl(0deg 0% 93%);
+                }
+
+                a {
+                    color: hsl(200deg 100% 65%);
+                }
+
+                blockquote {
+                    border-left-color: hsl(0deg 0% 40%);
+                    color: hsl(0deg 0% 70%);
+                }
+
+                code {
+                    background-color: hsl(227deg 30% 20%);
+                    color: hsl(212deg 19% 77%);
+                }
+
+                pre {
+                    background-color: hsl(227deg 30% 11%);
+                    border-color: hsl(0deg 0% 100% / 10%);
+
+                    code {
+                        background-color: transparent;
+                    }
+                }
+            }
+        }
+
+        .file-preview-csv-wrapper {
+            border-color: hsl(0deg 0% 100% / 15%);
+            background-color: hsl(227deg 40% 12%);
+        }
+
+        .file-preview-csv-table {
+            th {
+                background-color: hsl(227deg 40% 20%);
+                color: hsl(0deg 0% 100%);
+            }
+
+            td {
+                color: hsl(0deg 0% 90%);
+            }
+
+            th,
+            td {
+                border-bottom-color: hsl(0deg 0% 100% / 10%);
+            }
+
+            tbody tr:nth-child(even) {
+                background-color: hsl(227deg 40% 15%);
+            }
+
+            tbody tr:hover {
+                background-color: hsl(227deg 40% 22%);
+            }
+        }
+    }
+}
+
+@media screen {
+    :root:not(.color-scheme-automatic, .dark-theme) {
+        @extend %file-preview-light-theme;
+    }
+}
+
+@media screen and (not (prefers-color-scheme: dark)) {
+    :root.color-scheme-automatic {
+        @extend %file-preview-light-theme;
+    }
+}
+
+@media not screen {
+    :root {
+        @extend %file-preview-light-theme;
+    }
+}
+
+@media screen {
+    :root.dark-theme {
+        @extend %file-preview-dark-theme;
+    }
+}
+
+@media screen and (prefers-color-scheme: dark) {
+    :root.color-scheme-automatic {
+        @extend %file-preview-dark-theme;
+    }
+}
+
+#file-attachment-preview-overlay {
+    background-color: hsl(227deg 40% 16%);
+    display: flex;
+    flex-direction: column;
+    height: 100dvh;
+
+    /* Reuse lightbox header structure */
+    .media-info-wrapper {
+        display: flex;
+        justify-content: end;
+        align-items: start;
+        gap: 20px;
+        padding: 20px;
+        background-color: transparent;
+    }
+
+    .media-description {
+        flex: 1;
+        min-width: 0;
+        font-size: 1.1rem;
+        color: hsl(0deg 0% 100%);
+
+        .title {
+            font-weight: 400;
+            line-height: normal;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
+
+    .media-actions {
+        display: flex;
+        flex-shrink: 0;
+        gap: 10px;
+
+        .lightbox-media-action {
+            font-size: 0.9rem;
+            min-width: inherit;
+            padding: 4px 10px;
+            border: 1px solid hsl(0deg 0% 100% / 60%);
+            background-color: transparent;
+            color: hsl(0deg 0% 100%);
+            border-radius: 4px;
+            text-decoration: none;
+            display: inline-block;
+            cursor: pointer;
+
+            &:hover {
+                background-color: hsl(0deg 0% 100%);
+                border-color: hsl(0deg 0% 100%);
+                color: hsl(227deg 40% 16%);
+            }
+        }
+    }
+
+    .exit {
+        flex-shrink: 0;
+        color: hsl(0deg 0% 100% / 80%);
+        font-size: 14px;
+        line-height: 31px;
+        opacity: 0;
+        pointer-events: none;
+        cursor: pointer;
+        transition: opacity 0.2s ease;
+    }
+
+    &.show .exit {
+        pointer-events: auto;
+        opacity: 1;
+    }
+
+    .file-preview-content {
+        flex: 1;
+        overflow: auto;
+        padding: 0 24px 24px;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    .file-preview-loading {
+        display: none;
+        justify-content: center;
+        align-items: center;
+        flex: 1;
+    }
+
+    .file-preview-loading.show {
+        display: flex;
+    }
+
+    .file-preview-rendered {
+        display: none;
+        flex: 1;
+        min-height: 0;
+
+        &.show {
+            display: flex;
+            flex-direction: column;
+        }
+
+        &.rendered-markdown {
+            line-height: 1.6;
+            border-radius: 6px;
+            padding: 24px;
+            overflow: auto;
+
+            blockquote {
+                border-left: 3px solid;
+                padding-left: 12px;
+            }
+
+            code {
+                padding: 2px 4px;
+                border-radius: 3px;
+                font-size: 0.9em;
+            }
+
+            pre {
+                border-radius: 6px;
+                border: 1px solid;
+                padding: 12px;
+                overflow-x: auto;
+
+                code {
+                    padding: 0;
+                }
+            }
+        }
+
+        pre {
+            margin: 0;
+            padding: 16px;
+            border-radius: 6px;
+            overflow-x: auto;
+            border: 1px solid;
+            flex: 1;
+            min-height: 0;
+        }
+
+        code {
+            font-family: "Source Code Pro", monospace;
+            font-size: 14px;
+            line-height: 1.5;
+        }
+    }
+
+    .file-preview-csv-wrapper {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        border-radius: 6px;
+        border: 1px solid;
+    }
+
+    .file-preview-csv-table {
+        border-collapse: collapse;
+        font-family: "Source Code Pro", monospace;
+        font-size: 13px;
+
+        th,
+        td {
+            padding: 6px 12px;
+            text-align: left;
+            border-bottom: 1px solid;
+            white-space: nowrap;
+        }
+
+        th {
+            position: sticky;
+            top: 0;
+            font-weight: 600;
+        }
+    }
+
+    .file-preview-error {
+        display: none;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        gap: 16px;
+        text-align: center;
+
+        &.show {
+            display: flex;
+        }
+
+        .lightbox-media-action {
+            font-size: 0.9rem;
+            min-width: inherit;
+            padding: 4px 10px;
+            border: 1px solid hsl(0deg 0% 100% / 60%);
+            background-color: transparent;
+            color: hsl(0deg 0% 100%);
+            border-radius: 4px;
+            text-decoration: none;
+            display: inline-block;
+            cursor: pointer;
+
+            &:hover {
+                background-color: hsl(0deg 0% 100%);
+                border-color: hsl(0deg 0% 100%);
+                color: hsl(227deg 40% 16%);
+            }
+        }
+    }
+
+    .file-preview-error-message {
+        color: hsl(0deg 0% 100%);
+        font-size: 16px;
+    }
+}

--- a/web/styles/file_attachment_preview.css
+++ b/web/styles/file_attachment_preview.css
@@ -413,6 +413,63 @@
         }
     }
 
+    .file-preview-pdf-container {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+        gap: 8px;
+    }
+
+    .file-preview-pdf-controls {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        padding: 6px 0;
+        flex-shrink: 0;
+    }
+
+    .file-preview-pdf-controls button {
+        background: none;
+        border: 1px solid hsl(0deg 0% 80%);
+        border-radius: 4px;
+        font-size: 20px;
+        line-height: 1;
+        padding: 2px 10px;
+        cursor: pointer;
+        color: inherit;
+
+        &:disabled {
+            opacity: 0.3;
+            cursor: default;
+        }
+
+        &:hover:not(:disabled) {
+            background-color: hsl(0deg 0% 0% / 8%);
+        }
+    }
+
+    .file-preview-pdf-page-indicator {
+        font-size: 14px;
+        min-width: 70px;
+        text-align: center;
+    }
+
+    .file-preview-pdf-canvas-wrapper {
+        flex: 1;
+        overflow: auto;
+        display: flex;
+        justify-content: center;
+        min-height: 0;
+        border-radius: 6px;
+    }
+
+    .file-preview-pdf-canvas {
+        display: block;
+        max-width: 100%;
+    }
+
     .file-preview-loading {
         display: none;
         justify-content: center;

--- a/web/styles/file_attachment_preview.css
+++ b/web/styles/file_attachment_preview.css
@@ -372,11 +372,45 @@
 
     .file-preview-content {
         flex: 1;
+        overflow: hidden;
+        padding: 0 0 24px;
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+        min-height: 0;
+    }
+
+    .file-preview-main {
+        flex: 1;
         overflow: auto;
-        padding: 0 24px 24px;
         display: flex;
         flex-direction: column;
         min-height: 0;
+        padding: 0 24px;
+    }
+
+    .file-preview-nav-arrow {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 60px;
+        flex-shrink: 0;
+        cursor: pointer;
+        color: hsl(0deg 0% 100% / 60%);
+        font-size: 28px;
+        transition:
+            color 0.2s ease,
+            background-color 0.2s ease;
+        user-select: none;
+
+        &:hover {
+            color: hsl(0deg 0% 100%);
+            background-color: hsl(0deg 0% 100% / 8%);
+        }
+
+        &.visible {
+            display: flex;
+        }
     }
 
     .file-preview-loading {

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -4,6 +4,55 @@
     flex-direction: column;
     height: 100dvh;
 
+    .lightbox-content-wrapper {
+        flex: 1;
+        display: flex;
+        position: relative;
+        min-height: 0;
+    }
+
+    .lightbox-main-content {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+    }
+
+    .lightbox-side-nav {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 60px;
+        cursor: pointer;
+        color: hsl(0deg 0% 100% / 60%);
+        font-size: 28px;
+        z-index: 1;
+        user-select: none;
+        transition:
+            color 0.2s ease,
+            background-color 0.2s ease;
+
+        &.visible {
+            display: flex;
+        }
+
+        &:hover {
+            color: hsl(0deg 0% 100%);
+            background-color: hsl(0deg 0% 100% / 8%);
+        }
+    }
+
+    .lightbox-nav-prev {
+        left: 0;
+    }
+
+    .lightbox-nav-next {
+        right: 0;
+    }
+
     .image-preview {
         flex: 1;
         display: flex;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -785,6 +785,21 @@
         }
     }
 
+    .attachment-download-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: 3px;
+        vertical-align: middle;
+        font-size: 0.85em;
+        opacity: 0.5;
+
+        &:hover {
+            text-decoration: none;
+            opacity: 1;
+        }
+    }
+
     .message_embed {
         display: grid;
         grid-template-columns:

--- a/web/templates/file_attachment_preview.hbs
+++ b/web/templates/file_attachment_preview.hbs
@@ -1,0 +1,23 @@
+<div id="file-attachment-preview-overlay" class="overlay" data-overlay="file-attachment-preview" data-noclose="false">
+    <div class="media-info-wrapper">
+        <div class="media-description">
+            <div class="title file-preview-filename"></div>
+        </div>
+        <div class="media-actions">
+            <a class="lightbox-media-action file-preview-download" download>{{t "Download" }}</a>
+        </div>
+        <div class="file-preview-close exit" aria-label="{{t 'Close' }}">
+            <span aria-hidden="true" class="zulip-icon zulip-icon-close"></span>
+        </div>
+    </div>
+    <div class="file-preview-content">
+        <div class="file-preview-loading">
+            <div class="loading_indicator_spinner"></div>
+        </div>
+        <div class="file-preview-rendered"></div>
+        <div class="file-preview-error">
+            <p class="file-preview-error-message"></p>
+            <a class="file-preview-error-download lightbox-media-action" download>{{t "Download" }}</a>
+        </div>
+    </div>
+</div>

--- a/web/templates/file_attachment_preview.hbs
+++ b/web/templates/file_attachment_preview.hbs
@@ -11,13 +11,21 @@
         </div>
     </div>
     <div class="file-preview-content">
-        <div class="file-preview-loading">
-            <div class="loading_indicator_spinner"></div>
+        <div class="file-preview-nav-arrow file-preview-nav-prev no-select" aria-label="{{t 'Previous attachment' }}">
+            <i class="zulip-icon zulip-icon-chevron-left"></i>
         </div>
-        <div class="file-preview-rendered"></div>
-        <div class="file-preview-error">
-            <p class="file-preview-error-message"></p>
-            <a class="file-preview-error-download lightbox-media-action" download>{{t "Download" }}</a>
+        <div class="file-preview-main">
+            <div class="file-preview-loading">
+                <div class="loading_indicator_spinner"></div>
+            </div>
+            <div class="file-preview-rendered"></div>
+            <div class="file-preview-error">
+                <p class="file-preview-error-message"></p>
+                <a class="file-preview-error-download lightbox-media-action" download>{{t "Download" }}</a>
+            </div>
+        </div>
+        <div class="file-preview-nav-arrow file-preview-nav-next no-select" aria-label="{{t 'Next attachment' }}">
+            <i class="zulip-icon zulip-icon-chevron-right"></i>
         </div>
     </div>
 </div>

--- a/web/templates/lightbox_overlay.hbs
+++ b/web/templates/lightbox_overlay.hbs
@@ -14,11 +14,21 @@
         </div>
     </div>
 
-    <div class="image-preview no-select">
-        <div class="zoom-element no-select"></div>
+    <div class="lightbox-content-wrapper">
+        <div class="lightbox-side-nav lightbox-nav-prev" data-direction="prev">
+            <i class="zulip-icon zulip-icon-chevron-left"></i>
+        </div>
+        <div class="lightbox-main-content">
+            <div class="image-preview no-select">
+                <div class="zoom-element no-select"></div>
+            </div>
+            <div class="video-player"></div>
+            <div class="player-container"></div>
+        </div>
+        <div class="lightbox-side-nav lightbox-nav-next" data-direction="next">
+            <i class="zulip-icon zulip-icon-chevron-right"></i>
+        </div>
     </div>
-    <div class="video-player"></div>
-    <div class="player-container"></div>
     <div class="center">
         <div class="arrow no-select" data-direction="prev"><i class="zulip-icon zulip-icon-chevron-left"></i></div>
         <div class="image-list"></div>

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -91,4 +91,20 @@
               }}
         </div>
     </div>
+
+    <div class="input-group">
+        <label for="{{prefix}}file_preview_extensions" class="settings-field-label">
+            {{ settings_label.file_preview_extensions }}
+            {{#if for_realm_settings}}
+                {{> ../components/icon_button icon="reset" intent="neutral" custom_classes="reset-user-setting-to-default" data-tippy-content=(t "Reset users to default") aria-label=(t "Reset users to default") }}
+            {{/if}}
+        </label>
+        <input type="text"
+               name="file_preview_extensions"
+               class="setting_file_preview_extensions prop-element settings_text_input bootstrap-focus-style"
+               id="{{prefix}}file_preview_extensions"
+               value="{{settings_object.file_preview_extensions}}"
+               data-setting-widget-type="string"
+               placeholder="log,conf,env (leave empty for built-in types only; &quot;none&quot; to disable)" />
+    </div>
 </div>

--- a/web/tests/file_attachment_preview.test.cjs
+++ b/web/tests/file_attachment_preview.test.cjs
@@ -19,6 +19,7 @@ run_test("should_preview matches built-in extensions with empty setting", () => 
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.md"), true);
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.py"), true);
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.csv"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.pdf"), true);
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.rs"), true);
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.go"), true);
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.js"), true);
@@ -36,10 +37,9 @@ run_test("should_preview rejects non-matching extensions", () => {
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.zip"), false);
 });
 
-run_test("should_preview rejects pdf without pdf.js support", () => {
-    // PDF is not in the built-in set until pdf.js support is added
-    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.pdf"), false);
-    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.PDF"), false);
+run_test("should_preview matches pdf extension", () => {
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.pdf"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.PDF"), true);
 });
 
 run_test("should_preview rejects files without extensions", () => {
@@ -81,6 +81,7 @@ run_test("should_preview none disables all previews", () => {
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.txt"), false);
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.md"), false);
     assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.py"), false);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.pdf"), false);
 
     // Reset
     user_settings.file_preview_extensions = "";

--- a/web/tests/file_attachment_preview.test.cjs
+++ b/web/tests/file_attachment_preview.test.cjs
@@ -1,0 +1,87 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const {initialize_user_settings} = zrequire("user_settings");
+
+// Initialize with empty file_preview_extensions (default — built-in set is always active)
+const user_settings = {file_preview_extensions: ""};
+initialize_user_settings({user_settings});
+
+const file_attachment_preview = zrequire("file_attachment_preview");
+
+run_test("should_preview matches built-in extensions with empty setting", () => {
+    // Built-in types are always previewable when setting is empty (default)
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.txt"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.md"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.py"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.csv"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.rs"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.go"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.js"), true);
+});
+
+run_test("should_preview is case insensitive for URL extensions", () => {
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.TXT"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.Md"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.PY"), true);
+});
+
+run_test("should_preview rejects non-matching extensions", () => {
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.jpg"), false);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.png"), false);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.zip"), false);
+});
+
+run_test("should_preview rejects pdf without pdf.js support", () => {
+    // PDF is not in the built-in set until pdf.js support is added
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.pdf"), false);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.PDF"), false);
+});
+
+run_test("should_preview rejects files without extensions", () => {
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/Makefile"), false);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file"), false);
+});
+
+run_test("should_preview handles encoded filenames", () => {
+    assert.equal(
+        file_attachment_preview.should_preview("/user_uploads/1/ab/my%20file.txt"),
+        true,
+    );
+    assert.equal(
+        file_attachment_preview.should_preview("/user_uploads/1/ab/my%20file.jpg"),
+        false,
+    );
+});
+
+run_test("should_preview includes extra extensions from setting", () => {
+    // Add custom extra extensions
+    user_settings.file_preview_extensions = "log,conf,env";
+    // Extra extensions are previewable
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.log"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.conf"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.env"), true);
+    // Built-in types still work
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.py"), true);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.md"), true);
+    // Unknown extensions still rejected
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.jpg"), false);
+
+    // Reset
+    user_settings.file_preview_extensions = "";
+});
+
+run_test("should_preview none disables all previews", () => {
+    user_settings.file_preview_extensions = "none";
+    // Even built-in types are disabled
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.txt"), false);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.md"), false);
+    assert.equal(file_attachment_preview.should_preview("/user_uploads/1/ab/file.py"), false);
+
+    // Reset
+    user_settings.file_preview_extensions = "";
+});

--- a/zerver/migrations/0802_usersetting_file_preview_extensions.py
+++ b/zerver/migrations/0802_usersetting_file_preview_extensions.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0801_realmexport_backfill_export_from_prior_server_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="realmuserdefault",
+            name="file_preview_extensions",
+            field=models.TextField(default=""),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="file_preview_extensions",
+            field=models.TextField(default=""),
+        ),
+    ]

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -98,6 +98,12 @@ class UserBaseSettings(models.Model):
     # UI setting to control how animated images are played.
     web_animate_image_previews = models.TextField(default="on_hover")
 
+    # Comma-separated list of additional file extensions (without dots) to
+    # preview in the text attachment preview modal beyond the built-in set.
+    # The built-in set (txt, md, csv, pdf, plus 50+ source code types) is
+    # always previewable. Set to "none" to disable all previews.
+    file_preview_extensions = models.TextField(default="")
+
     # UI setting controlling Zulip's behavior of demoting in the sort
     # order and graying out streams with no recent traffic.  The
     # default behavior, automatic, enables this behavior once a user
@@ -376,6 +382,7 @@ class UserBaseSettings(models.Model):
         send_read_receipts=bool,
         send_stream_typing_notifications=bool,
         starred_message_counts=bool,
+        file_preview_extensions=str,
         translate_emoticons=bool,
         twenty_four_hour_time=bool,
         user_list_style=int,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15389,6 +15389,16 @@ paths:
                     messages](/help/star-a-message#display-the-number-of-starred-messages).
                   type: boolean
                   example: true
+                file_preview_extensions:
+                  description: |
+                    A comma-separated list of additional file extensions (without dots)
+                    to preview in the text attachment modal, beyond the built-in set
+                    (txt, md, csv, pdf, and 50+ source code types). Empty string means
+                    only built-in types. Set to "none" to disable all previews.
+
+                    **Changes**: New in Zulip 10.0 (feature level TBD).
+                  type: string
+                  example: "log,conf,env"
                 receives_typing_notifications:
                   description: |
                     Whether the user is configured to receive typing notifications from other users.
@@ -19395,6 +19405,15 @@ paths:
                             description: |
                               Whether clients should display the [number of starred
                               messages](/help/star-a-message#display-the-number-of-starred-messages).
+                          file_preview_extensions:
+                            type: string
+                            description: |
+                              A comma-separated list of additional file extensions (without dots)
+                              to preview in the text attachment modal, beyond the built-in set
+                              (txt, md, csv, pdf, and 50+ source code types). Empty string means
+                              only built-in types. Set to "none" to disable all previews.
+
+                              **Changes**: New in Zulip 10.0 (feature level TBD).
                           receives_typing_notifications:
                             type: boolean
                             description: |
@@ -21804,6 +21823,15 @@ paths:
                             description: |
                               Whether clients should display the [number of starred
                               messages](/help/star-a-message#display-the-number-of-starred-messages).
+                          file_preview_extensions:
+                            type: string
+                            description: |
+                              A comma-separated list of additional file extensions (without dots)
+                              to preview in the text attachment modal, beyond the built-in set
+                              (txt, md, csv, pdf, and 50+ source code types). Empty string means
+                              only built-in types. Set to "none" to disable all previews.
+
+                              **Changes**: New in Zulip 10.0 (feature level TBD).
                           receives_typing_notifications:
                             type: boolean
                             description: |
@@ -23091,6 +23119,16 @@ paths:
                     the `PATCH /settings/display` endpoint.
                   type: boolean
                   example: true
+                file_preview_extensions:
+                  description: |
+                    A comma-separated list of additional file extensions (without dots)
+                    to preview in the text attachment modal, beyond the built-in set
+                    (txt, md, csv, pdf, and 50+ source code types). Empty string means
+                    only built-in types. Set to "none" to disable all previews.
+
+                    **Changes**: New in Zulip 10.0 (feature level TBD).
+                  type: string
+                  example: "log,conf,env"
                 receives_typing_notifications:
                   description: |
                     Whether the user is configured to receive typing notifications from other users.

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -374,6 +374,7 @@ class ChangeSettingsTest(ZulipTestCase):
             automatically_follow_topics_policy=1,
             automatically_unmute_topics_in_muted_streams_policy=1,
             resolved_topic_notice_auto_read_policy=ResolvedTopicNoticeAutoReadPolicyEnum.always.name,
+            file_preview_extensions="txt,md,py",
         )
 
         self.login("hamlet")
@@ -759,6 +760,104 @@ class ChangeSettingsTest(ZulipTestCase):
         }
         result = self.client_patch("/json/settings", data)
         self.assert_json_error(result, "Either user_ids or group_ids must be provided.")
+
+
+class FilePreviewExtensionsTest(ZulipTestCase):
+    def test_change_file_preview_extensions(self) -> None:
+        self.login("hamlet")
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "")
+
+        # Test successful update with extra extensions
+        result = self.client_patch("/json/settings", {"file_preview_extensions": "log,conf,env"})
+        self.assert_json_success(result)
+        user_profile.refresh_from_db()
+        self.assertEqual(user_profile.file_preview_extensions, "log,conf,env")
+
+    def test_none_disables_previews(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch("/json/settings", {"file_preview_extensions": "none"})
+        self.assert_json_success(result)
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "none")
+
+    def test_normalization_lowercase(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch("/json/settings", {"file_preview_extensions": "TXT,MD,PY"})
+        self.assert_json_success(result)
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "txt,md,py")
+
+    def test_normalization_trim_whitespace(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch(
+            "/json/settings", {"file_preview_extensions": " txt , md , py "}
+        )
+        self.assert_json_success(result)
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "txt,md,py")
+
+    def test_normalization_strip_leading_dots(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch(
+            "/json/settings", {"file_preview_extensions": ".txt,.md,.py"}
+        )
+        self.assert_json_success(result)
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "txt,md,py")
+
+    def test_normalization_deduplicate(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch(
+            "/json/settings", {"file_preview_extensions": "txt,txt,md,md,py"}
+        )
+        self.assert_json_success(result)
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "txt,md,py")
+
+    def test_normalization_empty_parts(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch(
+            "/json/settings", {"file_preview_extensions": "txt,,md,,,py"}
+        )
+        self.assert_json_success(result)
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "txt,md,py")
+
+    def test_invalid_extension_characters(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch(
+            "/json/settings", {"file_preview_extensions": "txt,md,p y"}
+        )
+        self.assert_json_error(result, "Invalid text preview extension: 'p y'")
+
+    def test_invalid_extension_special_chars(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch(
+            "/json/settings", {"file_preview_extensions": "txt,md,py;js"}
+        )
+        self.assert_json_error(result, "Invalid text preview extension: 'py;js'")
+
+    def test_empty_string_accepted(self) -> None:
+        self.login("hamlet")
+        result = self.client_patch("/json/settings", {"file_preview_extensions": ""})
+        self.assert_json_success(result)
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.file_preview_extensions, "")
+
+    def test_event_emitted_on_change(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            result = self.client_patch(
+                "/json/settings", {"file_preview_extensions": "rs,toml"}
+            )
+        self.assert_json_success(result)
+        self.assertEqual(events[0]["event"]["type"], "user_settings")
+        self.assertEqual(events[0]["event"]["op"], "update")
+        self.assertEqual(events[0]["event"]["property"], "file_preview_extensions")
+        self.assertEqual(events[0]["event"]["value"], "rs,toml")
 
 
 class UserChangesTest(ZulipTestCase):

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -787,6 +787,7 @@ def update_realm_user_settings_defaults(
     send_read_receipts: Json[bool] | None = None,
     send_stream_typing_notifications: Json[bool] | None = None,
     starred_message_counts: Json[bool] | None = None,
+    file_preview_extensions: str | None = None,
     translate_emoticons: Json[bool] | None = None,
     twenty_four_hour_time: Json[bool] | None = None,
     user_list_style: Json[
@@ -825,6 +826,11 @@ def update_realm_user_settings_defaults(
 ) -> HttpResponse:
     if notification_sound is not None or email_notifications_batching_period_seconds is not None:
         check_settings_values(notification_sound, email_notifications_batching_period_seconds)
+
+    if file_preview_extensions is not None:
+        from zerver.views.user_settings import normalize_file_preview_extensions
+
+        file_preview_extensions = normalize_file_preview_extensions(file_preview_extensions)
 
     realm_user_default = RealmUserDefault.objects.get(realm=user_profile.realm)
 

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -1,4 +1,5 @@
 from email.headerregistry import Address
+import re
 from typing import Annotated, Any
 
 from django.conf import settings
@@ -210,6 +211,31 @@ emojiset_choices = {emojiset["key"] for emojiset in UserProfile.emojiset_choices
 web_home_view_options = ["recent", "inbox", "all_messages"]
 web_animate_image_previews_options = ["always", "on_hover", "never"]
 
+TEXT_PREVIEW_EXTENSION_RE = re.compile(r"^[a-z0-9]+$")
+
+
+def normalize_file_preview_extensions(raw: str) -> str:
+    """Normalize a comma-separated list of file extensions.
+
+    Strips whitespace, removes leading dots, lowercases, deduplicates,
+    and validates that each extension contains only [a-z0-9].
+    Returns the cleaned comma-separated string.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for part in raw.split(","):
+        ext = part.strip().lower().lstrip(".")
+        if ext == "":
+            continue
+        if not TEXT_PREVIEW_EXTENSION_RE.match(ext):
+            raise JsonableError(
+                _("Invalid text preview extension: '{extension}'").format(extension=ext)
+            )
+        if ext not in seen:
+            seen.add(ext)
+            result.append(ext)
+    return ",".join(result)
+
 
 def check_settings_values(
     notification_sound: str | None,
@@ -345,6 +371,7 @@ def json_change_settings(
     send_stream_typing_notifications: Json[bool] | None = None,
     starred_message_counts: Json[bool] | None = None,
     target_users: Json[TargetUsersData] | None = None,
+    file_preview_extensions: str | None = None,
     timezone: Annotated[str, timezone_validator()] | None = None,
     translate_emoticons: Json[bool] | None = None,
     twenty_four_hour_time: Json[bool] | None = None,
@@ -388,6 +415,9 @@ def json_change_settings(
     # TODO: Change the cache flushing strategy to make sure cache
     # does not contain stale objects.
     user_profile = UserProfile.objects.get(id=user_profile.id)
+
+    if file_preview_extensions is not None:
+        file_preview_extensions = normalize_file_preview_extensions(file_preview_extensions)
 
     # Loop over user_profile.property_types
     request_settings = {


### PR DESCRIPTION
**Add in-app previews and cross-attachment navigation for uploaded files, including PDF support**

This PR adds a file attachment preview experience for `/user_uploads/` links in the Zulip web app, so users can inspect common attachments without immediately downloading them. This version includes PDF support using `pdf.js`.

The new preview modal supports plain text files, Markdown files rendered through Zulip’s server-side Markdown renderer, CSV files rendered as tables, source/code files syntax-highlighted with `highlight.js`, and PDF files rendered with `pdf.js`. Unsupported file types are shown in a consistent download-only overlay instead of immediately downloading.

PDF files are rendered as canvas elements rather than through browser-native PDF viewers or iframes. This avoids embedded JavaScript execution in PDFs, avoids iframe/CSP complications, and keeps PDF parsing isolated in the `pdf.js` worker. The PDF preview supports multi-page navigation, a page indicator, high-DPI canvas rendering, and graceful error handling for unreadable PDF files.

This PR also adds cross-attachment navigation within the currently focused message list. Users can move between attachments using side arrows or left/right keyboard shortcuts, including across images, videos, PDFs, previewable text/code/CSV/Markdown files, and unsupported files. Image and video attachments continue to use the existing lightbox, while file attachments use the new preview modal.

Other user-facing changes include a direct download icon next to uploaded-file links and a per-user `file_preview_extensions` setting, allowing users to add extra previewable extensions or set the value to `none` to disable file previews.

Fixes: Adds an in-app preview/navigation flow for uploaded file attachments, addressing the current behavior where many attachments must be downloaded or opened individually to inspect them. Related to zulip/zulip#9081.

There are a few primary components that were added:

1. a new setting section that allows the user to add other file extensions that should be treated as text-previewable files
2. a new file preview modal that can display all allowed file types in a lightbox-style view, including PDF files rendered through `pdf.js`; this is incorporated with the existing lightbox for images and videos
3. added a direct download button for attachments so that you can do a one-click download if you don't want to open the file preview
4. added static-asset handling for `.mjs` files so the `pdf.js` worker is served with a JavaScript MIME type in production nginx

A key piece of all of this is functionality to collect a list of all the attachments in the current topic scope.

**How changes were tested:**

Automated coverage added:

* Backend tests for `file_preview_extensions` updates, normalization, deduplication, validation, the `none` value, and event emission.
* Frontend unit tests for file-preview eligibility logic.

Manual testing that has been completed:

* Created a new docker image from the branch, launched a container based on the local image.
* Upload and click a `.txt` file; confirm it opens in the preview modal.
* Upload and click a `.md` file; confirm Markdown is rendered through the server-side renderer.
* Upload and click a `.csv` file; confirm it renders as a table.
* Upload and click a source/code file, such as `.py`, `.ts`, `.rs`, or `.java`; confirm syntax highlighting works.
* Upload and click a `.pdf` file; confirm it opens in the preview modal and renders through `pdf.js`.
* Upload and click a multi-page `.pdf` file; confirm page navigation and the page indicator work correctly.
* Confirm PDF preview works in the production-style built container, including loading the `.mjs` `pdf.js` worker.
* Upload and click an unsupported file type; confirm the download-only overlay appears.
* Confirm the download button uses the `/user_uploads/download/` URL and downloads instead of previewing.
* Confirm the inline download icon appears next to uploaded-file links and does not appear for inline image/video previews.
* In a topic/message list with multiple attachments, use side arrows and left/right keyboard shortcuts to navigate between images, videos, PDFs, previewable files, and unsupported files.
* Confirm navigation wraps from the last attachment to the first and from the first to the last.
* Confirm `file_preview_extensions` can add a custom extension.
* Confirm `file_preview_extensions = none` disables previews.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

* [x] [[[Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
  (variable names, code reuse, readability, etc.).
* [x] Followed the [[[AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines)](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines)](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Completed manual review and testing of the following:

* [x] Visual appearance of the changes.
* [ ] Responsiveness and internationalization.
* [ ] Strings and tooltips.
* [x] End-to-end functionality of buttons, interactions and flows.
* [ ] Corner cases, error conditions, and easily imagined bugs.

</details>