### PR TITLE
Fix broken channel syntax on pressing escaping or focusing somewhere else.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1483,11 +1483,12 @@ export function content_typeahead_selected(
         }
         case "topic_list": {
             // If we use "Escape" we would want `#**design>this is a design topic` to be
-            // resolved to `#**design** this is a design topic`
+            // resolved to `#**design** this is a design topic`, i.e. a link to the
+            // channel followed by the partially typed topic as plain text.
             if (event?.key === "Escape") {
-                const topic_start_index = beginning.lastIndexOf(">");
-                const topic = beginning.slice(topic_start_index + 1);
-                beginning = beginning.slice(0, topic_start_index) + "** " + topic;
+                const syntax_start_index = beginning.lastIndexOf(item.used_syntax_prefix);
+                const stream_link = topic_link_util.get_stream_link_syntax(item.stream_data.name);
+                beginning = beginning.slice(0, syntax_start_index) + stream_link + " " + token;
                 break;
             }
 

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1126,19 +1126,25 @@ export function get_candidates(
             ];
         }
 
-        // Matches '#**stream name>some text' at the end of a split.
-        const stream_topic_regex = /#\*\*([^*>]+)>([^*\n]*)$/;
+        // Matches an in-progress (unterminated) '#**stream name>some text' mention
+        // where the closing '**' hasn't been typed yet.
+        const partial_stream_topic_regex = /#\*\*([^*>]+)>([^*\n]*)$/;
         // Matches '#>some text', which is a shortcut to
         // link to topics in the channel currently composing to.
         // `>` is enclosed in a capture group to use the below
         // code path for both syntaxes.
-        const shortcut_regex = /#(>)([^*\n]*)$/;
+        const topic_shortcut_regex = /#(>)([^*\n]*)$/;
         // Matches '[#channel](url)>some text' at the end of a split.
-        const fallback_stream_topic_regex = /(\[#)([^*>]+)]\(#[^)]*\)>([^*\n]*)$/;
-        const fallback_tokens = fallback_stream_topic_regex.exec(split[0]);
-        const stream_topic_tokens = stream_topic_regex.exec(split[0]);
-        const topic_shortcut_tokens = shortcut_regex.exec(split[0]);
-        const tokens = stream_topic_tokens ?? topic_shortcut_tokens ?? fallback_tokens;
+        const partial_fallback_stream_topic_regex = /(\[#)([^*>]+)]\(#[^)]*\)>([^*\n]*)$/;
+        const partial_fallback_stream_topic_tokens = partial_fallback_stream_topic_regex.exec(
+            split[0],
+        );
+        const partial_stream_topic_tokens = partial_stream_topic_regex.exec(split[0]);
+        const topic_shortcut_tokens = topic_shortcut_regex.exec(split[0]);
+        const tokens =
+            partial_stream_topic_tokens ?? // #**channel>topic
+            topic_shortcut_tokens ?? // #>topic
+            partial_fallback_stream_topic_tokens; // [#channel](url)>topic
         const should_begin_typeahead = tokens !== null;
         if (should_begin_typeahead) {
             completing = "topic_list";

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1136,15 +1136,40 @@ export function get_candidates(
         const topic_shortcut_regex = /#(>)([^*\n]*)$/;
         // Matches '[#channel](url)>some text' at the end of a split.
         const partial_fallback_stream_topic_regex = /(\[#)([^*>]+)]\(#[^)]*\)>([^*\n]*)$/;
+        // Matches a complete '#**stream name**' link, optionally followed
+        // by a topic query; reopening the typeahead here offers topic
+        // completion. The query must start immediately after the link —
+        // leading whitespace is rejected so an older link on the line
+        // can't match across message text and suppress other typeaheads.
+        // It excludes `>` to stay non-overlapping with topic_jump above.
+        const complete_stream_regex = /#\*\*([^*>]+)\*\*((?!\s)[^*>\n]*)$/;
+        // Matches the '[#channel](url)' fallback link for special characters.
+        const complete_fallback_stream_regex = /(\[#)([^*>]+)]\(#[^)]*\)((?!\s)[^*>\n]*)$/;
         const partial_fallback_stream_topic_tokens = partial_fallback_stream_topic_regex.exec(
             split[0],
         );
         const partial_stream_topic_tokens = partial_stream_topic_regex.exec(split[0]);
         const topic_shortcut_tokens = topic_shortcut_regex.exec(split[0]);
+        // A complete link is a valid final form, so only trigger topic
+        // completion while the typeahead is already open (the reopen flow
+        // after picking a channel), not when the cursor lands after an
+        // existing link.
+        const typeahead_already_shown = compose_ui.compose_textarea_typeahead?.shown ?? false;
+        const complete_channel_link_tokens = typeahead_already_shown
+            ? complete_stream_regex.exec(split[0])
+            : null;
+        const complete_fallback_link_tokens = typeahead_already_shown
+            ? complete_fallback_stream_regex.exec(split[0])
+            : null;
         const tokens =
             partial_stream_topic_tokens ?? // #**channel>topic
             topic_shortcut_tokens ?? // #>topic
-            partial_fallback_stream_topic_tokens; // [#channel](url)>topic
+            partial_fallback_stream_topic_tokens ?? // [#channel](url)>topic
+            complete_channel_link_tokens ?? // #**channel**
+            complete_fallback_link_tokens; // [#channel](url)
+        const is_complete_channel_link =
+            tokens !== null &&
+            (tokens === complete_channel_link_tokens || tokens === complete_fallback_link_tokens);
         const should_begin_typeahead = tokens !== null;
         if (should_begin_typeahead) {
             completing = "topic_list";
@@ -1184,6 +1209,15 @@ export function get_candidates(
             }
             // If we aren't composing to a channel, `sub` would be undefined.
             if (sub !== undefined) {
+                if (
+                    is_complete_channel_link &&
+                    stream_data.is_empty_topic_only_channel(sub.stream_id)
+                ) {
+                    // This channel only allows the empty topic, so the
+                    // complete channel link is the final form; don't offer
+                    // topic completion.
+                    return [];
+                }
                 // We always show topic suggestions after the user types a stream, and let them
                 // pick between just showing the stream (the first option, when nothing follows ">")
                 // or adding a topic.
@@ -1437,16 +1471,22 @@ export function content_typeahead_selected(
                 sub && stream_data.is_empty_topic_only_channel(sub.stream_id);
             const is_greater_than_key_pressed = event?.type === "keydown" && event.key === ">";
 
-            // For empty topic only channel, skip showing topic typeahead and
-            // insert direct channel link.
-            if (is_empty_topic_only_channel && !is_greater_than_key_pressed) {
-                beginning += topic_link_util.get_stream_link_syntax(item.name);
-            } else if (topic_link_util.will_produce_broken_stream_topic_link(item.name)) {
-                // for stream links, we use markdown link syntax if the #**stream** syntax
-                // will generate a broken url.
-                beginning += topic_link_util.get_fallback_markdown_link(item.name) + ">";
+            // For an empty-topic-only channel, the user pressed ">" to
+            // explicitly request a topic, so insert the partial syntax to
+            // open topic completion.
+            if (is_empty_topic_only_channel && is_greater_than_key_pressed) {
+                if (topic_link_util.will_produce_broken_stream_topic_link(item.name)) {
+                    // for stream links, we use markdown link syntax if the #**stream** syntax
+                    // will generate a broken url.
+                    beginning += topic_link_util.get_fallback_markdown_link(item.name) + ">";
+                } else {
+                    beginning += "#**" + item.name + ">";
+                }
             } else {
-                beginning += "#**" + item.name + ">";
+                // Insert a complete channel link; the topic typeahead reopens
+                // to offer topic completion, so dismissing it leaves a valid
+                // link rather than broken `#**channel>` syntax.
+                beginning += topic_link_util.get_stream_link_syntax(item.name);
             }
 
             void compose_validate.warn_if_private_stream_is_linked(item, $textbox);

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -737,6 +737,18 @@ const broken_link_stream = stream_item(
         can_create_topic_group: members.id,
     }),
 );
+const empty_topic_only_stream = stream_item(
+    make_stream({
+        name: "Announce",
+        description: "A channel that only allows the empty topic",
+        stream_id: 7,
+        subscribed: true,
+        topics_policy: "empty_topic_only",
+        can_administer_channel_group: support.id,
+        can_add_subscribers_group: support.id,
+        can_create_topic_group: members.id,
+    }),
+);
 
 stream_data.add_sub_for_tests(sweden_stream);
 stream_data.add_sub_for_tests(denmark_stream);
@@ -744,6 +756,7 @@ stream_data.add_sub_for_tests(netherland_stream);
 stream_data.add_sub_for_tests(mobile_stream);
 stream_data.add_sub_for_tests(mobile_team_stream);
 stream_data.add_sub_for_tests(broken_link_stream);
+stream_data.add_sub_for_tests(empty_topic_only_stream);
 
 const make_emoji = (emoji_dict) => ({
     emoji_name: emoji_dict.name,
@@ -1139,7 +1152,11 @@ test("content_typeahead_selected", ({override}) => {
     ct.get_or_set_completing_for_tests("stream");
     let warned_for_stream_link = false;
     override(compose_validate, "warn_if_private_stream_is_linked", (linked_stream) => {
-        assert.ok(linked_stream === sweden_stream || linked_stream === broken_link_stream);
+        assert.ok(
+            linked_stream === sweden_stream ||
+                linked_stream === broken_link_stream ||
+                linked_stream === empty_topic_only_stream,
+        );
         warned_for_stream_link = true;
     });
 
@@ -1171,6 +1188,25 @@ test("content_typeahead_selected", ({override}) => {
     ct.get_or_set_token_for_testing("#");
     actual_value = ct.content_typeahead_selected(broken_link_stream, query, input_element);
     expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>";
+    assert.equal(actual_value, expected_value);
+
+    // A channel that only allows the empty topic gets a complete channel
+    // link, and no topic typeahead is reopened for it.
+    query = "#Announ";
+    ct.get_or_set_token_for_testing("Announ");
+    actual_value = ct.content_typeahead_selected(empty_topic_only_stream, query, input_element);
+    expected_value = "#**Announce**";
+    assert.equal(actual_value, expected_value);
+
+    // Pressing ">" on such a channel still opens topic completion via the
+    // partial syntax, for the user who explicitly wants a topic link.
+    query = "#Announ";
+    ct.get_or_set_token_for_testing("Announ");
+    actual_value = ct.content_typeahead_selected(empty_topic_only_stream, query, input_element, {
+        type: "keydown",
+        key: ">",
+    });
+    expected_value = "#**Announce>";
     assert.equal(actual_value, expected_value);
 
     // topic_list
@@ -1324,6 +1360,94 @@ test("content_typeahead_selected", ({override}) => {
     );
     expected_value =
         "Hello [#A&#42; Algorithm > fast](#narrow/channel/6-A.2A-Algorithm/topic/fast) ";
+    assert.equal(actual_value, expected_value);
+
+    // Selecting a topic from the complete channel link form (the link
+    // inserted on channel selection, followed by the partially typed
+    // topic) rewrites the whole span into the full stream+topic link.
+    query = "Hello #**Sweden**plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "planning",
+            topic_display_name: "planning",
+            type: "topic_list",
+            used_syntax_prefix: "#**",
+            is_channel_link: false,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+    );
+    expected_value = "Hello #**Sweden>planning** ";
+    assert.equal(actual_value, expected_value);
+
+    // The same, but for the complete fallback markdown link form used
+    // for channel names with special characters.
+    query = "Hello [#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)fas";
+    ct.get_or_set_token_for_testing("fas");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "fast",
+            topic_display_name: "fast",
+            type: "topic_list",
+            used_syntax_prefix: "[#",
+            is_channel_link: false,
+            stream_data: {
+                name: "A* Algorithm",
+            },
+        },
+        query,
+        input_element,
+    );
+    expected_value =
+        "Hello [#A&#42; Algorithm > fast](#narrow/channel/6-A.2A-Algorithm/topic/fast) ";
+    assert.equal(actual_value, expected_value);
+
+    // Selecting the "(link to channel)" option from the complete link
+    // form keeps the channel link as-is, dropping any partially typed
+    // topic text.
+    query = "Hello #**Sweden**plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "Sweden",
+            topic_display_name: "Sweden",
+            type: "topic_list",
+            used_syntax_prefix: "#**",
+            is_channel_link: true,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+    );
+    expected_value = "Hello #**Sweden** ";
+    assert.equal(actual_value, expected_value);
+
+    // Escape resolves the partial stream+topic syntax to a channel
+    // link, keeping any partially typed topic as plain text.
+    query = "Hello #**Sweden>plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "planning",
+            topic_display_name: "planning",
+            type: "topic_list",
+            used_syntax_prefix: "#**",
+            is_channel_link: false,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+        {key: "Escape"},
+    );
+    expected_value = "Hello #**Sweden** plan";
     assert.equal(actual_value, expected_value);
 
     // syntax
@@ -2753,6 +2877,25 @@ test("begins_typeahead", ({override, override_rewire}) => {
         typed_topics("Sweden", ["totally new topic"], is_new_topic),
     );
     assert_typeahead_equals("#**Sweden>\n\nmore ice", typed_topics("Sweden", []));
+
+    // A complete channel link is a valid final form, so it only triggers
+    // topic completion while the typeahead is already open (the state
+    // right after a channel is selected). With the typeahead closed, the
+    // cursor merely sitting after a channel link offers nothing.
+    assert_typeahead_equals("#**Sweden**", []);
+
+    // The complete channel link inserted on channel selection reopens the
+    // topic typeahead, so the user can still pick a topic; selecting one
+    // rewrites the link into the partial-then-completed form. Typing after
+    // the link filters topics just like the `>` syntax does.
+    compose_ui.compose_textarea_typeahead = {shown: true};
+    // A space immediately after the complete link means the user has
+    // moved on to the message body, so no topic typeahead is offered.
+    assert_typeahead_equals("#**Sweden** more ice", []);
+    // A channel that only allows the empty topic gets a complete channel
+    // link with no topic completion offered.
+    assert_typeahead_equals("#**Announce**", []);
+    compose_ui.compose_textarea_typeahead = undefined;
 
     // time_jump
     const time_jump = [

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1450,6 +1450,50 @@ test("content_typeahead_selected", ({override}) => {
     expected_value = "Hello #**Sweden** plan";
     assert.equal(actual_value, expected_value);
 
+    // Escape with the shortcut syntax for the channel being composed to.
+    compose_state.set_stream_id(sweden_stream.stream_id);
+    query = "Hello #>plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "planning",
+            topic_display_name: "planning",
+            type: "topic_list",
+            used_syntax_prefix: "#>",
+            is_channel_link: false,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+        {key: "Escape"},
+    );
+    expected_value = "Hello #**Sweden** plan";
+    assert.equal(actual_value, expected_value);
+
+    // Escape with the fallback markdown link syntax used for channel
+    // names that would produce broken `#**channel**` links.
+    query = "Hello [#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>fast";
+    ct.get_or_set_token_for_testing("fast");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "fast",
+            topic_display_name: "fast",
+            type: "topic_list",
+            used_syntax_prefix: "[#",
+            is_channel_link: false,
+            stream_data: {
+                name: "A* Algorithm",
+            },
+        },
+        query,
+        input_element,
+        {key: "Escape"},
+    );
+    expected_value = "Hello [#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm) fast";
+    assert.equal(actual_value, expected_value);
+
     // syntax
     ct.get_or_set_completing_for_tests("syntax");
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1160,34 +1160,40 @@ test("content_typeahead_selected", ({override}) => {
         warned_for_stream_link = true;
     });
 
+    // Selecting a channel inserts a complete channel link; the topic
+    // typeahead then reopens to offer topic completion (see the
+    // get_candidates tests), so no broken `#**channel>` syntax is left
+    // behind if the user dismisses it without picking a topic.
     query = "#swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "#**Sweden>";
+    expected_value = "#**Sweden**";
     assert.equal(actual_value, expected_value);
 
     query = "Hello #swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "Hello #**Sweden>";
+    expected_value = "Hello #**Sweden**";
     assert.equal(actual_value, expected_value);
 
     query = "#**swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "#**Sweden>";
+    expected_value = "#**Sweden**";
     assert.equal(actual_value, expected_value);
 
+    // A channel name with special characters falls back to the markdown
+    // link syntax, still as a complete link.
     query = "#**A* al";
     ct.get_or_set_token_for_testing("A* al");
     actual_value = ct.content_typeahead_selected(broken_link_stream, query, input_element);
-    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>";
+    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)";
     assert.equal(actual_value, expected_value);
 
     query = "#>";
     ct.get_or_set_token_for_testing("#");
     actual_value = ct.content_typeahead_selected(broken_link_stream, query, input_element);
-    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>";
+    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)";
     assert.equal(actual_value, expected_value);
 
     // A channel that only allows the empty topic gets a complete channel
@@ -2933,9 +2939,35 @@ test("begins_typeahead", ({override, override_rewire}) => {
     // rewrites the link into the partial-then-completed form. Typing after
     // the link filters topics just like the `>` syntax does.
     compose_ui.compose_textarea_typeahead = {shown: true};
+    assert_typeahead_equals(
+        "#**Sweden**",
+        typed_topics("Sweden", ["Sweden", ...sweden_topics_to_show]),
+    );
+    assert_typeahead_equals(
+        "#**Sweden**more ice",
+        typed_topics("Sweden", ["more ice", "even more ice"]),
+    );
+    assert_typeahead_equals(
+        "#**Sweden**totally new topic",
+        typed_topics("Sweden", ["totally new topic"], is_new_topic),
+    );
     // A space immediately after the complete link means the user has
-    // moved on to the message body, so no topic typeahead is offered.
+    // moved on to the message body: the complete-link pattern doesn't
+    // match, and with no other token present there are no suggestions.
     assert_typeahead_equals("#**Sweden** more ice", []);
+    // The pattern rejects leading whitespace, so tokens typed after a
+    // complete channel link on the same line get their own typeaheads.
+    assert.deepEqual(
+        get_values("#**Sweden** see #den", "").map((item) => item.name),
+        ["Denmark", "Sweden"],
+    );
+    // The timestamp typeahead also still runs after a channel link.
+    assert_typeahead_equals("#**Sweden** at <time:something", [
+        {
+            message: "translated: Mention a time-zone-aware time",
+            type: "time_jump",
+        },
+    ]);
     // A channel that only allows the empty topic gets a complete channel
     // link with no topic completion offered.
     assert_typeahead_equals("#**Announce**", []);


### PR DESCRIPTION
Fixes: [#issues > Linking to channel, have to click its name twice](https://chat.zulip.org/#narrow/channel/9-issues/topic/Linking.20to.20channel.2C.20have.20to.20click.20its.20name.20twice/with/2476321)

Selecting a channel from the typeahead inserted the partial `#**channel>` syntax, so dismissing the topic typeahead without picking a topic left broken syntax behind. Now we insert a complete `#**channel**` link and reopen the topic typeahead, so picking a topic still completes to `#**channel>topic**` while dismissing leaves a valid link. 

The complete-link match only fires while the typeahead is already shown, so it doesn't trigger whenever the cursor lands after an existing link. Empty-topic-only channels get the complete link as the final form unless ">" is pressed.



**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="952" height="148" alt="topic autocomplete" src="https://github.com/user-attachments/assets/c3c91d2d-2e5f-4611-bfce-54a66640afd1" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
