### PR TITLE
click: Open channel links in a new tab on modified click.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -295,6 +295,11 @@ export function initialize(): void {
     });
 
     $("#main_div").on("click", "a.stream", function (this: HTMLAnchorElement, e) {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
+            // Let the browser handle modified clicks (open in a new
+            // tab/window) using the link's href.
+            return;
+        }
         e.preventDefault();
         // Note that we may have an href here, but we trust the stream id more,
         // so we re-encode the hash.


### PR DESCRIPTION
The `a.stream` click handler called preventDefault() unconditionally before navigating in place, so Cmd/Ctrl/Shift+click on a channel link never reached the browser's native "open in new tab/window" behavior.

We return early for modified clicks and let the browser follow the href, similar to the `.narrows_by_topic` handler . The href already encodes the stream id (the name slug is ignored when decoding), so the correct channel opens without the handler's re-encoding step.


Tested manually on my Mac with Cmd/Shift clicks			

[#issues > channel links don't open in new tab with cmnd+click @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/channel.20links.20don.27t.20open.20in.20new.20tab.20with.20cmnd.2Bclick/near/2484276)		
