### PR TITLE
popovers: Making channel and group card styling Consistent.

### DIFF
--- a/web/src/stream_card_popover.ts
+++ b/web/src/stream_card_popover.ts
@@ -5,6 +5,7 @@ import render_stream_card_popover from "../templates/popovers/stream_card_popove
 
 import * as browser_history from "./browser_history.ts";
 import * as hash_util from "./hash_util.ts";
+import {page_params} from "./page_params.ts";
 import * as peer_data from "./peer_data.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as stream_data from "./stream_data.ts";
@@ -36,6 +37,7 @@ export function initialize(): void {
                                 ...sub_store.get(stream_id),
                             },
                             subscribers_count,
+                            is_spectator: page_params.is_spectator,
                         }),
                     ),
                 );

--- a/web/src/stream_card_popover.ts
+++ b/web/src/stream_card_popover.ts
@@ -5,6 +5,7 @@ import render_stream_card_popover from "../templates/popovers/stream_card_popove
 
 import * as browser_history from "./browser_history.ts";
 import * as hash_util from "./hash_util.ts";
+import {page_params} from "./page_params.ts";
 import * as peer_data from "./peer_data.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as stream_data from "./stream_data.ts";
@@ -36,6 +37,8 @@ export function initialize(): void {
                                 ...sub_store.get(stream_id),
                             },
                             subscribers_count,
+                            // Spectators have no channel settings to open.
+                            can_open_settings: !page_params.is_spectator,
                         }),
                     ),
                 );

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -327,7 +327,6 @@ export function initialize(): void {
             ".spectator_narrow_login_button",
             ".error-icon-message-recipient .zulip-icon",
             "#personal-menu-dropdown .status-circle",
-            ".popover-group-menu-member-list .popover-group-menu-user-presence",
             ".delete-code-playground",
         ].join(","),
         appendTo: () => document.body,

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -13,9 +13,10 @@ import * as compose_state from "./compose_state.ts";
 import * as compose_validate from "./compose_validate.ts";
 import {$t} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
+import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as settings_config from "./settings_config.ts";
-import {realm} from "./state_data.ts";
+import {current_user, realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
@@ -330,6 +331,30 @@ export function initialize(): void {
             ".delete-code-playground",
         ].join(","),
         appendTo: () => document.body,
+    });
+
+    // The channel/group card description is clamped to two lines; when it
+    // overflows, point users to settings for the full text.
+    tippy.delegate("body", {
+        target: ".popover-card-description",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const description = instance.reference;
+            // Spectators see no settings link in either card, and guests
+            // see none in the group card. Don't point them to settings
+            // they cannot open.
+            const in_group_card = description.closest(".user-group-info-popover") !== null;
+            if (page_params.is_spectator || (in_group_card && current_user.is_guest)) {
+                return false;
+            }
+            // Only offer the tooltip when the description is truncated.
+            const line_height = Number.parseFloat(getComputedStyle(description).lineHeight);
+            const tolerance = Number.isNaN(line_height) ? 2 : line_height / 2;
+            if (description.scrollHeight <= description.clientHeight + tolerance) {
+                return false;
+            }
+            return undefined;
+        },
     });
 
     tippy.delegate("body", {

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -332,6 +332,24 @@ export function initialize(): void {
         appendTo: () => document.body,
     });
 
+    // The channel/group card description is clamped to two lines; when it
+    // overflows, point users to settings for the full text.
+    tippy.delegate("body", {
+        target: ".popover-card-description",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const description = instance.reference;
+            // The template only adds this tooltip for viewers who can open
+            // settings, so we just check that the text is actually truncated.
+            const line_height = Number.parseFloat(getComputedStyle(description).lineHeight);
+            const tolerance = Number.isNaN(line_height) ? 2 : line_height / 2;
+            if (description.scrollHeight <= description.clientHeight + tolerance) {
+                return false;
+            }
+            return undefined;
+        },
+    });
+
     tippy.delegate("body", {
         target: [
             "#scroll-to-bottom-button-clickable-area",

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -5,25 +5,22 @@ import type * as tippy from "tippy.js";
 import render_user_group_info_popover from "../templates/popovers/user_group_info_popover.hbs";
 
 import * as blueslip from "./blueslip.ts";
-import * as buddy_data from "./buddy_data.ts";
 import * as hash_util from "./hash_util.ts";
 import * as message_lists from "./message_lists.ts";
 import * as mouse_drag from "./mouse_drag.ts";
+import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as rows from "./rows.ts";
-import * as settings_data from "./settings_data.ts";
 import {current_user} from "./state_data.ts";
 import * as ui_util from "./ui_util.ts";
-import * as user_group_components from "./user_group_components.ts";
 import * as user_groups from "./user_groups.ts";
 import * as util from "./util.ts";
 
-const MAX_ROWS_IN_POPOVER = 30;
+// How many members to name before summarizing the rest as "and N more".
+const MAX_NAMES_IN_POPOVER = 2;
 let user_group_popover_instance: tippy.Instance | undefined;
-
-type PopoverGroupMember = User & {user_circle_class: string; user_last_seen_time_status: string};
 
 export function hide(): void {
     if (user_group_popover_instance !== undefined) {
@@ -96,41 +93,29 @@ export function toggle_user_group_info_popover(
                     message_lists.current.select_id(message_id);
                 }
                 user_group_popover_instance = instance;
-                const subgroups = user_groups.convert_name_to_display_name_for_groups(
-                    user_groups
-                        .get_direct_subgroups_of_group(group)
-                        .toSorted(user_group_components.sort_group_member_name),
-                );
-                const members = sort_group_members(fetch_group_members([...group.members]));
-                const all_individual_members = [...user_groups.get_recursive_group_members(group)];
-                const has_bots =
-                    group.is_system_group &&
-                    all_individual_members.some((member_id) => {
-                        const member = people.get_user_by_id_assert_valid(member_id);
-                        return people.is_active_user_or_system_bot(member.user_id) && member.is_bot;
-                    });
-                const displayed_subgroups = subgroups.slice(0, MAX_ROWS_IN_POPOVER);
-                const displayed_members =
-                    subgroups.length < MAX_ROWS_IN_POPOVER
-                        ? members.slice(0, MAX_ROWS_IN_POPOVER - subgroups.length)
-                        : [];
-                const display_all_subgroups_and_members =
-                    subgroups.length + members.length <= MAX_ROWS_IN_POPOVER;
+                // Only members the current user can see, so the names and
+                // count match the members list.
+                const member_ids = [...user_groups.get_recursive_group_members(group)];
+                const accessible_members = sort_group_members(fetch_group_members(member_ids));
+                const displayed_member_names = accessible_members
+                    .slice(0, MAX_NAMES_IN_POPOVER)
+                    .map((member) => member.full_name);
+                const num_other_members = accessible_members.length - displayed_member_names.length;
                 const args = {
                     group_name: user_groups.get_display_group_name(group.name),
                     group_description: group.description,
                     group_edit_url: hash_util.group_edit_url(group, "general"),
-                    is_guest: current_user.is_guest,
-                    is_system_group: group.is_system_group,
-                    deactivated: group.deactivated,
-                    members_count: all_individual_members.length,
                     group_members_url: hash_util.group_edit_url(group, "members"),
-                    display_all_subgroups_and_members,
-                    has_bots,
-                    user_can_access_all_other_users:
-                        settings_data.user_can_access_all_other_users(),
-                    displayed_subgroups,
-                    displayed_members,
+                    // Guests and spectators have no settings or members page to open.
+                    can_open_settings: !current_user.is_guest && !page_params.is_spectator,
+                    deactivated: group.deactivated,
+                    displayed_member_names,
+                    num_other_members,
+                    has_members: accessible_members.length > 0,
+                    has_other_members: num_other_members > 0,
+                    // Members exist but none are visible to this user; hide the
+                    // section rather than claiming the group is empty.
+                    show_member_section: accessible_members.length > 0 || member_ids.length === 0,
                 };
                 instance.setContent(ui_util.parse_html(render_user_group_info_popover(args)));
             },
@@ -204,28 +189,21 @@ export function register_click_handlers(): void {
     });
 }
 
-function fetch_group_members(member_ids: number[]): PopoverGroupMember[] {
+function fetch_group_members(member_ids: number[]): User[] {
     return (
         member_ids
-            .map((m: number) => people.get_user_by_id_assert_valid(m))
-            // Only include users that the current user is allowed to see in the popover.
-            // Inaccessible or unknown users should not appear in displayed_members.
+            .map((m: number) => people.maybe_get_user_by_id(m, true))
+            .filter((m: User | undefined): m is User => m !== undefined)
+            // Only include users that the current user is allowed to see.
             .filter(
                 (m: User) =>
                     people.is_active_user_or_system_bot(m.user_id) && !m.is_inaccessible_user,
             )
-            .map((p: User) => ({
-                ...p,
-                user_circle_class: buddy_data.get_user_circle_class(p.user_id),
-                user_last_seen_time_status: buddy_data.user_last_seen_time_status(p.user_id),
-            }))
     );
 }
 
-function sort_group_members(members: PopoverGroupMember[]): PopoverGroupMember[] {
-    return members.toSorted((a: PopoverGroupMember, b: PopoverGroupMember) =>
-        util.strcmp(a.full_name, b.full_name),
-    );
+function sort_group_members(members: User[]): User[] {
+    return members.toSorted((a: User, b: User) => util.strcmp(a.full_name, b.full_name));
 }
 
 // exporting these functions for testing purposes

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -5,7 +5,6 @@ import type * as tippy from "tippy.js";
 import render_user_group_info_popover from "../templates/popovers/user_group_info_popover.hbs";
 
 import * as blueslip from "./blueslip.ts";
-import * as buddy_data from "./buddy_data.ts";
 import * as hash_util from "./hash_util.ts";
 import * as message_lists from "./message_lists.ts";
 import * as mouse_drag from "./mouse_drag.ts";
@@ -16,14 +15,12 @@ import * as rows from "./rows.ts";
 import * as settings_data from "./settings_data.ts";
 import {current_user} from "./state_data.ts";
 import * as ui_util from "./ui_util.ts";
-import * as user_group_components from "./user_group_components.ts";
 import * as user_groups from "./user_groups.ts";
 import * as util from "./util.ts";
 
-const MAX_ROWS_IN_POPOVER = 30;
+// How many members to name before summarizing the rest as "and N more".
+const MAX_NAMES_IN_POPOVER = 2;
 let user_group_popover_instance: tippy.Instance | undefined;
-
-type PopoverGroupMember = User & {user_circle_class: string; user_last_seen_time_status: string};
 
 export function hide(): void {
     if (user_group_popover_instance !== undefined) {
@@ -96,41 +93,28 @@ export function toggle_user_group_info_popover(
                     message_lists.current.select_id(message_id);
                 }
                 user_group_popover_instance = instance;
-                const subgroups = user_groups.convert_name_to_display_name_for_groups(
-                    user_groups
-                        .get_direct_subgroups_of_group(group)
-                        .toSorted(user_group_components.sort_group_member_name),
-                );
-                const members = sort_group_members(fetch_group_members([...group.members]));
-                const all_individual_members = [...user_groups.get_recursive_group_members(group)];
-                const has_bots =
-                    group.is_system_group &&
-                    all_individual_members.some((member_id) => {
-                        const member = people.get_user_by_id_assert_valid(member_id);
-                        return people.is_active_user_or_system_bot(member.user_id) && member.is_bot;
-                    });
-                const displayed_subgroups = subgroups.slice(0, MAX_ROWS_IN_POPOVER);
-                const displayed_members =
-                    subgroups.length < MAX_ROWS_IN_POPOVER
-                        ? members.slice(0, MAX_ROWS_IN_POPOVER - subgroups.length)
-                        : [];
-                const display_all_subgroups_and_members =
-                    subgroups.length + members.length <= MAX_ROWS_IN_POPOVER;
+                // Count everyone the group reaches, each person once.
+                const member_ids = [...user_groups.get_recursive_group_members(group)];
+                const total_member_count = member_ids.length;
+                const displayed_member_names = sort_group_members(fetch_group_members(member_ids))
+                    .slice(0, MAX_NAMES_IN_POPOVER)
+                    .map((member) => member.full_name);
+                const num_other_members = total_member_count - displayed_member_names.length;
                 const args = {
                     group_name: user_groups.get_display_group_name(group.name),
                     group_description: group.description,
                     group_edit_url: hash_util.group_edit_url(group, "general"),
-                    is_guest: current_user.is_guest,
-                    is_system_group: group.is_system_group,
-                    deactivated: group.deactivated,
-                    members_count: all_individual_members.length,
                     group_members_url: hash_util.group_edit_url(group, "members"),
-                    display_all_subgroups_and_members,
-                    has_bots,
-                    user_can_access_all_other_users:
-                        settings_data.user_can_access_all_other_users(),
-                    displayed_subgroups,
-                    displayed_members,
+                    is_guest: current_user.is_guest,
+                    deactivated: group.deactivated,
+                    // Hide members from users who can't see all users.
+                    can_see_members: settings_data.user_can_access_all_other_users(),
+                    member_count: total_member_count,
+                    displayed_member_names,
+                    num_other_members,
+                    has_members: total_member_count > 0,
+                    has_named_members: displayed_member_names.length > 0,
+                    has_other_members: num_other_members > 0,
                 };
                 instance.setContent(ui_util.parse_html(render_user_group_info_popover(args)));
             },
@@ -204,28 +188,21 @@ export function register_click_handlers(): void {
     });
 }
 
-function fetch_group_members(member_ids: number[]): PopoverGroupMember[] {
+function fetch_group_members(member_ids: number[]): User[] {
     return (
         member_ids
-            .map((m: number) => people.get_user_by_id_assert_valid(m))
-            // Only include users that the current user is allowed to see in the popover.
-            // Inaccessible or unknown users should not appear in displayed_members.
+            .map((m: number) => people.maybe_get_user_by_id(m, true))
+            .filter((m: User | undefined): m is User => m !== undefined)
+            // Only include users that the current user is allowed to see.
             .filter(
                 (m: User) =>
                     people.is_active_user_or_system_bot(m.user_id) && !m.is_inaccessible_user,
             )
-            .map((p: User) => ({
-                ...p,
-                user_circle_class: buddy_data.get_user_circle_class(p.user_id),
-                user_last_seen_time_status: buddy_data.user_last_seen_time_status(p.user_id),
-            }))
     );
 }
 
-function sort_group_members(members: PopoverGroupMember[]): PopoverGroupMember[] {
-    return members.toSorted((a: PopoverGroupMember, b: PopoverGroupMember) =>
-        util.strcmp(a.full_name, b.full_name),
-    );
+function sort_group_members(members: User[]): User[] {
+    return members.toSorted((a: User, b: User) => util.strcmp(a.full_name, b.full_name));
 }
 
 // exporting these functions for testing purposes

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -621,12 +621,6 @@
     --compose-recipient-row-transition: 150ms ease;
 
     /*
-    User group info popover elements and values.
-    */
-    --user-group-popover-horizontal-padding: 0.6666em; /* 10px at 15px/1em */
-    --user-group-popover-icon-text-gap: 0.3125em; /* 5px at 16px/1em */
-
-    /*
     This isn't scaled with font-size because the flatpickr is a third
     party component that doesn't scale with font size.
     */

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -266,28 +266,32 @@
     outline-offset: -2px;
 }
 
-#stream-actions-menu-popover,
-#stream-card-popover {
+#stream-actions-menu-popover {
     .popover-stream-name {
         font-weight: 600;
         color: var(--color-text-popover-menu);
         line-height: 1.1;
-    }
-
-    .popover-stream-name,
-    .stream-privacy.filter-icon {
         margin-top: 4px;
     }
 
+    .stream-privacy.filter-icon {
+        margin-top: 4px;
+    }
+}
+
+#stream-actions-menu-popover,
+#stream-card-popover {
     .zulip-icon-lock {
         /* Override the margin-top set on the stream lock icon
            at the top-level, since we don't need to pull up this
            icon for the stream actions popover header.  */
         margin: 0 !important;
     }
+}
 
-    .popover-stream-info-menu-description {
-        color: var(--color-text-popover-menu);
+#stream-card-popover {
+    .simplebar-content {
+        min-width: var(--stream-card-popover-min-width);
     }
 }
 
@@ -310,31 +314,58 @@
     width: max-content;
 }
 
-.popover-group-menu-info {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-    padding: 3px var(--user-group-popover-horizontal-padding);
+/* The channel and group cards use the same header and description markup,
+   so that the two cards stay visually consistent. The .popover-menu-list-item
+   in these selectors is only there to outweigh the base .text-item rules. */
+.popover-menu-list-item.popover-card-header.text-item {
+    /* Keep the name and description tight together, rather than
+       padding them out to the height of a clickable menu item. */
+    min-height: 0;
 }
 
-.popover-group-menu-name-container {
-    display: flex;
-    align-items: flex-start;
-    gap: 5px;
-    /* 18px at 15px/1em */
-    font-size: 1.2em;
+.popover-menu-list-item.popover-card-description-item.text-item {
+    min-height: 0;
+    padding-top: 0;
+}
+
+.popover-menu-list-item.popover-card-header {
+    .popover-menu-icon {
+        color: var(--color-icon-purple);
+        /* Drop the 1px lift used for menu-item icons; the card header
+           icon is aligned with the name, not with a menu label. */
+        top: 0;
+    }
+
+    .stream-privacy {
+        /* Give the channel privacy icon the same box as the group card's
+           .popover-menu-icon, so both card headers are the same height;
+           otherwise the icon font's line box makes this header taller. */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        /* 16px at 15px/1em */
+        font-size: 1.0667em;
+        /* 16px at 16px/1em */
+        width: 1em;
+        height: 1em;
+    }
+}
+
+.popover-card-name {
     font-weight: 600;
-    /* 20px at 18px/1em */
-    line-height: 1.1111em;
-    color: var(--color-text-full-name);
+    line-height: 1.1;
+    color: var(--color-text-popover-menu);
+    /* Break very long channel and group names rather than
+       widening the card. */
     overflow-wrap: anywhere;
 }
 
-.popover-group-menu-description {
+.popover-card-description {
     /* 15px at 15px/1em */
     font-size: 1em;
     /* 16px at 15px/1em */
     line-height: 1.0667em;
+    color: var(--color-text-popover-menu);
 }
 
 ul.popover-group-menu-member-list {
@@ -385,7 +416,6 @@ ul.popover-group-menu-member-list {
     white-space: nowrap;
 }
 
-.popover-group-menu-description,
 .popover-group-menu-member-name,
 .popover-group-menu-placeholder {
     color: var(--color-text-popover-menu);
@@ -1189,12 +1219,6 @@ ul.popover-group-menu-member-list {
 .user-group-info-popover {
     .simplebar-content {
         min-width: var(--user-group-info-popover-min-width);
-    }
-}
-
-#stream-card-popover {
-    .simplebar-content {
-        min-width: var(--stream-card-popover-min-width);
     }
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -366,6 +366,21 @@
     /* 16px at 15px/1em */
     line-height: 1.0667em;
     color: var(--color-text-popover-menu);
+    /* Clamp the description to two lines, with a native ellipsis. The
+       tooltip set in tippyjs.ts points to settings for the full text. */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.popover-card-description.popover-card-description-full {
+    /* Show the full text to viewers who can't open settings. */
+    display: block;
+    overflow: visible;
 }
 
 .popover-group-menu-members-summary {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -368,66 +368,47 @@
     color: var(--color-text-popover-menu);
 }
 
-ul.popover-group-menu-member-list {
-    max-height: 300px;
+.popover-group-menu-members-summary {
     display: flex;
-    flex-direction: column;
-
-    .simplebar-content {
-        display: grid;
-        grid-template-areas: "group-member-icon gap group-member-name";
-        grid-template-columns:
-            max-content var(--user-group-popover-icon-text-gap)
-            minmax(0, 1fr);
-        width: unset;
-    }
-
-    .popover-group-menu-member {
-        display: grid;
-        grid-template-columns: subgrid;
-        grid-column: 1 / -1;
-        align-items: center;
-        padding: 0 var(--user-group-popover-horizontal-padding);
-    }
-
-    .popover-group-member-icon {
-        justify-self: center;
-        grid-area: group-member-icon;
-    }
-
-    .popover-group-menu-member-name {
-        grid-area: group-member-name;
-    }
+    min-width: 0;
 }
 
-.popover-group-menu-placeholder {
-    padding: 0 var(--user-group-popover-horizontal-padding);
-}
-
-.popover-group-menu-member {
-    .zulip-icon-user-group {
-        color: var(--color-icon-purple);
-    }
-}
-
-.popover-group-menu-member-name {
+.popover-group-menu-member-names {
     overflow: hidden;
     text-overflow: ellipsis;
+    min-width: 0;
     white-space: nowrap;
+    color: var(--color-text-popover-menu);
 }
 
-.popover-group-menu-member-name,
-.popover-group-menu-placeholder {
+.popover-group-menu-empty {
+    font-style: italic;
     color: var(--color-text-popover-menu);
+}
+
+.popover-group-menu-more {
+    flex: none;
+    white-space: nowrap;
+    color: var(--color-text-popover-menu);
+}
+
+a.popover-group-menu-more-count {
+    color: var(--color-text-popover-menu);
+
+    &:hover {
+        text-decoration: underline;
+    }
+
+    &:focus-visible {
+        color: var(--color-text-url-hover);
+        outline: 1px solid var(--color-outline-focus) !important;
+        outline-offset: 2px;
+        border-radius: 2px;
+    }
 }
 
 .user-status-icon-wrapper {
     display: flex;
-}
-
-.popover-group-menu-user-presence {
-    /* 11px at 16px/1em */
-    font-size: 0.6875em;
 }
 
 .user_profile_presence {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -369,6 +369,21 @@
     /* 16px at 15px/1em */
     line-height: 1.0667em;
     color: var(--color-text-popover-menu);
+    /* Clamp the description to two lines, with a native ellipsis. The
+       tooltip set in tippyjs.ts points to settings for the full text. */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.popover-card-description.popover-card-description-full {
+    /* Show the full text to viewers who can't open settings. */
+    display: block;
+    overflow: visible;
 }
 
 .popover-group-menu-members-summary {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -290,6 +290,9 @@
 }
 
 #stream-card-popover {
+    /* Cap the width so long content truncates instead of widening the card. */
+    --popover-menu-max-width: 21.4285em; /* 300px / 14px em */
+
     .simplebar-content {
         min-width: var(--stream-card-popover-min-width);
     }
@@ -368,66 +371,47 @@
     color: var(--color-text-popover-menu);
 }
 
-ul.popover-group-menu-member-list {
-    max-height: 300px;
+.popover-group-menu-members-summary {
     display: flex;
-    flex-direction: column;
-
-    .simplebar-content {
-        display: grid;
-        grid-template-areas: "group-member-icon gap group-member-name";
-        grid-template-columns:
-            max-content var(--user-group-popover-icon-text-gap)
-            minmax(0, 1fr);
-        width: unset;
-    }
-
-    .popover-group-menu-member {
-        display: grid;
-        grid-template-columns: subgrid;
-        grid-column: 1 / -1;
-        align-items: center;
-        padding: 0 var(--user-group-popover-horizontal-padding);
-    }
-
-    .popover-group-member-icon {
-        justify-self: center;
-        grid-area: group-member-icon;
-    }
-
-    .popover-group-menu-member-name {
-        grid-area: group-member-name;
-    }
+    min-width: 0;
 }
 
-.popover-group-menu-placeholder {
-    padding: 0 var(--user-group-popover-horizontal-padding);
-}
-
-.popover-group-menu-member {
-    .zulip-icon-user-group {
-        color: var(--color-icon-purple);
-    }
-}
-
-.popover-group-menu-member-name {
+.popover-group-menu-member-names {
     overflow: hidden;
     text-overflow: ellipsis;
+    min-width: 0;
     white-space: nowrap;
+    color: var(--color-text-popover-menu);
 }
 
-.popover-group-menu-member-name,
-.popover-group-menu-placeholder {
+.popover-group-menu-empty {
+    font-style: italic;
     color: var(--color-text-popover-menu);
+}
+
+.popover-group-menu-more {
+    flex: none;
+    white-space: nowrap;
+    color: var(--color-text-popover-menu);
+}
+
+a.popover-group-menu-more-count {
+    color: var(--color-text-popover-menu);
+
+    &:hover {
+        text-decoration: underline;
+    }
+
+    &:focus-visible {
+        color: var(--color-text-url-hover);
+        outline: 1px solid var(--color-outline-focus) !important;
+        outline-offset: 2px;
+        border-radius: 2px;
+    }
 }
 
 .user-status-icon-wrapper {
     display: flex;
-}
-
-.popover-group-menu-user-presence {
-    /* 11px at 16px/1em */
-    font-size: 0.6875em;
 }
 
 .user_profile_presence {
@@ -1217,6 +1201,9 @@ ul.popover-group-menu-member-list {
 }
 
 .user-group-info-popover {
+    /* Cap the width so long content truncates instead of widening the card. */
+    --popover-menu-max-width: 21.4285em; /* 300px / 14px em */
+
     .simplebar-content {
         min-width: var(--user-group-info-popover-min-width);
     }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -266,28 +266,32 @@
     outline-offset: -2px;
 }
 
-#stream-actions-menu-popover,
-#stream-card-popover {
+#stream-actions-menu-popover {
     .popover-stream-name {
         font-weight: 600;
         color: var(--color-text-popover-menu);
         line-height: 1.1;
-    }
-
-    .popover-stream-name,
-    .stream-privacy.filter-icon {
         margin-top: 4px;
     }
 
+    .stream-privacy.filter-icon {
+        margin-top: 4px;
+    }
+}
+
+#stream-actions-menu-popover,
+#stream-card-popover {
     .zulip-icon-lock {
         /* Override the margin-top set on the stream lock icon
            at the top-level, since we don't need to pull up this
            icon for the stream actions popover header.  */
         margin: 0 !important;
     }
+}
 
-    .popover-stream-info-menu-description {
-        color: var(--color-text-popover-menu);
+#stream-card-popover {
+    .simplebar-content {
+        min-width: var(--stream-card-popover-min-width);
     }
 }
 
@@ -335,6 +339,60 @@
     font-size: 1em;
     /* 16px at 15px/1em */
     line-height: 1.0667em;
+}
+
+/* The channel and group cards use the same header and description markup,
+   so that the two cards stay visually consistent. The .popover-menu-list-item
+   in these selectors is only there to outweigh the base .text-item rules. */
+.popover-menu-list-item.popover-card-header.text-item {
+    /* Keep the name and description tight together, rather than
+       padding them out to the height of a clickable menu item. */
+    min-height: 0;
+}
+
+.popover-menu-list-item.popover-card-description-item.text-item {
+    min-height: 0;
+    padding-top: 0;
+}
+
+.popover-menu-list-item.popover-card-header {
+    .popover-menu-icon {
+        color: var(--color-icon-purple);
+        /* Drop the 1px lift used for menu-item icons; the card header
+           icon is aligned with the name, not with a menu label. */
+        top: 0;
+    }
+
+    .stream-privacy {
+        /* Give the channel privacy icon the same box as the group card's
+           .popover-menu-icon, so both card headers are the same height;
+           otherwise the icon font's line box makes this header taller. */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        /* 16px at 15px/1em */
+        font-size: 1.0667em;
+        /* 16px at 16px/1em */
+        width: 1em;
+        height: 1em;
+    }
+}
+
+.popover-card-name {
+    font-weight: 600;
+    line-height: 1.1;
+    color: var(--color-text-popover-menu);
+    /* Break very long channel and group names rather than
+       widening the card. */
+    overflow-wrap: anywhere;
+}
+
+.popover-card-description {
+    /* 15px at 15px/1em */
+    font-size: 1em;
+    /* 16px at 15px/1em */
+    line-height: 1.0667em;
+    color: var(--color-text-popover-menu);
 }
 
 ul.popover-group-menu-member-list {
@@ -1189,12 +1247,6 @@ ul.popover-group-menu-member-list {
 .user-group-info-popover {
     .simplebar-content {
         min-width: var(--user-group-info-popover-min-width);
-    }
-}
-
-#stream-card-popover {
-    .simplebar-content {
-        min-width: var(--stream-card-popover-min-width);
     }
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -314,33 +314,6 @@
     width: max-content;
 }
 
-.popover-group-menu-info {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-    padding: 3px var(--user-group-popover-horizontal-padding);
-}
-
-.popover-group-menu-name-container {
-    display: flex;
-    align-items: flex-start;
-    gap: 5px;
-    /* 18px at 15px/1em */
-    font-size: 1.2em;
-    font-weight: 600;
-    /* 20px at 18px/1em */
-    line-height: 1.1111em;
-    color: var(--color-text-full-name);
-    overflow-wrap: anywhere;
-}
-
-.popover-group-menu-description {
-    /* 15px at 15px/1em */
-    font-size: 1em;
-    /* 16px at 15px/1em */
-    line-height: 1.0667em;
-}
-
 /* The channel and group cards use the same header and description markup,
    so that the two cards stay visually consistent. The .popover-menu-list-item
    in these selectors is only there to outweigh the base .text-item rules. */
@@ -443,7 +416,6 @@ ul.popover-group-menu-member-list {
     white-space: nowrap;
 }
 
-.popover-group-menu-description,
 .popover-group-menu-member-name,
 .popover-group-menu-placeholder {
     color: var(--color-text-popover-menu);

--- a/web/templates/popovers/stream_card_popover.hbs
+++ b/web/templates/popovers/stream_card_popover.hbs
@@ -1,20 +1,21 @@
 <div class="popover-menu" id="stream-card-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
-        <li role="none" class="popover-stream-header text-item popover-menu-list-item">
+        <li role="none" class="popover-card-header text-item popover-menu-list-item">
             <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
                 {{> ../stream_privacy
                   invite_only=stream.invite_only
                   is_web_public=stream.is_web_public
                   is_archived=stream.is_archived }}
             </span>
-            <span class="popover-stream-name">{{stream.name}}</span>
+            <span class="popover-card-name">{{stream.name}}</span>
         </li>
-        <li role="none" class="popover-stream-info-menu-description text-item popover-menu-list-item">
-            {{> ../stream_settings/stream_description
-              rendered_description=stream.rendered_description
-              use_view_only_styling=false
-              }}
+        <li role="none" class="popover-card-description-item text-item popover-menu-list-item">
+            <div class="popover-card-description">{{> ../stream_settings/stream_description
+                  rendered_description=stream.rendered_description
+                  use_view_only_styling=false}}
+            </div>
         </li>
+        <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="popover-menu-list-item text-item italic">
             {{#tr}}
             {subscribers_count, plural, =0 {No subscribers} =1 {1 subscriber} other {# subscribers}}

--- a/web/templates/popovers/stream_card_popover.hbs
+++ b/web/templates/popovers/stream_card_popover.hbs
@@ -25,7 +25,7 @@
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
             <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Channel settings" }}</span>
+                <span class="popover-menu-label">{{t "Settings" }}</span>
             </a>
         </li>
     </ul>

--- a/web/templates/popovers/stream_card_popover.hbs
+++ b/web/templates/popovers/stream_card_popover.hbs
@@ -10,10 +10,18 @@
             <span class="popover-card-name">{{stream.name}}</span>
         </li>
         <li role="none" class="popover-card-description-item text-item popover-menu-list-item">
-            <div class="popover-card-description">{{> ../stream_settings/stream_description
-                  rendered_description=stream.rendered_description
-                  use_view_only_styling=false}}
-            </div>
+            {{#if is_spectator}}
+                {{! Spectators get no settings link or tooltip, so show it in full. }}
+                <div class="popover-card-description popover-card-description-full">{{> ../stream_settings/stream_description
+                      rendered_description=stream.rendered_description
+                      use_view_only_styling=false}}
+                </div>
+            {{else}}
+                <div class="popover-card-description" data-tippy-content="{{t 'Open settings to see the full description.'}}">{{> ../stream_settings/stream_description
+                      rendered_description=stream.rendered_description
+                      use_view_only_styling=false}}
+                </div>
+            {{/if}}
         </li>
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="popover-menu-list-item text-item italic">

--- a/web/templates/popovers/stream_card_popover.hbs
+++ b/web/templates/popovers/stream_card_popover.hbs
@@ -10,10 +10,18 @@
             <span class="popover-card-name">{{stream.name}}</span>
         </li>
         <li role="none" class="popover-card-description-item text-item popover-menu-list-item">
-            <div class="popover-card-description">{{> ../stream_settings/stream_description
-                  rendered_description=stream.rendered_description
-                  use_view_only_styling=false}}
-            </div>
+            {{#if can_open_settings}}
+                <div class="popover-card-description" data-tippy-content="{{t 'Open settings to see the full description.'}}">{{> ../stream_settings/stream_description
+                      rendered_description=stream.rendered_description
+                      use_view_only_styling=false}}
+                </div>
+            {{else}}
+                {{! No settings link or tooltip for this viewer, so show it in full. }}
+                <div class="popover-card-description popover-card-description-full">{{> ../stream_settings/stream_description
+                      rendered_description=stream.rendered_description
+                      use_view_only_styling=false}}
+                </div>
+            {{/if}}
         </li>
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="popover-menu-list-item text-item italic">

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -1,16 +1,14 @@
 <div class="popover-menu user-group-info-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
-        <li role="none" class="link-item popover-menu-list-item">
-            <div class="popover-group-menu-info">
-                <div class="popover-group-menu-name-container">
-                    <i class="popover-menu-icon zulip-icon zulip-icon-user-group" aria-hidden="true"></i>
-                    <span class="popover-group-menu-name">{{group_name}}</span>
-                </div>
-                {{#if group_description}}
-                    <div class="popover-group-menu-description">{{group_description}}</div>
-                {{/if}}
-            </div>
+        <li role="none" class="popover-card-header text-item popover-menu-list-item">
+            <i class="popover-menu-icon zulip-icon zulip-icon-user-group" aria-hidden="true"></i>
+            <span class="popover-card-name">{{group_name}}</span>
         </li>
+        {{#if group_description}}
+            <li role="none" class="popover-card-description-item text-item popover-menu-list-item">
+                <div class="popover-card-description">{{group_description}}</div>
+            </li>
+        {{/if}}
         {{#unless (and (eq displayed_members.length 0) (eq displayed_subgroups.length 0))}}
             {{#if user_can_access_all_other_users}}
                 <li role="none" class="popover-menu-list-item text-item italic">

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -75,8 +75,8 @@
             <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
             <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
                 <a href="{{group_edit_url}}" role="menuitem" class="navigate-link-on-enter popover-menu-link" tabindex="0">
-                    <i class="popover-menu-icon zulip-icon zulip-icon-user-group-cog" aria-hidden="true"></i>
-                    <span class="popover-menu-label">{{t "Group settings" }}</span>
+                    <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Settings" }}</span>
                 </a>
             </li>
         {{/unless}}

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -9,76 +9,35 @@
                 <div class="popover-card-description">{{group_description}}</div>
             </li>
         {{/if}}
-        {{#unless (and (eq displayed_members.length 0) (eq displayed_subgroups.length 0))}}
-            {{#if user_can_access_all_other_users}}
-                <li role="none" class="popover-menu-list-item text-item italic">
-                    {{#tr}}
-                        {members_count, plural, =1 {1 member} other {# members}}
-                    {{/tr}}
-                </li>
-            {{/if}}
-        {{/unless}}
         {{#if deactivated}}
             <li role="none" class="popover-menu-list-item text-item italic hidden-for-spectators">
                 <span class="popover-menu-label">{{t "This group has been deactivated." }}</span>
             </li>
         {{/if}}
-        <li role="separator" class="popover-menu-separator"></li>
-        <li role="none" class="popover-menu-list-item">
-            {{#unless (and (eq displayed_members.length 0) (eq displayed_subgroups.length 0))}}
-                <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                    {{#each displayed_subgroups}}
-                        <li class="popover-group-menu-member">
-                            <i class="popover-group-member-icon popover-menu-icon zulip-icon zulip-icon-user-group" aria-hidden="true"></i>
-                            <span class="popover-group-menu-member-name">{{name}}</span>
-                        </li>
-                    {{/each}}
-                    {{#each displayed_members}}
-                        <li class="popover-group-menu-member">
-                            {{#if is_bot}}
-                                <i class="popover-group-member-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                            {{else}}
-                                <span class="popover-group-member-icon user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} popover-group-menu-user-presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
-                            {{/if}}
-                            <span class="popover-group-menu-member-name">{{full_name}}</span>
-                        </li>
-                    {{/each}}
-                    {{#unless display_all_subgroups_and_members}}
-                        <li class="popover-group-menu-member">
-                            <span class="popover-group-menu-member-name">
-                                {{#if is_system_group}}
-                                    {{#if has_bots}}
-                                        {{#tr class="popover-group-menu-member"}}
-                                            View all <z-link-users>users</z-link-users> and <z-link-bots>bots</z-link-bots>
-                                            {{#*inline "z-link-users"}}<a href="#organization/users">{{> @partial-block}}</a>{{/inline}}
-                                            {{#*inline "z-link-bots"}}<a href="#organization/bots">{{> @partial-block}}</a>{{/inline}}
-                                        {{/tr}}
-                                    {{else}}
-                                        <a href="#organization/users" role="menuitem">
-                                            {{t "View all users"}}
-                                        </a>
-                                    {{/if}}
-                                {{else}}
-                                    <a href="{{group_members_url}}" role="menuitem">
-                                        {{t "View all members"}}
-                                    </a>
-                                {{/if}}
-                            </span>
-                        </li>
-                    {{/unless}}
-                </ul>
-            {{else}}
-                <span class="popover-group-menu-placeholder"><i>{{t 'This group has no members.'}}</i></span>
-            {{/unless}}
-        </li>
-        {{#unless is_guest}}
-            <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
-            <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+        {{#if show_member_section}}
+            <li role="separator" class="popover-menu-separator"></li>
+            <li role="none" class="popover-menu-list-item text-item">
+                {{#if has_members}}
+                    <span class="popover-group-menu-members-summary">
+                        <span class="popover-group-menu-member-names">{{#each displayed_member_names}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}</span>
+                        {{#if has_other_members}}
+                            {{! Comma stays outside the link so only "and N more" underlines. }}
+                            <span class="popover-group-menu-more">,&nbsp;{{#if can_open_settings}}<a href="{{group_members_url}}" role="menuitem" class="navigate-link-on-enter popover-group-menu-more-count">{{#tr}}and {num_other_members} more{{/tr}}</a>{{else}}{{#tr}}and {num_other_members} more{{/tr}}{{/if}}</span>
+                        {{/if}}
+                    </span>
+                {{else}}
+                    <span class="popover-group-menu-empty">{{t 'This group has no members.'}}</span>
+                {{/if}}
+            </li>
+        {{/if}}
+        {{#if can_open_settings}}
+            <li role="separator" class="popover-menu-separator"></li>
+            <li role="none" class="link-item popover-menu-list-item">
                 <a href="{{group_edit_url}}" role="menuitem" class="navigate-link-on-enter popover-menu-link" tabindex="0">
                     <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
                     <span class="popover-menu-label">{{t "Settings" }}</span>
                 </a>
             </li>
-        {{/unless}}
+        {{/if}}
     </ul>
 </div>

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -9,68 +9,32 @@
                 <div class="popover-card-description">{{group_description}}</div>
             </li>
         {{/if}}
-        {{#unless (and (eq displayed_members.length 0) (eq displayed_subgroups.length 0))}}
-            {{#if user_can_access_all_other_users}}
-                <li role="none" class="popover-menu-list-item text-item italic">
-                    {{#tr}}
-                        {members_count, plural, =1 {1 member} other {# members}}
-                    {{/tr}}
-                </li>
-            {{/if}}
-        {{/unless}}
         {{#if deactivated}}
             <li role="none" class="popover-menu-list-item text-item italic hidden-for-spectators">
                 <span class="popover-menu-label">{{t "This group has been deactivated." }}</span>
             </li>
         {{/if}}
-        <li role="separator" class="popover-menu-separator"></li>
-        <li role="none" class="popover-menu-list-item">
-            {{#unless (and (eq displayed_members.length 0) (eq displayed_subgroups.length 0))}}
-                <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                    {{#each displayed_subgroups}}
-                        <li class="popover-group-menu-member">
-                            <i class="popover-group-member-icon popover-menu-icon zulip-icon zulip-icon-user-group" aria-hidden="true"></i>
-                            <span class="popover-group-menu-member-name">{{name}}</span>
-                        </li>
-                    {{/each}}
-                    {{#each displayed_members}}
-                        <li class="popover-group-menu-member">
-                            {{#if is_bot}}
-                                <i class="popover-group-member-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                            {{else}}
-                                <span class="popover-group-member-icon user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} popover-group-menu-user-presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
+        {{#if can_see_members}}
+            <li role="separator" class="popover-menu-separator"></li>
+            <li role="none" class="popover-menu-list-item text-item">
+                {{#if has_members}}
+                    {{#if has_named_members}}
+                        <span class="popover-group-menu-members-summary">
+                            <span class="popover-group-menu-member-names">{{#each displayed_member_names}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}</span>
+                            {{#if has_other_members}}
+                                {{! Comma stays outside the link so only "and N more" underlines. }}
+                                <span class="popover-group-menu-more">,&nbsp;{{#if is_guest}}{{#tr}}and {num_other_members} more{{/tr}}{{else}}<a href="{{group_members_url}}" role="menuitem" class="navigate-link-on-enter popover-group-menu-more-count">{{#tr}}and {num_other_members} more{{/tr}}</a>{{/if}}</span>
                             {{/if}}
-                            <span class="popover-group-menu-member-name">{{full_name}}</span>
-                        </li>
-                    {{/each}}
-                    {{#unless display_all_subgroups_and_members}}
-                        <li class="popover-group-menu-member">
-                            <span class="popover-group-menu-member-name">
-                                {{#if is_system_group}}
-                                    {{#if has_bots}}
-                                        {{#tr class="popover-group-menu-member"}}
-                                            View all <z-link-users>users</z-link-users> and <z-link-bots>bots</z-link-bots>
-                                            {{#*inline "z-link-users"}}<a href="#organization/users">{{> @partial-block}}</a>{{/inline}}
-                                            {{#*inline "z-link-bots"}}<a href="#organization/bots">{{> @partial-block}}</a>{{/inline}}
-                                        {{/tr}}
-                                    {{else}}
-                                        <a href="#organization/users" role="menuitem">
-                                            {{t "View all users"}}
-                                        </a>
-                                    {{/if}}
-                                {{else}}
-                                    <a href="{{group_members_url}}" role="menuitem">
-                                        {{t "View all members"}}
-                                    </a>
-                                {{/if}}
-                            </span>
-                        </li>
-                    {{/unless}}
-                </ul>
-            {{else}}
-                <span class="popover-group-menu-placeholder"><i>{{t 'This group has no members.'}}</i></span>
-            {{/unless}}
-        </li>
+                        </span>
+                    {{else}}
+                        {{! No members are visible by name, so just show the count. }}
+                        {{#tr}}{member_count, plural, =1 {1 member} other {# members}}{{/tr}}
+                    {{/if}}
+                {{else}}
+                    <span class="popover-group-menu-empty">{{t 'This group has no members.'}}</span>
+                {{/if}}
+            </li>
+        {{/if}}
         {{#unless is_guest}}
             <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
             <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -6,7 +6,12 @@
         </li>
         {{#if group_description}}
             <li role="none" class="popover-card-description-item text-item popover-menu-list-item">
-                <div class="popover-card-description">{{group_description}}</div>
+                {{#if is_guest}}
+                    {{! Guests get no settings link or tooltip, so show it in full. }}
+                    <div class="popover-card-description popover-card-description-full">{{group_description}}</div>
+                {{else}}
+                    <div class="popover-card-description" data-tippy-content="{{t 'Open settings to see the full description.'}}">{{group_description}}</div>
+                {{/if}}
             </li>
         {{/if}}
         {{#if deactivated}}

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -6,7 +6,12 @@
         </li>
         {{#if group_description}}
             <li role="none" class="popover-card-description-item text-item popover-menu-list-item">
-                <div class="popover-card-description">{{group_description}}</div>
+                {{#if can_open_settings}}
+                    <div class="popover-card-description" data-tippy-content="{{t 'Open settings to see the full description.'}}">{{group_description}}</div>
+                {{else}}
+                    {{! No settings link or tooltip for this viewer, so show it in full. }}
+                    <div class="popover-card-description popover-card-description-full">{{group_description}}</div>
+                {{/if}}
             </li>
         {{/if}}
         {{#if deactivated}}


### PR DESCRIPTION
The channel card and group card had a few styling inconsistencies:

- The channel card had extra vertical space between the channel name and its description.

- The group name was larger and used a different color than the channel name.

- Group card icons (header + footer) were shifted up by 1px, while the channel card icon was not.

This PR aligns both cards so they look visually consistent.

**Group card members:** instead of a scrolling member list, the card now names a couple of the group's members and the rest as "and N more". The count and names cover the individuals the group reaches through its subgroups (each person once) that the current user is allowed to see, so restricted guests still see the members they share channels with. "and N more" links to the group's members tab for viewers who can open it (plain text for guests and spectators, who can't).

**Channel card descriptions:** long channel descriptions are clamped to two lines, a divider separates the subscriber count, and the footer link is simplified to "Settings".

**Truncated descriptions:** when a description is truncated, hovering it shows a tooltip pointing to settings for the full text (it doesn't appear for short descriptions). Viewers who have no settings link guests on the group card; spectators on either card are shown the full description in place instead, so the text is never left unreachable.

Discussion: [CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/channel.20cards.3F/near/2481778) discussion 

Fixes: #38200.

<hr>


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

<details> 
<summary>Before and after shots</summary>

| Dark theme Before | Dark theme After |
|--------|-------|
|<img width="428" height="396" alt="image" src="https://github.com/user-attachments/assets/7459e2c8-7149-405c-ac3b-25a13a731edb" />|<img width="468" height="196" alt="image" src="https://github.com/user-attachments/assets/0f54060b-7622-4fe5-81a8-903eeeb5ecd5" />|

| Light theme Before | Light theme After |
|--------|-------|
|<img width="428" height="396" alt="image" src="https://github.com/user-attachments/assets/1325a452-6ca7-412a-840d-7e599037fc88" />|<img width="468" height="196" alt="image" src="https://github.com/user-attachments/assets/c65a96b1-2c40-4fdf-a915-6b3509548aa9" />|

| Dark theme Before | Dark theme After |
|--------|-------|
|<img width="427" height="94" alt="image" src="https://github.com/user-attachments/assets/7b42c09d-8147-4ab0-b368-4d83e49adab3" />|<img width="427" height="89" alt="image" src="https://github.com/user-attachments/assets/ff2af2fc-6d45-4844-92ce-c9906435ea5d" />|

| Light theme Before | Light theme After |
|--------|-------|
|<img width="427" height="94" alt="image" src="https://github.com/user-attachments/assets/835dfc67-6636-428b-bdca-0ad67de298ef" />|<img width="427" height="89" alt="image" src="https://github.com/user-attachments/assets/93eba28c-276a-4bfd-a82d-6c59f3a8ad57" />|


| Groups Long description before | Group Long description after |
|--------|-------|
|<img width="427" height="336" alt="image" src="https://github.com/user-attachments/assets/58a4d919-f435-44a3-8ac4-adbf78bf4346" />|<img width="427" height="225" alt="image" src="https://github.com/user-attachments/assets/736e6c84-eec7-4dae-82c4-ef74873989ee" />|


| Channel Long description before | Channel Long description after |
|--------|-------|
|<img width="427" height="334" alt="image" src="https://github.com/user-attachments/assets/195aa8df-5d01-4ce9-b92d-230e1e39079a" />|<img width="427" height="226" alt="image" src="https://github.com/user-attachments/assets/4cecd451-242b-4200-933e-526684cb0175" />|


</details>


<details> 
<summary>Comparision shots</summary>

| Group comparision | Channel comparision |
|--------|-------|
|<img width="427" height="116" alt="image" src="https://github.com/user-attachments/assets/24b1dd47-8efe-4435-9862-63004190c018" />|<img width="427" height="117" alt="image" src="https://github.com/user-attachments/assets/14aa881d-ac62-410d-a48b-80cc0c03b9d5" />|

| Group comparision | Channel comparision |
|--------|-------|
|<img width="444" height="225" alt="image" src="https://github.com/user-attachments/assets/ada48d9b-4e67-4913-bfd8-d8c58b74b567" />|<img width="427" height="226" alt="image" src="https://github.com/user-attachments/assets/13a44961-7226-4fd3-b287-92767f91f9ea" />|

| Tooltip only appears on long description | Tooltip only appears on long description |
|--------|-------|
|<img width="432" height="243" alt="image" src="https://github.com/user-attachments/assets/e435189f-9488-4e41-acbd-e95cf8064918" />|<img width="431" height="243" alt="image" src="https://github.com/user-attachments/assets/4f45052d-9965-4b0c-85fa-8bc48e54d5e3" />|

**Proof of no change in the other popover**

| Before | After |
|--------|-------|
|<img width="189" height="239" alt="2026-06-21_18-04-53" src="https://github.com/user-attachments/assets/d6440867-d5cb-4f6e-bd3e-1281a5812130" />|<img width="189" height="239" alt="2026-06-21_18-04-34" src="https://github.com/user-attachments/assets/8c4c57fb-35b4-4e43-b5fc-3b6fb2db8bf1" />|

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
