### PR TITLE
[ai] api docs: Correct update-subscriptions response key documentation.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13436,13 +13436,15 @@ paths:
                       subscribed:
                         type: object
                         description: |
-                          A dictionary where the key is the Zulip API email
-                          address of the user/bot and the value is a
-                          list of the names of the channels that were
-                          subscribed to as a result of the query.
+                          A dictionary where the key is the ID of the user and
+                          the value is a list of the names of the channels that
+                          were subscribed to as a result of the query.
+
+                          **Changes**: Before Zulip 10.0 (feature level 289), the user
+                          keys were Zulip API email addresses, not user ID.
                         additionalProperties:
                           description: |
-                            `{email_id}`: A list of the names of channels that
+                            `{id}`: A list of the names of channels that
                             the user was subscribed to as a result of the query.
                           type: array
                           items:
@@ -13450,13 +13452,15 @@ paths:
                       already_subscribed:
                         type: object
                         description: |
-                          A dictionary where the key is the Zulip API email
-                          address of the user/bot and the value is a
-                          list of the names of the channels that the
-                          user/bot is already subscribed to.
+                          A dictionary where the key is the ID of the user and
+                          the value is a list of the names of the channels that
+                          the user is already subscribed to.
+
+                          **Changes**: Before Zulip 10.0 (feature level 289), the user
+                          keys were Zulip API email addresses, not user IDs.
                         additionalProperties:
                           description: |
-                            `{email_id}`: A list of the names of channels that
+                            `{id}`: A list of the names of channels that
                             the user was already subscribed to.
                           type: array
                           items:


### PR DESCRIPTION
Fixes: No tracking issue; this is a small documentation-accuracy fix. (CZO discussion linked below.)

The `PATCH /users/me/subscriptions` endpoint shares
`add_subscriptions_backend` with `POST /users/me/subscriptions`, so its
`subscribed` and `already_subscribed` response dictionaries are keyed by
user ID — the backend builds them with `str(subscriber.id)`
(`zerver/views/streams.py`).

Feature level 289 (Zulip 10.0) switched these keys from Zulip API email
addresses to user IDs and updated the `POST` endpoint's OpenAPI
documentation, but the `PATCH` endpoint's documentation was missed and
still described the keys as email addresses (`{email_id}`). This misleads
API consumers into expecting the wrong key format.

This corrects the `PATCH` endpoint's response documentation to match the
actual behavior, mirroring the wording and the feature level 289
changelog note already present on the `POST` endpoint.

**How changes were tested:**

Documentation-only change. Verified the actual behavior by reading
`add_subscriptions_backend` in `zerver/views/streams.py` (keys built with
`str(subscriber.id)`) and the existing assertions in
`zerver/tests/test_subs.py`, which key the response by user ID. The
`backend + documentation` CI job (which runs the OpenAPI/documentation
tests) passes.

**Screenshots and screen captures:**

N/A — no UI changes.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
