### PR TITLE
[ai] search: Offer multi-word matches for channel: and topic: operands.

### DIFF
--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -172,6 +172,41 @@ const incompatible_patterns: Record<SearchFilter, TermPattern[]> = {
 
 export type Suggestion = string;
 
+// Operators whose operand identifies a person. When the user types a
+// space inside one (e.g. `sender:Ted Smith`), the typeahead merges the
+// trailing `search:` token into the preceding operator so the multi-word
+// name can be matched.
+const PERSON_OPS: ReadonlySet<NarrowCanonicalOperator> = new Set([
+    "sender",
+    "dm",
+    "dm-including",
+    "mentions",
+]);
+
+// If `text_search_terms` ends in `<operator>:<word1> search:<word2>` where
+// `operator` is in `supported_ops`, return the combined `<operator>:<word1>
+// <word2>` term. The caller uses this to replace the two trailing terms
+// with the merged one, so the multi-word operand can be matched.
+function compute_multi_word_merged_term(
+    text_search_terms: NarrowCanonicalTermSuggestion[],
+    supported_ops: ReadonlySet<NarrowCanonicalOperator>,
+): NarrowCanonicalTermSuggestion | undefined {
+    if (text_search_terms.length < 2) {
+        return undefined;
+    }
+    const last = text_search_terms.at(-1)!;
+    const prev = text_search_terms.at(-2)!;
+    if (last.operator !== "search" || !supported_ops.has(prev.operator)) {
+        return undefined;
+    }
+    return {
+        operator: prev.operator,
+        operand: prev.operand + " " + last.operand,
+        raw_operand: prev.raw_operand + " " + last.raw_operand,
+        negated: prev.negated,
+    };
+}
+
 export let max_num_of_search_results = MAX_ITEMS;
 export function rewire_max_num_of_search_results(value: typeof max_num_of_search_results): void {
     max_num_of_search_results = value;
@@ -1151,25 +1186,13 @@ export let get_suggestions = function (
         last = text_search_terms.at(-1)!;
     }
 
-    const person_suggestion_ops = ["sender", "dm", "dm-including", "mentions"];
-
-    // Handle spaces in person name in new suggestions only. Checks if the last operator is 'search'
-    // and the second last operator in search_terms is one out of person_suggestion_ops.
-    // e.g for `sender:Ted sm`, initially last = {operator: 'search', operand: 'sm'....}
-    // and second last is {operator: 'sender', operand: 'Ted'....}. The search operator
-    // will be deleted and new last will become {operator:'sender', operand: 'Ted sm'....}.
-    if (
-        text_search_terms.length > 1 &&
-        last.operator === "search" &&
-        person_suggestion_ops.includes(text_search_terms.at(-2)!.operator)
-    ) {
-        const person_op = text_search_terms.at(-2)!;
-        last = {
-            operator: person_op.operator,
-            operand: person_op.operand + " " + last.operand,
-            raw_operand: person_op.raw_operand + " " + last.raw_operand,
-            negated: person_op.negated,
-        };
+    // Handle spaces inside the operand of a person operator. For e.g.
+    // `sender:Ted sm` (parsed as `sender:Ted` + `search:sm`), we merge
+    // the two trailing terms into a single `sender:"Ted sm"` term so
+    // the multi-word name can match users like "Ted Smith".
+    const merged_person_term = compute_multi_word_merged_term(text_search_terms, PERSON_OPS);
+    if (merged_person_term !== undefined) {
+        last = merged_person_term;
         text_search_terms.splice(-2);
         text_search_terms.push(last);
         all_search_terms = [...pill_search_terms, ...text_search_terms];

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -1142,6 +1142,65 @@ export function search_term_description_html(operand: string): string {
     return `search for ${Handlebars.Utils.escapeExpression(operand)}`;
 }
 
+// The canonical list of filterers that the search typeahead runs. The
+// list is factored into its own function so that a follow-up commit
+// can reuse it from a second code path (the channel multi-word
+// suggestion handler) without duplicating the list.
+function build_filterer_list(
+    last: NarrowCanonicalTermSuggestion,
+): ((last: NarrowCanonicalTermSuggestion, terms: NarrowCanonicalTerm[]) => Suggestion[])[] {
+    // only make one people_getter to avoid duplicate work
+    const people_getter = make_people_getter(last);
+
+    function get_people(
+        flavor: "dm" | "sender" | "dm-including" | "mentions",
+    ): (last: NarrowCanonicalTermSuggestion, base_terms: NarrowCanonicalTerm[]) => Suggestion[] {
+        return function (
+            last: NarrowCanonicalTermSuggestion,
+            base_terms: NarrowCanonicalTerm[],
+        ): Suggestion[] {
+            return get_person_suggestions(people_getter, last, base_terms, flavor);
+        };
+    }
+
+    // Remember to update the spectator list when changing this.
+    let filterers = [
+        // This should show before other `get_people` suggestions
+        // because both are valid suggestions for typing a user's
+        // name, and if there's already has a DM pill then the
+        // searching user probably is looking to make a group DM.
+        get_group_suggestions("dm"),
+        get_group_suggestions("dm-including"),
+        get_channels_filter_suggestions,
+        get_operator_suggestions,
+        get_is_filter_suggestions,
+        get_sent_by_me_suggestions,
+        get_channel_suggestions,
+        get_people("dm"),
+        get_people("sender"),
+        get_people("dm-including"),
+        get_people("mentions"),
+        get_topic_suggestions,
+        get_has_filter_suggestions,
+        get_date_suggestions,
+    ];
+
+    if (page_params.is_spectator) {
+        filterers = [
+            get_channels_filter_suggestions,
+            get_operator_suggestions,
+            get_is_filter_suggestions,
+            get_channel_suggestions,
+            get_people("sender"),
+            get_topic_suggestions,
+            get_has_filter_suggestions,
+            get_date_suggestions,
+        ];
+    }
+
+    return filterers;
+}
+
 export let get_suggestions = function (
     pill_search_terms: NarrowCanonicalTerm[],
     text_search_terms_non_canonical: NarrowTermSuggestion[],
@@ -1220,54 +1279,7 @@ export let get_suggestions = function (
         attacher.push(suggestion_line);
     }
 
-    // only make one people_getter to avoid duplicate work
-    const people_getter = make_people_getter(last);
-
-    function get_people(
-        flavor: "dm" | "sender" | "dm-including" | "mentions",
-    ): (last: NarrowCanonicalTermSuggestion, base_terms: NarrowCanonicalTerm[]) => Suggestion[] {
-        return function (
-            last: NarrowCanonicalTermSuggestion,
-            base_terms: NarrowCanonicalTerm[],
-        ): Suggestion[] {
-            return get_person_suggestions(people_getter, last, base_terms, flavor);
-        };
-    }
-
-    // Remember to update the spectator list when changing this.
-    let filterers = [
-        // This should show before other `get_people` suggestions
-        // because both are valid suggestions for typing a user's
-        // name, and if there's already has a DM pill then the
-        // searching user probably is looking to make a group DM.
-        get_group_suggestions("dm"),
-        get_group_suggestions("dm-including"),
-        get_channels_filter_suggestions,
-        get_operator_suggestions,
-        get_is_filter_suggestions,
-        get_sent_by_me_suggestions,
-        get_channel_suggestions,
-        get_people("dm"),
-        get_people("sender"),
-        get_people("dm-including"),
-        get_people("mentions"),
-        get_topic_suggestions,
-        get_has_filter_suggestions,
-        get_date_suggestions,
-    ];
-
-    if (page_params.is_spectator) {
-        filterers = [
-            get_channels_filter_suggestions,
-            get_operator_suggestions,
-            get_is_filter_suggestions,
-            get_channel_suggestions,
-            get_people("sender"),
-            get_topic_suggestions,
-            get_has_filter_suggestions,
-            get_date_suggestions,
-        ];
-    }
+    const filterers = build_filterer_list(last);
 
     const max_items = max_num_of_search_results;
 

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -313,7 +313,7 @@ function sorted_channel_name_matches(query: string): string[] {
     return typeahead_helper.sorter(query, unsorted, (x) => x);
 }
 
-function channel_name_suggestion(channel_name: string, negated: boolean): Suggestion {
+function channel_name_suggestion(channel_name: string, negated: boolean | undefined): Suggestion {
     const channel = stream_data.get_sub_by_name(channel_name);
     assert(channel !== undefined);
     return Filter.unparse([{operator: "channel", operand: channel.stream_id.toString(), negated}]);
@@ -332,23 +332,28 @@ function get_channel_suggestions(
 
     assert(last.operator === "channel" || last.operator === "search" || last.operator === "");
 
-    const query = last.operand;
-    const channel_names = stream_data.subscribed_stream_names();
-    let matching_channel_names = channel_names.filter((channel_name) =>
-        channel_matches_query(channel_name, query),
+    // `Filter.parse` may have resolved an exact channel name to its
+    // `stream_id`, so match both the resolved name (surfacing siblings,
+    // e.g. "channel:core" → "core team") and the operand as literally
+    // typed (keeping a digit-named "7th floor" reachable via
+    // "channel:7"). Name first, so a real sibling outranks a channel
+    // that merely starts with the operand's id digits.
+    const queries = [last.operand];
+    if (last.operator === "channel") {
+        const sub = stream_data.get_sub_by_id_string(last.operand);
+        if (sub !== undefined) {
+            queries.unshift(sub.name);
+        }
+    }
+    const matching_channel_names = new Set<string>();
+    for (const channel_query of queries) {
+        for (const channel_name of sorted_channel_name_matches(channel_query)) {
+            matching_channel_names.add(channel_name);
+        }
+    }
+    return [...matching_channel_names].map((channel_name) =>
+        channel_name_suggestion(channel_name, last.negated),
     );
-    matching_channel_names = typeahead_helper.sorter(query, matching_channel_names, (x) => x);
-    return matching_channel_names.map((channel_name) => {
-        const channel = stream_data.get_sub_by_name(channel_name);
-        assert(channel !== undefined);
-        const term: NarrowTerm = {
-            operator: "channel",
-            operand: channel.stream_id.toString(),
-            negated: last.negated,
-        };
-        const search_string = Filter.unparse([term]);
-        return search_string;
-    });
 }
 
 // Find subscribed channels whose name matches the multi-word `query`,

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -199,9 +199,22 @@ function compute_multi_word_merged_term(
     if (last.operator !== "search" || !supported_ops.has(prev.operator)) {
         return undefined;
     }
+    // For `channel:`, the operand reaching this function may already
+    // be a `stream_id` (resolved by an earlier search-bar step). Use
+    // the channel's name when building the multi-word query so that
+    // typing `channel:core t` (visually) matches the "core team"
+    // channel even though `prev.operand` is the resolved stream_id,
+    // not the typed name.
+    let prev_operand_for_match = prev.operand;
+    if (prev.operator === "channel") {
+        const sub = stream_data.get_sub_by_id_string(prev.operand);
+        if (sub !== undefined) {
+            prev_operand_for_match = sub.name;
+        }
+    }
     return {
         operator: prev.operator,
-        operand: prev.operand + " " + last.operand,
+        operand: prev_operand_for_match + " " + last.operand,
         raw_operand: prev.raw_operand + " " + last.raw_operand,
         negated: prev.negated,
     };
@@ -293,6 +306,19 @@ function compare_by_direct_message_group(
     };
 }
 
+function sorted_channel_name_matches(query: string): string[] {
+    const unsorted = stream_data
+        .subscribed_stream_names()
+        .filter((channel_name) => channel_matches_query(channel_name, query));
+    return typeahead_helper.sorter(query, unsorted, (x) => x);
+}
+
+function channel_name_suggestion(channel_name: string, negated: boolean): Suggestion {
+    const channel = stream_data.get_sub_by_name(channel_name);
+    assert(channel !== undefined);
+    return Filter.unparse([{operator: "channel", operand: channel.stream_id.toString(), negated}]);
+}
+
 function get_channel_suggestions(
     last: NarrowCanonicalTermSuggestion,
     terms: NarrowCanonicalTerm[],
@@ -323,6 +349,27 @@ function get_channel_suggestions(
         const search_string = Filter.unparse([term]);
         return search_string;
     });
+}
+
+// Find subscribed channels whose name matches the multi-word `query`,
+// and split them into "strong" (name starts with the full query,
+// case-insensitive) and "weak" (matches but is not a prefix).
+function get_channel_multi_word_matches(
+    query: string,
+    negated: boolean,
+): {strong: Suggestion[]; weak: Suggestion[]} {
+    const strong: Suggestion[] = [];
+    const weak: Suggestion[] = [];
+    const query_lower = query.toLowerCase();
+    for (const channel_name of sorted_channel_name_matches(query)) {
+        const suggestion = channel_name_suggestion(channel_name, negated);
+        if (channel_name.toLowerCase().startsWith(query_lower)) {
+            strong.push(suggestion);
+        } else {
+            weak.push(suggestion);
+        }
+    }
+    return {strong, weak};
 }
 
 function get_group_suggestions(
@@ -1126,15 +1173,16 @@ class Attacher {
         }
     }
 
-    attach_many(suggestions: Suggestion[]): void {
+    attach_many(suggestions: Suggestion[], base_override?: SuggestionLine): void {
+        const base = base_override ?? this.base;
         for (const suggestion of suggestions) {
             let suggestion_line;
-            if (this.base.length === 0) {
+            if (base.length === 0) {
                 suggestion_line = [suggestion];
             } else {
                 // When we add a user to a user group, we
                 // replace the last pill.
-                const last_base_term = this.base.at(-1)!;
+                const last_base_term = base.at(-1)!;
                 const last_base_string = last_base_term;
                 const new_search_string = suggestion;
                 if (
@@ -1142,9 +1190,9 @@ class Attacher {
                         new_search_string.startsWith("dm-including:")) &&
                     new_search_string.includes(last_base_string)
                 ) {
-                    suggestion_line = [...this.base.slice(0, -1), suggestion];
+                    suggestion_line = [...base.slice(0, -1), suggestion];
                 } else {
-                    suggestion_line = [...this.base, suggestion];
+                    suggestion_line = [...base, suggestion];
                 }
             }
             this.push(suggestion_line);
@@ -1227,6 +1275,171 @@ function build_filterer_list(
     return filterers;
 }
 
+// Resolve a `channel:<X>` term to canonical form. The operand can
+// arrive in two shapes:
+//   - Already canonical (a `stream_id` string, e.g. when the search
+//     bar auto-resolved a typed name in an earlier keystroke).
+//   - A typed channel name not yet resolved.
+// Returns undefined when neither form matches a real channel.
+function resolve_channel_term(
+    channel_term: NarrowCanonicalTermSuggestion,
+): NarrowCanonicalTerm | undefined {
+    assert(channel_term.operator === "channel");
+    if (stream_data.get_sub_by_id_string(channel_term.operand) !== undefined) {
+        return Filter.convert_suggestion_to_term(channel_term);
+    }
+    // Use the same name lookup as `Filter.parse` so this layer and the
+    // parse layer agree on which channel a typed name means.
+    const sub = stream_data.get_sub(channel_term.operand);
+    if (sub === undefined) {
+        return undefined;
+    }
+    return {
+        operator: "channel",
+        operand: sub.stream_id.toString(),
+        negated: channel_term.negated,
+    };
+}
+
+// Build a tiered suggestion list when the user types a space inside a
+// `channel:` operand (e.g. `channel:automated testing`). The 5-tier
+// ranking is:
+// 1. The first N "strong" multi-word channel matches (channels whose
+//    name starts with the full multi-word query). We only show max N
+//    of these in tier 1 so that tiers 2 and 3 stay near the top of
+//    the list.
+// 2. Completions that interpret the text after the space as the start
+//    of a new operator. Only shown when the channel before the space
+//    resolves to a real channel.
+//    (e.g. `channel:automated h` → `channel:automated has:link`).
+// 3. The user's input read as the channel before the space plus the
+//    text after as a free-text search (e.g. `channel:automated testing`
+//    becomes channel `automated` + text search for `testing`).
+// 4. Remaining strong multi-word channel matches.
+// 5. "Weak" multi-word matches (phrase-match the full query but
+//    don't start with it).
+
+// MAX_STRONG_MULTI_WORD_MATCHES_ABOVE_FREE_TEXT is the N in step 1.
+const MAX_STRONG_MULTI_WORD_MATCHES_ABOVE_FREE_TEXT = 2;
+
+function get_suggestions_for_multi_word_channel(
+    pill_search_terms: NarrowCanonicalTerm[],
+    text_search_terms: NarrowCanonicalTermSuggestion[],
+    merged_term: NarrowCanonicalTermSuggestion,
+    add_current_filter: boolean,
+): Suggestion[] {
+    const last = text_search_terms.at(-1)!;
+    const prev = text_search_terms.at(-2)!;
+    const max_items = max_num_of_search_results;
+
+    // Base terms that precede the prev channel term. These are common
+    // to both interpretations (merged and un-merged).
+    const valid_text_terms_before_prev = text_search_terms
+        .slice(0, -2)
+        .map((term) => Filter.convert_suggestion_to_term(term))
+        .filter((term) => term !== undefined);
+    const base_terms_before_prev = [...pill_search_terms, ...valid_text_terms_before_prev];
+    const base_line_before_prev = get_default_suggestion_line(base_terms_before_prev);
+
+    // Does the prev term resolve to a real channel? This gates tier 2
+    // (suggesting a new operator after the channel only makes sense if
+    // the channel itself is real) and tier 3 display (un-resolvable
+    // channels are dropped from the suggestion).
+    const prev_canonical = resolve_channel_term(prev);
+
+    const attacher = new Attacher(base_line_before_prev, false, add_current_filter);
+
+    // Base terms/line including the resolved prev term, shared by
+    // tiers 2 and 3 and the post-tier filterer loop. When prev
+    // doesn't resolve, fall back to the before-prev base.
+    const base_terms_with_prev =
+        prev_canonical !== undefined
+            ? [...base_terms_before_prev, prev_canonical]
+            : base_terms_before_prev;
+    const base_line_with_prev =
+        prev_canonical !== undefined
+            ? get_default_suggestion_line(base_terms_with_prev)
+            : base_line_before_prev;
+
+    // Tiers 1 / 4 / 5: multi-word channel matches.
+    let strong: Suggestion[] = [];
+    let weak: Suggestion[] = [];
+    if (!match_criteria(base_terms_before_prev, incompatible_patterns.channel)) {
+        const negated = merged_term.negated ?? false;
+        ({strong, weak} = get_channel_multi_word_matches(merged_term.operand, negated));
+        // `merged_term.operand` used the channel's name when the operand
+        // before the space resolved to a `stream_id`. But a numeric
+        // operand can also be the literal start of a channel name (e.g.
+        // `channel:15 test` matching a channel named "15 test"), so also
+        // match the query as literally typed. The two interpretations
+        // rarely both match; the Attacher dedups.
+        const literal_query = `${prev.operand} ${last.operand}`;
+        if (literal_query !== merged_term.operand) {
+            const literal_matches = get_channel_multi_word_matches(literal_query, negated);
+            strong = [...strong, ...literal_matches.strong];
+            weak = [...weak, ...literal_matches.weak];
+        }
+    }
+
+    // Tier 1: the first N strong multi-word matches. We only show max N
+    // here so that tier 3 stays near the top of the list.
+    const tier_1 = strong.slice(0, MAX_STRONG_MULTI_WORD_MATCHES_ABOVE_FREE_TEXT);
+    const tier_4 = strong.slice(MAX_STRONG_MULTI_WORD_MATCHES_ABOVE_FREE_TEXT);
+    for (const suggestion of tier_1) {
+        attacher.push([...base_line_before_prev, suggestion]);
+    }
+
+    // Tier 2: treat the text after the space as the start of a new
+    // operator (e.g. `h` → `has:link`). This is the curated subset of
+    // `build_filterer_list` that produces operator-prefix completions.
+    // Note: If you're adding a new filterer that produces operator-prefix
+    // completions, add it here too for top-of-list visibility — but if you
+    // don't, it will still appear via the post-tier-5 loop below.
+    if (prev_canonical !== undefined) {
+        const tier_2_filterers = [
+            get_operator_suggestions,
+            get_is_filter_suggestions,
+            ...(page_params.is_spectator ? [] : [get_sent_by_me_suggestions]),
+            get_has_filter_suggestions,
+        ];
+        for (const filterer of tier_2_filterers) {
+            for (const suggestion of filterer(last, base_terms_with_prev)) {
+                attacher.push([...base_line_with_prev, suggestion]);
+            }
+        }
+    }
+
+    // Tier 3: the un-merged reading — `prev` kept as its own channel
+    // term plus the trailing fragment as a free-text search (e.g.
+    // `channel:automated testing`). When `prev` didn't resolve to a
+    // real channel, `base_line_with_prev` already omits it, so the row
+    // is just the free-text fragment (e.g. `testing`), matching the
+    // default-row behavior for a not-yet-real channel.
+    attacher.push([...base_line_with_prev, last.operand]);
+
+    // Tier 4: remaining strong multi-word matches.
+    for (const suggestion of tier_4) {
+        attacher.push([...base_line_before_prev, suggestion]);
+    }
+
+    // Tier 5: weak multi-word matches.
+    for (const suggestion of weak) {
+        attacher.push([...base_line_before_prev, suggestion]);
+    }
+
+    // After the explicit tiers, run the full filterer list with the
+    // un-merged interpretation — e.g. topic suggestions within the
+    // resolved channel. This re-runs tier 2's operator-prefix
+    // filterers, but the Attacher dedupes them.
+    for (const filterer of build_filterer_list(last)) {
+        if (attacher.result.length < max_items) {
+            attacher.attach_many(filterer(last, base_terms_with_prev), base_line_with_prev);
+        }
+    }
+
+    return attacher.get_result().slice(0, max_items);
+}
+
 export let get_suggestions = function (
     pill_search_terms: NarrowCanonicalTerm[],
     text_search_terms_non_canonical: NarrowTermSuggestion[],
@@ -1269,6 +1482,24 @@ export let get_suggestions = function (
     };
     if (text_search_terms.length > 0) {
         last = text_search_terms.at(-1)!;
+    }
+
+    // Handle spaces inside a `channel:` operand by offering both the
+    // multi-word interpretation and the single-word + free-text
+    // interpretation, per the 5-tier ranking in
+    // `get_suggestions_for_multi_word_channel`. A follow-up commit
+    // will apply the same treatment to `topic:`.
+    const merged_channel_term = compute_multi_word_merged_term(
+        text_search_terms,
+        new Set(["channel"]),
+    );
+    if (merged_channel_term !== undefined) {
+        return get_suggestions_for_multi_word_channel(
+            pill_search_terms,
+            text_search_terms,
+            merged_channel_term,
+            add_current_filter,
+        );
     }
 
     // Handle spaces inside the operand of a person operator. For e.g.

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -372,6 +372,61 @@ function get_channel_multi_word_matches(
     return {strong, weak};
 }
 
+// Find topics whose name matches the multi-word `query`, and split them
+// into "strong" (name starts with the full query, case-insensitive) and
+// "weak" (matches but is not a prefix).
+// Suggestions include a `channel:<id>` prefix when the channel isn't
+// already in `terms`, matching `get_topic_suggestions`'s output format.
+function get_topic_multi_word_matches(
+    query: string,
+    negated: boolean,
+    terms: NarrowCanonicalTerm[],
+): {strong: Suggestion[]; weak: Suggestion[]} {
+    const filter = new Filter(terms);
+    const excluded_channel_ids = negated_channel_ids(terms);
+    // Match and sort the scoped channel's topics separately from other
+    // channels' topics, mirroring `get_topic_suggestions`: each group
+    // gets its own match budget, and the scoped channel's topics rank
+    // above the rest. Scope to the channel in `terms` if any, else the
+    // current narrow's channel plus all other subscribed channels.
+    const {scoped_entries, other_entries} = filter.has_operator("channel")
+        ? gather_recent_topic_entries(
+              filter.terms_with_operator("channel")[0]!.operand,
+              false,
+              excluded_channel_ids,
+          )
+        : gather_recent_topic_entries(
+              narrow_state.stream_id()?.toString(),
+              true,
+              excluded_channel_ids,
+          );
+    const sorted_entries = [scoped_entries, other_entries].flatMap((candidate_topic_entries) =>
+        typeahead_helper.sorter(
+            query,
+            get_topic_suggestions_from_candidates({candidate_topic_entries, guess: query}),
+            ignore_resolved_topic_prefix,
+        ),
+    );
+
+    const strong: Suggestion[] = [];
+    const weak: Suggestion[] = [];
+    for (const entry of sorted_entries) {
+        const topic_term: NarrowTerm = {operator: "topic", operand: entry.topic, negated};
+        const suggestion_terms: NarrowTerm[] = filter.has_operator("channel")
+            ? [topic_term]
+            : [{operator: "channel", operand: entry.channel_id}, topic_term];
+        const suggestion = Filter.unparse(suggestion_terms);
+        // Classify with the same key the sorter uses, so that a
+        // resolved topic ranks the same as its unresolved name.
+        if (ignore_resolved_topic_prefix(entry, true).startsWith(query.toLowerCase())) {
+            strong.push(suggestion);
+        } else {
+            weak.push(suggestion);
+        }
+    }
+    return {strong, weak};
+}
+
 function get_group_suggestions(
     group_operator: "dm" | "dm-including",
 ): (last: NarrowCanonicalTermSuggestion, terms: NarrowCanonicalTerm[]) => Suggestion[] {
@@ -1302,27 +1357,27 @@ function resolve_channel_term(
 }
 
 // Build a tiered suggestion list when the user types a space inside a
-// `channel:` operand (e.g. `channel:automated testing`). The 5-tier
-// ranking is:
-// 1. The first N "strong" multi-word channel matches (channels whose
+// `channel:` or `topic:` operand (e.g. `channel:automated testing`,
+// `topic:release notes`). The 5-tier ranking is:
+// 1. The first N "strong" multi-word matches (channels/topics whose
 //    name starts with the full multi-word query). We only show max N
 //    of these in tier 1 so that tiers 2 and 3 stay near the top of
 //    the list.
 // 2. Completions that interpret the text after the space as the start
-//    of a new operator. Only shown when the channel before the space
-//    resolves to a real channel.
+//    of a new operator. For `channel:`, only shown when the channel
+//    before the space resolves to a real channel.
 //    (e.g. `channel:automated h` → `channel:automated has:link`).
-// 3. The user's input read as the channel before the space plus the
+// 3. The user's input read as the operator before the space plus the
 //    text after as a free-text search (e.g. `channel:automated testing`
 //    becomes channel `automated` + text search for `testing`).
-// 4. Remaining strong multi-word channel matches.
+// 4. Remaining strong multi-word matches.
 // 5. "Weak" multi-word matches (phrase-match the full query but
 //    don't start with it).
 
 // MAX_STRONG_MULTI_WORD_MATCHES_ABOVE_FREE_TEXT is the N in step 1.
 const MAX_STRONG_MULTI_WORD_MATCHES_ABOVE_FREE_TEXT = 2;
 
-function get_suggestions_for_multi_word_channel(
+function get_suggestions_for_multi_word_channel_or_topic(
     pill_search_terms: NarrowCanonicalTerm[],
     text_search_terms: NarrowCanonicalTermSuggestion[],
     merged_term: NarrowCanonicalTermSuggestion,
@@ -1332,8 +1387,8 @@ function get_suggestions_for_multi_word_channel(
     const prev = text_search_terms.at(-2)!;
     const max_items = max_num_of_search_results;
 
-    // Base terms that precede the prev channel term. These are common
-    // to both interpretations (merged and un-merged).
+    // Base terms that precede the prev term. These are common to both
+    // interpretations (merged and un-merged).
     const valid_text_terms_before_prev = text_search_terms
         .slice(0, -2)
         .map((term) => Filter.convert_suggestion_to_term(term))
@@ -1341,11 +1396,21 @@ function get_suggestions_for_multi_word_channel(
     const base_terms_before_prev = [...pill_search_terms, ...valid_text_terms_before_prev];
     const base_line_before_prev = get_default_suggestion_line(base_terms_before_prev);
 
-    // Does the prev term resolve to a real channel? This gates tier 2
-    // (suggesting a new operator after the channel only makes sense if
-    // the channel itself is real) and tier 3 display (un-resolvable
-    // channels are dropped from the suggestion).
-    const prev_canonical = resolve_channel_term(prev);
+    // Resolve the prev operand to a canonical term. Might be undefined for
+    // incomplete channel terms.
+    let prev_canonical: NarrowCanonicalTerm | undefined;
+    if (prev.operator === "channel") {
+        // Does the prev term resolve to a real channel? This gates tier 2
+        // (suggesting a new operator after the channel only makes sense if
+        // the channel itself is real) and tier 3 display (un-resolvable
+        // channels are dropped from the suggestion).
+        prev_canonical = resolve_channel_term(prev);
+    } else {
+        // For `topic:` the operand canonicalizes directly and
+        // should never be undefined.
+        assert(prev.operator === "topic");
+        prev_canonical = Filter.convert_suggestion_to_term(prev);
+    }
 
     const attacher = new Attacher(base_line_before_prev, false, add_current_filter);
 
@@ -1361,23 +1426,32 @@ function get_suggestions_for_multi_word_channel(
             ? get_default_suggestion_line(base_terms_with_prev)
             : base_line_before_prev;
 
-    // Tiers 1 / 4 / 5: multi-word channel matches.
+    // Tiers 1 / 4 / 5: multi-word matches.
     let strong: Suggestion[] = [];
     let weak: Suggestion[] = [];
-    if (!match_criteria(base_terms_before_prev, incompatible_patterns.channel)) {
-        const negated = merged_term.negated ?? false;
-        ({strong, weak} = get_channel_multi_word_matches(merged_term.operand, negated));
-        // `merged_term.operand` used the channel's name when the operand
-        // before the space resolved to a `stream_id`. But a numeric
-        // operand can also be the literal start of a channel name (e.g.
-        // `channel:15 test` matching a channel named "15 test"), so also
-        // match the query as literally typed. The two interpretations
-        // rarely both match; the Attacher dedups.
-        const literal_query = `${prev.operand} ${last.operand}`;
-        if (literal_query !== merged_term.operand) {
-            const literal_matches = get_channel_multi_word_matches(literal_query, negated);
-            strong = [...strong, ...literal_matches.strong];
-            weak = [...weak, ...literal_matches.weak];
+    if (!match_criteria(base_terms_before_prev, incompatible_patterns[merged_term.operator])) {
+        if (merged_term.operator === "channel") {
+            const negated = merged_term.negated ?? false;
+            ({strong, weak} = get_channel_multi_word_matches(merged_term.operand, negated));
+            // `merged_term.operand` used the channel's name when the
+            // operand before the space resolved to a `stream_id`. But a
+            // numeric operand can also be the literal start of a channel
+            // name (e.g. `channel:15 test` matching a channel named "15
+            // test"), so also match the query as literally typed. The
+            // two interpretations rarely both match; the Attacher dedups.
+            const literal_query = `${prev.operand} ${last.operand}`;
+            if (literal_query !== merged_term.operand) {
+                const literal_matches = get_channel_multi_word_matches(literal_query, negated);
+                strong = [...strong, ...literal_matches.strong];
+                weak = [...weak, ...literal_matches.weak];
+            }
+        } else {
+            assert(merged_term.operator === "topic");
+            ({strong, weak} = get_topic_multi_word_matches(
+                merged_term.operand,
+                merged_term.negated ?? false,
+                base_terms_before_prev,
+            ));
         }
     }
 
@@ -1409,8 +1483,8 @@ function get_suggestions_for_multi_word_channel(
         }
     }
 
-    // Tier 3: the un-merged reading — `prev` kept as its own channel
-    // term plus the trailing fragment as a free-text search (e.g.
+    // Tier 3: the un-merged reading — `prev` kept as its own term plus
+    // the trailing fragment as a free-text search (e.g.
     // `channel:automated testing`). When `prev` didn't resolve to a
     // real channel, `base_line_with_prev` already omits it, so the row
     // is just the free-text fragment (e.g. `testing`), matching the
@@ -1484,20 +1558,19 @@ export let get_suggestions = function (
         last = text_search_terms.at(-1)!;
     }
 
-    // Handle spaces inside a `channel:` operand by offering both the
-    // multi-word interpretation and the single-word + free-text
-    // interpretation, per the 5-tier ranking in
-    // `get_suggestions_for_multi_word_channel`. A follow-up commit
-    // will apply the same treatment to `topic:`.
-    const merged_channel_term = compute_multi_word_merged_term(
+    // Handle spaces inside a `channel:` or `topic:` operand by
+    // offering both the multi-word interpretation and the single-word
+    // + free-text interpretation, per the 5-tier ranking in
+    // `get_suggestions_for_multi_word_channel_or_topic`.
+    const merged_term = compute_multi_word_merged_term(
         text_search_terms,
-        new Set(["channel"]),
+        new Set(["channel", "topic"]),
     );
-    if (merged_channel_term !== undefined) {
-        return get_suggestions_for_multi_word_channel(
+    if (merged_term !== undefined) {
+        return get_suggestions_for_multi_word_channel_or_topic(
             pill_search_terms,
             text_search_terms,
-            merged_channel_term,
+            merged_term,
             add_current_filter,
         );
     }

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -578,6 +578,64 @@ function get_date_suggestions(
     return date_util.get_matching_default_date_suggestions(last.operand);
 }
 
+function negated_channel_ids(terms: NarrowCanonicalTerm[]): Set<string> {
+    const channel_ids = new Set<string>();
+    for (const term of terms) {
+        if (term.negated && term.operator === "channel") {
+            channel_ids.add(term.operand);
+        }
+    }
+    return channel_ids;
+}
+
+// The scoped channel's topics and the other channels' are returned
+// separately so each gets its own match budget and the scoped
+// channel's topics can rank first.
+function gather_recent_topic_entries(
+    scoped_channel_id_string: string | undefined,
+    include_other_channels: boolean,
+    excluded_channel_ids: Set<string>,
+): {scoped_entries: ChannelTopicEntry[]; other_entries: ChannelTopicEntry[]} {
+    const scoped_entries: ChannelTopicEntry[] = [];
+    if (scoped_channel_id_string && !excluded_channel_ids.has(scoped_channel_id_string)) {
+        // We do this outside the stream_data.subscribed_stream_ids loop,
+        // since we could be viewing a channel we can't read.
+        const sub = stream_data.get_sub_by_id_string(scoped_channel_id_string);
+        if (sub && stream_data.can_access_topic_history(sub)) {
+            stream_topic_history_util.get_server_history(sub.stream_id, () => {
+                // Fetch topic history from the server, in case we will
+                // need it.  Note that we won't actually use the results
+                // from the server here for this particular keystroke from
+                // the user, because we want to show results immediately.
+            });
+
+            for (const topic of stream_topic_history.get_recent_topic_names(sub.stream_id)) {
+                scoped_entries.push({channel_id: scoped_channel_id_string, topic});
+            }
+        }
+    }
+
+    const other_entries: ChannelTopicEntry[] = [];
+    if (include_other_channels) {
+        for (const subscribed_channel_id of stream_data.subscribed_stream_ids()) {
+            const subscribed_id_string = subscribed_channel_id.toString();
+            if (
+                subscribed_id_string === scoped_channel_id_string ||
+                excluded_channel_ids.has(subscribed_id_string)
+            ) {
+                continue;
+            }
+            for (const topic of stream_topic_history.get_recent_topic_names(
+                subscribed_channel_id,
+            )) {
+                other_entries.push({channel_id: subscribed_id_string, topic});
+            }
+        }
+    }
+
+    return {scoped_entries, other_entries};
+}
+
 function get_topic_suggestions(
     last: NarrowCanonicalTermSuggestion,
     terms: NarrowCanonicalTerm[],
@@ -652,66 +710,34 @@ function get_topic_suggestions(
     }
 
     // We don't want to show topic suggestions from negated channels
-    const excluded_channel_ids = new Set(
-        terms
-            .filter((term) => term.negated && term.operator === "channel")
-            .map((term) => term.operand),
+    const excluded_channel_ids = negated_channel_ids(terms);
+
+    // A `channel:` last term whose operand isn't a valid channel id gets
+    // no topic suggestions at all, rather than falling through to every
+    // other channel's topics.
+    if (
+        last.operator === "channel" &&
+        channel_id_or_operand_str &&
+        !excluded_channel_ids.has(channel_id_or_operand_str) &&
+        stream_data.get_sub_by_id_string(channel_id_or_operand_str) === undefined
+    ) {
+        return [];
+    }
+
+    const {scoped_entries, other_entries} = gather_recent_topic_entries(
+        channel_id_or_operand_str,
+        show_topics_from_other_channels,
+        excluded_channel_ids,
     );
-
-    const current_channel_topic_entries: ChannelTopicEntry[] = [];
-    if (channel_id_or_operand_str && !excluded_channel_ids.has(channel_id_or_operand_str)) {
-        // We do this outside the stream_data.subscribed_stream_ids loop,
-        // since we could be viewing a channel we can't read.
-        const sub = stream_data.get_sub_by_id_string(channel_id_or_operand_str);
-        if (sub === undefined && last.operator === "channel") {
-            // Since the channel_id_or_operand_str is not a
-            // valid channel id we avoid sending any topic
-            // suggestions for a channel as the last term.
-            return [];
-        }
-        if (sub && stream_data.can_access_topic_history(sub)) {
-            const current_channel_id = sub.stream_id;
-            stream_topic_history_util.get_server_history(current_channel_id, () => {
-                // Fetch topic history from the server, in case we will
-                // need it.  Note that we won't actually use the results
-                // from the server here for this particular keystroke from
-                // the user, because we want to show results immediately.
-            });
-
-            for (const topic of stream_topic_history.get_recent_topic_names(current_channel_id)) {
-                current_channel_topic_entries.push({channel_id: channel_id_or_operand_str, topic});
-            }
-        }
-    }
-
-    const other_channel_topic_entries: ChannelTopicEntry[] = [];
-    for (const subscribed_channel_id of stream_data.subscribed_stream_ids()) {
-        if (
-            subscribed_channel_id.toString() === channel_id_or_operand_str ||
-            excluded_channel_ids.has(subscribed_channel_id.toString())
-        ) {
-            continue;
-        }
-        if (!show_topics_from_other_channels) {
-            continue;
-        }
-
-        for (const topic of stream_topic_history.get_recent_topic_names(subscribed_channel_id)) {
-            other_channel_topic_entries.push({
-                channel_id: subscribed_channel_id.toString(),
-                topic,
-            });
-        }
-    }
 
     assert(guess !== undefined);
 
     let current_channel_topic_suggestion_entries = get_topic_suggestions_from_candidates({
-        candidate_topic_entries: current_channel_topic_entries,
+        candidate_topic_entries: scoped_entries,
         guess,
     });
     let other_channel_topic_suggestion_entries = get_topic_suggestions_from_candidates({
-        candidate_topic_entries: other_channel_topic_entries,
+        candidate_topic_entries: other_entries,
         guess,
     });
 

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -1030,6 +1030,203 @@ test("channel_completion", ({override}) => {
     assert.deepEqual(suggestions, expected);
 });
 
+test("channel_multi_word_completion", ({override}) => {
+    override(narrow_state, "stream_id", noop);
+    override(stream_topic_history_util, "get_server_history", noop);
+
+    const automated_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: automated_id, name: "automated", subscribed: true}),
+    );
+    const automated_testing_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({
+            stream_id: automated_testing_id,
+            name: "automated testing",
+            subscribed: true,
+        }),
+    );
+    const q1_automated_testing_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({
+            stream_id: q1_automated_testing_id,
+            name: "Q1 automated testing",
+            subscribed: true,
+        }),
+    );
+
+    // Strong multi-word match ("automated testing" starts with the
+    // typed query) ranks above the literal-input row, weak match ("Q1
+    // automated testing" matches but doesn't start with the query)
+    // ranks below.
+    let query = "channel:automated testing";
+    let suggestions = get_suggestions(query);
+    let expected = [
+        `channel:${automated_testing_id}`,
+        `channel:${automated_id} testing`,
+        `channel:${q1_automated_testing_id}`,
+    ];
+    assert.deepEqual(suggestions, expected);
+
+    // Trailing fragment is a prefix of `has:*` with no multi-word
+    // match, so tier 2 surfaces those completions above the
+    // literal-input row. Only fires because the single-word channel
+    // `automated` resolves.
+    query = "channel:automated h";
+    suggestions = get_suggestions(query);
+    expected = [
+        `channel:${automated_id} has:link`,
+        `channel:${automated_id} has:image`,
+        `channel:${automated_id} has:attachment`,
+        `channel:${automated_id} has:reaction`,
+        `channel:${automated_id} h`,
+    ];
+    assert.deepEqual(suggestions, expected);
+
+    // Single-word channel doesn't resolve. Strong multi-word match
+    // floats to the top. Tier 3 drops the un-resolvable channel and
+    // shows just the trailing fragment. The post-tier filterer loop
+    // also offers channels matching the trailing fragment alone.
+    query = "channel:Q1 automated";
+    suggestions = get_suggestions(query);
+    expected = [
+        `channel:${q1_automated_testing_id}`,
+        "automated",
+        `channel:${automated_id}`,
+        `channel:${automated_testing_id}`,
+    ];
+    assert.deepEqual(suggestions, expected);
+
+    // No multi-word match and the typed channel doesn't resolve: tier
+    // 3 row degrades to just the trailing fragment.
+    query = "channel:nonexistent foo";
+    suggestions = get_suggestions(query);
+    expected = ["foo"];
+    assert.deepEqual(suggestions, expected);
+
+    // Resolved single-word channel with no multi-word match: tier 3
+    // shows the resolved channel + free-text search.
+    query = "channel:automated nonexistent";
+    suggestions = get_suggestions(query);
+    expected = [`channel:${automated_id} nonexistent`];
+    assert.deepEqual(suggestions, expected);
+
+    // When the channel resolves, the post-tier filterer loop runs with
+    // the resolved-channel context, surfacing e.g. topic suggestions.
+    stream_topic_history.add_message({stream_id: automated_id, topic_name: "release prep"});
+    query = "channel:automated release";
+    suggestions = get_suggestions(query);
+    expected = [`channel:${automated_id} release`, `channel:${automated_id} topic:release+prep`];
+    assert.deepEqual(suggestions, expected);
+
+    // `se` is an operator-prefix fragment: tier 2 surfaces both the
+    // `sender:` operator completion and the sent-by-me completion.
+    query = "channel:automated se";
+    suggestions = get_suggestions(query);
+    expected = [
+        `channel:${automated_id} sender:`,
+        `channel:${automated_id} sender:${me.user_id}`,
+        `channel:${automated_id} se`,
+    ];
+    assert.deepEqual(suggestions, expected);
+
+    // With the same channel already pilled, the tier-3 row shows the
+    // channel only once, and multi-word channel matches (which would
+    // add a second channel term) are suppressed as invalid.
+    suggestions = get_suggestions("channel:automated testing", "channel:automated");
+    expected = [`channel:${automated_id} testing`];
+    assert.deepEqual(suggestions, expected);
+
+    // An `is:dm` pill is incompatible with channel terms, so no
+    // multi-word channel matches are offered; only the literal input
+    // row remains.
+    suggestions = get_suggestions("channel:automated testing", "is:dm");
+    expected = [`is:dm channel:${automated_id} testing`];
+    assert.deepEqual(suggestions, expected);
+
+    // When the trailing fragment is both a strong multi-word match and
+    // an operator prefix ("h" prefixes `has:*`), the multi-word channel
+    // match ("deploy hooks") ranks above the operator completions: a
+    // two-word channel name is the likelier intent than starting a new
+    // operator.
+    const deploy_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: deploy_id, name: "deploy", subscribed: true}),
+    );
+    const deploy_hooks_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: deploy_hooks_id, name: "deploy hooks", subscribed: true}),
+    );
+    suggestions = get_suggestions("channel:deploy h");
+    expected = [
+        `channel:${deploy_hooks_id}`,
+        `channel:${deploy_id} has:link`,
+        `channel:${deploy_id} has:image`,
+        `channel:${deploy_id} has:attachment`,
+        `channel:${deploy_id} has:reaction`,
+        `channel:${deploy_id} h`,
+    ];
+    assert.deepEqual(suggestions, expected);
+});
+
+test("channel_multi_word_renamed_completion", ({override, override_rewire}) => {
+    override(narrow_state, "stream_id", noop);
+    override_rewire(stream_data, "set_max_channel_width_css_variable", noop);
+
+    const pipelines_id = new_stream_id();
+    const pipelines_sub = make_stream({
+        stream_id: pipelines_id,
+        name: "pipeline",
+        subscribed: true,
+    });
+    stream_data.add_sub_for_tests(pipelines_sub);
+    stream_data.rename_sub(pipelines_sub, "pipelines");
+
+    // A channel's pre-rename name is not resolved (matching
+    // `Filter.parse`'s name resolution), so it reads as free text.
+    const suggestions = get_suggestions("channel:pipeline x");
+    const expected = ["x"];
+    assert.deepEqual(suggestions, expected);
+});
+
+test("channel_multi_word_digit_prefix_completion", ({override}) => {
+    override(narrow_state, "stream_id", noop);
+
+    // "7th floor" starts with digits. `get_sub_by_id_string` accepts
+    // only an exact canonical id, so "7th" isn't read as the unrelated
+    // channel with id 7 — it's matched by name to "7th floor"
+    // (channel:8). "7th" also isn't a valid channel id, so there's no
+    // `channel:7th` literal row.
+    stream_data.add_sub_for_tests(make_stream({stream_id: 7, name: "general", subscribed: true}));
+    stream_data.add_sub_for_tests(make_stream({stream_id: 8, name: "7th floor", subscribed: true}));
+
+    let suggestions = get_suggestions("channel:7th");
+    let expected = ["channel:8"];
+    assert.deepEqual(suggestions, expected);
+
+    suggestions = get_suggestions("channel:7th fl");
+    expected = ["channel:8", "fl"];
+    assert.deepEqual(suggestions, expected);
+});
+
+test("channel_multi_word_name_starting_with_id", ({override}) => {
+    override(stream_topic_history_util, "get_server_history", noop);
+
+    // A channel named "15 test" whose leading word ("15") is also
+    // another channel's stream_id. Typing `channel:15 test` resolves
+    // "15" to the id-15 channel for the merged query, but we also match
+    // the query as literally typed, so "15 test" still surfaces by name.
+    stream_data.add_sub_for_tests(make_stream({stream_id: 15, name: "lobby", subscribed: true}));
+    const fifteen_test_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: fifteen_test_id, name: "15 test", subscribed: true}),
+    );
+
+    const suggestions = get_suggestions("channel:15 test");
+    const expected = [`channel:${fifteen_test_id}`, "channel:15 test"];
+    assert.deepEqual(suggestions, expected);
+});
+
 test("people_suggestions", ({override}) => {
     let query = "te";
 

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -1034,6 +1034,63 @@ test("channel_completion", ({override}) => {
     assert.deepEqual(suggestions, expected);
 });
 
+test("channel_exact_name_surfaces_siblings", ({override}) => {
+    override(stream_topic_history_util, "get_server_history", noop);
+
+    const core_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: core_id, name: "core", subscribed: true}),
+    );
+    const core_team_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: core_team_id, name: "core team", subscribed: true}),
+    );
+
+    // Typing the exact name "core" resolves to its stream_id via
+    // `Filter.parse`, but we still phrase-match the name so the
+    // sibling channel "core team" surfaces as an alternative
+    // interpretation, just as it would for the still-incomplete
+    // "channel:cor".
+    let query = "channel:core";
+    let suggestions = get_suggestions(query);
+    let expected = [`channel:${core_id}`, `channel:${core_team_id}`];
+    assert.deepEqual(suggestions, expected);
+
+    // The still-incomplete name behaves identically, confirming the
+    // exact-match case isn't a special-cased regression.
+    query = "channel:cor";
+    suggestions = get_suggestions(query);
+    expected = [`channel:${core_id}`, `channel:${core_team_id}`];
+    assert.deepEqual(suggestions, expected);
+
+    // A numeric operand resolves to that stream_id's channel, but we
+    // also match it as literally typed, so `channel:7` surfaces both
+    // #Venice (id 7) and a channel whose name starts with "7".
+    stream_data.add_sub_for_tests(make_stream({stream_id: 7, name: "Venice", subscribed: true}));
+    const seventh_floor_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: seventh_floor_id, name: "7th floor", subscribed: true}),
+    );
+    query = "channel:7";
+    suggestions = get_suggestions(query);
+    expected = ["channel:7", `channel:${seventh_floor_id}`];
+    assert.deepEqual(suggestions, expected);
+
+    // "Venice" (id 7) has a genuine sibling "Venice beach". Typing the
+    // exact name resolves the operand to the id "7", so we match both
+    // the name "Venice" and the literal "7". The genuine sibling
+    // "Venice beach" (a name match) must rank above "7th floor" (only a
+    // coincidental match on the id-7 literal).
+    const venice_beach_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: venice_beach_id, name: "Venice beach", subscribed: true}),
+    );
+    query = "channel:Venice";
+    suggestions = get_suggestions(query);
+    expected = ["channel:7", `channel:${venice_beach_id}`, `channel:${seventh_floor_id}`];
+    assert.deepEqual(suggestions, expected);
+});
+
 test("channel_multi_word_completion", ({override}) => {
     override(narrow_state, "stream_id", noop);
     override(stream_topic_history_util, "get_server_history", noop);

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -643,6 +643,7 @@ test("check_is_suggestions", ({override}) => {
 
 test("sent_by_me_suggestions", ({override}) => {
     override(narrow_state, "stream_id", noop);
+    override(stream_topic_history_util, "get_server_history", noop);
 
     let query = "";
     let suggestions = get_suggestions(query);
@@ -694,11 +695,14 @@ test("sent_by_me_suggestions", ({override}) => {
         stream_id: denmark_id,
     });
     stream_data.add_sub_for_tests(sub);
+    // `sent` is an exact keyword shorthand for the sent-by-me
+    // suggestion (`get_sent_by_me_suggestions` → `sender:me`), which
+    // tier 2 surfaces above the literal-input row.
     query = `channel:${denmark_id} topic:Denmark1 sent`;
     suggestions = get_suggestions(query);
     expected = [
-        `channel:${denmark_id} topic:Denmark1 sent`,
         `channel:${denmark_id} topic:Denmark1 sender:${me.user_id}`,
+        `channel:${denmark_id} topic:Denmark1 sent`,
     ];
     assert.deepEqual(suggestions, expected);
 
@@ -1224,6 +1228,109 @@ test("channel_multi_word_name_starting_with_id", ({override}) => {
 
     const suggestions = get_suggestions("channel:15 test");
     const expected = [`channel:${fifteen_test_id}`, "channel:15 test"];
+    assert.deepEqual(suggestions, expected);
+});
+
+test("topic_multi_word_completion", ({override}) => {
+    override(narrow_state, "stream_id", noop);
+
+    const releases_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: releases_id, name: "releases", subscribed: true}),
+    );
+    stream_topic_history.add_message({stream_id: releases_id, topic_name: "release notes"});
+    stream_topic_history.add_message({
+        stream_id: releases_id,
+        message_id: 1,
+        topic_name: "release hotfix",
+    });
+
+    // Strong multi-word topic match (cross-channel, since no channel
+    // pill) ranks above the pinned default-row.
+    let query = "topic:release notes";
+    let suggestions = get_suggestions(query);
+    let expected = [`channel:${releases_id} topic:release+notes`, "topic:release notes"];
+    assert.deepEqual(suggestions, expected);
+
+    // When the trailing fragment is both a strong multi-word match and
+    // an operator prefix ("h" prefixes `has:*`), the multi-word topic
+    // match ("release hotfix") ranks above the operator completions,
+    // which precede the literal-input row.
+    query = "topic:release h";
+    suggestions = get_suggestions(query);
+    expected = [
+        `channel:${releases_id} topic:release+hotfix`,
+        "topic:release has:link",
+        "topic:release has:image",
+        "topic:release has:attachment",
+        "topic:release has:reaction",
+        "topic:release h",
+    ];
+    assert.deepEqual(suggestions, expected);
+
+    // An `is:dm` pill is incompatible with topic terms, so no
+    // multi-word topic matches are offered; only the literal input
+    // row remains.
+    query = "topic:release notes";
+    suggestions = get_suggestions(query, "is:dm");
+    expected = ["is:dm topic:release notes"];
+    assert.deepEqual(suggestions, expected);
+
+    // A resolved topic ranks as a strong match: classification ignores
+    // the resolved-topic prefix, like the sort key does.
+    stream_topic_history.add_message({
+        stream_id: releases_id,
+        message_id: 2,
+        topic_name: "✔ release docs",
+    });
+    query = "topic:release docs";
+    suggestions = get_suggestions(query);
+    expected = [`channel:${releases_id} topic:✔+release+docs`, "topic:release docs"];
+    assert.deepEqual(suggestions, expected);
+});
+
+test("topic_multi_word_match_budget", ({override}) => {
+    override(stream_topic_history_util, "get_server_history", noop);
+
+    const narrow_stream_id = new_stream_id();
+    override(narrow_state, "stream_id", () => narrow_stream_id);
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: narrow_stream_id, name: "core team", subscribed: true}),
+    );
+
+    const releases_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({stream_id: releases_id, name: "releases", subscribed: true}),
+    );
+
+    // Enough weak matches in the narrowed channel to exhaust a
+    // 10-topic match budget on their own.
+    for (let i = 1; i <= 10; i += 1) {
+        stream_topic_history.add_message({
+            stream_id: narrow_stream_id,
+            message_id: i,
+            topic_name: `old release notes ${i}`,
+        });
+    }
+    stream_topic_history.add_message({
+        stream_id: releases_id,
+        message_id: 100,
+        topic_name: "release notes",
+    });
+
+    // The narrowed channel's topics and other channels' topics each
+    // get their own match budget, so the strong match from another
+    // channel still surfaces; the narrowed channel's weak matches
+    // follow in recency order.
+    const suggestions = get_suggestions("topic:release notes");
+    const expected = [
+        `channel:${releases_id} topic:release+notes`,
+        "topic:release notes",
+        ...Array.from(
+            {length: 10},
+            (_, i) => `channel:${narrow_stream_id} topic:old+release+notes+${10 - i}`,
+        ),
+    ];
     assert.deepEqual(suggestions, expected);
 });
 


### PR DESCRIPTION
When you type a space inside a `channel:` or `topic:` operand (e.g. `channel:automated testing`, `topic:release notes`), the parser splits it into `<operator>:<word1>` + `search:<word2>`, so the typeahead used to drop the operator and just search the trailing word — losing the intent of naming a multi-word channel/topic.

This adds a tiered suggestion list that surfaces channels/topics whose name matches the *full* multi-word query, ranked alongside the existing single-word + free-text interpretation, operator-prefix completions (`channel:automated h` → `has:*`), and the in-context filterers. It also surfaces sibling channels when an exact channel name is typed (`channel:core` now also offers `channel: core team`, matching what `channel:cor` already did).

Design discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/Typeahead.20handling.20of.20spaces/with/2456782

Structured as two no-op refactors (extract the person-merge helper and the filterer list) followed by the channel, topic, and exact-name commits.

**Manual testing with screenshots** 

On a dev realm with channels `automated` / `automated testing` / `Q1 automated testing` / `core` / `core team` / `7th floor`, and topics `release notes` / a resolved `✔ release docs

- [x] `channel:automated testing` → strong match `#automated testing` on top, then `channel:automated` + free-text `testing`, then weak match `#Q1 automated testing`.

<img width="943" height="169" alt="1" src="https://github.com/user-attachments/assets/83ce1244-52e2-41cf-a830-0ce87cb5eae8" />

- [x] `channel:automated te` (partial) → same shape.

<img width="928" height="241" alt="2" src="https://github.com/user-attachments/assets/2f7c2096-339a-41cc-bfba-9ffa9037c967" />

- [x] `channel:nonexistent foo` → degrades to "Search for foo".

<img width="445" height="96" alt="3" src="https://github.com/user-attachments/assets/7303d5d4-7d5f-4c29-9d1f-607f1fc34159" />

- [x] `topic:release notes` → jumps to the `release notes` topic, plus the `topic:release` + free-text row.

<img width="327" height="126" alt="4" src="https://github.com/user-attachments/assets/a8c4a74b-3cf4-42c9-a10c-fb63765032a4" />

- [x] `topic:release docs` (resolved `✔ release docs`) → still matched (classification ignores the ✔ prefix).

<img width="367" height="129" alt="5" src="https://github.com/user-attachments/assets/a507840f-93d8-41d5-a5ac-aa84ec34abbd" />

- [x] Per-channel match budget: a strong cross-channel topic still surfaces above a narrowed channel's many weak matches.

<img width="839" height="413" alt="image" src="https://github.com/user-attachments/assets/77cb71bb-59cc-4f7c-aa64-34a89856c1e2" />

- [x] `channel:core` (exact) → offers both `channel: core` and `channel: core team`.

<img width="551" height="167" alt="7" src="https://github.com/user-attachments/assets/36ca80f7-e2e9-4b23-9a4e-ee3842e873a4" />

- [x] `channel:automated h` → `has:link/image/attachment/reaction` rank above the literal row; `channel:automated se` → `sender:` / sent-by-me.

<img width="931" height="296" alt="9" src="https://github.com/user-attachments/assets/d16fef28-934f-40ca-9460-2b371b0b164c" />

- [x] Incompatibility gating: with an `is:dm` pill, or the channel/topic already pilled, no multi-word matches are offered.

<img width="439" height="86" alt="12" src="https://github.com/user-attachments/assets/9d91be31-fbef-4968-8e91-a8f5766519a5" />

I noticed the search bar can still suggest rows that combine incompatible operators (e.g. `is:dm channel:…`); that's pre-existing and tracked in #39400, out of scope here.

- [x] `channel:7th floor` (digit-leading) → matches the channel by name.

<img width="932" height="319" alt="15" src="https://github.com/user-attachments/assets/9f695a16-8916-4ab7-964a-67ea03b96595" />

Venice showing up is an existing bug on main, so I opened #39562 to fix it.

<img width="505" height="117" alt="16" src="https://github.com/user-attachments/assets/580d5b1e-ae99-4ed2-a9dc-60324c83c64f" />

- [x] Renamed channel: the pre-rename name reads as free text.
- [x] Regressions: `sender:Ted Smith`, `dm:Ted Smith, Alice Ignore` still resolve to user pills; single-word `channel:`/`topic:`/`is:`/`has:` completions unchanged.
- [x] Spectator: repeated channel/topic cases on a web-public realm.
- [x] Keyboard navigation selects multi-word results correctly.
