### PR TITLE
uploads: Show file sizes for uploaded attachments

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -1,6 +1,7 @@
 import assert from "minimalistic-assert";
 
 import {$t} from "./i18n.ts";
+import {bytes_to_size} from "./attachments_ui.ts";
 import * as thumbnail from "./thumbnail.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
@@ -110,6 +111,21 @@ export function postprocess_content(html: string): string {
                 "title",
                 ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`,
             );
+
+            // Add visible file size text for non-media attachments
+            const size_attribute = elt.getAttribute("data-file-size");
+            if (size_attribute) {
+                const size_bytes = Number(size_attribute);
+                if (!isNaN(size_bytes)) {
+                    let size_elt = elt.nextElementSibling;
+                    if (!size_elt || !size_elt.classList.contains("user-upload-file-size")) {
+                        size_elt = inertDocument.createElement("span");
+                        size_elt.classList.add("user-upload-file-size");
+                        size_elt.textContent = ` (${bytes_to_size(size_bytes)})`;
+                        elt.after(size_elt);
+                    }
+                }
+            }
         }
     }
 

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -11,6 +11,12 @@ const thumbnail = mock_esm("../src/thumbnail", {
     },
 });
 
+mock_esm("../src/attachments_ui", {
+    bytes_to_size(bytes) {
+        return `${bytes} B`;
+    },
+});
+
 const {postprocess_content} = zrequire("postprocess_content");
 const {initialize_user_settings} = zrequire("user_settings");
 
@@ -559,5 +565,26 @@ run_test("inline_images", ({override}) => {
             '<img class="inline-image" data-original-src="https://zulip.%20[Click%20to%20join%20video%20call](https://meeting.example.com/abcd1234)%20example.com/user_uploads/2/ab/abcd1234/image.png" src="https://zulip.%20[Click%20to%20join%20video%20call](https://meeting.example.com/abcd1234)%20example.com/user_uploads/2/ab/abcd1234/image.png">',
         ),
         "",
+    );
+});
+
+run_test("user_upload_file_size", () => {
+    // Basic test
+    assert.equal(
+        postprocess_content(
+            '<a href="/user_uploads/1/ff/test_file.txt" data-file-size="250880">file</a>',
+        ),
+        '<a href="/user_uploads/1/ff/test_file.txt" data-file-size="250880" target="_blank" rel="noopener noreferrer" title="translated: Download test_file.txt">file</a>' +
+            '<span class="user-upload-file-size"> (250880 B)</span>',
+    );
+
+    // Duplicate render protection test
+    assert.equal(
+        postprocess_content(
+            '<a href="/user_uploads/1/ff/test_file.txt" data-file-size="250880">file</a>' +
+                '<span class="user-upload-file-size"> (250880 B)</span>',
+        ),
+        '<a href="/user_uploads/1/ff/test_file.txt" data-file-size="250880" target="_blank" rel="noopener noreferrer" title="translated: Download test_file.txt">file</a>' +
+            '<span class="user-upload-file-size"> (250880 B)</span>',
     );
 });

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2030,6 +2030,20 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
         # Make changes to <a> tag attributes
         el.set("href", href)
 
+        if db_data:
+            path_id = href
+            if path_id.startswith("/user_uploads/"):
+                path_id = path_id.removeprefix("/user_uploads/")
+            elif path_id.startswith("user_uploads/"):
+                path_id = path_id.removeprefix("user_uploads/")
+            else:
+                path_id = None
+
+            if path_id is not None:
+                size = db_data.user_upload_previews.path_ids_to_sizes.get(path_id)
+                if size is not None:
+                    el.set("data-file-size", str(size))
+
         # Show link href if title is empty
         if not el.text or not el.text.strip():
             el.text = href

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -419,6 +419,7 @@ class MarkdownImageMetadata:
 class AttachmentData:
     audio_path_ids: set[str]
     image_metadata: dict[str, MarkdownImageMetadata]
+    path_ids_to_sizes: dict[str, int]
 
 
 def manifest_and_get_user_upload_previews(
@@ -434,6 +435,7 @@ def manifest_and_get_user_upload_previews(
         return AttachmentData(
             audio_path_ids=set(),
             image_metadata={},
+            path_ids_to_sizes={},
         )
 
     image_metadata: dict[str, MarkdownImageMetadata] = {}
@@ -488,9 +490,18 @@ def manifest_and_get_user_upload_previews(
         and bare_content_type(attachment.content_type) in AUDIO_INLINE_MIME_TYPES
     }
 
+    attachments = Attachment.objects.filter(
+        realm_id=realm_id, path_id__in=path_ids
+    ).values("path_id", "size")
+    path_ids_to_sizes = {
+        attachment["path_id"]: attachment["size"]
+        for attachment in attachments
+    }
+
     return AttachmentData(
         audio_path_ids=audio_path_ids,
         image_metadata=image_metadata,
+        path_ids_to_sizes=path_ids_to_sizes,
     )
 
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -70,7 +70,7 @@ from zerver.lib.tex import render_tex
 from zerver.lib.types import UserGroupMembersData
 from zerver.lib.upload import get_emoji_url, upload_message_attachment
 from zerver.lib.user_groups import UserGroupMembershipDetails
-from zerver.models import Message, NamedUserGroup, RealmEmoji, RealmFilter, UserMessage, UserProfile
+from zerver.models import Attachment, Message, NamedUserGroup, RealmEmoji, RealmFilter, UserMessage, UserProfile
 from zerver.models.clients import get_client
 from zerver.models.groups import SystemGroups
 from zerver.models.linkifiers import linkifiers_for_realm
@@ -734,6 +734,27 @@ class MarkdownLinkTest(ZulipTestCase):
         self.assertEqual(
             markdown_convert(msg, message_realm=realm, message=message).rendered_content,
             '<p><a href="http://zulip.testserver/not:relative">hello</a></p>',
+        )
+
+    def test_user_upload_file_size(self) -> None:
+        realm = get_realm("zulip")
+        sender = self.example_user("othello")
+        message = Message(sender=sender, sending_client=get_client("test"), realm=realm)
+
+        path_id = "1/ff/test_file.txt"
+        Attachment.objects.create(
+            file_name="test_file.txt",
+            path_id=path_id,
+            owner=sender,
+            realm=realm,
+            size=250880,
+            content_type="text/plain",
+        )
+
+        msg = f"[file](/user_uploads/{path_id})"
+        self.assertEqual(
+            markdown_convert(msg, message_realm=realm, message=message).rendered_content,
+            f'<p><a data-file-size="250880" href="/user_uploads/{path_id}">file</a></p>',
         )
 
     def test_inline_file(self) -> None:


### PR DESCRIPTION
Fixes #39533

## Summary

This change displays human-readable file sizes next to uploaded file attachments in message content, allowing users to understand attachment sizes before downloading them.

Before:
<img width="373" height="128" alt="image" src="https://github.com/user-attachments/assets/0bf42749-6ce5-4db2-a8c7-556ab3dcf8d3" />

```text
resume.pdf
```

After:
<img width="379" height="138" alt="image" src="https://github.com/user-attachments/assets/c1f988ef-2846-4479-b9d5-006658273029" />

```text
resume.pdf (120 KB)
```

## Implementation

### Backend

* Extended `AttachmentData` in `zerver/lib/thumbnail.py` to include a mapping of attachment path IDs to file sizes.
* Populated attachment size metadata while collecting upload preview data.
* Updated `LinkInlineProcessor` in `zerver/lib/markdown/__init__.py` to attach a `data-file-size` attribute to uploaded file links during markdown rendering.

Example rendered HTML:

```html
<a href="/user_uploads/1/ff/resume.pdf"
   data-file-size="122880">
   resume.pdf
</a>
```

### Frontend

* Updated `postprocess_content.ts` to read the `data-file-size` attribute and render a human-readable size next to uploaded file links.
* Added duplicate-render protection for rerendered message content.
* Kept inline image previews unchanged.

Rendered result:

```html
<a href="/user_uploads/1/ff/resume.pdf">resume.pdf</a>
<span class="user-upload-file-size"> (120 KB)</span>
```

## Testing

### Backend

Added markdown rendering coverage in:

* `zerver/tests/test_markdown.py`

Verified that uploaded file links receive the correct `data-file-size` attribute.

### Frontend

Added tests in:

* `web/tests/postprocess_content.test.cjs`

Verified:

* File size rendering for uploaded file links.
* Duplicate render protection.
* Existing upload-link behavior remains unchanged.

### Manual testing

* Uploaded a file in a development environment.
* Verified file sizes appear next to uploaded file links.
* Verified image previews remain unaffected.
* Verified file size text is displayed outside the clickable link.