### PR TITLE
Optimize moving topic

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -935,12 +935,13 @@ def do_update_message(
     realm = user_profile.realm
     attachment_reference_change = AttachmentChangeResult(False, [])
 
-    ums = UserMessage.objects.filter(message=target_message.id)
+    ums_queryset = UserMessage.objects.filter(message=target_message.id)
 
-    def user_info(um: UserMessage) -> dict[str, Any]:
+    def user_info(um_row: tuple[int, int]) -> dict[str, Any]:
+        # um_row: (user_profile_id, flags) UserMessage row.
         return {
-            "id": um.user_profile_id,
-            "flags": um.flags_list(),
+            "id": um_row[0],
+            "flags": UserMessage.flags_list_for_flags(um_row[1]),
         }
 
     if message_edit_request.is_content_edited:
@@ -985,7 +986,9 @@ def do_update_message(
             save_message_for_edit_use_case(message=target_message)
 
             event["message_ids"] = sorted(update_message_cache([target_message]))
-            users_to_be_notified = list(map(user_info, ums))
+            users_to_be_notified = list(
+                map(user_info, ums_queryset.values_list("user_profile_id", "flags"))
+            )
             send_event_on_commit(user_profile.realm, event, users_to_be_notified)
 
             changed_messages_count = 1
@@ -1052,7 +1055,9 @@ def do_update_message(
             # If it's moving to a private stream, all non-subscribed users are losing access
             users_losing_access = users_losing_usermessages
 
-        unmodified_user_messages = ums.exclude(user_profile__in=users_losing_usermessages)
+        unmodified_user_messages = ums_queryset.exclude(
+            user_profile__in=users_losing_usermessages
+        ).values_list("user_profile_id", "flags")
 
         if not new_stream.is_history_public_to_subscribers():
             # We need to guarantee that every currently-subscribed
@@ -1072,8 +1077,8 @@ def do_update_message(
             )
     else:
         # If we're not moving the topic to another stream, we don't
-        # modify the original set of UserMessage objects queried.
-        unmodified_user_messages = ums
+        # modify the original set of UserMessage rows queried.
+        unmodified_user_messages = ums_queryset.values_list("user_profile_id", "flags")
 
     if message_edit_request.is_topic_edited:
         topic_name = message_edit_request.target_topic_name
@@ -1221,9 +1226,7 @@ def do_update_message(
             # in users_to_be_notified list.  This is the case where a
             # user both has a UserMessage row and is a current
             # Subscriber
-            subs = subs.exclude(
-                user_profile_id__in=[um.user_profile_id for um in unmodified_user_messages]
-            )
+            subs = subs.exclude(user_profile_id__in=[um[0] for um in unmodified_user_messages])
 
             if message_edit_request.is_stream_edited:
                 subs = subs.exclude(user_profile__in=users_losing_access)

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -86,7 +86,7 @@ from zerver.lib.types import DirectMessageEditRequest, EditHistoryEvent, StreamM
 from zerver.lib.url_encoding import stream_message_url
 from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.lib.user_message import bulk_insert_all_ums
-from zerver.lib.user_topics import get_users_with_user_topic_visibility_policy
+from zerver.lib.user_topics import get_users_with_user_topic_visibility_policy_on_move
 from zerver.lib.widget import is_widget_message
 from zerver.models import (
     ArchivedAttachment,
@@ -693,22 +693,30 @@ def update_user_topic_visibility_policies_on_move(
     target_topic_user_profile_to_visibility_policy: dict[UserProfile, int] = {}
     user_ids_losing_access = {user.id for user in users_losing_access}
 
-    for user_topic in get_users_with_user_topic_visibility_policy(
-        stream_being_edited.id, orig_topic_name
+    for user_topic in get_users_with_user_topic_visibility_policy_on_move(
+        stream_being_edited, target_stream, orig_topic_name, target_topic_name
     ):
-        if is_stream_edited and user_topic.user_profile_id in user_ids_losing_access:
-            stream_inaccessible_to_user_profiles.append(user_topic.user_profile)
-        else:
-            orig_topic_user_profile_to_visibility_policy[user_topic.user_profile] = (
+        # For a topic-only move, both topics share a stream,
+        # so we match on topic as well as stream to route each
+        # to the correct bucket.
+        if (
+            user_topic.stream_id == stream_being_edited.id
+            and user_topic.topic_name.upper() == orig_topic_name.upper()
+        ):
+            if is_stream_edited and user_topic.user_profile_id in user_ids_losing_access:
+                stream_inaccessible_to_user_profiles.append(user_topic.user_profile)
+            else:
+                orig_topic_user_profile_to_visibility_policy[user_topic.user_profile] = (
+                    user_topic.visibility_policy
+                )
+
+        if (
+            user_topic.stream_id == target_stream.id
+            and user_topic.topic_name.upper() == target_topic_name.upper()
+        ):
+            target_topic_user_profile_to_visibility_policy[user_topic.user_profile] = (
                 user_topic.visibility_policy
             )
-
-    for user_topic in get_users_with_user_topic_visibility_policy(
-        target_stream.id, target_topic_name
-    ):
-        target_topic_user_profile_to_visibility_policy[user_topic.user_profile] = (
-            user_topic.visibility_policy
-        )
 
     # User profiles having any of the visibility policies set for either the original or target topic.
     user_profiles_having_visibility_policy: set[UserProfile] = set(

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -7,13 +7,14 @@ from datetime import timedelta
 from typing import Any
 
 from django.conf import settings
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.models import Q, QuerySet
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 from django.utils.translation import override as override_language
 from django_stubs_ext import StrPromise
+from psycopg2.sql import SQL, Identifier
 
 from zerver.actions.message_delete import DeleteMessagesEvent, do_delete_messages
 from zerver.actions.message_flags import do_update_mobile_push_notification
@@ -117,6 +118,62 @@ class UpdateMessageResult:
 # already lets users keep editing near the deadline via
 # `min_seconds_to_edit + seconds_left_buffer` in `message_edit.ts`.
 MESSAGE_EDIT_TIME_LIMIT_BUFFER_SECONDS = 20
+
+
+def reset_attachments_visibility_cache(
+    changed_message_ids: list[int],
+    target_stream: Stream,
+    stream_being_edited: Stream,
+) -> None:
+    """
+    Reset the Attachment.is_*_public caches for all messages
+    moved to another stream with different access permissions.
+    """
+    is_web_public_match = target_stream.is_web_public == stream_being_edited.is_web_public
+    invite_only_match = target_stream.invite_only == stream_being_edited.invite_only
+
+    # Both streams already have the same access permissions,
+    # so no update needed.
+    if is_web_public_match and invite_only_match:
+        return
+
+    updates = []
+    if not invite_only_match:
+        updates.append(SQL("is_realm_public = NULL"))
+
+    if not is_web_public_match:
+        updates.append(SQL("is_web_public = NULL"))
+
+    query = SQL(
+        """
+        UPDATE {attachment}
+        SET {update_fields_segment}
+        WHERE {attachment}.id IN
+        (
+            SELECT {attachment_messages}.attachment_id
+            FROM {attachment_messages}
+            WHERE {attachment_messages}.message_id = ANY(%(changed_message_ids)s)
+        );
+
+        UPDATE {archived_attachment}
+        SET {update_fields_segment}
+        WHERE {archived_attachment}.id IN
+        (
+            SELECT {archived_attachment_messages}.archivedattachment_id
+            FROM {archived_attachment_messages}
+            WHERE {archived_attachment_messages}.archivedmessage_id = ANY(%(changed_message_ids)s)
+        );
+    """
+    ).format(
+        # Table names:
+        attachment=Identifier(Attachment._meta.db_table),
+        attachment_messages=Identifier(Attachment.messages.through._meta.db_table),
+        archived_attachment=Identifier(ArchivedAttachment._meta.db_table),
+        archived_attachment_messages=Identifier(ArchivedAttachment.messages.through._meta.db_table),
+        update_fields_segment=SQL(", ").join(updates),
+    )
+    with connection.cursor() as cursor:
+        cursor.execute(query, {"changed_message_ids": changed_message_ids})
 
 
 def subscriber_info(user_id: int) -> dict[str, Any]:
@@ -1113,23 +1170,11 @@ def do_update_message(
             user_profile.realm, delete_event, [user.id for user in users_losing_access]
         )
 
-        # Reset the Attachment.is_*_public caches for all messages
-        # moved to another stream with different access permissions.
-        if message_edit_request.target_stream.invite_only != stream_being_edited.invite_only:
-            Attachment.objects.filter(messages__in=changed_messages.values("id")).update(
-                is_realm_public=None,
-            )
-            ArchivedAttachment.objects.filter(messages__in=changed_messages.values("id")).update(
-                is_realm_public=None,
-            )
-
-        if message_edit_request.target_stream.is_web_public != stream_being_edited.is_web_public:
-            Attachment.objects.filter(messages__in=changed_messages.values("id")).update(
-                is_web_public=None,
-            )
-            ArchivedAttachment.objects.filter(messages__in=changed_messages.values("id")).update(
-                is_web_public=None,
-            )
+        reset_attachments_visibility_cache(
+            changed_message_ids,
+            message_edit_request.target_stream,
+            stream_being_edited,
+        )
 
     # This does message.save(update_fields=[...])
     save_message_for_edit_use_case(message=target_message)

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1373,21 +1373,23 @@ def do_update_message(
         target_stream = message_edit_request.target_stream
         target_topic = message_edit_request.target_topic_name
 
-        assert target_stream.recipient_id is not None
-
-        messages_in_target_topic = messages_for_topic(
-            realm.id, target_stream.recipient_id, target_topic
-        ).exclude(id__in=[*changed_message_ids])
-
         # All behavior in channels with protected history depends on
         # the permissions of users who might learn information about
         # whether the topic previously existed. So we need to look at
         # whether this message is becoming the first message in the
         # target topic, as seen by the user who we might change topic
         # visibility policy for in this code path.
-        first_message_in_target_topic = bulk_access_stream_messages_query(
-            sender, messages_in_target_topic, target_stream
-        ).first()
+        first_message_in_target_topic: Message | None = None
+        if target_topic_has_messages:
+            assert target_stream.recipient_id is not None
+
+            messages_in_target_topic = messages_for_topic(
+                realm.id, target_stream.recipient_id, target_topic
+            ).exclude(id__in=[*changed_message_ids])
+
+            first_message_in_target_topic = bulk_access_stream_messages_query(
+                sender, messages_in_target_topic, target_stream
+            ).first()
 
         is_target_message_first = False
         # the target_message would be the first message in the moved topic
@@ -1465,25 +1467,27 @@ def do_update_message(
                 and not message_edit_request.topic_unresolved
             )
         ):
-            stream_for_new_topic = message_edit_request.target_stream
-            assert stream_for_new_topic.recipient_id is not None
-
-            new_topic_name = message_edit_request.target_topic_name
-
             # We calculate whether the user moved the entire topic
             # using that user's own permissions, which is important to
             # avoid leaking information about whether there are
             # messages in the destination topic's deeper history that
             # the acting user does not have permission to access.
-            preexisting_topic_messages = messages_for_topic(
-                realm.id, stream_for_new_topic.recipient_id, new_topic_name
-            ).exclude(id__in=[*changed_message_ids, resolved_topic_message_id])
+            no_visible_preexisting_messages = True
+            if target_topic_has_messages:
+                stream_for_new_topic = message_edit_request.target_stream
+                assert stream_for_new_topic.recipient_id is not None
 
-            visible_preexisting_messages = bulk_access_stream_messages_query(
-                user_profile, preexisting_topic_messages, stream_for_new_topic
-            )
+                new_topic_name = message_edit_request.target_topic_name
 
-            no_visible_preexisting_messages = not visible_preexisting_messages.exists()
+                preexisting_topic_messages = messages_for_topic(
+                    realm.id, stream_for_new_topic.recipient_id, new_topic_name
+                ).exclude(id__in=[*changed_message_ids, resolved_topic_message_id])
+
+                visible_preexisting_messages = bulk_access_stream_messages_query(
+                    user_profile, preexisting_topic_messages, stream_for_new_topic
+                )
+
+                no_visible_preexisting_messages = not visible_preexisting_messages.exists()
 
             if no_visible_preexisting_messages and moved_all_visible_messages:
                 new_thread_notification_string = gettext_lazy(

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from django.conf import settings
 from django.db import connection, transaction
-from django.db.models import Q, QuerySet
+from django.db.models import Q
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -686,12 +686,11 @@ def update_user_topic_visibility_policies_on_move(
     target_stream: Stream,
     target_topic_name: str,
     target_topic_has_messages: bool,
-    users_losing_access: Iterable[UserProfile],
+    user_ids_losing_access: set[int],
 ) -> dict[UserProfile, int]:
     stream_inaccessible_to_user_profiles: list[UserProfile] = []
     orig_topic_user_profile_to_visibility_policy: dict[UserProfile, int] = {}
     target_topic_user_profile_to_visibility_policy: dict[UserProfile, int] = {}
-    user_ids_losing_access = {user.id for user in users_losing_access}
 
     for user_topic in get_users_with_user_topic_visibility_policy_on_move(
         stream_being_edited, target_stream, orig_topic_name, target_topic_name
@@ -1015,11 +1014,76 @@ def do_update_message(
     if message_edit_request.is_message_moved:
         event["propagate_mode"] = message_edit_request.propagate_mode
 
-    users_losing_access = UserProfile.objects.none()
+    user_ids_losing_access: set[int] = set()
     user_ids_gaining_usermessages: list[int] = []
+
+    # The sets below describe the old and new streams' subscribers.
+    # Which of them are needed depends on the kind of move, so each
+    # branch fetches what its case consumes.
+    old_stream_all_user_ids: set[int] = set()
+    old_stream_current_user_ids: set[int] = set()
+    old_stream_active_user_ids: set[int] = set()
+
+    new_stream_current_user_ids: set[int] = set()
+    new_stream_active_user_ids: set[int] = set()
+
+    guest_user_ids: set[int] = set()
+
+    # In both conditions, we exclude long-term idle users from
+    # new_stream_active_user_ids and old_stream_active_user_ids,
+    # because they have no active clients, so they are never
+    # notified about the move.
     if message_edit_request.is_stream_edited:
         new_stream = message_edit_request.target_stream
+        # A move to another stream needs several overlapping subsets of
+        # both streams' subscribers; fetch their Subscriptions in
+        # a single query and derive every set from it in one pass.
+        subscriptions = Subscription.objects.filter(
+            recipient__type=Recipient.STREAM,
+            recipient__type_id__in=[stream_being_edited.id, new_stream.id],
+        )
+        for (
+            user_id,
+            stream_id,
+            sub_active,
+            is_user_active,
+            user_long_term_idle,
+            user_role,
+        ) in subscriptions.values_list(
+            "user_profile_id",
+            "recipient__type_id",
+            "active",
+            "is_user_active",
+            "user_profile__long_term_idle",
+            "user_profile__role",
+        ):
+            if user_role == UserProfile.ROLE_GUEST:
+                guest_user_ids.add(user_id)
 
+            if stream_id == stream_being_edited.id:
+                old_stream_all_user_ids.add(user_id)
+                if sub_active:
+                    old_stream_current_user_ids.add(user_id)
+
+                if sub_active and is_user_active and not user_long_term_idle:
+                    old_stream_active_user_ids.add(user_id)
+
+            if stream_id == new_stream.id and sub_active:
+                new_stream_current_user_ids.add(user_id)
+                if is_user_active and not user_long_term_idle:
+                    new_stream_active_user_ids.add(user_id)
+
+    elif stream_being_edited.is_history_public_to_subscribers():
+        # A topic-only move only needs new_stream_active_user_ids.
+        new_stream_active_user_ids = set(
+            get_active_subscriptions_for_stream_id(
+                message_edit_request.target_stream.id, include_deactivated_users=False
+            )
+            .exclude(user_profile__long_term_idle=True)
+            .values_list("user_profile_id", flat=True)
+        )
+
+    if message_edit_request.is_stream_edited:
         edit_history_event["prev_stream"] = stream_being_edited.id
         edit_history_event["stream"] = new_stream.id
         event[ORIG_TOPIC] = orig_topic_name
@@ -1055,13 +1119,13 @@ def do_update_message(
 
         users_losing_usermessages = old_stream_all_users.difference(new_stream_current_users)
         if new_stream.is_public():
-            # Only guest users are losing access, if it's moving to a public stream
-            users_losing_access = old_stream_all_users.filter(
-                role=UserProfile.ROLE_GUEST
-            ).difference(new_stream_current_users)
+            # If it's moving to a public stream, only non-subscribed guest users are losing access.
+            user_ids_losing_access = (
+                old_stream_all_user_ids & guest_user_ids
+            ) - new_stream_current_user_ids
         else:
             # If it's moving to a private stream, all non-subscribed users are losing access
-            users_losing_access = users_losing_usermessages
+            user_ids_losing_access = old_stream_all_user_ids - new_stream_current_user_ids
 
         unmodified_user_messages = ums_queryset.exclude(
             user_profile__in=users_losing_usermessages
@@ -1080,9 +1144,7 @@ def do_update_message(
             # There may be current users of the new stream who already
             # have a usermessage row -- we handle this via `ON
             # CONFLICT DO NOTHING` during insert.
-            user_ids_gaining_usermessages = list(
-                new_stream_current_users.values_list("id", flat=True)
-            )
+            user_ids_gaining_usermessages = list(new_stream_current_user_ids)
     else:
         # If we're not moving the topic to another stream, we don't
         # modify the original set of UserMessage rows queried.
@@ -1179,9 +1241,7 @@ def do_update_message(
             "stream_id": stream_being_edited.id,
             "topic": orig_topic_name,
         }
-        send_event_on_commit(
-            user_profile.realm, delete_event, [user.id for user in users_losing_access]
-        )
+        send_event_on_commit(user_profile.realm, delete_event, user_ids_losing_access)
 
         reset_attachments_visibility_cache(
             changed_message_ids,
@@ -1220,46 +1280,8 @@ def do_update_message(
     # where possible.
     users_to_be_notified = list(map(user_info, unmodified_user_messages))
     if stream_being_edited.is_history_public_to_subscribers():
-        subscriptions = get_active_subscriptions_for_stream_id(
-            message_edit_request.target_stream.id, include_deactivated_users=False
-        )
+        subscriber_ids = new_stream_active_user_ids.copy()
 
-        def exclude_duplicates_from_subscription(
-            subs: QuerySet[Subscription],
-        ) -> QuerySet[Subscription]:
-            # We exclude long-term idle users, since they by
-            # definition have no active clients.
-            subs = subs.exclude(user_profile__long_term_idle=True)
-            # Remove duplicates by excluding the id of users already
-            # in users_to_be_notified list.  This is the case where a
-            # user both has a UserMessage row and is a current
-            # Subscriber
-            subs = subs.exclude(user_profile_id__in=[um[0] for um in unmodified_user_messages])
-
-            if message_edit_request.is_stream_edited:
-                subs = subs.exclude(user_profile__in=users_losing_access)
-
-            return subs
-
-        old_stream_subs_not_in_new_stream = set()
-        if message_edit_request.is_stream_edited:
-            # We also need to include users who are not subscribed to new stream
-            # but are subscribed to the old stream.
-            old_stream_subscriptions = get_active_subscriptions_for_stream_id(
-                stream_being_edited.id, include_deactivated_users=False
-            )
-            old_stream_subscriptions = exclude_duplicates_from_subscription(
-                old_stream_subscriptions
-            )
-            old_stream_subscriber_ids = set(
-                old_stream_subscriptions.values_list("user_profile_id", flat=True)
-            )
-            new_stream_subscriber_ids = set(subscriptions.values_list("user_profile_id", flat=True))
-            old_stream_subs_not_in_new_stream = old_stream_subscriber_ids.difference(
-                new_stream_subscriber_ids
-            )
-
-        subscriptions = exclude_duplicates_from_subscription(subscriptions)
         if message_edit_request.is_stream_edited:
             # TODO: Guest users don't see the new moved topic
             # unless breadcrumb message for new stream is
@@ -1272,20 +1294,25 @@ def do_update_message(
             # Don't send this event to guest subs who are not
             # subscribers of the old stream but are subscribed to
             # the new stream; clients will be confused.
-            old_stream_current_users = UserProfile.objects.filter(
-                id__in=get_active_subscriptions_for_stream_id(
-                    stream_being_edited.id, include_deactivated_users=True
-                ).values_list("user_profile_id", flat=True)
-            ).only("id")
-            subscriptions = subscriptions.exclude(
-                user_profile__in=new_stream_current_users.filter(
-                    role=UserProfile.ROLE_GUEST
-                ).difference(old_stream_current_users)
-            )
+            new_stream_guest_users_not_in_old_stream = (
+                new_stream_current_user_ids & guest_user_ids
+            ) - old_stream_current_user_ids
+            subscriber_ids -= new_stream_guest_users_not_in_old_stream
 
-        subscriber_ids = set(subscriptions.values_list("user_profile_id", flat=True))
-        notifiable_ids = subscriber_ids.union(old_stream_subs_not_in_new_stream)
-        users_to_be_notified += map(subscriber_info, sorted(notifiable_ids))
+            # Subscribers of the old stream are notified of the move too.
+            subscriber_ids |= old_stream_active_user_ids
+
+            # Exclude users who are losing access;
+            # instead they get a delete_message event.
+            subscriber_ids -= user_ids_losing_access
+
+        # Exclude the id of users already in users_to_be_notified list.
+        # This is the case where a user both has a UserMessage row
+        # and is a current Subscriber
+        unmodified_user_messages_user_ids = {um[0] for um in unmodified_user_messages}
+        subscriber_ids -= unmodified_user_messages_user_ids
+
+        users_to_be_notified += map(subscriber_info, sorted(subscriber_ids))
 
     # UserTopic updates and the content of notifications depend on
     # whether we've moved the entire topic, or just part of it. We
@@ -1336,7 +1363,7 @@ def do_update_message(
                 target_stream=target_stream,
                 target_topic_name=target_topic_name,
                 target_topic_has_messages=target_topic_has_messages,
-                users_losing_access=users_losing_access,
+                user_ids_losing_access=user_ids_losing_access,
             )
         )
 
@@ -1373,7 +1400,11 @@ def do_update_message(
         ):
             is_target_message_first = True
 
-        if not sender.is_bot and sender not in users_losing_access and is_target_message_first:
+        if (
+            not sender.is_bot
+            and sender.id not in user_ids_losing_access
+            and is_target_message_first
+        ):
             apply_automatic_unmute_follow_topics_policy(sender, target_stream, target_topic)
 
     send_event_on_commit(user_profile.realm, event, users_to_be_notified)

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1380,7 +1380,7 @@ def do_update_message(
         ).exclude(id__in=[*changed_message_ids])
 
         # All behavior in channels with protected history depends on
-        # the permissions of users who might glean information about
+        # the permissions of users who might learn information about
         # whether the topic previously existed. So we need to look at
         # whether this message is becoming the first message in the
         # target topic, as seen by the user who we might change topic

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1367,7 +1367,7 @@ def do_update_message(
             )
         )
 
-    elif message_edit_request.is_stream_edited or message_edit_request.is_topic_edited:
+    elif message_edit_request.is_message_moved:
         sender = target_message.sender
 
         target_stream = message_edit_request.target_stream

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -887,11 +887,12 @@ def filter_presence_idle_user_ids(user_ids: set[int]) -> list[int]:
         return []
 
     recent = timezone_now() - timedelta(seconds=settings.OFFLINE_THRESHOLD_SECS)
-    rows = UserPresence.objects.filter(
-        user_profile_id__in=user_ids,
-        last_active_time__gte=recent,
-    ).values("user_profile_id")
-    active_user_ids = {row["user_profile_id"] for row in rows}
+    active_user_ids = set(
+        UserPresence.objects.filter(
+            user_profile_id__in=user_ids,
+            last_active_time__gte=recent,
+        ).values_list("user_profile_id", flat=True),
+    )
     idle_user_ids = user_ids - active_user_ids
     return sorted(idle_user_ids)
 

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -926,11 +926,12 @@ def filter_presence_idle_user_ids(user_ids: set[int]) -> list[int]:
         return []
 
     recent = timezone_now() - timedelta(seconds=settings.OFFLINE_THRESHOLD_SECS)
-    rows = UserPresence.objects.filter(
-        user_profile_id__in=user_ids,
-        last_active_time__gte=recent,
-    ).values("user_profile_id")
-    active_user_ids = {row["user_profile_id"] for row in rows}
+    active_user_ids = set(
+        UserPresence.objects.filter(
+            user_profile_id__in=user_ids,
+            last_active_time__gte=recent,
+        ).values_list("user_profile_id", flat=True),
+    )
     idle_user_ids = user_ids - active_user_ids
     return sorted(idle_user_ids)
 

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -12,7 +12,7 @@ from psycopg2.sql import SQL, Literal
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import topic_match_q
 from zerver.lib.types import UserTopicDict
-from zerver.models import Recipient, Subscription, UserProfile, UserTopic
+from zerver.models import Recipient, Stream, Subscription, UserProfile, UserTopic
 from zerver.models.streams import get_stream
 
 
@@ -349,4 +349,16 @@ def get_users_with_user_topic_visibility_policy(
 ) -> QuerySet[UserTopic]:
     return UserTopic.objects.filter(
         stream_id=stream_id, topic_name__iexact=topic_name
+    ).select_related("user_profile", "user_profile__realm")
+
+
+def get_users_with_user_topic_visibility_policy_on_move(
+    stream_being_edited: Stream, target_stream: Stream, orig_topic_name: str, target_topic_name: str
+) -> QuerySet[UserTopic]:
+    # Parallel to get_users_with_user_topic_visibility_policy
+    # but returns rows for both the original and target
+    # (stream, topic) pairs at once.
+    return UserTopic.objects.filter(
+        Q(stream_id=stream_being_edited.id, topic_name__iexact=orig_topic_name)
+        | Q(stream_id=target_stream.id, topic_name__iexact=target_topic_name),
     ).select_related("user_profile", "user_profile__realm")

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -11,7 +11,7 @@ from psycopg2.sql import SQL, Literal
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import matching_user_topic_exists_q
 from zerver.lib.types import UserTopicDict
-from zerver.models import Recipient, Subscription, UserProfile, UserTopic
+from zerver.models import Recipient, Stream, Subscription, UserProfile, UserTopic
 from zerver.models.streams import get_stream
 
 
@@ -311,4 +311,16 @@ def get_users_with_user_topic_visibility_policy(
 ) -> QuerySet[UserTopic]:
     return UserTopic.objects.filter(
         stream_id=stream_id, topic_name__iexact=topic_name
+    ).select_related("user_profile", "user_profile__realm")
+
+
+def get_users_with_user_topic_visibility_policy_on_move(
+    stream_being_edited: Stream, target_stream: Stream, orig_topic_name: str, target_topic_name: str
+) -> QuerySet[UserTopic]:
+    # Parallel to get_users_with_user_topic_visibility_policy
+    # but returns rows for both the original and target
+    # (stream, topic) pairs at once.
+    return UserTopic.objects.filter(
+        Q(stream_id=stream_being_edited.id, topic_name__iexact=orig_topic_name)
+        | Q(stream_id=target_stream.id, topic_name__iexact=target_topic_name),
     ).select_related("user_profile", "user_profile__realm")

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1592,7 +1592,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(56), self.assert_memcached_count(17):
+        with self.assert_database_query_count(55), self.assert_memcached_count(17):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1592,7 +1592,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(55), self.assert_memcached_count(17):
+        with self.assert_database_query_count(52), self.assert_memcached_count(17):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1592,7 +1592,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(57), self.assert_memcached_count(19):
+        with self.assert_database_query_count(56), self.assert_memcached_count(19):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1592,7 +1592,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(53), self.assert_memcached_count(19):
+        with self.assert_database_query_count(52), self.assert_memcached_count(19):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1592,7 +1592,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(56), self.assert_memcached_count(19):
+        with self.assert_database_query_count(53), self.assert_memcached_count(19):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -615,7 +615,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         ]
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
-        with self.assert_database_query_count(31):
+        with self.assert_database_query_count(30):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -585,7 +585,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(21):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -615,7 +615,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         ]
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
-        with self.assert_database_query_count(29):
+        with self.assert_database_query_count(25):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -648,7 +648,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(27):
+        with self.assert_database_query_count(24):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -671,7 +671,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         second_message_id = self.send_stream_message(
             hamlet, stream_name, topic_name="changed topic name", content="Second message"
         )
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(18):
             check_update_message(
                 user_profile=desdemona,
                 message_id=second_message_id,

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -488,7 +488,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         # state + 1/user with a UserTopic row for the events data)
         # beyond what is typical were there not UserTopic records to
         # update. Ideally, we'd eliminate the per-user component.
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(23):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,
@@ -585,7 +585,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(25):
+        with self.assert_database_query_count(24):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -615,7 +615,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         ]
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
-        with self.assert_database_query_count(30):
+        with self.assert_database_query_count(29):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -648,7 +648,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(28):
+        with self.assert_database_query_count(27):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -671,7 +671,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         second_message_id = self.send_stream_message(
             hamlet, stream_name, topic_name="changed topic name", content="Second message"
         )
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(21):
             check_update_message(
                 user_profile=desdemona,
                 message_id=second_message_id,
@@ -750,7 +750,7 @@ class MessageMoveTopicTest(ZulipTestCase):
             users_to_be_notified_via_muted_topics_event.append(user_topic.user_profile_id)
 
         change_all_topic_name = "Topic 1 edited"
-        with self.assert_database_query_count(29):
+        with self.assert_database_query_count(28):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,


### PR DESCRIPTION
Fixes  #21819.
# 1st commit

## Author
Identified and fully implemented by me. 
## Details

When moving messages/topic to a channel with different access permissions, we execute either 4 queries or 2 queries.

1. When one channel is **private** and the other is **web-public**: 4 queries.
2. When **only one**  of the channels is **private** or **web-public**: 2 queries. 
## Changes

Replace the 4 `.update()` calls with a single efficient raw SQL query that reproduces the exact behvaior:

- No queries are executed when both access permissions match.
- Only the relevant column/s  is/are upated according to which access permission differs. 

## Execution time difference
### Data setup
A realm with 
 - `6k` users.
 - `3,472` total Attachments.
 - `17,756` total Messages. 

The function simulates exactly (only for the "relevatn" update attachment part) moving a topic with `436` messages, `2` archived (deleted) messages, `434` attachments, and `75` archived attachments. 

I tested against the first case (4 queries) using  `%timeit -n 1000 -r 10 function()` essentially running each one **10k** times:

#### Results
 - Main (4 ORM queries) -->  **43** ms
 - PR (single raw query) --> **9** ms	

A reduction in execution time by **80%** and PR is **4.7x** faster than main !


# 2nd commit
## Author
Identified by Claude and fully implemented by me. 

## Details
In `do_update_message`, only `user_profile_id` and `flags` fields for  `UserMessage`s are needed, so we replace the full rows fetch with just those two.

This is significantly more efficient when moving a  topic/message in large streams. For example, a stream with **20k** results in fetching **20k**  `UserMessag` rows. We now fetch 2 fewer columns from the large `UserMessage` table and avoid building full ORM objects in memory for potentially thousands of rows.

## Execution time difference
Code setup that simulates fetching 20k rows and doing the real work done in `do_update_message` :

```python
# Main
def fetch_ums():
    ums = UserMessage.objects.all()[:20_000]
    usage = list(map(user_info, ums))

# PR
def fetch_ums():
    ums = UserMessage.objects.all()[:20_000].values_list("user_profile_id", "flags")
    usage = list(map(user_info, ums))
```
Tested using `%timeit -n 100 -r 10 func()`, running each function 1k times

### Results
 - Main -->  **386 ms**
 - PR   --> **74 ms**

A reduction in execution time by **80%** and PR is **~5x** faster than main !

# 3rd commit
## Author
Identified by me and partially implemented by me. 

## Details
Inside `update_user_topic_visibility_policies_on_move`, we call `get_users_with_user_topic_visibility_policy` twice: one for target (stream, topic_name) and another for original (stream, topic_name) resulting in two separate queries.

**Changes:**  Replace the 2 calls to that function with a single parallel helper  `get_users_with_user_topic_visibility_policy_on_move` which executes a single query and ORs the two pairs, matching the exact same rows fetched by the two calls to the original function.

# 4th commit
## Author
Identified by me and full implemented by me. 

## Details
More of a cleanup, consistency, and being Python idiomatic than a real performance gain.

## Execution time difference
Difference is negligible especially on few rows but **commit** is **still faster** than main.

Tested using `%timeit -n 1000 -r 10 func()`, running each function 10k times. The Test fetches **5k** `active_user_ids` rows in each case.
 
### Results
 - Main -->  **7.6 ms**
 - PR   --> **3.6 ms**

# 5th commit

## Author
Identified by Claude and implemented by me. 

## Details
A lot of changes I know. **But**, the main idea is that we replace the  4 and 5 `Subscription` queries with a single query, construct all the needed sets in Python by iterating over the fetched query once, and apply the filters (previously done in db) using Python Set Algebra. 

A lot of motivations besides saving 3 and 4 db round trips:
- Each execution of those queries is expensive: For example `users_losing_access` in **main** is a `.difference()` queryset (`old_stream_all_users` EXCEPT `new_stream_current_users`) and it was planned and executed **3 times** , once standalone for the `delete_message` event, and twice more inlined as a nested subquery inside `exclude_duplicates_from_subscription` function.
- Those separate queries share the same underlying data, they are just filtered differently.
- Set Algebra in Python is very fast.

I refactored the code to be cleaner and simpler. At first glance, it might seem that we diverged logically from `main` but I  made sure that the exact behavior is preserved. 

# 6th commit
Typo fix

# 7th and 8th commit

## Author
Identified and implemented by Claude. 

## Details
Details are in the commit message, it's detailed on purpose for explantion and cam be ammended later.

 