### PR TITLE
search_pill: Drop unreachable code.

### DIFF
--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -81,9 +81,6 @@ export function get_search_string_from_item(item: SearchPill): string {
             operand = util.get_final_topic_display_name(item.operand);
             break;
         case "channel":
-            if (item.operand === "") {
-                operand = "";
-            }
             operand = stream_data.get_valid_sub_by_id_string(item.operand).name;
             break;
         default:


### PR DESCRIPTION
`operand` cannot be empty here since this is used
for creating pills which have non empty operand.

Verified that we call `is_valid_canonical_term` on term before it reaches here.

`operand` is anyway overridden in the next line.
