### PR TITLE
=css: Fix channel-folder selector spacing and row alignment

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2243,11 +2243,30 @@ body:not(.spectator-view) {
         }
     }
 
-    &.folder_id-dropdown-list-container {
-        width: calc(var(--modal-input-width) * 0.75);
+    &.saved_snippets-dropdown-list-container {
+        width: fit-content;
+        max-width: 100vw; /* Prevent overflow of viewport */
+
+        .dropdown-list-wrapper {
+            min-width: fit-content;
+        }
+    }
+
+    &.folder_id-dropdown-list-container,
+    &.new_channel_folder_id-dropdown-list-container {
+        width: fit-content;
+        max-width: calc(var(--modal-input-width) * 0.75);
+
+        .dropdown-list-wrapper {
+            min-width: fit-content;
+        }
+
+        .dropdown-list-item-common-styles {
+            padding-left: 14px;
+        }
 
         /* Alignment adjustments on channel-folder selector. */
-        .dropdown-list-item-name:has(.dropdown-list-buttons) {
+        .dropdown-list-item-name {
             /* We hold the first row height to 28px at 16px/1em
                for the sake of the buttons plus their padding. */
             grid-template-rows: 1.75em minmax(0, auto);
@@ -2256,7 +2275,8 @@ body:not(.spectator-view) {
                buttons. */
             align-items: start;
 
-            .dropdown-list-text-neutral {
+            .dropdown-list-text-neutral,
+            .dropdown-list-text-selected {
                 /* 0.2em is an eyeballed value that keeps the buttons
                    well aligned with the first/only line of text. */
                 padding-top: 0.2em;


### PR DESCRIPTION
## Summary

Fix spacing and layout inconsistencies in the channel-folder selector dropdown.

## Changes

* Balance left-side spacing for folder rows.
* Standardize row height for the "None" option.
* Improve dropdown sizing behavior for channel-folder and saved-snippets selectors.
* Keep the changes scoped only to the affected dropdown containers.

## Notes

I investigated the issue through code analysis and implemented a targeted CSS fix focused on spacing, row alignment, and dropdown sizing.


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


