### PR TITLE
mattermost: Do not use `convert_html_to_text`.

### DIFF
--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -33,7 +33,6 @@ from zerver.data_import.import_util import (
     build_stream_subscriptions,
     build_user_profile,
     build_zerver_realm,
-    convert_html_to_text,
     create_converted_data_files,
     get_attachment_path_and_content,
     get_domain_name_for_import,
@@ -542,12 +541,6 @@ def process_raw_message_batch(
             mention_user_ids=mention_user_ids,
         )
 
-        try:
-            content = convert_html_to_text(content)
-        except Exception:  # nocoverage
-            logging.warning("Error converting HTML to text for message: '%s'; continuing", content)
-            logging.warning(str(raw_message))
-
         date_sent = raw_message["date_sent"]
         sender_user_id = raw_message["sender_id"]
         if "channel_name" in raw_message:
@@ -592,6 +585,8 @@ def process_raw_message_batch(
                 output_dir=output_dir,
             )
 
+            if content:
+                content += "\n\n"
             content += attachment_markdown
 
         topic_name = "imported from mattermost"

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -2,7 +2,6 @@ import filecmp
 import json
 import os
 import shutil
-import sys
 import tempfile
 from collections import defaultdict
 from collections.abc import Sequence
@@ -1092,15 +1091,6 @@ class MatterMostImporter(MattermostImportTestBase):
             warn_log.output,
             [
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
-                *(
-                    [
-                        # Check error log when trying to process a message with faulty HTML.
-                        "WARNING:root:Error converting HTML to text for message: 'This will crash html2text!!! <g:brand><![CDATSALOMON NORTH AMERICA, IN}}]]></g:brand>'; continuing",
-                        "WARNING:root:{'sender_id': 2, 'content': 'This will crash html2text!!! <g:brand><![CDATSALOMON NORTH AMERICA, IN}}]]></g:brand>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
-                    ]
-                    if sys.version_info < (3, 13)
-                    else []
-                ),
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
             ],
         )
@@ -1311,7 +1301,7 @@ class MatterMostImporter(MattermostImportTestBase):
 
         self.assertEqual(group_direct_messages[1].sender.email, "ginny@zulip.com")
         self.assertEqual(
-            group_direct_messages[1].content, "Who is going to Hogsmeade this weekend?\n\n"
+            group_direct_messages[1].content, "Who is going to Hogsmeade this weekend?"
         )
         self.assertEqual(group_direct_messages[1].topic_name(), Message.DM_TOPIC)
 
@@ -1330,14 +1320,6 @@ class MatterMostImporter(MattermostImportTestBase):
             warn_log.output,
             [
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
-                *(
-                    [
-                        "WARNING:root:Error converting HTML to text for message: 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>'; continuing",
-                        "WARNING:root:{'sender_id': 2, 'content': 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
-                    ]
-                    if sys.version_info < (3, 13)
-                    else []
-                ),
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
             ],
         )
@@ -1361,14 +1343,6 @@ class MatterMostImporter(MattermostImportTestBase):
             warn_log.output,
             [
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
-                *(
-                    [
-                        "WARNING:root:Error converting HTML to text for message: 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>'; continuing",
-                        "WARNING:root:{'sender_id': 2, 'content': 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
-                    ]
-                    if sys.version_info < (3, 13)
-                    else []
-                ),
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
             ],
         )


### PR DESCRIPTION
Mattermost does not format message content as HTML, and HTML is not a text formatting feature it supports. It is unclear whether HTML formatting was supported in the past, but most likely it was not, since the earliest test fixtures are also formatted with Markdown.

Any non-convertible HTML tag gets silently removed from the message by `convert_html_to_text`. For example, if a message contains `</rant>` or `<username>` (used by chat-bridging software) and gets passed through it, those two invalid HTML tags disappear.

This also speeds up the converter considerably. For example, it now converts ~350k messages in about 55 seconds on a 4-core machine, whereas it previously took hours.

CZO: [#issues > mattermost converter alters meaning of messages](https://chat.zulip.org/#narrow/channel/9-issues/topic/mattermost.20converter.20alters.20meaning.20of.20messages/with/2478576)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
