### PR TITLE
dark_theme: Use red-250 variable for dropdown-list-delete

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -28,15 +28,14 @@
     }
 
     .dropdown-list-delete {
-        /* hsl(7deg 100% 74%) corresponds to var(--red-250) */
         color: color-mix(
             in oklch,
-            hsl(7deg 100% 74%) 70%,
+            var(--red-250) 70%,
             transparent
         ) !important;
 
         &:hover {
-            color: hsl(7deg 100% 74%) !important;
+            color: var(--red-250) !important;
         }
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -28,11 +28,7 @@
     }
 
     .dropdown-list-delete {
-        color: color-mix(
-            in oklch,
-            var(--red-250) 70%,
-            transparent
-        ) !important;
+        color: color-mix(in oklch, var(--red-250) 70%, transparent) !important;
 
         &:hover {
             color: var(--red-250) !important;


### PR DESCRIPTION
## Summary

Replace hardcoded color values in `web/styles/dark_theme.css` with the existing `--red-250` CSS variable (described in `web/styles/app_variables.css` as `--red-250: #ff8b7c;`) for `.dropdown-list-delete`.

## Details

`web/styles/dark_theme.css` contained the following comment:

> `hsl(7deg 100% 74%) corresponds to var(--red-250)`

This change replaces the hardcoded `hsl(7deg 100% 74%)` values used in both the default and hover states of `.dropdown-list-delete` with `var(--red-250)` and removes the now-unnecessary comment.

### Before

```css
.dropdown-list-delete {
    /* hsl(7deg 100% 74%) corresponds to var(--red-250) */
    color: color-mix(
        in oklch,
        hsl(7deg 100% 74%) 70%,
        transparent
    ) !important;

    &:hover {
        color: hsl(7deg 100% 74%) !important;
    }
}
```

### After

```css
.dropdown-list-delete {
    color: color-mix(
        in oklch,
        var(--red-250) 70%,
        transparent
    ) !important;

    &:hover {
        color: var(--red-250) !important;
    }
}
```

This is a cleanup-only change intended to reduce hardcoded color usage in `dark_theme.css` without any visual or behavioral changes.

## Testing

* Reloaded the development server after the change.
* Confirmed that the application loads successfully.
* Confirmed that the stylesheet change does not introduce build or runtime issues.
* No visual changes intended.

## Screenshots

### Dark theme

#### Before (default)

<img width="1919" height="991" alt="dark-mode-before-change-without-hover" src="https://github.com/user-attachments/assets/779ee570-6265-4d96-b14c-5529f8fb5cd3" />

#### Before (hover)

<img width="1919" height="993" alt="dark-mode-before-change-with-hover" src="https://github.com/user-attachments/assets/f9d9b82e-493a-4eca-8424-5d284a052406" />

#### After (default)

<img width="1919" height="992" alt="dark-after-without-hover" src="https://github.com/user-attachments/assets/c44dd9e5-6ada-4c36-b8b5-42b49c8c74bc" />

#### After (hover)

<img width="1919" height="993" alt="dark-after-with-hover" src="https://github.com/user-attachments/assets/5fbee5ab-9894-4154-9a39-eb081f3a2f24" />

### Light theme

#### Before (default)

<img width="1919" height="991" alt="light-mode-before-change-without-hover" src="https://github.com/user-attachments/assets/ece64c93-11c0-4ee5-a500-0a85e7fba7ca" />

#### Before (hover)

<img width="1919" height="992" alt="light-mode-before-change-with-hover" src="https://github.com/user-attachments/assets/e67c4148-0141-4455-b3ba-9d3b922ebfb1" />

#### After (default)

<img width="1919" height="992" alt="light-after-without-hover" src="https://github.com/user-attachments/assets/66aa1840-f810-4e7b-a45c-0456be689754" />

#### After (hover)

<img width="1919" height="991" alt="light-after-with-hover" src="https://github.com/user-attachments/assets/4c8e2a24-fcbe-4e5b-840d-cb1ebd193a46" />

Fixes #39354
