### PR TITLE
compose_box: Prevent scroller arrows from blinking on button clicks.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -622,9 +622,11 @@
    the formatting bar via Tab. Scroller-button state
    silently updates despite their being hidden, and
    scroller buttons reappear once focus has moved out
-   of the formatting bar. */
+   of the formatting bar. Using :focus-visible (instead
+   of :focus-within) avoids hiding the buttons during a
+   mouse click, which would otherwise cause a blink. */
 .compose-scrolling-buttons-container:has(
-        .compose-scrollable-buttons:focus-within
+        .compose-scrollable-buttons :focus-visible
     ) {
     .formatting-scroller-backward,
     .formatting-scroller-forward {


### PR DESCRIPTION
Follow-up PR to [discussion](https://github.com/zulip/zulip/pull/39580#issuecomment-4765624237) on #39580

The formatting-bar scroller arrows hide when focus is within the formatting buttons. Clicking a formatting button briefly puts focus inside the formatting bar before returning it to the textarea, which caused the arrows to blink off and back on during the click.

Add `:not(:has(.compose_control_button:active))`, so the arrows stay visible while a formatting button is actively being clicked. The existing Tab to hide behavior is preserved.

Fixes: https://github.com/zulip/zulip/pull/39580#issuecomment-4765624237

----

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img alt="2026-06-23_12-17-21" src="https://github.com/user-attachments/assets/6b904267-4724-4161-b16d-bad26de6d5bf" /> | <img alt="2026-06-23_12-16-03" src="https://github.com/user-attachments/assets/44d81aa1-ea54-4a73-8ed8-0b615ed3ce75" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
