### PR TITLE
style: Add keyboard focus styling for view all users link

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -574,6 +574,7 @@
         );
         align-items: center;
         color: var(--color-text-sidebar-action-heading);
+        text-decoration: none;
 
         .right-sidebar-wrappable-text-inner {
             margin: var(--spacing-top-bottom-sidebar-topic-inner) 0;
@@ -587,6 +588,26 @@
             );
         }
         text-transform: var(--text-transform-sidebar-action-heading);
+    }
+}
+
+.buddy-list-user-link {
+    &:focus-within {
+        outline: 2px solid var(--color-outline-focus);
+        outline-offset: -2px;
+        background-color: var(--color-background-hover-narrow-filter);
+    }
+
+    &:active {
+        background-color: var(--color-background-sidebar-action-heading-hover);
+        outline: 1px solid var(--color-border-sidebar-action-heading);
+        outline-offset: -1px;
+    }
+
+    .right-sidebar-wrappable-text-container {
+        &:focus {
+            outline: none;
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Fixed a visual bug in the right sidebar where navigating the buddy list with the Tab key caused a double focus outline — one custom ring on the .buddy-list-user-link container and one default browser ring on the inner .right-sidebar-wrappable-text-container.
 I saw this happening when working on the "Invite to organisation" button and got the fix approved in CZO.

 Fixes: https://chat.zulip.org/#narrow/channel/101-design/topic/focus.20styles.20for.20.27View.20all.20users.27/with/2477693

 How changes were tested:

* Launched the Zulip dev environment on local machine (localhost:9991)
* Opened the right sidebar and navigated through buddy list items using the Tab key
* Verified that only a single, clean focus outline appears on each user link — no double ring or inner box artifact
* Confirmed :active state styling also applies correctly on click
* Verified text-decoration: none suppresses the unwanted underline during focus
* Tested in both Light and Dark themes

**Screenshots and screen captures:**

| Theme | Before | After |
| --- | --- | --- |
| **Light Theme** |<img width="362" height="51" alt="dUBd0GzYZR" src="https://github.com/user-attachments/assets/c85fafe6-27e0-4d1b-a283-4fd43ffb1777" />|<img width="362" height="51" alt="3eTFM6K8ud" src="https://github.com/user-attachments/assets/67bb05f0-3fc3-4bc6-bc23-19163bd0fd14" />|
| **Dark Theme** |<img width="362" height="51" alt="HdXR9KCjm3" src="https://github.com/user-attachments/assets/f8027f1d-68f3-45d9-a2cd-50952aff8f3a" />|<img width="362" height="51" alt="chrome_cg1SbaVPzu" src="https://github.com/user-attachments/assets/a0f0272d-3a72-492e-8cbd-33e8e9922a3e" />|


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>