### PR TITLE
[ai] stream_data: Fully reset stream state in clear_subscriptions.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -348,7 +348,7 @@ export function set_subscriber_count(stream_id: number, count: number): void {
     subscriber_counts.set(stream_id, count);
 }
 
-export function clear_subscriber_counts_for_tests(): void {
+export function clear_subscriber_counts(): void {
     subscriber_counts.clear();
 }
 

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -140,6 +140,10 @@ export function clear_subscriptions(for_tests = true): void {
     // it should only be used in tests.
     stream_info = new BinaryDict((sub) => sub.subscribed);
     sub_store.clear();
+    stream_ids_by_name.clear();
+    stream_ids_by_old_names.clear();
+    default_stream_ids.clear();
+    realm_web_public_stream_ids.clear();
     if (for_tests) {
         peer_data.clear_subscriber_counts_for_tests();
     }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -135,7 +135,7 @@ const stream_ids_by_old_names = new FoldDict<number>();
 const default_stream_ids = new Set<number>();
 const realm_web_public_stream_ids = new Set<number>();
 
-export function clear_subscriptions(for_tests = true): void {
+export function clear_subscriptions(): void {
     // This function is only used once at page load, and then
     // it should only be used in tests.
     stream_info = new BinaryDict((sub) => sub.subscribed);
@@ -144,12 +144,10 @@ export function clear_subscriptions(for_tests = true): void {
     stream_ids_by_old_names.clear();
     default_stream_ids.clear();
     realm_web_public_stream_ids.clear();
-    if (for_tests) {
-        peer_data.clear_subscriber_counts_for_tests();
-    }
+    peer_data.clear_subscriber_counts();
 }
 
-clear_subscriptions(false);
+clear_subscriptions();
 
 export function rename_sub(sub: StreamSubscription, new_name: string): void {
     const old_name = sub.name;


### PR DESCRIPTION
`clear_subscriptions` — the reset used at page load and between
frontend tests — only tore down `stream_info` and `sub_store`, leaving
four module-level indexes populated: `stream_ids_by_name`,
`stream_ids_by_old_names`, `default_stream_ids`, and
`realm_web_public_stream_ids`. That's harmless in production (the only
non-test caller runs once at load, when they're empty) but leaked
state between tests — most notably `stream_ids_by_old_names`, which
only `rename_sub` writes and nothing overwrites, so a channel renamed
in one test kept resolving under its old name in later ones.

The first commit clears all four so the reset is complete. The second
drops the now-pointless `for_tests` flag: it only skipped `peer_data`'s
subscriber-count reset at load, which is a no-op there anyway, and
renames that helper to `clear_subscriber_counts` since it's no longer
test-only.
