### PR TITLE
message_feed_notice: Fix history-limited-box icon escaping its border.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -208,18 +208,6 @@ p.n-margin {
     }
 }
 
-.history-limited-box {
-    border-radius: 4px;
-    display: none;
-    /* Difference should be 16px to accommodate the icon. */
-    /* This emulates hanging indent. */
-    padding-left: 26px;
-    text-indent: -10px;
-    color: hsl(16deg 60% 45%);
-    border: 1px solid hsl(16deg 60% 45%);
-    box-shadow: 0 0 2px hsl(16deg 60% 45%);
-}
-
 .history-limited-box,
 .all-messages-search-caution,
 .combined-feed-notice {
@@ -230,6 +218,18 @@ p.n-margin {
         margin: 0;
         padding: 4px;
     }
+}
+
+.history-limited-box {
+    border-radius: 4px;
+    display: none;
+    /* Difference should be 16px to accommodate the icon. */
+    /* This emulates hanging indent. */
+    padding-left: 26px;
+    text-indent: -10px;
+    color: hsl(16deg 60% 45%);
+    border: 1px solid hsl(16deg 60% 45%);
+    box-shadow: 0 0 2px hsl(16deg 60% 45%);
 }
 
 .messages-logo-svg {


### PR DESCRIPTION
The `.history-limited-box` rule already sets `padding-left: 26px` to create a hanging indent for notice text that wraps onto the next line.

As part of the refactor of `.history-limited-box` in commit 96338a983c0975ee458569ce018aa5b6caedeb2c, a shared padding shorthand was introduced for all message feed top notices. This shared padding overrides the `padding-left: 26px` required for the indent to work.

We refactor the `.history-limited-box` specific rule to come after the shared rule so that its padding takes effect.

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

|Before|After|
|-|-|
|<img width="935" height="63" alt="Screenshot from 2026-06-23 16-01-29" src="https://github.com/user-attachments/assets/1739cc00-240e-4da4-8984-a61efd9ae400" />|<img width="935" height="63" alt="Screenshot from 2026-06-23 16-01-08" src="https://github.com/user-attachments/assets/b3356290-836d-4bab-b7c3-26f323009bb8" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
