### PR TITLE
Fix migration status in zulip-cloud-current

### DIFF
--- a/zerver/migrations/0801_realmexport_backfill_export_from_prior_server_status.py
+++ b/zerver/migrations/0801_realmexport_backfill_export_from_prior_server_status.py
@@ -9,15 +9,18 @@ EXPORT_FROM_PRIOR_SERVER = 6
 def backfill_export_from_prior_server_status(
     apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
 ) -> None:
-    # RealmExport rows with SUCCEEDED status but no export_path are
-    # records carried across a realm export->import, where the tarball
-    # is not preserved. Fix them up to use EXPORT_FROM_PRIOR_SERVER status.
+    # RealmExport rows with SUCCEEDED status and no export_path, created
+    # via the UI, are records carried across a realm export->import, where
+    # the tarball is not preserved. Fix them up to use the
+    # EXPORT_FROM_PRIOR_SERVER status. Exports created via the manage.py
+    # export command have no acting_user and likewise lack an export_path,
+    # but they are not surfaced via the UI/API, so we leave them untouched.
     with connection.cursor() as cursor:
         cursor.execute(
             """
             UPDATE zerver_realmexport
             SET status = %s
-            WHERE status = %s AND export_path IS NULL
+            WHERE status = %s AND export_path IS NULL AND acting_user_id IS NOT NULL
             RETURNING id, realm_id
             """,
             [EXPORT_FROM_PRIOR_SERVER, SUCCEEDED],

--- a/zerver/migrations/0802_realmexport_restore_command_line_export_status.py
+++ b/zerver/migrations/0802_realmexport_restore_command_line_export_status.py
@@ -1,0 +1,44 @@
+from django.db import connection, migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+SUCCEEDED = 3
+EXPORT_FROM_PRIOR_SERVER = 6
+
+
+def restore_command_line_export_status(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    # The original version of migration 0801 flipped every SUCCEEDED row
+    # without an export_path to EXPORT_FROM_PRIOR_SERVER, incorrectly
+    # including command-line (manage.py export) exports, which have no
+    # acting_user. Restore those rows to SUCCEEDED.
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            UPDATE zerver_realmexport
+            SET status = %s
+            WHERE status = %s AND acting_user_id IS NULL
+            RETURNING id, realm_id
+            """,
+            [SUCCEEDED, EXPORT_FROM_PRIOR_SERVER],
+        )
+        for export_id, realm_id in cursor.fetchall():
+            print(
+                f"Restored RealmExport id={export_id} realm_id={realm_id}: "
+                f"EXPORT_FROM_PRIOR_SERVER -> SUCCEEDED"
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0801_realmexport_backfill_export_from_prior_server_status"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            restore_command_line_export_status,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]


### PR DESCRIPTION
cherry picked  24aefb6609fdd09b9f42af5d87203f7b20e271f4

Since I can't push to `zulip-cloud-current` directly, I can get around it via a pull request. The point is for `zulip-cloud-current` to have the correct migration status reflecting the state of Zulip Cloud.