### PR TITLE
tests: Assert specific log lines instead of fuzzy `any()` matches.

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -506,6 +506,10 @@ faster and easier to just plan and write them well the first time.
   foos = {f.id: f for f in Foo.objects.filter(id__in=[b.foo_id for b in bars])}
   ```
 
+- In tests, don't assert on `assertLogs` output with
+  `any(phrase in line for line in mock_log.output)`; pin the full line
+  against `mock_log.output`, or a substring to a specific `mock_log.output[i]`.
+
 ### Process:
 
 - Always check if you're working on top of the latest upstream/main, and

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4433,8 +4433,10 @@ class SAMLAuthBackendTest(SocialAuthBase):
         hamlet.refresh_from_db()
         # Email should NOT have changed.
         self.assertEqual(hamlet.delivery_email, self.email)
-        self.assertTrue(
-            any("Can't sync email" in output for output in m.output),
+        self.assertIn(
+            f"Can't sync email for user {hamlet.id}: "
+            f"another user exists with target email {othello_email}",
+            m.output[1],
         )
 
     def test_external_auth_id_saml_cross_realm_bot_email(self) -> None:
@@ -4480,8 +4482,9 @@ class SAMLAuthBackendTest(SocialAuthBase):
         hamlet.refresh_from_db()
         # Email should NOT have changed.
         self.assertEqual(hamlet.delivery_email, self.email)
-        self.assertTrue(
-            any("reserved for system bots" in output for output in m.output),
+        self.assertIn(
+            f"Can't sync email for user {hamlet.id}: {bot_email} is reserved for system bots",
+            m.output[1],
         )
 
     def test_external_auth_id_saml_deactivated_user(self) -> None:


### PR DESCRIPTION
Claude Code likes to assert on captured logs with
`any(phrase in line for line in mock_log.output)`, which passes even when the level, logger, line count, or full message is wrong. Two SAML email-sync tests had picked up this pattern; anchor them to the specific warning line, and document the anti-pattern in CLAUDE.md so it stops recurring.

