### PR TITLE
compose: Correct DM icon alignment in picker.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1788,6 +1788,10 @@ textarea.new_message_textarea {
 
         .channel-privacy-type-icon {
             grid-area: privacy-icon;
+            /* Maintain correct vertical alignment on
+               DM picker, which does not participate in
+               the subgrid above used for channel icons. */
+            align-self: center;
 
             .zulip-icon {
                 color: var(--privacy-icon-color-original);


### PR DESCRIPTION
This corrects a regression in the DM icon in the compose box DM picker that was likely introduced by 8366b3d66884e0fe38d592af3ec8a5d44eff9afc.

Fixes: [#issues > compose DM picker icon alignment](https://chat.zulip.org/#narrow/channel/9-issues/topic/compose.20DM.20picker.20icon.20alignment/with/2478320)

**Screenshots and screen captures:**

| Before | After (no change on channel picker) |
| --- | --- |
| <img width="1640" height="342" alt="dm-icon-before" src="https://github.com/user-attachments/assets/f5d2302e-7ce7-4e55-9837-aa3b7b0c2f66" /> | <img width="1640" height="342" alt="dm-icon-after" src="https://github.com/user-attachments/assets/00947521-704b-4978-adc4-9e3ede5308c1" /> |
| <img width="1640" height="342" alt="channel-icon-before" src="https://github.com/user-attachments/assets/d7e56edd-2bde-4e92-85a1-15a8bee8b96a" /> | <img width="1640" height="342" alt="channel-icon-after--no-change" src="https://github.com/user-attachments/assets/cdb96fc1-84c9-4806-8038-6ea83fba1f16" /> | 



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
