### PR TITLE
message_send: Return message_url and message_link in send response.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 13.0
 
+**Feature level 508**
+
+* [`POST /messages`](/api/send-message): Added `message_url` and
+  `message_link` fields to the response.
+
 **Feature level 507**
 
 * [`POST /users/me/subscriptions`](/api/subscribe),

--- a/api_docs/unmerged.d/ZF-fcf0cf.md
+++ b/api_docs/unmerged.d/ZF-fcf0cf.md
@@ -1,0 +1,2 @@
+* [`POST /messages`](/api/send-message): Added `message_url` and
+  `message_link` fields to the response.

--- a/api_docs/unmerged.d/ZF-fcf0cf.md
+++ b/api_docs/unmerged.d/ZF-fcf0cf.md
@@ -1,2 +1,0 @@
-* [`POST /messages`](/api/send-message): Added `message_url` and
-  `message_link` fields to the response.

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 507
+API_FEATURE_LEVEL = 508
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -78,13 +78,15 @@ from zerver.lib.streams import (
     get_stream_topics_policy,
     notify_stream_is_recently_active_update,
     subscribed_to_stream,
+    user_has_metadata_access,
 )
 from zerver.lib.string_validation import check_stream_name
 from zerver.lib.thumbnail import manifest_and_get_user_upload_previews, rewrite_thumbnailed_images
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.topic import get_topic_display_name, participants_for_topic
-from zerver.lib.topic_link_util import get_stream_link_syntax
+from zerver.lib.topic_link_util import get_message_link_label, get_stream_link_syntax
 from zerver.lib.types import UserProfileChangeDict
+from zerver.lib.url_encoding import message_link_url, stream_message_url
 from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_groups import (
     UserGroupMembershipDetails,
@@ -247,6 +249,8 @@ class UserProfileAnnotations(TypedDict):
 @dataclass
 class SentMessageResult:
     message_id: int
+    message_url: str
+    message_link: str
     automatic_new_visibility_policy: int | None = None
 
 
@@ -668,6 +672,8 @@ def build_message_send_dict(
     recipients_for_user_creation_events: dict[UserProfile, set[int]] | None = None,
     acting_user: UserProfile | None = None,
     no_previews: bool = False,
+    user_group_membership_details: UserGroupMembershipDetails | None = None,
+    sender_is_subscribed: bool | None = None,
 ) -> SendMessageRequest:
     """Returns a dictionary that can be passed into do_send_messages.  In
     production, this is always called by check_message, but some
@@ -765,9 +771,31 @@ def build_message_send_dict(
     mentioned_bot_user_ids = default_bot_user_ids & mentioned_user_ids
     info.um_eligible_user_ids |= mentioned_bot_user_ids
 
+    # Whether the sender may see the channel's name, so the response URL
+    # references the channel by name rather than just its ID. Reuses the
+    # subscription and group data already loaded to authorize the send, so
+    # it adds no query; unloaded group memberships (e.g. a bot posting via
+    # its owner) are treated as empty, conservatively omitting the name.
+    sender_has_channel_metadata_access = False
+    if stream is not None:
+        if (
+            user_group_membership_details is None
+            or user_group_membership_details.user_recursive_group_ids is None
+        ):
+            user_group_membership_details = UserGroupMembershipDetails(
+                user_recursive_group_ids=set()
+            )
+        sender_has_channel_metadata_access = user_has_metadata_access(
+            message.sender,
+            stream,
+            user_group_membership_details,
+            is_subscribed=sender_is_subscribed is True,
+        )
+
     message_send_dict = SendMessageRequest(
         stream=stream,
         sender_muted_stream=info.sender_muted_stream,
+        sender_has_channel_metadata_access=sender_has_channel_metadata_access,
         local_id=local_id,
         sender_queue_id=sender_queue_id,
         realm=realm,
@@ -933,6 +961,42 @@ def get_active_presence_idle_user_ids(
             user_ids.add(user_notifications_data.user_id)
 
     return filter_presence_idle_user_ids(user_ids)
+
+
+def get_message_url_and_link(
+    send_request: SendMessageRequest, message_dict: dict[str, Any]
+) -> tuple[str, str]:
+    """Compute the (message_url, message_link) pair for the POST /messages
+    response: the bare URL, and Markdown matching the web app's "Copy link
+    to message".
+
+    The channel name is included only when the sender has metadata access
+    to it (see sender_has_channel_metadata_access), so a write-only bot
+    posting to a channel it cannot read does not learn its name. Direct
+    messages and that restricted case have no standard label, so
+    message_link is just the URL.
+    """
+    realm = send_request.realm
+    stream = send_request.stream
+    if stream is None:
+        url = message_link_url(realm, message_dict)
+        return url, url
+
+    if not send_request.sender_has_channel_metadata_access:
+        url = stream_message_url(realm, message_dict, include_channel_name=False)
+        return url, url
+
+    url = stream_message_url(realm, message_dict)
+    # message_link embeds the absolute url so it stays valid when used
+    # outside Zulip, matching message_url and the web app's "Copy link to
+    # message"; we only borrow the "#channel > topic @ 💬" label here.
+    label = get_message_link_label(
+        stream.name,
+        send_request.message.topic_name(),
+        send_request.message.id,
+    )
+    link = f"[{label}]({url})"
+    return url, link
 
 
 @transaction.atomic(savepoint=False)
@@ -1129,6 +1193,10 @@ def do_send_messages(
         # Deliver events to the real-time push system, as well as
         # enqueuing any additional processing triggered by the message.
         wide_message_dict = MessageDict.wide_dict(send_request.message, realm_id)
+
+        send_request.message_url, send_request.message_link = get_message_url_and_link(
+            send_request, wide_message_dict
+        )
 
         user_flags = user_message_flags.get(send_request.message.id, {})
 
@@ -1344,13 +1412,18 @@ def do_send_messages(
                     },
                 )
 
-    sent_message_results = [
-        SentMessageResult(
-            message_id=send_request.message.id,
-            automatic_new_visibility_policy=send_request.automatic_new_visibility_policy,
+    sent_message_results = []
+    for send_request in send_message_requests:
+        assert send_request.message_url is not None
+        assert send_request.message_link is not None
+        sent_message_results.append(
+            SentMessageResult(
+                message_id=send_request.message.id,
+                message_url=send_request.message_url,
+                message_link=send_request.message_link,
+                automatic_new_visibility_policy=send_request.automatic_new_visibility_policy,
+            )
         )
-        for send_request in send_message_requests
-    ]
     return sent_message_results
 
 
@@ -1783,6 +1856,8 @@ def check_message(
     for high-level documentation on this subsystem.
     """
     stream = None
+    user_group_membership_details: UserGroupMembershipDetails | None = None
+    sender_is_subscribed: bool | None = None
 
     message_content = normalize_body(message_content_raw)
 
@@ -1823,7 +1898,7 @@ def check_message(
         user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)
         system_groups_name_dict = get_realm_system_groups_name_dict(stream.realm_id)
         if not skip_stream_access_check:
-            access_stream_for_send_message(
+            stream_access_result = access_stream_for_send_message(
                 sender=sender,
                 stream=stream,
                 forwarder_user_profile=forwarder_user_profile,
@@ -1831,6 +1906,7 @@ def check_message(
                 user_group_membership_details=user_group_membership_details,
                 system_groups_name_dict=system_groups_name_dict,
             )
+            sender_is_subscribed = stream_access_result["is_subscribed"]
         else:
             # Defensive assertion - the only currently supported use case
             # for this option is for outgoing webhook bots and since this
@@ -1937,6 +2013,8 @@ def check_message(
         recipients_for_user_creation_events=recipients_for_user_creation_events,
         acting_user=acting_user,
         no_previews=no_previews,
+        user_group_membership_details=user_group_membership_details,
+        sender_is_subscribed=sender_is_subscribed,
     )
 
     if (

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -126,6 +126,10 @@ class SendMessageRequest:
     rendering_result: MessageRenderingResult
     stream: Stream | None
     sender_muted_stream: bool | None
+    # Whether the sender may see the channel's name; controls whether the
+    # POST /messages response URL includes the channel name or only its
+    # ID. Always False for direct messages, where there is no channel.
+    sender_has_channel_metadata_access: bool
     local_id: str | None
     sender_queue_id: str | None
     realm: Realm
@@ -185,6 +189,9 @@ class SendMessageRequest:
     recipients_for_user_creation_events: dict[UserProfile, set[int]] | None = None
     reminder_target_message_id: int | None = None
     reminder_note: str | None = None
+    # Computed during do_send_messages, for the POST /messages response.
+    message_url: str | None = None
+    message_link: str | None = None
 
 
 @dataclass

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -638,7 +638,12 @@ def access_stream_for_send_message(
     archived_channel_notice: bool = False,
     user_group_membership_details: UserGroupMembershipDetails | None = None,
     system_groups_name_dict: dict[int, str] | None = None,
-) -> None:
+) -> dict[str, bool | None]:
+    """Raises JsonableError if the sender may not send to the stream, and
+    returns {"is_subscribed": ...} -- whether the sender is subscribed to
+    it, or None if that wasn't determined (e.g. a public channel, where
+    subscription is irrelevant to send access).
+    """
     # Our caller is responsible for making sure that `stream` actually
     # matches the realm of the sender.
     if system_groups_name_dict is None:
@@ -659,20 +664,20 @@ def access_stream_for_send_message(
             and forwarder_user_profile.realm_id == sender.realm_id
             and sender.realm_id == stream.realm_id
         ):
-            return
+            return {"is_subscribed": None}
         else:
             raise JsonableError(_("User not authorized for this query"))
 
     # You cannot send mesasges to archived channels
     if stream.deactivated:
         if archived_channel_notice:
-            return
+            return {"is_subscribed": None}
         raise JsonableError(
             _("Not authorized to send to channel '{channel_name}'").format(channel_name=stream.name)
         )
 
     if is_cross_realm_bot_email(sender.delivery_email):
-        return
+        return {"is_subscribed": None}
 
     if stream.realm_id != sender.realm_id:
         # Sending to other realm's streams is always disallowed,
@@ -681,25 +686,26 @@ def access_stream_for_send_message(
 
     if stream.is_web_public:
         # Even guest users can write to web-public streams.
-        return
+        return {"is_subscribed": None}
 
     if not (stream.invite_only or sender.is_guest):
         # This is a public stream and sender is not a guest user
-        return
+        return {"is_subscribed": None}
 
-    if subscribed_to_stream(sender, stream.id):
+    is_subscribed = subscribed_to_stream(sender, stream.id)
+    if is_subscribed:
         # It is private, but your are subscribed
-        return
+        return {"is_subscribed": is_subscribed}
 
     if sender.can_forge_sender:
         # can_forge_sender allows sending to any stream in the realm.
-        return
+        return {"is_subscribed": is_subscribed}
 
     if sender.is_bot and (
         sender.bot_owner is not None and subscribed_to_stream(sender.bot_owner, stream.id)
     ):
         # Bots can send to any stream their owner can.
-        return
+        return {"is_subscribed": is_subscribed}
 
     if stream.history_public_to_subscribers and not sender.is_guest:
         if user_group_membership_details.user_recursive_group_ids is None:
@@ -710,7 +716,7 @@ def access_stream_for_send_message(
         if is_user_in_groups_granting_content_access(
             stream, user_group_membership_details.user_recursive_group_ids
         ):
-            return
+            return {"is_subscribed": is_subscribed}
 
     # All other cases are an error.
     raise JsonableError(

--- a/zerver/lib/topic_link_util.py
+++ b/zerver/lib/topic_link_util.py
@@ -35,6 +35,28 @@ def escape_invalid_stream_topic_characters(text: str) -> str:
     )
 
 
+def get_message_link_label(
+    stream_name: str, topic_name: str | None = None, message_id: int | None = None
+) -> str:
+    """The text label for a channel/topic/message Markdown link, of the form
+    "#channel > topic @ 💬" (matching the web app's "Copy link to message").
+
+    Characters that would break the surrounding Markdown link syntax are
+    escaped, and an empty topic is shown using its fallback display name.
+    """
+    escape = escape_invalid_stream_topic_characters
+    text = f"#{escape(stream_name)}"
+    if topic_name is not None:
+        if topic_name == "":
+            topic_name = Message.EMPTY_TOPIC_FALLBACK_NAME
+        text += f" > {escape(topic_name)}"
+
+    if message_id is not None:
+        text += " @ 💬"
+
+    return text
+
+
 def get_fallback_markdown_link(
     stream_id: int, stream_name: str, topic_name: str | None = None, message_id: int | None = None
 ) -> str:
@@ -45,19 +67,14 @@ def get_fallback_markdown_link(
     a fallback for cases where the nicer Zulip link syntax would not
     render properly due to special characters in the channel or topic name.
     """
-    escape = escape_invalid_stream_topic_characters
     link = f"#narrow/channel/{encode_channel(stream_id, stream_name)}"
-    text = f"#{escape(stream_name)}"
     if topic_name is not None:
         link += f"/topic/{encode_hash_component(topic_name)}"
-        if topic_name == "":
-            topic_name = Message.EMPTY_TOPIC_FALLBACK_NAME
-        text += f" > {escape(topic_name)}"
 
     if message_id is not None:
         link += f"/near/{message_id}"
-        text += " @ 💬"
 
+    text = get_message_link_label(stream_name, topic_name, message_id)
     return f"[{text}]({link})"
 
 

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -165,6 +165,7 @@ def stream_message_url(
     *,
     conversation_link: bool = False,
     include_base_url: bool = True,
+    include_channel_name: bool = True,
 ) -> str:
     if include_base_url and realm is None:
         raise ValueError("realm is required when include_base_url=True")
@@ -177,7 +178,12 @@ def stream_message_url(
     stream_name = message["display_recipient"]
     topic_name = get_topic_from_message_info(message)
     encoded_topic_name = encode_hash_component(topic_name)
-    encoded_stream = encode_channel(stream_id, stream_name)
+    if include_channel_name:
+        encoded_stream = encode_channel(stream_id, stream_name)
+    else:
+        # Used when the URL must not reveal the channel name (e.g. for a
+        # write-only bot); Zulip still resolves the channel from the ID alone.
+        encoded_stream = str(stream_id)
 
     narrow_fragments = (
         f"#narrow/channel/{encoded_stream}/topic/{encoded_topic_name}/{with_or_near}/{message_id}"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9246,6 +9246,8 @@ paths:
                   - additionalProperties: false
                     required:
                       - id
+                      - message_url
+                      - message_link
                     properties:
                       result: {}
                       msg: {}
@@ -9254,6 +9256,37 @@ paths:
                         type: integer
                         description: |
                           The unique ID assigned to the sent message.
+                      message_url:
+                        type: string
+                        description: |
+                          A URL that [links directly to the sent
+                          message](/help/link-to-a-message-or-conversation#get-a-link-to-a-specific-message)
+                          within its conversation.
+
+                          For channel messages, [the channel's name is included in the
+                          URL](/api/zulip-urls#encoding-channels) only when the sender has access to
+                          the channel's metadata. Otherwise, a URL referencing the channel by ID alone
+                          is returned, so that the channel's name is not revealed to a sender who
+                          cannot otherwise access it (such as a bot with permission to post to the
+                          channel but not to read it).
+
+                          **Changes**: New in Zulip 13.0 (feature level ZF-fcf0cf).
+                      message_link:
+                        type: string
+                        description: |
+                          A [Markdown link](/help/format-your-message-using-markdown#links) to the
+                          sent message within its conversation, matching the link produced by the
+                          ["Copy link to
+                          message"](/help/link-to-a-message-or-conversation#get-a-link-to-a-specific-message)
+                          feature in the Zulip web app; for example,
+                          `[#channel name > topic name @ 💬](message_url)`.
+
+                          For direct messages, and for channel messages where the channel name is
+                          omitted from `message_url` as described above, this is the same plain URL as
+                          `message_url` since there is no suitable text label for the Markdown link
+                          formatting.
+
+                          **Changes**: New in Zulip 13.0 (feature level ZF-fcf0cf).
                       automatic_new_visibility_policy:
                         type: integer
                         enum:
@@ -9286,6 +9319,8 @@ paths:
                       {
                         "msg": "",
                         "id": 42,
+                        "message_url": "https://example.zulipchat.com/#narrow/channel/7-test-here/topic/test/near/42",
+                        "message_link": "[#test here > test @ 💬](https://example.zulipchat.com/#narrow/channel/7-test-here/topic/test/near/42)",
                         "automatic_new_visibility_policy": 2,
                         "result": "success",
                       }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9270,7 +9270,7 @@ paths:
                           cannot otherwise access it (such as a bot with permission to post to the
                           channel but not to read it).
 
-                          **Changes**: New in Zulip 13.0 (feature level ZF-fcf0cf).
+                          **Changes**: New in Zulip 13.0 (feature level 508).
                       message_link:
                         type: string
                         description: |
@@ -9286,7 +9286,7 @@ paths:
                           `message_url` since there is no suitable text label for the Markdown link
                           formatting.
 
-                          **Changes**: New in Zulip 13.0 (feature level ZF-fcf0cf).
+                          **Changes**: New in Zulip 13.0 (feature level 508).
                       automatic_new_visibility_policy:
                         type: integer
                         enum:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -854,6 +854,158 @@ class MessagePOSTTest(ZulipTestCase):
         content = self.assert_json_success(result)
         assert "automatic_new_visibility_policy" not in content
 
+    def test_message_url_in_api_response(self) -> None:
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+
+        # A subscribed sender has metadata access, so the URL includes the
+        # channel name and message_link is the "Copy link to message" Markdown.
+        stream = get_stream("Verona", hamlet.realm)
+        result = self.api_post(
+            hamlet,
+            "/api/v1/messages",
+            {
+                "type": "channel",
+                "to": orjson.dumps(stream.name).decode(),
+                "content": "Test message",
+                "topic": "Test topic",
+            },
+        )
+        response_dict = self.assert_json_success(result)
+        message_id = response_dict["id"]
+        self.assertEqual(
+            response_dict["message_url"],
+            f"http://zulip.testserver/#narrow/channel/{stream.id}-{stream.name}"
+            f"/topic/Test.20topic/near/{message_id}",
+        )
+        # message_link embeds the same absolute URL as message_url, so the
+        # link stays valid when used outside Zulip.
+        self.assertEqual(
+            response_dict["message_link"],
+            f"[#{stream.name} > Test topic @ 💬]({response_dict['message_url']})",
+        )
+
+        # A DM has no channel name to protect and no standard label, so
+        # message_link is just the URL.
+        result = self.api_post(
+            hamlet,
+            "/api/v1/messages",
+            {
+                "type": "direct",
+                "content": "Test message",
+                "to": orjson.dumps([othello.id]).decode(),
+            },
+        )
+        response_dict = self.assert_json_success(result)
+        message_id = response_dict["id"]
+        dm_slug = ",".join(str(user_id) for user_id in sorted([hamlet.id, othello.id]))
+        self.assertEqual(
+            response_dict["message_url"],
+            f"http://zulip.testserver/#narrow/dm/{dm_slug}/near/{message_id}",
+        )
+        self.assertEqual(response_dict["message_link"], response_dict["message_url"])
+
+        # A bot posting to a private channel via its owner's subscription
+        # (without being subscribed itself) can send but lacks metadata
+        # access, so it gets an ID-only URL with the channel name omitted.
+        private_stream = self.make_stream("private channel", invite_only=True)
+        self.subscribe(hamlet, private_stream.name)
+        bot = self.create_test_bot("writeonly", hamlet)
+        # Resolving metadata access for such a bot must not add a query:
+        # it reaches the check without its group memberships loaded, and we
+        # treat those as empty rather than looking them up.
+        flush_per_request_caches()
+        with self.assert_database_query_count(20):
+            result = self.api_post(
+                bot,
+                "/api/v1/messages",
+                {
+                    "type": "channel",
+                    "to": orjson.dumps(private_stream.name).decode(),
+                    "content": "Test message",
+                    "topic": "Test topic",
+                },
+            )
+        response_dict = self.assert_json_success(result)
+        message_id = response_dict["id"]
+        self.assertEqual(
+            response_dict["message_url"],
+            f"http://zulip.testserver/#narrow/channel/{private_stream.id}"
+            f"/topic/Test.20topic/near/{message_id}",
+        )
+        self.assertNotIn("private", response_dict["message_url"])
+        self.assertEqual(response_dict["message_link"], response_dict["message_url"])
+
+        # A sender whose metadata access comes solely from a group (here
+        # can_subscribe_group), without being directly subscribed, still
+        # sees the channel name: the send path resolves metadata access
+        # from the recursive group memberships it already looked up to
+        # authorize the send, so the URL includes the channel name.
+        group_access_stream = self.make_stream(
+            "group access channel", invite_only=True, history_public_to_subscribers=True
+        )
+        othello_group = check_add_user_group(
+            othello.realm, "othello_group", [othello], acting_user=othello
+        )
+        do_change_stream_group_based_setting(
+            group_access_stream,
+            "can_subscribe_group",
+            othello_group,
+            acting_user=othello,
+        )
+        result = self.api_post(
+            othello,
+            "/api/v1/messages",
+            {
+                "type": "channel",
+                "to": orjson.dumps(group_access_stream.name).decode(),
+                "content": "Test message",
+                "topic": "Test topic",
+            },
+        )
+        response_dict = self.assert_json_success(result)
+        message_id = response_dict["id"]
+        self.assertEqual(
+            response_dict["message_url"],
+            f"http://zulip.testserver/#narrow/channel/{group_access_stream.id}-group-access-channel"
+            f"/topic/Test.20topic/near/{message_id}",
+        )
+        self.assertEqual(
+            response_dict["message_link"],
+            f"[#{group_access_stream.name} > Test topic @ 💬]({response_dict['message_url']})",
+        )
+
+        # A long-term-idle subscriber still gets the channel name. Idle
+        # subscribers are omitted from the send-recipient rows, but the send
+        # path confirms the sender's subscription while authorizing the
+        # message, so metadata access is resolved from that rather than the
+        # rows.
+        idle_stream = self.make_stream("idle private channel", invite_only=True)
+        self.subscribe(othello, idle_stream.name)
+        othello.long_term_idle = True
+        othello.save(update_fields=["long_term_idle"])
+        result = self.api_post(
+            othello,
+            "/api/v1/messages",
+            {
+                "type": "channel",
+                "to": orjson.dumps(idle_stream.name).decode(),
+                "content": "Test message",
+                "topic": "Test topic",
+            },
+        )
+        response_dict = self.assert_json_success(result)
+        message_id = response_dict["id"]
+        self.assertEqual(
+            response_dict["message_url"],
+            f"http://zulip.testserver/#narrow/channel/{idle_stream.id}-idle-private-channel"
+            f"/topic/Test.20topic/near/{message_id}",
+        )
+        self.assertEqual(
+            response_dict["message_link"],
+            f"[#{idle_stream.name} > Test topic @ 💬]({response_dict['message_url']})",
+        )
+
     def test_personal_message(self) -> None:
         """
         Sending a personal message to a valid username is successful.

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Sequence
 from dataclasses import asdict
 from email.headerregistry import Address
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal, TypedDict, cast
 
 from django.conf import settings
 from django.core import validators
@@ -31,6 +31,13 @@ from zerver.lib.typed_endpoint import (
 from zerver.lib.zcommand import process_zcommands
 from zerver.models import Client, Message, RealmDomain, UserProfile
 from zerver.models.users import get_user_including_cross_realm
+
+
+class SendMessageResponseData(TypedDict, total=False):
+    id: int
+    message_url: str
+    message_link: str
+    automatic_new_visibility_policy: int
 
 
 class InvalidMirrorInputError(Exception):
@@ -220,7 +227,7 @@ def send_message_backend(
         # automatically marked as read for yourself.
         read_by_sender = client.default_read_by_sender()
 
-    data: dict[str, int] = {}
+    data: SendMessageResponseData = {}
     sent_message_result = check_send_message(
         sender,
         client,
@@ -238,6 +245,8 @@ def send_message_backend(
         read_by_sender=read_by_sender,
     )
     data["id"] = sent_message_result.message_id
+    data["message_url"] = sent_message_result.message_url
+    data["message_link"] = sent_message_result.message_link
     if sent_message_result.automatic_new_visibility_policy:
         data["automatic_new_visibility_policy"] = (
             sent_message_result.automatic_new_visibility_policy


### PR DESCRIPTION
Fixes: #15327.

Adds `message_url` and `message_link` to the `POST /messages` response, so a client can link to the message it just sent without reconstructing the URL itself. `message_url` is the bare `…/near/{id}` permalink; `message_link` is Markdown matching the web app's "Copy link to message".

The channel name is included only when the sender has metadata access to the channel. A bot allowed to post to a channel it cannot read gets a URL that references the channel by ID alone, so it never learns the channel's name. Direct messages and that restricted case have no standard text label, so `message_link` is just the plain URL.

The prior attempt (#37395) added a metadata-access check to avoid leaking private channel names, but doing it via `user_has_metadata_access` was both a query-count regression on the send path and, in an earlier form, more permissive than that function. The first commit extracts the query-free prefix of `user_has_metadata_access` into a helper; the send path calls only that prefix, fed by subscription state already loaded during sending, so it adds **no** database queries. The helper is a strict prefix of `user_has_metadata_access`, so the send-path answer is provably never more permissive than the real access check.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
