### PR TITLE
bots: Confirm before regenerating a bot's API key.

### DIFF
--- a/starlight_help/src/content/docs/manage-a-bot.mdx
+++ b/starlight_help/src/content/docs/manage-a-bot.mdx
@@ -6,6 +6,7 @@ import {TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import NavigationSteps from "../../components/NavigationSteps.astro";
+import ZulipNote from "../../components/ZulipNote.astro";
 import ZulipTip from "../../components/ZulipTip.astro";
 import AdminOnly from "../include/_AdminOnly.mdx";
 
@@ -104,8 +105,13 @@ Only a bot's owner has access to its API key.
 
   <ZulipTip>
     To generate a new API key, click the **generate new API key** (<RefreshIcon />)
-    icon.
+    icon, and then click **Confirm key rotation**.
   </ZulipTip>
+
+  <ZulipNote>
+    Generating a new API key invalidates the bot's current key. Any
+    integrations using the old key will stop working until you update them.
+  </ZulipNote>
 </FlattenedSteps>
 
 ## Related articles

--- a/web/src/banners.ts
+++ b/web/src/banners.ts
@@ -9,6 +9,7 @@ import type {ComponentIntent} from "./types.ts";
 export type Banner = {
     intent: ComponentIntent;
     label: string | Handlebars.SafeString;
+    label_id?: string;
     buttons: ActionButton[];
     close_button: boolean;
     custom_classes?: string;

--- a/web/src/bot_helper.ts
+++ b/web/src/bot_helper.ts
@@ -6,6 +6,7 @@ import * as z from "zod/mini";
 import render_bot_api_key_details from "../templates/settings/bot_api_key_details.hbs";
 
 import * as banners from "./banners.ts";
+import * as blueslip from "./blueslip.ts";
 import * as bot_data from "./bot_data.ts";
 import type {Bot} from "./bot_data.ts";
 import * as buttons from "./buttons.ts";
@@ -13,7 +14,7 @@ import * as channel from "./channel.ts";
 import * as clipboard_handler from "./clipboard_handler.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as dialog_widget from "./dialog_widget.ts";
-import {$t_html} from "./i18n.ts";
+import {$t, $t_html} from "./i18n.ts";
 import {realm} from "./state_data.ts";
 
 export function validate_bot_short_name(value: string): boolean {
@@ -148,6 +149,8 @@ async function copy_zuliprc_content(bot: Bot, api_key: string): Promise<void> {
     });
 }
 
+const REGENERATE_WARNING_ID = "bot-api-key-regenerate-warning";
+
 export async function show_api_key_modal(bot_id: number): Promise<void> {
     const api_key = await fetch_bot_api_key(
         bot_id,
@@ -164,6 +167,7 @@ export async function show_api_key_modal(bot_id: number): Promise<void> {
     const modal_content_html = render_bot_api_key_details({
         bot_id,
         api_key,
+        regenerate_warning_id: REGENERATE_WARNING_ID,
     });
     dialog_widget.launch({
         modal_title_html: $t_html(
@@ -181,36 +185,100 @@ export async function show_api_key_modal(bot_id: number): Promise<void> {
     });
 }
 
+const REGENERATE_CONFIRMATION_BANNER: banners.Banner = {
+    intent: "warning",
+    label: $t({
+        defaultMessage:
+            "This invalidates the current API key. Integrations using the old key will stop working.",
+    }),
+    label_id: REGENERATE_WARNING_ID,
+    buttons: [
+        {
+            variant: "subtle",
+            label: $t({defaultMessage: "Confirm key rotation"}),
+            custom_classes: "bot-modal-confirm-regenerate-bot-api-key",
+            "aria-describedby": REGENERATE_WARNING_ID,
+        },
+    ],
+    close_button: false,
+    custom_classes: "banner-in-modal",
+};
+
+// Focus goes to Cancel, not Confirm: Cancel takes the exact spot the
+// regenerate icon was in, so a double-click (or a second Enter) backs out
+// instead of rotating the key.
+function show_api_key_regenerate_confirmation($container: JQuery): void {
+    $container.find(".bot-modal-api-key-error").hide();
+    $container.find(".bot-modal-regenerate-bot-api-key").addClass("hide");
+    banners.open(REGENERATE_CONFIRMATION_BANNER, $container.find(".bot-api-key-regenerate-banner"));
+    $container
+        .find(".bot-modal-cancel-regenerate-bot-api-key")
+        .removeClass("hide")
+        .trigger("focus");
+}
+
+function hide_api_key_regenerate_confirmation($container: JQuery): void {
+    banners.close($container.find(".bot-api-key-regenerate-banner .banner"));
+    $container
+        .find(".bot-modal-cancel-regenerate-bot-api-key")
+        .prop("disabled", false)
+        .addClass("hide");
+    $container.find(".bot-modal-regenerate-bot-api-key").removeClass("hide").trigger("focus");
+}
+
+function show_api_key_regenerate_error($container: JQuery, message_html: string): void {
+    $container.find(".bot-modal-api-key-error").html(message_html).show();
+}
+
 export function initialize_bot_click_handlers(): void {
     $("body").on("click", "button.bot-modal-regenerate-bot-api-key", (e) => {
         e.preventDefault();
-        const bot_id = Number.parseInt(
-            $(e.currentTarget).closest("span").attr("data-user-id")!,
-            10,
-        );
-        const $row = $(e.currentTarget).closest(".input-group");
-
-        void channel.post({
-            url: `/json/bots/${encodeURIComponent(bot_id)}/api_key/regenerate`,
-            success(data) {
-                const parsed_data = z
-                    .object({
-                        api_key: z.string(),
-                    })
-                    .parse(data);
-
-                $row.find(".api-key").val(parsed_data.api_key);
-                $row.closest(".bot-api-key-container").attr("data-api-key", parsed_data.api_key);
-                $row.find(".bot-modal-api-key-error").hide();
-            },
-            error(xhr) {
-                const parsed = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
-                if (parsed.success && parsed.data.msg) {
-                    $row.find(".bot-modal-api-key-error").text(parsed.data.msg).show();
-                }
-            },
-        });
+        show_api_key_regenerate_confirmation($(e.currentTarget).closest(".bot-api-key-container"));
     });
+
+    $("body").on("click", "button.bot-modal-cancel-regenerate-bot-api-key", (e) => {
+        e.preventDefault();
+        hide_api_key_regenerate_confirmation($(e.currentTarget).closest(".bot-api-key-container"));
+    });
+
+    $("body").on(
+        "click",
+        "button.bot-modal-confirm-regenerate-bot-api-key",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            const $button = $(this);
+            const $container = $button.closest(".bot-api-key-container");
+            const bot_id = Number.parseInt($container.attr("data-user-id")!, 10);
+
+            $container.find(".bot-modal-cancel-regenerate-bot-api-key").prop("disabled", true);
+            $button.prop("disabled", true);
+            buttons.show_button_loading_indicator($button);
+            const failure_message_html = $t_html({
+                defaultMessage: "Failed to generate new API key",
+            });
+            void channel.post({
+                url: `/json/bots/${encodeURIComponent(bot_id)}/api_key/regenerate`,
+                success(data) {
+                    const parsed = z.object({api_key: z.string()}).safeParse(data);
+                    hide_api_key_regenerate_confirmation($container);
+                    if (!parsed.success) {
+                        blueslip.error("Unexpected response to bot API key regeneration");
+                        show_api_key_regenerate_error($container, failure_message_html);
+                        return;
+                    }
+                    $container.find(".api-key").val(parsed.data.api_key);
+                    $container.attr("data-api-key", parsed.data.api_key);
+                },
+                error(xhr) {
+                    hide_api_key_regenerate_confirmation($container);
+                    show_api_key_regenerate_error(
+                        $container,
+                        channel.xhr_error_message(failure_message_html, xhr),
+                    );
+                },
+            });
+        },
+    );
 
     $("body").on("click", "button.download-bot-zuliprc", function () {
         void (async () => {

--- a/web/src/bot_helper.ts
+++ b/web/src/bot_helper.ts
@@ -13,7 +13,7 @@ import * as channel from "./channel.ts";
 import * as clipboard_handler from "./clipboard_handler.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as dialog_widget from "./dialog_widget.ts";
-import {$t_html} from "./i18n.ts";
+import {$t, $t_html} from "./i18n.ts";
 import {realm} from "./state_data.ts";
 
 export function validate_bot_short_name(value: string): boolean {
@@ -181,36 +181,94 @@ export async function show_api_key_modal(bot_id: number): Promise<void> {
     });
 }
 
+const REGENERATE_WARNING_ID = "bot-api-key-regenerate-warning";
+
+const REGENERATE_CONFIRMATION_BANNER: banners.Banner = {
+    intent: "warning",
+    label: $t({
+        defaultMessage:
+            "This invalidates the current API key. Integrations using the old key will stop working.",
+    }),
+    label_id: REGENERATE_WARNING_ID,
+    buttons: [
+        {
+            variant: "subtle",
+            label: $t({defaultMessage: "Confirm key rotation"}),
+            custom_classes: "bot-modal-confirm-regenerate-bot-api-key",
+            "aria-describedby": REGENERATE_WARNING_ID,
+        },
+    ],
+    close_button: false,
+};
+
+// Focus goes to Cancel, not Confirm: Cancel takes the exact spot the
+// regenerate icon was in, so a double-click (or a second Enter) backs out
+// instead of rotating the key.
+function show_api_key_regenerate_confirmation($container: JQuery): void {
+    $container.find(".bot-modal-api-key-error").hide();
+    $container.find(".bot-modal-regenerate-bot-api-key").addClass("hide");
+    banners.open(REGENERATE_CONFIRMATION_BANNER, $container.find(".bot-api-key-regenerate-banner"));
+    $container
+        .find(".bot-modal-cancel-regenerate-bot-api-key")
+        .removeClass("hide")
+        .trigger("focus");
+}
+
+function hide_api_key_regenerate_confirmation($container: JQuery): void {
+    banners.close($container.find(".bot-api-key-regenerate-banner .banner"));
+    $container
+        .find(".bot-modal-cancel-regenerate-bot-api-key")
+        .prop("disabled", false)
+        .addClass("hide");
+    $container.find(".bot-modal-regenerate-bot-api-key").removeClass("hide").trigger("focus");
+}
+
 export function initialize_bot_click_handlers(): void {
     $("body").on("click", "button.bot-modal-regenerate-bot-api-key", (e) => {
         e.preventDefault();
-        const bot_id = Number.parseInt(
-            $(e.currentTarget).closest("span").attr("data-user-id")!,
-            10,
-        );
-        const $row = $(e.currentTarget).closest(".input-group");
-
-        void channel.post({
-            url: `/json/bots/${encodeURIComponent(bot_id)}/api_key/regenerate`,
-            success(data) {
-                const parsed_data = z
-                    .object({
-                        api_key: z.string(),
-                    })
-                    .parse(data);
-
-                $row.find(".api-key").val(parsed_data.api_key);
-                $row.closest(".bot-api-key-container").attr("data-api-key", parsed_data.api_key);
-                $row.find(".bot-modal-api-key-error").hide();
-            },
-            error(xhr) {
-                const parsed = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
-                if (parsed.success && parsed.data.msg) {
-                    $row.find(".bot-modal-api-key-error").text(parsed.data.msg).show();
-                }
-            },
-        });
+        show_api_key_regenerate_confirmation($(e.currentTarget).closest(".bot-api-key-container"));
     });
+
+    $("body").on("click", "button.bot-modal-cancel-regenerate-bot-api-key", (e) => {
+        e.preventDefault();
+        hide_api_key_regenerate_confirmation($(e.currentTarget).closest(".bot-api-key-container"));
+    });
+
+    $("body").on(
+        "click",
+        "button.bot-modal-confirm-regenerate-bot-api-key",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            const $button = $(this);
+            const $container = $button.closest(".bot-api-key-container");
+            const bot_id = Number.parseInt($container.attr("data-user-id")!, 10);
+
+            $container.find(".bot-modal-cancel-regenerate-bot-api-key").prop("disabled", true);
+            $button.prop("disabled", true);
+            buttons.show_button_loading_indicator($button);
+            void channel.post({
+                url: `/json/bots/${encodeURIComponent(bot_id)}/api_key/regenerate`,
+                success(data) {
+                    const parsed_data = z.object({api_key: z.string()}).parse(data);
+                    $container.find(".api-key").val(parsed_data.api_key);
+                    $container.attr("data-api-key", parsed_data.api_key);
+                    $container.find(".bot-modal-api-key-error").hide();
+                },
+                error(xhr) {
+                    const parsed = z.object({msg: z.string()}).safeParse(xhr.responseJSON);
+                    const message =
+                        parsed.success && parsed.data.msg !== ""
+                            ? parsed.data.msg
+                            : $t({defaultMessage: "Failed to generate new API key"});
+                    $container.find(".bot-modal-api-key-error").text(message).show();
+                },
+                complete() {
+                    buttons.hide_button_loading_indicator($button);
+                    hide_api_key_regenerate_confirmation($container);
+                },
+            });
+        },
+    );
 
     $("body").on("click", "button.download-bot-zuliprc", function () {
         void (async () => {

--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -15,6 +15,7 @@ export type ActionButton = {
     icon?: string;
     id?: string;
     custom_classes?: string;
+    "aria-describedby"?: string;
 };
 
 let loading_indicator_count = 0;

--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -151,6 +151,29 @@
     }
 }
 
+.banner-in-modal {
+    .banner-content {
+        flex-direction: column;
+    }
+
+    .banner-label {
+        /* Reset to initial value */
+        flex: 0 1 auto;
+    }
+
+    .banner-action-buttons {
+        max-width: 100%;
+    }
+
+    .action-button {
+        min-width: 0;
+    }
+
+    .action-button-label {
+        max-width: none;
+    }
+}
+
 .banner-neutral {
     background-color: var(--color-background-neutral-banner);
     color: var(--color-text-neutral-banner);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -480,6 +480,11 @@ select.settings_select {
     .modal_text_input {
         margin-bottom: 0;
     }
+
+    .bot-api-key-regenerate-banner:has(.banner) {
+        /* Only space the banner off the API key row when it's present. */
+        margin-top: 0.625em; /* 10px at 16px/1em */
+    }
 }
 
 #zuliprc-section {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -473,6 +473,15 @@ select.settings_select {
     .modal_text_input {
         margin-bottom: 0;
     }
+
+    .bot-api-key-regenerate-banner:has(.banner) {
+        /* Only space the banner off the API key row when it's present. */
+        margin-top: 0.625em; /* 10px at 16px/1em */
+    }
+
+    .bot-api-key-regenerate-banner .banner-action-buttons {
+        align-self: center;
+    }
 }
 
 #zuliprc-section {

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,4 +1,4 @@
-<button type="{{#if type}}{{type}}{{else}}button{{/if}}" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{variant}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tippy-content}}data-tippy-content="{{data-tippy-content}}"{{/if}} {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+<button type="{{#if type}}{{type}}{{else}}button{{/if}}" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{variant}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tippy-content}}data-tippy-content="{{data-tippy-content}}"{{/if}} {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}} {{#if aria-describedby}}aria-describedby="{{aria-describedby}}"{{/if}}
   {{#if disabled}}disabled{{/if}}
   >
     {{#if icon}}

--- a/web/templates/components/banner.hbs
+++ b/web/templates/components/banner.hbs
@@ -1,6 +1,6 @@
 <div {{#if process}}data-process="{{process}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}banner banner-{{intent}}">
     <span class="banner-content">
-        <span class="banner-label">
+        <span class="banner-label" {{#if label_id}}id="{{label_id}}"{{/if}}>
             {{#if label}}
                 {{label}}
             {{else}}

--- a/web/templates/components/icon_button.hbs
+++ b/web/templates/components/icon_button.hbs
@@ -1,4 +1,4 @@
-<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}icon-button {{#if squared}}icon-button-square {{/if}}icon-button-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}icon-button {{#if squared}}icon-button-square {{/if}}icon-button-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}} {{#if aria-describedby}}aria-describedby="{{aria-describedby}}"{{/if}}
   {{#if data-tippy-content}}data-tippy-content="{{data-tippy-content}}"{{/if}}
   {{#if data-micromodal-close}}data-micromodal-close{{/if}}
   {{#if disabled}}disabled{{/if}}

--- a/web/templates/settings/bot_api_key_details.hbs
+++ b/web/templates/settings/bot_api_key_details.hbs
@@ -4,12 +4,23 @@
         <div class="api-key-details-container">
             <input type="text" autocomplete="off" name="api-key" class="modal_text_input api-key inline-block" value="{{ api_key }}" readonly/>
             <div class="buttons-container">
-                <span data-user-id="{{bot_id}}">
+                <span>
                     {{> ../components/icon_button
                       icon="refresh-cw"
                       intent="brand"
                       custom_classes="bot-modal-regenerate-bot-api-key tippy-zulip-delayed-tooltip"
                       data-tippy-content=(t "Generate new API key")
+                      }}
+                </span>
+                <span>
+                    {{> ../components/icon_button
+                      icon="close"
+                      intent="neutral"
+                      hidden=true
+                      custom_classes="bot-modal-cancel-regenerate-bot-api-key tippy-zulip-delayed-tooltip"
+                      aria-label=(t "Cancel key rotation")
+                      aria-describedby="bot-api-key-regenerate-warning"
+                      data-tippy-content=(t "Cancel key rotation")
                       }}
                 </span>
                 <span>
@@ -23,6 +34,7 @@
                 </span>
             </div>
         </div>
+        <div class="bot-api-key-regenerate-banner banner-wrapper"></div>
         <div class="bot-modal-api-key-error text-error"></div>
     </div>
 </div>

--- a/web/templates/settings/bot_api_key_details.hbs
+++ b/web/templates/settings/bot_api_key_details.hbs
@@ -4,12 +4,23 @@
         <div class="api-key-details-container">
             <input type="text" autocomplete="off" name="api-key" class="modal_text_input api-key inline-block" value="{{ api_key }}" readonly/>
             <div class="buttons-container">
-                <span data-user-id="{{bot_id}}">
+                <span>
                     {{> ../components/icon_button
                       icon="refresh-cw"
                       intent="brand"
                       custom_classes="bot-modal-regenerate-bot-api-key tippy-zulip-delayed-tooltip"
                       data-tippy-content=(t "Generate new API key")
+                      }}
+                </span>
+                <span>
+                    {{> ../components/icon_button
+                      icon="close"
+                      intent="neutral"
+                      hidden=true
+                      custom_classes="bot-modal-cancel-regenerate-bot-api-key tippy-zulip-delayed-tooltip"
+                      aria-label=(t "Cancel key rotation")
+                      aria-describedby=regenerate_warning_id
+                      data-tippy-content=(t "Cancel key rotation")
                       }}
                 </span>
                 <span>
@@ -23,6 +34,7 @@
                 </span>
             </div>
         </div>
+        <div class="bot-api-key-regenerate-banner banner-wrapper"></div>
         <div class="bot-modal-api-key-error text-error"></div>
     </div>
 </div>

--- a/web/tests/settings_bots.test.cjs
+++ b/web/tests/settings_bots.test.cjs
@@ -4,8 +4,14 @@ const assert = require("node:assert/strict");
 
 const {make_realm} = require("./lib/example_realm.cjs");
 const {make_user} = require("./lib/example_user.cjs");
-const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+const blueslip = require("./lib/zblueslip.cjs");
+const {$} = require("./lib/zjquery.cjs");
+
+const banners = mock_esm("../src/banners");
+const buttons = mock_esm("../src/buttons");
+const channel = mock_esm("../src/channel");
 
 const bot_data = zrequire("bot_data");
 const bot_helper = zrequire("bot_helper");
@@ -79,6 +85,120 @@ test("generate_zuliprc_content", () => {
         "site=https://chat.example.com\n";
 
     assert.equal(content, expected);
+});
+
+test("regenerate_bot_api_key_confirmation_banner", ({override}) => {
+    bot_helper.initialize_bot_click_handlers();
+
+    const $container = $.create("bot-api-key-container-stub");
+    $container.attr("data-user-id", "1");
+
+    const $regenerate_button = $(".regenerate-button-stub");
+    const $cancel_button = $(".cancel-stub");
+    const $confirm_button = $(".confirm-stub");
+    $regenerate_button.set_closest_results(".bot-api-key-container", $container);
+    $cancel_button.set_closest_results(".bot-api-key-container", $container);
+    $confirm_button.set_closest_results(".bot-api-key-container", $container);
+
+    const $api_key_input = $.create("api-key-input-stub");
+    const $error = $.create("api-key-error-stub");
+    const $banner = $.create("regenerate-banner-stub");
+    $container.set_find_results(".bot-modal-regenerate-bot-api-key", $regenerate_button);
+    $container.set_find_results(".bot-modal-cancel-regenerate-bot-api-key", $cancel_button);
+    $container.set_find_results(".api-key", $api_key_input);
+    $container.set_find_results(".bot-modal-api-key-error", $error);
+    $container.set_find_results(
+        ".bot-api-key-regenerate-banner",
+        $.create("regenerate-banner-container-stub"),
+    );
+    $container.set_find_results(".bot-api-key-regenerate-banner .banner", $banner);
+
+    let opened_banner;
+    override(banners, "open", (banner) => {
+        opened_banner = banner;
+        return $banner;
+    });
+    let $closed_banner;
+    override(banners, "close", ($banner_to_close) => {
+        $closed_banner = $banner_to_close;
+    });
+    override(buttons, "show_button_loading_indicator", noop);
+
+    let post_opts;
+    override(channel, "post", (opts) => {
+        post_opts = opts;
+    });
+    override(
+        channel,
+        "xhr_error_message",
+        (message_html, xhr) => `${message_html} (status ${xhr.status})`,
+    );
+
+    const regenerate_handler = $("body").get_on_handler(
+        "click",
+        "button.bot-modal-regenerate-bot-api-key",
+    );
+
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    assert.equal(post_opts, undefined);
+    assert.equal(opened_banner.intent, "warning");
+    assert.ok($cancel_button.is_focused());
+
+    const [confirm_button] = opened_banner.buttons;
+    // Confirm describes itself with the banner's own warning text, so the
+    // consequences are announced when focus reaches it. Cancel gets focus
+    // first but lives in the template, which is handed the same id; a typo
+    // there would silently render no attribute at all.
+    assert.equal(confirm_button["aria-describedby"], opened_banner.label_id);
+    const rendered_api_key_details = require("../templates/settings/bot_api_key_details.hbs")({
+        bot_id: 1,
+        api_key: "api-key",
+        regenerate_warning_id: opened_banner.label_id,
+    });
+    assert.ok(rendered_api_key_details.includes(`aria-describedby="${opened_banner.label_id}"`));
+    const cancel_handler = $("body").get_on_handler(
+        "click",
+        "button.bot-modal-cancel-regenerate-bot-api-key",
+    );
+    const confirm_handler = $("body").get_on_handler(
+        "click",
+        `button.${confirm_button.custom_classes}`,
+    );
+
+    cancel_handler({preventDefault: noop, currentTarget: ".cancel-stub"});
+    assert.equal(post_opts, undefined);
+    assert.equal($closed_banner[0], $banner[0]);
+    assert.ok($regenerate_button.is_focused());
+
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    confirm_handler.call(".confirm-stub", {preventDefault: noop});
+    assert.equal(post_opts.url, "/json/bots/1/api_key/regenerate");
+
+    post_opts.success({api_key: "new-api-key"});
+    assert.equal($api_key_input.val(), "new-api-key");
+    assert.equal($container.attr("data-api-key"), "new-api-key");
+    assert.equal($closed_banner[0], $banner[0]);
+
+    // A failed rotation backs out of the confirmation and reports why below
+    // the key; a 403 is what access_bot_by_id raises when the owner loses
+    // permission for the bot between opening the modal and confirming.
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    confirm_handler.call(".confirm-stub", {preventDefault: noop});
+    post_opts.error({status: 403, responseJSON: {msg: "Insufficient permission"}});
+    assert.equal($error.html(), "translated: Failed to generate new API key (status 403)");
+    assert.ok($error.visible());
+    assert.equal($closed_banner[0], $banner[0]);
+
+    // Asking to rotate again clears the stale error from the failed attempt.
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    assert.ok(!$error.visible());
+
+    confirm_handler.call(".confirm-stub", {preventDefault: noop});
+    blueslip.expect("error", "Unexpected response to bot API key regeneration");
+    post_opts.success({});
+    assert.equal($error.html(), "translated: Failed to generate new API key");
+    assert.ok($error.visible());
+    assert.equal($api_key_input.val(), "new-api-key");
 });
 
 test("generate_botserverrc_content", () => {

--- a/web/tests/settings_bots.test.cjs
+++ b/web/tests/settings_bots.test.cjs
@@ -4,8 +4,16 @@ const assert = require("node:assert/strict");
 
 const {make_realm} = require("./lib/example_realm.cjs");
 const {make_user} = require("./lib/example_user.cjs");
-const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
+
+const banners = mock_esm("../src/banners", {open: noop, close: noop});
+const channel = mock_esm("../src/channel", {post: noop});
+mock_esm("../src/buttons", {
+    show_button_loading_indicator: noop,
+    hide_button_loading_indicator: noop,
+});
 
 const bot_data = zrequire("bot_data");
 const bot_helper = zrequire("bot_helper");
@@ -79,6 +87,104 @@ test("generate_zuliprc_content", () => {
         "site=https://chat.example.com\n";
 
     assert.equal(content, expected);
+});
+
+test("regenerate_bot_api_key_confirmation_banner", () => {
+    bot_helper.initialize_bot_click_handlers();
+
+    const $container = $.create("bot-api-key-container-stub");
+    $container.attr("data-user-id", "1");
+
+    const $regenerate_button = $(".regenerate-button-stub");
+    const $confirm_button = $(".confirm-stub");
+    $regenerate_button.set_closest_results(".bot-api-key-container", $container);
+    $confirm_button.set_closest_results(".bot-api-key-container", $container);
+
+    const $api_key_input = $.create("api-key-input-stub");
+    const $error = $.create("api-key-error-stub");
+    const $banner = $.create("regenerate-banner-stub");
+    $container.set_find_results(".bot-modal-regenerate-bot-api-key", $regenerate_button);
+    $container.set_find_results(".bot-modal-cancel-regenerate-bot-api-key", $(".cancel-stub"));
+    $container.set_find_results(".api-key", $api_key_input);
+    $container.set_find_results(".bot-modal-api-key-error", $error);
+    $container.set_find_results(
+        ".bot-api-key-regenerate-banner",
+        $.create("regenerate-banner-container-stub"),
+    );
+    $container.set_find_results(".bot-api-key-regenerate-banner .banner", $banner);
+
+    let opened_banner;
+    banners.open = (banner) => {
+        opened_banner = banner;
+        return $banner;
+    };
+    let $closed_banner;
+    banners.close = ($banner_to_close) => {
+        $closed_banner = $banner_to_close;
+    };
+
+    let post_opts;
+    channel.post = (opts) => {
+        post_opts = opts;
+    };
+
+    const regenerate_handler = $("body").get_on_handler(
+        "click",
+        "button.bot-modal-regenerate-bot-api-key",
+    );
+
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    assert.equal(post_opts, undefined);
+    assert.equal(opened_banner.intent, "warning");
+
+    const [confirm_button] = opened_banner.buttons;
+    // Both buttons describe themselves with the banner's warning text, so
+    // the consequences are announced whichever one focus reaches. Cancel
+    // gets focus first and lives in the template, outside the banner, so
+    // assert its hardcoded id still matches the one the banner stamps on.
+    assert.equal(confirm_button["aria-describedby"], opened_banner.label_id);
+    const rendered_api_key_details = require("../templates/settings/bot_api_key_details.hbs")({
+        bot_id: 1,
+        api_key: "api-key",
+    });
+    assert.ok(rendered_api_key_details.includes(`aria-describedby="${opened_banner.label_id}"`));
+    const confirm_handler = $("body").get_on_handler(
+        "click",
+        `button.${confirm_button.custom_classes}`,
+    );
+
+    confirm_handler.call(".confirm-stub", {preventDefault: noop});
+    assert.equal(post_opts.url, "/json/bots/1/api_key/regenerate");
+
+    post_opts.success({api_key: "new-api-key"});
+    post_opts.complete();
+    assert.equal($api_key_input.val(), "new-api-key");
+    assert.equal($container.attr("data-api-key"), "new-api-key");
+    assert.equal($closed_banner[0], $banner[0]);
+
+    // A crafted server error message is shown below the key; this one is
+    // what access_bot_by_id raises when the owner loses permission for
+    // the bot between opening the modal and confirming.
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    confirm_handler.call(".confirm-stub", {preventDefault: noop});
+    post_opts.error({status: 400, responseJSON: {msg: "Insufficient permission"}});
+    post_opts.complete();
+    assert.equal($error.text(), "Insufficient permission");
+    assert.ok($error.visible());
+
+    // A failure without a JSON body (network failure, or a proxy-level
+    // 502 during a server restart) must still surface a generic error
+    // rather than failing silently.
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    confirm_handler.call(".confirm-stub", {preventDefault: noop});
+    post_opts.error({status: 0});
+    post_opts.complete();
+    assert.equal($error.text(), "translated: Failed to generate new API key");
+    assert.ok($error.visible());
+
+    // Asking to rotate again clears the stale error from the failed attempt.
+    regenerate_handler({preventDefault: noop, currentTarget: ".regenerate-button-stub"});
+    assert.ok(!$error.visible());
 });
 
 test("generate_botserverrc_content", () => {


### PR DESCRIPTION

The "generate new API key" button sits directly next to the "copy API key" button in a bot's API key modal, and clicking it regenerated the key immediately. 

[#design > Make it harder to accidentally change a bot's API key #39317](https://chat.zulip.org/#narrow/channel/101-design/topic/Make.20it.20harder.20to.20accidentally.20change.20a.20bot.27s.20API.20key.20.2339317),

Adds a warning  banner with a "Confirm Key Rotation" button.

Adds a **Prep Commit** :- 
components: Allow buttons to be described by a banner's label.
Screen readers announce only a button's own name, so warning text rendered beside it goes unread when the button takes focus. Linking the two needs **aria-describedby** on the button and an id on the text it points at, and neither template could emit those.
Both are optional, so existing callers render unchanged.

Fixes #39317.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
<details>
<summary>Screenshots </summary>
<img width="676" height="331" alt="image" src="https://github.com/user-attachments/assets/f89d1fba-f2b2-41e7-908b-57818458d44d" />
<img width="675" height="328" alt="image" src="https://github.com/user-attachments/assets/adcd8735-f2c3-4bb0-a42f-c268cd00392f" />

Translated: (German)
<img width="673" height="335" alt="image" src="https://github.com/user-attachments/assets/d8b5264a-68ab-4876-a6ce-08a27ad66456" />

On failing:
<img width="592" height="216" alt="Screenshot From 2026-06-17 00-41-08" src="https://github.com/user-attachments/assets/fe45f92c-6f90-4439-82a1-35960a82cf7a" />

Help Centre(Manage a Bot)
<img width="729" height="185" alt="image" src="https://github.com/user-attachments/assets/b6a7d39c-9b41-4f91-bafe-ec17e1a31450" />

</details>


<details>
<summary>Self-review checklist</summary>


<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
