### PR TITLE
markdown: Fix nested lists not rendering with tab indentation.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1578,10 +1578,10 @@ class Fence:
 # Matches a bullet or numbered list item: marker, whitespace, then content.
 LIST_ITEM_REGEX = re.compile(
     r"""
-    ^[ ]*        # Start with zero or more spaces
-    ([*+-]|\d\.) # A bullet marker (*, +, or -) or a digit followed by "."
-    [ ]+         # Followed by one or more spaces
-    (.*)         # The list content, which could be empty
+    ^[ ]*           # Start with zero or more spaces
+    ([*+-]|\d+\.)   # A bullet marker (*, +, or -) or one or more digits followed by "."
+    [ ]+            # Followed by one or more spaces
+    (.*)            # The list content, which could be empty
     """,
     re.MULTILINE | re.VERBOSE,
 )

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1587,6 +1587,26 @@ LIST_ITEM_REGEX = re.compile(
 )
 
 
+def line_is_in_code_fence(line: str, open_fences: list[Fence]) -> bool:
+    """Update `open_fences` in place based on `line`, and return whether
+    we are currently inside a non-quote fenced code block. Shared by
+    preprocessors that need to skip fenced code while scanning lines."""
+    m = FENCE_RE.match(line)
+    if m:
+        fence_str = m.group("fence")
+        lang: str | None = m.group("lang")
+        is_code = lang not in ("quote", "quoted")
+        matches_last_fence = fence_str == open_fences[-1].fence_str if open_fences else False
+        closes_last_fence = not lang and matches_last_fence
+
+        if closes_last_fence:
+            open_fences.pop()
+        else:
+            open_fences.append(Fence(fence_str, is_code))
+
+    return any(fence.is_code for fence in open_fences)
+
+
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     """Allows list blocks that come directly after another block
     to be rendered as a list.
@@ -1599,28 +1619,12 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     def run(self, lines: list[str]) -> list[str]:
         """Insert a newline between a paragraph and ulist if missing"""
         inserts = 0
-        in_code_fence: bool = False
         open_fences: list[Fence] = []
         copy = lines[:]
         for i in range(len(lines) - 1):
             # Ignore anything that is inside a fenced code block but not quoted.
             # We ignore all lines where some parent is a non-quote code block.
-            m = FENCE_RE.match(lines[i])
-            if m:
-                fence_str = m.group("fence")
-                lang: str | None = m.group("lang")
-                is_code = lang not in ("quote", "quoted")
-                matches_last_fence = (
-                    fence_str == open_fences[-1].fence_str if open_fences else False
-                )
-                closes_last_fence = not lang and matches_last_fence
-
-                if closes_last_fence:
-                    open_fences.pop()
-                else:
-                    open_fences.append(Fence(fence_str, is_code))
-
-                in_code_fence = any(fence.is_code for fence in open_fences)
+            in_code_fence = line_is_in_code_fence(lines[i], open_fences)
 
             # If we're not in a fenced block and we detect an upcoming list
             # hanging off any block (including a list of another type), add

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1574,6 +1574,19 @@ class Fence:
     is_code: bool
 
 
+
+# Matches a bullet or numbered list item: marker, whitespace, then content.
+LIST_ITEM_REGEX = re.compile(
+    r"""
+    ^[ ]*        # Start with zero or more spaces
+    ([*+-]|\d\.) # A bullet marker (*, +, or -) or a digit followed by "."
+    [ ]+         # Followed by one or more spaces
+    (.*)         # The list content, which could be empty
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     """Allows list blocks that come directly after another block
     to be rendered as a list.
@@ -1581,8 +1594,6 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     Detects paragraphs that have a matching list item that comes
     directly after a line of text, and inserts a newline between
     to satisfy Markdown"""
-
-    LI_RE = re.compile(r"^[ ]*([*+-]|\d\.)[ ]+(.*)", re.MULTILINE)
 
     @override
     def run(self, lines: list[str]) -> list[str]:
@@ -1614,8 +1625,8 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
             # If we're not in a fenced block and we detect an upcoming list
             # hanging off any block (including a list of another type), add
             # a newline.
-            li1 = self.LI_RE.match(lines[i])
-            li2 = self.LI_RE.match(lines[i + 1])
+            li1 = LIST_ITEM_REGEX.match(lines[i])
+            li2 = LIST_ITEM_REGEX.match(lines[i + 1])
             if (
                 not in_code_fence
                 and lines[i]

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1481,7 +1481,7 @@ class AutoLink(CompiledPattern):
 
 class OListProcessor(sane_lists.SaneOListProcessor):
     def __init__(self, parser: BlockParser) -> None:
-        parser.md.tab_length = 2
+        parser.md.tab_length = ZULIP_LIST_TAB_LENGTH
         super().__init__(parser)
         parser.md.tab_length = 4
 
@@ -1490,7 +1490,7 @@ class UListProcessor(sane_lists.SaneUListProcessor):
     """Unordered lists, but with 2-space indent"""
 
     def __init__(self, parser: BlockParser) -> None:
-        parser.md.tab_length = 2
+        parser.md.tab_length = ZULIP_LIST_TAB_LENGTH
         super().__init__(parser)
         parser.md.tab_length = 4
 
@@ -1505,7 +1505,7 @@ class ListIndentProcessor(markdown.blockprocessors.ListIndentProcessor):
         # HACK: Set the tab length to 2 just for the initialization of
         # this class, so that bulleted lists (and only bulleted lists)
         # work off 2-space indentation.
-        parser.md.tab_length = 2
+        parser.md.tab_length = ZULIP_LIST_TAB_LENGTH
         super().__init__(parser)
         parser.md.tab_length = 4
 
@@ -1574,6 +1574,7 @@ class Fence:
     is_code: bool
 
 
+ZULIP_LIST_TAB_LENGTH = 2
 
 # Matches a bullet or numbered list item: marker, whitespace, then content.
 LIST_ITEM_REGEX = re.compile(
@@ -1584,6 +1585,15 @@ LIST_ITEM_REGEX = re.compile(
     (.*)            # The list content, which could be empty
     """,
     re.MULTILINE | re.VERBOSE,
+)
+
+TAB_INDENTED_LIST_ITEM_REGEX = re.compile(
+    r"""
+    ^(\t+)        # One or more leading tabs
+    ([*+-]|\d+\.) # A bullet marker (*, +, or -) or one or more digits followed by "."
+    [ ]+          # Followed by one or more spaces
+    """,
+    re.VERBOSE,
 )
 
 
@@ -1605,6 +1615,42 @@ def line_is_in_code_fence(line: str, open_fences: list[Fence]) -> bool:
             open_fences.append(Fence(fence_str, is_code))
 
     return any(fence.is_code for fence in open_fences)
+
+
+class TabIndentedListPreprocessor(markdown.preprocessors.Preprocessor):
+    """Convert leading tabs of tab-indented nested list items to
+    Zulip's 2-space list indentation.
+
+    This is needed because Python-Markdown's NormalizeWhitespace
+    preprocessor, which runs after this one, would expand the tabs to
+    4 spaces, preventing the items from nesting under Zulip's 2-space
+    list indentation convention.
+
+    Only list items directly continuing a list are converted: a
+    leading tab anywhere else begins an indented code block, which
+    must be left untouched, even if its content happens to look like
+    a list item. Lines inside fenced code blocks are also left
+    untouched.
+    """
+
+    @override
+    def run(self, lines: list[str]) -> list[str]:
+        copy: list[str] = []
+        open_fences: list[Fence] = []
+        prev_line_is_li = False
+        for line in lines:
+            in_code_fence = line_is_in_code_fence(line, open_fences)
+            if in_code_fence:
+                prev_line_is_li = False
+            else:
+                tabbed_li = TAB_INDENTED_LIST_ITEM_REGEX.match(line)
+                if prev_line_is_li and tabbed_li:
+                    leading_tabs = tabbed_li.group(1)
+                    indent = leading_tabs.expandtabs(ZULIP_LIST_TAB_LENGTH)
+                    line = indent + line[len(leading_tabs) :]
+                prev_line_is_li = bool(LIST_ITEM_REGEX.match(line))
+            copy.append(line)
+        return copy
 
 
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
@@ -2290,6 +2336,7 @@ class ZulipMarkdown(markdown.Markdown):
         # reference - references don't make sense in a chat context.
         preprocessors = markdown.util.Registry[markdown.preprocessors.Preprocessor]()
         preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 35)
+        preprocessors.register(TabIndentedListPreprocessor(self), "tab_indented_lists", 32)
         preprocessors.register(
             markdown.preprocessors.NormalizeWhitespace(self), "normalize_whitespace", 30
         )

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1533,6 +1533,17 @@ class Fence:
     is_code: bool
 
 
+LIST_ITEM_REGEX = re.compile(
+    r"""
+    ^[ ]*        # Start with zero or more spaces
+    ([*+-]|\d\.) # A bullet marker (*, +, or -) or a digit followed by "."
+    [ ]+         # Followed by one or more spaces
+    (.*)         # The list content, which could be empty
+    """,
+    re.VERBOSE,
+)
+
+
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     """Allows list blocks that come directly after another block
     to be rendered as a list.
@@ -1540,8 +1551,6 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     Detects paragraphs that have a matching list item that comes
     directly after a line of text, and inserts a newline between
     to satisfy Markdown"""
-
-    LI_RE = re.compile(r"^[ ]*([*+-]|\d\.)[ ]+(.*)")
 
     @override
     def run(self, lines: list[str]) -> list[str]:
@@ -1573,8 +1582,8 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
             # If we're not in a fenced block and we detect an upcoming list
             # hanging off any block (including a list of another type), add
             # a newline.
-            li1 = self.LI_RE.match(lines[i])
-            li2 = self.LI_RE.match(lines[i + 1])
+            li1 = LIST_ITEM_REGEX.match(lines[i])
+            li2 = LIST_ITEM_REGEX.match(lines[i + 1])
             if (
                 not in_code_fence
                 and lines[i]

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1544,6 +1544,26 @@ LIST_ITEM_REGEX = re.compile(
 )
 
 
+def line_is_in_code_fence(line: str, open_fences: list[Fence]) -> bool:
+    """Update `open_fences` in place based on `line`, and return whether
+    we are currently inside a non-quote fenced code block. Shared by
+    preprocessors that need to skip fenced code while scanning lines."""
+    m = FENCE_RE.match(line)
+    if m:
+        fence_str = m.group("fence")
+        lang: str | None = m.group("lang")
+        is_code = lang not in ("quote", "quoted")
+        matches_last_fence = fence_str == open_fences[-1].fence_str if open_fences else False
+        closes_last_fence = not lang and matches_last_fence
+
+        if closes_last_fence:
+            open_fences.pop()
+        else:
+            open_fences.append(Fence(fence_str, is_code))
+
+    return any(fence.is_code for fence in open_fences)
+
+
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     """Allows list blocks that come directly after another block
     to be rendered as a list.
@@ -1556,28 +1576,12 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     def run(self, lines: list[str]) -> list[str]:
         """Insert a newline between a paragraph and ulist if missing"""
         inserts = 0
-        in_code_fence: bool = False
         open_fences: list[Fence] = []
         copy = lines[:]
         for i in range(len(lines) - 1):
             # Ignore anything that is inside a fenced code block but not quoted.
             # We ignore all lines where some parent is a non-quote code block.
-            m = FENCE_RE.match(lines[i])
-            if m:
-                fence_str = m.group("fence")
-                lang: str | None = m.group("lang")
-                is_code = lang not in ("quote", "quoted")
-                matches_last_fence = (
-                    fence_str == open_fences[-1].fence_str if open_fences else False
-                )
-                closes_last_fence = not lang and matches_last_fence
-
-                if closes_last_fence:
-                    open_fences.pop()
-                else:
-                    open_fences.append(Fence(fence_str, is_code))
-
-                in_code_fence = any(fence.is_code for fence in open_fences)
+            in_code_fence = line_is_in_code_fence(lines[i], open_fences)
 
             # If we're not in a fenced block and we detect an upcoming list
             # hanging off any block (including a list of another type), add

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1541,7 +1541,7 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     directly after a line of text, and inserts a newline between
     to satisfy Markdown"""
 
-    LI_RE = re.compile(r"^[ ]*([*+-]|\d\.)[ ]+(.*)", re.MULTILINE)
+    LI_RE = re.compile(r"^[ ]*([*+-]|\d\.)[ ]+(.*)")
 
     @override
     def run(self, lines: list[str]) -> list[str]:

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1535,10 +1535,10 @@ class Fence:
 
 LIST_ITEM_REGEX = re.compile(
     r"""
-    ^[ ]*        # Start with zero or more spaces
-    ([*+-]|\d\.) # A bullet marker (*, +, or -) or a digit followed by "."
-    [ ]+         # Followed by one or more spaces
-    (.*)         # The list content, which could be empty
+    ^[ ]*           # Start with zero or more spaces
+    ([*+-]|\d+\.)   # A bullet marker (*, +, or -) or one or more digits followed by "."
+    [ ]+            # Followed by one or more spaces
+    (.*)            # The list content, which could be empty
     """,
     re.VERBOSE,
 )

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -406,6 +406,12 @@
       "text_content": "1. A\n2. B\n  2. C\n3. D"
     },
     {
+      "name": "numbered_list_double_digit",
+      "input": "List without a gap\n10. One\n11. Two",
+      "expected_output": "<p>List without a gap</p>\n<ol start=\"10\">\n<li>One</li>\n<li>Two</li>\n</ol>",
+      "text_content": "List without a gap\n10. One\n11. Two"
+    },
+    {
       "name": "linkify_interference",
       "input": "link: xx, x xxxxx xx xxxx xx\n\n[xxxxx #xx](http://xxxxxxxxx:xxxx/xxx/xxxxxx%78xxxx/xx/):**xxxxxxx**\n\nxxxxxxx xxxxx xxxx xxxxx:\n`xxxxxx`: xxxxxxx\n`xxxxxx`: xxxxx\n`xxxxxx`: xxxxx xxxxx",
       "expected_output": "<p>link: xx, x xxxxx xx xxxx xx</p>\n<p><a href=\"http://xxxxxxxxx:xxxx/xxx/xxxxxx%78xxxx/xx/\">xxxxx #xx</a>:<strong>xxxxxxx</strong></p>\n<p>xxxxxxx xxxxx xxxx xxxxx:<br>\n<code>xxxxxx</code>: xxxxxxx<br>\n<code>xxxxxx</code>: xxxxx<br>\n<code>xxxxxx</code>: xxxxx xxxxx</p>",

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -55,6 +55,12 @@
       "text_content": "Hamlet once said\ndef func():\n    x = 1\n\n    y = 2\n\n    z = 3\n\nAnd all was good."
     },
     {
+      "name": "indented_codeblock",
+      "input": "\tprint(hello_world)",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>print(hello_world)\n</code></pre></div>",
+      "text_content": "print(hello_world)\n"
+    },
+    {
       "name": "inline_code_spaces",
       "input": "` outer ` ```    space    ```",
       "expected_output": "<p><code> outer </code> <code>    space    </code></p>",

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -412,6 +412,13 @@
       "text_content": "1. A\n2. B\n  2. C\n3. D"
     },
     {
+      "name": "numbered_list_double_digit",
+      "input": "8. eight\n9. nine\n   - sub item\n10. ten",
+      "expected_output": "<ol start=\"8\">\n<li>eight</li>\n<li>\n<p>nine</p>\n<ul>\n<li>sub item</li>\n</ul>\n</li>\n<li>\n<p>ten</p>\n</li>\n</ol>",
+      "marked_expected_output": "<ol start=\"8\">\n<li>eight</li>\n<li>nine<ul>\n<li>sub item</li>\n</ul>\n</li>\n<li>ten</li>\n</ol>",
+      "text_content": "8. eight\n9. nine\n\nsub item\n10. ten"
+    },
+    {
       "name": "linkify_interference",
       "input": "link: xx, x xxxxx xx xxxx xx\n\n[xxxxx #xx](http://xxxxxxxxx:xxxx/xxx/xxxxxx%78xxxx/xx/):**xxxxxxx**\n\nxxxxxxx xxxxx xxxx xxxxx:\n`xxxxxx`: xxxxxxx\n`xxxxxx`: xxxxx\n`xxxxxx`: xxxxx xxxxx",
       "expected_output": "<p>link: xx, x xxxxx xx xxxx xx</p>\n<p><a href=\"http://xxxxxxxxx:xxxx/xxx/xxxxxx%78xxxx/xx/\">xxxxx #xx</a>:<strong>xxxxxxx</strong></p>\n<p>xxxxxxx xxxxx xxxx xxxxx:<br>\n<code>xxxxxx</code>: xxxxxxx<br>\n<code>xxxxxx</code>: xxxxx<br>\n<code>xxxxxx</code>: xxxxx xxxxx</p>",

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -55,6 +55,18 @@
       "text_content": "Hamlet once said\ndef func():\n    x = 1\n\n    y = 2\n\n    z = 3\n\nAnd all was good."
     },
     {
+      "name": "indented_codeblock",
+      "input": "\tprint(hello_world)",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>print(hello_world)\n</code></pre></div>",
+      "text_content": "print(hello_world)\n"
+    },
+    {
+      "name": "tab_indented_codeblock_after_paragraph",
+      "input": "Here is some code:\n\n\tdef f():\n\t\treturn 1",
+      "expected_output": "<p>Here is some code:</p>\n<div class=\"codehilite\"><pre><span></span><code>def f():\n    return 1\n</code></pre></div>",
+      "text_content": "Here is some code:\ndef f():\n    return 1\n"
+    },
+    {
       "name": "inline_code_spaces",
       "input": "` outer ` ```    space    ```",
       "expected_output": "<p><code> outer </code> <code>    space    </code></p>",

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -284,6 +284,12 @@
       "text_content": "Nested list\n\nI am outer list\nI am inner nested list first item\nI am inner nested list second item\n\n\n"
     },
     {
+        "name": "ulist_nested_ulist_tab_indent",
+        "input": "- outer\n\t- inner first\n\t- inner second\n\t\t- deep nested",
+        "expected_output": "<ul>\n<li>outer<ul>\n<li>inner first</li>\n<li>inner second<ul>\n<li>deep nested</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>",
+        "text_content": "\nouter\ninner first\ninner second\ndeep nested\n\n\n\n\n"
+    },
+    {
       "name": "ulist_list_two_space_indent",
       "input": "* I am outer list\n  I am something inside",
       "expected_output": "<ul>\n<li>I am outer list<br>\n  I am something inside</li>\n</ul>",
@@ -407,9 +413,10 @@
     },
     {
       "name": "numbered_list_double_digit",
-      "input": "List without a gap\n10. One\n11. Two",
-      "expected_output": "<p>List without a gap</p>\n<ol start=\"10\">\n<li>One</li>\n<li>Two</li>\n</ol>",
-      "text_content": "List without a gap\n10. One\n11. Two"
+      "input": "8. eight\n9. nine\n   - sub item\n10. ten",
+      "expected_output": "<ol start=\"8\">\n<li>eight</li>\n<li>\n<p>nine</p>\n<ul>\n<li>sub item</li>\n</ul>\n</li>\n<li>\n<p>ten</p>\n</li>\n</ol>",
+      "marked_expected_output": "<ol start=\"8\">\n<li>eight</li>\n<li>nine<ul>\n<li>sub item</li>\n</ul>\n</li>\n<li>ten</li>\n</ol>",
+      "text_content": "8. eight\n9. nine\n\nsub item\n10. ten"
     },
     {
       "name": "linkify_interference",

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -491,6 +491,11 @@ class MarkdownListPreprocessorTest(ZulipTestCase):
         original, expected = self.split_message("List without a gap\n<>* One\n* Two")
         self.assertEqual(preprocessor.run(original), expected)
 
+    def test_basic_list_with_double_digit_numbers(self) -> None:
+        preprocessor = MarkdownListPreprocessor()
+        original, expected = self.split_message("List without a gap\n<>10. One\n11. Two")
+        self.assertEqual(preprocessor.run(original), expected)
+
     def test_list_after_quotes(self) -> None:
         preprocessor = MarkdownListPreprocessor()
         original, expected = self.split_message(

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -489,6 +489,11 @@ class MarkdownListPreprocessorTest(ZulipTestCase):
         original, expected = self.split_message("List without a gap\n<>* One\n* Two")
         self.assertEqual(preprocessor.run(original), expected)
 
+    def test_basic_list_with_double_digit_numbers(self) -> None:
+        preprocessor = MarkdownListPreprocessor()
+        original, expected = self.split_message("List without a gap\n<>10. One\n11. Two")
+        self.assertEqual(preprocessor.run(original), expected)
+
     def test_list_after_quotes(self) -> None:
         preprocessor = MarkdownListPreprocessor()
         original, expected = self.split_message(

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -39,6 +39,7 @@ from zerver.lib.markdown import (
     InlineInterestingLinkProcessor,
     MarkdownListPreprocessor,
     MessageRenderingResult,
+    TabIndentedListPreprocessor,
     clear_web_link_regex_for_testing,
     content_has_emoji_syntax,
     image_preview_enabled,
@@ -569,6 +570,62 @@ Outside. Should convert:<>
         """
         original, expected = self.split_message(msg)
         self.assertEqual(preprocessor.run(original), expected)
+
+
+class TabIndentedListPreprocessorTest(ZulipTestCase):
+    def test_single_level_nesting(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["- outer", "\t- inner"]
+        expected = ["- outer", "  - inner"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_multi_level_nesting(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["- outer", "\t- inner", "\t\t- deep"]
+        expected = ["- outer", "  - inner", "    - deep"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_numbered_list(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["1. outer", "\t1. inner"]
+        expected = ["1. outer", "  1. inner"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_numbered_list_with_double_digit_numbers(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["10. outer", "\t10. inner"]
+        expected = ["10. outer", "  10. inner"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_tabs_inside_fence_are_untouched(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["```", "- outer", "\t- inner", "```"]
+        # Lines inside a fenced code block are left alone entirely.
+        self.assertEqual(preprocessor.run(original), original)
+
+    def test_tabs_for_non_list_item_is_not_converted(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        # A tab-indented line that is *not* itself a list item (e.g. an
+        # indented code block) must be left untouched, since converting
+        # it to 2 spaces would break indented-code-block rendering.
+        original = ["Here is some code:", "", "\tdef f():", "\t\treturn 1"]
+        self.assertEqual(preprocessor.run(original), original)
+
+    def test_indented_code_block_end_to_end(self) -> None:
+        # Regression test: a tab-indented code block should still render
+        # as a <code> block, not get folded into list handling.
+        rendered = markdown_convert_wrapper("Here is some code:\n\n\tdef f():\n\t\treturn 1")
+        self.assertIn("<code>", rendered)
+        self.assertNotIn("<li>", rendered)
+
+    def test_tab_list_marker_without_preceding_list_context(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        # A tab + list-marker line is only converted if it directly
+        # continues a preceding list item. Without that context it
+        # must be left untouched so it still renders as an indented
+        # code block.
+        original = ["Some text", "", "\t- text"]
+        self.assertEqual(preprocessor.run(original), original)
 
 
 class MarkdownFixtureTest(ZulipTestCase):


### PR DESCRIPTION
When users paste tab-indented nested lists, the tabs are expanded
to 4 spaces by Python-Markdown's NormalizeWhitespace preprocessor.
Since Zulip's list parser requires 2-space indentation for nesting,
this caused nested lists to render as flat lists instead of properly
nested ones.

This adds a TabIndentedListPreprocessor that runs before
NormalizeWhitespace and converts each leading tab to 2 spaces.
Lines inside fenced code blocks are left untouched.

Fixes: #38436

**How changes were tested:**
Ran `./tools/test-backend zerver.tests.test_markdown` — all 138 tests pass.
Added fixture test case `ulist_nested_ulist_tab_indent` in
`zerver/tests/fixtures/markdown_test_cases.json`.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>