### PR TITLE
[ai] typeahead: Improve channel sort priorities in sort_streams.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -1027,19 +1027,23 @@ export function compare_by_activity(
         return diff;
     }
 
-    // Subscribed channels sort above unsubscribed ones, which aren't
-    // ranked further by the criteria below.
+    // Archived channels sort below all unarchived channels, and within
+    // each of those groups subscribed channels sort above unsubscribed
+    // ones.
+    diff = prefer_true(!stream_a.is_archived, !stream_b.is_archived);
+    if (diff !== 0) {
+        return diff;
+    }
     diff = prefer_true(stream_a.subscribed, stream_b.subscribed);
     if (diff !== 0) {
         return diff;
     }
+
     if (stream_a.subscribed) {
-        // Prioritize unmuted channels, then pinned channels, then
-        // recently active ones.
-        diff = prefer_true(!stream_a.is_muted, !stream_b.is_muted);
-        if (diff !== 0) {
-            return diff;
-        }
+        // Among subscribed channels of the same archived status, order
+        // them by the same priorities as the left sidebar: pinned, then
+        // recently active, then unmuted. Unsubscribed channels aren't
+        // ranked by these, falling through to the tiebreakers below.
         diff = prefer_true(stream_a.pin_to_top, stream_b.pin_to_top);
         if (diff !== 0) {
             return diff;
@@ -1048,6 +1052,10 @@ export function compare_by_activity(
             stream_list_sort.has_recent_activity(stream_a),
             stream_list_sort.has_recent_activity(stream_b),
         );
+        if (diff !== 0) {
+            return diff;
+        }
+        diff = prefer_true(!stream_a.is_muted, !stream_b.is_muted);
         if (diff !== 0) {
             return diff;
         }

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -1004,43 +1004,56 @@ export function sort_slash_commands(
     return [...results.matches, ...results.rest];
 }
 
-function activity_score(sub: StreamSubscription): number {
-    // We assign the highest score to the stream being composed
-    // to, and the lowest score to unsubscribed streams. For others,
-    // we prioritise pinned unmuted streams > unpinned unmuted streams
-    // > pinned muted streams > unpinned muted streams, using recent
-    // activity as a tiebreaker.
-    if (sub.name === compose_state.stream_name()) {
-        return 8;
-    }
-    if (!sub.subscribed) {
-        return -1;
-    }
-
-    let stream_score = 0;
-    if (!sub.is_muted) {
-        stream_score += 4;
-    }
-    if (sub.pin_to_top) {
-        stream_score += 2;
-    }
-    if (stream_list_sort.has_recent_activity(sub)) {
-        stream_score += 1;
-    }
-    return stream_score;
+// Comparator for a boolean property that sorts truthy values before
+// falsy ones.
+function prefer_true(a: boolean, b: boolean): number {
+    return (b ? 1 : 0) - (a ? 1 : 0);
 }
 
-// Sort streams by ranking them by activity. If activity is equal,
-// as defined bv activity_score, decide based on our weekly traffic
-// stats.
+// Sort streams by checking each property below in priority order,
+// deciding as soon as the two streams differ on one of them.
 export function compare_by_activity(
     stream_a: StreamSubscription,
     stream_b: StreamSubscription,
 ): number {
-    let diff = activity_score(stream_b) - activity_score(stream_a);
+    // The channel currently selected in the compose box always sorts
+    // first.
+    const selected_stream_name = compose_state.stream_name();
+    let diff = prefer_true(
+        stream_a.name === selected_stream_name,
+        stream_b.name === selected_stream_name,
+    );
     if (diff !== 0) {
         return diff;
     }
+
+    // Subscribed channels sort above unsubscribed ones, which aren't
+    // ranked further by the criteria below.
+    diff = prefer_true(stream_a.subscribed, stream_b.subscribed);
+    if (diff !== 0) {
+        return diff;
+    }
+    if (stream_a.subscribed) {
+        // Prioritize unmuted channels, then pinned channels, then
+        // recently active ones.
+        diff = prefer_true(!stream_a.is_muted, !stream_b.is_muted);
+        if (diff !== 0) {
+            return diff;
+        }
+        diff = prefer_true(stream_a.pin_to_top, stream_b.pin_to_top);
+        if (diff !== 0) {
+            return diff;
+        }
+        diff = prefer_true(
+            stream_list_sort.has_recent_activity(stream_a),
+            stream_list_sort.has_recent_activity(stream_b),
+        );
+        if (diff !== 0) {
+            return diff;
+        }
+    }
+
+    // Fall back to recent traffic, and then the channel name.
     diff = (stream_b.stream_weekly_traffic ?? 0) - (stream_a.stream_weekly_traffic ?? 0);
     if (diff !== 0) {
         return diff;

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -280,10 +280,10 @@ test("sort_streams", ({override}) => {
     test_streams = th.sort_streams(test_streams, "d");
     assert.deepEqual(test_streams[0].name, "Dev"); // Stream being composed to
     assert.deepEqual(test_streams[1].name, "Denmark"); // Pinned stream
-    assert.deepEqual(test_streams[2].name, "Docs"); // Active stream
-    assert.deepEqual(test_streams[3].name, "dead (almost)"); // Relatively inactive stream
-    assert.deepEqual(test_streams[4].name, "dead"); // Completely inactive stream
-    assert.deepEqual(test_streams[5].name, "Derp"); // Muted stream last
+    assert.deepEqual(test_streams[2].name, "Docs"); // Active stream, more traffic
+    assert.deepEqual(test_streams[3].name, "dead (almost)"); // Active stream, less traffic
+    assert.deepEqual(test_streams[4].name, "Derp"); // Active but muted stream
+    assert.deepEqual(test_streams[5].name, "dead"); // Inactive stream last
 
     // Sort streams by name
     test_streams = th.sort_streams_by_name(test_streams, "d");
@@ -411,6 +411,41 @@ test("sort_streams", ({override}) => {
     test_streams = th.sort_streams(test_streams, "d");
     assert.deepEqual(test_streams[0].name, "Dusk"); // More traffic
     assert.deepEqual(test_streams[1].name, "Dawn"); // Less traffic
+
+    // Archived channels sort below all unarchived channels, and within
+    // each group subscribed channels sort above unsubscribed ones.
+    test_streams = [
+        {
+            stream_id: 403,
+            name: "archived and subscribed",
+            subscribed: true,
+            is_archived: true,
+        },
+        {
+            stream_id: 404,
+            name: "unarchived and subscribed",
+            subscribed: true,
+            is_archived: false,
+        },
+        {
+            stream_id: 405,
+            name: "archived and unsubscribed",
+            subscribed: false,
+            is_archived: true,
+        },
+        {
+            stream_id: 406,
+            name: "unarchived and unsubscribed",
+            subscribed: false,
+            is_archived: false,
+        },
+    ];
+
+    test_streams = th.sort_streams(test_streams, "and");
+    assert.deepEqual(test_streams[0].name, "unarchived and subscribed");
+    assert.deepEqual(test_streams[1].name, "unarchived and unsubscribed");
+    assert.deepEqual(test_streams[2].name, "archived and subscribed");
+    assert.deepEqual(test_streams[3].name, "archived and unsubscribed");
 });
 
 function language_items(languages) {

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -389,6 +389,28 @@ test("sort_streams", ({override}) => {
     assert.deepEqual(test_streams[3].name, "Ether"); // Unsubscribed and description starts with query
     assert.deepEqual(test_streams[4].name, "New"); // Subscribed and no match
     assert.deepEqual(test_streams[5].name, "Mew"); // Unsubscribed and no match
+
+    // Unsubscribed channels are ordered by recent traffic, then name.
+    // "Dusk" sorts after "Dawn" by name, so leading with it confirms
+    // traffic takes precedence over the name tiebreaker.
+    test_streams = [
+        {
+            stream_id: 401,
+            name: "Dawn",
+            subscribed: false,
+            stream_weekly_traffic: 5,
+        },
+        {
+            stream_id: 402,
+            name: "Dusk",
+            subscribed: false,
+            stream_weekly_traffic: 50,
+        },
+    ];
+
+    test_streams = th.sort_streams(test_streams, "d");
+    assert.deepEqual(test_streams[0].name, "Dusk"); // More traffic
+    assert.deepEqual(test_streams[1].name, "Dawn"); // Less traffic
 });
 
 function language_items(languages) {


### PR DESCRIPTION
Fixes #36370.
