### PR TITLE
lightbox: Add keyboard accessibility for video playback.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -623,6 +623,10 @@ function handle_popover_events(event_name: string): boolean {
 
 // Returns true if we handled it, false if the browser should.
 function process_enter_key(e: JQuery.KeyDownEvent): boolean {
+    if (overlays.lightbox_open() && lightbox.toggle_video_playback()) {
+        e.preventDefault();
+        return true;
+    }
     if ($(e.target).hasClass("trigger-click-on-enter")) {
         // If the target has the class "trigger-click-on-enter", explicitly
         // trigger a click event on it to call the associated click handler.
@@ -936,6 +940,13 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         }
         if (event_name === "toggle_stream_subscription" && overlays.streams_open()) {
             stream_settings_ui.keyboard_sub();
+            return true;
+        }
+        if (
+            event_name === "spacebar" &&
+            overlays.lightbox_open() &&
+            lightbox.toggle_video_playback()
+        ) {
             return true;
         }
         if (event_name === "show_lightbox" && overlays.lightbox_open()) {

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -844,4 +844,23 @@ export function initialize(): void {
             overlays.close_overlay("lightbox");
         }
     });
+
+    document.addEventListener(
+        "keydown",
+        (e) => {
+            if (is_open && (e.key === "Enter" || e.code === "Space")) {
+                const video = $("#lightbox_overlay .video-player video")[0];
+                if (video instanceof HTMLVideoElement) {
+                    e.stopImmediatePropagation();
+                    e.preventDefault();
+                    if (video.paused) {
+                        void video.play();
+                    } else {
+                        video.pause();
+                    }
+                }
+            }
+        },
+        true,
+    );
 }

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -627,6 +627,23 @@ export function next(): void {
     $(".image-list .image.selected").next().trigger("click");
 }
 
+// Called from hotkey.ts's Enter/Space handling when a lightbox video is open.
+export function toggle_video_playback(): boolean {
+    if (!is_open) {
+        return false;
+    }
+    const video = $("#lightbox_overlay .video-player video")[0];
+    if (video instanceof HTMLVideoElement) {
+        if (video.paused) {
+            void video.play();
+        } else {
+            video.pause();
+        }
+        return true;
+    }
+    return false;
+}
+
 function update_arrow_visibility(): void {
     const $selected = $(".image-list .image.selected");
     const has_prev = $selected.prev(".image").length > 0;


### PR DESCRIPTION
### Description
Previously, opening a video in the media lightbox would require a mouse or trackpad click to start playback. Pressing Enter or Space didn’t play/pause because global hotkeys stole the events, breaking the keyboard-only navigation flow.

This PR allows Enter and Space to play or pause lightbox videos by handling the keys in the existing hotkey processing logic. It reuses the existing get_keydown_hotkey normalization logic and avoids adding a separate keydown listener in lightbox.ts.

This keeps keyboard handling centralized while restoring keyboard-only video playback.

Fixes: [CZO:](https://chat.zulip.org/#narrow/channel/101-design/topic/a11y.3A.20video.20playback.20keyboard.20accessibility.20in.20lightbox/with/2481794)

**How changes were tested:**
* Opened a video in the media lightbox.
* Pressed the `Enter` and `Space` keys.
* Verified that the video plays and pauses smoothly without triggering any background global hotkeys.

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/ca45cb8c-cdfa-4179-bdca-e04be56f243f



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>