### PR TITLE
llms_txt: Make the worked example URL-safe and clarify encoding.

### DIFF
--- a/zerver/tests/test_llms_txt.py
+++ b/zerver/tests/test_llms_txt.py
@@ -38,6 +38,13 @@ class LlmsTxtTest(ZulipTestCase):
         # can build narrows directly.
         rome_id = get_stream("Rome", realm).id
         self.assertIn(f"Rome ({rome_id})", content)
+        # The worked example must URL-encode the entire narrow value; a raw
+        # JSON array in the query string is not a valid request.
+        self.assertIn(
+            "narrow=%5B%7B%22operator%22%3A%22channels%22%2C%22operand%22%3A%22web-public%22%7D",
+            content,
+        )
+        self.assertNotIn("narrow=[", content)
 
     def test_llms_txt_spectator_access_disabled(self) -> None:
         """

--- a/zerver/tests/test_llms_txt.py
+++ b/zerver/tests/test_llms_txt.py
@@ -45,6 +45,10 @@ class LlmsTxtTest(ZulipTestCase):
             content,
         )
         self.assertNotIn("narrow=[", content)
+        # The `#narrow/...` URL segments use Zulip's hash-encoding, which
+        # the doc must not conflate with the URL-encoding of API requests.
+        self.assertIn("hash-encoded", content)
+        self.assertNotIn("URL-encoded channel name", content)
 
     def test_llms_txt_spectator_access_disabled(self) -> None:
         """

--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -105,10 +105,12 @@ API requests, use the numeric ID as the `channel` operand (e.g.,
 string and not the channel name. Channel IDs are stable; channel
 names can be renamed.
 
-Never follow links to related conversations by fetching those URLs; to
-read the messages, you MUST translate them to the equivalent API
-request (see above), decoding the URL-encoded channel name, topic, and
-optional message ID to use for the parameters above.
+Never follow links to related conversations by fetching those URLs;
+translate them to the equivalent API request instead (see above). In a
+`#narrow/...` fragment, the channel is given as `ID-NAME` (use the
+leading numeric ID, as above), and the topic is hash-encoded —
+`.`-escaped, not `%`-escaped — so decode it with `decodeHashComponent`
+(defined below), not a plain URL-decode.
 
 (`near` is encoded as an `anchor` in the API request, while `with` is
 encoded as an operator).
@@ -120,7 +122,7 @@ fetching a copy of the Zulip web app, which you likely don't have a
 browser engine able to run. The following code from
 web/src/internal_url.ts may be helpful for doing the encoding/decoding.
 
-``` ts
+```ts
 // ' and ! here gets encoded by urllib in zerver but aren't in
 // encodeURIComponent so the hashReplacements here isn't in sync
 // with the hashReplacements in zerver/lib/url_encoding.py.

--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -1,3 +1,6 @@
+import json
+from urllib.parse import urlencode
+
 from django.http import HttpRequest, HttpResponse
 
 from zerver.context_processors import get_valid_realm_from_request
@@ -30,6 +33,17 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
 
     server_url = realm.url
     example_channel_id = streams[0][0]
+    example_narrow = json.dumps(
+        [
+            {"operator": "channels", "operand": "web-public"},
+            {"operator": "channel", "operand": example_channel_id},
+            {"operator": "topic", "operand": "TOPIC_NAME"},
+        ],
+        separators=(",", ":"),
+    )
+    example_url = f"{server_url}/json/messages?" + urlencode(
+        {"anchor": "oldest", "num_before": 0, "num_after": 100, "narrow": example_narrow}
+    )
     channel_list = "\n".join(f"- {name} ({channel_id})" for channel_id, name in streams)
 
     content = f"""\
@@ -51,7 +65,8 @@ Required query parameters:
 - `anchor` — message ID or keyword (`oldest`, `newest`, `first_unread`)
 - `num_before` — number of messages before anchor (e.g. `0`)
 - `num_after` — number of messages after anchor (e.g. `100`)
-- `narrow` — JSON array of filter operators, e.g.:
+- `narrow` — JSON array of filter operators; URL-encode the entire
+  value in the query string. For example:
   `[{{"operator":"channels","operand":"web-public"}},{{"operator":"channel","operand":CHANNEL_ID}},{{"operator":"topic","operand":"TOPIC_NAME"}}]`
 
 **Important**: the narrow must include `{{"operator":"channels","operand":"web-public"}}`
@@ -72,7 +87,7 @@ request returned the entire conversation.
 
 Fetch the 100 oldest messages from a topic:
 
-    GET {server_url}/json/messages?anchor=oldest&num_before=0&num_after=100&narrow=[{{"operator":"channels","operand":"web-public"}},{{"operator":"channel","operand":{example_channel_id}}},{{"operator":"topic","operand":"TOPIC_NAME"}}]
+    GET {example_url}
 
 ## Fetching messages in specific conversations / views
 


### PR DESCRIPTION
Two more encoding fixes from the Opus 4.7 review, following #39541 (now merged).

The worked example was interpolating the raw narrow straight into the query string, so the URL it printed wasn't actually a valid request. Switched it to build the narrow with `json.dumps` and the query with `urlencode` (Anders' suggestion from the thread). The result is now the example is something you can paste and run as-is.

The other bit: the "translating a conversation URL" section said to decode the channel name, topic, and message ID - but the channel is just the leading numeric ID (which the doc already says to use), the message ID is a bare integer, and only the topic actually needs decoding - with `decodeHashComponent` (it's `.`-escaped, not `%`-escaped), not a plain URL-decode. Reworded to that, and fixed the `ts` code-fence tag.

Fixes: part of the review @rht raised in the [CZO thread](https://chat.zulip.org/#narrow/channel/137-feedback/topic/web.20public.20streams.20not.20readable.20by.20agentic.20ai.20tools/near/2450322).

**How changes were tested:**

- [x] `./tools/test-backend zerver.tests.test_llms_txt`
- [x] `./tools/lint zerver/views/llms_txt.py zerver/tests/test_llms_txt.py`
- [x] Rendered the live endpoint and read the whole document to confirm the example, the encoding note, and the listing all come out right.
- [x] Ran the documented request as a logged-out client and got `200` back with the channel's messages - so the URL the doc now produces is a valid, working web-public request, not just syntactically encoded.

<details>
<summary>**Screenshots and screen captures:**</summary>

Opus 4.8 (claude.ai) reading the llms.txt and constructing the request from it:
<img width="1115" height="480" alt="image" src="https://github.com/user-attachments/assets/51882570-3ce9-4417-b21a-3dc7201e427f" />

End-to-end with Opus 4.8 reading the rendered `llms.txt` cold (no Zulip priming): it pulled the channel's numeric ID straight from the listing and built a valid URL-encoded web-public narrow, and that request returns the channel's messages. On claude.ai the agent built the same correct request but its web sandbox couldn't send it (web_fetch's URL-length cap / egress allowlist) - the same harness limitation noted earlier in the thread, not a doc issue.

</details>



<!-- paste your claude.ai screenshot here -->

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
