### PR TITLE
[ai] emoji: Add "native" emojiset option.

### DIFF
--- a/api_docs/unmerged.d/ZF-e6bf89.md
+++ b/api_docs/unmerged.d/ZF-e6bf89.md
@@ -1,0 +1,6 @@
+* [`POST /register`](/api/register-queue),
+  [`PATCH /settings`](/api/update-settings),
+  [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
+  Added `"native"` as a new option for the `emojiset` setting, which
+  renders Unicode emoji using the operating system's native emoji
+  font.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "handlebars-loader": "^1.7.1",
     "html-webpack-plugin": "^5.3.2",
     "intl-messageformat": "^11.0.7",
+    "is-emoji-supported": "^0.0.5",
     "is-url": "^1.2.4",
     "jdenticon": "^3.3.0",
     "jquery": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       intl-messageformat:
         specifier: ^11.0.7
         version: 11.2.14
+      is-emoji-supported:
+        specifier: ^0.0.5
+        version: 0.0.5
       is-url:
         specifier: ^1.2.4
         version: 1.2.4
@@ -6411,6 +6414,9 @@ packages:
   is-document.all@1.0.0:
     resolution: {integrity: sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==}
     engines: {node: '>= 0.4'}
+
+  is-emoji-supported@0.0.5:
+    resolution: {integrity: sha512-WOlXUhDDHxYqcSmFZis+xWhhqXiK2SU0iYiqmth5Ip0FHLZQAt9rKL5ahnilE8/86WH8tZ3bmNNNC+bTzamqlw==}
 
   is-empty@1.2.0:
     resolution: {integrity: sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==}
@@ -17195,6 +17201,8 @@ snapshots:
   is-document.all@1.0.0:
     dependencies:
       call-bound: 1.0.4
+
+  is-emoji-supported@0.0.5: {}
 
   is-empty@1.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       intl-messageformat:
         specifier: ^11.0.7
         version: 11.2.12
+      is-emoji-supported:
+        specifier: ^0.0.5
+        version: 0.0.5
       is-url:
         specifier: ^1.2.4
         version: 1.2.4
@@ -6346,6 +6349,9 @@ packages:
   is-document.all@1.0.0:
     resolution: {integrity: sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==}
     engines: {node: '>= 0.4'}
+
+  is-emoji-supported@0.0.5:
+    resolution: {integrity: sha512-WOlXUhDDHxYqcSmFZis+xWhhqXiK2SU0iYiqmth5Ip0FHLZQAt9rKL5ahnilE8/86WH8tZ3bmNNNC+bTzamqlw==}
 
   is-empty@1.2.0:
     resolution: {integrity: sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==}
@@ -17061,6 +17067,8 @@ snapshots:
   is-document.all@1.0.0:
     dependencies:
       call-bound: 1.0.4
+
+  is-emoji-supported@0.0.5: {}
 
   is-empty@1.2.0: {}
 

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 507
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (386, 0)  # bumped 2026-07-28 to upgrade JavaScript dependencies
+PROVISION_VERSION = (386, 1)  # bumped 2026-07-29 to add is-emoji-supported

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 509
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (389, 0)  # bumped 2026-08-19 to upgrade Python requirements
+PROVISION_VERSION = (389, 1)  # bumped 2026-08-19 to add is-emoji-supported

--- a/web/src/emoji.ts
+++ b/web/src/emoji.ts
@@ -1,8 +1,11 @@
+import {isEmojiSupported} from "is-emoji-supported";
 import _ from "lodash";
 import type * as z from "zod/mini";
 
 import * as blueslip from "./blueslip.ts";
 import type {StateData, realm_emoji_map_schema, server_emoji_schema} from "./state_data.ts";
+import {parse_unicode_emoji_code} from "./typeahead.ts";
+import {user_settings} from "./user_settings.ts";
 
 // This is the data structure that we get from the server on initialization.
 export type ServerEmoji = z.infer<typeof server_emoji_schema>;
@@ -56,6 +59,9 @@ export type EmojiRenderingDetails = {
     emoji_code: string;
     url?: string;
     still_url?: string | null;
+    // The Unicode glyph, set only for the "native" emojiset when the
+    // platform can render this emoji (see get_native_emoji_info).
+    unicode_emoji?: string;
 };
 
 // We will get actual values when we get initialized.
@@ -289,6 +295,22 @@ function rebuild_emoji_data(): void {
     });
 }
 
+// Returns {unicode_emoji} when the "native" emojiset is active and the
+// platform can render this Unicode emoji as a color glyph, else {}.
+// Kept out of get_emoji_details_by_name, which builds the (sprite-only)
+// typeahead catalog, to avoid running this detection over every emoji.
+export function get_native_emoji_info(emoji_details: EmojiRenderingDetails): {
+    unicode_emoji?: string;
+} {
+    if (user_settings.emojiset === "native" && emoji_details.reaction_type === "unicode_emoji") {
+        const emoji_text = parse_unicode_emoji_code(emoji_details.emoji_code);
+        if (isEmojiSupported(emoji_text)) {
+            return {unicode_emoji: emoji_text};
+        }
+    }
+    return {};
+}
+
 // This function will provide required parameters that would
 // need by template to render an emoji.
 export function get_emoji_details_by_name(emoji_name: string): EmojiRenderingDetails {
@@ -339,11 +361,12 @@ export function get_emoji_details_for_rendering(opts: {
         };
     }
     // else
-    return {
+    const details: EmojiRenderingDetails = {
         emoji_name: opts.emoji_name,
         emoji_code: opts.emoji_code,
         reaction_type: opts.reaction_type,
     };
+    return {...details, ...get_native_emoji_info(details)};
 }
 
 function build_default_emoji_aliases({

--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -136,7 +136,12 @@ class UserStatusSession {
             emoji_alt_code: user_settings.emojiset === "text",
         };
         if (!emoji_info.emoji_alt_code) {
-            emoji_info = {...emoji_info, ...emoji.get_emoji_details_by_name(emoji_name)};
+            const details = emoji.get_emoji_details_by_name(emoji_name);
+            emoji_info = {
+                ...emoji_info,
+                ...details,
+                ...emoji.get_native_emoji_info(details),
+            };
         }
         user_status_ui.set_selected_emoji_info(emoji_info);
         user_status_ui.update_button();
@@ -514,7 +519,7 @@ function reset_emoji_showcase(): void {
     $(".emoji-showcase-container").empty();
 }
 
-function update_emoji_showcase($focused_emoji: JQuery): void {
+export function update_emoji_showcase($focused_emoji: JQuery): void {
     // Don't use jQuery's data() function here. It has the side-effect
     // of converting emoji names like :100:, :1234: etc to number.
     const focused_emoji_name = $focused_emoji.attr("data-emoji-name")!;
@@ -530,6 +535,10 @@ function update_emoji_showcase($focused_emoji: JQuery): void {
     const emoji_dict = {
         ...focused_emoji_dict,
         name: focused_emoji_name.replaceAll("_", " "),
+        // For the "native" emojiset, preview the platform's own glyph
+        // rather than the Google sprite, matching how the emoji renders
+        // in messages. Returns {} for realm emoji and other emojisets.
+        ...emoji.get_native_emoji_info(emoji.get_emoji_details_by_name(canonical_name)),
     };
     const rendered_showcase = render_emoji_showcase({
         emoji_dict,

--- a/web/src/emojisets.ts
+++ b/web/src/emojisets.ts
@@ -21,9 +21,10 @@ const emojisets = new Map<string, EmojiSet>([
     ["twitter", {css: twitter_css, sheet: twitter_sheet}],
 ]);
 
-// For `text` emoji set we fallback to `google` emoji set
+// For `text` and `native` emoji sets we fallback to `google` emoji set
 // for displaying emojis in emoji picker and typeahead.
 emojisets.set("text", emojisets.get("google")!);
+emojisets.set("native", emojisets.get("google")!);
 
 let current_emojiset: EmojiSet | undefined;
 

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -161,6 +161,7 @@ export type MessageCleanReaction = {
     label: string;
     local_id: string;
     reaction_type: "zulip_extra_emoji" | "realm_emoji" | "unicode_emoji";
+    unicode_emoji?: string;
     user_ids: number[];
     vote_text: string;
 };
@@ -418,6 +419,17 @@ export function update_status_emoji_info(
         const message = message_data.message;
         if (message.sender_id && message.sender_id === user_id) {
             message.status_emoji_info = new_info;
+        }
+    }
+}
+
+export function update_all_status_emoji_info(
+    get_status_emoji: (user_id: number) => UserStatusEmojiInfo | undefined,
+): void {
+    for (const message_data of stored_messages.values()) {
+        const message = message_data.message;
+        if (message.sender_id) {
+            message.status_emoji_info = get_status_emoji(message.sender_id);
         }
     }
 }

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -161,6 +161,7 @@ export type MessageCleanReaction = {
     label: string;
     local_id: string;
     reaction_type: "zulip_extra_emoji" | "realm_emoji" | "unicode_emoji";
+    unicode_emoji?: string;
     user_ids: number[];
     vote_text: string;
 };

--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -596,7 +596,20 @@ export function update_clean_reactions(message: Message): void {
     const should_display_reactors = check_should_display_reactors(reaction_counts_and_user_ids);
     for (const clean_reaction of message.clean_reactions.values()) {
         update_user_fields(clean_reaction, should_display_reactors);
+        update_emoji_fields(clean_reaction);
     }
+}
+
+function update_emoji_fields(clean_reaction_object: MessageCleanReaction): void {
+    const emoji_details = emoji.get_emoji_details_for_rendering({
+        emoji_name: clean_reaction_object.emoji_name,
+        emoji_code: clean_reaction_object.emoji_code,
+        reaction_type: clean_reaction_object.reaction_type,
+    });
+    delete clean_reaction_object.unicode_emoji;
+    Object.assign(clean_reaction_object, emoji_details, {
+        emoji_alt_code: user_settings.emojiset === "text",
+    });
 }
 
 function make_clean_reaction({

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -1,5 +1,6 @@
 import ClipboardJS from "clipboard";
 import {isValid, parseISO} from "date-fns";
+import {isEmojiSupported} from "is-emoji-supported";
 import {$} from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
@@ -25,6 +26,7 @@ import * as rows from "./rows.ts";
 import * as rtl from "./rtl.ts";
 import * as sub_store from "./sub_store.ts";
 import * as timerender from "./timerender.ts";
+import {parse_unicode_emoji_code} from "./typeahead.ts";
 import * as user_groups from "./user_groups.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
@@ -428,5 +430,19 @@ export const update_elements = ($content: JQuery): void => {
             })
             .contents()
             .unwrap();
+    } else if (user_settings.emojiset === "native") {
+        // For the "native" emojiset, replace Unicode emoji sprites with the
+        // glyph. Only span.emoji (Unicode) is touched; img.emoji (realm and
+        // custom emoji) is left as an image. Unsupported emoji keep the sprite.
+        $content.find("span.emoji").each(function () {
+            const classes = $(this).attr("class") ?? "";
+            const match = /emoji-([0-9a-f-]+)/.exec(classes);
+            if (match?.[1]) {
+                const emoji_text = parse_unicode_emoji_code(match[1]);
+                if (isEmojiSupported(emoji_text)) {
+                    $(this).addClass("emoji-native").text(emoji_text);
+                }
+            }
+        });
     }
 };

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -103,6 +103,7 @@ import * as user_group_edit from "./user_group_edit.ts";
 import * as user_groups from "./user_groups.ts";
 import {user_settings} from "./user_settings.ts";
 import * as user_status from "./user_status.ts";
+import * as user_status_ui from "./user_status_ui.ts";
 import * as user_topics from "./user_topics.ts";
 import * as user_topics_ui from "./user_topics_ui.ts";
 
@@ -1109,12 +1110,17 @@ export function dispatch_normal_event(event) {
                     settings_preferences.report_emojiset_change(
                         settings_preferences.user_settings_panel,
                     );
+                    // Refresh cached status emoji details before rerendering.
+                    user_status.rerender_emoji_info();
+                    message_store.update_all_status_emoji_info(user_status.get_status_emoji);
                     // Rerender the whole message list UI
                     for (const msg_list of message_lists.all_rendered_message_lists()) {
                         msg_list.rerender();
                     }
-                    // Rerender buddy list status emoji
+                    // Rerender status emoji shown outside the message feed
                     activity_ui.build_user_sidebar();
+                    pm_list.update_private_messages();
+                    user_status_ui.rerender_status_emoji_ui();
                     break;
                 case "display_emoji_reaction_users":
                     message_live_update.rerender_messages_view();

--- a/web/src/user_status.ts
+++ b/web/src/user_status.ts
@@ -94,13 +94,15 @@ export function set_status_emoji(event: UserStatusEvent): void {
         return;
     }
 
+    const emoji_details = emoji.get_emoji_details_for_rendering({
+        emoji_name: opts.emoji_name,
+        emoji_code: opts.emoji_code,
+        reaction_type: opts.reaction_type,
+    });
+
     user_status_emoji_info.set(opts.user_id, {
         emoji_alt_code: user_settings.emojiset === "text",
-        ...emoji.get_emoji_details_for_rendering({
-            emoji_name: opts.emoji_name,
-            emoji_code: opts.emoji_code,
-            reaction_type: opts.reaction_type,
-        }),
+        ...emoji_details,
     });
 }
 

--- a/web/src/user_status.ts
+++ b/web/src/user_status.ts
@@ -94,14 +94,29 @@ export function set_status_emoji(event: UserStatusEvent): void {
         return;
     }
 
+    const emoji_details = emoji.get_emoji_details_for_rendering({
+        emoji_name: opts.emoji_name,
+        emoji_code: opts.emoji_code,
+        reaction_type: opts.reaction_type,
+    });
+
     user_status_emoji_info.set(opts.user_id, {
         emoji_alt_code: user_settings.emojiset === "text",
-        ...emoji.get_emoji_details_for_rendering({
-            emoji_name: opts.emoji_name,
-            emoji_code: opts.emoji_code,
-            reaction_type: opts.reaction_type,
-        }),
+        ...emoji_details,
     });
+}
+
+export function rerender_emoji_info(): void {
+    for (const [user_id, emoji_info] of user_status_emoji_info) {
+        user_status_emoji_info.set(user_id, {
+            emoji_alt_code: user_settings.emojiset === "text",
+            ...emoji.get_emoji_details_for_rendering({
+                emoji_name: emoji_info.emoji_name,
+                emoji_code: emoji_info.emoji_code,
+                reaction_type: emoji_info.reaction_type,
+            }),
+        });
+    }
 }
 
 export function initialize(params: StateData["user_status"]): void {

--- a/web/src/user_status_ui.ts
+++ b/web/src/user_status_ui.ts
@@ -206,35 +206,42 @@ function navigate_status_options($focused_element: JQuery, key: "ArrowUp" | "Arr
     $navigable_elements.eq(next_index).trigger("focus");
 }
 
+// Looks up the rendering details for a default status emoji, including
+// the native Unicode glyph when the "native" emojiset is active.
+function get_default_status_emoji(emoji_name: string): EmojiRenderingDetails {
+    const details = emoji.get_emoji_details_by_name(emoji_name);
+    return {...details, ...emoji.get_native_emoji_info(details)};
+}
+
 export function initialize(): void {
     default_status_messages_and_emoji_info = [
         {
             status_text: $t({defaultMessage: "Busy"}),
-            emoji: emoji.get_emoji_details_by_name("working_on_it"),
+            emoji: get_default_status_emoji("working_on_it"),
         },
         {
             status_text: $t({defaultMessage: "In a meeting"}),
-            emoji: emoji.get_emoji_details_by_name("calendar"),
+            emoji: get_default_status_emoji("calendar"),
         },
         {
             status_text: $t({defaultMessage: "Commuting"}),
-            emoji: emoji.get_emoji_details_by_name("bus"),
+            emoji: get_default_status_emoji("bus"),
         },
         {
             status_text: $t({defaultMessage: "Out sick"}),
-            emoji: emoji.get_emoji_details_by_name("hurt"),
+            emoji: get_default_status_emoji("hurt"),
         },
         {
             status_text: $t({defaultMessage: "Vacationing"}),
-            emoji: emoji.get_emoji_details_by_name("palm_tree"),
+            emoji: get_default_status_emoji("palm_tree"),
         },
         {
             status_text: $t({defaultMessage: "Working remotely"}),
-            emoji: emoji.get_emoji_details_by_name("house"),
+            emoji: get_default_status_emoji("house"),
         },
         {
             status_text: $t({defaultMessage: "At the office"}),
-            emoji: emoji.get_emoji_details_by_name("office"),
+            emoji: get_default_status_emoji("office"),
         },
     ];
 }

--- a/web/src/user_status_ui.ts
+++ b/web/src/user_status_ui.ts
@@ -10,6 +10,7 @@ import type {EmojiRenderingDetails} from "./emoji.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as people from "./people.ts";
+import {user_settings} from "./user_settings.ts";
 import * as user_status from "./user_status.ts";
 import type {UserStatusEmojiInfo} from "./user_status.ts";
 
@@ -141,18 +142,7 @@ function rebuild_status_emoji_selector_ui(selected_emoji_info: Partial<UserStatu
     $("#set-user-status-modal .status-emoji-wrapper").html(rendered_status_emoji_selector);
 }
 
-function user_status_post_render(): void {
-    const user_id = people.my_current_user_id();
-    const old_status_text = user_status.get_status_text(user_id) ?? "";
-    const old_emoji_info = user_status.get_status_emoji(user_id) ?? {};
-    set_selected_emoji_info(old_emoji_info);
-    const $field = input_field();
-    $field.val(old_status_text);
-    toggle_clear_status_button();
-
-    const $button = submit_button();
-    $button.prop("disabled", true);
-
+function bind_default_status_options_click_handler(): void {
     $("#set-user-status-modal .user-status-value").on("click", (event) => {
         event.stopPropagation();
         const user_status_value = $(event.currentTarget).text().trim();
@@ -166,6 +156,61 @@ function user_status_post_render(): void {
         toggle_clear_status_button();
         update_button();
     });
+}
+
+function refresh_selected_emoji_info(): void {
+    if (
+        selected_emoji_info.emoji_name === undefined ||
+        selected_emoji_info.emoji_code === undefined ||
+        selected_emoji_info.reaction_type === undefined
+    ) {
+        return;
+    }
+    selected_emoji_info = {
+        emoji_alt_code: user_settings.emojiset === "text",
+        ...emoji.get_emoji_details_for_rendering({
+            emoji_name: selected_emoji_info.emoji_name,
+            emoji_code: selected_emoji_info.emoji_code,
+            reaction_type: selected_emoji_info.reaction_type,
+        }),
+    };
+}
+
+export function rerender_status_emoji_ui(): void {
+    // Recompute the emojiset-dependent details for the default status
+    // presets and the selected emoji, then re-render the "Set status"
+    // modal if it is open.
+    initialize();
+    if (!user_status_picker_open()) {
+        return;
+    }
+    refresh_selected_emoji_info();
+    rebuild_status_emoji_selector_ui(selected_emoji_info);
+    const $rerendered_overlay = $(
+        render_set_status_overlay({
+            default_status_messages_and_emoji_info,
+            selected_emoji_info: {},
+        }),
+    );
+    $("#set-user-status-modal ul.user-status-options").replaceWith(
+        $rerendered_overlay.filter("ul.user-status-options"),
+    );
+    bind_default_status_options_click_handler();
+}
+
+function user_status_post_render(): void {
+    const user_id = people.my_current_user_id();
+    const old_status_text = user_status.get_status_text(user_id) ?? "";
+    const old_emoji_info = user_status.get_status_emoji(user_id) ?? {};
+    set_selected_emoji_info(old_emoji_info);
+    const $field = input_field();
+    $field.val(old_status_text);
+    toggle_clear_status_button();
+
+    const $button = submit_button();
+    $button.prop("disabled", true);
+
+    bind_default_status_options_click_handler();
 
     $("#set-user-status-modal").on("keydown", "input.user-status, .user-status-value", (event) => {
         if (event.key !== "ArrowUp" && event.key !== "ArrowDown") {
@@ -206,35 +251,42 @@ function navigate_status_options($focused_element: JQuery, key: "ArrowUp" | "Arr
     $navigable_elements.eq(next_index).trigger("focus");
 }
 
+// Looks up the rendering details for a default status emoji, including
+// the native Unicode glyph when the "native" emojiset is active.
+function get_default_status_emoji(emoji_name: string): EmojiRenderingDetails {
+    const details = emoji.get_emoji_details_by_name(emoji_name);
+    return {...details, ...emoji.get_native_emoji_info(details)};
+}
+
 export function initialize(): void {
     default_status_messages_and_emoji_info = [
         {
             status_text: $t({defaultMessage: "Busy"}),
-            emoji: emoji.get_emoji_details_by_name("working_on_it"),
+            emoji: get_default_status_emoji("working_on_it"),
         },
         {
             status_text: $t({defaultMessage: "In a meeting"}),
-            emoji: emoji.get_emoji_details_by_name("calendar"),
+            emoji: get_default_status_emoji("calendar"),
         },
         {
             status_text: $t({defaultMessage: "Commuting"}),
-            emoji: emoji.get_emoji_details_by_name("bus"),
+            emoji: get_default_status_emoji("bus"),
         },
         {
             status_text: $t({defaultMessage: "Out sick"}),
-            emoji: emoji.get_emoji_details_by_name("hurt"),
+            emoji: get_default_status_emoji("hurt"),
         },
         {
             status_text: $t({defaultMessage: "Vacationing"}),
-            emoji: emoji.get_emoji_details_by_name("palm_tree"),
+            emoji: get_default_status_emoji("palm_tree"),
         },
         {
             status_text: $t({defaultMessage: "Working remotely"}),
-            emoji: emoji.get_emoji_details_by_name("house"),
+            emoji: get_default_status_emoji("house"),
         },
         {
             status_text: $t({defaultMessage: "At the office"}),
-            emoji: emoji.get_emoji_details_by_name("office"),
+            emoji: get_default_status_emoji("office"),
         },
     ];
 }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -481,6 +481,10 @@
     /* Box shadow for overlays across the web app */
     --box-shadow-overlay: none;
 
+    /* Font family for rendering native Unicode emoji. */
+    --font-family-native-emoji:
+        "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+
     /* Shared sidebar typography and effects values. */
     --font-weight-sidebar-heading: 600;
     --font-weight-sidebar-action-heading: 370;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -286,6 +286,13 @@
             margin-top: 0;
         }
 
+        /* A native glyph sizes to its font rather than the sprite box, so
+           set a font-size that matches the 32px sprite preview above. */
+        .emoji-preview.emoji-native {
+            font-size: 2.1333em; /* 32px at 15px/em */
+            line-height: 1;
+        }
+
         .emoji-canonical-name {
             font-size: 1.0667em; /* 16px at 15px/em */
             position: relative;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -997,6 +997,32 @@
     }
 }
 
+/* Render native Unicode emoji as a text glyph: undo the sprite-sheet
+   technique (background image + hidden text) so the glyph shows and
+   sizes to its font. These selectors out-specify the sprite rules
+   without !important, in messages, reactions, and status emoji.
+   Per-context margins are intentionally left untouched. */
+span.emoji.emoji-native,
+div.emoji.emoji-native {
+    /* Reveal the glyph instead of the hidden sprite text. */
+    background: none;
+    text-indent: 0;
+    overflow: visible;
+    white-space: normal;
+    /* Size to the glyph, not the fixed sprite box. */
+    width: auto;
+    height: auto;
+    font-family: var(--font-family-native-emoji);
+}
+
+/* The message .emoji box is oversized with a compensating negative
+   margin tuned for a background image; a native glyph sizes to its font,
+   so drop that margin here. Scoped to .rendered_markdown so reaction and
+   status-emoji margins are preserved. */
+.rendered_markdown .emoji.emoji-native {
+    margin: 0;
+}
+
 .group_mention,
 .direct_mention {
     & .rendered_markdown pre {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1443,6 +1443,12 @@ label.preferences-radio-choice-label {
     margin-right: 1px;
 }
 
+.emoji-native-preview {
+    font-family: var(--font-family-native-emoji);
+    font-size: 1.5714em; /* 22px at 14px / em */
+    line-height: 1;
+}
+
 .download_bot_zuliprc,
 .copy_zuliprc,
 .open_bots_subscribed_streams,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1422,6 +1422,12 @@ label.preferences-radio-choice-label {
     margin-right: 1px;
 }
 
+.emoji-native-preview {
+    font-family: var(--font-family-native-emoji);
+    font-size: 1.5714em; /* 22px at 14px / em */
+    line-height: 1;
+}
+
 .download_bot_zuliprc,
 .copy_zuliprc,
 .open_bots_subscribed_streams,

--- a/web/templates/message_reaction.hbs
+++ b/web/templates/message_reaction.hbs
@@ -2,6 +2,8 @@
     <div class="{{this.class}} {{#if is_archived}}disabled{{/if}}" aria-label="{{this.label}}" data-reaction-id="{{this.local_id}}">
         {{#if this.emoji_alt_code}}
             <div class="emoji_alt_code">&nbsp;:{{this.emoji_name}}:</div>
+        {{else if this.unicode_emoji}}
+            <div class="emoji emoji-native">{{this.unicode_emoji}}</div>
         {{else if this.is_realm_emoji}}
             <img src="{{this.url}}" class="emoji" />
         {{else}}

--- a/web/templates/popovers/emoji/emoji_showcase.hbs
+++ b/web/templates/popovers/emoji/emoji_showcase.hbs
@@ -2,6 +2,8 @@
 <div class="emoji-showcase">
     {{#if is_realm_emoji}}
     <img src="{{url}}" class="emoji emoji-preview"/>
+    {{else if unicode_emoji}}
+    <div class="emoji emoji-preview emoji-native">{{unicode_emoji}}</div>
     {{else}}
     <div class="emoji emoji-preview emoji-{{emoji_code}}"></div>
     {{/if}}

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -22,6 +22,8 @@
                         {{#if status_emoji_info}}
                             {{#if status_emoji_info.emoji_alt_code}}
                             <span class="emoji_alt_code">&nbsp;:{{status_emoji_info.emoji_name}}:</span>
+                            {{else if status_emoji_info.unicode_emoji}}
+                            <span class="emoji status_emoji emoji-native">{{status_emoji_info.unicode_emoji}}</span>
                             {{else if status_emoji_info.url}}
                             <img src="{{status_emoji_info.url}}" class="emoji status_emoji" />
                             {{else}}

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -40,6 +40,8 @@
                     {{#if status_emoji_info}}
                         {{#if status_emoji_info.emoji_alt_code}}
                             <span class="emoji_alt_code">&nbsp;:{{status_emoji_info.emoji_name}}:</span>
+                        {{else if status_emoji_info.unicode_emoji}}
+                            <span class="emoji status_emoji emoji-native" data-tippy-content=":{{status_emoji_info.emoji_name}}:">{{status_emoji_info.unicode_emoji}}</span>
                         {{else if status_emoji_info.url}}
                             <img src="{{status_emoji_info.url}}" class="emoji status_emoji" data-tippy-content=":{{status_emoji_info.emoji_name}}:"/>
                         {{else}}

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -11,13 +11,7 @@
     {{#each default_status_messages_and_emoji_info}}
         <li class="user-status-option">
             <a class="modal-option-content trigger-click-on-enter user-status-value" tabindex="0">
-                {{#if emoji.emoji_alt_code}}
-                    <div class="emoji_alt_code">&nbsp;:{{emoji.emoji_name}}:</div>
-                {{else if emoji.url}}
-                    <img src="{{emoji.url}}" class="emoji status-emoji" />
-                {{else}}
-                    <div class="emoji status-emoji emoji-{{emoji.emoji_code}}"></div>
-                {{/if}}
+                {{> status_emoji_choice emoji extra_class="status-emoji"}}
                 <span class="status-text">{{status_text}}</span>
             </a>
         </li>

--- a/web/templates/settings/preferences_emoji.hbs
+++ b/web/templates/settings/preferences_emoji.hbs
@@ -21,6 +21,8 @@
                     <span class="right">
                         {{#if (eq this.key "text") }}
                         <span class="emoji_alt_code">&nbsp;:relaxed:</span>
+                        {{else if (eq this.key "native") }}
+                        <span class="emoji-native-preview">&nbsp;&#x1f604;&#x1f44d;&#x1f680;&#x1f389;</span>
                         {{else}}
                         <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f604.png" />
                         <img class="emoji" src="/static/generated/emoji/images-{{this.key}}-64/1f44d.png" />

--- a/web/templates/status_emoji.hbs
+++ b/web/templates/status_emoji.hbs
@@ -1,6 +1,8 @@
 {{~#if . ~}}
 {{~#if emoji_alt_code ~}}
 <span class="emoji_alt_code">&nbsp;:{{emoji_name}}:</span>
+{{~else if unicode_emoji ~}}
+<span class="emoji status-emoji status-emoji-name emoji-native" data-tippy-content=":{{emoji_name}}:">{{unicode_emoji}}</span>
 {{~else if still_url ~}}
 <img src="{{still_url}}" class="emoji status-emoji status-emoji-name" data-animated-url="{{url}}" data-still-url="{{still_url}}" data-tippy-content=":{{emoji_name}}:" />
 {{~else if url ~}}

--- a/web/templates/status_emoji_choice.hbs
+++ b/web/templates/status_emoji_choice.hbs
@@ -1,0 +1,11 @@
+{{! Renders one status emoji: text colon syntax, native Unicode glyph,
+realm image, or sprite span. `extra_class` is the context-specific class. }}
+{{#if emoji_alt_code}}
+<div class="emoji_alt_code">&nbsp;:{{emoji_name}}:</div>
+{{else if unicode_emoji}}
+<div class="emoji {{extra_class}} emoji-native">{{unicode_emoji}}</div>
+{{else if url}}
+<img src="{{url}}" class="emoji {{extra_class}}" />
+{{else}}
+<div class="emoji {{extra_class}} emoji-{{emoji_code}}"></div>
+{{/if}}

--- a/web/templates/status_emoji_selector.hbs
+++ b/web/templates/status_emoji_selector.hbs
@@ -1,11 +1,5 @@
 {{#if selected_emoji}}
-    {{#if selected_emoji.emoji_alt_code}}
-        <div class="emoji_alt_code">&nbsp;:{{selected_emoji.emoji_name}}:</div>
-    {{else if selected_emoji.url}}
-        <img src="{{selected_emoji.url}}" class="emoji selected-emoji" />
-    {{else}}
-        <div class="emoji selected-emoji emoji-{{selected_emoji.emoji_code}}"></div>
-    {{/if}}
+    {{> status_emoji_choice selected_emoji extra_class="selected-emoji"}}
 {{else}}
     <span class="smiley-icon show zulip-icon zulip-icon-smile"></span>
 {{/if}}

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -52,7 +52,12 @@ const user_topics_ui = mock_esm("../src/user_topics_ui");
 const muted_users_ui = mock_esm("../src/muted_users_ui");
 const narrow_title = mock_esm("../src/narrow_title");
 const navbar_alerts = mock_esm("../src/navbar_alerts");
-const pm_list = mock_esm("../src/pm_list");
+const pm_list = mock_esm("../src/pm_list", {
+    update_private_messages() {},
+});
+mock_esm("../src/user_status_ui", {
+    rerender_status_emoji_ui() {},
+});
 const reactions = mock_esm("../src/reactions", {
     generate_clean_reactions() {},
 });

--- a/web/tests/emoji.test.cjs
+++ b/web/tests/emoji.test.cjs
@@ -3,13 +3,22 @@
 const assert = require("node:assert/strict");
 
 const events = require("./lib/events.cjs");
-const {zrequire} = require("./lib/namespace.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 
+let is_emoji_supported_result = true;
+mock_esm("is-emoji-supported", {
+    isEmojiSupported: () => is_emoji_supported_result,
+});
+
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
+const {initialize_user_settings} = zrequire("user_settings");
 
 const emoji = zrequire("emoji");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const realm_emoji = events.test_realm_emojis;
 
@@ -130,4 +139,60 @@ run_test("get_emoji_details_by_name", () => {
             message: "Bad emoji name: unknown-emoji",
         },
     );
+});
+
+run_test("native emojiset unicode_emoji", ({override}) => {
+    // The "native" emojiset attaches the Unicode glyph in a unicode_emoji
+    // field when the platform can render it; otherwise it's absent.
+    const smile = {
+        emoji_name: "smile",
+        emoji_code: "1f604",
+        reaction_type: "unicode_emoji",
+    };
+
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+    assert.deepEqual(emoji.get_emoji_details_for_rendering(smile), {
+        ...smile,
+        unicode_emoji: "\u{1F604}",
+    });
+
+    // Non-native emojisets never set unicode_emoji, even for supported emoji.
+    for (const emojiset of ["google", "text", "twitter"]) {
+        override(user_settings, "emojiset", emojiset);
+        assert.deepEqual(emoji.get_emoji_details_for_rendering(smile), smile);
+    }
+
+    // Unicode emoji the platform can't render fall back to sprites.
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = false;
+    assert.deepEqual(emoji.get_emoji_details_for_rendering(smile), smile);
+
+    // Realm and zulip_extra emoji are always images, never native.
+    is_emoji_supported_result = true;
+    assert.deepEqual(emoji.get_emoji_details_by_name("spain"), {
+        emoji_name: "spain",
+        reaction_type: "realm_emoji",
+        emoji_code: "101",
+        url: "/some/path/to/spain.gif",
+        still_url: "/some/path/to/spain.png",
+    });
+    assert.deepEqual(emoji.get_emoji_details_by_name("zulip"), {
+        emoji_name: "zulip",
+        reaction_type: "zulip_extra_emoji",
+        emoji_code: "zulip",
+        url: "/static/generated/emoji/images/emoji/unicode/zulip.png",
+        still_url: null,
+    });
+
+    // Multi-codepoint emoji (e.g., flags) join into the full glyph.
+    const flag = {
+        emoji_name: "united_states",
+        emoji_code: "1f1fa-1f1f8",
+        reaction_type: "unicode_emoji",
+    };
+    assert.deepEqual(emoji.get_emoji_details_for_rendering(flag), {
+        ...flag,
+        unicode_emoji: "\u{1F1FA}\u{1F1F8}",
+    });
 });

--- a/web/tests/emoji_picker.test.cjs
+++ b/web/tests/emoji_picker.test.cjs
@@ -6,9 +6,16 @@ const _ = require("lodash");
 
 const {zrequire, set_global, mock_esm} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
+
+let is_emoji_supported_result = true;
+mock_esm("is-emoji-supported", {
+    isEmojiSupported: () => is_emoji_supported_result,
+});
 
 const emoji = zrequire("emoji");
 const emoji_frequency = zrequire("emoji_frequency");
+const {initialize_user_settings} = zrequire("user_settings");
 
 const map = new Map();
 const emoji_frequency_data = mock_esm("../src/emoji_frequency_data", {
@@ -30,6 +37,9 @@ const emoji_picker = zrequire("emoji_picker");
 const typeahead = zrequire("typeahead");
 
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 set_global("document", "document-stub");
 
@@ -144,4 +154,35 @@ run_test("is_emoji_present_in_text", () => {
         emoji_picker.is_emoji_present_in_text("emojis with text no space😎🌡🎧", headphones_emoji),
         true,
     );
+});
+
+run_test("update_emoji_showcase native emojiset", ({override}) => {
+    // The showcase (the large preview at the bottom of the emoji picker)
+    // must render the platform glyph under the "native" emojiset, not a
+    // Google sprite. "smile" is U+1F604.
+    const $focused_emoji = {attr: () => "smile"};
+    const get_showcase_html = () => {
+        emoji_picker.update_emoji_showcase($focused_emoji);
+        return $(".emoji-showcase-container").html();
+    };
+
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+    let html = get_showcase_html();
+    assert.ok(html.includes("emoji-native"));
+    assert.ok(html.includes("\u{1F604}"));
+    assert.ok(!html.includes("emoji-1f604"));
+
+    // Sprite emojisets, and native emoji the platform can't render, keep
+    // the sprite preview.
+    override(user_settings, "emojiset", "google");
+    html = get_showcase_html();
+    assert.ok(html.includes("emoji-1f604"));
+    assert.ok(!html.includes("emoji-native"));
+
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = false;
+    html = get_showcase_html();
+    assert.ok(html.includes("emoji-1f604"));
+    assert.ok(!html.includes("emoji-native"));
 });

--- a/web/tests/message_store.test.cjs
+++ b/web/tests/message_store.test.cjs
@@ -405,6 +405,17 @@ test("update_property", () => {
     assert.equal(message1.display_recipient, "Prod");
     assert.equal(message2.stream_id, denmark.stream_id);
     assert.equal(message2.display_recipient, denmark.name);
+
+    const alice_status_emoji = {
+        emoji_name: "smile",
+        emoji_code: "1f604",
+        reaction_type: "unicode_emoji",
+    };
+    message_store.update_all_status_emoji_info((user_id) =>
+        user_id === alice.user_id ? alice_status_emoji : undefined,
+    );
+    assert.deepEqual(message1.status_emoji_info, alice_status_emoji);
+    assert.equal(message2.status_emoji_info, undefined);
 });
 
 test("remove", () => {

--- a/web/tests/reactions.test.cjs
+++ b/web/tests/reactions.test.cjs
@@ -55,6 +55,11 @@ const message_lists = mock_esm("../src/message_lists", {
     },
 });
 
+let is_emoji_supported_result = true;
+mock_esm("is-emoji-supported", {
+    isEmojiSupported: () => is_emoji_supported_result,
+});
+
 set_global("document", "document-stub");
 
 const emoji = zrequire("emoji");
@@ -1507,4 +1512,34 @@ test("process_reaction_click bad local id", ({override}) => {
     override(message_store, "get", () => stub_message);
     blueslip.expect("error", "Data integrity problem for reaction");
     reactions.process_reaction_click("some-msg-id", "bad-local-id");
+});
+
+test("rerender reaction emoji on emojiset change", ({override}) => {
+    settings_data.user_can_access_all_other_users = () => true;
+    const message = sample_message_with_clean_reactions();
+    const smile = () =>
+        reactions
+            .get_message_reactions(message)
+            .find((reaction) => reaction.local_id === "unicode_emoji,1f604");
+
+    assert.equal(smile().unicode_emoji, undefined);
+    assert.equal(smile().emoji_alt_code, false);
+
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+    assert.equal(smile().unicode_emoji, "\u{1F604}");
+
+    is_emoji_supported_result = false;
+    assert.equal(smile().unicode_emoji, undefined);
+
+    override(user_settings, "emojiset", "text");
+    assert.equal(smile().unicode_emoji, undefined);
+    assert.equal(smile().emoji_alt_code, true);
+
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+    assert.equal(smile().unicode_emoji, "\u{1F604}");
+    override(user_settings, "emojiset", "google");
+    assert.equal(smile().unicode_emoji, undefined);
+    assert.equal(smile().emoji_alt_code, false);
 });

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -26,6 +26,11 @@ class Clipboard {
 
 mock_cjs("clipboard", Clipboard);
 
+let is_emoji_supported_result = false;
+mock_esm("is-emoji-supported", {
+    isEmojiSupported: () => is_emoji_supported_result,
+});
+
 const realm_playground = mock_esm("../src/realm_playground");
 const copied_tooltip = mock_esm("../src/copied_tooltip");
 
@@ -136,6 +141,7 @@ const get_content_element = () => {
     $content.set_find_results("time", []);
     $content.set_find_results("span.timestamp-error", []);
     $content.set_find_results(".emoji", []);
+    $content.set_find_results("span.emoji", []);
     $content.set_find_results("div.spoiler-header", []);
     $content.set_find_results("div.codehilite", []);
     $content.set_find_results(".message_inline_video video", []);
@@ -775,6 +781,57 @@ run_test("emoji", ({override}) => {
 
     // Set page parameters back so that test run order is independent
     override(user_settings, "emojiset", "apple");
+});
+
+run_test("emoji-native", ({override}) => {
+    // With the "native" emojiset and a supported emoji, the span gains
+    // "emoji-native" and its sprite-hidden text becomes the glyph.
+    const $content = get_content_element();
+    const $emoji = $.create("native-supported");
+    $emoji.attr("class", "emoji emoji-1f604");
+    $emoji.text(":smile:");
+    $content.set_find_results("span.emoji", $emoji);
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+
+    rm.update_elements($content);
+
+    assert.ok($emoji.hasClass("emoji-native"));
+    assert.equal($emoji.text(), "\u{1F604}");
+});
+
+run_test("emoji-native-unsupported", ({override}) => {
+    // When isEmojiSupported returns false, the span is left unchanged
+    // (keeping the Google sprite).
+    const $content = get_content_element();
+    const $emoji = $.create("native-unsupported");
+    $emoji.attr("class", "emoji emoji-1f604");
+    $emoji.text(":smile:");
+    $content.set_find_results("span.emoji", $emoji);
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = false;
+
+    rm.update_elements($content);
+
+    assert.ok(!$emoji.hasClass("emoji-native"));
+    assert.equal($emoji.text(), ":smile:");
+});
+
+run_test("emoji-native-not-active-for-other-emojisets", ({override}) => {
+    // With emojiset="google", span.emoji elements are not modified by
+    // the native emoji logic.
+    const $content = get_content_element();
+    const $emoji = $.create("google-emojiset");
+    $emoji.attr("class", "emoji emoji-1f604");
+    $emoji.text(":smile:");
+    $content.set_find_results("span.emoji", $emoji);
+    override(user_settings, "emojiset", "google");
+    is_emoji_supported_result = true;
+
+    rm.update_elements($content);
+
+    assert.ok(!$emoji.hasClass("emoji-native"));
+    assert.equal($emoji.text(), ":smile:");
 });
 
 run_test("spoiler-header", () => {

--- a/web/tests/user_status.test.cjs
+++ b/web/tests/user_status.test.cjs
@@ -7,12 +7,18 @@ const {run_test} = require("./lib/test.cjs");
 
 const channel = mock_esm("../src/channel");
 
+let is_emoji_supported_result = true;
+mock_esm("is-emoji-supported", {
+    isEmojiSupported: () => is_emoji_supported_result,
+});
+
 const user_status = zrequire("user_status");
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
 const emoji = zrequire("emoji");
 const {initialize_user_settings} = zrequire("user_settings");
 
-initialize_user_settings({user_settings: {}});
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const emoji_params = {
     realm_emoji: {
@@ -153,6 +159,36 @@ run_test("server", () => {
 
     success();
     assert.ok(called);
+});
+
+run_test("rerender status emoji on emojiset change", ({override}) => {
+    initialize();
+
+    assert.equal(user_status.get_status_emoji(4).unicode_emoji, undefined);
+
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+    user_status.rerender_emoji_info();
+    assert.equal(user_status.get_status_emoji(4).unicode_emoji, "\u{1F603}");
+    assert.equal(user_status.get_status_emoji(5).unicode_emoji, undefined);
+    assert.equal(user_status.get_status_emoji(5).url, "/url/for/992");
+
+    is_emoji_supported_result = false;
+    user_status.rerender_emoji_info();
+    assert.equal(user_status.get_status_emoji(4).unicode_emoji, undefined);
+
+    override(user_settings, "emojiset", "text");
+    user_status.rerender_emoji_info();
+    assert.equal(user_status.get_status_emoji(4).unicode_emoji, undefined);
+    assert.equal(user_status.get_status_emoji(4).emoji_alt_code, true);
+
+    override(user_settings, "emojiset", "native");
+    is_emoji_supported_result = true;
+    user_status.rerender_emoji_info();
+    assert.equal(user_status.get_status_emoji(4).unicode_emoji, "\u{1F603}");
+    override(user_settings, "emojiset", "google");
+    user_status.rerender_emoji_info();
+    assert.equal(user_status.get_status_emoji(4).unicode_emoji, undefined);
 });
 
 run_test("defensive checks", () => {

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -26,6 +26,7 @@ from markupsafe import Markup
 
 from confirmation.models import one_click_unsubscribe_link
 from zerver.lib.display_recipient import get_display_recipient
+from zerver.lib.emoji_utils import hex_codepoint_to_emoji
 from zerver.lib.markdown.fenced_code import FENCE_RE
 from zerver.lib.message import bulk_access_messages
 from zerver.lib.message_cache import MessageDict
@@ -130,7 +131,7 @@ def relative_to_full_url(fragment: lxml.html.HtmlElement, base_url: str) -> None
 
 
 def fix_emojis(fragment: lxml.html.HtmlElement, emojiset: str) -> None:
-    def make_emoji_img_elem(emoji_span_elem: lxml.html.HtmlElement) -> dict[str, Any]:
+    def make_emoji_img_elem(emoji_span_elem: lxml.html.HtmlElement) -> lxml.html.HtmlElement:
         # Convert the emoji spans to img tags.
         classes = emoji_span_elem.get("class")
         match = re.search(r"emoji-(?P<emoji_code>\S+)", classes)
@@ -158,13 +159,26 @@ def fix_emojis(fragment: lxml.html.HtmlElement, emojiset: str) -> None:
             height="20",
             width="20",
         )
-        img_elem.tail = emoji_span_elem.tail
         return img_elem
 
     for elem in fragment.cssselect("span.emoji"):
         parent = elem.getparent()
-        img_elem = make_emoji_img_elem(elem)
-        parent.replace(elem, img_elem)
+        if emojiset == "native":
+            # Render the Unicode glyph directly; email clients display it well.
+            classes = elem.get("class")
+            match = re.search(r"emoji-(?P<emoji_code>\S+)", classes)
+            assert match is not None
+            replacement: lxml.html.HtmlElement = e.SPAN(
+                hex_codepoint_to_emoji(match.group("emoji_code"))
+            )
+        elif emojiset == "text":
+            # Plain ":emoji_name:" text, as the "text" emojiset shows in the
+            # message view (and avoids broken "images-text-64/" sprite URLs).
+            replacement = e.SPAN(elem.text)
+        else:
+            replacement = make_emoji_img_elem(elem)
+        replacement.tail = elem.tail
+        parent.replace(elem, replacement)
 
     for realm_emoji in fragment.cssselect("img.emoji"):
         del realm_emoji.attrib["class"]

--- a/zerver/migrations/0753_remove_google_blob_emojiset.py
+++ b/zerver/migrations/0753_remove_google_blob_emojiset.py
@@ -24,7 +24,12 @@ class Migration(migrations.Migration):
             model_name="realmuserdefault",
             name="emojiset",
             field=models.CharField(
-                choices=[("google", "Google"), ("twitter", "Twitter"), ("text", "Plain text")],
+                choices=[
+                    ("google", "Google"),
+                    ("twitter", "Twitter"),
+                    ("native", "Native"),
+                    ("text", "Plain text"),
+                ],
                 default="google",
                 max_length=20,
             ),
@@ -33,7 +38,12 @@ class Migration(migrations.Migration):
             model_name="userprofile",
             name="emojiset",
             field=models.CharField(
-                choices=[("google", "Google"), ("twitter", "Twitter"), ("text", "Plain text")],
+                choices=[
+                    ("google", "Google"),
+                    ("twitter", "Twitter"),
+                    ("native", "Native"),
+                    ("text", "Plain text"),
+                ],
                 default="google",
                 max_length=20,
             ),

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -154,11 +154,13 @@ class UserBaseSettings(models.Model):
 
     # Emoji sets
     GOOGLE_EMOJISET = "google"
+    NATIVE_EMOJISET = "native"
     TEXT_EMOJISET = "text"
     TWITTER_EMOJISET = "twitter"
     EMOJISET_CHOICES = (
         (GOOGLE_EMOJISET, "Google"),
         (TWITTER_EMOJISET, "Twitter"),
+        (NATIVE_EMOJISET, "Native"),
         (TEXT_EMOJISET, "Plain text"),
     )
     emojiset = models.CharField(default=GOOGLE_EMOJISET, choices=EMOJISET_CHOICES, max_length=20)

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -155,11 +155,13 @@ class UserBaseSettings(models.Model):
 
     # Emoji sets
     GOOGLE_EMOJISET = "google"
+    NATIVE_EMOJISET = "native"
     TEXT_EMOJISET = "text"
     TWITTER_EMOJISET = "twitter"
     EMOJISET_CHOICES = (
         (GOOGLE_EMOJISET, "Google"),
         (TWITTER_EMOJISET, "Twitter"),
+        (NATIVE_EMOJISET, "Native"),
         (TEXT_EMOJISET, "Plain text"),
     )
     emojiset = models.CharField(default=GOOGLE_EMOJISET, choices=EMOJISET_CHOICES, max_length=20)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15582,7 +15582,10 @@ paths:
 
                     - "google" - Google
                     - "twitter" - Twitter
+                    - "native" - Native
                     - "text" - Plain text
+
+                    **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
                   type: string
                   example: "google"
                 demote_inactive_streams:
@@ -19705,7 +19708,10 @@ paths:
 
                               - "google" - Google modern
                               - "twitter" - Twitter
+                              - "native" - Native
                               - "text" - Plain text
+
+                              **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
                           demote_inactive_streams:
                             type: integer
                             description: |
@@ -22114,7 +22120,10 @@ paths:
 
                               - "google" - Google modern
                               - "twitter" - Twitter
+                              - "native" - Native
                               - "text" - Plain text
+
+                              **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
                           demote_inactive_streams:
                             type: integer
                             description: |
@@ -23454,9 +23463,12 @@ paths:
 
                     - "google" - Google modern
                     - "twitter" - Twitter
+                    - "native" - Native
                     - "text" - Plain text
 
-                    **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
+                    **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
+
+                    Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/display` endpoint.
 
                     Unnecessary JSON-encoding of this parameter was removed in Zulip 4.0 (feature level 64).

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15746,7 +15746,10 @@ paths:
 
                     - "google" - Google
                     - "twitter" - Twitter
+                    - "native" - Native
                     - "text" - Plain text
+
+                    **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
                   type: string
                   example: "google"
                 demote_inactive_streams:
@@ -19946,7 +19949,10 @@ paths:
 
                               - "google" - Google modern
                               - "twitter" - Twitter
+                              - "native" - Native
                               - "text" - Plain text
+
+                              **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
                           demote_inactive_streams:
                             type: integer
                             description: |
@@ -22355,7 +22361,10 @@ paths:
 
                               - "google" - Google modern
                               - "twitter" - Twitter
+                              - "native" - Native
                               - "text" - Plain text
+
+                              **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
                           demote_inactive_streams:
                             type: integer
                             description: |
@@ -23695,9 +23704,12 @@ paths:
 
                     - "google" - Google modern
                     - "twitter" - Twitter
+                    - "native" - Native
                     - "text" - Plain text
 
-                    **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
+                    **Changes**: New `"native"` option added in Zulip 12.0 (feature level ZF-e6bf89).
+
+                    Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/display` endpoint.
 
                     Unnecessary JSON-encoding of this parameter was removed in Zulip 4.0 (feature level 64).

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1232,6 +1232,57 @@ class TestMessageNotificationEmails(ZulipTestCase):
             verify_html_body=True,
         )
 
+    def test_native_emojiset_in_missed_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        hamlet.emojiset = "native"
+        hamlet.save(update_fields=["emojiset"])
+        msg_id = self.send_personal_message(
+            self.example_user("othello"),
+            self.example_user("hamlet"),
+            "Extremely personal message with a hamburger :hamburger:!",
+        )
+        verify_body_include = [
+            "<span>\U0001f354</span>",
+        ]
+        # Native emojiset emits the Unicode glyph, not an <img> tag.
+        verify_body_does_not_include = [
+            "images-native-64",
+        ]
+        email_subject = "DMs with Othello, the Moor of Venice"
+        self._test_cases(
+            msg_id,
+            verify_body_include,
+            email_subject,
+            verify_html_body=True,
+            verify_body_does_not_include=verify_body_does_not_include,
+        )
+
+    def test_text_emojiset_in_missed_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        hamlet.emojiset = "text"
+        hamlet.save(update_fields=["emojiset"])
+        msg_id = self.send_personal_message(
+            self.example_user("othello"),
+            self.example_user("hamlet"),
+            "Extremely personal message with a hamburger :hamburger:!",
+        )
+        # Text emojiset emits ":emoji_name:" as plain text (matching the
+        # message view), not broken "images-text-64/" image URLs.
+        verify_body_include = [
+            "<span>:hamburger:</span>",
+        ]
+        verify_body_does_not_include = [
+            "images-text-64",
+        ]
+        email_subject = "DMs with Othello, the Moor of Venice"
+        self._test_cases(
+            msg_id,
+            verify_body_include,
+            email_subject,
+            verify_html_body=True,
+            verify_body_does_not_include=verify_body_does_not_include,
+        )
+
     def test_stream_link_in_missed_message(self) -> None:
         msg_id = self.send_personal_message(
             self.example_user("othello"),
@@ -1785,22 +1836,75 @@ class TestMessageNotificationEmails(ZulipTestCase):
             verify_body_does_not_include=verify_body_does_not_include,
         )
 
+    def _assert_fix_emojis(self, input_html: str, emojiset: str, expected_html: str) -> None:
+        fragment = lxml.html.fromstring(input_html)
+        fix_emojis(fragment, emojiset)
+        actual_output = lxml.html.tostring(fragment, encoding="unicode")
+        self.assertEqual(actual_output, expected_html)
+
     def test_fix_emoji(self) -> None:
-        # An emoji.
-        test_data = (
+        # The same input renders per emojiset; only the emojiset arg differs.
+        emoji_html = (
             '<p>See <span aria-label="cloud with lightning and rain" class="emoji emoji-26c8"'
             ' role="img" title="cloud with lightning and'
             ' rain">:cloud_with_lightning_and_rain:</span>.</p>'
         )
-        fragment = lxml.html.fromstring(test_data)
-        fix_emojis(fragment, "google")
-        actual_output = lxml.html.tostring(fragment, encoding="unicode")
-        expected_output = (
+
+        # Google emojiset replaces the span with an img tag.
+        self._assert_fix_emojis(
+            emoji_html,
+            "google",
             '<p>See <img alt=":cloud_with_lightning_and_rain:"'
             ' src="http://testserver/static/generated/emoji/images-google-64/26c8.png"'
-            ' title="cloud with lightning and rain" height="20" width="20">.</p>'
+            ' title="cloud with lightning and rain" height="20" width="20">.</p>',
         )
-        self.assertEqual(actual_output, expected_output)
+
+        # Native emojiset replaces span content with the Unicode character.
+        self._assert_fix_emojis(emoji_html, "native", "<p>See <span>\u26c8</span>.</p>")
+
+        # Text emojiset renders the ":emoji_name:" syntax as plain text.
+        self._assert_fix_emojis(
+            emoji_html, "text", "<p>See <span>:cloud_with_lightning_and_rain:</span>.</p>"
+        )
+
+    def test_fix_emoji_multi_codepoint(self) -> None:
+        # Multi-codepoint emoji like flags use dash-separated hex codes
+        # (e.g., "1f1fa-1f1f8" for the US flag).
+        emoji_html = (
+            '<p><span aria-label="United States" class="emoji emoji-1f1fa-1f1f8"'
+            ' role="img" title="United States">:united_states:</span></p>'
+        )
+        self._assert_fix_emojis(emoji_html, "native", "<p><span>\U0001f1fa\U0001f1f8</span></p>")
+
+    def test_fix_emoji_realm_emoji_with_native_emojiset(self) -> None:
+        # Realm emoji (img.emoji) should be left as images regardless of
+        # emojiset, since they are custom uploaded images, not Unicode.
+        emoji_html = (
+            '<p><img alt=":green_tick:" class="emoji"'
+            ' src="/user_avatars/1/emoji/images/1.png"'
+            ' title="green tick"></p>'
+        )
+        self._assert_fix_emojis(
+            emoji_html,
+            "native",
+            '<p><img alt=":green_tick:"'
+            ' src="/user_avatars/1/emoji/images/1.png"'
+            ' title="green tick" height="20" width="20"></p>',
+        )
+
+    def test_fix_emoji_preserves_tail_text(self) -> None:
+        # Verify that text following an emoji span is preserved.
+        emoji_html = (
+            '<p>Hello <span aria-label="smile" class="emoji emoji-1f604"'
+            ' role="img" title="smile">:smile:</span> world'
+            ' <span aria-label="tada" class="emoji emoji-1f389"'
+            ' role="img" title="tada">:tada:</span>!</p>'
+        )
+        self._assert_fix_emojis(
+            emoji_html,
+            "native",
+            "<p>Hello <span>\U0001f604</span> world <span>\U0001f389</span>!</p>",
+        )
 
     def test_latex_math_formulas_in_email(self) -> None:
         msg_id = self.send_stream_message(

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -531,7 +531,7 @@ class ChangeSettingsTest(ZulipTestCase):
     def test_emojiset(self) -> None:
         """Test banned emoji sets are not accepted."""
         banned_emojisets = ["apple", "emojione", "google-blob"]
-        valid_emojisets = ["google", "text", "twitter"]
+        valid_emojisets = ["google", "native", "text", "twitter"]
 
         for emojiset in banned_emojisets:
             result = self.do_change_emojiset(emojiset)


### PR DESCRIPTION
Fixes: #37564.

Continues @timabbott's #37766: rebased onto current `main` to resolve the merge conflicts flagged there, and addresses all the review feedback from the reviewers.

<!-- Describe your pull request here.-->

Adds a new **"native"** emojiset that renders Unicode emoji using the operating system / browser's native color emoji font instead of Zulip's bundled sprite sheets. This gives users emoji that match the rest of their OS.

Each Unicode emoji is checked at render time with the
[`is-emoji-supported`](https://www.npmjs.com/package/is-emoji-supported) library, which detects whether the platform can display it as a color glyph. Emoji the platform can't render (e.g. newer Unicode additions on older OSes, or flags on Windows) gracefully fall back to the Google sprites. Custom and realm emoji are always rendered as images, regardless of the emojiset.

In notification emails, the "native" emojiset renders the Unicode glyph directly (email clients display these well). As a related fix, the "text" emojiset now renders the `:emoji_name:` colon syntax as plain text in emails - matching how it displays emoji in the message view - which also fixes a pre-existing bug where "text" generated broken image
URLs pointing at the nonexistent `images-text-64/` sprites.

PR's commits:
- **`emoji: Add "native" emojiset option (backend).`** : the `"native"`
  choice on `UserProfile`/`RealmUserDefault`, API docs, and email
  rendering for the `native`/`text` emojisets.
- **`emoji: Render the "native" emojiset in the web app.`** : web app
  rendering across messages, reactions, and status emoji; the
  `is-emoji-supported` dependency; settings UI; and tests.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Emoji-theme setting - new **Native** option with live preview:

![Emoji theme setting](https://github.com/user-attachments/assets/2cd7132d-b172-41b3-91e0-1187a46efcce)

Message view, same conversation - **Google vs Native**:

| Google (sprites) | Native (OS glyphs) |
| :--: | :--: |
| ![Google emojiset](https://github.com/user-attachments/assets/96bb53e6-eaa4-4507-8fc7-8c6fdabe59a0) | ![Native emojiset](https://github.com/user-attachments/assets/1db1a46c-b020-4a67-9475-ffc03715f80f) |

Emoji typeahead filters by name with no error:

![Emoji typeahead](https://github.com/user-attachments/assets/8ba16b26-66c9-49ca-a37a-bb3d779784be)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
