### PR TITLE
[ai] echo: Recompute mention booleans when locally re-rendering edits.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -412,7 +412,13 @@ export function edit_locally(message: Message, request: LocalEditRequest): Messa
             // message, and not its rendering.
             const {content, flags, is_me_message} = markdown.render(raw_content);
             message_store.update_message_content(message, content);
-            message.flags = flags;
+            // Recompute the content-driven boolean flags (mentioned,
+            // mentioned_me_directly, etc.) from the freshly rendered
+            // flags. Without this, the message keeps its stale mention
+            // booleans until the server event arrives, which (e.g. when
+            // editing away a personal mention) briefly miscolors the
+            // message as a group mention.
+            message_store.update_booleans(message, flags);
             message.is_me_message = is_me_message;
             if (request.starred !== undefined) {
                 message.starred = request.starred;

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -14,6 +14,8 @@ const hash_util = mock_esm("../src/hash_util");
 const markdown = mock_esm("../src/markdown");
 const message_lists = mock_esm("../src/message_lists");
 const message_events_util = mock_esm("../src/message_events_util");
+const pm_list = mock_esm("../src/pm_list");
+const stream_list = mock_esm("../src/stream_list");
 
 let disparities = [];
 
@@ -32,6 +34,8 @@ const message_store = mock_esm("../src/message_store", {
     get: () => ({failed_request: true}),
 
     update_booleans() {},
+
+    maybe_update_raw_content() {},
 
     update_message_content(message, new_content) {
         message.content = new_content;
@@ -404,6 +408,48 @@ run_test("insert_local_message direct message", ({override}) => {
     echo.insert_local_message(message_request, local_id_float, insert_new_messages);
     assert.ok(render_called);
     assert.ok(insert_message_called);
+});
+
+run_test("edit_locally recomputes content-driven booleans", ({override}) => {
+    // A content edit that drops a personal mention should immediately
+    // clear the message's mention booleans from the locally rendered
+    // flags, rather than leaving them stale until the server event
+    // arrives (which would briefly miscolor the message).
+    override(markdown, "render", () => ({
+        content: "<p>edited, no longer mentions me</p>",
+        flags: [],
+        is_me_message: false,
+    }));
+    override(stream_list, "update_streams_sidebar", noop);
+    override(pm_list, "update_private_messages", noop);
+    override(message_lists, "all_rendered_message_lists", () => [
+        {view: {rerender_messages: noop}},
+    ]);
+
+    let update_booleans_args;
+    override(message_store, "update_booleans", (message, flags) => {
+        update_booleans_args = {message, flags};
+        message.mentioned = flags.includes("mentioned");
+        message.mentioned_me_directly = flags.includes("mentioned");
+    });
+
+    const message = {
+        id: 42,
+        type: "stream",
+        stream_id: general_sub.stream_id,
+        topic: "test",
+        raw_content: "@**me** original",
+        content: "<p>original</p>",
+        mentioned: true,
+        mentioned_me_directly: true,
+    };
+
+    echo.edit_locally(message, {raw_content: "edited, no longer mentions me"});
+
+    assert.equal(update_booleans_args.message, message);
+    assert.deepEqual(update_booleans_args.flags, []);
+    assert.equal(message.mentioned, false);
+    assert.equal(message.mentioned_me_directly, false);
 });
 
 run_test("test reify_message_id", ({override}) => {


### PR DESCRIPTION
When locally echoing a content-only edit, `edit_locally` re-rendered the Markdown and stored the resulting `flags` array, but never derived the content-driven boolean fields (`mentioned`,
`mentioned_me_directly`, etc.) from it. Those booleans stayed stale until the server's `update_message` event arrived.

`message_list_view` colors a row from both `mentioned_me_directly` and a re-parse of the rendered content for a non-silent self mention. So editing away a personal mention left `mentioned_me_directly` stale at `true` while the freshly rendered content no longer matched, which selected the group-mention background: the row flashed from the purple direct-mention color through the teal group-mention color before settling on the default once the server event corrected the booleans. Other windows, which skip the local-echo step, updated cleanly.

Derive the booleans via `message_store.update_booleans`, the same helper used by the send-echo and message-edit-event paths, so the local echo matches the new content immediately. Storing `flags` on the message was also inconsistent with how processed messages are represented elsewhere, where `flags` is dropped in favor of the booleans.

---

before:

<img width="1478" height="282" alt="Kapture 2026-06-18 at 21 06 11" src="https://github.com/user-attachments/assets/208bf489-40d8-4ed2-acf7-689878e14f93" />


after:


<img width="1478" height="282" alt="Kapture 2026-06-18 at 21 05 07" src="https://github.com/user-attachments/assets/8befa229-44e8-4213-bc03-7503e0e76de8" />
