### PR TITLE
export: Fix backfill migration mislabeling command-line exports.

### DIFF
--- a/zerver/migrations/0801_realmexport_backfill_export_from_prior_server_status.py
+++ b/zerver/migrations/0801_realmexport_backfill_export_from_prior_server_status.py
@@ -9,15 +9,18 @@ EXPORT_FROM_PRIOR_SERVER = 6
 def backfill_export_from_prior_server_status(
     apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
 ) -> None:
-    # RealmExport rows with SUCCEEDED status but no export_path are
-    # records carried across a realm export->import, where the tarball
-    # is not preserved. Fix them up to use EXPORT_FROM_PRIOR_SERVER status.
+    # RealmExport rows with SUCCEEDED status and no export_path, created
+    # via the UI, are records carried across a realm export->import, where
+    # the tarball is not preserved. Fix them up to use the
+    # EXPORT_FROM_PRIOR_SERVER status. Exports created via the manage.py
+    # export command have no acting_user and likewise lack an export_path,
+    # but they are not surfaced via the UI/API, so we leave them untouched.
     with connection.cursor() as cursor:
         cursor.execute(
             """
             UPDATE zerver_realmexport
             SET status = %s
-            WHERE status = %s AND export_path IS NULL
+            WHERE status = %s AND export_path IS NULL AND acting_user_id IS NOT NULL
             RETURNING id, realm_id
             """,
             [EXPORT_FROM_PRIOR_SERVER, SUCCEEDED],

--- a/zerver/migrations/0802_realmexport_restore_command_line_export_status.py
+++ b/zerver/migrations/0802_realmexport_restore_command_line_export_status.py
@@ -1,0 +1,44 @@
+from django.db import connection, migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+SUCCEEDED = 3
+EXPORT_FROM_PRIOR_SERVER = 6
+
+
+def restore_command_line_export_status(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    # The original version of migration 0801 flipped every SUCCEEDED row
+    # without an export_path to EXPORT_FROM_PRIOR_SERVER, incorrectly
+    # including command-line (manage.py export) exports, which have no
+    # acting_user. Restore those rows to SUCCEEDED.
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            UPDATE zerver_realmexport
+            SET status = %s
+            WHERE status = %s AND acting_user_id IS NULL
+            RETURNING id, realm_id
+            """,
+            [SUCCEEDED, EXPORT_FROM_PRIOR_SERVER],
+        )
+        for export_id, realm_id in cursor.fetchall():
+            print(
+                f"Restored RealmExport id={export_id} realm_id={realm_id}: "
+                f"EXPORT_FROM_PRIOR_SERVER -> SUCCEEDED"
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0801_realmexport_backfill_export_from_prior_server_status"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            restore_command_line_export_status,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]


### PR DESCRIPTION
Fixes an oversight in #38862

Migration 0801 didn't account for exports generated via the manage.py export command, as opposed to exports created through the UI. UI exports always have an acting_user set, while the command does not. The command also doesn't set export_path on succeeded exports, but those exports aren't surfaced via the UI or the API it uses, so they were never affected by the bug 0801 was meant to fix.

Restrict 0801 to rows with an acting_user, and add 0802 to restore the rows the original 0801 incorrectly flipped on servers that already ran it.

