### PR TITLE
i18n: Improve displayed names for a few languages

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -429,9 +429,9 @@ async function assert_language_changed_to_chinese(page: Page): Promise<void> {
         visible: true,
     });
     const default_language = await common.get_text_from_selector(page, ".dropdown_widget_value");
-    assert.strictEqual(
-        default_language.slice(0, 7),
-        "中文 (简体)",
+    assert.match(
+        default_language,
+        /^中文（简体）/v,
         "Default language has not been changed to Chinese.",
     );
 }

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -69,29 +69,30 @@ export function get_language_name(language_code: string): string | undefined {
 }
 
 function get_language_display_name(language_code: string): string {
-    // For "Monoglian" and "Bqi", "Intl.DisplayNames" returns their English names
-    // in Chromium based browsers. So, we hard-code the display names for these
-    // two languages.
-    if (language_code === "bqi") {
-        return "Bakhtiari";
+    switch (language_code) {
+        // Chromium's Intl.DisplayNames returns English names for a few
+        // languages, so we hard-code these ones.
+        case "bqi":
+            return "Bakhtiari";
+        case "cy":
+            return "Cymraeg";
+        case "mn":
+            return "Монгол";
+        case "si":
+            return "සිංහල";
+
+        // Clarify our convention for these bare codes.
+        case "en":
+            language_code = "en-US";
+            break;
+        case "pt":
+            language_code = "pt-BR";
+            break;
     }
 
-    if (language_code === "mn") {
-        return "Монгол";
-    }
-
-    const locale = new Intl.Locale(language_code === "en" ? "en-US" : language_code);
-    let language_display_name = new Intl.DisplayNames([locale], {type: "language"})
-        .of(locale.language)!
-        .replace(/^./u, (c) => c.toLocaleUpperCase(locale));
-
-    if (locale.script !== undefined) {
-        language_display_name += ` (${new Intl.DisplayNames([locale], {type: "script"}).of(locale.script)})`;
-    }
-    if (locale.region !== undefined) {
-        language_display_name += ` (${new Intl.DisplayNames([locale], {type: "region"}).of(locale.region)})`;
-    }
-    return language_display_name;
+    return new Intl.DisplayNames([language_code], {type: "language", languageDisplay: "standard"})
+        .of(language_code)!
+        .replace(/^./u, (c) => c.toLocaleUpperCase(language_code));
 }
 
 export function initialize(language_params: {language_list: typeof language_list}): void {

--- a/web/tests/i18n.test.cjs
+++ b/web/tests/i18n.test.cjs
@@ -120,76 +120,29 @@ run_test("{{#tr}} to tag for translation", ({mock_template}) => {
 
 run_test("language_list", () => {
     const language_list = [
-        {
-            code: "en",
-            locale: "en",
-            name: "English",
-        },
-        {
-            code: "en-gb",
-            locale: "en_GB",
-            name: "British English",
-            percent_translated: 99,
-        },
-        {
-            code: "id",
-            locale: "id",
-            name: "Bahasa Indonesia",
-            percent_translated: 32,
-        },
-        {
-            code: "mn",
-            locale: "mn",
-            name: "Mongolian",
-            percent_translated: 53,
-        },
-        {
-            code: "bqi",
-            locale: "bqi",
-            name: "Luri (Bakhtiari)",
-            percent_translated: 5,
-        },
-        {
-            code: "zh-hans",
-            locale: "zh_Hans",
-            name: "简体中文",
-            percent_translated: 86,
-        },
+        {code: "bqi", locale: "bqi", name: "Luri (Bakhtiari)", percent_translated: 5},
+        {code: "cy", locale: "cy", name: "Cymraeg", percent_translated: 36},
+        {code: "en", locale: "en", name: "English"},
+        {code: "en-gb", locale: "en_GB", name: "British English", percent_translated: 99},
+        {code: "id", locale: "id", name: "Bahasa Indonesia", percent_translated: 32},
+        {code: "mn", locale: "mn", name: "Mongolian", percent_translated: 53},
+        {code: "pt", locale: "pt", name: "Português", percent_translated: 81},
+        {code: "si", locale: "si", name: "Sinhala", percent_translated: 20},
+        {code: "zh-hans", locale: "zh_Hans", name: "简体中文", percent_translated: 86},
     ];
     initialize({language_list});
     assert.equal(get_language_name("en"), "English");
 
     const successful_formatted_list = [
-        {
-            code: "en",
-            name_with_percent: "English (United States)",
-            selected: true,
-        },
-        {
-            code: "en-gb",
-            name_with_percent: "English (United Kingdom) (99%)",
-            selected: false,
-        },
-        {
-            code: "id",
-            name_with_percent: "Indonesia (32%)",
-            selected: false,
-        },
-        {
-            code: "mn",
-            name_with_percent: "Монгол (53%)",
-            selected: false,
-        },
-        {
-            code: "bqi",
-            name_with_percent: "Bakhtiari (5%)",
-            selected: false,
-        },
-        {
-            code: "zh-hans",
-            name_with_percent: "中文 (简体) (86%)",
-            selected: false,
-        },
+        {code: "bqi", name_with_percent: "Bakhtiari (5%)", selected: false},
+        {code: "cy", name_with_percent: "Cymraeg (36%)", selected: false},
+        {code: "en", name_with_percent: "English (United States)", selected: true},
+        {code: "en-gb", name_with_percent: "English (United Kingdom) (99%)", selected: false},
+        {code: "id", name_with_percent: "Indonesia (32%)", selected: false},
+        {code: "mn", name_with_percent: "Монгол (53%)", selected: false},
+        {code: "pt", name_with_percent: "Português (Brasil) (81%)", selected: false},
+        {code: "si", name_with_percent: "සිංහල (20%)", selected: false},
+        {code: "zh-hans", name_with_percent: "中文（简体） (86%)", selected: false},
     ];
 
     const formatted_list = get_language_list_columns("en");


### PR DESCRIPTION
code | old | new
--- | --- | ---
cy | Welsh [Chromium] | Cymraeg
pt | Português | [Português (Brasil)](https://chat.zulip.org/#narrow/channel/58-translation/topic/Brazilian.20Portuguese.20Translation/near/2269403)
si | Sinhala [Chromium] | සිංහල
zh-hans | 中文 (简体中文) [Firefox], 中文 (简体) [Chromium] | 中文（简体）
zh-tw | 中文 (台灣) | 中文（台灣）

<img width="1125" height="798" alt="languages" src="https://github.com/user-attachments/assets/b997b580-197e-40c6-bd82-99781005c518" />
