### PR TITLE
markdown: exempt user-uploaded media from inline preview setting

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -329,6 +329,19 @@ def maybe_add_attachment_path_id(url: str, zmd: "ZulipMarkdown") -> None:
     zmd.zulip_rendering_result.potential_attachment_path_ids.append(path_id)
 
 
+def get_local_user_upload_path_id(url: str, zmd: "ZulipMarkdown") -> str | None:
+    parsed_url = urlsplit(urljoin("/", url))
+    host = parsed_url.netloc
+
+    if host != "" and (zmd.zulip_realm is None or host != zmd.zulip_realm.host):
+        return None
+
+    if not parsed_url.path.startswith("/user_uploads/"):
+        return None
+
+    return parsed_url.path.removeprefix("/user_uploads/")
+
+
 def url_embed_preview_enabled(
     message: Message | None = None, realm: Realm | None = None, no_previews: bool = False
 ) -> bool:
@@ -761,19 +774,22 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         return url
 
     def is_image(self, url: str) -> bool:
-        if not self.zmd.image_preview_enabled:
-            return False
         parsed_url = urlsplit(url)
         # remove HTML URLs which end with image extensions that cannot be shorted
         if parsed_url.netloc == "pasteboard.co":
             return False
 
-        # Check against the previews we generated -- if we didn't have
-        # a row for the ImageAttachment, then its header didn't parse
-        # as a valid image type which libvips handles.
-        if url.startswith("/user_uploads/") and self.zmd.zulip_db_data:
-            path_id = url.removeprefix("/user_uploads/")
+        path_id = get_local_user_upload_path_id(url, self.zmd)
+        if path_id is not None and self.zmd.zulip_db_data:
+            # Check against the previews we generated -- if we didn't
+            # have a row for the ImageAttachment, then its header
+            # didn't parse as a valid image type which libvips
+            # handles. User-uploaded media is exempt from the
+            # inline-image-preview organization setting.
             return path_id in self.zmd.zulip_db_data.user_upload_previews.image_metadata
+
+        if not self.zmd.image_preview_enabled:
+            return False
 
         return any(parsed_url.path.lower().endswith(ext) for ext in IMAGE_EXTENSIONS)
 
@@ -1040,16 +1056,24 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 return insertion_index
 
     def is_video(self, url: str) -> bool:
-        if not self.zmd.image_preview_enabled:
-            return False
-
-        url_type = guess_type(url)[0]
         # Video container formats broadly supported across browsers; see
         # https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#index_of_media_container_formats_file_types
         # Whether a specific file actually plays depends on the codecs
         # inside the container; the frontend hides the preview on a
         # playback error and falls back to the download link.
         supported_mimetypes = ["video/mp4", "video/quicktime", "video/webm"]
+
+        path_id = get_local_user_upload_path_id(url, self.zmd)
+        if path_id is not None:
+            # User-uploaded media is exempt from the
+            # inline-image-preview organization setting.
+            url_type = guess_type(path_id)[0]
+            return url_type in supported_mimetypes
+
+        if not self.zmd.image_preview_enabled:
+            return False
+
+        url_type = guess_type(url)[0]
         return url_type in supported_mimetypes
 
     def add_video(

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1220,6 +1220,22 @@ class MarkdownEmbedsTest(ZulipTestCase):
             "</video></a></div>",
         )
 
+    def test_inline_mov_video_respects_realm_setting_for_external_links(self) -> None:
+        sender_user_profile = self.example_user("othello")
+        sender_user_profile.realm.inline_image_preview = False
+        sender_user_profile.realm.save(update_fields=["inline_image_preview"])
+
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        converted = render_message_markdown(msg, "Check out: https://example.com/video.mov")
+        self.assertEqual(
+            converted.rendered_content,
+            '<p>Check out: <a href="https://example.com/video.mov">https://example.com/video.mov</a></p>',
+        )
+
     def test_inline_dropbox_preview(self) -> None:
         # Test photo album previews
         msg = "https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5"

--- a/zerver/tests/test_markdown_thumbnail.py
+++ b/zerver/tests/test_markdown_thumbnail.py
@@ -171,6 +171,68 @@ class MarkdownThumbnailTest(ZulipTestCase):
         )
         self.assert_message_content_is(message_id, expected)
 
+    def test_uploaded_images_ignore_inline_image_preview_setting(self) -> None:
+        path_id = self.upload_and_thumbnail_image("img.png")
+
+        sender_user_profile = self.example_user("othello")
+        sender_user_profile.realm.inline_image_preview = False
+        sender_user_profile.realm.save(update_fields=["inline_image_preview"])
+
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        converted = render_message_markdown(
+            msg,
+            f"[linked image](/user_uploads/{path_id})\n\n![inline image](/user_uploads/{path_id})",
+        )
+
+        self.assertEqual(
+            converted.rendered_content,
+            (
+                f'<p><a href="/user_uploads/{path_id}">linked image</a></p>\n'
+                f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="linked image">'
+                "<img"
+                ' data-original-content-type="image/png"'
+                ' data-original-dimensions="128x128"'
+                f' src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>\n'
+                f'<p><img alt="inline image" class="inline-image"'
+                ' data-original-content-type="image/png"'
+                ' data-original-dimensions="128x128"'
+                f' data-original-src="/user_uploads/{path_id}"'
+                f' src="/user_uploads/thumbnail/{path_id}/840x560.webp"></p>'
+            ),
+        )
+
+    def test_uploaded_videos_ignore_inline_image_preview_setting(self) -> None:
+        path_id = upload_message_attachment(
+            "video.mov",
+            "video/quicktime",
+            b"",
+            self.example_user("othello"),
+        )[0].removeprefix("/user_uploads/")
+
+        sender_user_profile = self.example_user("othello")
+        sender_user_profile.realm.inline_image_preview = False
+        sender_user_profile.realm.save(update_fields=["inline_image_preview"])
+
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        converted = render_message_markdown(msg, f"[uploaded video](/user_uploads/{path_id})")
+
+        self.assertEqual(
+            converted.rendered_content,
+            (
+                f'<p><a href="/user_uploads/{path_id}">uploaded video</a></p>\n'
+                f'<div class="message_inline_image message_inline_video"><a href="/user_uploads/{path_id}" title="uploaded video">'
+                f'<video preload="metadata" src="/user_uploads/{path_id}"></video></a></div>'
+            ),
+        )
+
     def test_thumbnail_escaping(self) -> None:
         self.login("othello")
         with self.captureOnCommitCallbacks(execute=True):


### PR DESCRIPTION
  Legacy `/user_uploads/...` media previews were being controlled inconsistently by the
  organization-level "Show previews of linked images and videos" setting.

  This change makes that setting apply only to externally linked media:
  - user-uploaded images/videos continue to preview regardless of the setting
  - externally linked images/videos still respect the setting

  This brings legacy uploaded-media links in line with Markdown image syntax.

  Fixes: #39597

  **How changes were tested:**

  - Added regression tests for uploaded image links, uploaded Markdown images, and uploaded video links when `realm_inline_image_preview` is disabled.
  - Added a regression test confirming external `.mov` links still respect the setting.
  - Ran:
    - `python3 -m py_compile zerver/lib/markdown/__init__.py zerver/tests/test_markdown.py zerver/tests/test_markdown_thumbnail.py`

  I could not run the targeted Zulip backend test suite in this checkout because the local Zulip dev environment/virtualenv is not present.

  **Screenshots and screen captures:**

  N/A; backend-only behavior change with no visual UI changes.

  <details>
  <summary>Self-review checklist</summary>

  - [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
        (variable names, code reuse, readability, etc.).
  - [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

  Communicate decisions, questions, and potential concerns.

  - [x] Explains differences from previous plans (e.g., issue description).
  - [x] Highlights technical choices and bugs encountered.
  - [x] Calls out remaining decisions and concerns.
  - [x] Automated tests verify logic where appropriate.

  Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

  - [x] Each commit is a coherent idea.
  - [x] Commit message(s) explain reasoning and motivation for changes.

  Completed manual review and testing of the following:

  - [ ] Visual appearance of the changes.
  - [ ] Responsiveness and internationalization.
  - [ ] Strings and tooltips.
  - [ ] End-to-end functionality of buttons, interactions and flows.
  - [x] Corner cases, error conditions, and easily imagined bugs.
  </details>
