### PR TITLE
memcached: Enable TCP keepalives on connections to memcached.

### DIFF
--- a/zerver/lib/singleton_bmemcached.py
+++ b/zerver/lib/singleton_bmemcached.py
@@ -1,10 +1,70 @@
 import pickle
+import socket
 from functools import lru_cache
 from typing import Any
 
+from bmemcached.protocol import Protocol
 from django_bmemcached.memcached import BMemcached
 
 from zerver.lib import zstd_level9
+
+
+def _enable_tcp_keepalive(sock: socket.socket) -> None:
+    # Turn on TCP keepalives, with aggressive timers, on a freshly
+    # opened connection to memcached.
+    #
+    # bmemcached keeps a long-lived connection per thread and exposes no
+    # hook to configure the underlying socket, so without this a
+    # connection silently reaped while idle -- e.g. by a Kubernetes CNI
+    # or a stateful firewall dropping the idle conntrack entry -- is only
+    # noticed on its next use.  That surfaces as a spurious "Cannot query
+    # memcached" failure (the lost write makes the round-trip read return
+    # nothing), most visibly on the every-10s /health check.
+    #
+    # Keepalives both keep the idle connection fresh (so it is less
+    # likely to be reaped) and detect a genuinely dead peer promptly
+    # rather than on next use.
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        # Start probing after 60s idle, then every 10s, dropping the
+        # connection after 3 failed probes.
+        #
+        # KEEPIDLE is the constant that matters: a probe every 60s keeps
+        # the flow from looking idle, so it is not reaped in the first
+        # place.  It must sit comfortably below the shortest idle timeout
+        # on the path (conntrack / firewall); 60s clears the common
+        # aggressive reapers (~1-5min) with margin.  KEEPINTVL * KEEPCNT
+        # (~30s) only governs how fast a genuinely dead peer is noticed,
+        # and is kept loose enough not to misfire on a transient blip.
+        #
+        # These constants are only available on Linux; guard so dev
+        # environments on other platforms still work.
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
+        if hasattr(socket, "TCP_KEEPCNT"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
+    except OSError:  # nocoverage
+        # Best-effort: never let socket tuning break cache connectivity.
+        pass
+
+
+_original_open_connection = Protocol._open_connection
+
+
+def _open_connection_with_keepalive(self: Protocol) -> None:
+    # Only apply keepalives when we actually open a new TCP connection;
+    # _open_connection() is called before every command and short-circuits
+    # when a connection already exists.  self.host is falsey for
+    # Unix-domain sockets, where the TCP options do not apply.
+    was_connected = self.connection is not None
+    _original_open_connection(self)
+    if not was_connected and self.connection is not None and self.host:
+        _enable_tcp_keepalive(self.connection)
+
+
+Protocol._open_connection = _open_connection_with_keepalive
 
 
 @lru_cache(None)


### PR DESCRIPTION
bmemcached keeps a long-lived connection per worker process.  When such a connection is silently reaped while idle -- for example by a Kubernetes CNI or a stateful firewall dropping the idle conntrack entry -- bmemcached does not notice until its next use, where the first operation fails.  Luckily, Zulip usually fails safe -- reads resort back to the database, and writes are ignored.

This is mostly invisible to the application (except an occasional spurious cache miss), but the every-10s /health check writes a key and then reads it back, so it reliably turns each stale connection into a "Cannot query memcached" error.  Request-driven traffic cannot keep all the connections warm, since uwsgi (without thunder-lock) concentrates requests on the low-numbered workers and leaves the rest of the worker processes idle for long enough for their memcached connections to be closed due to disuse.

Set SO_KEEPALIVE so the kernel keeps every worker's connection fresh on a fixed cadence regardless of request routing; this both prevents the idle reaping, and bounds how quickly a genuinely dead peer is detected.

See [#production help > k8s: Cannot query memcached](https://chat.zulip.org/#narrow/channel/31-production-help/topic/k8s.3A.20Cannot.20query.20memcached/with/2484429)

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
