### PR TITLE
corporate: Add notice to senior-backend posting.

### DIFF
--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -101,6 +101,12 @@
                     </p>
                     <hr/>
                     <h2 id="infra">Senior Backend/Infrastructure Engineer</h2>
+                    <div class="intro_quote">
+                        <blockquote>
+                            <strong>Note:</strong> We are not currently accepting new
+                            applications for this role.
+                        </blockquote>
+                    </div>
                     <p>
                         <a href="/">Zulip</a> is an open-source team chat
                         application designed for seamless remote and hybrid


### PR DESCRIPTION
Pausing accepting new applications, but leaving the ad itself posted.