### PR TITLE
search: Focus search_query when tabbing to search box

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -157,6 +157,16 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
 
     $("#searchbox_form").on("focusin", () => {
         $("#searchbox-input-container").toggleClass("focused", true);
+
+        const active = document.activeElement;
+
+        if (
+            active &&
+            $(active).is("#searchbox-input-container") &&
+            !$("#search_query").is(":focus")
+        ) {
+            initiate_search();
+        }
     });
 
     $("#searchbox_form").on("focusout", () => {


### PR DESCRIPTION
Fixes #39440.

When navigating to the search box using keyboard Tab navigation, focus landed on `#searchbox-input-container` instead of the editable `#search_query` element.

This change uses the existing `initiate_search()` flow to move focus into `#search_query` when the search container receives keyboard focus.

Testing:

* Reproduced the issue locally.
* Verified focus now lands on `#search_query`.
* Verified mouse interaction still works.
* Verified Esc behavior still works.
* Verified tab navigation still works.
* Ran `./tools/test-js-with-node web/tests/search.test.cjs`.


Verification:

Before:
* Tabbing to the search box focused `searchbox-input-container`.

https://github.com/user-attachments/assets/08bb4af0-3139-4c42-b9d3-a92eeae442e0



After:
* Tabbing to the search box focuses `search_query`.

https://github.com/user-attachments/assets/cdeab2fd-3ec6-4326-a1ce-38cdd92748b6





Verified using:
`document.activeElement.id`

<img width="640" height="143" alt="image" src="https://github.com/user-attachments/assets/0ba8b053-24b2-4760-a73f-7508bc91c549" />

