### PR TITLE
[ai] inbox: Don't treat folder-header unread counts as mark-as-read targets.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -2482,20 +2482,28 @@ export function initialize({hide_other_views}: {hide_other_views: () => void}): 
         "click",
         "#inbox-list .unread-count-focus-outline",
         function (this: HTMLElement, e) {
-            e.stopPropagation();
-            e.preventDefault();
             const $badge = $(this).find(".unread_count");
             if ($badge.length === 0) {
                 return;
             }
+            // This handler marks conversations as read for a DM conversation
+            // or a channel. If the badge was for neither of these (e.g. a channel
+            // folder or the full DM folder), we don't want to do anything here.
+            // Let the click fall through to the header's collapse/expand handler.
+            const user_ids_string = $badge.attr("data-user-ids-string");
+            const stream_id_string = $badge.attr("data-stream-id");
+            if (user_ids_string === undefined && stream_id_string === undefined) {
+                return;
+            }
+            e.stopPropagation();
+            e.preventDefault();
             col_focus = COLUMNS.UNREAD_COUNT;
             focus_clicked_list_element($(this));
-            const user_ids_string = $badge.attr("data-user-ids-string");
-            if (user_ids_string) {
+            if (user_ids_string !== undefined) {
                 unread_ops.mark_pm_as_read(user_ids_string);
                 return;
             }
-            const stream_id = Number($badge.attr("data-stream-id"));
+            const stream_id = Number(stream_id_string);
             const topic = $badge.attr("data-topic-name");
             if (topic !== undefined) {
                 unread_ops.mark_topic_as_read(stream_id, topic);

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -19,10 +19,6 @@
         .unread_count {
             opacity: 1;
             outline: 0 solid var(--color-background-unread-counter);
-
-            &:hover {
-                outline-width: var(--focus-ring-width-in-views);
-            }
         }
 
         .search_group {
@@ -374,6 +370,15 @@
                    count from affecting overall row
                    size as test scales up. */
                 align-self: stretch;
+            }
+
+            /* Channels, topics, and direct messages mark their unread
+               messages as read when their count is clicked. Folder
+               headers (channel folders and the direct messages section)
+               only show a combined count for everything inside them, so
+               they don't get the clickable affordance. */
+            :is(.inbox-row, .inbox-header:not(.inbox-folder))
+                .unread-count-focus-outline {
                 /* Whole 30×stretched hit area is clickable; surface
                    the same pointer cursor users had on the smaller
                    badge before the click target was expanded. */
@@ -751,12 +756,7 @@
 
 .inbox-container #inbox-pane .inbox-folder .unread_count {
     transition: none;
-    cursor: default;
     display: none;
-
-    &:hover {
-        outline: 0;
-    }
 }
 
 #inbox-pane #inbox-list .collapsible-button {


### PR DESCRIPTION
Clicking the unread count on a folder header (a channel folder or the direct messages section) ran the mark-as-read code path with no conversation to act on: the badge has no data-stream-id, so the handler called mark_stream_as_read(NaN), which serialized the channel operand to null and the server rejected with "Invalid narrow[1]: operand is missing". The click was also swallowed, so it didn't toggle the folder the way the rest of the header does.

Guard the handler so folder headers, which show a combined count for everything inside them rather than a single conversation, skip the mark-as-read path and let the click fall through to the header's collapse/expand handler.

Scope the unread-count column's pointer cursor and hover outline to the conversation rows, so folder counts no longer present a clickable affordance, and drop the now-redundant .inbox-folder .unread_count cursor and hover-outline overrides that only existed to counteract that affordance reaching folder headers. The standalone .unread_count:hover outline is likewise redundant with the wrapper's hover rule and is removed; together this fixes the cursor and outline flickering when the pointer was directly over a folder's count.
