### PR TITLE
jdenticon: Re-upload Jdenticon avatars salted with the wrong realm UUID.

### DIFF
--- a/tools/semgrep-py.yml
+++ b/tools/semgrep-py.yml
@@ -96,6 +96,7 @@ rules:
         - zerver/migrations/0387_reupload_realmemoji_again.py
         - zerver/migrations/0443_userpresence_new_table_schema.py
         - zerver/migrations/0493_rename_userhotspot_to_onboardingstep.py
+        - zerver/migrations/0805_reupload_jdenticon_avatars.py
         - pgroonga/migrations/0002_html_escape_subject.py
 
   - id: use-addindexconcurrently

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -378,19 +378,22 @@ def do_change_avatar_fields(
     skip_notify: bool = False,
     *,
     acting_user: UserProfile | None,
+    skip_audit_log: bool = False,
 ) -> None:
     user_profile.avatar_source = avatar_source
     user_profile.avatar_version += 1
     user_profile.save(update_fields=["avatar_source", "avatar_version"])
-    event_time = timezone_now()
-    RealmAuditLog.objects.create(
-        realm=user_profile.realm,
-        modified_user=user_profile,
-        event_type=AuditLogEventType.USER_AVATAR_SOURCE_CHANGED,
-        extra_data={"avatar_source": avatar_source},
-        event_time=event_time,
-        acting_user=acting_user,
-    )
+
+    if not skip_audit_log:
+        event_time = timezone_now()
+        RealmAuditLog.objects.create(
+            realm=user_profile.realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_AVATAR_SOURCE_CHANGED,
+            extra_data={"avatar_source": avatar_source},
+            event_time=event_time,
+            acting_user=acting_user,
+        )
 
     if not skip_notify:
         notify_avatar_url_change(user_profile)
@@ -418,6 +421,23 @@ def set_avatar_to_default(user_profile: UserProfile, *, acting_user: UserProfile
             user_profile, realm_uuid=str(user_profile.realm.uuid), future=True
         )
     do_change_avatar_fields(user_profile, default_avatar_source, acting_user=acting_user)
+
+
+def reupload_realm_jdenticon_avatars(realm: Realm) -> None:
+    # We bump the avatar_version to bust the immutable avatar cache.
+    # We skip the audit log because the avatar source is unchanged
+    # and it'll create a lot of audit logs on large servers without
+    # much benefit.
+    for user_profile in UserProfile.objects.filter(
+        realm=realm, avatar_source=UserProfile.AVATAR_FROM_JDENTICON
+    ):
+        generate_and_upload_jdenticon_avatar(user_profile, str(realm.uuid), future=True)
+        do_change_avatar_fields(
+            user_profile,
+            UserProfile.AVATAR_FROM_JDENTICON,
+            acting_user=None,
+            skip_audit_log=True,
+        )
 
 
 def update_scheduled_email_notifications_time(

--- a/zerver/migrations/0805_reupload_jdenticon_avatars.py
+++ b/zerver/migrations/0805_reupload_jdenticon_avatars.py
@@ -1,0 +1,49 @@
+from django.conf import settings
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+from zerver.lib.queue import queue_json_publish_rollback_unsafe
+
+
+def reupload_jdenticon_avatars(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    """A bug in the import_realm codepath re-generated the Jdenticon avatars
+    of every user on the server -- not just the imported realm's -- using
+    the imported realm's UUID as salt for Jdenticon's key.
+    For users outside the imported realm, that produced an avatar salted
+    with the wrong realm's UUID. See #39468.
+
+    We queue a deferred_work event per affected realm, which regenerates
+    those avatars with each user's own realm UUID and bumps avatar_version
+    so the corrected image is served.
+    """
+    Realm = apps.get_model("zerver", "Realm")
+    if settings.TEST_SUITE:
+        # This migration repairs data corrupted by a past bug,
+        # not needed for tests.
+        return
+
+    non_system_realms = Realm.objects.exclude(string_id=settings.SYSTEM_BOT_REALM)
+    if non_system_realms.count() < 2:
+        # The bug only affected avatars of realms *other* than the one
+        # being imported, so a server that has only ever hosted a single
+        # non-system-bot realm has nothing to repair.
+        return
+
+    for realm_id in non_system_realms.order_by("id").values_list("id", flat=True):
+        event = {"type": "reupload_jdenticon_avatars", "realm_id": realm_id}
+        queue_json_publish_rollback_unsafe("deferred_work", event)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0804_backfill_user_created_audit_logs"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            reupload_jdenticon_avatars,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -2,6 +2,7 @@ import base64
 import os
 import signal
 import time
+import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager, suppress
@@ -16,14 +17,23 @@ from django.db.utils import IntegrityError
 from django.test import override_settings
 from typing_extensions import override
 
+from zerver.actions.create_realm import do_create_realm
+from zerver.actions.create_user import do_create_user
+from zerver.lib.avatar import generate_and_upload_jdenticon_avatar, generate_avatar_jdenticon
 from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
-from zerver.lib.queue import MAX_REQUEST_RETRIES
+from zerver.lib.queue import MAX_REQUEST_RETRIES, queue_json_publish_rollback_unsafe
 from zerver.lib.remote_server import PushNotificationBouncerRetryLaterError
 from zerver.lib.send_email import EmailNotDeliveredError, FromAddress
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import mock_queue_publish
-from zerver.models import ScheduledMessageNotificationEmail, UserActivity, UserProfile
+from zerver.lib.test_helpers import avatar_disk_path, mock_queue_publish
+from zerver.models import (
+    RealmAuditLog,
+    ScheduledMessageNotificationEmail,
+    UserActivity,
+    UserProfile,
+)
 from zerver.models.clients import get_client
+from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.realms import get_realm
 from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.streams import get_stream
@@ -838,3 +848,71 @@ class WorkerTest(ZulipTestCase):
         self.assertNotIn("soft_reactivation", get_active_worker_queues())
         with override_settings(DEDICATED_SOFT_REACTIVATION_QUEUE=True):
             self.assertIn("soft_reactivation", get_active_worker_queues())
+
+    def test_reupload_jdenticon_avatars(self) -> None:
+        realm = do_create_realm("reupload-jdenticon", "Jdenticon Test")
+        imported_realm_uuid = str(uuid.uuid4())
+
+        user_a = do_create_user("a@jd.test", None, realm, "A", acting_user=None)
+        user_b = do_create_user("b@jd.test", None, realm, "B", acting_user=None)
+        jdenticon_users = [user_a, user_b]
+        versions_before = {}
+        for user in jdenticon_users:
+            self.assertEqual(user.avatar_source, UserProfile.AVATAR_FROM_JDENTICON)
+            versions_before[user.id] = user.avatar_version
+            # Reproduce the bug: store an avatar salted with the imported
+            # realm's UUID rather than the user's own realm's UUID.
+            generate_and_upload_jdenticon_avatar(user, imported_realm_uuid, future=False)
+            with open(avatar_disk_path(user), "rb") as f:
+                self.assertEqual(
+                    f.read(),
+                    generate_avatar_jdenticon(f"{imported_realm_uuid}:{user.id}", medium=False),
+                )
+
+        # A non-Jdenticon user in the realm must be left untouched.
+        user_c = do_create_user(
+            "c@jd.test",
+            None,
+            realm,
+            "C",
+            avatar_source=UserProfile.AVATAR_FROM_USER,
+            acting_user=None,
+        )
+        versions_before[user_c.id] = user_c.avatar_version
+
+        audit_logs_before = RealmAuditLog.objects.filter(
+            event_type=AuditLogEventType.USER_AVATAR_SOURCE_CHANGED
+        ).count()
+
+        event = {"type": "reupload_jdenticon_avatars", "realm_id": realm.id}
+        # One realm_user avatar-update event is sent per repaired user.
+        with self.capture_send_event_calls(expected_num_events=len(jdenticon_users)) as events:
+            queue_json_publish_rollback_unsafe("deferred_work", event)
+
+        for user in jdenticon_users:
+            user.refresh_from_db()
+            # Verify avatar_version is bumped.
+            self.assertEqual(user.avatar_version, versions_before[user.id] + 1)
+            # The stored avatar is now salted with the user's own realm UUID.
+            for medium in (False, True):
+                with open(avatar_disk_path(user, medium=medium), "rb") as f:
+                    self.assertEqual(
+                        f.read(),
+                        generate_avatar_jdenticon(f"{realm.uuid}:{user.id}", medium=medium),
+                    )
+
+        for event_data in events:
+            self.assertEqual(event_data["event"]["type"], "realm_user")
+            self.assertEqual(event_data["event"]["op"], "update")
+
+        # The non-Jdenticon user remains untouched.
+        user_c.refresh_from_db()
+        self.assertEqual(user_c.avatar_version, versions_before[user_c.id])
+
+        # The avatar source did not change, so no audit log is written.
+        self.assertEqual(
+            RealmAuditLog.objects.filter(
+                event_type=AuditLogEventType.USER_AVATAR_SOURCE_CHANGED
+            ).count(),
+            audit_logs_before,
+        )

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -15,6 +15,7 @@ from zerver.actions.message_flags import do_mark_stream_messages_as_read
 from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_export import notify_realm_export
 from zerver.actions.realm_settings import scrub_deactivated_realm
+from zerver.actions.user_settings import reupload_realm_jdenticon_avatars
 from zerver.lib.export import export_realm_wrapper, export_tarball_prefix
 from zerver.lib.push_notifications import clear_push_device_tokens
 from zerver.lib.queue import retry_event
@@ -172,6 +173,14 @@ class DeferredWorker(QueueProcessingWorker):
             realm = Realm.objects.get(id=event["realm_id"])
             logger.info("Processing reupload_realm_emoji event for realm %s", realm.id)
             handle_reupload_emojis_event(realm, logger)
+        elif event["type"] == "reupload_jdenticon_avatars":
+            # This is a special event queued by the migration to repair Jdenticon avatars
+            # that an import_realm bug (#39468) re-generated using the imported realm's
+            # UUID for users in *other* realms. As with reupload_realm_emoji above, the
+            # migration only queues the event and the work is done here.
+            realm = Realm.objects.get(id=event["realm_id"])
+            logger.info("Processing reupload_jdenticon_avatars event for realm %s", realm.id)
+            reupload_realm_jdenticon_avatars(realm)
         elif event["type"] == "soft_reactivate":
             # Soft reactivations are normally enqueued here. A server can
             # opt into a dedicated soft_reactivation queue via the


### PR DESCRIPTION
This repairs the Jdenticon avatars corrupted by the import_realm bug fixed in #39468.

For each affected realm, queue a deferred_work event that regenerates its users' Jdenticon avatars with the realm's own UUID.

**How changes were tested:**

Added unit test.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
