### PR TITLE
llms_txt: Use numeric channel IDs in the example and channel listing.

### DIFF
--- a/zerver/tests/test_llms_txt.py
+++ b/zerver/tests/test_llms_txt.py
@@ -1,6 +1,7 @@
 from zerver.actions.realm_settings import do_set_realm_property
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models.realms import get_realm
+from zerver.models.streams import Stream, get_stream
 
 
 class LlmsTxtTest(ZulipTestCase):
@@ -30,6 +31,13 @@ class LlmsTxtTest(ZulipTestCase):
         self.assertIn("use the numeric ID as the `channel` operand", content)
         self.assertIn("Channel IDs are stable", content)
         self.assertIn("names can be renamed", content)
+        # The channel narrow operand must be the numeric channel ID (an
+        # unquoted integer), never a quoted name, everywhere it appears.
+        self.assertNotIn('"operator":"channel","operand":"', content)
+        # The channel listing exposes each channel's numeric ID so clients
+        # can build narrows directly.
+        rome_id = get_stream("Rome", realm).id
+        self.assertIn(f"Rome ({rome_id})", content)
 
     def test_llms_txt_spectator_access_disabled(self) -> None:
         """
@@ -45,8 +53,6 @@ class LlmsTxtTest(ZulipTestCase):
         GET /llms.txt returns 404 when spectator access is enabled but there
         are no web-public channels in the realm.
         """
-        from zerver.models.streams import Stream
-
         realm = get_realm("zulip")
         do_set_realm_property(realm, "enable_spectator_access", True, acting_user=None)
         # Mark all previously web-public streams as not web-public.

--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -20,7 +20,7 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=404)
 
     streams = list(
-        get_web_public_streams_queryset(realm).values_list("name", flat=True).order_by("name")
+        get_web_public_streams_queryset(realm).order_by("name").values_list("id", "name")
     )
 
     # Return 404 if the feature is enabled at the realm level but no
@@ -29,8 +29,8 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=404)
 
     server_url = realm.url
-    example_channel = streams[0]
-    channel_list = "\n".join(f"- {name}" for name in streams)
+    example_channel_id = streams[0][0]
+    channel_list = "\n".join(f"- {name} ({channel_id})" for channel_id, name in streams)
 
     content = f"""\
 # {realm.name}
@@ -52,7 +52,7 @@ Required query parameters:
 - `num_before` — number of messages before anchor (e.g. `0`)
 - `num_after` — number of messages after anchor (e.g. `100`)
 - `narrow` — JSON array of filter operators, e.g.:
-  `[{{"operator":"channels","operand":"web-public"}},{{"operator":"channel","operand":"CHANNEL_NAME"}},{{"operator":"topic","operand":"TOPIC_NAME"}}]`
+  `[{{"operator":"channels","operand":"web-public"}},{{"operator":"channel","operand":CHANNEL_ID}},{{"operator":"topic","operand":"TOPIC_NAME"}}]`
 
 **Important**: the narrow must include `{{"operator":"channels","operand":"web-public"}}`
 to enable unauthenticated access.
@@ -72,7 +72,7 @@ request returned the entire conversation.
 
 Fetch the 100 oldest messages from a topic:
 
-    GET {server_url}/json/messages?anchor=oldest&num_before=0&num_after=100&narrow=[{{"operator":"channels","operand":"web-public"}},{{"operator":"channel","operand":"{example_channel}"}},{{"operator":"topic","operand":"TOPIC_NAME"}}]
+    GET {server_url}/json/messages?anchor=oldest&num_before=0&num_after=100&narrow=[{{"operator":"channels","operand":"web-public"}},{{"operator":"channel","operand":{example_channel_id}}},{{"operator":"topic","operand":"TOPIC_NAME"}}]
 
 ## Fetching messages in specific conversations / views
 
@@ -170,6 +170,8 @@ sparingly.
   of a Zulip installation before considering such a tool.
 
 ## Web-public channels on this server
+
+Each entry below is in the format `channel name (channel ID)`:
 
 {channel_list}
 


### PR DESCRIPTION
The doc already tells clients to use a channel's numeric ID as the `channel` operand, but the example, the parameter template, and the channel list were all still using names. So there was no actual ID anywhere in the doc to plug in, and the name-based example would also break for any channel whose name has spaces or quotes once it's in a URL.

This switches the example and template to an unquoted integer operand and lists each channel's ID, so you can build a working narrow straight from the doc.

Fixes: part of the review @rht stated in the [CZO Thread](https://chat.zulip.org/#narrow/channel/137-feedback/topic/web.20public.20streams.20not.20readable.20by.20agentic.20ai.20tools/near/2450322).

**How changes were tested:**

- `./tools/test-backend zerver.tests.test_llms_txt --coverage` 
- `./tools/lint zerver/views/llms_txt.py zerver/tests/test_llms_txt.py`

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
