### PR TITLE
scroll_to_bottom: Add next unread topic/DM navigation.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -22,6 +22,7 @@ import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import * as message_view from "./message_view.ts";
+import * as message_viewport from "./message_viewport.ts";
 import * as mouse_drag from "./mouse_drag.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as navigate from "./navigate.ts";
@@ -325,6 +326,19 @@ export function initialize(): void {
     $("body").on("click", "#scroll-to-bottom-button-clickable-area", (e) => {
         e.preventDefault();
         e.stopPropagation();
+
+        if (message_viewport.bottom_rendered_message_visible()) {
+            if (narrow_state.narrowed_by_topic_reply()) {
+                message_view.narrow_to_next_topic({
+                    trigger: "next_topic_unread_hotkey",
+                    only_followed_topics: false,
+                });
+                return;
+            } else if (narrow_state.narrowed_by_pm_reply()) {
+                message_view.narrow_to_next_pm_string({trigger: "hotkey"});
+                return;
+            }
+        }
 
         // Since it take a few milliseconds for this button complete disappear transition,
         // it is possible for user to click it before it hides when switching narrows.

--- a/web/src/message_scroll.ts
+++ b/web/src/message_scroll.ts
@@ -23,14 +23,16 @@ export function hide_scroll_to_bottom(): void {
         return;
     }
 
-    if (
-        message_viewport.bottom_rendered_message_visible() ||
-        message_lists.current.visibly_empty()
-    ) {
-        // If last message is visible, just hide the
-        // scroll to bottom button.
+    if (message_lists.current.visibly_empty()) {
         $show_scroll_to_bottom_button.removeClass("show");
         return;
+    }
+
+    const $icon = $("#scroll-to-bottom-button .zulip-icon");
+    if (message_viewport.bottom_rendered_message_visible()) {
+        $icon.removeClass("zulip-icon-chevron-down").addClass("zulip-icon-chevron-right");
+    } else {
+        $icon.removeClass("zulip-icon-chevron-right").addClass("zulip-icon-chevron-down");
     }
 
     hide_scroll_to_bottom_timer = setInterval(() => {
@@ -47,11 +49,15 @@ export function hide_scroll_to_bottom(): void {
 }
 
 export function show_scroll_to_bottom_button(): void {
-    if (message_viewport.bottom_rendered_message_visible()) {
-        // Only show scroll to bottom button when
-        // last message is not visible in the
-        // current scroll position.
+    if (message_lists.current === undefined || message_lists.current.visibly_empty()) {
         return;
+    }
+
+    const $icon = $("#scroll-to-bottom-button .zulip-icon");
+    if (message_viewport.bottom_rendered_message_visible()) {
+        $icon.removeClass("zulip-icon-chevron-down").addClass("zulip-icon-chevron-right");
+    } else {
+        $icon.removeClass("zulip-icon-chevron-right").addClass("zulip-icon-chevron-down");
     }
 
     clearInterval(hide_scroll_to_bottom_timer);

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -13,6 +13,8 @@ import * as compose_state from "./compose_state.ts";
 import * as compose_validate from "./compose_validate.ts";
 import {$t} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
+import * as message_viewport from "./message_viewport.ts";
+import * as narrow_state from "./narrow_state.ts";
 import * as people from "./people.ts";
 import * as settings_config from "./settings_config.ts";
 import {realm} from "./state_data.ts";
@@ -334,8 +336,41 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: "#scroll-to-bottom-button-clickable-area",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onShow(instance) {
+            if (
+                message_viewport.bottom_rendered_message_visible() &&
+                narrow_state.narrowed_by_topic_reply()
+            ) {
+                $(instance.reference).attr(
+                    "data-tooltip-template-id",
+                    "next-unread-topic-tooltip-template",
+                );
+            } else if (
+                message_viewport.bottom_rendered_message_visible() &&
+                narrow_state.narrowed_by_pm_reply()
+            ) {
+                $(instance.reference).attr(
+                    "data-tooltip-template-id",
+                    "next-unread-pm-tooltip-template",
+                );
+            } else {
+                $(instance.reference).attr(
+                    "data-tooltip-template-id",
+                    "scroll-to-bottom-button-tooltip-template",
+                );
+            }
+            instance.setContent(get_tooltip_content(instance.reference));
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: [
-            "#scroll-to-bottom-button-clickable-area",
             "#compose_close",
             ".expand-composebox-button",
             ".collapse-composebox-button",

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -10,6 +10,15 @@
     {{t 'Scroll to bottom' }}
     {{tooltip_hotkey_hints "End"}}
 </template>
+<template id="next-unread-topic-tooltip-template">
+    {{t 'Next unread topic' }}
+    {{tooltip_hotkey_hints "N"}}
+</template>
+<template id="next-unread-pm-tooltip-template">
+    {{t 'Next unread DM conversation' }}
+    {{tooltip_hotkey_hints "P"}}
+</template>
+
 <template id="compose_disable_stream_reply_button_tooltip_template">
     {{t 'You do not have permission to post in this channel.' }}
 </template>


### PR DESCRIPTION
When the users is already at the bottom of a view, the floating scroll-down button currently disappears. Instead, we should:

    - In topic views, have the button become a button to go to the next unread topic (N), represented with a right arrow.
    - In DM conversation views, have the button become a button to go to the next unread DM conversation (P), also represented with a right arrow.

https://github.com/zulip/zulip/issues/38966

**Screenshots and screen captures:**

<img width="1173" height="353" alt="image" src="https://github.com/user-attachments/assets/5b2fb3ad-0208-4bcf-b4e2-52ac037f9574" />

<img width="569" height="292" alt="image" src="https://github.com/user-attachments/assets/e68cc02c-8de5-41f6-9a1e-2016b47fdb3d" />


<details>
<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
