### PR TITLE
compose_closed_ui: Restore label_text for stream/topic recipients.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -17,8 +17,12 @@ import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import * as util from "./util.ts";
 
+// `label_text` is a flat, pre-formatted string used by the call-creation
+// paths in compose_call_ui.ts to build a meeting/room name.
+// The reply-button template uses the structured `stream` / `topic_display_name`
+// fields instead, so it can render the decorated channel icon.
 type RecipientLabel = {
-    label_text?: string;
+    label_text: string;
     has_empty_string_topic?: boolean;
     stream?: StreamSubscription;
     topic_display_name?: string;
@@ -31,6 +35,7 @@ function get_stream_recipient_label(stream_id: number, topic: string): Recipient
     const topic_display_name = util.get_final_topic_display_name(topic);
     if (stream) {
         const recipient_label: RecipientLabel = {
+            label_text: `#${stream.name} > ${topic_display_name}`,
             has_empty_string_topic: topic === "",
             stream,
             topic_display_name,

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -251,6 +251,34 @@ run_test("test_non_message_list_input", ({mock_template}) => {
     assert.equal(label, "translated: Compose message");
 });
 
+run_test("recipient_label_text_for_call_creation", () => {
+    recent_view_util.is_visible = () => true;
+    message_lists.current = undefined;
+    const stream = make_stream({
+        subscribed: true,
+        name: "stream test",
+        stream_id: 11,
+    });
+    stream_data.add_sub_for_tests(stream);
+
+    assert.equal(
+        compose_closed_ui.get_recipient_label({
+            stream_id: stream.stream_id,
+            topic: "topic test",
+        })?.label_text,
+        "#stream test > topic test",
+    );
+
+    // Empty topic falls back to the realm's empty-topic display name.
+    assert.equal(
+        compose_closed_ui.get_recipient_label({
+            stream_id: stream.stream_id,
+            topic: "",
+        })?.label_text,
+        `#stream test > translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`,
+    );
+});
+
 run_test("update_reply_button_state", ({override, override_rewire}) => {
     const $compose_reply_wrapper = $("#legacy-closed-compose-box .compose-reply-button-wrapper");
     const $reply_button = $(".compose_reply_button");


### PR DESCRIPTION
Commit 0cd5c18e71d66119d7136c43975d88026435849e refactored the reply-button label to use a template that consumes the structured fields (stream, topic_display_name, has_empty_string_topic) directly, and dropped the now-redundant label_text for stream/topic recipients.

However, label_text is still consumed by the BigBlueButton and Nextcloud Talk call-creation paths in compose_call_ui.ts.   With `label_text` missing for stream/topic recipients, the generated meeting/room names lose their channel and topic context, falling back to `" meeting"` / `" conversation"`. Restore the label_text field for stream/topic recipients using the same format the refactor removed.

Before this PR:

<img width="380" height="163" alt="image" src="https://github.com/user-attachments/assets/2f19ef80-a150-4c64-976a-28b237dcd6b6" />

With this fix:

<img width="634" height="163" alt="image" src="https://github.com/user-attachments/assets/635d9302-9d4a-44ea-8f10-627b090b1221" />

**BigBlueButton**
<img width="1684" height="724" alt="image" src="https://github.com/user-attachments/assets/1fd94d4f-3e49-4989-841d-d24ed845a6b3" />

**How changes were tested:**
Manually in Nextcloud Talk server. I also tested for BigBlueBotton. This company https://www.bigbluemeeting.com/ offers a free trial for 1 month.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Conversation: [#issues > Stream/topic calls get empty meeting/room name (nextcloud)](https://chat.zulip.org/#narrow/channel/9-issues/topic/Stream.2Ftopic.20calls.20get.20empty.20meeting.2Froom.20name.20.28nextcloud.29/with/2480866)**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
