### PR TITLE
requirements: Upgrade pika to 1.4.1 to fix Tornado shutdown crash.

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3317,11 +3317,11 @@ wheels = [
 
 [[package]]
 name = "pika"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/15/b6a706f1e886335aedc1e21d23913fe1a0fdaadd597d7721b26f11fe306a/pika-1.4.0.tar.gz", hash = "sha256:84aa6d0cf60bbdb79d5780544a4a4e1799392760127bf9de2a03d3c3b92f5f1a", size = 154264, upload-time = "2026-05-06T18:04:32.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/09/8c42dd00c4b3e09ebd174455d30823c261eefef9d2b7e94ae9ca779704c1/pika-1.4.1.tar.gz", hash = "sha256:e851f3e4992adfbf8eb64e9b86d94e3382f92ba0200055abedbb29676b8e713b", size = 154268, upload-time = "2026-05-22T18:01:24.855Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/07/b7269c5367995648897a40ae37054780fc68b71afcc51c169a739c653d4b/pika-1.4.0-py3-none-any.whl", hash = "sha256:937d8576f92a1ce3673d442161fefef614ac557583e10b9d84c14a6e228ed6a7", size = 164964, upload-time = "2026-05-06T18:04:31.343Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7b/a09c0d378ee8604220902c58103104b2304ef99744c4b7fc45312d280484/pika-1.4.1-py3-none-any.whl", hash = "sha256:2daae7bd422a0fc4f4879fd48c9a1932ed74a0bc7172e1e5f9bde63a101ed074", size = 164962, upload-time = "2026-05-22T18:01:23.429Z" },
 ]
 
 [[package]]

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 506
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (382, 0)  # bumped 2026-05-21 to remove sqlalchemy
+PROVISION_VERSION = (382, 1)  # bumped 2026-06-24 to upgrade pika


### PR DESCRIPTION
pika 1.4.0's Channel.close() iterates self._consumers.keys() while basic_cancel(nowait=True) deletes from that same dict, raising "RuntimeError: dictionary changed size during iteration". Tornado's TornadoQueueClient always has a consumer registered, so this fires on every graceful Tornado shutdown, e.g. during a deploy restart.

The crash happens after event queues are dumped, so no events are lost, but it pollutes deploy logs and can leave Tornado briefly unavailable while restarting, which is enough to make scripts/reload-clients fail to connect to port 9800.

pika 1.4.1 fixes this via upstream PR [#1596](https://github.com/pika/pika/pull/1596), which snapshots the consumer tags with list() before iterating.


---

Same traceback can be reproduced on local dev server by starting a dev server and pressing `ctrl + c` without this commit.