### PR TITLE
user card: Display pronouns in header area.

### DIFF
--- a/api_docs/unmerged.d/ZF-dd215b.md
+++ b/api_docs/unmerged.d/ZF-dd215b.md
@@ -1,0 +1,1 @@
+* [`POST /register`](/api/register-queue): Added `max_display_in_profile_summary_fields` to the response, which specifies the maximum number of custom profile fields that can be displayed in the profile summary (user card). Note that the first pronoun field (by order) does not count toward this limit.

--- a/starlight_help/src/content/docs/custom-profile-fields.mdx
+++ b/starlight_help/src/content/docs/custom-profile-fields.mdx
@@ -84,6 +84,12 @@ There's a limit to the number of custom profile fields that can be displayed
 at a time. If the maximum number of fields is already selected, all unselected
 checkboxes will be disabled.
 
+**Special behavior for Pronouns fields:** If you have multiple Pronouns fields,
+the first one (by order) is always displayed on user cards and does not count
+toward the display limit. Its **Display on user card** checkbox will be checked
+and disabled. This ensures that pronouns are prominently displayed to help users
+address each other respectfully.
+
 <FlattenedSteps>
   <NavigationSteps target="settings/profile-field-settings" />
 

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -313,9 +313,12 @@ function update_form_for_field_type_selection(): void {
     // Not showing "display on user card" option for long text/user profile field.
     if (is_valid_to_display_in_summary(profile_field_type)) {
         $("#profile_field_display_in_profile_summary").closest(".input-group").show();
+        const is_pronoun_field = profile_field_type === field_types.PRONOUNS.id;
+        const is_first_pronoun_field =
+            is_pronoun_field && get_first_pronoun_field_id_by_order() === null;
         const check_display_in_profile_summary_by_default =
-            profile_field_type === field_types.PRONOUNS.id &&
-            !display_in_profile_summary_fields_limit_reached;
+            is_first_pronoun_field ||
+            (is_pronoun_field && !display_in_profile_summary_fields_limit_reached);
         $("#profile_field_display_in_profile_summary").prop(
             "checked",
             check_display_in_profile_summary_by_default,
@@ -484,7 +487,7 @@ function show_modal_for_deleting_options(
     });
 }
 
-function get_profile_field(id: number): CustomProfileField | undefined {
+export function get_profile_field(id: number): CustomProfileField | undefined {
     return realm.custom_profile_fields.find((field) => field.id === id);
 }
 
@@ -641,16 +644,28 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
 
     function set_initial_values_of_profile_field(): void {
         const $profile_field_form = $("#edit-custom-profile-field-form-" + field_id);
+        const first_pronoun_id = get_first_pronoun_field_id_by_order();
+        const is_first_pronoun = field_id === first_pronoun_id;
+        const $checkbox = $profile_field_form.find("input[name=display_in_profile_summary]");
+        const $label = $profile_field_form.find(".edit_profile_field_display_label");
 
-        // If it exceeds or equals the max limit, we are disabling option for display custom
-        // profile field on user card and adding tooltip, unless the field is already checked.
-        if (display_in_profile_summary_fields_limit_reached && !field.display_in_profile_summary) {
-            $profile_field_form
-                .find("input[name=display_in_profile_summary]")
-                .prop("disabled", true);
-            $profile_field_form
-                .find(".edit_profile_field_display_label")
-                .addClass("display_in_profile_summary_tooltip disabled_label");
+        // The first pronoun field is always disabled and checked. For other fields,
+        // if the limit is reached, we disable the option to display the custom profile
+        // field on user card and add a tooltip, unless the field is already checked.
+        if (is_first_pronoun) {
+            $checkbox.prop({
+                disabled: true,
+                checked: true,
+            });
+            $label
+                .removeClass("display_in_profile_summary_tooltip disabled_label")
+                .addClass("first_pronoun_field_tooltip");
+        } else if (
+            display_in_profile_summary_fields_limit_reached &&
+            !field.display_in_profile_summary
+        ) {
+            $checkbox.prop("disabled", true);
+            $label.addClass("display_in_profile_summary_tooltip disabled_label");
         }
 
         if (field.type === field_types.DROPDOWN.id) {
@@ -777,10 +792,25 @@ function open_custom_profile_field_edit_form_modal(this: HTMLElement): void {
     });
 }
 
-// If exceeds or equals the max limit, we are disabling option for
-// display custom profile field on user card and adding tooltip.
-function update_profile_fields_checkboxes(): void {
-    // Disabling only uncheck checkboxes in table, so user should able uncheck checked checkboxes.
+export function get_first_field_id_by_type_and_order(field_type: number): number | null {
+    const matching_fields = realm.custom_profile_fields
+        .filter((field) => field.type === field_type)
+        .toSorted((a, b) => a.order - b.order);
+
+    return matching_fields[0]?.id ?? null;
+}
+
+export function get_first_pronoun_field_id_by_order(): number | null {
+    return get_first_field_id_by_type_and_order(realm.custom_profile_field_types.PRONOUNS.id);
+}
+
+function update_profile_fields_checkboxes(first_pronoun_id: number | null): void {
+    const count = realm.custom_profile_fields.filter(
+        (field) => field.display_in_profile_summary === true && field.id !== first_pronoun_id,
+    ).length;
+    display_in_profile_summary_fields_limit_reached =
+        count >= realm.max_display_in_profile_summary_fields;
+
     $("#admin_profile_fields_table .display_in_profile_summary_checkbox_false").prop(
         "disabled",
         display_in_profile_summary_fields_limit_reached,
@@ -796,6 +826,17 @@ function toggle_display_in_profile_summary_profile_field(
     _event: JQuery.Event,
 ): void {
     const field_id = Number.parseInt($(this).attr("data-profile-field-id")!, 10);
+
+    const first_pronoun_id = get_first_pronoun_field_id_by_order();
+    if (field_id === first_pronoun_id && !this.checked) {
+        this.checked = true;
+        return;
+    }
+
+    if (this.checked && display_in_profile_summary_fields_limit_reached) {
+        this.checked = false;
+        return;
+    }
 
     const data = {
         display_in_profile_summary: this.checked,
@@ -854,19 +895,12 @@ export function populate_profile_fields(profile_fields_data: CustomProfileField[
 export function do_populate_profile_fields(profile_fields_data: CustomProfileField[]): void {
     // We should only call this internally or from tests.
     const $profile_fields_table = $("#admin_profile_fields_table").expectOne();
+    const first_pronoun_id = get_first_pronoun_field_id_by_order();
 
     order = [];
 
-    let display_in_profile_summary_fields_count = 0;
-
     for (const profile_field of profile_fields_data) {
         order.push(profile_field.id);
-
-        // Keeping counts of all display_in_profile_summary profile fields,
-        // to keep track of whether the limit has been reached.
-        if (profile_field.display_in_profile_summary) {
-            display_in_profile_summary_fields_count += 1;
-        }
     }
 
     ListWidget.create($profile_fields_table, profile_fields_data, {
@@ -877,6 +911,7 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
         modifier_html(profile_field) {
             const display_in_profile_summary = profile_field.display_in_profile_summary === true;
             const required = profile_field.required;
+            const is_first_pronoun_field = first_pronoun_id === profile_field.id;
 
             return render_admin_profile_field_list({
                 profile_field: {
@@ -887,6 +922,7 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
                     display_in_profile_summary,
                     valid_to_display_in_summary: is_valid_to_display_in_summary(profile_field.type),
                     required,
+                    is_first_pronoun_field,
                 },
                 can_modify: current_user.is_admin,
                 realm_default_external_accounts: realm.realm_default_external_accounts,
@@ -895,9 +931,6 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
         $parent_container: $("#profile-field-settings").expectOne(),
         $simplebar_container: $("#profile-field-settings .progressive-table-wrapper"),
     });
-
-    // Update whether we're at the limit for display_in_profile_summary.
-    display_in_profile_summary_fields_limit_reached = display_in_profile_summary_fields_count >= 2;
 
     if (current_user.is_admin) {
         const field_list = util.the($("#admin_profile_fields_table"));
@@ -908,7 +941,7 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
         });
     }
 
-    update_profile_fields_checkboxes();
+    update_profile_fields_checkboxes(first_pronoun_id);
     loading.destroy_indicator($("#admin_page_profile_fields_loading_indicator"));
 }
 

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -452,6 +452,7 @@ export const realm_schema = z.object({
     max_avatar_file_size_mib: z.number(),
     max_channel_folder_description_length: z.number(),
     max_channel_folder_name_length: z.number(),
+    max_display_in_profile_summary_fields: z.number(),
     max_file_upload_size_mib: z.number(),
     max_icon_file_size_mib: z.number(),
     max_logo_file_size_mib: z.number(),

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -439,6 +439,23 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: [
+            "#profile-field-settings .first_pronoun_field_tooltip",
+            "#edit-custom-profile-field-form-modal .first_pronoun_field_tooltip",
+        ].join(","),
+        content: $t({
+            defaultMessage:
+                "This pronoun field is displayed prominently on the user card, and does not count against the user card’s limit on custom fields.",
+        }),
+        appendTo: () => document.body,
+        onTrigger(instance) {
+            if (!instance.reference.classList.contains("first_pronoun_field_tooltip")) {
+                instance.destroy();
+            }
+        },
+    });
+
+    tippy.delegate("body", {
         target: "#full_name_input_container.disabled_setting_tooltip",
         content: $t({
             defaultMessage:

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -40,6 +40,7 @@ import {hide_all} from "./popovers.ts";
 import * as presence from "./presence.ts";
 import * as rows from "./rows.ts";
 import * as settings_panel_menu from "./settings_panel_menu.ts";
+import {get_first_pronoun_field_id_by_order, get_profile_field} from "./settings_profile_fields.ts";
 import * as sidebar_ui from "./sidebar_ui.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as timerender from "./timerender.ts";
@@ -225,6 +226,7 @@ type UserCardPopoverData = {
     user_last_seen_time_status: string;
     user_time: string | undefined;
     user_type: string | undefined;
+    user_pronouns: string | undefined;
     status_content_available: boolean;
     status_text: string | undefined;
     status_emoji_info: user_status.UserStatusEmojiInfo | undefined;
@@ -348,9 +350,35 @@ function get_user_card_popover_data(
     }
     // Filtering out only those profile fields that can be display in the popover and are not empty.
     const field_types = realm.custom_profile_field_types;
-    const display_profile_fields = realm.custom_profile_fields
-        .flatMap((f) => user_profile.get_custom_profile_field_data(user, f, field_types) ?? [])
-        .filter((f) => f.display_in_profile_summary && f.value !== undefined && f.value !== null);
+
+    // Get the first pronoun field (by order) to display in the header.
+    const first_pronoun_field_id = get_first_pronoun_field_id_by_order();
+
+    let pronouns = "";
+    if (first_pronoun_field_id !== null) {
+        const first_pronoun_field = get_profile_field(first_pronoun_field_id);
+        if (first_pronoun_field) {
+            const first_pronoun_data = user_profile.get_custom_profile_field_data(
+                user,
+                first_pronoun_field,
+                field_types,
+            );
+            if (first_pronoun_data) {
+                pronouns = first_pronoun_data.value ?? "";
+            }
+        }
+    }
+
+    const display_profile_fields = [];
+    for (const f of realm.custom_profile_fields) {
+        if (f.id === first_pronoun_field_id) {
+            continue;
+        }
+        const data = user_profile.get_custom_profile_field_data(user, f, field_types);
+        if (data?.display_in_profile_summary && data.value !== null && data.value !== undefined) {
+            display_profile_fields.push(data);
+        }
+    }
 
     const user_id_string = user.user_id.toString();
     const can_send_private_message =
@@ -379,6 +407,7 @@ function get_user_card_popover_data(
         user_last_seen_time_status,
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),
+        user_pronouns: pronouns,
         status_content_available: Boolean(status_text ?? status_emoji_info),
         status_text,
         status_emoji_info,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -898,13 +898,15 @@ ul.popover-group-menu-member-list {
         }
     }
 
-    .popover-menu-user-type {
+    .popover-menu-user-type,
+    .popover-menu-user-pronouns {
         /* 14px at 15px/1em */
         font-size: 0.9333em;
         font-weight: 400;
         /* 16px at 14px/1em */
         line-height: 1.1428em;
         color: var(--color-text-item);
+        overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -16,6 +16,9 @@
                     <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                 {{/if}}
             </div>
+            {{#if user_pronouns}}
+                <div class="popover-menu-user-pronouns">{{user_pronouns}}</div>
+            {{/if}}
             <div class="popover-menu-user-type">
                 {{#if is_bot}}
                     {{#if is_system_bot}}

--- a/web/templates/settings/admin_profile_field_list.hbs
+++ b/web/templates/settings/admin_profile_field_list.hbs
@@ -18,8 +18,8 @@
     <td class="display_in_profile_summary_cell">
         {{#if valid_to_display_in_summary}}
         <span class="profile_field_display_in_profile_summary">
-            <label class="checkbox display_in_profile_summary_{{#if display_in_profile_summary}}true{{else}}false{{/if}}" for="profile_field_display_in_profile_summary_{{id}}">
-                <input class="display_in_profile_summary display_in_profile_summary_checkbox_{{#if display_in_profile_summary}}true{{else}}false{{/if}}" type="checkbox" id="profile_field_display_in_profile_summary_{{id}}" {{#if display_in_profile_summary}} checked="checked" {{/if}} data-profile-field-id="{{id}}"/>
+            <label class="checkbox display_in_profile_summary_{{#if display_in_profile_summary}}true{{else}}false{{/if}}{{#if is_first_pronoun_field}} first_pronoun_field_tooltip{{/if}}" for="profile_field_display_in_profile_summary_{{id}}">
+                <input class="display_in_profile_summary display_in_profile_summary_checkbox_{{#if display_in_profile_summary}}true{{else}}false{{/if}}" type="checkbox" id="profile_field_display_in_profile_summary_{{id}}" {{#if display_in_profile_summary}} checked="checked" {{/if}}{{#if is_first_pronoun_field}} disabled="disabled"{{/if}} data-profile-field-id="{{id}}"/>
                 <span class="rendered-checkbox"></span>
             </label>
         </span>

--- a/web/tests/settings_profile_fields.test.cjs
+++ b/web/tests/settings_profile_fields.test.cjs
@@ -14,12 +14,14 @@ const DROPDOWN_ID = 3;
 const EXTERNAL_ACCOUNT_ID = 7;
 const PARAGRAPH_ID = 2;
 const USER_FIELD_ID = 6;
+const PRONOUNS_ID = 8;
 
 const SHORT_TEXT_NAME = "Short text";
 const DROPDOWN_NAME = "Dropdown";
 const EXTERNAL_ACCOUNT_NAME = "External account";
 const PARAGRAPH_NAME = "Paragraph";
 const USER_FIELD_NAME = "Person";
+const PRONOUNS_NAME = "Pronouns";
 
 const custom_profile_field_types = {
     SHORT_TEXT: {
@@ -41,6 +43,10 @@ const custom_profile_field_types = {
     USER: {
         id: USER_FIELD_ID,
         name: USER_FIELD_NAME,
+    },
+    PRONOUNS: {
+        id: PRONOUNS_ID,
+        name: PRONOUNS_NAME,
     },
 };
 
@@ -84,7 +90,7 @@ function test_populate(opts, template_data) {
 run_test("populate_profile_fields", ({mock_template, override}) => {
     make_list_widget_only_render_items(override);
 
-    override(realm, "custom_profile_fields", {});
+    override(realm, "custom_profile_fields", []);
     override(realm, "realm_default_external_accounts", JSON.stringify({}));
 
     const template_data = [];
@@ -159,6 +165,7 @@ run_test("populate_profile_fields", ({mock_template, override}) => {
                 display_in_profile_summary: false,
                 valid_to_display_in_summary: true,
                 required: false,
+                is_first_pronoun_field: false,
             },
             can_modify: true,
             realm_default_external_accounts: realm.realm_default_external_accounts,
@@ -172,6 +179,7 @@ run_test("populate_profile_fields", ({mock_template, override}) => {
                 display_in_profile_summary: false,
                 valid_to_display_in_summary: true,
                 required: false,
+                is_first_pronoun_field: false,
             },
             can_modify: true,
             realm_default_external_accounts: realm.realm_default_external_accounts,
@@ -185,6 +193,7 @@ run_test("populate_profile_fields", ({mock_template, override}) => {
                 display_in_profile_summary: true,
                 valid_to_display_in_summary: true,
                 required: false,
+                is_first_pronoun_field: false,
             },
             can_modify: true,
             realm_default_external_accounts: realm.realm_default_external_accounts,
@@ -198,6 +207,7 @@ run_test("populate_profile_fields", ({mock_template, override}) => {
                 display_in_profile_summary: true,
                 valid_to_display_in_summary: true,
                 required: false,
+                is_first_pronoun_field: false,
             },
             can_modify: true,
             realm_default_external_accounts: realm.realm_default_external_accounts,
@@ -212,4 +222,44 @@ run_test("populate_profile_fields", ({mock_template, override}) => {
         },
         template_data,
     );
+});
+
+run_test("get_first_field_id_by_type_and_order", ({override}) => {
+    override(realm, "custom_profile_fields", []);
+    assert.equal(settings_profile_fields.get_first_field_id_by_type_and_order(PRONOUNS_ID), null);
+
+    override(realm, "custom_profile_fields", [
+        {id: 10, type: PRONOUNS_ID, order: 5, name: "Pronouns", hint: "", field_data: ""},
+    ]);
+    assert.equal(settings_profile_fields.get_first_field_id_by_type_and_order(PRONOUNS_ID), 10);
+
+    override(realm, "custom_profile_fields", [
+        {id: 20, type: PRONOUNS_ID, order: 10, name: "Pronouns B", hint: "", field_data: ""},
+        {id: 10, type: PRONOUNS_ID, order: 3, name: "Pronouns A", hint: "", field_data: ""},
+        {id: 30, type: PRONOUNS_ID, order: 7, name: "Pronouns C", hint: "", field_data: ""},
+    ]);
+    assert.equal(settings_profile_fields.get_first_field_id_by_type_and_order(PRONOUNS_ID), 10);
+
+    override(realm, "custom_profile_fields", [
+        {id: 40, type: SHORT_TEXT_ID, order: 1, name: "Color", hint: "", field_data: ""},
+    ]);
+    assert.equal(settings_profile_fields.get_first_field_id_by_type_and_order(PRONOUNS_ID), null);
+});
+
+run_test("get_first_pronoun_field_id_by_order", ({override}) => {
+    override(realm, "custom_profile_field_types", custom_profile_field_types);
+
+    override(realm, "custom_profile_fields", []);
+    assert.equal(settings_profile_fields.get_first_pronoun_field_id_by_order(), null);
+
+    override(realm, "custom_profile_fields", [
+        {id: 99, type: PRONOUNS_ID, order: 1, name: "Pronouns", hint: "", field_data: ""},
+    ]);
+    assert.equal(settings_profile_fields.get_first_pronoun_field_id_by_order(), 99);
+
+    override(realm, "custom_profile_fields", [
+        {id: 50, type: PRONOUNS_ID, order: 20, name: "Pronouns B", hint: "", field_data: ""},
+        {id: 40, type: PRONOUNS_ID, order: 5, name: "Pronouns A", hint: "", field_data: ""},
+    ]);
+    assert.equal(settings_profile_fields.get_first_pronoun_field_id_by_order(), 40);
 });

--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -12,9 +12,19 @@ from zerver.lib.streams import render_stream_description
 from zerver.lib.types import ProfileDataElementUpdateDict, ProfileFieldData, UserProfileChangeDict
 from zerver.lib.users import get_user_ids_who_can_access_user
 from zerver.models import CustomProfileField, CustomProfileFieldValue, Realm, UserProfile
-from zerver.models.custom_profile_fields import custom_profile_fields_for_realm
+from zerver.models.custom_profile_fields import (
+    custom_profile_fields_for_realm,
+    get_first_pronoun_field,
+)
 from zerver.models.users import active_user_ids
 from zerver.tornado.django_api import send_event_on_commit
+
+
+class _FirstPronounFieldNotSpecified:
+    pass
+
+
+FirstPronounFieldNotSpecified: _FirstPronounFieldNotSpecified = _FirstPronounFieldNotSpecified()
 
 
 def notify_realm_custom_profile_fields(realm: Realm) -> None:
@@ -62,7 +72,16 @@ def try_add_realm_custom_profile_field(
     required: bool = False,
     editable_by_user: bool = True,
     use_for_user_matching: bool = False,
+    first_pronoun_field: CustomProfileField
+    | _FirstPronounFieldNotSpecified
+    | None = FirstPronounFieldNotSpecified,
 ) -> CustomProfileField:
+    if field_type == CustomProfileField.PRONOUNS:
+        if first_pronoun_field is FirstPronounFieldNotSpecified:
+            first_pronoun_field = get_first_pronoun_field(realm)
+        if first_pronoun_field is None:
+            display_in_profile_summary = True
+
     custom_profile_field = CustomProfileField(
         realm=realm,
         name=name,
@@ -92,7 +111,19 @@ def do_remove_realm_custom_profile_field(realm: Realm, field: CustomProfileField
     Deleting a field will also delete the user profile data
     associated with it in CustomProfileFieldValue model.
     """
+    first_pronoun_field_before_delete = (
+        get_first_pronoun_field(realm) if field.field_type == CustomProfileField.PRONOUNS else None
+    )
+    was_first_pronoun_field = first_pronoun_field_before_delete == field
+
     field.delete()
+
+    if was_first_pronoun_field:
+        new_first_pronoun_field = get_first_pronoun_field(realm)
+        if new_first_pronoun_field and not new_first_pronoun_field.display_in_profile_summary:
+            new_first_pronoun_field.display_in_profile_summary = True
+            new_first_pronoun_field.save(update_fields=["display_in_profile_summary"])
+
     notify_realm_custom_profile_fields(realm)
 
 
@@ -175,13 +206,47 @@ def try_update_realm_custom_profile_field(
 @transaction.atomic(durable=True)
 def try_reorder_realm_custom_profile_fields(realm: Realm, order: Iterable[int]) -> None:
     order_mapping = {_[1]: _[0] for _ in enumerate(order)}
-    custom_profile_fields = CustomProfileField.objects.filter(realm=realm)
+    custom_profile_fields = list(
+        CustomProfileField.objects.filter(realm=realm).select_for_update(no_key=False)
+    )
+
     for custom_profile_field in custom_profile_fields:
         if custom_profile_field.id not in order_mapping:
             raise JsonableError(_("Invalid order mapping."))
+
+    pronoun_fields = [
+        f for f in custom_profile_fields if f.field_type == CustomProfileField.PRONOUNS
+    ]
+    old_first_pronoun_field = min(pronoun_fields, key=lambda f: f.order) if pronoun_fields else None
+
+    new_first_pronoun_field = None
+    min_pronoun_order = float("inf")
+
     for custom_profile_field in custom_profile_fields:
         custom_profile_field.order = order_mapping[custom_profile_field.id]
+
+        if (
+            custom_profile_field.field_type == CustomProfileField.PRONOUNS
+            and custom_profile_field.order < min_pronoun_order
+        ):
+            min_pronoun_order = custom_profile_field.order
+            new_first_pronoun_field = custom_profile_field
+
         custom_profile_field.save(update_fields=["order"])
+
+    if (
+        old_first_pronoun_field is not None
+        and new_first_pronoun_field is not None
+        and old_first_pronoun_field.id != new_first_pronoun_field.id
+    ):
+        if not new_first_pronoun_field.display_in_profile_summary:
+            new_first_pronoun_field.display_in_profile_summary = True
+            new_first_pronoun_field.save(update_fields=["display_in_profile_summary"])
+
+        if old_first_pronoun_field.display_in_profile_summary:
+            old_first_pronoun_field.display_in_profile_summary = False
+            old_first_pronoun_field.save(update_fields=["display_in_profile_summary"])
+
     notify_realm_custom_profile_fields(realm)
 
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -596,6 +596,9 @@ def fetch_initial_state_data(
         state["max_channel_folder_name_length"] = ChannelFolder.MAX_NAME_LENGTH
         state["max_channel_folder_description_length"] = ChannelFolder.MAX_DESCRIPTION_LENGTH
         state["max_reminder_note_length"] = settings.MAX_REMINDER_NOTE_LENGTH
+        state["max_display_in_profile_summary_fields"] = (
+            CustomProfileField.MAX_DISPLAY_IN_PROFILE_SUMMARY_FIELDS
+        )
         if realm.demo_organization_scheduled_deletion_date is not None:
             state["demo_organization_scheduled_deletion_date"] = datetime_to_timestamp(
                 realm.demo_organization_scheduled_deletion_date

--- a/zerver/migrations/0810_set_display_in_profile_summary_for_first_pronoun_field.py
+++ b/zerver/migrations/0810_set_display_in_profile_summary_for_first_pronoun_field.py
@@ -1,0 +1,45 @@
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+
+def set_display_in_profile_summary_for_first_pronoun_field(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    """
+    Ensure the first pronoun field in each realm has display_in_profile_summary=True.
+    This matches the UI behavior where the first pronoun field checkbox is forced
+    to be checked and disabled.
+    """
+    Realm = apps.get_model("zerver", "Realm")
+    CustomProfileField = apps.get_model("zerver", "CustomProfileField")
+
+    PRONOUNS = 8
+
+    for realm in Realm.objects.all().iterator():
+        first_pronoun_field = (
+            CustomProfileField.objects.filter(
+                realm=realm,
+                field_type=PRONOUNS,
+            )
+            .order_by("order")
+            .first()
+        )
+
+        if first_pronoun_field and not first_pronoun_field.display_in_profile_summary:
+            first_pronoun_field.display_in_profile_summary = True
+            first_pronoun_field.save(update_fields=["display_in_profile_summary"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0809_remove_message_nulls_last_topic_indexes"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            set_display_in_profile_summary_for_first_pronoun_field,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        )
+    ]

--- a/zerver/models/custom_profile_fields.py
+++ b/zerver/models/custom_profile_fields.py
@@ -196,6 +196,17 @@ def custom_profile_fields_for_realm(realm_id: int) -> QuerySet[CustomProfileFiel
     return CustomProfileField.objects.filter(realm=realm_id).order_by("order")
 
 
+def get_first_pronoun_field(realm: Realm) -> CustomProfileField | None:
+    return (
+        CustomProfileField.objects.filter(
+            realm=realm,
+            field_type=CustomProfileField.PRONOUNS,
+        )
+        .order_by("order")
+        .first()
+    )
+
+
 class CustomProfileFieldValue(models.Model):
     user_profile = models.ForeignKey(UserProfile, on_delete=CASCADE)
     field = models.ForeignKey(CustomProfileField, on_delete=CASCADE)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18876,6 +18876,16 @@ paths:
 
                           **Changes**: New in Zulip 11.0 (feature level 410). Clients should use
                           1024 as a fallback value on previous feature levels.
+                      max_display_in_profile_summary_fields:
+                        type: integer
+                        description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
+                          The maximum number of custom profile fields that can be displayed
+                          in the profile summary (user card). Note that the first pronoun field
+                          (by order) does not count toward this limit.
+
+                          **Changes**: New in Zulip 12.0 (feature level ZF-dd215b).
                       max_topic_length:
                         type: integer
                         description: |

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -713,9 +713,148 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
                 "display_in_profile_summary": "true",
             },
         )
+        self.assert_json_success(result)
+        field.refresh_from_db()
+        self.assertEqual(field.display_in_profile_summary, True)
+
+        field = CustomProfileField.objects.get(name="Favorite editor", realm=realm)
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            info={
+                "display_in_profile_summary": "true",
+            },
+        )
         self.assert_json_error(
             result, "Only 2 custom profile fields can be displayed in the profile summary."
         )
+
+    def test_first_pronoun_field_must_be_displayed(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+
+        pronoun_field = CustomProfileField.objects.get(name="Pronouns", realm=realm)
+
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{pronoun_field.id}",
+            info={
+                "display_in_profile_summary": "true",
+            },
+        )
+        self.assert_json_success(result)
+        pronoun_field.refresh_from_db()
+        self.assertEqual(pronoun_field.display_in_profile_summary, True)
+
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{pronoun_field.id}",
+            info={
+                "display_in_profile_summary": "false",
+            },
+        )
+        self.assert_json_error(
+            result, "The first pronouns field must be displayed in the profile summary."
+        )
+
+        pronoun_field.refresh_from_db()
+        self.assertEqual(pronoun_field.display_in_profile_summary, True)
+
+    def test_first_pronoun_field_auto_display(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+
+        existing_pronoun = CustomProfileField.objects.get(name="Pronouns", realm=realm)
+        do_remove_realm_custom_profile_field(realm, existing_pronoun)
+
+        data = {
+            "name": "My Pronouns",
+            "hint": "What pronouns should people use?",
+            "field_type": CustomProfileField.PRONOUNS,
+            "display_in_profile_summary": "false",  # Explicitly try to set it to false
+        }
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_success(result)
+
+        new_pronoun_field = CustomProfileField.objects.get(name="My Pronouns", realm=realm)
+        self.assertEqual(new_pronoun_field.display_in_profile_summary, True)
+
+    def test_delete_first_pronoun_field_promotes_next(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+
+        first_pronoun = CustomProfileField.objects.get(name="Pronouns", realm=realm)
+        self.assertEqual(first_pronoun.display_in_profile_summary, True)
+
+        second_pronoun = try_add_realm_custom_profile_field(
+            realm=realm,
+            name="Secondary Pronouns",
+            field_type=CustomProfileField.PRONOUNS,
+            hint="Alternative pronouns",
+            display_in_profile_summary=False,
+        )
+        self.assertEqual(second_pronoun.display_in_profile_summary, False)
+
+        do_remove_realm_custom_profile_field(realm, first_pronoun)
+
+        second_pronoun.refresh_from_db()
+        self.assertEqual(second_pronoun.display_in_profile_summary, True)
+
+    def test_create_pronoun_after_deleting_all(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+
+        existing_pronouns = CustomProfileField.objects.filter(
+            realm=realm, field_type=CustomProfileField.PRONOUNS
+        )
+        for pronoun_field in existing_pronouns:
+            do_remove_realm_custom_profile_field(realm, pronoun_field)
+
+        self.assertEqual(
+            CustomProfileField.objects.filter(
+                realm=realm, field_type=CustomProfileField.PRONOUNS
+            ).count(),
+            0,
+        )
+
+        new_pronoun = try_add_realm_custom_profile_field(
+            realm=realm,
+            name="New Pronouns",
+            field_type=CustomProfileField.PRONOUNS,
+            hint="Your pronouns",
+            display_in_profile_summary=False,
+        )
+
+        self.assertEqual(new_pronoun.display_in_profile_summary, True)
+
+    def test_reorder_pronoun_fields_updates_display_flag(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+
+        first_pronoun = CustomProfileField.objects.get(name="Pronouns", realm=realm)
+        self.assertEqual(first_pronoun.display_in_profile_summary, True)
+
+        second_pronoun = try_add_realm_custom_profile_field(
+            realm=realm,
+            name="Secondary Pronouns",
+            field_type=CustomProfileField.PRONOUNS,
+            hint="Alternative pronouns",
+            display_in_profile_summary=False,
+        )
+        self.assertEqual(second_pronoun.display_in_profile_summary, False)
+
+        all_fields = list(
+            CustomProfileField.objects.filter(realm=realm)
+            .order_by("order")
+            .values_list("id", flat=True)
+        )
+
+        new_order = [second_pronoun.id] + [fid for fid in all_fields if fid != second_pronoun.id]
+
+        try_reorder_realm_custom_profile_fields(realm, new_order)
+
+        second_pronoun.refresh_from_db()
+        self.assertEqual(second_pronoun.display_in_profile_summary, True)
+
+        first_pronoun.refresh_from_db()
+        self.assertEqual(first_pronoun.display_in_profile_summary, False)
 
     def test_update_use_for_user_matching(self) -> None:
         self.login("iago")

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -109,6 +109,7 @@ class HomeTest(ZulipTestCase):
         "max_bulk_new_subscription_messages",
         "max_channel_folder_description_length",
         "max_channel_folder_name_length",
+        "max_display_in_profile_summary_fields",
         "max_file_upload_size_mib",
         "max_icon_file_size_mib",
         "max_logo_file_size_mib",

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -25,7 +25,10 @@ from zerver.lib.types import ProfileDataElementUpdateDict, ProfileFieldData
 from zerver.lib.users import validate_user_custom_profile_data
 from zerver.lib.validator import check_capped_string, validate_custom_profile_field_choices
 from zerver.models import CustomProfileField, Realm, UserProfile
-from zerver.models.custom_profile_fields import custom_profile_fields_for_realm
+from zerver.models.custom_profile_fields import (
+    custom_profile_fields_for_realm,
+    get_first_pronoun_field,
+)
 
 
 def list_realm_custom_profile_fields(
@@ -165,10 +168,34 @@ def update_only_display_in_profile_summary(
     return True
 
 
-def display_in_profile_summary_limit_reached(
-    realm: Realm, profile_field_id: int | None = None
+def is_first_pronoun_field(
+    realm: Realm,
+    field_id: int | None,
+    field_type: int,
+    first_pronoun_field: CustomProfileField | None = None,
 ) -> bool:
+    if field_type != CustomProfileField.PRONOUNS:
+        return False
+
+    if first_pronoun_field is None:
+        first_pronoun_field = get_first_pronoun_field(realm)
+
+    return first_pronoun_field is None or (
+        field_id is not None and first_pronoun_field.id == field_id
+    )
+
+
+def display_in_profile_summary_limit_reached(
+    realm: Realm,
+    profile_field_id: int | None = None,
+    first_pronoun_field: CustomProfileField | None = None,
+) -> bool:
+    if first_pronoun_field is None:
+        first_pronoun_field = get_first_pronoun_field(realm)
+
     query = CustomProfileField.objects.filter(realm=realm, display_in_profile_summary=True)
+    if first_pronoun_field is not None:
+        query = query.exclude(id=first_pronoun_field.id)
     if profile_field_id is not None:
         query = query.exclude(id=profile_field_id)
     return query.count() >= CustomProfileField.MAX_DISPLAY_IN_PROFILE_SUMMARY_FIELDS
@@ -191,7 +218,18 @@ def create_realm_custom_profile_field(
 ) -> HttpResponse:
     if field_data is None:
         field_data = {}
-    if display_in_profile_summary and display_in_profile_summary_limit_reached(user_profile.realm):
+
+    first_pronoun_field = (
+        get_first_pronoun_field(user_profile.realm)
+        if field_type == CustomProfileField.PRONOUNS
+        else None
+    )
+    is_first = is_first_pronoun_field(user_profile.realm, None, field_type, first_pronoun_field)
+    if (
+        display_in_profile_summary
+        and not is_first
+        and display_in_profile_summary_limit_reached(user_profile.realm, None, first_pronoun_field)
+    ):
         raise JsonableError(
             _("Only 2 custom profile fields can be displayed in the profile summary.")
         )
@@ -223,6 +261,7 @@ def create_realm_custom_profile_field(
                 required=required,
                 editable_by_user=editable_by_user,
                 use_for_user_matching=use_for_user_matching,
+                first_pronoun_field=first_pronoun_field,
             )
             return json_success(request, data={"id": field.id})
     except IntegrityError:
@@ -263,8 +302,23 @@ def update_realm_custom_profile_field(
     except CustomProfileField.DoesNotExist:
         raise JsonableError(_("Field id {id} not found.").format(id=field_id))
 
-    if display_in_profile_summary and display_in_profile_summary_limit_reached(
-        user_profile.realm, field.id
+    first_pronoun_field = (
+        get_first_pronoun_field(user_profile.realm)
+        if field.field_type == CustomProfileField.PRONOUNS
+        else None
+    )
+    is_first = is_first_pronoun_field(
+        user_profile.realm, field.id, field.field_type, first_pronoun_field
+    )
+    if display_in_profile_summary is not None and not display_in_profile_summary and is_first:
+        raise JsonableError(_("The first pronouns field must be displayed in the profile summary."))
+
+    if (
+        display_in_profile_summary
+        and not is_first
+        and display_in_profile_summary_limit_reached(
+            user_profile.realm, field.id, first_pronoun_field
+        )
     ):
         raise JsonableError(
             _("Only 2 custom profile fields can be displayed in the profile summary.")

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -872,6 +872,7 @@ class Command(ZulipBaseCommand):
                 "Pronouns",
                 CustomProfileField.PRONOUNS,
                 hint="What pronouns should people use to refer to you?",
+                display_in_profile_summary=True,
             )
 
             # Fill in values for Iago and Hamlet


### PR DESCRIPTION
Display pronoun-type custom profile fields in the user card header, positioned on a separate line between the user's name and role. This makes pronouns more easily discoverable.

Pronouns are styled consistently with role text (gray color, 14px font) and truncate with ellipsis if too long. Multiple pronoun fields are joined with comma-space separator.

Pronoun fields shown in the header do not count toward the 2-field user card limit for other custom profile fields.

<!-- Describe your pull request here.-->

**Design discussion:** [#design > Move pronouns adjacent the username](https://chat.zulip.org/#narrow/channel/101-design/topic/Move.20pronouns.20adjacent.20the.20username.2E.28.2339348.29/with/2483841)

Fixes: https://github.com/zulip/zulip/issues/39348<!-- Issue link, or clear description.-->

**How changes were tested:**
- Ran ./tools/lint - all linting checks passed
- Ran tools/test-js-with-node - all 150+ tests passed
- Manual testing with various pronoun configurations:
  - User with single pronoun field
  - User with multiple pronoun fields (comma-separated display)
  - User with long pronouns (ellipsis truncation verified)
  - User without pronouns (no display, no errors)
- Verified pronouns don't count toward 2-field limit for other custom profile fields
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before (main) | After (this PR) |
| :--- | :--- |
| **User with pronouns**<br><img width="251" height="361" alt="Screenshot 2026-06-27 at 14-10-41 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/96c63d59-c777-48f6-80b0-754df05131d4" />  | <br><img width="251" height="361" alt="Screenshot 2026-06-27 at 14-10-11 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/44264117-0fd6-4e0d-a571-129b2ccb4ec9" />|
| **Multiple pronoun fields**<br><img width="202" height="397" alt="Screenshot 2026-06-27 at 14-13-24 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/d65cdd4f-75fe-458a-b7f2-075812987ecc" /> | <br><img width="264" height="397" alt="Screenshot 2026-06-27 at 14-13-02 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/a2afc94a-ddbc-45f9-b449-d60190ca422e" /> |
| **Long name with pronouns**<br><img width="303" height="397" alt="Screenshot 2026-06-27 at 14-16-45 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/c0874ba7-2f1b-4774-8268-bfa3bbc02508" /> | <br><img width="303" height="397" alt="Screenshot 2026-06-27 at 14-16-24 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/ab2e6951-46ba-4dd3-a605-9e2d76bd24b1" /> |
| **Long pronouns (ellipsis truncation)**<br><img width="308" height="397" alt="Screenshot 2026-06-27 at 14-18-21 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/666e836f-0601-409d-bcdc-cd151a2c09b2" /> | <br><img width="308" height="397" alt="Screenshot 2026-06-27 at 14-18-52 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/445a0a79-428e-4a09-9001-fee71795b7bb" />|
| **User without pronouns(No change)**<br><img width="308" height="384" alt="Screenshot 2026-06-27 at 14-21-26 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/4f77b153-b709-4003-b649-e06d25cc98d0" /> | <br><img width="308" height="384" alt="Screenshot 2026-06-27 at 14-21-26 Inbox - Zulip Dev - Zulip" src="https://github.com/user-attachments/assets/4f77b153-b709-4003-b649-e06d25cc98d0" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
