### PR TITLE
[ai] search_results: Rank deactivated users below active users in suggestions.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -260,6 +260,15 @@ export function sorter<T>(query: string, objs: T[], get_item: (x: T) => string):
 }
 
 export function compare_by_pms(user_a: User, user_b: User): number {
+    const a_is_active = people.is_active_user(user_a.user_id);
+    const b_is_active = people.is_active_user(user_b.user_id);
+
+    if (a_is_active && !b_is_active) {
+        return -1;
+    } else if (!a_is_active && b_is_active) {
+        return 1;
+    }
+
     const count_a = people.get_recipient_count(user_a);
     const count_b = people.get_recipient_count(user_b);
 

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -1153,6 +1153,20 @@ test("compare_by_pms", () => {
 
     assert.equal(th.compare_by_pms(a_user, b_user_1), 1);
     assert.equal(th.compare_by_pms(b_user_1, a_user), -1);
+
+    // Deactivated users rank below active users regardless of PM count
+    const deactivated_user = make_user({
+        email: "deactivated@zulip.net",
+        full_name: "Deactivated User",
+        user_id: 999,
+    });
+    people.add_active_user(deactivated_user);
+    people.deactivate(deactivated_user);
+    people.set_recipient_count_for_testing(deactivated_user.user_id, 100);
+
+    assert.equal(th.compare_by_pms(a_user, deactivated_user), -1);
+    assert.equal(th.compare_by_pms(deactivated_user, a_user), 1);
+    assert.equal(th.compare_by_pms(deactivated_user, deactivated_user), 0);
 });
 
 test("sort_group_setting_options", ({override_rewire}) => {


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/35976

When a user's name matches both active and deactivated accounts, search
suggestions for \`dm:\`, \`sender:\`, and \`dm-including:\` previously ranked
deactivated users by PM count alone — meaning a heavily-messaged deactivated
user could appear above all active users. This is confusing since deactivated
users are rarely the intended recipient.

The fix adds an active/inactive check at the top of \`compare_by_pms\` in
\`typeahead_helper.ts\`. Active users are now always ranked above deactivated
users; within each group, the existing ordering (PM count → partner status →
alphabetical) is preserved unchanged.

**How changes were tested:**

- Ran \`web/tests/typeahead_helper.test.cjs\` — passes, including a new test
  asserting a deactivated user with PM count 100 ranks below an active user
  with PM count 0.
- Verified all 172 JS tests: zero new failures introduced (5 pre-existing
  failures on \`main\` are timezone-related and unrelated to this change).

**Screenshots and screen captures:**

No UI changes — this is a sort-order fix in TypeScript logic only.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Followed the AI use policy.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [ ] Visual appearance of the changes. (N/A — logic-only change)
- [ ] Responsiveness and internationalization. (N/A)
- [ ] Strings and tooltips. (N/A)
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>