### PR TITLE
Don't auto-expand sidebar topics for list-of-topics view.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -19,6 +19,7 @@ import * as compose_actions from "./compose_actions.ts";
 import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
+import * as inbox_util from "./inbox_util.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import {localstorage} from "./localstorage.ts";
@@ -70,6 +71,12 @@ const left_sidebar_scroll_state: {
 const collapsed_sections = new Set<string>();
 const sections_with_only_inactive_or_muted = new Set<string>();
 const sections_showing_inactive_or_muted = new Set<string>();
+
+// The channel whose sidebar topic list the user last expanded or
+// collapsed with its expand chevron, and which of the two they did.
+// This overrides the default that `is_topic_list_expanded` computes
+// for that channel, until the user narrows away from it.
+let topic_list_expanded_override: {stream_id: number; is_expanded: boolean} | undefined;
 
 // Persistence for collapsed sections state
 const collapsed_sections_ls_key = "left_sidebar_collapsed_stream_sections";
@@ -318,6 +325,9 @@ export function add_sidebar_row(sub: StreamSubscription): void {
 
 export function remove_sidebar_row(stream_id: number): void {
     stream_sidebar.remove_row(stream_id);
+    if (topic_list_expanded_override?.stream_id === stream_id) {
+        topic_list_expanded_override = undefined;
+    }
     const force_rerender = stream_id === topic_list.active_stream_id();
     update_streams_sidebar(force_rerender);
 }
@@ -841,6 +851,7 @@ function build_stream_sidebar_li(sub: StreamSubscription, for_modal = false): JQ
     const is_muted = stream_data.is_muted(sub.stream_id);
     const can_post_messages = stream_data.can_post_messages_in_stream(sub);
     const url = hash_util.channel_url_by_user_setting(sub.stream_id);
+    const is_empty_topic_only_channel = stream_data.is_empty_topic_only_channel(sub.stream_id);
     const args = {
         name,
         id: sub.stream_id,
@@ -854,7 +865,12 @@ function build_stream_sidebar_li(sub: StreamSubscription, for_modal = false): JQ
         cannot_create_topics_in_channel: !stream_data.can_create_new_topics_in_stream(
             sub.stream_id,
         ),
-        is_empty_topic_only_channel: stream_data.is_empty_topic_only_channel(sub.stream_id),
+        is_empty_topic_only_channel,
+        // Only this setting needs a separate control for the sidebar
+        // topic list, since clicking the channel navigates instead of
+        // expanding it.
+        show_expand_topics_button:
+            channel_links_to_list_of_topics() && !is_empty_topic_only_channel && !for_modal,
         for_modal,
     };
     const $list_item = $(render_stream_sidebar_row(args));
@@ -1187,7 +1203,10 @@ export function get_sidebar_stream_topic_info(filter: Filter): {
 }
 
 function deselect_stream_items(): void {
-    $("ul#stream_filters li").removeClass("active-filter stream-expanded");
+    $("ul#stream_filters li").removeClass(
+        "active-filter stream-expanded topic-list-expanded hide-expand-topics-button",
+    );
+    $("ul#stream_filters .channel-expand-topics-button").attr("aria-expanded", "false");
 }
 
 export function update_stream_sidebar_for_topic_search(): void {
@@ -1243,10 +1262,6 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
         return undefined;
     }
 
-    if (!info.topic_selected && !zoomed_in) {
-        $stream_li.addClass("active-filter");
-    }
-
     // Always add 'stream-expanded' class irrespective of whether
     // topic is selected or not. This is required for proper styling
     // masked unread counts.
@@ -1259,6 +1274,25 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
     // We want to update channel view for inbox for the same reasons
     // we want to the topics list here.
     update_inbox_channel_view_callback(stream_id);
+
+    const is_expanded = is_topic_list_expanded(stream_id);
+    if (channel_links_to_list_of_topics()) {
+        // Only these channel rows have an expand chevron to update.
+        update_topic_list_expanded_ui($stream_li, is_expanded);
+        // A "topic:" search replaces the sidebar topic lists with its
+        // results, leaving the chevron nothing to control.
+        $stream_li.toggleClass("hide-expand-topics-button", rerender_topics_for_search);
+    }
+    update_channel_row_active_filter($stream_li, info.topic_selected, is_expanded);
+
+    if (!is_expanded && !rerender_topics_for_search) {
+        // The clear is for a list built by an earlier narrow into this
+        // same channel, which the check above leaves in place.
+        clear_topics();
+        maybe_hide_topic_bracket(get_section_id_for_stream_li($stream_li));
+        return $stream_li;
+    }
+
     if (!rerender_topics_for_search) {
         topic_list.rebuild_left_sidebar($stream_li, stream_id);
     }
@@ -1270,6 +1304,68 @@ export function update_stream_sidebar_for_narrow(filter: Filter): JQuery | undef
     maybe_hide_topic_bracket(get_section_id_for_stream_li($stream_li));
 
     return $stream_li;
+}
+
+function update_topic_list_expanded_ui($stream_li: JQuery, is_expanded: boolean): void {
+    $stream_li.toggleClass("topic-list-expanded", is_expanded);
+    $stream_li
+        .find(".channel-expand-topics-button")
+        .attr("aria-expanded", is_expanded ? "true" : "false");
+}
+
+// The current topic's own row takes over the selection when visible
+// below, since `capture_left_sidebar_selection_anchor` needs exactly
+// one selected row to anchor sidebar scrolling to.
+function update_channel_row_active_filter(
+    $stream_li: JQuery,
+    topic_selected: boolean,
+    is_expanded: boolean,
+): void {
+    $stream_li.toggleClass("active-filter", !zoomed_in && !(topic_selected && is_expanded));
+}
+
+function channel_links_to_list_of_topics(): boolean {
+    return (
+        user_settings.web_channel_default_view ===
+        web_channel_default_view_values.list_of_topics.code
+    );
+}
+
+// The sidebar topic list is how one navigates between a channel's
+// topics, so it's shown for whichever channel the user is reading.
+// The exception, and the only case with a chevron to override it, is
+// that channel's own "List of topics" view, which already shows the
+// same list in the middle pane.
+function is_topic_list_expanded(stream_id: number): boolean {
+    if (!channel_links_to_list_of_topics()) {
+        return true;
+    }
+    if (topic_list_expanded_override?.stream_id === stream_id) {
+        return topic_list_expanded_override.is_expanded;
+    }
+    return !(inbox_util.is_channel_view() && inbox_util.get_channel_id() === stream_id);
+}
+
+export function toggle_topic_list_expanded(stream_id: number): void {
+    const $stream_li = get_stream_li(stream_id);
+    if (!$stream_li) {
+        blueslip.error("No stream_li for subscribed stream", {stream_id});
+        return;
+    }
+
+    const is_expanded = !is_topic_list_expanded(stream_id);
+    topic_list_expanded_override = {stream_id, is_expanded};
+    if (is_expanded) {
+        topic_list.rebuild_left_sidebar($stream_li, stream_id);
+    } else if (topic_list.active_stream_id() === stream_id) {
+        clear_topics();
+    }
+
+    update_topic_list_expanded_ui($stream_li, is_expanded);
+    const topic_selected =
+        narrow_state.stream_id() === stream_id && narrow_state.topic() !== undefined;
+    update_channel_row_active_filter($stream_li, topic_selected, is_expanded);
+    maybe_hide_topic_bracket(get_section_id_for_stream_li($stream_li));
 }
 
 export let get_section_id_for_stream_li = function ($stream_li: JQuery): string {
@@ -1288,6 +1384,11 @@ export function handle_narrow_activated(
     show_more_topics: boolean,
 ): void {
     const previously_expanded_stream_id = topic_list.active_stream_id();
+    const info = get_sidebar_stream_topic_info(filter);
+
+    if (topic_list_expanded_override?.stream_id !== info.stream_id) {
+        topic_list_expanded_override = undefined;
+    }
 
     // Zoom out, if needed, so that get_stream_li returns the correct
     // value when calling update_stream_sidebar_for_narrow.
@@ -1297,13 +1398,11 @@ export function handle_narrow_activated(
 
     const $stream_li = update_stream_sidebar_for_narrow(filter);
     if ($stream_li && !change_hash && !is_zoomed_in() && show_more_topics) {
-        const info = get_sidebar_stream_topic_info(filter);
         assert(info.stream_id !== undefined);
         zoom_in(info.stream_id);
     }
 
     // Do not auto scroll when switching topics in an already expanded channel.
-    const info = get_sidebar_stream_topic_info(filter);
     if (info.stream_id !== previously_expanded_stream_id) {
         scroll_stream_into_view();
     }
@@ -1311,6 +1410,7 @@ export function handle_narrow_activated(
 
 export function handle_message_view_deactivated(): void {
     deselect_stream_items();
+    topic_list_expanded_override = undefined;
     clear_topics();
 }
 
@@ -1392,6 +1492,21 @@ export function initialize({
 }
 
 export function initialize_tippy_tooltips(): void {
+    tippy.delegate("body", {
+        target: "#stream_filters .channel-expand-topics-button",
+        delay: LONG_HOVER_DELAY,
+        onShow(instance) {
+            const stream_id = stream_id_for_elt($(instance.reference).parents("li.narrow-filter"));
+            instance.setContent(
+                is_topic_list_expanded(stream_id)
+                    ? $t({defaultMessage: "Collapse topic list"})
+                    : $t({defaultMessage: "Expand topic list"}),
+            );
+            return undefined;
+        },
+        appendTo: () => document.body,
+    });
+
     for (const parent_class of ["#stream_filters li", "#left-sidebar-modal"]) {
         tippy.delegate("body", {
             target: `${parent_class} .subscription_block .stream-name`,
@@ -1469,10 +1584,9 @@ export function on_sidebar_channel_click(
         return;
     }
 
-    if (
-        user_settings.web_channel_default_view ===
-        web_channel_default_view_values.list_of_topics.code
-    ) {
+    if (channel_links_to_list_of_topics()) {
+        // Navigating is all this click does; expanding the sidebar
+        // topic list is the chevron's business.
         browser_history.go_to_location(hash_util.by_channel_topic_list_url(stream_id));
         return;
     }
@@ -1589,6 +1703,34 @@ export function set_event_handlers({
             keep_composebox_empty: true,
         });
     }
+
+    function on_expand_topics_press(
+        element: HTMLElement,
+        e: JQuery.ClickEvent | JQuery.KeyDownEvent,
+    ): void {
+        e.stopPropagation();
+        e.preventDefault();
+        const stream_id = Number.parseInt(element.getAttribute("data-stream-id")!, 10);
+        toggle_topic_list_expanded(stream_id);
+    }
+
+    $("#stream_filters").on(
+        "click",
+        ".channel-expand-topics-button",
+        function (this: HTMLElement, e) {
+            on_expand_topics_press(this, e);
+        },
+    );
+
+    $("#stream_filters").on(
+        "keydown",
+        ".channel-expand-topics-button",
+        function (this: HTMLElement, e) {
+            if (keydown_util.is_enter_event(e)) {
+                on_expand_topics_press(this, e);
+            }
+        },
+    );
 
     $("#stream_filters").on("click", ".channel-new-topic-button", function (this: HTMLElement, e) {
         on_new_topic_press(this, e);

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -106,7 +106,10 @@ export function update(): void {
 export function update_widget_for_stream(stream_id: number): void {
     const widget = active_widgets.get(stream_id);
     if (widget === undefined) {
-        blueslip.warn("User re-narrowed before topic history was returned.");
+        // There is no inline sidebar topic list to rebuild; the user
+        // may have re-narrowed, or with the "List of topics"
+        // channel-link setting the sidebar topic list may be collapsed
+        // for the narrowed channel. Either way, rebuilding is a no-op.
         return;
     }
     widget.build();
@@ -157,13 +160,18 @@ export function zoom_out(): void {
     }
     zoomed_in_widget = undefined;
 
-    const widget = active_widgets.get(stream_id);
-    assert(widget !== undefined);
-    const $stream_li = widget.get_stream_li();
-
     // Reset the resolved topic filter since we moved away
     // from the view.
     topic_filter_pill_widget?.clear(true);
+
+    const widget = active_widgets.get(stream_id);
+    if (widget === undefined) {
+        // There is no inline sidebar topic list to rebuild; with the
+        // "List of topics" channel-link setting, the sidebar topic
+        // list may be collapsed for the zoomed channel.
+        return;
+    }
+    const $stream_li = widget.get_stream_li();
 
     rebuild_left_sidebar($stream_li, stream_id);
 }
@@ -616,18 +624,25 @@ export function zoom_in($stream_li: JQuery, stream_id: number): void {
     zoomed_in_widget.build(spinner);
     reset_topic_list_cursor({show_highlight: false});
 
-    function on_success(): void {
-        if (!active_widgets.has(stream_id)) {
-            blueslip.warn("User re-narrowed before topic history was returned.");
-            return;
-        }
+    // Capture the widget this zoom created, so that the success
+    // callback can tell whether the user has since zoomed into a
+    // different channel. We can't use active_widgets for this check,
+    // since with the "List of topics" channel-link setting, the inline
+    // sidebar topic list may be collapsed, with no active widget.
+    const my_zoomed_in_widget = zoomed_in_widget;
 
+    function on_success(): void {
         if (!zoomed) {
             blueslip.warn("User zoomed out before topic history was returned.");
             // Note that we could attempt to re-draw the zoomed out topic list
             // here, given that we have more history, but that might be more
             // confusing than helpful to a user who is likely trying to browse
             // other streams.
+            return;
+        }
+
+        if (zoomed_in_widget !== my_zoomed_in_widget) {
+            blueslip.warn("User re-narrowed before topic history was returned.");
             return;
         }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -225,7 +225,8 @@
 
     .stream-expanded {
         .channel-new-topic-button,
-        .channel-search-topics-button {
+        .channel-search-topics-button,
+        .channel-expand-topics-button {
             display: flex;
         }
 
@@ -243,6 +244,12 @@
                 display: inline;
             }
         }
+    }
+
+    /* Overrides the rule above while a "topic:" search is showing its
+       results in place of the channel's own topic list. */
+    .hide-expand-topics-button .channel-expand-topics-button {
+        display: none;
     }
 
     .toggle_stream_mute {
@@ -2170,7 +2177,8 @@ li.active-sub-filter {
 }
 
 .channel-new-topic-button,
-.channel-search-topics-button {
+.channel-search-topics-button,
+.channel-expand-topics-button {
     /* display: flex; is set on visible channels and
        channel-row hovers. */
     display: none;
@@ -2184,6 +2192,22 @@ li.active-sub-filter {
         color: var(--color-sidebar-action-hover);
         background-color: var(--color-background-sidebar-action-hover);
     }
+}
+
+.channel-expand-topics-button {
+    &:focus:not(:focus-visible) {
+        outline: none;
+    }
+
+    .zulip-icon-chevron-right {
+        transition: rotate 140ms linear;
+    }
+}
+
+.narrow-filter.topic-list-expanded
+    .channel-expand-topics-button
+    .zulip-icon-chevron-right {
+    rotate: 90deg;
 }
 
 .narrow-filter:hover {

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -10,6 +10,11 @@
             <span class="stream-name">{{name}}</span>
 
             <div class="left-sidebar-controls">
+                {{#if show_expand_topics_button}}
+                <div class="channel-expand-topics-button" tabindex="0" role="button" aria-label="{{t 'Toggle topic list' }}" aria-expanded="false" data-stream-id="{{id}}">
+                    <i class="zulip-icon zulip-icon-chevron-right" aria-hidden="true"></i>
+                </div>
+                {{/if}}
                 <div class="channel-search-topics-button" tabindex="0" data-tippy-content="{{t 'Search topics' }}" data-stream-id="{{id}}">
                     <i class="zulip-icon zulip-icon-search" aria-hidden="true"></i>
                 </div>

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -7,6 +7,7 @@ const {make_realm} = require("./lib/example_realm.cjs");
 const {make_stream} = require("./lib/example_stream.cjs");
 const {make_user} = require("./lib/example_user.cjs");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
+const {make_stub} = require("./lib/stub.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const {$} = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
@@ -25,6 +26,20 @@ let unread_unmuted_count;
 let stream_has_any_unread_mentions;
 
 const topic_list = mock_esm("../src/topic_list");
+const browser_history = mock_esm("../src/browser_history", {
+    go_to_location: noop,
+});
+// These two are what `narrow_state` reads to describe the current
+// view: `inbox_util` for the "List of topics" channel view, and
+// `message_lists` for message views.
+const message_lists = mock_esm("../src/message_lists", {current: undefined});
+const inbox_util = mock_esm("../src/inbox_util", {
+    filter: undefined,
+    is_visible: () => inbox_util.filter !== undefined,
+    is_channel_view: () => inbox_util.filter !== undefined,
+    get_channel_id: () =>
+        Number.parseInt(inbox_util.filter.terms_with_operator("channel")[0].operand, 10),
+});
 mock_esm("../src/unread", {
     unread_count_info_for_stream: () => ({
         unmuted_count: unread_unmuted_count,
@@ -41,11 +56,13 @@ mock_esm("../src/unread", {
 });
 
 const {Filter} = zrequire("../src/filter");
+const hash_util = zrequire("hash_util");
 const left_sidebar_navigation_area = zrequire("left_sidebar_navigation_area");
 const stream_data = zrequire("stream_data");
 const stream_list = zrequire("stream_list");
 stream_list.set_update_inbox_channel_view_callback(noop);
 const stream_list_sort = zrequire("stream_list_sort");
+const ui_util = zrequire("ui_util");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 const settings_config = zrequire("settings_config");
@@ -428,6 +445,270 @@ test_ui("narrowing", ({override_rewire}) => {
     assert.ok(topics_closed);
 });
 
+function channel_filter(sub) {
+    return new Filter([{operator: "stream", operand: sub.stream_id.toString()}]);
+}
+
+function topic_filter(sub, topic) {
+    return new Filter([
+        {operator: "stream", operand: sub.stream_id.toString()},
+        {operator: "topic", operand: topic},
+    ]);
+}
+
+// The chevron's aria-expanded must track the class it renders, so
+// always assert the two together.
+function assert_topic_list_expanded($sidebar_row, is_expanded) {
+    assert.equal($sidebar_row.hasClass("topic-list-expanded"), is_expanded);
+    assert.equal(
+        $sidebar_row.find(".channel-expand-topics-button").attr("aria-expanded"),
+        is_expanded ? "true" : "false",
+    );
+}
+
+function setup_list_of_topics_test({override, override_rewire}) {
+    override(
+        user_settings,
+        "web_channel_default_view",
+        settings_config.web_channel_default_view_values.list_of_topics.code,
+    );
+
+    topic_list.get_stream_li = noop;
+    override_rewire(stream_list, "scroll_stream_into_view", noop);
+    override_rewire(stream_list, "get_section_id_for_stream_li", () => "normal");
+    override_rewire(stream_list, "maybe_hide_topic_bracket", noop);
+
+    // The channel whose topic list is currently built in the sidebar.
+    const topic_list_state = {stream_id: undefined};
+    topic_list.active_stream_id = () => topic_list_state.stream_id;
+    topic_list.rebuild_left_sidebar = (_$stream_li, stream_id) => {
+        topic_list_state.stream_id = stream_id;
+    };
+    topic_list.close = () => {
+        topic_list_state.stream_id = undefined;
+    };
+
+    initialize_stream_data();
+
+    function sidebar_row(name) {
+        const $sidebar_row = $(`<${name}-sidebar-row-stub>`);
+        $sidebar_row.set_find_results(
+            ".channel-expand-topics-button",
+            $.create(`${name}-expand-topics-button`),
+        );
+        return $sidebar_row;
+    }
+
+    const $devel_row = sidebar_row("devel");
+    const $rome_row = sidebar_row("Rome");
+
+    stream_list.handle_message_view_deactivated();
+
+    // The "List of topics" channel view is rendered by the inbox
+    // code, which is how the sidebar knows that the middle pane is
+    // already showing the channel's topic list.
+    function narrow_to_channel_topic_list_view(sub) {
+        const filter = channel_filter(sub);
+        override(message_lists, "current", undefined);
+        override(inbox_util, "filter", filter);
+        stream_list.handle_narrow_activated(filter);
+    }
+
+    function narrow_to_message_view(filter) {
+        override(inbox_util, "filter", undefined);
+        override(message_lists, "current", {data: {filter}});
+        stream_list.handle_narrow_activated(filter);
+    }
+
+    return {
+        topic_list_state,
+        $devel_row,
+        $rome_row,
+        narrow_to_channel_topic_list_view,
+        narrow_to_message_view,
+    };
+}
+
+test_ui("list_of_topics_expansion_follows_narrow", (helpers) => {
+    const {
+        topic_list_state,
+        $devel_row,
+        $rome_row,
+        narrow_to_channel_topic_list_view,
+        narrow_to_message_view,
+    } = setup_list_of_topics_test(helpers);
+
+    narrow_to_channel_topic_list_view(develSub);
+    assert_topic_list_expanded($devel_row, false);
+    assert.equal(topic_list_state.stream_id, undefined);
+    assert.ok($devel_row.hasClass("active-filter"));
+
+    narrow_to_message_view(topic_filter(develSub, "python"));
+    assert_topic_list_expanded($devel_row, true);
+    assert.equal(topic_list_state.stream_id, develSub.stream_id);
+    assert.ok(!$devel_row.hasClass("active-filter"));
+
+    narrow_to_message_view(channel_filter(develSub));
+    assert_topic_list_expanded($devel_row, true);
+    assert.ok($devel_row.hasClass("active-filter"));
+
+    $("ul#stream_filters li").addClass("topic-list-expanded");
+    narrow_to_channel_topic_list_view(RomeSub);
+    assert.ok(!$("ul#stream_filters li").hasClass("topic-list-expanded"));
+    assert_topic_list_expanded($rome_row, false);
+    assert.equal(topic_list_state.stream_id, undefined);
+
+    narrow_to_message_view(channel_filter(RomeSub));
+    assert_topic_list_expanded($rome_row, true);
+
+    $("ul#stream_filters li").addClass("topic-list-expanded");
+    stream_list.handle_message_view_deactivated();
+    assert.ok(!$("ul#stream_filters li").hasClass("topic-list-expanded"));
+    assert.equal(topic_list_state.stream_id, undefined);
+});
+
+test_ui("list_of_topics_chevron_toggle", (helpers) => {
+    const {
+        topic_list_state,
+        $devel_row,
+        narrow_to_channel_topic_list_view,
+        narrow_to_message_view,
+    } = setup_list_of_topics_test(helpers);
+
+    narrow_to_channel_topic_list_view(develSub);
+    assert_topic_list_expanded($devel_row, false);
+
+    stream_list.toggle_topic_list_expanded(develSub.stream_id);
+    assert_topic_list_expanded($devel_row, true);
+    assert.equal(topic_list_state.stream_id, develSub.stream_id);
+
+    stream_list.toggle_topic_list_expanded(develSub.stream_id);
+    assert_topic_list_expanded($devel_row, false);
+    assert.equal(topic_list_state.stream_id, undefined);
+
+    stream_list.toggle_topic_list_expanded(develSub.stream_id);
+    assert_topic_list_expanded($devel_row, true);
+    assert.equal(topic_list_state.stream_id, develSub.stream_id);
+
+    narrow_to_message_view(topic_filter(develSub, "python"));
+    assert_topic_list_expanded($devel_row, true);
+    assert.ok(!$devel_row.hasClass("active-filter"));
+
+    // ...and collapsing while reading a topic moves the selection
+    // back onto the channel row, since the topic's own row is gone.
+    stream_list.toggle_topic_list_expanded(develSub.stream_id);
+    assert_topic_list_expanded($devel_row, false);
+    assert.ok($devel_row.hasClass("active-filter"));
+
+    // Narrowing away from the channel forgets the choice.
+    narrow_to_message_view(topic_filter(RomeSub, "gardens"));
+    narrow_to_message_view(topic_filter(develSub, "python"));
+    assert_topic_list_expanded($devel_row, true);
+});
+
+test_ui("list_of_topics_sidebar_row_click", (helpers) => {
+    const {override} = helpers;
+    const {
+        topic_list_state,
+        $devel_row,
+        narrow_to_channel_topic_list_view,
+        narrow_to_message_view,
+    } = setup_list_of_topics_test(helpers);
+
+    const go_to_location_stub = make_stub();
+    override(browser_history, "go_to_location", go_to_location_stub.f);
+
+    narrow_to_message_view(topic_filter(develSub, "python"));
+    assert_topic_list_expanded($devel_row, true);
+
+    stream_list.on_sidebar_channel_click(develSub.stream_id, null, noop);
+    assert.equal(go_to_location_stub.num_calls, 1);
+    assert.equal(
+        go_to_location_stub.get_args("url").url,
+        hash_util.by_channel_topic_list_url(develSub.stream_id),
+    );
+    assert_topic_list_expanded($devel_row, true);
+
+    narrow_to_channel_topic_list_view(develSub);
+    assert_topic_list_expanded($devel_row, false);
+    assert.equal(topic_list_state.stream_id, undefined);
+
+    // Clicking the row of the channel we're already viewing assigns an
+    // unchanged hash, so nothing happens; in particular, the click is
+    // not a second control for expanding and collapsing.
+    stream_list.on_sidebar_channel_click(develSub.stream_id, null, noop);
+    assert_topic_list_expanded($devel_row, false);
+
+    stream_list.toggle_topic_list_expanded(develSub.stream_id);
+    stream_list.on_sidebar_channel_click(develSub.stream_id, null, noop);
+    assert_topic_list_expanded($devel_row, true);
+});
+
+test_ui("list_of_topics_expand_button_hidden_for_topic_search", (helpers) => {
+    const {override_rewire} = helpers;
+    const {$devel_row, narrow_to_message_view} = setup_list_of_topics_test(helpers);
+
+    narrow_to_message_view(topic_filter(develSub, "python"));
+    assert.ok(!$devel_row.hasClass("hide-expand-topics-button"));
+
+    // A "topic:" search replaces the sidebar topic lists with its
+    // results, which the chevron has no say over.
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "topic: python");
+    stream_list.update_stream_sidebar_for_narrow(topic_filter(develSub, "python"));
+    assert.ok($devel_row.hasClass("hide-expand-topics-button"));
+
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "");
+    stream_list.update_stream_sidebar_for_narrow(topic_filter(develSub, "python"));
+    assert.ok(!$devel_row.hasClass("hide-expand-topics-button"));
+});
+
+test_ui("list_of_topics_expand_button_visibility", ({override, mock_template}) => {
+    override(
+        user_settings,
+        "web_channel_default_view",
+        settings_config.web_channel_default_view_values.list_of_topics.code,
+    );
+
+    function show_expand_topics_button_for(sub) {
+        const $sidebar_row = $("<" + sub.name + "-sidebar-row-stub>");
+        const $subscription_block = $.create(sub.name + "-block");
+        const $unread_count = $.create(sub.name + "-count");
+        const $unread_mention_info = $.create(sub.name + "-mention-info");
+        $sidebar_row.set_find_results(".subscription_block", $subscription_block);
+        $subscription_block.set_find_results(".unread_count", $unread_count);
+        $subscription_block.set_find_results(".unread_mention_info", $unread_mention_info);
+
+        let show_expand_topics_button;
+        mock_template("stream_sidebar_row.hbs", false, (data) => {
+            show_expand_topics_button = data.show_expand_topics_button;
+            return "<" + sub.name + "-sidebar-row-stub>";
+        });
+
+        stream_data.add_sub_for_tests(sub);
+        stream_list.create_sidebar_row(sub);
+        return show_expand_topics_button;
+    }
+
+    const normal = make_stream({
+        name: "normal",
+        stream_id: 7000,
+        subscribed: true,
+        can_create_topic_group: everyone_group.id,
+        can_send_message_group: everyone_group.id,
+    });
+    assert.equal(show_expand_topics_button_for(normal), true);
+
+    const empty_topic_only = make_stream({
+        name: "general",
+        stream_id: 7001,
+        subscribed: true,
+        topics_policy: "empty_topic_only",
+        can_create_topic_group: everyone_group.id,
+        can_send_message_group: everyone_group.id,
+    });
+    assert.equal(show_expand_topics_button_for(empty_topic_only), false);
+});
+
 test_ui("sort_streams", ({override_rewire, mock_template}) => {
     override_rewire(stream_list, "update_dom_with_unread_counts", noop);
     override_rewire(stream_list, "update_stream_section_mention_indicators", noop);
@@ -585,6 +866,7 @@ test_ui("rename_stream", ({mock_template, override, override_rewire}) => {
             can_post_messages: true,
             is_empty_topic_only_channel: false,
             cannot_create_topics_in_channel: false,
+            show_expand_topics_button: false,
         });
         return "<li-stub>";
     });


### PR DESCRIPTION
This PR adds a dedicated **expand chevron(>)** to the left sidebar topic-list widget. For user using a List of Topics setting
1) A Click on topic widget should move the topic list to the middle panel
2) A click on the chevron should exapand/collapse the topic-list in the left sidebar
3) The sidebar should show the topic list when a user is inside a topic to allow them to navigate.

Fixes [#35197](https://github.com/zulip/zulip/pull/35197) with some changes as discussed in [design > channel mis-clicks are hard to recover from](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20mis-clicks.20are.20hard.20to.20recover.20from/with/2477594)

### Implementation notes

Prep Commit : **`topic_list: Don't assume an inline topic list exists when zoomed.`** 
Before this feature, the narrowed channel always had an active inline topic-list widget, and several paths used "widget missing" to mean  "user re-narrowed" . Once the sidebar list can be collapsed for the narrowed channel, "missing" is also just  "collapsed", so this commit loosens those assumptions without changing behavior letting the next commit introduce collapse without regressions (assert crash / spurious "User re-narrowed…" console warning).


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<details>
<summary>Chevron:</summary>
Before: No Chevron
<br>
<img width="313" height="28" alt="Screenshot From 2026-07-14 12-16-41" src="https://github.com/user-attachments/assets/a486dd4a-a12f-49c0-b7ae-e98fe153d8ae" />
<br>
After:
<br>
<img width="298" height="35" alt="Screenshot From 2026-06-19 16-15-38" src="https://github.com/user-attachments/assets/8487f109-1b06-4fc2-b3af-f199f434d1c6" />
<br>
AfterExpanding:
<br>
<img width="316" height="221" alt="Screenshot From 2026-06-19 16-15-55" src="https://github.com/user-attachments/assets/c30f82c8-ed5a-4d79-9070-5fb9e4ff21d6" />

</details>



https://github.com/user-attachments/assets/bf0babc8-1fde-4e5f-9544-b32f7fd835b5



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
