### PR TITLE
compose: Fix list formatting buttons on empty lines.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -966,10 +966,15 @@ export let format_text = (
         const should_mark = selected_lines.split("\n").some((line) => !is_marked(line));
         if (should_mark) {
             const lines = selected_lines.split("\n");
+            // Only skip blank lines for multi-line selections, where blanks
+            // act as spacing between list items. For a single line (including
+            // when the cursor is on an empty line with no selection), always
+            // insert the list marker so the button is not a noop.
+            const skip_blank_lines = lines.length > 1;
             const processed_lines = [];
             let counter = 1;
             for (const line of lines) {
-                if (line.trim() === "") {
+                if (skip_blank_lines && line.trim() === "") {
                     processed_lines.push(line);
                 } else {
                     if (type === "bulleted") {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -366,7 +366,11 @@
     border-radius: 4px;
     border: 1px solid var(--color-message-content-container-border);
 
-    &:has(.new_message_textarea:focus) {
+    /* The :active selector ensures we don't have a moment
+       where the compose-area focus ring disappears while
+       a formatting button is clicked. */
+    &:has(.new_message_textarea:focus),
+    &:has(~ #message-formatting-controls-container:active) {
         border-color: var(--color-message-content-container-border-focus);
     }
 

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -832,6 +832,15 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
     compose_ui.format_text($textarea, "bulleted");
     assert.equal(get_textarea_state(), "<- first_item\n- second_item>");
 
+    // Cursor on an empty line (no selection) should still insert the marker.
+    init_textarea_state("|");
+    compose_ui.format_text($textarea, "bulleted");
+    assert.equal(get_textarea_state(), "- |");
+
+    init_textarea_state("first_line\n|");
+    compose_ui.format_text($textarea, "bulleted");
+    assert.equal(get_textarea_state(), "first_line\n- |");
+
     init_textarea_state("<\nfirst_item\nsecond_item>");
     compose_ui.format_text($textarea, "bulleted");
     assert.equal(get_textarea_state(), "<\n- first_item\n- second_item>");
@@ -858,6 +867,15 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
     init_textarea_state("<first_item\nsecond_item>");
     compose_ui.format_text($textarea, "numbered");
     assert.equal(get_textarea_state(), "<1. first_item\n2. second_item>");
+
+    // Cursor on an empty line (no selection) should still insert the marker.
+    init_textarea_state("|");
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(get_textarea_state(), "1. |");
+
+    init_textarea_state("first_line\n|");
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(get_textarea_state(), "first_line\n1. |");
 
     init_textarea_state("<first_item\nsecond_item\n>");
     compose_ui.format_text($textarea, "numbered");


### PR DESCRIPTION
Fixes the regression introduced in #38855, where the bulleted and numbered list formatting buttons became a noop when the cursor is on an empty line with no selection (e.g., empty compose box, or a blank line after some text).

PR #38855 added logic to skip blank lines when applying list formatting, so that blanks between list items act as visual
separators. That logic is incorrectly applied to the single-line case too, making the button do nothing on an empty line.

The fix only skips blank lines for multi-line selections, where blanks act as spacing between list items. For a single line (including an empty one), the marker is always inserted, so the button works as expected on empty lines.

Fixes: [#issues > List formatting includes blank lines @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/List.20formatting.20includes.20blank.20lines/near/2481809)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/ec2eab6d-e95a-4398-9965-03653acf2de9" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/f5d3bc57-3652-444a-a35b-d48eedb0a1ae" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
