### PR TITLE
openapi: Improve description for default_group_name.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -685,9 +685,9 @@ group DM conversations.
 
 **Feature level 427**
 
-* [`POST /register`](/api/register-queue): `stream_creator_or_nobody`
+* [`POST /register`](/api/register-queue): `"stream_creator_or_nobody"`
   value for `default_group_name` field in `server_supported_permission_settings`
-  object is renamed to `channel_creator`.
+  object is renamed to `"channel_creator"`.
 
 **Feature level 426**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -29767,7 +29767,11 @@ components:
           description: |
             Name of the default system group for the setting.
 
-            For some channel settings, this can also be `channel_creator`.
+            For some group settings, this can be `"group_creator"`. In that
+            case, the default for the setting is an anonymous group whose
+            only member is the group's creator.
+
+            For some channel settings, this can be `"channel_creator"`.
             In that case:
 
             - If the channel's [`creator_id`][channel-response] is not `null`, default for the
@@ -29777,7 +29781,7 @@ components:
               is `role:nobody` system group.
 
             **Changes**: In Zulip 12.0 (feature level 427), renamed
-            `stream_creator_or_nobody` value to `channel_creator`.
+            `"stream_creator_or_nobody"` value to `"channel_creator"`.
 
             [channel-response]: /api/get-stream-by-id#response
         default_for_system_groups:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -26171,12 +26171,9 @@ paths:
 
                                 A `null` value means the user group has no recorded creator, which is often
                                 because the group predates the metadata being tracked starting in Zulip 8.0,
-                                or because it was created via a data import tool
-                                or [management command][management-commands].
+                                or because it was created via a data import tool.
 
                                 **Changes**: New in Zulip 10.0 (feature level 292).
-
-                                [management-commands]: https://zulip.readthedocs.io/en/latest/production/management-commands.html
                             members:
                               type: array
                               description: |
@@ -28219,10 +28216,9 @@ components:
 
             A `null` value means the user group has no recorded creator, which is often
             because the user group is very old, or because it was created via a data
-            import tool or [management command][management-commands].
+            import tool.
 
             **Changes**: New in Zulip 10.0 (feature level 292).
-            [management-commands]: https://zulip.readthedocs.io/en/latest/production/management-commands.html
         description:
           type: string
           description: |


### PR DESCRIPTION
This PR improves description of default_group_name field of `GroupPermissionSetting` to
specify that "group_creator" is also one of the supported values along with "channel_creator".

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->[#api documentation > server_supported_permission_settings docs inconsistency @ 💬](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/server_supported_permission_settings.20docs.20inconsistency/near/2478067)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1426" height="676" alt="image" src="https://github.com/user-attachments/assets/f4448a5d-3ada-4aaf-9182-9c67ce66a358" />

<img width="1336" height="310" alt="image" src="https://github.com/user-attachments/assets/3b3cc0c4-de00-4ecf-8ac1-e674729e29a7" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
