### PR TITLE
webhook: Separate command and text field for slack outgoing webhook.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import logging
+import re
 from contextlib import suppress
 from dataclasses import dataclass
 from time import perf_counter
@@ -133,6 +134,16 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
         # text=googlebot: What is the air-speed velocity of an unladen swallow?
         # trigger_word=googlebot:
 
+        text = event["command"]
+        command = ""
+
+        if event["trigger"] == "mention":
+            match = re.match(r"^@\*\*([^*]+?)(?:\|\d+)?\*\*\s*(.*)", text)
+            if match:
+                bot_name = match.group(1)
+                command = f"/{bot_name}"
+                text = match.group(2)
+
         request_data = [
             ("token", self.token),
             ("team_id", f"T{realm.id}"),
@@ -143,10 +154,14 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
+            ("text", text),
             ("trigger_word", event["trigger"]),
             ("service_id", event["user_profile_id"]),
         ]
+
+        if command:
+            request_data.append(("command", command))
+
         return self.session.post(base_url, data=request_data)
 
     @override

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -222,9 +222,11 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         self.assertEqual(request_data[6][1], 123456)  # timestamp
         self.assertEqual(request_data[7][1], "U21")  # user_id
         self.assertEqual(request_data[8][1], "Sample User")  # user_name
-        self.assertEqual(request_data[9][1], "@**test**")  # text
+        self.assertEqual(request_data[9][1], "")  # text
         self.assertEqual(request_data[10][1], "mention")  # trigger_word
         self.assertEqual(request_data[11][1], 12)  # user_profile_id
+        self.assertEqual(request_data[12][0], "command")
+        self.assertEqual(request_data[12][1], "/test")  # command
 
     @mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
     def test_make_request_private_message(self, mock_fail_with_message: mock.Mock) -> None:


### PR DESCRIPTION
Currently, Slack-compatible outgoing webhooks package the entire message (including the bot mention) into the `text` field. However, POST requests from Slack format slash commands with a separated `command` field and only include the remaining message body inside `text`.\n\nThis commit extracts the bot mention into the `command` parameter to align with the standard Slack API format when a message is triggered by mentioning the bot, resolving integration incompatibilities.\n\nFixes #19589.