### PR TITLE
rocketchat: Use uploadDate as date_created for realm emoji.

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
+from datetime import datetime
 from email.errors import HeaderDefect
 from email.headerregistry import Address
 from typing import Any, Generic, Protocol, TypeAlias, TypeVar
@@ -755,15 +756,27 @@ def download_and_export_upload_file(
     write_response_file_stream_to_path(response, file_output_path)
 
 
-def build_realm_emoji(realm_id: int, name: str, id: int, file_name: str) -> ZerverFieldsT:
-    return model_to_dict(
-        RealmEmoji(
-            realm_id=realm_id,
-            name=name,
-            id=id,
-            file_name=file_name,
-        ),
+def build_realm_emoji(
+    realm_id: int,
+    name: str,
+    id: int,
+    file_name: str,
+    date_created: datetime | None = None,
+) -> ZerverFieldsT:
+
+    date_created_kwargs = {}
+    if date_created is not None:
+        date_created_kwargs["date_created"] = date_created
+
+    realmemoji = RealmEmoji(
+        realm_id=realm_id,
+        name=name,
+        id=id,
+        file_name=file_name,
+        **date_created_kwargs,
     )
+
+    return model_to_dict(realmemoji)
 
 
 def get_emojis(

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -403,9 +403,13 @@ def build_custom_emoji(
     # Map emoji file_id to emoji file data
     emoji_file_data = defaultdict(list)
     object_id_to_filename = {}
+    filename_to_upload_date: dict[str, Any] = {}
+
     for emoji_file in custom_emoji_data["file"]:
         if isinstance(emoji_file["_id"], bson.objectid.ObjectId):  # nocoverage
             object_id_to_filename[str(emoji_file["_id"])] = emoji_file["filename"]
+            filename_to_upload_date[emoji_file["filename"]] = emoji_file.get("uploadDate")
+
     for emoji_chunk in sorted(custom_emoji_data["chunk"], key=lambda c: c["n"]):
         file_id = str(emoji_chunk["files_id"])
         emoji_file_data[object_id_to_filename.get(file_id, file_id)].append(emoji_chunk["data"])
@@ -442,6 +446,7 @@ def build_custom_emoji(
                 name=alias,
                 id=NEXT_ID("realmemoji"),
                 file_name=emoji_filename,
+                date_created=filename_to_upload_date.get(emoji_filename),
             )
             zerver_realmemoji.append(realmemoji)
 


### PR DESCRIPTION


<!-- Describe your pull request here.-->
This PR resolves the missing custom emoji timestamp issue in the Rocket.Chat data importer.

**Changes:**
* **Fixed Indentation in `rocketchat.py`:** Moved the chunk-processing loop outside of the file-processing loop so that emoji file chunks are mapped and parsed correctly.
* **Extracted Timestamp:** Safely extracts `uploadDate` from the Rocket.Chat BSON custom emoji data to use as the `date_created` value. (Since the source is BSON, `uploadDate` parses directly to a native Python `datetime` object).
* **Updated Object Initialization:** Modified `build_realm_emoji` in `zerver/data_import/import_util.py` to properly accept `date_created` as a parameter using `**kwargs` during instantiation, adhering to Django/Zulip best practices.

Fixes #39061.

**How changes were tested:**
Tested locally
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
