### PR TITLE
compose: Fix list buttons stacking markers on selections with blank lines.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -977,10 +977,20 @@ export let format_text = (
                 if (line.trim() === "") {
                     processed_lines.push(line);
                 } else {
+                    // Strip any existing list marker first, so switching
+                    // between bulleted and numbered doesn't stack markers
+                    // (e.g. "- x" + numbered click should give "1. x", not
+                    // "1. - x").
+                    let stripped = line;
+                    if (bulleted_numbered_list_util.is_bulleted(line)) {
+                        stripped = bulleted_numbered_list_util.strip_bullet(line);
+                    } else if (bulleted_numbered_list_util.is_numbered(line)) {
+                        stripped = bulleted_numbered_list_util.strip_numbering(line);
+                    }
                     if (type === "bulleted") {
-                        processed_lines.push("- " + line);
+                        processed_lines.push("- " + stripped);
                     } else {
-                        processed_lines.push(counter + ". " + line);
+                        processed_lines.push(counter + ". " + stripped);
                         counter += 1;
                     }
                 }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -962,8 +962,13 @@ export let format_text = (
         const sections = section_off_selected_lines();
         let {before_lines, selected_lines, after_lines} = sections;
         const {separating_new_line_before, separating_new_line_after} = sections;
-        // If there is even a single unmarked line selected, we mark all.
-        const should_mark = selected_lines.split("\n").some((line) => !is_marked(line));
+        // Blank lines never have markers, so exclude them when deciding whether
+        // to mark or unmark. Otherwise a selection containing blank lines would
+        // always be detected as "needs marking", causing the marker to be
+        // prepended again on every click instead of toggling off.
+        const non_blank_lines = selected_lines.split("\n").filter((line) => line.trim() !== "");
+        const should_mark =
+            non_blank_lines.length === 0 || non_blank_lines.some((line) => !is_marked(line));
         if (should_mark) {
             const lines = selected_lines.split("\n");
             const processed_lines = [];

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -841,6 +841,12 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
     compose_ui.format_text($textarea, "bulleted");
     assert.equal(get_textarea_state(), "<\n- first_item\n\n- second_item\n\n- third_item>");
 
+    // Toggling off a bulleted list that contains blank lines between items
+    // should strip markers, not prepend new ones.
+    init_textarea_state("<- first_item\n\n- second_item\n\n- third_item>");
+    compose_ui.format_text($textarea, "bulleted");
+    assert.equal(get_textarea_state(), "<first_item\n\nsecond_item\n\nthird_item>");
+
     // Toggling off bulleted list
     init_textarea_state("<- first_item\n- second_item>");
     compose_ui.format_text($textarea, "bulleted");
@@ -877,6 +883,12 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
     init_textarea_state("<\nfirst_item\n\nsecond_item\n\nthird_item>");
     compose_ui.format_text($textarea, "numbered");
     assert.equal(get_textarea_state(), "<\n1. first_item\n\n2. second_item\n\n3. third_item>");
+
+    // Toggling off a numbered list that contains blank lines between items
+    // should strip markers, not prepend new ones.
+    init_textarea_state("<1. first_item\n\n2. second_item\n\n3. third_item>");
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(get_textarea_state(), "<first_item\n\nsecond_item\n\nthird_item>");
 
     // Toggling off numbered list
     init_textarea_state("<1. first_item\n2. second_item>");

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -847,6 +847,12 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
     compose_ui.format_text($textarea, "bulleted");
     assert.equal(get_textarea_state(), "<first_item\n\nsecond_item\n\nthird_item>");
 
+    // Converting a numbered list to a bulleted list should replace the
+    // markers, not stack them (e.g. "- 1. item").
+    init_textarea_state("<1. first_item\n2. second_item>");
+    compose_ui.format_text($textarea, "bulleted");
+    assert.equal(get_textarea_state(), "<- first_item\n- second_item>");
+
     // Toggling off bulleted list
     init_textarea_state("<- first_item\n- second_item>");
     compose_ui.format_text($textarea, "bulleted");
@@ -889,6 +895,12 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
     init_textarea_state("<1. first_item\n\n2. second_item\n\n3. third_item>");
     compose_ui.format_text($textarea, "numbered");
     assert.equal(get_textarea_state(), "<first_item\n\nsecond_item\n\nthird_item>");
+
+    // Converting a bulleted list to a numbered list should replace the
+    // markers, not stack them (e.g. "1. - item").
+    init_textarea_state("<- first_item\n- second_item>");
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(get_textarea_state(), "<1. first_item\n2. second_item>");
 
     // Toggling off numbered list
     init_textarea_state("<1. first_item\n2. second_item>");


### PR DESCRIPTION
Follow-up to #39580. Both PRs fix regressions introduced by #38855.

When a selection contains blank lines between items (e.g., an existing bulleted or numbered list with blank separator lines),
clicking the bulleted/numbered list button stacks the marker on every click instead of toggling the list off. For example, selecting `- first line  - second line` and clicking the bulleted button produces `- - first line - - second line`, and each subsequent click adds another `- / 1.`

Root cause - `should_mark` checks if any selected line is unmarked, but blank lines never carry a marker, so `should_mark` stays `true` forever when blank lines are in the selection. This became a problem after #38855 started preserving blank lines in list selections.

The fix excludes blank lines from the `should_mark` calculation, so the toggle decision reflects only the lines that actually
carry a marker.


Fixes: [#issues > List formatting includes blank lines @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/List.20formatting.20includes.20blank.20lines/near/2482014)

----

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/38a3ed16-c8e7-490f-87f2-a0a785a4cedb" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/2ff2eb2f-ca2b-461b-89cb-33511542cff1" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
