### PR TITLE
invite: Improve handling of comma-separated email input.

### DIFF
--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -91,7 +91,7 @@ export function create_pills(
         create_item_from_text: create_item_from_email,
         get_text_from_item: get_email_from_item,
         get_display_value_from_item: get_email_from_item,
-        split_text_on_comma: false,
+        allow_comma_in_item_text: true,
         split_text_to_form_pills: split_text_to_form_email_pills,
         generate_pill_html,
     });

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -92,6 +92,7 @@ export function create_pills(
         get_text_from_item: get_email_from_item,
         get_display_value_from_item: get_email_from_item,
         allow_comma_in_item_text: true,
+        create_pill_on_comma: true,
         split_text_to_form_pills: split_text_to_form_email_pills,
         generate_pill_html,
     });

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -41,13 +41,13 @@ export function get_email_from_item(item: EmailPill): string {
     return item.email;
 }
 
-export function get_current_email(
+export function get_current_emails(
     pill_container: input_pill.InputPillContainer<EmailPill>,
 ): string | null {
     const current_text = pill_container.getCurrentText();
     if (current_text !== null) {
-        const parsed_address = parseOneAddress(current_text);
-        if (parsed_address?.type === "mailbox") {
+        const parsed_addresses = parseAddressList(current_text);
+        if (parsed_addresses !== null && parsed_addresses.length > 0) {
             return current_text;
         }
     }

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -41,13 +41,13 @@ export function get_email_from_item(item: EmailPill): string {
     return item.email;
 }
 
-export function get_current_email(
+export function get_current_emails(
     pill_container: input_pill.InputPillContainer<EmailPill>,
 ): string | null {
     const current_text = pill_container.getCurrentText();
     if (current_text !== null) {
-        const parsed_address = parseOneAddress(current_text);
-        if (parsed_address?.type === "mailbox") {
+        const parsed_addresses = parseAddressList(current_text);
+        if (parsed_addresses !== null && parsed_addresses.length > 0) {
             return current_text;
         }
     }
@@ -92,6 +92,7 @@ export function create_pills(
         get_text_from_item: get_email_from_item,
         get_display_value_from_item: get_email_from_item,
         allow_comma_in_item_text: true,
+        create_pill_on_comma: true,
         split_text_to_form_pills: split_text_to_form_email_pills,
         generate_pill_html,
     });

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -21,7 +21,7 @@ export type InputPillConfig = {
 type InputPillCreateOptions<ItemType> = {
     $container: JQuery;
     pill_config?: InputPillConfig | undefined;
-    split_text_on_comma?: boolean;
+    allow_comma_in_item_text?: boolean;
     convert_to_pill_on_enter?: boolean;
     create_item_from_text: (
         text: string,
@@ -61,7 +61,7 @@ type InputPillStore<ItemType> = {
     onPillRemove?: (pill: InputPill<ItemType>, trigger: RemovePillTrigger) => void;
     onPillExpand?: (pill: JQuery) => void;
     createPillonPaste?: () => void;
-    split_text_on_comma: boolean;
+    allow_comma_in_item_text: boolean;
     convert_to_pill_on_enter: boolean;
     show_outline_on_invalid_input: boolean;
     split_text_to_form_pills: InputPillCreateOptions<ItemType>["split_text_to_form_pills"];
@@ -108,7 +108,7 @@ export function create<ItemType extends {type: string}>(
         create_item_from_text: opts.create_item_from_text,
         get_text_from_item: opts.get_text_from_item,
         get_display_value_from_item: opts.get_display_value_from_item,
-        split_text_on_comma: opts.split_text_on_comma ?? true,
+        allow_comma_in_item_text: opts.allow_comma_in_item_text ?? false,
         convert_to_pill_on_enter: opts.convert_to_pill_on_enter ?? true,
         generate_pill_html: opts.generate_pill_html,
         on_pill_exit: opts.on_pill_exit,
@@ -204,7 +204,7 @@ export function create<ItemType extends {type: string}>(
             if (value.length === 0) {
                 return true;
             }
-            if (store.split_text_on_comma && value.includes(",")) {
+            if (!store.allow_comma_in_item_text && value.includes(",")) {
                 funcs.insertManyPills(value);
                 return false;
             }
@@ -273,7 +273,7 @@ export function create<ItemType extends {type: string}>(
 
         insertManyPills(pills: string | string[]) {
             if (typeof pills === "string") {
-                if (!store.split_text_on_comma && store.split_text_to_form_pills) {
+                if (store.allow_comma_in_item_text && store.split_text_to_form_pills) {
                     pills = store.split_text_to_form_pills(pills);
                 } else {
                     pills = pills.split(/,/g).map((pill) => pill.trim());
@@ -367,7 +367,7 @@ export function create<ItemType extends {type: string}>(
                 if (value.length > 0) {
                     // If there are multiple values separated by commas, we should use insertManyPills
                     // to handle them properly when pressing the Enter key.
-                    if (!store.split_text_on_comma && value.includes(",")) {
+                    if (store.allow_comma_in_item_text && value.includes(",")) {
                         funcs.insertManyPills(value);
                         return;
                     }
@@ -416,7 +416,7 @@ export function create<ItemType extends {type: string}>(
 
             // Typing of the comma is prevented if the last field doesn't validate,
             // as well as when the new pill is created.
-            if (e.key === "," && store.split_text_on_comma) {
+            if (e.key === "," && !store.allow_comma_in_item_text) {
                 // if the pill is successful, it will create the pill and clear
                 // the input.
                 if (funcs.appendPill(store.$input.text().trim())) {

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -22,6 +22,7 @@ type InputPillCreateOptions<ItemType> = {
     $container: JQuery;
     pill_config?: InputPillConfig | undefined;
     allow_comma_in_item_text?: boolean;
+    create_pill_on_comma?: boolean;
     convert_to_pill_on_enter?: boolean;
     create_item_from_text: (
         text: string,
@@ -62,6 +63,7 @@ type InputPillStore<ItemType> = {
     onPillExpand?: (pill: JQuery) => void;
     createPillonPaste?: () => void;
     allow_comma_in_item_text: boolean;
+    create_pill_on_comma: boolean;
     convert_to_pill_on_enter: boolean;
     show_outline_on_invalid_input: boolean;
     split_text_to_form_pills: InputPillCreateOptions<ItemType>["split_text_to_form_pills"];
@@ -109,6 +111,8 @@ export function create<ItemType extends {type: string}>(
         get_text_from_item: opts.get_text_from_item,
         get_display_value_from_item: opts.get_display_value_from_item,
         allow_comma_in_item_text: opts.allow_comma_in_item_text ?? false,
+        create_pill_on_comma:
+            opts.create_pill_on_comma ?? !(opts.allow_comma_in_item_text ?? false),
         convert_to_pill_on_enter: opts.convert_to_pill_on_enter ?? true,
         generate_pill_html: opts.generate_pill_html,
         on_pill_exit: opts.on_pill_exit,
@@ -146,14 +150,16 @@ export function create<ItemType extends {type: string}>(
             return store.$input.text().trim() !== "";
         },
 
-        create_item(text: string) {
+        create_item(text: string, show_invalid_feedback = true) {
             const existing_items = funcs.items();
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
             if (!item) {
-                store.$input.addClass("shake");
+                if (show_invalid_feedback) {
+                    store.$input.addClass("shake");
 
-                if (store.show_outline_on_invalid_input) {
-                    store.$parent.addClass("invalid");
+                    if (store.show_outline_on_invalid_input) {
+                        store.$parent.addClass("invalid");
+                    }
                 }
                 return undefined;
             }
@@ -200,7 +206,7 @@ export function create<ItemType extends {type: string}>(
 
         // this appends a pill to the end of the container but before the
         // input block.
-        appendPill(value: string) {
+        appendPill(value: string, show_invalid_feedback = true) {
             if (value.length === 0) {
                 return true;
             }
@@ -209,7 +215,7 @@ export function create<ItemType extends {type: string}>(
                 return false;
             }
 
-            const payload = this.create_item(value);
+            const payload = this.create_item(value, show_invalid_feedback);
             // if the pill object is undefined, then it means the pill was
             // rejected so we should return out of this.
             if (payload === undefined) {
@@ -416,15 +422,20 @@ export function create<ItemType extends {type: string}>(
 
             // Typing of the comma is prevented if the last field doesn't validate,
             // as well as when the new pill is created.
-            if (e.key === "," && !store.allow_comma_in_item_text) {
-                // if the pill is successful, it will create the pill and clear
-                // the input.
-                if (funcs.appendPill(store.$input.text().trim())) {
+            if (e.key === ",") {
+                if (
+                    store.create_pill_on_comma &&
+                    funcs.appendPill(store.$input.text().trim(), !store.allow_comma_in_item_text)
+                ) {
                     funcs.clear(util.the(store.$input));
+                    e.preventDefault();
+                    return;
                 }
-                e.preventDefault();
 
-                return;
+                if (!store.allow_comma_in_item_text) {
+                    e.preventDefault();
+                    return;
+                }
             }
         });
 

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -22,6 +22,7 @@ type InputPillCreateOptions<ItemType> = {
     $container: JQuery;
     pill_config?: InputPillConfig | undefined;
     allow_comma_in_item_text?: boolean;
+    create_pill_on_comma?: boolean;
     convert_to_pill_on_enter?: boolean;
     create_item_from_text: (
         text: string,
@@ -62,6 +63,7 @@ type InputPillStore<ItemType> = {
     onPillExpand?: (pill: JQuery) => void;
     createPillonPaste?: () => void;
     allow_comma_in_item_text: boolean;
+    create_pill_on_comma: boolean;
     convert_to_pill_on_enter: boolean;
     show_outline_on_invalid_input: boolean;
     split_text_to_form_pills: InputPillCreateOptions<ItemType>["split_text_to_form_pills"];
@@ -100,6 +102,7 @@ export function create<ItemType extends {type: string}>(
 ): InputPillContainer<ItemType> {
     // a stateful object of this `pill_container` instance.
     // all unique instance information is stored in here.
+    const allow_comma_in_item_text = opts.allow_comma_in_item_text ?? false;
     const store: InputPillStore<ItemType> = {
         pills: [],
         pill_config: opts.pill_config,
@@ -108,7 +111,8 @@ export function create<ItemType extends {type: string}>(
         create_item_from_text: opts.create_item_from_text,
         get_text_from_item: opts.get_text_from_item,
         get_display_value_from_item: opts.get_display_value_from_item,
-        allow_comma_in_item_text: opts.allow_comma_in_item_text ?? false,
+        allow_comma_in_item_text,
+        create_pill_on_comma: opts.create_pill_on_comma ?? !allow_comma_in_item_text,
         convert_to_pill_on_enter: opts.convert_to_pill_on_enter ?? true,
         generate_pill_html: opts.generate_pill_html,
         on_pill_exit: opts.on_pill_exit,
@@ -146,14 +150,16 @@ export function create<ItemType extends {type: string}>(
             return store.$input.text().trim() !== "";
         },
 
-        create_item(text: string) {
+        create_item(text: string, show_invalid_feedback = true) {
             const existing_items = funcs.items();
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
             if (!item) {
-                store.$input.addClass("shake");
+                if (show_invalid_feedback) {
+                    store.$input.addClass("shake");
 
-                if (store.show_outline_on_invalid_input) {
-                    store.$parent.addClass("invalid");
+                    if (store.show_outline_on_invalid_input) {
+                        store.$parent.addClass("invalid");
+                    }
                 }
                 return undefined;
             }
@@ -200,7 +206,7 @@ export function create<ItemType extends {type: string}>(
 
         // this appends a pill to the end of the container but before the
         // input block.
-        appendPill(value: string) {
+        appendPill(value: string, show_invalid_feedback = true) {
             if (value.length === 0) {
                 return true;
             }
@@ -209,7 +215,7 @@ export function create<ItemType extends {type: string}>(
                 return false;
             }
 
-            const payload = this.create_item(value);
+            const payload = this.create_item(value, show_invalid_feedback);
             // if the pill object is undefined, then it means the pill was
             // rejected so we should return out of this.
             if (payload === undefined) {
@@ -416,15 +422,22 @@ export function create<ItemType extends {type: string}>(
 
             // Typing of the comma is prevented if the last field doesn't validate,
             // as well as when the new pill is created.
-            if (e.key === "," && !store.allow_comma_in_item_text) {
-                // if the pill is successful, it will create the pill and clear
-                // the input.
-                if (funcs.appendPill(store.$input.text().trim())) {
+            if (e.key === ",") {
+                const trimmed_text = store.$input.text().trim();
+                if (
+                    trimmed_text.length > 0 &&
+                    store.create_pill_on_comma &&
+                    funcs.appendPill(trimmed_text, !store.allow_comma_in_item_text)
+                ) {
                     funcs.clear(util.the(store.$input));
+                    e.preventDefault();
+                    return;
                 }
-                e.preventDefault();
 
-                return;
+                if (!store.allow_comma_in_item_text) {
+                    e.preventDefault();
+                    return;
+                }
             }
         });
 

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -119,12 +119,12 @@ function get_common_invitation_data(): CommonInvitationData {
             .join(","),
         include_realm_default_subscriptions: JSON.stringify(include_realm_default_subscriptions),
     };
-    const current_email = email_pill.get_current_email(email_pill_widget);
-    if (current_email) {
+    const current_emails = email_pill.get_current_emails(email_pill_widget);
+    if (current_emails) {
         if (email_pill_widget.items().length === 0) {
-            data.invitee_emails = current_email;
+            data.invitee_emails = current_emails;
         } else {
-            data.invitee_emails += "," + current_email;
+            data.invitee_emails += "," + current_emails;
         }
     }
 
@@ -568,7 +568,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
                 !user_has_email_set ||
                     (selected_tab === "invite-email-tab" &&
                         email_pill_widget.items().length === 0 &&
-                        email_pill.get_current_email(email_pill_widget) === null) ||
+                        email_pill.get_current_emails(email_pill_widget) === null) ||
                     ($expires_in.val() === "custom" && !valid_custom_time),
             );
             if (selected_tab === "invite-email-tab") {

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -359,7 +359,7 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
         $container: $pill_container,
         create_item_from_text: create_item_from_search_string,
         get_text_from_item: get_search_string_from_item,
-        split_text_on_comma: false,
+        allow_comma_in_item_text: true,
         convert_to_pill_on_enter: false,
         generate_pill_html(item) {
             switch (item.operator) {

--- a/web/tests/email_pill.test.cjs
+++ b/web/tests/email_pill.test.cjs
@@ -1,0 +1,40 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const email_pill = zrequire("email_pill");
+
+run_test("get_current_emails", () => {
+    let current_text = null;
+    const mock_pill_container = {
+        getCurrentText: () => current_text,
+    };
+
+    // When current text is null
+    assert.equal(email_pill.get_current_emails(mock_pill_container), null);
+
+    // Single valid email address
+    current_text = "alice@example.com";
+    assert.equal(email_pill.get_current_emails(mock_pill_container), "alice@example.com");
+
+    // Multiple comma-separated email addresses
+    current_text = "alice@example.com, bob@example.com";
+    assert.equal(
+        email_pill.get_current_emails(mock_pill_container),
+        "alice@example.com, bob@example.com",
+    );
+
+    // Comma-separated emails with display names
+    current_text = '"Alice Smith" <alice@example.com>, "Bob Jones" <bob@example.com>';
+    assert.equal(
+        email_pill.get_current_emails(mock_pill_container),
+        '"Alice Smith" <alice@example.com>, "Bob Jones" <bob@example.com>',
+    );
+
+    // Invalid email input
+    current_text = "not-an-email";
+    assert.equal(email_pill.get_current_emails(mock_pill_container), null);
+});

--- a/web/tests/input_pill.test.cjs
+++ b/web/tests/input_pill.test.cjs
@@ -287,6 +287,40 @@ run_test("comma", ({mock_template}) => {
     });
 
     assert.deepEqual(widget.items(), [items.blue, items.red, items.yellow]);
+
+    // Test with allow_comma_in_item_text: true
+    {
+        $.clear_all_elements();
+        const info = set_up();
+        const config = {
+            ...info.config,
+            allow_comma_in_item_text: true,
+            create_pill_on_comma: true,
+        };
+        const widget = input_pill.create(config);
+        widget.appendValue("blue");
+
+        const key_handler = info.$container.get_on_handler("keydown", ".input");
+        const $pill_input = info.$pill_input;
+
+        // Invalid item should NOT clear the input when a comma is pressed
+        $pill_input.text(" yel");
+        key_handler({
+            key: ",",
+            preventDefault: noop,
+        });
+        assert.deepEqual(widget.items(), [items.blue]);
+        assert.equal($pill_input.text(), " yel");
+
+        // Valid item SHOULD be converted to a pill and the input cleared
+        $pill_input.text(" yellow");
+        key_handler({
+            key: ",",
+            preventDefault: noop,
+        });
+        assert.deepEqual(widget.items(), [items.blue, items.yellow]);
+        assert.equal($pill_input.text(), "");
+    }
 });
 
 run_test("Enter key with text", ({mock_template}) => {

--- a/web/tests/input_pill.test.cjs
+++ b/web/tests/input_pill.test.cjs
@@ -287,6 +287,56 @@ run_test("comma", ({mock_template}) => {
     });
 
     assert.deepEqual(widget.items(), [items.blue, items.red, items.yellow]);
+
+    // Test with allow_comma_in_item_text: true
+    {
+        $.clear_all_elements();
+        const info = set_up();
+        const config = {
+            ...info.config,
+            allow_comma_in_item_text: true,
+            create_pill_on_comma: true,
+        };
+        const widget = input_pill.create(config);
+        widget.appendValue("blue");
+
+        const key_handler = info.$container.get_on_handler("keydown", ".input");
+        const $pill_input = info.$pill_input;
+
+        let prevent_default_count = 0;
+        const preventDefault = () => {
+            prevent_default_count += 1;
+        };
+
+        // Pressing comma on empty input should NOT prevent default
+        $pill_input.text("");
+        key_handler({
+            key: ",",
+            preventDefault,
+        });
+        assert.equal(prevent_default_count, 0);
+        assert.deepEqual(widget.items(), [items.blue]);
+
+        // Invalid item should NOT clear the input when a comma is pressed
+        $pill_input.text(" yel");
+        key_handler({
+            key: ",",
+            preventDefault,
+        });
+        assert.equal(prevent_default_count, 0);
+        assert.deepEqual(widget.items(), [items.blue]);
+        assert.equal($pill_input.text(), " yel");
+
+        // Valid item SHOULD be converted to a pill and the input cleared
+        $pill_input.text(" yellow");
+        key_handler({
+            key: ",",
+            preventDefault,
+        });
+        assert.equal(prevent_default_count, 1);
+        assert.deepEqual(widget.items(), [items.blue, items.yellow]);
+        assert.equal($pill_input.text(), "");
+    }
 });
 
 run_test("Enter key with text", ({mock_template}) => {


### PR DESCRIPTION
<!-- Describe your pull request here. -->
This PR improves the email input behavior in the invite modal by allowing a comma to behave like Enter when typed immediately after a valid email address.
Previously, pressing Enter after typing a valid email would create an email pill, but pressing a comma would leave the email as plain text. This change preserves the existing behavior that allows commas inside display names (for example, `"Satyam, Monkey" <satyam@example.com>`), while creating an email pill when the text before the comma is itself a valid email address.
**Key Changes:**
- Renamed the confusing `split_text_on_comma` configuration property to `allow_comma_in_item_text` so the intent is clearer.
- Introduced a new configuration property `create_pill_on_comma` to explicitly enable this eager pill-creation behavior for email pills without breaking comma usage in search pills.
- Renamed `ignore_invalid_text` to `show_invalid_feedback` to remove double negatives and improve clarity.
- Updated `get_current_email` to `get_current_emails` so that multiple pending valid email addresses in the input continue to be recognized and parsed correctly by the invite form.
Fixes: #39432
**How changes were tested:**
- Added a new test to `input_pill.test.cjs` to specifically verify the comma behavior when `allow_comma_in_item_text` and `create_pill_on_comma` are `true`.
- Ran the Node test suite locally (`./tools/test-js-with-node`) to ensure 100% statement and branch coverage is maintained.
- Manually tested pasting a list of emails, typing individual emails followed by a comma, and typing display names with commas.

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/83bd288e-92bf-47fe-9b08-4820eea6a937



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
