### PR TITLE
click_handlers: Don't cancel compose on external link clicks.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -1060,6 +1060,15 @@ export function initialize(): void {
 
     // MAIN CLICK HANDLER
 
+    // Read at pointerdown — before browsers detach e.target on target="_blank"
+    // link clicks — so the click handler can reliably identify link presses.
+    let last_pointerdown_was_within_link = false;
+    $(document).on("pointerdown", (e) => {
+        if (e.button === 0) {
+            last_pointerdown_was_within_link = $(e.target).closest("a").length > 0;
+        }
+    });
+
     $(document).on("click", (e) => {
         if (e.button !== 0 || $(e.target).is(".drag")) {
             // Firefox emits right click events on the document, but not on
@@ -1069,7 +1078,8 @@ export function initialize(): void {
         }
 
         if (compose_state.composing() && $(e.target).parents("#compose").length === 0) {
-            const is_click_within_link = $(e.target).closest("a").length > 0;
+            const is_click_within_link =
+                last_pointerdown_was_within_link || $(e.target).closest("a").length > 0;
             if (is_click_within_link || $(e.target).closest(".copy_codeblock").length > 0) {
                 const is_selecting_link_text = is_click_within_link && mouse_drag.is_drag(e);
                 if (is_selecting_link_text) {


### PR DESCRIPTION
When composing a message and clicking an external link in the feed,
the compose box unexpectedly closes and the draft is lost.

Fixes: #38548

The root cause is a browser timing issue: when a link has
`target="_blank"`, some browsers shift focus to the new tab *before*
the click event finishes bubbling up to the document level. By that
point, `e.target` has been detached from the `<a>` element, so
`$(e.target).closest("a")` returns empty — making the click handler
think the user clicked somewhere outside a link, and calling
`compose_actions.cancel()`.

The fix captures whether the press started on a link at `pointerdown`
time, which fires before any browser-driven DOM changes. That value
is then used as a fallback in the existing `is_click_within_link`
check. This follows the same pattern already used in `mouse_drag.ts`.

**How changes were tested:**

Ran the full node unit test suite (172 tests, all passing). Could not
test in the live dev environment as it requires Linux/Vagrant, which
I don't have set up locally. The logic is contained to a single
closure inside `initialize()` and mirrors an existing pattern in the
codebase.

**Screenshots and screen captures:**

N/A (no visual changes)
