### PR TITLE
message_edit: Preserve topic visibility policy on a case-only rename.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -631,6 +631,42 @@ def update_user_topic_visibility_policies_on_move(
     target_topic_has_messages: bool,
     users_losing_access: Iterable[UserProfile],
 ) -> dict[UserProfile, int]:
+    if not is_stream_edited and orig_topic_name.lower() == target_topic_name.lower():
+        # A case-only topic rename within the same stream is not a real
+        # move: topic matching is case-insensitive, so the existing
+        # UserTopic rows already apply to the renamed topic. The general
+        # logic below would resolve both topics to that one row, delete
+        # it, then skip recreating it (seeing the target as already set)
+        # and clear the policy. Recreate each row under the new casing.
+        preserved_visibility_policy = {
+            row.user_profile: row.visibility_policy
+            for row in get_users_with_user_topic_visibility_policy(
+                stream_being_edited.id, orig_topic_name
+            )
+        }
+
+        # bulk_do_set_user_topic_visibility_policy is a no-op when the
+        # policy is unchanged, so the casing can't be rewritten in place.
+        bulk_do_set_user_topic_visibility_policy(
+            list(preserved_visibility_policy.keys()),
+            stream_being_edited,
+            orig_topic_name,
+            visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
+            # The per-policy calls below send the muted_topics events.
+            skip_muted_topics_event=True,
+        )
+        user_profiles_for_visibility_policy: dict[int, list[UserProfile]] = defaultdict(list)
+        for user_profile, visibility_policy in preserved_visibility_policy.items():
+            user_profiles_for_visibility_policy[visibility_policy].append(user_profile)
+        for visibility_policy, user_profiles in user_profiles_for_visibility_policy.items():
+            bulk_do_set_user_topic_visibility_policy(
+                user_profiles,
+                stream_being_edited,
+                target_topic_name,
+                visibility_policy=visibility_policy,
+            )
+        return preserved_visibility_policy
+
     stream_inaccessible_to_user_profiles: list[UserProfile] = []
     orig_topic_user_profile_to_visibility_policy: dict[UserProfile, int] = {}
     target_topic_user_profile_to_visibility_policy: dict[UserProfile, int] = {}

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -424,6 +424,97 @@ class MessageMoveTopicTest(ZulipTestCase):
         do_update_message_topic_success(hamlet, message, "Change again", users_to_be_notified)
 
     @mock.patch("zerver.actions.user_topics.send_event_on_commit")
+    def test_case_only_topic_rename_preserves_visibility_policy(
+        self, mock_send_event_on_commit: mock.MagicMock
+    ) -> None:
+        # Renaming a topic with only a case change is, for matching
+        # purposes, the same topic; each user's visibility policy must
+        # survive the rename rather than being reset to inherit.
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        stream = self.make_stream("case rename stream")
+        self.subscribe(hamlet, stream.name)
+        self.subscribe(cordelia, stream.name)
+        self.login_user(hamlet)
+
+        message_id = self.send_stream_message(hamlet, stream.name, topic_name="Test Topic")
+        do_set_user_topic_visibility_policy(
+            hamlet, stream, "Test Topic", visibility_policy=UserTopic.VisibilityPolicy.MUTED
+        )
+        do_set_user_topic_visibility_policy(
+            cordelia, stream, "Test Topic", visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        mock_send_event_on_commit.reset_mock()
+
+        result = self.client_patch(
+            f"/json/messages/{message_id}",
+            {"topic": "test topic", "propagate_mode": "change_all"},
+        )
+        self.assert_json_success(result)
+
+        # Each affected user is notified just like for a regular move: a
+        # user_topic event removing the old row, one adding the row under
+        # the new casing, and a muted_topics event with the full updated
+        # set of muted topics.
+        user_topic_events: dict[int, list[tuple[str, int]]] = {hamlet.id: [], cordelia.id: []}
+        muted_topics_events: dict[int, list[list[list[str | int]]]] = {
+            hamlet.id: [],
+            cordelia.id: [],
+        }
+        for call_args in mock_send_event_on_commit.call_args_list:
+            (_arg_realm, arg_event, arg_notified_users) = call_args[0]
+            [notified_user_id] = arg_notified_users
+            if arg_event["type"] == "user_topic":
+                self.assertEqual(arg_event["stream_id"], stream.id)
+                user_topic_events[notified_user_id].append(
+                    (arg_event["topic_name"], arg_event["visibility_policy"])
+                )
+            elif arg_event["type"] == "muted_topics":
+                muted_topics_events[notified_user_id].append(arg_event["muted_topics"])
+        self.assertEqual(
+            user_topic_events[hamlet.id],
+            [
+                ("Test Topic", UserTopic.VisibilityPolicy.INHERIT),
+                ("test topic", UserTopic.VisibilityPolicy.MUTED),
+            ],
+        )
+        self.assertEqual(
+            user_topic_events[cordelia.id],
+            [
+                ("Test Topic", UserTopic.VisibilityPolicy.INHERIT),
+                ("test topic", UserTopic.VisibilityPolicy.FOLLOWED),
+            ],
+        )
+        self.assertEqual(muted_topics_events[hamlet.id], [[[stream.name, "test topic", mock.ANY]]])
+        self.assertEqual(muted_topics_events[cordelia.id], [[]])
+
+        # The policies survive and still apply to the renamed topic
+        # (matched case-insensitively).
+        self.assertTrue(
+            topic_has_visibility_policy(
+                hamlet, stream.id, "test topic", UserTopic.VisibilityPolicy.MUTED
+            )
+        )
+        self.assertTrue(
+            topic_has_visibility_policy(
+                cordelia, stream.id, "test topic", UserTopic.VisibilityPolicy.FOLLOWED
+            )
+        )
+        # The stored topic name is updated to the new casing, and no row
+        # is duplicated or lost.
+        self.assertEqual(
+            sorted(
+                UserTopic.objects.filter(stream_id=stream.id).values_list(
+                    "topic_name", "visibility_policy"
+                )
+            ),
+            [
+                ("test topic", UserTopic.VisibilityPolicy.MUTED),
+                ("test topic", UserTopic.VisibilityPolicy.FOLLOWED),
+            ],
+        )
+
+    @mock.patch("zerver.actions.user_topics.send_event_on_commit")
     def test_edit_muted_topic(self, mock_send_event_on_commit: mock.MagicMock) -> None:
         stream_name = "Stream 123"
         stream = self.make_stream(stream_name)


### PR DESCRIPTION
Renaming a topic with only a case change ("Test Topic" -> "test topic") within the same stream went through the same UserTopic migration as a real move. Because topic matching is case-insensitive (a unique index on lower(topic_name) means there is exactly one UserTopic row per topic), the migration resolved both the original and target topics to that one row: it deleted the row for the original name and then skipped recreating it for the target, having seen the target as already holding the policy. The user's mute/follow was silently reset to inherit.

A case-only rename within a stream needs no merge logic, since the existing row already applies to the renamed topic. Short-circuit that case, recreating each user's row under the new casing with its policy preserved. Reusing bulk_do_set_user_topic_visibility_policy for the rewrite also notifies clients with the same user_topic/muted_topics event sequence as a regular move; a bare .update() would have changed the row's API-visible topic_name without telling live clients.

---

Found as part of Claude audit.