### PR TITLE
sidebar_ui: Preserve scroll position when toggling sidebars.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -17,7 +17,6 @@ import {ListCursor} from "./list_cursor.ts";
 import {localstorage} from "./localstorage.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_reminder from "./message_reminder.ts";
-import * as message_viewport from "./message_viewport.ts";
 import {page_params} from "./page_params.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -38,6 +37,25 @@ import * as util from "./util.ts";
 const LEFT_SIDEBAR_NAVIGATION_AREA_TITLE = $t({defaultMessage: "VIEWS"});
 
 export let left_sidebar_cursor: ListCursor<JQuery>;
+
+// Toggling a sidebar changes the message feed's width, causing rows to
+// reflow and shift vertically. Preserve the selected row's viewport
+// offset across the layout change to keep the user's reading position
+// stable.
+function toggle_sidebar_preserving_selected_row_offset(classname: string): void {
+    let saved_selected_row_offset: number | undefined;
+    if (message_lists.current !== undefined) {
+        const $selected_row = message_lists.current.selected_row();
+        if ($selected_row.length > 0) {
+            saved_selected_row_offset = $selected_row.get_offset_to_window().top;
+        }
+    }
+    $("body").toggleClass(classname);
+    if (saved_selected_row_offset !== undefined) {
+        assert(message_lists.current !== undefined);
+        message_lists.current.view.set_message_offset(saved_selected_row_offset);
+    }
+}
 
 function save_sidebar_toggle_status(): void {
     const ls = localstorage();
@@ -232,15 +250,7 @@ export function initialize(): void {
         e.stopPropagation();
 
         if (ui_util.matches_viewport_state("gte_md_min")) {
-            $("body").toggleClass("hide-left-sidebar");
-            if (
-                message_lists.current !== undefined &&
-                !ui_util.matches_viewport_state("gte_xl_min")
-            ) {
-                // We expand the middle column width between md and xl breakpoints when the
-                // left sidebar is hidden. This can cause the pointer to move out of view.
-                message_viewport.scroll_to_selected();
-            }
+            toggle_sidebar_preserving_selected_row_offset("hide-left-sidebar");
             // We recheck the scrolling-button status of the compose
             // box, which may change for users who've chosen to
             // use full width on wide screens.

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -223,7 +223,7 @@ export function initialize(): void {
         e.stopPropagation();
 
         if (ui_util.matches_viewport_state("gte_xl_min")) {
-            $("body").toggleClass("hide-right-sidebar");
+            toggle_sidebar_preserving_selected_row_offset("hide-right-sidebar");
             if (!$("body").hasClass("hide-right-sidebar")) {
                 fix_invite_user_button_flicker();
             }


### PR DESCRIPTION
Toggling the left or right sidebar changes the message feed's max-width, which rewraps text and shifts every row's vertical position. The browser preserves `scrollTop` on hide but not on `show`, so the feed visibly jumps on expand, taking the user away from their reading position.

The existing handler called `scroll_to_selected()` for the left sidebar inside a `!gte_xl_min` gate, but the layout actually shifts at `xl` widths too. leaving the buggy range (~1200-1600px) unhandled, and also recentering on the selected row rather than preserving the reading position. The right sidebar handler had no scroll preservation at all.

Apply the same anchor approach as `message_list_view.ts` (in its `render()` function) to both sidebar handlers in `sidebar_ui.ts`: capture the selected row's viewport offset before the class change, then restore it via `view.set_message_offset()` afterwards.

Fixes: [#issues > Content scroll position changes when toggling left sidebar.](https://chat.zulip.org/#narrow/channel/9-issues/topic/Content.20scroll.20position.20changes.20when.20toggling.20left.20sidebar.2E/with/2473994)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/be50e08c-e904-45d9-bc22-9de52d58cd91" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/3f9b8e9e-2123-42f6-923e-e4d21e84b259" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
