### PR TITLE
Optimize get_subscribers_of_target_user_subscriptions

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -92,9 +92,9 @@ from zerver.lib.user_groups import (
 )
 from zerver.lib.user_message import UserMessageLite, bulk_insert_ums
 from zerver.lib.users import (
+    bulk_get_subscribers_of_target_user_subscriptions,
     check_can_access_user,
     get_inaccessible_user_ids,
-    get_subscribers_of_target_user_subscriptions,
     get_user_ids_who_can_access_user,
     get_users_involved_in_dms_with_target_users,
     user_access_restricted_in_realm,
@@ -1707,8 +1707,8 @@ def get_recipients_for_user_creation_events(
         return recipients_for_user_creation_events
 
     users_involved_in_dms = get_users_involved_in_dms_with_target_users(guest_recipients, realm)
-    subscribers_of_guest_recipient_subscriptions = get_subscribers_of_target_user_subscriptions(
-        guest_recipients
+    subscribers_of_guest_recipient_subscriptions = (
+        bulk_get_subscribers_of_target_user_subscriptions(guest_recipients)
     )
 
     for recipient_user in guest_recipients:

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -97,8 +97,8 @@ from zerver.lib.user_groups import (
 )
 from zerver.lib.user_message import UserMessageLite, bulk_insert_ums
 from zerver.lib.users import (
+    bulk_get_subscribers_of_target_user_subscriptions,
     check_can_access_user,
-    get_subscribers_of_target_user_subscriptions,
     get_user_ids_who_can_access_user,
     user_access_restricted_in_realm,
 )
@@ -1795,12 +1795,12 @@ def get_recipients_for_user_creation_events(
     ).exists():
         return recipients_for_user_creation_events
 
-    # TODO: get_subscribers_of_target_user_subscriptions
+    # TODO: bulk_get_subscribers_of_target_user_subscriptions
     # executes 2 queries. While this is only for a new DirectMessageGroup,
     # it's still worth optimizing, also because it's called
     # in other code paths.
-    subscribers_of_guest_recipient_subscriptions = get_subscribers_of_target_user_subscriptions(
-        guest_recipients
+    subscribers_of_guest_recipient_subscriptions = (
+        bulk_get_subscribers_of_target_user_subscriptions(guest_recipients)
     )
 
     for recipient_user in guest_recipients:

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1795,10 +1795,6 @@ def get_recipients_for_user_creation_events(
     ).exists():
         return recipients_for_user_creation_events
 
-    # TODO: bulk_get_subscribers_of_target_user_subscriptions
-    # executes 2 queries. While this is only for a new DirectMessageGroup,
-    # it's still worth optimizing, also because it's called
-    # in other code paths.
     subscribers_of_guest_recipient_subscriptions = (
         bulk_get_subscribers_of_target_user_subscriptions(guest_recipients)
     )

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -59,7 +59,7 @@ from zerver.lib.user_groups import (
 )
 from zerver.lib.users import (
     all_users_accessible_by_everyone_in_realm,
-    get_subscribers_of_target_user_subscriptions,
+    bulk_get_subscribers_of_target_user_subscriptions,
     get_users_involved_in_dms_with_target_users,
 )
 from zerver.lib.utils import assert_is_not_none
@@ -860,8 +860,8 @@ def bulk_add_subscriptions(
 
     if not all_users_accessible_by_everyone_in_realm(realm):
         altered_users = list(altered_streams_dict.keys())
-        subscribers_of_altered_user_subscriptions = get_subscribers_of_target_user_subscriptions(
-            altered_users
+        subscribers_of_altered_user_subscriptions = (
+            bulk_get_subscribers_of_target_user_subscriptions(altered_users)
         )
 
     bulk_add_subs_to_db_with_logging(
@@ -1028,7 +1028,7 @@ def send_user_remove_events_on_removing_subscriptions(
         altered_stream_ids |= stream_ids
 
     users_involved_in_dms = get_users_involved_in_dms_with_target_users(altered_users, realm)
-    subscribers_of_altered_user_subscriptions = get_subscribers_of_target_user_subscriptions(
+    subscribers_of_altered_user_subscriptions = bulk_get_subscribers_of_target_user_subscriptions(
         altered_users
     )
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -59,7 +59,7 @@ from zerver.lib.user_groups import (
 )
 from zerver.lib.users import (
     all_users_accessible_by_everyone_in_realm,
-    get_subscribers_of_target_user_subscriptions,
+    bulk_get_subscribers_of_target_user_subscriptions,
 )
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
@@ -852,8 +852,8 @@ def bulk_add_subscriptions(
 
     if not all_users_accessible_by_everyone_in_realm(realm):
         altered_users = list(altered_streams_dict.keys())
-        subscribers_of_altered_user_subscriptions = get_subscribers_of_target_user_subscriptions(
-            altered_users
+        subscribers_of_altered_user_subscriptions = (
+            bulk_get_subscribers_of_target_user_subscriptions(altered_users)
         )
 
     bulk_add_subs_to_db_with_logging(
@@ -1019,7 +1019,7 @@ def send_user_remove_events_on_removing_subscriptions(
     for stream_ids in altered_user_dict.values():
         altered_stream_ids |= stream_ids
 
-    subscribers_of_altered_user_subscriptions = get_subscribers_of_target_user_subscriptions(
+    subscribers_of_altered_user_subscriptions = bulk_get_subscribers_of_target_user_subscriptions(
         altered_users
     )
 

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -386,8 +386,8 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
     non_guest_user_ids = active_non_guest_user_ids(realm.id)
     users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users([user_profile], realm)
 
-    # This code path is parallel to
-    # bulk_get_subscribers_of_target_user_subscriptions, but can't reuse it
+    # This code path is similar to
+    # get_subscribers_of_target_user_subscriptions, but can't reuse it
     # because we need to process stream and direct_message_group
     # subscriptions separately.
     deactivated_user_subs = Subscription.objects.filter(

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -387,7 +387,7 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
     users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users([user_profile], realm)
 
     # This code path is parallel to
-    # get_subscribers_of_target_user_subscriptions, but can't reuse it
+    # bulk_get_subscribers_of_target_user_subscriptions, but can't reuse it
     # because we need to process stream and direct_message_group
     # subscriptions separately.
     deactivated_user_subs = Subscription.objects.filter(

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -385,7 +385,7 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
     non_guest_user_ids = active_non_guest_user_ids(realm.id)
 
     # This code path is parallel to
-    # get_subscribers_of_target_user_subscriptions, but can't reuse it
+    # bulk_get_subscribers_of_target_user_subscriptions, but can't reuse it
     # because we need to process stream and direct_message_group
     # subscriptions separately.
     deactivated_user_subs = Subscription.objects.filter(

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -384,8 +384,8 @@ def send_events_for_user_deactivation(user_profile: UserProfile) -> None:
 
     non_guest_user_ids = active_non_guest_user_ids(realm.id)
 
-    # This code path is parallel to
-    # bulk_get_subscribers_of_target_user_subscriptions, but can't reuse it
+    # This code path is similar to
+    # get_subscribers_of_target_user_subscriptions, but can't reuse it
     # because we need to process stream and direct_message_group
     # subscriptions separately.
     deactivated_user_subs = Subscription.objects.filter(

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -823,7 +823,9 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 
     active_non_guest_user_ids_in_realm = active_non_guest_user_ids(realm.id)
 
-    users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions([target_user])
+    users_sharing_any_subscription = bulk_get_subscribers_of_target_user_subscriptions(
+        [target_user]
+    )
     users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users([target_user], realm)
 
     user_ids_who_can_access_target_user = (
@@ -835,7 +837,7 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
     return list(user_ids_who_can_access_target_user)
 
 
-def get_subscribers_of_target_user_subscriptions(
+def bulk_get_subscribers_of_target_user_subscriptions(
     target_users: list[UserProfile], include_deactivated_users_for_dm_groups: bool = False
 ) -> dict[int, set[int]]:
     target_user_ids = [user.id for user in target_users]
@@ -1017,8 +1019,10 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
 def get_accessible_user_ids(
     realm: Realm, user_profile: UserProfile, include_deactivated_users: bool = False
 ) -> list[int]:
-    subscribers_dict_of_target_user_subscriptions = get_subscribers_of_target_user_subscriptions(
-        [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
+    subscribers_dict_of_target_user_subscriptions = (
+        bulk_get_subscribers_of_target_user_subscriptions(
+            [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
+        )
     )
     users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users(
         [user_profile], realm, include_deactivated_users=include_deactivated_users

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -834,14 +834,10 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 
     active_non_guest_user_ids_in_realm = active_non_guest_user_ids(realm.id)
 
-    users_sharing_any_subscription = bulk_get_subscribers_of_target_user_subscriptions(
-        [target_user]
-    )
+    users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions(target_user)
 
     user_ids_who_can_access_target_user = (
-        {target_user.id}
-        | set(active_non_guest_user_ids_in_realm)
-        | users_sharing_any_subscription[target_user.id]
+        {target_user.id} | set(active_non_guest_user_ids_in_realm) | users_sharing_any_subscription
     )
     return list(user_ids_who_can_access_target_user)
 
@@ -849,7 +845,11 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 def bulk_get_subscribers_of_target_user_subscriptions(
     target_users: list[UserProfile], include_deactivated_users_for_dm_groups: bool = False
 ) -> dict[int, set[int]]:
-    """Get all users involved in stream and direct message groups with target_users."""
+    """Get all users involved in stream and direct message groups with target_users.
+
+    For a single target_user, use the more efficient
+    get_subscribers_of_target_user_subscriptions.
+    """
     target_user_ids = [user.id for user in target_users]
     target_user_subscriptions = (
         Subscription.objects.filter(
@@ -876,6 +876,8 @@ def bulk_get_subscribers_of_target_user_subscriptions(
         active=True,
     )
 
+    # This flag is currently dead code, but we keep it to be consistent
+    # with its equivalent get_subscribers_of_target_user_subscriptions.
     if include_deactivated_users_for_dm_groups:
         subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
             Q(recipient__type=Recipient.STREAM, is_user_active=True)
@@ -907,6 +909,33 @@ def bulk_get_subscribers_of_target_user_subscriptions(
             )
 
     return users_subbed_to_target_user_subscriptions_dict
+
+
+def get_subscribers_of_target_user_subscriptions(
+    target_user: UserProfile, include_deactivated_users_for_dm_groups: bool = False
+) -> set[int]:
+    target_user_subbed_recipient_ids = Subscription.objects.filter(
+        user_profile=target_user,
+        active=True,
+        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
+    ).values("recipient_id")
+
+    subs_in_target_user_subscriptions_query = Subscription.objects.filter(
+        recipient_id__in=target_user_subbed_recipient_ids,
+        active=True,
+    )
+
+    if include_deactivated_users_for_dm_groups:
+        subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
+            Q(recipient__type=Recipient.STREAM, is_user_active=True)
+            | Q(recipient__type=Recipient.DIRECT_MESSAGE_GROUP)
+        )
+    else:
+        subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
+            is_user_active=True,
+        )
+
+    return set(subs_in_target_user_subscriptions_query.values_list("user_profile_id", flat=True))
 
 
 def user_profile_to_user_row(user_profile: UserProfile) -> RawUserDict:
@@ -989,17 +1018,13 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
 def get_accessible_user_ids(
     user_profile: UserProfile, include_deactivated_users: bool = False
 ) -> set[int]:
-    subscribers_dict_of_target_user_subscriptions = (
-        bulk_get_subscribers_of_target_user_subscriptions(
-            [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
-        )
+    users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions(
+        user_profile, include_deactivated_users_for_dm_groups=include_deactivated_users
     )
 
     # This does not include bots, because either the caller
     # wants only human users or it handles bots separately.
-    accessible_user_ids = {user_profile.id} | subscribers_dict_of_target_user_subscriptions[
-        user_profile.id
-    ]
+    accessible_user_ids = {user_profile.id} | users_sharing_any_subscription
 
     return accessible_user_ids
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -823,15 +823,13 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 
     active_non_guest_user_ids_in_realm = active_non_guest_user_ids(realm.id)
 
-    users_sharing_any_subscription = bulk_get_subscribers_of_target_user_subscriptions(
-        [target_user]
-    )
+    users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions(target_user)
     users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users([target_user], realm)
 
     user_ids_who_can_access_target_user = (
         {target_user.id}
         | set(active_non_guest_user_ids_in_realm)
-        | users_sharing_any_subscription[target_user.id]
+        | users_sharing_any_subscription
         | users_involved_in_dms_dict[target_user.id]
     )
     return list(user_ids_who_can_access_target_user)
@@ -840,6 +838,9 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 def bulk_get_subscribers_of_target_user_subscriptions(
     target_users: list[UserProfile], include_deactivated_users_for_dm_groups: bool = False
 ) -> dict[int, set[int]]:
+    # For a single target_user, use
+    # get_subscribers_of_target_user_subscriptions
+    # as it's more efficient.
     target_user_ids = [user.id for user in target_users]
     target_user_subscriptions = (
         Subscription.objects.filter(
@@ -897,6 +898,33 @@ def bulk_get_subscribers_of_target_user_subscriptions(
             )
 
     return users_subbed_to_target_user_subscriptions_dict
+
+
+def get_subscribers_of_target_user_subscriptions(
+    target_user: UserProfile, include_deactivated_users_for_dm_groups: bool = False
+) -> set[int]:
+    target_user_subbed_recipient_ids = Subscription.objects.filter(
+        user_profile=target_user,
+        active=True,
+        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
+    ).values("recipient_id")
+
+    subs_in_target_user_subscriptions_query = Subscription.objects.filter(
+        recipient_id__in=target_user_subbed_recipient_ids,
+        active=True,
+    )
+
+    if include_deactivated_users_for_dm_groups:
+        subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
+            Q(recipient__type=Recipient.STREAM, is_user_active=True)
+            | Q(recipient__type=Recipient.DIRECT_MESSAGE_GROUP)
+        )
+    else:
+        subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
+            is_user_active=True,
+        )
+
+    return set(subs_in_target_user_subscriptions_query.values_list("user_profile_id", flat=True))
 
 
 def get_users_involved_in_dms_with_target_users(
@@ -1019,10 +1047,8 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
 def get_accessible_user_ids(
     realm: Realm, user_profile: UserProfile, include_deactivated_users: bool = False
 ) -> list[int]:
-    subscribers_dict_of_target_user_subscriptions = (
-        bulk_get_subscribers_of_target_user_subscriptions(
-            [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
-        )
+    users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions(
+        user_profile, include_deactivated_users_for_dm_groups=include_deactivated_users
     )
     users_involved_in_dms_dict = get_users_involved_in_dms_with_target_users(
         [user_profile], realm, include_deactivated_users=include_deactivated_users
@@ -1032,7 +1058,7 @@ def get_accessible_user_ids(
     # wants only human users or it handles bots separately.
     accessible_user_ids = (
         {user_profile.id}
-        | subscribers_dict_of_target_user_subscriptions[user_profile.id]
+        | users_sharing_any_subscription
         | users_involved_in_dms_dict[user_profile.id]
     )
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -4,7 +4,7 @@ import unicodedata
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from email.headerregistry import Address
-from operator import itemgetter
+from operator import attrgetter
 from typing import Any, TypedDict
 
 from django.conf import settings
@@ -849,16 +849,17 @@ def bulk_get_subscribers_of_target_user_subscriptions(
             recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
         )
         .order_by("user_profile_id")
-        .values("user_profile_id", "recipient_id")
+        .values_list("user_profile_id", "recipient_id", named=True)
     )
 
     target_users_subbed_recipient_ids = set()
     target_user_subscriptions_dict: dict[int, set[int]] = defaultdict(set)
 
-    for user_profile_id, sub_rows in itertools.groupby(
-        target_user_subscriptions, itemgetter("user_profile_id")
+    for user_profile_id, target_sub_rows in itertools.groupby(
+        target_user_subscriptions,
+        attrgetter("user_profile_id"),
     ):
-        recipient_ids = {row["recipient_id"] for row in sub_rows}
+        recipient_ids = {row.recipient_id for row in target_sub_rows}
         target_user_subscriptions_dict[user_profile_id] = recipient_ids
         target_users_subbed_recipient_ids |= recipient_ids
 
@@ -874,26 +875,24 @@ def bulk_get_subscribers_of_target_user_subscriptions(
         )
     else:
         subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
-            recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
             is_user_active=True,
         )
 
     subs_in_target_user_subscriptions = subs_in_target_user_subscriptions_query.order_by(
         "recipient_id"
-    ).values("user_profile_id", "recipient_id")
+    ).values_list("user_profile_id", "recipient_id", named=True)
 
     subscribers_dict_by_recipient_ids: dict[int, set[int]] = defaultdict(set)
     for recipient_id, sub_rows in itertools.groupby(
-        subs_in_target_user_subscriptions, itemgetter("recipient_id")
+        subs_in_target_user_subscriptions, attrgetter("recipient_id")
     ):
-        user_ids = {row["user_profile_id"] for row in sub_rows}
+        user_ids = {row.user_profile_id for row in sub_rows}
         subscribers_dict_by_recipient_ids[recipient_id] = user_ids
 
     users_subbed_to_target_user_subscriptions_dict: dict[int, set[int]] = defaultdict(set)
-    for user_id in target_user_ids:
-        target_user_subbed_recipients = target_user_subscriptions_dict[user_id]
+    for target_user_id, target_user_subbed_recipients in target_user_subscriptions_dict.items():
         for recipient_id in target_user_subbed_recipients:
-            users_subbed_to_target_user_subscriptions_dict[user_id] |= (
+            users_subbed_to_target_user_subscriptions_dict[target_user_id] |= (
                 subscribers_dict_by_recipient_ids[recipient_id]
             )
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -834,7 +834,9 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
 
     active_non_guest_user_ids_in_realm = active_non_guest_user_ids(realm.id)
 
-    users_sharing_any_subscription = get_subscribers_of_target_user_subscriptions([target_user])
+    users_sharing_any_subscription = bulk_get_subscribers_of_target_user_subscriptions(
+        [target_user]
+    )
 
     user_ids_who_can_access_target_user = (
         {target_user.id}
@@ -844,7 +846,7 @@ def get_user_ids_who_can_access_user(target_user: UserProfile) -> list[int]:
     return list(user_ids_who_can_access_target_user)
 
 
-def get_subscribers_of_target_user_subscriptions(
+def bulk_get_subscribers_of_target_user_subscriptions(
     target_users: list[UserProfile], include_deactivated_users_for_dm_groups: bool = False
 ) -> dict[int, set[int]]:
     """Get all users involved in stream and direct message groups with target_users."""
@@ -987,8 +989,10 @@ def get_data_for_inaccessible_user(realm: Realm, user_id: int) -> APIUserDict:
 def get_accessible_user_ids(
     user_profile: UserProfile, include_deactivated_users: bool = False
 ) -> set[int]:
-    subscribers_dict_of_target_user_subscriptions = get_subscribers_of_target_user_subscriptions(
-        [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
+    subscribers_dict_of_target_user_subscriptions = (
+        bulk_get_subscribers_of_target_user_subscriptions(
+            [user_profile], include_deactivated_users_for_dm_groups=include_deactivated_users
+        )
     )
 
     # This does not include bots, because either the caller

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -4,7 +4,7 @@ import unicodedata
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from email.headerregistry import Address
-from operator import itemgetter
+from operator import attrgetter
 from typing import Any, TypedDict
 
 from django.conf import settings
@@ -858,16 +858,17 @@ def bulk_get_subscribers_of_target_user_subscriptions(
             recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
         )
         .order_by("user_profile_id")
-        .values("user_profile_id", "recipient_id")
+        .values_list("user_profile_id", "recipient_id", named=True)
     )
 
     target_users_subbed_recipient_ids = set()
     target_user_subscriptions_dict: dict[int, set[int]] = defaultdict(set)
 
-    for user_profile_id, sub_rows in itertools.groupby(
-        target_user_subscriptions, itemgetter("user_profile_id")
+    for user_profile_id, target_sub_rows in itertools.groupby(
+        target_user_subscriptions,
+        attrgetter("user_profile_id"),
     ):
-        recipient_ids = {row["recipient_id"] for row in sub_rows}
+        recipient_ids = {row.recipient_id for row in target_sub_rows}
         target_user_subscriptions_dict[user_profile_id] = recipient_ids
         target_users_subbed_recipient_ids |= recipient_ids
 
@@ -885,26 +886,24 @@ def bulk_get_subscribers_of_target_user_subscriptions(
         )
     else:
         subs_in_target_user_subscriptions_query = subs_in_target_user_subscriptions_query.filter(
-            recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
             is_user_active=True,
         )
 
     subs_in_target_user_subscriptions = subs_in_target_user_subscriptions_query.order_by(
         "recipient_id"
-    ).values("user_profile_id", "recipient_id")
+    ).values_list("user_profile_id", "recipient_id", named=True)
 
     subscribers_dict_by_recipient_ids: dict[int, set[int]] = defaultdict(set)
     for recipient_id, sub_rows in itertools.groupby(
-        subs_in_target_user_subscriptions, itemgetter("recipient_id")
+        subs_in_target_user_subscriptions, attrgetter("recipient_id")
     ):
-        user_ids = {row["user_profile_id"] for row in sub_rows}
+        user_ids = {row.user_profile_id for row in sub_rows}
         subscribers_dict_by_recipient_ids[recipient_id] = user_ids
 
     users_subbed_to_target_user_subscriptions_dict: dict[int, set[int]] = defaultdict(set)
-    for user_id in target_user_ids:
-        target_user_subbed_recipients = target_user_subscriptions_dict[user_id]
+    for target_user_id, target_user_subbed_recipients in target_user_subscriptions_dict.items():
         for recipient_id in target_user_subbed_recipients:
-            users_subbed_to_target_user_subscriptions_dict[user_id] |= (
+            users_subbed_to_target_user_subscriptions_dict[target_user_id] |= (
                 subscribers_dict_by_recipient_ids[recipient_id]
             )
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -63,6 +63,7 @@ from zerver.lib.users import (
     Account,
     access_user_by_id,
     access_user_by_id_including_cross_realm,
+    bulk_get_subscribers_of_target_user_subscriptions,
     check_can_access_user,
     get_accounts_for_email,
     get_cross_realm_dicts,
@@ -3590,7 +3591,7 @@ class GetProfileTest(ZulipTestCase):
         self.set_up_db_for_testing_user_access()
 
         self.login("polonius")
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(8):
             result = orjson.loads(self.client_get("/json/users").content)
         accessible_users = result["members"]
         # The user can access 3 bot users and 7 human users.
@@ -3645,7 +3646,7 @@ class GetProfileTest(ZulipTestCase):
         accessible_user_ids_subset = [hamlet.id, iago.id, aaron.id, zoe.id, webhook_bot.id]
         inaccessible_user_ids_subset = [cordelia.id, desdemona.id]
         user_ids_to_fetch = accessible_user_ids_subset + inaccessible_user_ids_subset
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(8):
             result = orjson.loads(
                 self.client_get(
                     "/json/users", {"user_ids": orjson.dumps(user_ids_to_fetch).decode()}
@@ -3714,7 +3715,7 @@ class GetProfileTest(ZulipTestCase):
             result = self.client_get(f"/json/users/{user.id}")
             self.assert_json_error(result, "Insufficient permission")
 
-        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(9):
+        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(8):
             result = self.client_get("/json/users")
         self.assert_json_success(result)
 
@@ -3846,6 +3847,41 @@ class GetProfileTest(ZulipTestCase):
         )
         self.assertIn(othello.id, users_involved_with_deactivated[hamlet.id])
         self.assertIn(cordelia.id, users_involved_with_deactivated[hamlet.id])
+
+    def test_bulk_get_subscribers_of_target_user_subscriptions(
+        self,
+    ) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        aaron = self.example_user("aaron")
+        othello = self.example_user("othello")
+
+        self.send_group_direct_message(hamlet, [othello, cordelia])
+
+        # othello is deactivated while subscribed to a DM group with
+        # hamlet.
+        do_deactivate_user(othello, acting_user=None)
+        # aaron is deactivated while subscribed to a stream
+        # with hamlet.
+        do_deactivate_user(aaron, acting_user=None)
+
+        subscribers_dict = bulk_get_subscribers_of_target_user_subscriptions([hamlet])
+        self.assertIn(cordelia.id, subscribers_dict[hamlet.id])
+
+        # By default, we exclude all deactivated subscribers.
+        self.assertNotIn(othello.id, subscribers_dict[hamlet.id])
+        self.assertNotIn(aaron.id, subscribers_dict[hamlet.id])
+
+        subscribers_dict_with_deactivated = bulk_get_subscribers_of_target_user_subscriptions(
+            [hamlet], include_deactivated_users_for_dm_groups=True
+        )
+        self.assertIn(cordelia.id, subscribers_dict_with_deactivated[hamlet.id])
+
+        # othello is now included because the flag is scoped to DM groups.
+        self.assertIn(othello.id, subscribers_dict_with_deactivated[hamlet.id])
+        # aaron is still excluded; deactivated stream subscribers
+        # are always excluded.
+        self.assertNotIn(aaron.id, subscribers_dict_with_deactivated[hamlet.id])
 
     def test_get_users_for_spectators(self) -> None:
         # Checks that spectators can fetch users data.

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -64,6 +64,7 @@ from zerver.lib.users import (
     Account,
     access_user_by_id,
     access_user_by_id_including_cross_realm,
+    bulk_get_subscribers_of_target_user_subscriptions,
     check_can_access_user,
     get_accessible_user_ids,
     get_accounts_for_email,
@@ -3591,7 +3592,7 @@ class GetProfileTest(ZulipTestCase):
         self.set_up_db_for_testing_user_access()
 
         self.login("polonius")
-        with self.assert_database_query_count(7):
+        with self.assert_database_query_count(6):
             result = orjson.loads(self.client_get("/json/users").content)
         accessible_users = result["members"]
         # The user can access 3 bot users and 7 human users.
@@ -3684,7 +3685,7 @@ class GetProfileTest(ZulipTestCase):
         accessible_user_ids_subset = [hamlet.id, iago.id, aaron.id, zoe.id, webhook_bot.id]
         inaccessible_user_ids_subset = [cordelia.id, desdemona.id]
         user_ids_to_fetch = accessible_user_ids_subset + inaccessible_user_ids_subset
-        with self.assert_database_query_count(7):
+        with self.assert_database_query_count(6):
             result = orjson.loads(
                 self.client_get(
                     "/json/users", {"user_ids": orjson.dumps(user_ids_to_fetch).decode()}
@@ -3753,7 +3754,7 @@ class GetProfileTest(ZulipTestCase):
             result = self.client_get(f"/json/users/{user.id}")
             self.assert_json_error(result, "Insufficient permission")
 
-        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(7):
+        with self.settings(PARTIAL_USERS=True), self.assert_database_query_count(6):
             result = self.client_get("/json/users")
         self.assert_json_success(result)
 
@@ -3848,6 +3849,81 @@ class GetProfileTest(ZulipTestCase):
         # already have very limited access to users.
         hamlet = self.example_user("hamlet")
         self.assertTrue(check_can_access_user(hamlet, None))
+
+    def test_bulk_get_subscribers_of_target_user_subscriptions(self) -> None:
+        hamlet = self.example_user("hamlet")
+        aaron = self.example_user("aaron")
+        desdemona = self.example_user("desdemona")
+        iago = self.example_user("iago")
+        prospero = self.example_user("prospero")
+        shiva = self.example_user("shiva")
+        zoe = self.example_user("ZOE")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        polonius = self.example_user("polonius")
+        imported_user = self.example_user("imported_user")
+
+        # Unsubscribe cordelia and polonius from their
+        # ONLY stream subscription, so we can be sure
+        # they are included/excluded only because of DM interactions.
+        self.unsubscribe(cordelia, "Verona")
+        self.unsubscribe(polonius, "Verona")
+
+        self.send_group_direct_message(hamlet, [cordelia, polonius, othello])
+        self.send_personal_message(aaron, cordelia)
+
+        do_deactivate_user(cordelia, acting_user=None)
+        do_deactivate_user(zoe, acting_user=None)
+
+        subscribers_dict = bulk_get_subscribers_of_target_user_subscriptions([hamlet, aaron])
+
+        # polonius shares a DirectMessage group with hamlet.
+        # The rest share a stream with hamlet.
+        hamlet_subscribers = {
+            polonius.id,
+            aaron.id,
+            hamlet.id,
+            othello.id,
+            desdemona.id,
+            iago.id,
+            prospero.id,
+            shiva.id,
+            imported_user.id,
+        }
+
+        # polonius does NOT share any subscription with aaron.
+        # The rest share a stream with aaron.
+        aaron_subscribers = {
+            aaron.id,
+            hamlet.id,
+            othello.id,
+            desdemona.id,
+            iago.id,
+            prospero.id,
+            shiva.id,
+        }
+
+        # By default, all deactivated subscribers, cordelia and zoe,
+        # are excluded.
+
+        self.assertEqual(hamlet_subscribers, subscribers_dict[hamlet.id])
+        self.assertEqual(aaron_subscribers, subscribers_dict[aaron.id])
+
+        # We use the flag to also include deactivated subscribers
+        # who share a DirectMessage (1:1 or group) subscription.
+        subscribers_dict = bulk_get_subscribers_of_target_user_subscriptions(
+            [hamlet, aaron], include_deactivated_users_for_dm_groups=True
+        )
+
+        # Same subscribers as above BUT with cordelia,
+        # who shares a DirectMessage with hamlet and aaron,
+        # now included, since the flag is scoped to DM interaction.
+        # Deactivated stream subscribers (zoe) are still excluded.
+        hamlet_subscribers.add(cordelia.id)
+        aaron_subscribers.add(cordelia.id)
+
+        self.assertEqual(hamlet_subscribers, subscribers_dict[hamlet.id])
+        self.assertEqual(aaron_subscribers, subscribers_dict[aaron.id])
 
     def test_get_users_for_spectators(self) -> None:
         # Checks that spectators can fetch users data.


### PR DESCRIPTION
## Overview
`get_user_ids_who_can_access_user` and `get_accessible_user_ids`, the hot path for this function, only need the subscribers of a single user's subscriptions, but reached that through the bulk `get_subscribers_of_target_user_subscriptions` which pays for work that is pointless for one user: extra query and very expensive Python-side mapping to construct the final result.

## Changes
Rename `get_subscribers_of_target_user_subscriptions` to `bulk_get_subscribers_of_target_user_subscriptions` to explicity state its bulk nature.

Add a dedicated `get_subscribers_of_target_user_subscriptions` that takes a single `UserProfile` and feeds the target's subscribed `recipient_ids` into the subscribers query as a subquery, so the database resolves everything in one round trip. This eliminates all intermediate expensive Python processing and mappers, since all fetched subscribers already belong to that single target_user.

## Testing execution time
### `get_subscribers_of_target_user_subscriptions`

Takes a single target_user. 
Tested in a realm with **4k** users using 

**Command:** `%timeit -n 50 -r 10 function()`:

#### Results:
- **main**:  `bulk_get_subscribers_of_target_user_subscriptions([target_user])` ->  **111 ms**
- **PR**:  `get_subscribers_of_target_user_subscriptions(target_user)` ->   **37 ms**

PR is  ~ **66.7% faster**

### `bulk_get_subscribers_of_target_user_subscriptions`

Tested in a realm with **4k** users and 214,000+ `Subscription`s, passing **100** target users.

**Command:** `%timeit -n 50 -r 5 function()`:

 #### Results:
- **main**:  `bulk_get_subscribers_of_target_user_subscriptions(target_users)` ->  **924 ms**
- **PR**:  `bulk_get_subscribers_of_target_user_subscriptions(target_users)` ->   **811 ms**

PR is **12%** faster.

### Faster alternative for `bulk_get_subscribers_of_target_user_subscriptions` with a caveat

I rewrote the bulk function to the following:

```python
def experimental_bulk_get_subscribers_of_target_user_subscriptions(
    target_users: list[UserProfile],
) -> dict[int, set[int]]:
    target_user_ids = {user.id for user in target_users}
    target_user_recipient_ids = Subscription.objects.filter(
        user_profile__in=target_user_ids,
        active=True,
        recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
    ).values("recipient_id")
    subs_in_target_user_subscriptions = (
        Subscription.objects.filter(
            recipient_id__in=target_user_recipient_ids,
            active=True,
            is_user_active=True,
        )
        .order_by("recipient_id")
        .values_list("user_profile_id", "recipient_id")
    )

    users_subbed_to_target_user_subscriptions_dict: dict[int, set[int]] = defaultdict(set)
    # Group by recipient_id.
    for recipient_id, sub_rows in itertools.groupby(
        subs_in_target_user_subscriptions, itemgetter(1)
    ):
        user_ids = {row[0] for row in sub_rows}
        for target_user_id in (target_user_ids & user_ids):
            users_subbed_to_target_user_subscriptions_dict[target_user_id] |= user_ids

    return users_subbed_to_target_user_subscriptions_dict
```

It executes only 1 query (as opposed to 2), faster (643 ms vs 811ms), and uses less memory. **However**, It's logically not identical to **main** (PR preserves the exact logic of **main**).

In main, `is_user_active` filter is applied only to the target subscribers (in 2nd queryset), so we still fetch the subscribers for **inactive** `target_users`. But this proposed version applies `is_user_active` to all rows so **inactive** `target_users` are **filtered out**! This not wrong or right but  depends on the behavior we want, if we are sure that callers only pass **active** `target_users` **OR** if we don't actually care about subscribers for **inactive** `target_users` then we should proceed with this further optimized variant, it's worth it. 