### PR TITLE
[ai] filter: Handle channel operands whose name starts with a digit.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -490,11 +490,11 @@ export class Filter {
                 }
                 operand = Filter.decodeOperand(parts.join(":"), operator);
 
-                // Check for user-entered channel name. If the name is valid,
-                // convert it to id.
+                // Resolve a user-entered channel name to its id. A purely
+                // numeric operand is taken to be a stream id already.
                 if (
                     (operator === "channel" || util.is_channel_synonym(operator)) &&
-                    Number.isNaN(Number.parseInt(operand, 10))
+                    !util.is_numeric_string(operand)
                 ) {
                     const sub = stream_data.get_sub(operand);
                     if (sub) {

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -1,6 +1,7 @@
 // See the Zulip URL spec at https://zulip.com/api/zulip-urls
 
 import {type NarrowTerm, narrow_operator_schema} from "./state_data.ts";
+import * as util from "./util.ts";
 
 export function get_hash_category(hash?: string): string {
     // given "#channels/subscribed", returns "channels"
@@ -46,7 +47,7 @@ export function is_same_server_message_link(url: string): boolean {
         get_hash_category(url) === "narrow" &&
         (get_hash_section(url) === "channel" || get_hash_section(url) === "dm") &&
         get_nth_hash_section(url, -2) === "near" &&
-        /^\d+$/.test(get_nth_hash_section(url, -1))
+        util.is_numeric_string(get_nth_hash_section(url, -1))
     );
 }
 

--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -35,6 +35,7 @@ import * as ui_report from "./ui_report.ts";
 import * as user_group_edit from "./user_group_edit.ts";
 import * as user_profile from "./user_profile.ts";
 import {user_settings} from "./user_settings.ts";
+import * as util from "./util.ts";
 
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
 // or locally: docs/subsystems/hashchange-system.md
@@ -87,7 +88,7 @@ function channels_overlay_state_from_hash(): {
     if (hash_section === "new") {
         return {right_panel: "new", left_side_tab: undefined};
     }
-    if (/^\d+$/.test(hash_section)) {
+    if (util.is_numeric_string(hash_section)) {
         return {right_panel: Number.parseInt(hash_section, 10), left_side_tab: undefined};
     }
     // validate_channels_settings_hash has already constrained

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -200,8 +200,15 @@ export function get_sub(stream_name: string): StreamSubscription | undefined {
 
 export function get_sub_by_id_string(stream_id_string: string): StreamSubscription | undefined {
     const stream_id = Number.parseInt(stream_id_string, 10);
-    const stream = stream_info.get(stream_id);
-    return stream;
+    // Only treat the operand as a stream id when it is exactly the
+    // canonical decimal form of that id. Otherwise `Number.parseInt`
+    // reads a digit-leading channel name like "7th floor" as the
+    // unrelated stream 7, so e.g. searching `channel:7th` would resolve
+    // to whatever channel happens to have id 7.
+    if (stream_id.toString() !== stream_id_string) {
+        return undefined;
+    }
+    return stream_info.get(stream_id);
 }
 
 export function get_valid_sub_by_id_string(stream_id_string: string): StreamSubscription {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -284,6 +284,10 @@ export function is_channels_synonym(text: string): boolean {
     return text === "streams";
 }
 
+export function is_numeric_string(text: string): boolean {
+    return /^\d+$/.test(text);
+}
+
 export function prefix_match({value, search_term}: {value: string; search_term: string}): boolean {
     return filter_by_word_prefix_match([value], search_term, (s) => s).length === 1;
 }
@@ -581,7 +585,7 @@ export function parse_youtube_start_time(url: string): number | undefined {
     }
 
     // t can be in seconds (e.g. 120) or in #h#m#s format (e.g. 1h2m30s)
-    if (/^\d+$/.test(t)) {
+    if (is_numeric_string(t)) {
         return Number.parseInt(t, 10);
     }
 

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1666,6 +1666,19 @@ test("parse", () => {
     ];
     _test();
 
+    // A digit-leading channel name resolves by name, not by reading
+    // its leading digits as a stream id.
+    make_sub("7th", 7000);
+    string = "channel:7th";
+    terms = [{operator: "channel", operand: "7000"}];
+    _test();
+
+    // A digit-leading operand with no matching channel is left as-is,
+    // not coerced into a stream id.
+    string = "channel:9th";
+    terms = [{operator: "channel", operand: "9th"}];
+    _test();
+
     string = `channel:${foo_stream_id} topic:bar yo`;
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -974,6 +974,30 @@ test("delete_sub", () => {
     stream_data.delete_sub(99999);
 });
 
+test("get_sub_by_id_string", () => {
+    const general = {
+        stream_id: 7,
+        name: "general",
+        subscribed: true,
+    };
+    stream_data.add_sub_for_tests(general);
+
+    // A canonical id string resolves to the stream.
+    assert.equal(stream_data.get_sub_by_id_string("7"), general);
+
+    // A digit-leading channel name must not be read as that id, so
+    // that e.g. searching `channel:7th` doesn't resolve to the
+    // unrelated stream 7.
+    assert.equal(stream_data.get_sub_by_id_string("7th"), undefined);
+    assert.equal(stream_data.get_sub_by_id_string("7th floor"), undefined);
+
+    // Other non-canonical forms don't resolve either.
+    assert.equal(stream_data.get_sub_by_id_string("07"), undefined);
+    assert.equal(stream_data.get_sub_by_id_string("7.0"), undefined);
+    assert.equal(stream_data.get_sub_by_id_string(""), undefined);
+    assert.equal(stream_data.get_sub_by_id_string("general"), undefined);
+});
+
 test("mark_archived", () => {
     const canada = {
         is_archived: false,


### PR DESCRIPTION
Typing a `channel:` operand whose name starts with a digit was
mishandled in two ways, both because the leading digits were read as a
stream id:

- `channel:7th` (where the real channel is `7th floor`) surfaced — and
  narrowed to — whichever channel happened to have stream id 7.
  `get_sub_by_id_string` resolved its operand with `Number.parseInt`,
  so `"7th" → 7`. It now requires the operand to be the canonical
  decimal form of an id, so a non-id string like `"7th"` no longer
  resolves to an unrelated channel; it's treated like any other string
  that isn't a real channel.

- A channel literally named something like `7th` couldn't be reached by
  typing its name, because `Filter.parse` skipped name → id resolution
  for any operand starting with a digit. It now only treats a purely
  numeric operand as an id, so a digit-leading name resolves like any
  other, while `channel:7` still means stream id 7.
