### PR TITLE
streams: Add join/leave notifications for private channels.

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from collections.abc import Collection, Iterable, Mapping
 from typing import Any, TypeAlias
@@ -752,6 +753,60 @@ def send_user_creation_events_on_adding_subscriptions(
 SubT: TypeAlias = tuple[list[SubInfo], list[SubInfo]]
 
 
+def send_private_channel_subscription_notification(
+    stream: Stream,
+    subscribed_users: list[UserProfile],
+    *,
+    acting_user: UserProfile,
+    op: str,
+) -> None:
+    if not stream.invite_only:
+        return
+
+    sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
+    acting_user_mention = silent_mention_syntax_for_user(acting_user)
+
+    with override_language(stream.realm.default_language):
+        for user in subscribed_users:
+            if op == "add":
+                if user.id == acting_user.id:
+                    # User subscribed themselves — no notice needed; they already know.
+                    continue
+                notification_string = _(
+                    "{acting_user} subscribed {subscribed_user} to this channel."
+                )
+                notification_string = notification_string.format(
+                    acting_user=acting_user_mention,
+                    subscribed_user=silent_mention_syntax_for_user(user),
+                )
+            else:
+                if user.id == acting_user.id:
+                    notification_string = _("{user} unsubscribed from this channel.")
+                    notification_string = notification_string.format(
+                        user=acting_user_mention,
+                    )
+                else:
+                    notification_string = _(
+                        "{acting_user} unsubscribed {unsubscribed_user} from this channel."
+                    )
+                    notification_string = notification_string.format(
+                        acting_user=acting_user_mention,
+                        unsubscribed_user=silent_mention_syntax_for_user(user),
+                    )
+            try:
+                maybe_send_channel_events_notice(
+                    sender,
+                    stream,
+                    notification_string,
+                )
+            except Exception:
+                logging.exception(
+                    "Failed to send subscription notice to stream %d",
+                    stream.id,
+                    stack_info=True,
+                )
+
+
 @transaction.atomic(savepoint=False)
 def bulk_add_subscriptions(
     realm: Realm,
@@ -917,6 +972,28 @@ def bulk_add_subscriptions(
         stream_dict=stream_dict,
         subscriber_peer_info=subscriber_peer_info,
     )
+
+    if not from_user_creation and acting_user is not None:
+        users_by_stream: dict[int, list[UserProfile]] = defaultdict(list)
+        for sub_info in subs_to_add + subs_to_activate:
+            users_by_stream[sub_info.stream.id].append(sub_info.user)
+        streams_to_notify = [
+            (stream, users_by_stream[stream.id])
+            for stream in streams
+            if stream.id in users_by_stream
+        ]
+        acting_user_non_none: UserProfile = acting_user
+
+        def send_add_notifications() -> None:
+            for notify_stream, notify_users in streams_to_notify:
+                send_private_channel_subscription_notification(
+                    notify_stream,
+                    notify_users,
+                    acting_user=acting_user_non_none,
+                    op="add",
+                )
+
+        transaction.on_commit(send_add_notifications)
 
     return (
         subs_to_add + subs_to_activate,
@@ -1169,6 +1246,19 @@ def bulk_remove_subscriptions(
         for user, stream in removed_sub_tuples:
             altered_user_dict[user].add(stream.id)
         send_user_remove_events_on_removing_subscriptions(realm, altered_user_dict)
+
+    if acting_user is not None and not skip_events_for_removed_user:
+        users_by_stream: dict[int, list[UserProfile]] = defaultdict(list)
+        for user, stream in removed_sub_tuples:
+            users_by_stream[stream.id].append(user)
+        for stream in streams:
+            if stream.id in users_by_stream:
+                send_private_channel_subscription_notification(
+                    stream,
+                    users_by_stream[stream.id],
+                    acting_user=acting_user,
+                    op="remove",
+                )
 
     return (
         removed_sub_tuples,

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -763,6 +763,12 @@ def send_private_channel_subscription_notification(
     if not stream.invite_only:
         return
 
+    # Skip notifications for deactivated streams — the notification bot
+    # cannot post to an archived invite-only channel, and there is no
+    # meaningful audience for join/leave events on a stream being torn down.
+    if stream.deactivated:
+        return
+
     sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
     acting_user_mention = silent_mention_syntax_for_user(acting_user)
 
@@ -1252,7 +1258,7 @@ def bulk_remove_subscriptions(
         for user, stream in removed_sub_tuples:
             users_by_stream[stream.id].append(user)
         for stream in streams:
-            if stream.id in users_by_stream:
+            if stream.id in users_by_stream and not stream.deactivated:
                 send_private_channel_subscription_notification(
                     stream,
                     users_by_stream[stream.id],

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -5556,6 +5556,140 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertNotIn("new_subscription_messages_sent", data)
 
 
+class PrivateChannelSubscriptionNotificationTest(ZulipTestCase):
+    """Tests for channel events notices sent when subscribing/unsubscribing from private channels."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.hamlet = self.example_user("hamlet")
+        self.iago = self.example_user("iago")
+        self.realm = self.hamlet.realm
+        do_set_realm_property(self.realm, "send_channel_events_messages", True, acting_user=None)
+
+    def _make_private_stream(self, stream_name: str) -> Stream:
+        stream = self.make_stream(stream_name, invite_only=True)
+        self.subscribe(self.iago, stream_name)
+        return stream
+
+    def test_admin_subscribes_another_user_sends_notification(self) -> None:
+        """When an admin subscribes another user to a private channel, a notification is sent."""
+        stream = self._make_private_stream("private_stream")
+        self.login_user(self.iago)
+
+        result = self.subscribe_via_post(
+            self.iago,
+            ["private_stream"],
+            extra_post_data={"principals": orjson.dumps([self.hamlet.id]).decode()},
+        )
+        self.assert_json_success(result)
+
+        # Use get_topic_messages rather than get_last_message because
+        # subscribe_via_post also sends a "you were subscribed" DM to
+        # the newly subscribed user, which would otherwise be last.
+        messages = get_topic_messages(stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+        self.assert_length(messages, 1)
+        self.assertEqual(messages[0].sender_id, self.notification_bot(self.realm).id)
+        expected_content = (
+            f"@_**Iago|{self.iago.id}** subscribed "
+            f"@_**King Hamlet|{self.hamlet.id}** to this channel."
+        )
+        self.assertEqual(messages[0].content, expected_content)
+
+    def test_self_subscribe_to_private_channel_sends_no_notification(self) -> None:
+        """When a user subscribes themselves, no notification is sent (they already know)."""
+        stream = self._make_private_stream("private_stream2")
+        # Grant hamlet permission to subscribe to this stream.
+        setting_group_members_dict = UserGroupMembersData(
+            direct_members=[self.hamlet.id], direct_subgroups=[]
+        )
+        do_change_stream_group_based_setting(
+            stream,
+            "can_subscribe_group",
+            setting_group_members_dict,
+            acting_user=self.iago,
+        )
+
+        self.login_user(self.hamlet)
+        result = self.subscribe_via_post(self.hamlet, ["private_stream2"])
+        self.assert_json_success(result)
+
+        messages = get_topic_messages(stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+        self.assert_length(messages, 0)
+
+    def test_public_channel_subscription_sends_no_notification(self) -> None:
+        """Subscription notifications are only sent for private channels."""
+        stream = self.make_stream("public_stream")
+        self.login_user(self.iago)
+
+        result = self.subscribe_via_post(
+            self.iago,
+            ["public_stream"],
+            extra_post_data={"principals": orjson.dumps([self.hamlet.id]).decode()},
+        )
+        self.assert_json_success(result)
+
+        messages = get_topic_messages(stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+        self.assert_length(messages, 0)
+
+    def test_admin_unsubscribes_another_user_sends_notification(self) -> None:
+        """When an admin removes another user from a private channel, a notification is sent."""
+        stream = self._make_private_stream("private_stream3")
+        self.subscribe(self.hamlet, "private_stream3")
+        self.login_user(self.iago)
+
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {
+                "subscriptions": orjson.dumps(["private_stream3"]).decode(),
+                "principals": orjson.dumps([self.hamlet.id]).decode(),
+            },
+        )
+        self.assert_json_success(result)
+
+        messages = get_topic_messages(stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+        self.assert_length(messages, 1)
+        self.assertEqual(messages[0].sender_id, self.notification_bot(self.realm).id)
+        expected_content = (
+            f"@_**Iago|{self.iago.id}** unsubscribed "
+            f"@_**King Hamlet|{self.hamlet.id}** from this channel."
+        )
+        self.assertEqual(messages[0].content, expected_content)
+
+    def test_user_unsubscribes_self_sends_notification(self) -> None:
+        """When a user unsubscribes themselves from a private channel, a notification is sent."""
+        stream = self._make_private_stream("private_stream4")
+        self.subscribe(self.hamlet, "private_stream4")
+        self.login_user(self.hamlet)
+
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {"subscriptions": orjson.dumps(["private_stream4"]).decode()},
+        )
+        self.assert_json_success(result)
+
+        messages = get_topic_messages(stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+        self.assert_length(messages, 1)
+        self.assertEqual(messages[0].sender_id, self.notification_bot(self.realm).id)
+        expected_content = f"@_**King Hamlet|{self.hamlet.id}** unsubscribed from this channel."
+        self.assertEqual(messages[0].content, expected_content)
+
+    def test_notification_not_sent_when_setting_disabled(self) -> None:
+        """No notification is sent when send_channel_events_messages is False."""
+        do_set_realm_property(self.realm, "send_channel_events_messages", False, acting_user=None)
+        stream = self._make_private_stream("private_stream5")
+        self.login_user(self.iago)
+
+        result = self.subscribe_via_post(
+            self.iago,
+            ["private_stream5"],
+            extra_post_data={"principals": orjson.dumps([self.hamlet.id]).decode()},
+        )
+        self.assert_json_success(result)
+
+        messages = get_topic_messages(stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME)
+        self.assert_length(messages, 0)
+
+
 class InviteOnlyStreamTest(ZulipTestCase):
     def test_must_be_subbed_to_send(self) -> None:
         """


### PR DESCRIPTION
Fixes part of #2746.

## Overview

When a user is subscribed or unsubscribed from a private channel, other
members currently receive no indication of who joined or left. This PR adds
channel events notices for these actions, using the same mechanism already
used for permission changes, renames, and description updates.

**Notification messages** sent to the "channel events" topic:

- `@acting_user subscribed @user to this channel.` — when someone subscribes another user
- `@acting_user unsubscribed @user from this channel.` — when someone removes another user
- `@user unsubscribed from this channel.` — when a user leaves themselves

**No notification** is sent when a user subscribes themselves (they already know),
for public/web-public channels, during new-user creation, or during user deletion.

Notifications are gated on the realm's `send_channel_events_messages` setting,
consistent with all other channel event notices.

## Technical approach

Added `send_private_channel_subscription_notification()` in
`zerver/actions/streams.py`, called from both `bulk_add_subscriptions` and
`bulk_remove_subscriptions` after all WebSocket events are dispatched.
Follows the same pattern as `send_change_stream_permission_notification` —
uses `get_system_bot(NOTIFICATION_BOT)`, `silent_mention_syntax_for_user`,
`override_language`, and `maybe_send_channel_events_notice`.

## How changes were tested

New test class `PrivateChannelSubscriptionNotificationTest` in
`zerver/tests/test_subs.py` covering:
- Admin subscribing another user → correct notification content and topic
- Self-subscription → no notification
- Public channel → no notification
- Admin unsubscribing another user → correct notification
- User leaving → correct notification
- `send_channel_events_messages = False` → no notification

**Screenshots and screen captures:**

No visual changes (backend only).

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.
- [x] Explains differences from previous plans (no prior plan; implementing directly from issue).
- [x] Highlights technical choices: reuses existing `maybe_send_channel_events_notice` rather than a custom send path; skips self-subscription silently rather than sending a redundant notice.
- [x] Calls out remaining decisions: should public channels also get notifications? Currently excluded — open to feedback.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message explains reasoning and motivation.
- [ ] Visual appearance — N/A (backend only).
- [ ] Responsiveness and internationalization — strings are wrapped in `_()` and formatted with `.format()` per Zulip convention; `override_language` is used.
- [ ] End-to-end functionality — tested via unit tests; manual testing requires a provisioned dev environment.
- [x] Corner cases: user deletion (`skip_events_for_removed_user`), new-user creation (`from_user_creation`), acting_user=None (management commands).

</details>
