### PR TITLE
stream_data: Rename subscribed_stream_names for clarity.

### DIFF
--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -267,13 +267,12 @@ function get_channel_suggestions(
     assert(last.operator === "channel" || last.operator === "search" || last.operator === "");
 
     const query = last.operand;
-    let channels = stream_data.subscribed_streams();
-
-    channels = channels.filter((channel_name) => channel_matches_query(channel_name, query));
-
-    channels = typeahead_helper.sorter(query, channels, (x) => x);
-
-    return channels.map((channel_name) => {
+    const channel_names = stream_data.subscribed_stream_names();
+    let matching_channel_names = channel_names.filter((channel_name) =>
+        channel_matches_query(channel_name, query),
+    );
+    matching_channel_names = typeahead_helper.sorter(query, matching_channel_names, (x) => x);
+    return matching_channel_names.map((channel_name) => {
         const channel = stream_data.get_sub_by_name(channel_name);
         assert(channel !== undefined);
         const term: NarrowTerm = {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -382,7 +382,7 @@ export function unsubscribed_subs(): StreamSubscription[] {
     return [...stream_info.false_values()];
 }
 
-export function subscribed_streams(): string[] {
+export function subscribed_stream_names(): string[] {
     return subscribed_subs().map((sub) => sub.name);
 }
 
@@ -1381,7 +1381,7 @@ export function get_streams_for_move_messages_widget(): (dropdown_widget.Option 
 export let set_max_channel_width_css_variable = async (): Promise<void> => {
     // Return a promise to avoid blocking main thread.
     const promise = new Promise<void>((resolve) => {
-        const length = util.max_text_content_width([...subscribed_streams()]);
+        const length = util.max_text_content_width([...subscribed_stream_names()]);
         $(":root").css("--longest-subscribed-channel-name-width", `${length}px`);
         resolve();
     });

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -211,7 +211,7 @@ test("basics", () => {
     assert.equal(stream_data.get_sub("web_public_stream"), web_public_stream);
     assert.ok(stream_data.is_web_public(web_public_stream.stream_id));
 
-    assert.deepEqual(stream_data.subscribed_streams(), ["social", "test"]);
+    assert.deepEqual(stream_data.subscribed_stream_names(), ["social", "test"]);
     assert.deepEqual(stream_data.get_colors(), ["red", "yellow"]);
     assert.deepEqual(stream_data.subscribed_stream_ids(), [social.stream_id, test.stream_id]);
 


### PR DESCRIPTION
We generally use `stream` for the full stream object, or else maybe stream ids, so this name was confusing.