### PR TITLE
search: Match people suggestions against typed text, not resolved id.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1222,7 +1222,7 @@ export function build_person_matcher(query: string): (user: User) => boolean {
     const termlet_matchers = termlets.map((termlet) => build_termlet_matcher(termlet));
 
     return function (user: User): boolean {
-        if (String(user.user_id).startsWith(query)) {
+        if (String(user.user_id) === query) {
             return true;
         }
 

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -391,7 +391,11 @@ function make_people_getter(last: NarrowCanonicalTermSuggestion): () => User[] {
         if (last.operator === "is" && last.operand === "dm") {
             query = "";
         } else {
-            query = last.operand;
+            // We match people against the text the user actually typed
+            // (`raw_operand`), not `last.operand`, since that may have
+            // been canonicalized from a name to a user id (e.g. `dm:John`
+            // becomes `dm:50` when "John" is a unique full name).
+            query = last.raw_operand;
         }
 
         persons = people.get_people_for_search_bar(query);
@@ -407,7 +411,7 @@ function get_person_suggestions(
     autocomplete_operator: "dm" | "sender" | "dm-including" | "mentions",
 ): Suggestion[] {
     if (last.operator === "is" && last.operand === "dm") {
-        last = {operator: "dm", operand: "", negated: false};
+        last = {operator: "dm", operand: "", raw_operand: "", negated: false};
     }
 
     const valid = ["search", autocomplete_operator];
@@ -1093,12 +1097,14 @@ export let get_suggestions = function (
                 return {
                     operator: canonical_term.operator,
                     operand: String(canonical_term.operand),
+                    raw_operand: term.operand,
                     negated: canonical_term.negated,
                 };
             }
             return {
                 operator: filter_util.canonicalize_operator(term.operator),
                 operand: term.operand,
+                raw_operand: term.operand,
                 negated: term.negated,
             };
         },
@@ -1110,7 +1116,12 @@ export let get_suggestions = function (
 
     // `last` will always be a text term, not a pill term. If there is no
     // text, then `last` is this default empty term.
-    let last: NarrowCanonicalTermSuggestion = {operator: "", operand: "", negated: false};
+    let last: NarrowCanonicalTermSuggestion = {
+        operator: "",
+        operand: "",
+        raw_operand: "",
+        negated: false,
+    };
     if (text_search_terms.length > 0) {
         last = text_search_terms.at(-1)!;
     }
@@ -1131,6 +1142,7 @@ export let get_suggestions = function (
         last = {
             operator: person_op.operator,
             operand: person_op.operand + " " + last.operand,
+            raw_operand: person_op.raw_operand + " " + last.raw_operand,
             negated: person_op.negated,
         };
         text_search_terms.splice(-2);

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -31,6 +31,12 @@ export type NarrowTermSuggestion = {
 export type NarrowCanonicalTermSuggestion = {
     operator: NarrowCanonicalTerm["operator"];
     operand: string;
+    // The operand as the user actually typed it, before any
+    // canonicalization from a name to a user id (e.g. `dm:John`
+    // becomes `dm:50` when "John" is a unique full name). People
+    // suggestions match against this so that completing a unique name
+    // does not hide other name matches like "John Doe".
+    raw_operand: string;
     negated?: boolean | undefined;
 };
 

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -225,6 +225,14 @@ const linus = make_user({
     full_name: "Linus Torvalds",
 });
 
+// A user whose full name starts with digits, used to verify that
+// id matching is exact and does not collide with digit-leading names.
+const digit_named = make_user({
+    email: "digit-named@example.com",
+    user_id: 9001,
+    full_name: "304 Robot",
+});
+
 const emp401 = make_user({
     email: "emp401@example.com",
     user_id: 401,
@@ -882,6 +890,7 @@ run_test("dm_matches_search_string", () => {
     people.add_active_user(linus);
     people.add_active_user(noah);
     people.add_active_user(plain_noah);
+    people.add_active_user(digit_named);
 
     let result = people.dm_matches_search_string([ashton], "a");
     assert.ok(result);
@@ -904,6 +913,13 @@ run_test("dm_matches_search_string", () => {
 
     // Match with user id.
     result = people.dm_matches_search_string([linus], "304");
+    assert.ok(result);
+    result = people.dm_matches_search_string([linus], "30");
+    assert.ok(!result);
+
+    // A full name starting with digits is still matched by name, and
+    // is not affected by the (unrelated) id of any other user.
+    result = people.dm_matches_search_string([digit_named], "304");
     assert.ok(result);
 
     // Test filtering of names with diacritics. This should match

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -324,6 +324,39 @@ test("dm_suggestions", ({override}) => {
     assert.deepEqual(suggestions, expected);
 });
 
+test("dm_suggestions_for_exact_full_name", () => {
+    // When the typed text exactly matches a unique full name, it is
+    // resolved to that user's id internally. We must still suggest other
+    // users whose names match the typed text as a prefix, rather than
+    // collapsing to just the exactly-named user.
+    const john = make_user({
+        email: "john@zulip.com",
+        user_id: 200,
+        full_name: "John",
+    });
+    const john_doe = make_user({
+        email: "john-doe@zulip.com",
+        user_id: 201,
+        full_name: "John Doe",
+    });
+    people.add_active_user(john, "server_events");
+    people.add_active_user(john_doe, "server_events");
+
+    // A partial query matches both users by name prefix.
+    let suggestions = get_suggestions("dm:joh");
+    assert.deepEqual(suggestions, [`dm:${john.user_id}`, `dm:${john_doe.user_id}`]);
+
+    // Completing the unique full name "John" must still suggest "John Doe",
+    // not collapse to just "John".
+    suggestions = get_suggestions("dm:John");
+    assert.deepEqual(suggestions, [`dm:${john.user_id}`, `dm:${john_doe.user_id}`]);
+
+    // A multi-word continuation after the resolved name still matches by
+    // name, narrowing to "John Doe".
+    suggestions = get_suggestions("dm:John Do");
+    assert.deepEqual(suggestions, [`dm:${john_doe.user_id}`]);
+});
+
 test("group_suggestions", () => {
     // If there's an existing completed user pill right before
     // the input string, we suggest a user group as one of the


### PR DESCRIPTION
Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/Search.20typeahead.20matches.20get.20slashed.20sometimes/with/2479827

When typing a person operator like `dm:`, `get_suggestions` canonicalizes the term, resolving a unique full name to that user's id (e.g. `dm:John` becomes `dm:50`). `make_people_getter` then queried people by that id instead of the typed text, collapsing the dropdown to the single exactly-named user `dm:joh` listed both "John" and "John Doe", but `dm:John` listed only "John".

Now, we track the originally typed text on the term and use it for the people query, so suggestions match what the user typed.

The second commit deals with not comparing user id with startswith as highlighted in https://github.com/zulip/zulip/pull/39558#pullrequestreview-4536457790

<!-- Describe your pull request here.-->


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Before:
<img width="950" height="330" alt="before_dm_exact" src="https://github.com/user-attachments/assets/db3aaa26-b9a3-46d0-834e-74b4a6cbb11e" />

After:
<img width="950" height="330" alt="after_dm_exact" src="https://github.com/user-attachments/assets/942162d5-a72a-46ed-8c79-7a94b96d218a" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
