### PR TITLE
api-docs: Document the `/bots` endpoint.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -123,6 +123,8 @@
 * [Add alert words](/api/add-alert-words)
 * [Remove alert words](/api/remove-alert-words)
 * [Regenerate your API key](/api/regenerate-api-key)
+* [Get all bots](/api/get-bots)
+* [Add a bot](/api/add-bot)
 * [Get a bot's API key](/api/get-bot-api-key)
 * [Regenerate a bot's API key](/api/regenerate-bot-api-key)
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -121,6 +121,8 @@
 * [Add alert words](/api/add-alert-words)
 * [Remove alert words](/api/remove-alert-words)
 * [Regenerate your API key](/api/regenerate-api-key)
+* [Get all bots](/api/get-bots)
+* [Add a bot](/api/add-bot)
 * [Get a bot's API key](/api/get-bot-api-key)
 * [Regenerate a bot's API key](/api/regenerate-bot-api-key)
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -184,6 +184,7 @@ class ZulipClientHandler(ClientHandler):
             and not (
                 response.status_code == 302 and response.headers["Location"].startswith("/login/")
             )
+            and not request.META.get("skip_openapi_validation", False)
         ):
             openapi_request = DjangoOpenAPIRequest(request)
             openapi_response = DjangoOpenAPIResponse(response)
@@ -580,6 +581,7 @@ Output:
         headers: Mapping[str, Any] | None = None,
         query_params: Mapping[str, Any] | None = None,
         intentionally_undocumented: bool = False,
+        skip_openapi_validation: bool = False,
         content_type: str | None = None,
         **extra: str,
     ) -> "TestHttpResponse":
@@ -609,6 +611,7 @@ Output:
             query_params=query_params,
             content_type=content_type,
             intentionally_undocumented=intentionally_undocumented,
+            skip_openapi_validation=skip_openapi_validation,
             **extra,
         )
 
@@ -637,6 +640,7 @@ Output:
         headers: Mapping[str, Any] | None = None,
         query_params: Mapping[str, Any] | None = None,
         intentionally_undocumented: bool = False,
+        skip_openapi_validation: bool = False,
         **extra: str,
     ) -> "TestHttpResponse":
         django_client = self.client  # see WRAPPER_COMMENT
@@ -649,6 +653,7 @@ Output:
             headers=headers,
             query_params=query_params,
             intentionally_undocumented=intentionally_undocumented,
+            skip_openapi_validation=skip_openapi_validation,
             **extra,
         )
 
@@ -804,6 +809,7 @@ Output:
             headers=None,
             query_params=None,
             intentionally_undocumented=False,
+            skip_openapi_validation=False,
             **extra,
         )
         self.assertNotEqual(result.status_code, 500)
@@ -951,6 +957,7 @@ Output:
             headers=None,
             query_params=None,
             intentionally_undocumented=False,
+            skip_openapi_validation=False,
             **extra,
         )
 
@@ -1109,6 +1116,7 @@ Output:
             headers=None,
             query_params=None,
             intentionally_undocumented=False,
+            skip_openapi_validation=False,
             **extra,
         )
 
@@ -1129,6 +1137,7 @@ Output:
             headers=None,
             query_params=None,
             intentionally_undocumented=False,
+            skip_openapi_validation=False,
             **extra,
         )
 
@@ -1146,6 +1155,7 @@ Output:
             headers=None,
             query_params=None,
             intentionally_undocumented=False,
+            skip_openapi_validation=False,
             **extra,
         )
 
@@ -1169,6 +1179,7 @@ Output:
             headers=None,
             query_params=None,
             intentionally_undocumented=intentionally_undocumented,
+            skip_openapi_validation=False,
             **extra,
         )
 
@@ -1804,6 +1815,7 @@ Output:
             headers=None,
             query_params=None,
             intentionally_undocumented=False,
+            skip_openapi_validation=False,
             **extra,
         )
         self.assert_json_success(result)

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -25,6 +25,7 @@ from zerver.lib.initial_password import initial_password
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import read_test_image_file
 from zerver.lib.upload import upload_message_attachment
+from zerver.lib.users import validate_short_name_and_construct_bot_email
 from zerver.models import Client, Message, NamedUserGroup, UserPresence
 from zerver.models.channel_folders import ChannelFolder
 from zerver.models.realms import get_realm
@@ -257,6 +258,28 @@ def get_user_presence() -> dict[str, object]:
 def create_user() -> dict[str, object]:
     return {
         "email": helpers.nonreg_email("test"),
+    }
+
+
+@openapi_param_value_generator(["/bots:post"])
+def add_bot_names() -> dict[str, object]:
+    # This runs against a development database that persists between
+    # runs, so pick names that a previous run has not already used.
+    realm = get_realm("zulip")
+    count = 0
+    exists = True
+    while exists:
+        count += 1
+        short_name = f"hambot{count}"
+        full_name = f"Bot of Hamlet {count}"
+        email = validate_short_name_and_construct_bot_email(short_name, realm)[1]
+        exists = (
+            UserProfile.objects.filter(realm=realm, delivery_email=email).exists()
+            or UserProfile.objects.filter(realm=realm, full_name=full_name, is_active=True).exists()
+        )
+    return {
+        "short_name": short_name,
+        "full_name": full_name,
     }
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -26675,6 +26675,257 @@ paths:
                       }
                     description: |
                       An example JSON response when the channel folder ID is invalid:
+  /bots:
+    get:
+      operationId: get-bots
+      summary: Get all bots
+      tags: ["users"]
+      description: |
+        Get all of the bots owned by the current user.
+
+        See also [getting all users](/api/get-users), the more
+        general endpoint for fetching details on users in the
+        organization.
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      bots:
+                        type: array
+                        description: |
+                          An array of objects, where each object contains details
+                          about a bot owned by the current user.
+                        items:
+                          type: object
+                          additionalProperties: false
+                          properties:
+                            username:
+                              type: string
+                              description: |
+                                The Zulip API email address of the bot.
+                            full_name:
+                              type: string
+                              description: |
+                                The full name of the bot.
+                            api_key:
+                              type: string
+                              description: |
+                                The API key that the bot uses to make API requests.
+                            avatar_url:
+                              type: string
+                              nullable: true
+                              description: |
+                                The URL of the bot's avatar.
+                            default_sending_stream:
+                              type: string
+                              nullable: true
+                              description: |
+                                The default channel that the bot sends messages to.
+
+                                Will be `null` if the bot has no default sending
+                                channel.
+                            default_events_register_stream:
+                              type: string
+                              nullable: true
+                              description: |
+                                The default channel from which the bot will receive
+                                events and register data.
+
+                                Will be `null` if the bot has no such default
+                                channel.
+                            default_all_public_streams:
+                              type: boolean
+                              description: |
+                                Whether the bot can send messages to all public
+                                channels in the organization.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "bots":
+                          [
+                            {
+                              "username": "hambot-bot@zulip.testserver",
+                              "full_name": "The Bot of Hamlet",
+                              "api_key": "QadL2gObGOJjAQuC6MQACzaA3iEjvyOY",
+                              "avatar_url": "https://secure.gravatar.com/avatar/1cf27cf7a25c5b7c91a857a3872738e7?d=identicon&version=1",
+                              "default_sending_stream": null,
+                              "default_events_register_stream": null,
+                              "default_all_public_streams": false,
+                            },
+                          ],
+                      }
+    post:
+      operationId: add-bot
+      summary: Add a bot
+      tags: ["users"]
+      description: |
+        Create (or "add") a new [bot user](/help/bots-overview).
+
+        Whether the current user can create bots, and of which types,
+        is controlled by the organization's [bot creation
+        policy](/help/restrict-bot-creation).
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                full_name:
+                  type: string
+                  description: |
+                    The full name of the new bot.
+                  example: Bot of Hamlet
+                short_name:
+                  type: string
+                  description: |
+                    The short name of the new bot. Used to construct the bot's
+                    Zulip API email address; see `username` in the response of
+                    [getting all bots](/api/get-bots).
+                  example: hambot
+                bot_type:
+                  type: integer
+                  default: 1
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                  description: |
+                    The [type of bot](/help/bots-overview#bot-types) to create:
+
+                    - 1 = Generic bot
+                    - 2 = Incoming webhook bot
+                    - 3 = Outgoing webhook bot
+                    - 4 = Embedded bot
+                service_name:
+                  type: string
+                  description: |
+                    For outgoing webhook and embedded bots, the name of the service
+                    the bot should use. For embedded bots, this must be the name of
+                    one of the bots enabled in the server's `EMBEDDED_BOTS` setting.
+
+                    Ignored for other bot types.
+                payload_url:
+                  type: string
+                  description: |
+                    For outgoing webhook bots, the URL that the bot's messages will
+                    be sent to.
+
+                    Ignored for other bot types.
+                interface_type:
+                  type: integer
+                  default: 1
+                  enum:
+                    - 1
+                    - 2
+                  description: |
+                    For outgoing webhook bots, the interface to use when
+                    communicating with the configured `payload_url`:
+
+                    - 1 = Generic
+                    - 2 = Slack-compatible
+
+                    Ignored for other bot types.
+                config_data:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: |
+                    For incoming webhook and embedded bots, a dictionary of
+                    configuration values for the bot's service, encoded as a string
+                    to string mapping.
+
+                    Ignored for other bot types.
+                default_sending_stream:
+                  type: string
+                  description: |
+                    The default channel that the new bot will send messages to.
+                default_events_register_stream:
+                  type: string
+                  description: |
+                    The default channel from which the new bot will receive events
+                    and register data.
+                default_all_public_streams:
+                  type: boolean
+                  description: |
+                    Whether the new bot can send messages to all public channels in
+                    the organization.
+              required:
+                - full_name
+                - short_name
+            encoding:
+              payload_url:
+                contentType: application/json
+              config_data:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      user_id:
+                        type: integer
+                        description: |
+                          The user ID assigned to the newly created bot.
+                      api_key:
+                        type: string
+                        description: |
+                          The API key that the bot uses to make API requests.
+                      avatar_url:
+                        type: string
+                        nullable: true
+                        description: |
+                          The URL of the bot's avatar.
+                      default_sending_stream:
+                        type: string
+                        nullable: true
+                        description: |
+                          The default channel that the bot sends messages to.
+
+                          Will be `null` if the bot has no default sending channel.
+                      default_events_register_stream:
+                        type: string
+                        nullable: true
+                        description: |
+                          The default channel from which the bot receives events and
+                          register data.
+
+                          Will be `null` if the bot has no such default channel.
+                      default_all_public_streams:
+                        type: boolean
+                        description: |
+                          Whether the bot can send messages to all public channels
+                          in the organization.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "user_id": 45,
+                        "api_key": "QadL2gObGOJjAQuC6MQACzaA3iEjvyOY",
+                        "avatar_url": "https://secure.gravatar.com/avatar/1cf27cf7a25c5b7c91a857a3872738e7?d=identicon&version=1",
+                        "default_sending_stream": null,
+                        "default_events_register_stream": null,
+                        "default_all_public_streams": false,
+                      }
   /bots/{bot_id}/api_key:
     get:
       operationId: get-bot-api-key

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27031,6 +27031,273 @@ paths:
                       }
                     description: |
                       An example JSON response when the channel folder ID is invalid:
+  /bots:
+    get:
+      operationId: get-bots
+      summary: Get all bots
+      tags: ["users"]
+      description: |
+        Get all of the bots owned by the current user.
+
+        See also [getting all users](/api/get-users), the more
+        general endpoint for fetching details on users in the
+        organization.
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      bots:
+                        type: array
+                        description: |
+                          An array of objects, where each object contains details
+                          about a bot owned by the current user.
+                        items:
+                          type: object
+                          additionalProperties: false
+                          properties:
+                            username:
+                              type: string
+                              description: |
+                                The Zulip API email address of the bot.
+                            full_name:
+                              type: string
+                              description: |
+                                The full name of the bot.
+                            api_key:
+                              type: string
+                              description: |
+                                The API key that the bot uses to make API requests.
+                            avatar_url:
+                              type: string
+                              nullable: true
+                              description: |
+                                The URL of the bot's avatar.
+                            default_sending_stream:
+                              type: string
+                              nullable: true
+                              description: |
+                                The default channel that the bot sends messages to.
+
+                                Will be `null` if the bot has no default sending
+                                channel.
+                            default_events_register_stream:
+                              type: string
+                              nullable: true
+                              description: |
+                                The default channel from which the bot will receive
+                                events and register data.
+
+                                Will be `null` if the bot has no such default
+                                channel.
+                            default_all_public_streams:
+                              type: boolean
+                              description: |
+                                Whether the bot can send messages to all public
+                                channels in the organization.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "bots":
+                          [
+                            {
+                              "username": "hambot-bot@zulip.testserver",
+                              "full_name": "The Bot of Hamlet",
+                              "api_key": "QadL2gObGOJjAQuC6MQACzaA3iEjvyOY",
+                              "avatar_url": "https://secure.gravatar.com/avatar/1cf27cf7a25c5b7c91a857a3872738e7?d=identicon&version=1",
+                              "default_sending_stream": null,
+                              "default_events_register_stream": null,
+                              "default_all_public_streams": false,
+                            },
+                          ],
+                      }
+    post:
+      operationId: add-bot
+      summary: Add a bot
+      tags: ["users"]
+      description: |
+        Create (or "add") a new [bot user](/help/bots-overview).
+
+        Whether the current user can create bots, and of which types,
+        is controlled by the organization's [bot creation
+        policy](/help/restrict-bot-creation).
+      x-curl-examples-parameters:
+        oneOf:
+          - type: include
+            parameters:
+              enum:
+                - full_name
+                - short_name
+                - bot_type
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                full_name:
+                  type: string
+                  description: |
+                    The full name of the new bot.
+                  example: Bot of Hamlet
+                short_name:
+                  type: string
+                  description: |
+                    The short name of the new bot. Used to construct the bot's
+                    Zulip API email address; see `username` in the response of
+                    [getting all bots](/api/get-bots).
+                  example: hambot
+                bot_type:
+                  type: integer
+                  default: 1
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                  description: |
+                    The [type of bot](/help/bots-overview#bot-types) to create:
+
+                    - 1 = Generic bot
+                    - 2 = Incoming webhook bot
+                    - 3 = Outgoing webhook bot
+                    - 4 = Embedded bot
+                  example: 1
+                service_name:
+                  type: string
+                  description: |
+                    For outgoing webhook and embedded bots, the name of the service
+                    the bot should use. For embedded bots, this must be the name of
+                    one of the bots enabled in the server's `EMBEDDED_BOTS` setting.
+
+                    Ignored for other bot types.
+                  example: helloworld
+                payload_url:
+                  type: string
+                  description: |
+                    For outgoing webhook bots, the URL that the bot's messages will
+                    be sent to.
+
+                    Ignored for other bot types.
+                  example: https://bot.example.com/webhook
+                interface_type:
+                  type: integer
+                  default: 1
+                  enum:
+                    - 1
+                    - 2
+                  description: |
+                    For outgoing webhook bots, the interface to use when
+                    communicating with the configured `payload_url`:
+
+                    - 1 = Generic
+                    - 2 = Slack-compatible
+
+                    Ignored for other bot types.
+                  example: 1
+                config_data:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: |
+                    For incoming webhook and embedded bots, a dictionary of
+                    configuration values for the bot's service, encoded as a string
+                    to string mapping.
+
+                    Ignored for other bot types.
+                  example: {"api_key": "abcd1234"}
+                default_sending_stream:
+                  type: string
+                  description: |
+                    The default channel that the new bot will send messages to.
+                  example: Denmark
+                default_events_register_stream:
+                  type: string
+                  description: |
+                    The default channel from which the new bot will receive events
+                    and register data.
+                  example: Denmark
+                default_all_public_streams:
+                  type: boolean
+                  description: |
+                    Whether the new bot can send messages to all public channels in
+                    the organization.
+                  example: true
+              required:
+                - full_name
+                - short_name
+            encoding:
+              payload_url:
+                contentType: application/json
+              config_data:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      user_id:
+                        type: integer
+                        description: |
+                          The user ID assigned to the newly created bot.
+                      api_key:
+                        type: string
+                        description: |
+                          The API key that the bot uses to make API requests.
+                      avatar_url:
+                        type: string
+                        nullable: true
+                        description: |
+                          The URL of the bot's avatar.
+                      default_sending_stream:
+                        type: string
+                        nullable: true
+                        description: |
+                          The default channel that the bot sends messages to.
+
+                          Will be `null` if the bot has no default sending channel.
+                      default_events_register_stream:
+                        type: string
+                        nullable: true
+                        description: |
+                          The default channel from which the bot receives events and
+                          register data.
+
+                          Will be `null` if the bot has no such default channel.
+                      default_all_public_streams:
+                        type: boolean
+                        description: |
+                          Whether the bot can send messages to all public channels
+                          in the organization.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "user_id": 45,
+                        "api_key": "QadL2gObGOJjAQuC6MQACzaA3iEjvyOY",
+                        "avatar_url": "https://secure.gravatar.com/avatar/1cf27cf7a25c5b7c91a857a3872738e7?d=identicon&version=1",
+                        "default_sending_stream": null,
+                        "default_events_register_stream": null,
+                        "default_all_public_streams": false,
+                      }
   /bots/{bot_id}/api_key:
     get:
       operationId: get-bot-api-key

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -67,6 +67,11 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_length(response_dict["bots"], count)
 
     def create_bot(self, **extras: Any) -> dict[str, Any]:
+        # These are popped rather than declared as keyword-only
+        # parameters because several callers pass a `dict[str, object]`
+        # of bot settings with `**`, which mypy cannot check against
+        # narrower parameter types.
+        intentionally_undocumented = extras.pop("intentionally_undocumented", False)
         skip_openapi_validation = extras.pop("skip_openapi_validation", False)
         bot_info = {
             "full_name": "The Bot of Hamlet",
@@ -75,7 +80,10 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         bot_info.update(extras)
         result = self.client_post(
-            "/json/bots", bot_info, skip_openapi_validation=skip_openapi_validation
+            "/json/bots",
+            bot_info,
+            intentionally_undocumented=intentionally_undocumented,
+            skip_openapi_validation=skip_openapi_validation,
         )
         response_dict = self.assert_json_success(result)
         return response_dict
@@ -308,7 +316,10 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.login("hamlet")
         self.assert_num_bots_equal(0)
         with get_test_image_file("img.png") as fp:
-            self.create_bot(file=fp)
+            # Uploading an avatar makes this a multipart/form-data
+            # request, which the OpenAPI documentation for this
+            # endpoint does not describe.
+            self.create_bot(file=fp, intentionally_undocumented=True)
             profile = get_user(email, realm)
             # Make sure that avatar image that we've uploaded is same with avatar image in the server
             self.assertTrue(

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -61,19 +61,22 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot = get_user(email, realm)
         return bot
 
-    def assert_num_bots_equal(self, count: int) -> None:
-        result = self.client_get("/json/bots")
+    def assert_num_bots_equal(self, count: int, skip_openapi_validation: bool = False) -> None:
+        result = self.client_get("/json/bots", skip_openapi_validation=skip_openapi_validation)
         response_dict = self.assert_json_success(result)
         self.assert_length(response_dict["bots"], count)
 
     def create_bot(self, **extras: Any) -> dict[str, Any]:
+        skip_openapi_validation = extras.pop("skip_openapi_validation", False)
         bot_info = {
             "full_name": "The Bot of Hamlet",
             "short_name": "hambot",
             "bot_type": "1",
         }
         bot_info.update(extras)
-        result = self.client_post("/json/bots", bot_info)
+        result = self.client_post(
+            "/json/bots", bot_info, skip_openapi_validation=skip_openapi_validation
+        )
         response_dict = self.assert_json_success(result)
         return response_dict
 
@@ -147,20 +150,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain", REALM_HOSTS={"zulip": "127.0.0.1"})
     def test_add_bot_with_invalid_fake_email_domain(self) -> None:
         self.login("hamlet")
-        self.assert_num_bots_equal(0)
+        self.assert_num_bots_equal(0, skip_openapi_validation=True)
         bot_info = {
             "full_name": "The Bot of Hamlet",
             "short_name": "hambot",
             "bot_type": "1",
         }
-        result = self.client_post("/json/bots", bot_info)
+        result = self.client_post("/json/bots", bot_info, skip_openapi_validation=True)
 
         error_message = (
             "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
             "Please contact your server administrator."
         )
         self.assert_json_error(result, error_message)
-        self.assert_num_bots_equal(0)
+        self.assert_num_bots_equal(0, skip_openapi_validation=True)
 
     def test_add_bot_with_no_name(self) -> None:
         self.login("hamlet")
@@ -234,9 +237,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     @override_settings(FAKE_EMAIL_DOMAIN="fakedomain.com", REALM_HOSTS={"zulip": "127.0.0.1"})
     def test_add_bot_with_fake_email_domain(self) -> None:
         self.login("hamlet")
-        self.assert_num_bots_equal(0)
-        self.create_bot()
-        self.assert_num_bots_equal(1)
+        self.assert_num_bots_equal(0, skip_openapi_validation=True)
+        self.create_bot(skip_openapi_validation=True)
+        self.assert_num_bots_equal(1, skip_openapi_validation=True)
 
         email = "hambot-bot@fakedomain.com"
         self.get_bot_user(email)
@@ -244,9 +247,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     @override_settings(EXTERNAL_HOST="example.com")
     def test_add_bot_verify_subdomain_in_email_address(self) -> None:
         self.login("hamlet")
-        self.assert_num_bots_equal(0)
-        self.create_bot()
-        self.assert_num_bots_equal(1)
+        self.assert_num_bots_equal(0, skip_openapi_validation=True)
+        self.create_bot(skip_openapi_validation=True)
+        self.assert_num_bots_equal(1, skip_openapi_validation=True)
 
         email = "hambot-bot@zulip.example.com"
         self.get_bot_user(email)
@@ -256,9 +259,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     )
     def test_add_bot_host_used_as_domain_if_valid(self) -> None:
         self.login("hamlet")
-        self.assert_num_bots_equal(0)
-        self.create_bot()
-        self.assert_num_bots_equal(1)
+        self.assert_num_bots_equal(0, skip_openapi_validation=True)
+        self.create_bot(skip_openapi_validation=True)
+        self.assert_num_bots_equal(1, skip_openapi_validation=True)
 
         email = "hambot-bot@zulip.example.com"
         self.get_bot_user(email)

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -229,7 +229,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/zcommand",
         #### These "organization settings" endpoint have modest value to document:
         "/realm",
-        "/bots",
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
         "/realm/profile_fields/{field_id}",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -227,7 +227,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/zcommand",
         #### These "organization settings" endpoint have modest value to document:
         "/realm",
-        "/bots",
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
         "/realm/profile_fields/{field_id}",


### PR DESCRIPTION
Documents `GET /bots` and `POST /bots` in the OpenAPI spec and drops `/bots` from `pending_endpoints`. 


**Note to maintainers**

Two convention calls, both settled in [this thread][thread] with @0xthedance. Neither had maintainer input, so flagging them here.

- **Tests under host overrides.** Documenting a path enables request and response validation for every test that touches it, and four bot tests run under `REALM_HOSTS`/`EXTERNAL_HOST` overrides whose host isn't in the spec's `servers` list, so they fail with `ServerNotFound`. `intentionally_undocumented` doesn't apply, since response validation runs first and ignores it, hence the `skip_openapi_validation` flag in the first commit. Alternatives I tested and rejected: the ORM rework doesn't fix the create-bot POST (`Realm.host_for_subdomain()` also sets the test client's default Host), pinning `HTTP_HOST` fixes only 3 of 4 and affects the 15+ tests sharing those helpers, and extending `servers:` would publish `127.0.0.1` and `zulip.example.com` in our canonical spec. **This is shared test infrastructure on contributor-to-contributor agreement,  happy to redo it another way.**

- **Avatar upload.** The optional avatar makes the request `multipart/form-data`. Only the urlencoded body is documented, with `test_add_bot_with_user_avatar` marked `intentionally_undocumented`. The multipart variant needs #39454's `x-curl-examples-parameters` fix, so I'd rather follow up once that merges than chainthis PR onto an open one.

Two problems surfaced outside that discussion:

- Request-body properties without an `example:` reach the docs tooling as `None` rather than the `NO_EXAMPLE` sentinel `parameters:`-style params get. This wascrashing the rendered `/api/add-bot` page outright and would have left `Example: null` across the arguments table. All properties now have examples.
- `tools/test-api` executes the generated cURL example, which can't succeed while sending every parameter at once,  `service_name`, `payload_url` and `config_data` are each meaningful for only some bot types. Scoped to the generic-bot parameters via `x-curl-examples-parameters`, plus a value generator for the bot name, since that database persists across runs.

[thread]: https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/PR.20.2338716.3A.20Document.20POST.20.2Fbots.20endpoint

<details>
<summary>**Screenshots and screen captures:**</summary>
The rendered documentation page: POST /bots
<img width="1400" height="3355" alt="add-bot-page" src="https://github.com/user-attachments/assets/b244671b-d689-4944-bd1e-3807af54d6fd" />

The rendered documentation page: GET /bots
<img width="1400" height="1789" alt="get-bots-page" src="https://github.com/user-attachments/assets/187e4c56-0505-47f5-a33a-5cecf002aecc" />


</details>
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
