### PR TITLE
webhook/slack: Handle webhook payloads without an event object.

### DIFF
--- a/zerver/webhooks/slack/fixtures/app_rate_limited.json
+++ b/zerver/webhooks/slack/fixtures/app_rate_limited.json
@@ -1,0 +1,7 @@
+{
+	"token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+	"type": "app_rate_limited",
+	"team_id": "T123ABC456",
+	"minute_rate_limited": 1518467820,
+	"api_app_id": "A123ABC456"
+}

--- a/zerver/webhooks/slack/fixtures/example_anomalous_payload.json
+++ b/zerver/webhooks/slack/fixtures/example_anomalous_payload.json
@@ -1,0 +1,23 @@
+{
+  "createdAt": 1780754580717,
+  "id": "REDACTED",
+  "payload": {
+    "groupId": "REDACTED",
+    "level": "critical",
+    "project": {
+      "id": "REDACTED"
+    },
+    "projectId": "REDACTED",
+    "projectSlug": "REDACTED",
+    "startedAt": 1780754580717,
+    "team": {
+      "id": "REDACTED"
+    },
+    "teamId": "REDACTED",
+    "teamSlug": "REDACTED",
+    "user": {
+      "id": "REDACTED"
+    }
+  },
+  "type": "observability.usage-anomaly"
+}

--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -169,6 +169,22 @@ class SlackWebhookTests(WebhookTestCase):
         )
         self.assertJSONEqual(result.content.decode("utf-8"), expected_challenge_response)
 
+    def test_app_rate_limited(self) -> None:
+        payload = self.get_body("app_rate_limited")
+        result = self.client_post(self.url, payload, content_type="application/json")
+        self.assert_json_success(result)
+        self.assert_in_response(
+            "The 'app_rate_limited' event isn't currently supported by the Slack webhook; ignoring",
+            result,
+        )
+
+    def test_anomalous_webhook_payload_error(self) -> None:
+        payload = self.get_body("example_anomalous_payload")
+        result = self.client_post(self.url, payload, content_type="application/json")
+        self.assert_json_error(
+            result, "Unable to parse request: Did Slack generate this event?", 400
+        )
+
     @mock_slack_api_calls
     def test_block_message_from_slack_bridge_bot(self) -> None:
         self.check_webhook(

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -15,7 +15,11 @@ from zerver.data_import.slack_message_conversion import (
     replace_links,
 )
 from zerver.decorator import webhook_view
-from zerver.lib.exceptions import JsonableError, UnsupportedWebhookEventTypeError
+from zerver.lib.exceptions import (
+    AnomalousWebhookPayloadError,
+    JsonableError,
+    UnsupportedWebhookEventTypeError,
+)
 from zerver.lib.request import RequestVariableMissingError
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import ApiParamConfig, typed_endpoint
@@ -124,10 +128,6 @@ def get_message_body(text: str, sender: str, files: SlackFileListT) -> str:
     return body
 
 
-def is_challenge_handshake(payload: WildValue) -> bool:
-    return payload.get("type").tame(check_string) == "url_verification"
-
-
 def handle_slack_webhook_message(
     request: HttpRequest,
     user_profile: UserProfile,
@@ -219,8 +219,12 @@ def api_slack_webhook(
         raise JsonableError(_("Malformed payload"))
     payload = to_wild_value("payload", val)
 
+    # The Slack Events API documents three outer event types:
+    # "url_verification", "app_rate_limited" and "event_callback".
+    payload_type = payload.get("type").tame(check_string)
+
     # Handle initial URL verification handshake for Slack Events API.
-    if is_challenge_handshake(payload):
+    if payload_type == "url_verification":
         challenge = payload.get("challenge").tame(check_string)
         try:
             if slack_app_token == "":
@@ -257,9 +261,20 @@ def api_slack_webhook(
     if is_zulip_slack_bridge_bot_message(payload):
         return json_success(request)
 
-    event_dict = payload.get("event", {})
-    event_type = event_dict.get("type").tame(check_string)
+    # Dispatched when a user's Slack app is rate limited:
+    # https://docs.slack.dev/reference/events/app_rate_limited.
+    # TODO: We could potentially handle this event by letting the bot owner
+    # know that their Slack app has been rate limited on Slack's end.
+    if payload_type == "app_rate_limited":
+        raise UnsupportedWebhookEventTypeError("app_rate_limited")
 
+    # Slack Event API payloads with an outer event type of "event_callback"
+    # should have an inner event object.
+    event_dict = payload.get("event", {})
+    if not event_dict:
+        raise AnomalousWebhookPayloadError
+
+    event_type = event_dict.get("type").tame(check_string)
     if event_type != "message":
         raise UnsupportedWebhookEventTypeError(event_type)
 


### PR DESCRIPTION
The message handling code read payload.get("event", {}) with an empty-dict default, but the next line immediately tamed `event.type` as a required string. When a payload arrived without an `event` object, this raised a `ValidationError`, which returned as errors in our sentry logs. A well-formed Slack `event_callback` request always contains an event object. 
There are two cases when it is missing: 
- `app_rate_limited` is the one event-less request Slack itself sends, so we report it as an unsupported event since there is no message to forward.
- Otherwise, the payload did not come from Slack and is treated as an AnomalousWebhookPayloadError, matching how other integrations handle misdirected webhooks.

Have added two fixtures
- `app_rate_limited.json` Taken from Slack documentation
- `example_anomalous_payload.json` This is taken from the issue itself mentioned by @amanagr
<!-- Describe your pull request here.-->

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Slack.20non.20event.20payloads/with/2475070)[#integrations > Slack non event payloads](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Slack.20non.20event.20payloads/with/2475070)

**How changes were tested:**
Added tests and all tests are passing

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
