### PR TITLE
s3: Disable Smokescreen proxy for boto3 at startup in every process.

### DIFF
--- a/zerver/apps.py
+++ b/zerver/apps.py
@@ -34,6 +34,23 @@ def create_zulip_schema(sender: AppConfig, **kwargs: Any) -> None:  # nocoverage
         cursor.execute("SET search_path = zulip,public")
 
 
+def skip_smokescreen_proxy_for_boto3() -> None:
+    # https://github.com/boto/botocore/issues/2644: the request boto3
+    # makes to fetch EC2 instance credentials from the IMDS endpoint
+    # always reads the proxy configuration from the environment,
+    # ignoring any per-client setting. Our application processes route
+    # outgoing HTTP through Smokescreen, so that metadata request would
+    # be proxied; and Smokescreen would refuse the internal
+    # IMDS address (169.254.169.254). Disable proxying for boto3 so the
+    # metadata request (and other boto3 traffic) goes direct.
+    #
+    # This must run at process startup so that it takes effect in every
+    # process, including queue workers.
+    import botocore.utils
+
+    botocore.utils.should_bypass_proxies = lambda url: True
+
+
 class ZerverConfig(AppConfig):
     name: str = "zerver"
 
@@ -53,6 +70,9 @@ class ZerverConfig(AppConfig):
         from django.contrib.auth.forms import SetPasswordMixin
 
         django_stubs_ext.monkeypatch(extra_classes=[SetPasswordMixin])
+
+        if settings.S3_SKIP_PROXY is True and settings.LOCAL_UPLOADS_DIR is None:  # nocoverage
+            skip_smokescreen_proxy_for_boto3()
 
         # We import zerver.signals here for the side effect of
         # registering the user_logged_in signal receiver.  This import

--- a/zerver/lib/upload/s3.py
+++ b/zerver/lib/upload/s3.py
@@ -47,13 +47,8 @@ DELETE_BATCH_SIZE = 1000
 # "file name" is the original filename provided by the user run
 # through a sanitization function.
 
-
-# https://github.com/boto/botocore/issues/2644 means that the IMDS
-# request _always_ pulls from the environment.  Monkey-patch the
-# `should_bypass_proxies` function if we need to skip them, based
-# on S3_SKIP_PROXY.
-if settings.S3_SKIP_PROXY is True:  # nocoverage
-    botocore.utils.should_bypass_proxies = lambda url: True
+# Note: boto3 is configured to bypass the Smokescreen outgoing proxy in
+# zerver.apps, making sure the setup runs at process startup.
 
 
 def get_bucket(bucket_name: str, authed: bool = True) -> "Bucket":

--- a/zerver/tests/test_outgoing_http.py
+++ b/zerver/tests/test_outgoing_http.py
@@ -2,6 +2,7 @@ import os
 from typing import Any
 from unittest import mock
 
+import botocore.utils
 import requests
 import responses
 from django.test import override_settings
@@ -9,6 +10,7 @@ from requests.adapters import HTTPAdapter
 from typing_extensions import override
 from urllib3.util import Retry
 
+from zerver.apps import skip_smokescreen_proxy_for_boto3
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.test_classes import ZulipTestCase
 
@@ -154,3 +156,28 @@ class TestOutgoingHttp(ZulipTestCase):
         self.assertEqual(session.adapters["http://"].max_retries.total, 5)
         assert isinstance(session.adapters["https://"], HTTPAdapter)
         self.assertEqual(session.adapters["https://"].max_retries.total, 5)
+
+
+class TestBoto3SmokescreenBypass(ZulipTestCase):
+    # boto3 is set up at startup to bypass the Smokescreen proxy; see
+    # skip_smokescreen_proxy_for_boto3 for why.
+    @mock.patch.dict(os.environ, {"http_proxy": "http://smokescreen.example:4750"})
+    def test_skip_smokescreen_proxy_for_boto3(self) -> None:
+        # Restore botocore's global state however the test exits, so the
+        # bypass doesn't leak into other tests in this process.
+        original = botocore.utils.should_bypass_proxies
+        self.addCleanup(setattr, botocore.utils, "should_bypass_proxies", original)
+
+        imds_url = "http://169.254.169.254/latest/api/token"
+
+        # Without the setup done by skip_smokescreen_proxy_for_boto3, boto3
+        # would route IMDS requests through Smokescreen.
+        self.assertEqual(
+            botocore.utils.get_environ_proxies(imds_url),
+            {"http": "http://smokescreen.example:4750"},
+        )
+
+        skip_smokescreen_proxy_for_boto3()
+
+        # After the patch, boto3 bypasses Smokescreen and connects directly.
+        self.assertEqual(botocore.utils.get_environ_proxies(imds_url), {})


### PR DESCRIPTION
boto3's request to fetch instance-role credentials from the IMDS endpoint reads its proxy configuration from the environment, ignoring per-client settings, as documented in the original comment. Smokescreen will always deny such requests, as they are to an internal IP address.

We worked around this by monkey-patching botocore's should_bypass_proxies, but installed it as a side effect of importing the S3 upload backend.  Processes that never import it -- notably the email_sender queue worker -- still proxied the IMDS request, so fetching credentials there failed: usually silently (returning no credentials), and occasionally crashing an email send when the proxy connect timed out instead of being refused.

Move the patch into `ZerverConfig.ready()`, so it runs at startup in every process when the S3 backend is in use. This restores SES suppression-list cleanup in the email-sender worker, and protects future boto3-using code that might run outside upload-handling processes (e.g. migrations could easily make that mistake. Existing migrations avoid the bug, as they pass explicit credentials and don't need to query IMDS).


----

Verified the original bug by running `maybe_remove_from_suppression_list(["<my email>"])`  on staging in `manage.py shell` with `HTTP(S)_PROXY` values set in the env, while watching `smokescreen.log` on the smokescreen host. As expected, the `maybe_...`  call triggered `no valid IP found among resolved addresses - 169.254.169.254 denied by rule 'Deny: Not Global Unicast'` deny in smokescreen.

