### PR TITLE
Make headings across settings UI consistent.

### DIFF
--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -45,7 +45,7 @@ async function click_create_new_stream(page: Page): Promise<void> {
 }
 
 async function clear_ot_filter_with_backspace(page: Page): Promise<void> {
-    await page.click(".add-user-list-filter");
+    await page.click("#people_to_add input.search");
     await page.keyboard.press("Backspace");
     await page.keyboard.press("Backspace");
 }
@@ -58,7 +58,7 @@ async function test_user_filter_ui(page: Page): Promise<void> {
     await add_user_to_stream(page, common.fullname.cordelia);
     await add_user_to_stream(page, common.fullname.othello);
 
-    await page.type(`form#stream_creation_form [name="user_list_filter"]`, "ot", {delay: 100});
+    await page.type(`#people_to_add input.search`, "ot", {delay: 100});
     await page.waitForSelector("#create_stream_subscribers", {visible: true});
     // Wait until filtering is completed.
     await page.waitForFunction(

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -122,7 +122,7 @@ export function build_widgets(): void {
             ...ListWidget.generic_sort_functions("alphabetic", ["full_name"]),
         },
         filter: {
-            $element: $("#people_to_add .add-user-list-filter"),
+            $element: $("#people_to_add input.search"),
             predicate(user, search_term) {
                 return people.build_person_matcher(search_term)(user);
             },

--- a/web/src/user_group_create_members.ts
+++ b/web/src/user_group_create_members.ts
@@ -175,7 +175,7 @@ export function build_widgets(): void {
             return render_new_user_group_subgroup(item);
         },
         filter: {
-            $element: $("#people_to_add_in_group .add-user-list-filter"),
+            $element: $("#people_to_add_in_group input.search"),
             predicate(member, search_term) {
                 return user_group_components.build_group_member_matcher(search_term)(member);
             },

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -55,10 +55,6 @@ kbd {
     }
 }
 
-.light {
-    font-weight: 300;
-}
-
 .highlighted-element {
     font-weight: 600;
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -346,10 +346,6 @@ h3,
         padding-bottom: 4px;
         height: 1.4em; /* To match height of input elements */
     }
-
-    .account-settings-heading {
-        margin-right: 10px;
-    }
 }
 
 /* Make this one less wide because it's indented, so that the right
@@ -771,11 +767,6 @@ input[type="checkbox"] {
     border-radius: 4px;
     color: hsl(156deg 30% 50%);
     padding: 3px 10px;
-
-    &.account-alert-notification {
-        margin: 0 0 10px;
-        vertical-align: middle;
-    }
 
     &:not(:empty) {
         border: 1px solid hsl(156deg 30% 50%);
@@ -1474,6 +1465,13 @@ label.preferences-radio-choice-label {
         font-size: 1.5em;
         font-weight: normal;
         line-height: 1.5;
+    }
+
+    /* All non-table section headings sit in a '.subsection-header' and
+       share this margin; table-panel headings ('.settings_panel_list_header
+       h3') keep their own spacing. */
+    .subsection-header h3 {
+        margin: calc(0.3125 * var(--base-font-size-px)) 0; /* 5px 0 at 16px font size. */
     }
 
     & h5 {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -3,7 +3,6 @@ label {
 }
 
 label,
-h4,
 h3,
 /* We need settings-section-title here because some legacy settings
    widgets use a <div> with this class for their heading. */
@@ -555,18 +554,8 @@ input[type="checkbox"] {
     margin-bottom: 0;
 }
 
-.admin-realm-form {
-    .subsection-header h3 {
-        display: inline;
-    }
-}
-
 .preferences-settings-form,
 .notification-settings-form {
-    .subsection-header h3 {
-        display: inline-block;
-    }
-
     .tip {
         width: fit-content;
         margin-top: 0;
@@ -2267,10 +2256,6 @@ label.preferences-radio-choice-label {
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-
-    & h3 {
-        display: inline-block;
-    }
 
     .user_filters,
     .bot-filters {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -697,20 +697,12 @@ input[type="checkbox"] {
     margin-bottom: 1em;
 }
 
-.organization-settings-parent {
-    padding-top: 5px;
-}
-
 #id_org_profile_preview {
     width: max-content;
     display: flex;
     gap: 5px;
     align-items: center;
     margin-bottom: 20px;
-}
-
-.inline-block.organization-permissions-parent {
-    padding-top: 5px;
 }
 
 #org-other-permissions .tip {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -281,13 +281,14 @@ h3,
         }
     }
 
-    /* Bare <h3> section titles in settings panels get their font-size,
+    /* Bare <h3> section titles in settings panels (e.g. table-panel
+       headers in '.settings_panel_list_header') get their font-size,
        font-weight, and line-height from the '#settings_page h3' rule
        further down in this file; previously their margin came from the
        universal h1-h4 reset in bootstrap.app.css. Set the margin
        explicitly here so the spacing survives that reset's removal.
-       Specificity matches the existing '.admin-realm-form h3' margin
-       override, which appears later in this file and so still wins. */
+       Headings inside a '.subsection-header' are overridden by the
+       higher-specificity '#settings_page .subsection-header h3' rule. */
     & h3 {
         margin: 10px 0;
     }
@@ -555,10 +556,6 @@ input[type="checkbox"] {
 }
 
 .admin-realm-form {
-    & h3 {
-        margin: calc(0.3125 * var(--base-font-size-px)) 0; /* 5px 0 at 16px font size. */
-    }
-
     .subsection-header h3 {
         display: inline;
     }
@@ -568,7 +565,6 @@ input[type="checkbox"] {
 .notification-settings-form {
     .subsection-header h3 {
         display: inline-block;
-        margin: calc(0.3125 * var(--base-font-size-px)) 0; /* 5px 0 at 16px font size. */
     }
 
     .tip {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -3,7 +3,8 @@ label {
 }
 
 label,
-h3,
+.settings-subsection-title,
+.settings-table-title,
 /* We need settings-section-title here because some legacy settings
    widgets use a <div> with this class for their heading. */
 .settings-section-title {
@@ -11,6 +12,27 @@ h3,
         top: 1px;
         position: relative;
     }
+}
+
+/* Shared font for the subsection and table/list-panel headings across the
+   settings, channel, and group settings overlays. */
+.settings-subsection-title,
+.settings-table-title {
+    font-size: 1.5em;
+    font-weight: normal;
+    line-height: 1.5;
+}
+
+/* Subsection headings, used by both the settings panels and the channel
+   and group overlays. */
+.settings-subsection-title {
+    margin: calc(0.3125 * var(--base-font-size-px)) 0; /* 5px 0 at 16px font size. */
+}
+
+/* Table/list-panel headings ('.settings_panel_list_header') use the larger
+   table heading margin rather than the subsection margin. */
+.settings-table-title {
+    margin: 10px 0;
 }
 
 /* TODO: This should ideally be added to help_link_widget.hbs,
@@ -42,7 +64,8 @@ a.help_link_widget {
     }
 }
 
-h3,
+.settings-subsection-title,
+.settings-table-title,
 .settings-section-title {
     .help_link_widget {
         margin-left: 5px;
@@ -278,18 +301,6 @@ h3,
             background-color: transparent;
             color: inherit;
         }
-    }
-
-    /* Bare <h3> section titles in settings panels (e.g. table-panel
-       headers in '.settings_panel_list_header') get their font-size,
-       font-weight, and line-height from the '#settings_page h3' rule
-       further down in this file; previously their margin came from the
-       universal h1-h4 reset in bootstrap.app.css. Set the margin
-       explicitly here so the spacing survives that reset's removal.
-       Headings inside a '.subsection-header' are overridden by the
-       higher-specificity '#settings_page .subsection-header h3' rule. */
-    & h3 {
-        margin: 10px 0;
     }
 
     .table-sticky-headers {
@@ -662,7 +673,7 @@ input[type="checkbox"] {
         align-items: center;
         gap: 0 0.625em;
 
-        .stream_setting_subsection_title {
+        .settings-subsection-title {
             margin: 4px 0;
         }
 
@@ -1436,19 +1447,6 @@ label.preferences-radio-choice-label {
 
     .realm-time-limit-label {
         vertical-align: middle;
-    }
-
-    & h3 {
-        font-size: 1.5em;
-        font-weight: normal;
-        line-height: 1.5;
-    }
-
-    /* All non-table section headings sit in a '.subsection-header' and
-       share this margin; table-panel headings ('.settings_panel_list_header
-       h3') keep their own spacing. */
-    .subsection-header h3 {
-        margin: calc(0.3125 * var(--base-font-size-px)) 0; /* 5px 0 at 16px font size. */
     }
 
     & h5 {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1833,6 +1833,12 @@ label.preferences-radio-choice-label {
     width: fit-content;
 }
 
+#realm_invite_required_container {
+    /* Keep the disabled-setting tooltip's hover area on the checkbox, not
+       the empty space its wider siblings stretch this container across. */
+    width: fit-content;
+}
+
 #realm-user-default-settings {
     .settings-field-label,
     .settings-checkbox-wrapper,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -134,7 +134,6 @@
 /* TODO: Unify with settings.css definition */
 h3.stream_setting_subsection_title,
 h3.user_group_setting_subsection_title {
-    display: inline-block;
     font-size: 1.5em;
     font-weight: normal;
     line-height: 1.5;
@@ -436,7 +435,6 @@ h3.user_group_setting_subsection_title {
             font-weight: normal;
             line-height: 1.5;
             margin: 10px 0;
-            display: inline;
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -335,7 +335,12 @@ h3.user_group_setting_subsection_title {
     & a {
         color: inherit;
     }
-    margin-bottom: 10px;
+
+    /* Only reserve bottom margin when a banner is actually present, so
+       the empty wrapper doesn't take up space. */
+    &:not(:empty) {
+        margin-bottom: 10px;
+    }
 }
 
 .member-search,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -131,25 +131,6 @@
     margin-bottom: 20px;
 }
 
-/* TODO: Unify with settings.css definition */
-h3.stream_setting_subsection_title,
-h3.user_group_setting_subsection_title {
-    font-size: 1.5em;
-    font-weight: normal;
-    line-height: 1.5;
-    /* Match the org settings subsection h3 margin. */
-    margin: calc(0.3125 * var(--base-font-size-px)) 0; /* 5px 0 at 16px font size. */
-}
-
-/* Member/subscriber list headers are table headings, not subsections, so
-   they keep the larger org settings table heading margin rather than the
-   subsection margin above. */
-.subscribers-heading h3,
-.members-list-header h3,
-.create_user_group_member_list_header h3 {
-    margin: 10px 0;
-}
-
 .subscriber_list_settings_container.no-display {
     display: none;
 }
@@ -429,13 +410,11 @@ h3.user_group_setting_subsection_title {
         margin: 10px 0;
     }
 
-    .subsection-header {
-        h3 {
-            font-size: 1.5em;
-            font-weight: normal;
-            line-height: 1.5;
-            margin: 10px 0;
-        }
+    /* Per-permission subsection headings; a larger margin than other
+       subsection headings, with font from the shared
+       '.settings-subsection-title' rule. */
+    .subsection-header .settings-subsection-title {
+        margin: 10px 0;
     }
 
     .subsection-settings {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -138,7 +138,17 @@ h3.user_group_setting_subsection_title {
     font-size: 1.5em;
     font-weight: normal;
     line-height: 1.5;
-    margin: 4px 0;
+    /* Match the org settings subsection h3 margin. */
+    margin: calc(0.3125 * var(--base-font-size-px)) 0; /* 5px 0 at 16px font size. */
+}
+
+/* Member/subscriber list headers are table headings, not subsections, so
+   they keep the larger org settings table heading margin rather than the
+   subsection margin above. */
+.subscribers-heading h3,
+.members-list-header h3,
+.create_user_group_member_list_header h3 {
+    margin: 10px 0;
 }
 
 .subscriber_list_settings_container.no-display {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -181,20 +181,13 @@ h3.user_group_setting_subsection_title {
     }
 }
 
-.subscribers-list-header,
-.create_stream_subscriber_list_header {
+.subscribers-heading {
     display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    align-items: center;
 
-    .subscribers-heading {
-        display: flex;
-        align-items: center;
-
-        .loading_indicator_spinner {
-            width: 100%;
-            height: 100%;
-        }
+    .loading_indicator_spinner {
+        width: 100%;
+        height: 100%;
     }
 }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -141,19 +141,6 @@ h3.user_group_setting_subsection_title {
     margin: 4px 0;
 }
 
-h4.stream_setting_subsection_title,
-h4.user_group_setting_subsection_title {
-    display: inline-block;
-    font-size: 1.35em;
-    font-weight: normal;
-    line-height: 1.5;
-    margin: 10px 0;
-}
-
-h4.stream_setting_subsection_title {
-    margin-bottom: 5px;
-}
-
 .subscriber_list_settings_container.no-display {
     display: none;
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -198,6 +198,11 @@ h3.user_group_setting_subsection_title {
     }
 }
 
+.subscribers-list-header .search,
+.members-list-header .search {
+    max-width: 160px;
+}
+
 .add-group-member-loading-spinner {
     align-self: center;
 }
@@ -340,23 +345,6 @@ h3.user_group_setting_subsection_title {
        the empty wrapper doesn't take up space. */
     &:not(:empty) {
         margin-bottom: 10px;
-    }
-}
-
-.member-search,
-.subscriber-search {
-    margin: 10px 0 0;
-
-    .search {
-        max-width: 160px;
-    }
-
-    @media (max-width: $ms_min) {
-        float: none;
-        display: flex;
-        justify-content: flex-start;
-        align-items: center;
-        margin: 0 0 5px;
     }
 }
 
@@ -1246,20 +1234,8 @@ h3.user_group_setting_subsection_title {
             }
         }
 
-        .create_user_group_member_list_header,
-        .create_stream_subscriber_list_header {
-            margin-top: 10px;
-            margin-bottom: 3px;
-
-            & h5 {
-                display: inline-block;
-            }
-        }
-
         .add-user-list-filter {
             width: 140px;
-            float: right;
-            margin-top: 10px;
         }
 
         #user_group_creation_form,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -198,11 +198,6 @@ h3.user_group_setting_subsection_title {
     }
 }
 
-.subscribers-list-header .search,
-.members-list-header .search {
-    max-width: 160px;
-}
-
 .add-group-member-loading-spinner {
     align-self: center;
 }
@@ -1232,10 +1227,6 @@ h3.user_group_setting_subsection_title {
             .settings-sticky-footer {
                 border-radius: 0 0 6px;
             }
-        }
-
-        .add-user-list-filter {
-            width: 140px;
         }
 
         #user_group_creation_form,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -332,6 +332,7 @@ p.n-margin {
     & h3 {
         font-size: 16pt;
         margin-top: 2px;
+        font-weight: 300;
     }
 
     .exit-me {

--- a/web/templates/feedback_container.hbs
+++ b/web/templates/feedback_container.hbs
@@ -1,6 +1,6 @@
 <div id="feedback-container-content-wrapper">
     <div class="float-header">
-        <h3 class="light no-margin small-line-height float-left feedback_title"></h3>
+        <h3 class="no-margin small-line-height float-left feedback_title"></h3>
         <div class="feedback-button-container">
             {{#if has_undo_button}}
                 {{> components/action_button intent="neutral" variant="subtle" custom_classes="feedback_undo"}}

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -3,7 +3,7 @@
     <div class="account-settings-form">
         <div id="user_details_section">
             <div class="subsection-header">
-                <h3>{{t "Account" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Account" }}</h3>
                 <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
             </div>
             <form class="grid">
@@ -111,7 +111,7 @@
 
         <div id="api_key_button_box">
             <div class="subsection-header">
-                <h3>{{t "API key" }}</h3>
+                <h3 class="settings-subsection-title">{{t "API key" }}</h3>
             </div>
 
             <div class="input-group">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -2,8 +2,10 @@
     <div class="alert" id="dev-account-settings-status"></div>
     <div class="account-settings-form">
         <div id="user_details_section">
-            <h3 class="inline-block account-settings-heading">{{t "Account" }}</h3>
-            <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
+            <div class="subsection-header">
+                <h3>{{t "Account" }}</h3>
+                <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
+            </div>
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
@@ -108,7 +110,9 @@
         {{> privacy_settings . for_realm_settings=false prefix="user_" read_receipts_help_icon_tooltip_text=send_read_receipts_tooltip hide_read_receipts_tooltip=realm.realm_enable_read_receipts}}
 
         <div id="api_key_button_box">
-            <h3>{{t "API key" }}</h3>
+            <div class="subsection-header">
+                <h3>{{t "API key" }}</h3>
+            </div>
 
             <div class="input-group">
                 <p class="api-key-note">

--- a/web/templates/settings/active_user_list_admin.hbs
+++ b/web/templates/settings/active_user_list_admin.hbs
@@ -1,7 +1,7 @@
 <div id="admin-active-users-list" class="user-settings-section user-or-bot-settings-section" data-user-settings-section="active">
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Users"}}</h3>
+        <h3 class="settings-table-title">{{t "Users"}}</h3>
         <div class="alert-notification" id="user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=active_user_list_dropdown_widget_name}}

--- a/web/templates/settings/admin_channel_folders.hbs
+++ b/web/templates/settings/admin_channel_folders.hbs
@@ -1,6 +1,6 @@
 <div id="channel-folder-settings" class="settings-section" data-name="channel-folders">
     <div class="settings_panel_list_header">
-        <h3>{{t "Channel folders"}}</h3>
+        <h3 class="settings-table-title">{{t "Channel folders"}}</h3>
         <div class="alert-notification" id="admin-channel-folder-status"></div>
         {{#if is_admin}}
             {{> ../components/action_button

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -12,7 +12,7 @@
       }}
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Alert words"}}</h3>
+        <h3 class="settings-table-title">{{t "Alert words"}}</h3>
     </div>
     <div class="banner-wrapper" id="alert_word_status"></div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -1,7 +1,7 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder" class="banner-wrapper"></div>
     <div class="settings_panel_list_header">
-        <h3>{{t "Your uploads"}}</h3>
+        <h3 class="settings-table-title">{{t "Your uploads"}}</h3>
         {{> filter_text_input id="upload_file_search" placeholder=(t 'Filter') aria_label=(t 'Filter uploads')}}
     </div>
     <div class="clear-float"></div>

--- a/web/templates/settings/auth_methods_settings_admin.hbs
+++ b/web/templates/settings/auth_methods_settings_admin.hbs
@@ -11,7 +11,7 @@
     <form class="admin-realm-form org-authentications-form">
         <div id="org-auth_settings" class="settings-subsection-parent">
             <div class ="subsection-header">
-                <h3>{{t "Authentication methods" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Authentication methods" }}</h3>
                 {{> settings_save_discard_widget section_name="auth_settings" show_save_discard_buttons=true }}
             </div>
 

--- a/web/templates/settings/bot_list.hbs
+++ b/web/templates/settings/bot_list.hbs
@@ -1,5 +1,5 @@
 <div class="settings_panel_list_header">
-    <h3>{{section_title}}</h3>
+    <h3 class="settings-table-title">{{section_title}}</h3>
     <div class="alert-notification"></div>
     <div class="bot-filters">
         {{> ../dropdown_widget widget_name=dropdown_widget_name}}

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -1,7 +1,9 @@
 <div id="data-exports" class="settings-section" data-name="data-exports-admin">
-    <h3>{{t "Export organization" }}
-        {{> ../help_link_widget link="/help/export-your-organization" }}
-    </h3>
+    <div class="subsection-header">
+        <h3>{{t "Export organization" }}
+            {{> ../help_link_widget link="/help/export-your-organization" }}
+        </h3>
+    </div>
     <p>
         {{t 'Your organization’s data will be exported in a format designed for imports into Zulip Cloud or a self-hosted installation of Zulip.' }}
         {{t 'You will be able to export all public data, and (optionally) private data from users who have given their permission.' }}

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -1,6 +1,6 @@
 <div id="data-exports" class="settings-section" data-name="data-exports-admin">
     <div class="subsection-header">
-        <h3>{{t "Export organization" }}
+        <h3 class="settings-subsection-title">{{t "Export organization" }}
             {{> ../help_link_widget link="/help/export-your-organization" }}
         </h3>
     </div>
@@ -37,7 +37,7 @@
 
     <div class="export_section" data-export-section="data-exports">
         <div class="settings_panel_list_header">
-            <h3>{{t "Data exports"}}</h3>
+            <h3 class="settings-table-title">{{t "Data exports"}}</h3>
             <input type="hidden" class="search" placeholder="{{t 'Filter exports' }}"
               aria-label="{{t 'Filter exports' }}"/>
         </div>
@@ -64,7 +64,7 @@
 
     <div class="export_section" data-export-section="export-permissions">
         <div class="settings_panel_list_header">
-            <h3>{{t "Export permissions"}}</h3>
+            <h3 class="settings-table-title">{{t "Export permissions"}}</h3>
             <div class="user_filters">
                 {{> ../dropdown_widget widget_name="filter_by_consent"}}
                 {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter users')}}

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -2,7 +2,7 @@
     <div class="clear-float"></div>
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Deactivated users" }}
+        <h3 class="settings-table-title">{{t "Deactivated users" }}
             {{> ../help_link_widget link="/help/deactivate-or-reactivate-a-user" }}
         </h3>
         <div class="alert-notification" id="deactivated-user-field-status"></div>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -2,7 +2,7 @@
     <p>{{t "Configure the default channels new users are subscribed to when joining your organization." }}</p>
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Default channels"}}</h3>
+        <h3 class="settings-table-title">{{t "Default channels"}}</h3>
         <div class="add_default_streams_button_container">
             {{> ../components/action_button
               id="show-add-default-streams-modal"

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -14,7 +14,7 @@
       }}
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Custom emoji"}}</h3>
+        <h3 class="settings-table-title">{{t "Custom emoji"}}</h3>
         {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter emoji')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/imported_user_list_admin.hbs
+++ b/web/templates/settings/imported_user_list_admin.hbs
@@ -1,7 +1,7 @@
 <div id="admin-imported-users-list" class="user-settings-section user-or-bot-settings-section" data-user-settings-section="imported">
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Imported users"}}</h3>
+        <h3 class="settings-table-title">{{t "Imported users"}}</h3>
         <div class="alert-notification" id="user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=imported_user_list_dropdown_widget_name}}

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -22,7 +22,7 @@
       custom_classes="user-settings-invite-user-label invite-user-link"
       }}
     <div class="settings_panel_list_header">
-        <h3>{{t "Invitations "}}</h3>
+        <h3 class="settings-table-title">{{t "Invitations "}}</h3>
         <div class="alert-notification" id="invites-field-status"></div>
         {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter invitations')}}
     </div>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -27,7 +27,7 @@
     {{/if}}
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Linkifiers"}}</h3>
+        <h3 class="settings-table-title">{{t "Linkifiers"}}</h3>
         <div class="alert-notification edit-linkifier-status" id="linkifier-field-status"></div>
         {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter linkifiers')}}
     </div>

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -1,6 +1,6 @@
 <div id="muted-user-settings" class="settings-section" data-name="muted-users">
     <div class="settings_panel_list_header">
-        <h3>{{t "Muted users"}}</h3>
+        <h3 class="settings-table-title">{{t "Muted users"}}</h3>
         {{> filter_text_input id="muted_users_search" placeholder=(t 'Filter') aria_label=(t 'Filter muted users')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -1,7 +1,7 @@
 <form class="notification-settings-form">
     <div class="general_notifications {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
-            <h3>{{t "Notification triggers" }}</h3>
+            <h3 class="settings-subsection-title">{{t "Notification triggers" }}</h3>
             {{#if for_realm_settings}}
                 {{> ../components/icon_button icon="reset" intent="neutral" custom_classes="reset-user-setting-to-default" data-tippy-content=(t "Reset users to default") aria-label=(t "Reset users to default") }}
             {{/if}}
@@ -76,7 +76,7 @@
     <div class="topic_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header">
-            <h3>{{t "Topic notifications" }}
+            <h3 class="settings-subsection-title">{{t "Topic notifications" }}
                 {{> ../help_link_widget link="/help/topic-notifications" }}
             </h3>
             {{> settings_save_discard_widget section_name="topic-notifications-settings" show_save_discard_buttons=for_realm_settings }}
@@ -140,7 +140,7 @@
     <div class="desktop_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header">
-            <h3>{{t "Desktop message notifications" }}
+            <h3 class="settings-subsection-title">{{t "Desktop message notifications" }}
                 {{> ../help_link_widget link="/help/desktop-notifications" }}
             </h3>
             {{> settings_save_discard_widget section_name="desktop-message-settings" show_save_discard_buttons=for_realm_settings }}
@@ -207,7 +207,7 @@
     <div class="mobile_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header">
-            <h3>{{t "Mobile message notifications" }}
+            <h3 class="settings-subsection-title">{{t "Mobile message notifications" }}
                 {{> ../help_link_widget link="/help/mobile-notifications" }}
             </h3>
             {{> settings_save_discard_widget section_name="mobile-message-settings" show_save_discard_buttons=for_realm_settings }}
@@ -231,7 +231,7 @@
     <div class="email_message_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header">
-            <h3>{{t "Email message notifications" }}
+            <h3 class="settings-subsection-title">{{t "Email message notifications" }}
                 {{> ../help_link_widget link="/help/email-notifications" }}
             </h3>
             {{> settings_save_discard_widget section_name="email-message-settings" show_save_discard_buttons=for_realm_settings }}
@@ -289,7 +289,7 @@
     <div class="other_email_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header">
-            <h3>{{t "Other emails" }}</h3>
+            <h3 class="settings-subsection-title">{{t "Other emails" }}</h3>
             {{> settings_save_discard_widget section_name="other-emails-settings" show_save_discard_buttons=for_realm_settings }}
         </div>
         {{#each notification_settings.other_email_settings}}

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -3,7 +3,7 @@
 
         <div id="org-join-settings" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>
+                <h3 class="settings-subsection-title">
                     {{t "Joining the organization" }}
                     <i class="fa fa-info-circle settings-info-icon tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change these settings.' }}"></i>
                 </h3>
@@ -60,7 +60,7 @@
 
         <div id="org-stream-permissions" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Channel permissions" }}
+                <h3 class="settings-subsection-title">{{t "Channel permissions" }}
                     {{> ../help_link_widget link="/help/channel-permissions" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="stream-permissions" show_save_discard_buttons=true }}
@@ -105,7 +105,7 @@
 
         <div id="org-group-permissions" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Group permissions" }}
+                <h3 class="settings-subsection-title">{{t "Group permissions" }}
                     {{> ../help_link_widget link="/help/manage-user-groups" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="group-permissions" show_save_discard_buttons=true }}
@@ -121,7 +121,7 @@
 
         <div id="org-direct-message-permissions" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Direct message permissions" }}
+                <h3 class="settings-subsection-title">{{t "Direct message permissions" }}
                     {{> ../help_link_widget link="/help/restrict-direct-messages" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="direct-message-permissions" show_save_discard_buttons=true }}
@@ -138,7 +138,7 @@
 
         <div id="org-msg-editing" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Message editing" }}
+                <h3 class="settings-subsection-title">{{t "Message editing" }}
                     {{> ../help_link_widget link="/help/restrict-message-editing-and-deletion" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="msg-editing" show_save_discard_buttons=true }}
@@ -184,7 +184,7 @@
 
         <div id="org-moving-msgs" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Moving messages" }}
+                <h3 class="settings-subsection-title">{{t "Moving messages" }}
                     {{> ../help_link_widget link="/help/restrict-moving-messages" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="moving-msgs" show_save_discard_buttons=true }}
@@ -247,7 +247,7 @@
 
         <div id="org-msg-deletion" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Message deletion" }}
+                <h3 class="settings-subsection-title">{{t "Message deletion" }}
                     {{> ../help_link_widget link="/help/delete-a-message" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="msg-deletion" show_save_discard_buttons=true }}
@@ -289,7 +289,7 @@
 
         <div id="org-user-identity" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "User identity" }}
+                <h3 class="settings-subsection-title">{{t "User identity" }}
                     {{> ../help_link_widget link="/help/restrict-name-and-email-changes" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="user-identity" show_save_discard_buttons=true }}
@@ -324,7 +324,7 @@
 
         <div id="org-guest-settings" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Guests" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Guests" }}</h3>
                 {{> settings_save_discard_widget section_name="guest-settings" show_save_discard_buttons=true }}
             </div>
 
@@ -349,7 +349,7 @@
 
         <div id="org-other-permissions" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Other permissions" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Other permissions" }}</h3>
                 {{> settings_save_discard_widget section_name="other-permissions" show_save_discard_buttons=true }}
             </div>
             <div class="disabled-unfinished-feature"

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -9,53 +9,51 @@
                 </h3>
                 {{> settings_save_discard_widget section_name="join-settings" show_save_discard_buttons=true }}
             </div>
-            <div class="m-10 inline-block organization-permissions-parent">
-                <div id="realm_invite_required_container" {{#unless user_has_email_set}}class="disabled_setting_tooltip"{{/unless}}>
-                    {{> settings_checkbox
-                      setting_name="realm_invite_required"
-                      prefix="id_"
-                      is_checked=realm_invite_required
-                      is_disabled=(not user_has_email_set)
-                      label=admin_settings_label.realm_invite_required}}
-                </div>
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_invite_users_group"
-                  label=group_setting_labels.can_invite_users_group}}
+            <div id="realm_invite_required_container" {{#unless user_has_email_set}}class="disabled_setting_tooltip"{{/unless}}>
+                {{> settings_checkbox
+                  setting_name="realm_invite_required"
+                  prefix="id_"
+                  is_checked=realm_invite_required
+                  is_disabled=(not user_has_email_set)
+                  label=admin_settings_label.realm_invite_required}}
+            </div>
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_invite_users_group"
+              label=group_setting_labels.can_invite_users_group}}
 
-                {{> group_setting_value_pill_input
-                  setting_name="realm_create_multiuse_invite_group"
-                  label=group_setting_labels.create_multiuse_invite_group}}
+            {{> group_setting_value_pill_input
+              setting_name="realm_create_multiuse_invite_group"
+              label=group_setting_labels.create_multiuse_invite_group}}
 
-                <div class="input-group">
-                    <label for="id_realm_org_join_restrictions" class="settings-field-label">{{t "Restrict email domains of new users" }}</label>
-                    <select name="realm_org_join_restrictions" id="id_realm_org_join_restrictions" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
-                        <option value="no_restriction">{{t "No restrictions" }}</option>
-                        <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
-                        <option value="only_selected_domain">{{t "Restrict to a list of domains" }}</option>
-                    </select>
-                    <div class="dependent-settings-block">
-                        <p id="allowed_domains_label" class="inline-block"></p>
-                        {{#if is_owner }}
-                        <a id="show_realm_domains_modal" role="button">{{t "[Configure]" }}</a>
-                        {{/if}}
-                    </div>
+            <div class="input-group">
+                <label for="id_realm_org_join_restrictions" class="settings-field-label">{{t "Restrict email domains of new users" }}</label>
+                <select name="realm_org_join_restrictions" id="id_realm_org_join_restrictions" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
+                    <option value="no_restriction">{{t "No restrictions" }}</option>
+                    <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
+                    <option value="only_selected_domain">{{t "Restrict to a list of domains" }}</option>
+                </select>
+                <div class="dependent-settings-block">
+                    <p id="allowed_domains_label" class="inline-block"></p>
+                    {{#if is_owner }}
+                    <a id="show_realm_domains_modal" role="button">{{t "[Configure]" }}</a>
+                    {{/if}}
                 </div>
-                <div class="input-group time-limit-setting">
-                    <label for="id_realm_waiting_period_threshold" class="settings-field-label">
-                        {{t "Waiting period before new members turn into full members" }}
-                        {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
-                    </label>
-                    <select name="realm_waiting_period_threshold" id="id_realm_waiting_period_threshold" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="time-limit">
-                        {{> dropdown_options_widget option_values=waiting_period_threshold_dropdown_values}}
-                    </select>
-                    {{!-- This setting is hidden unless `custom_period` --}}
-                    <div class="dependent-settings-block">
-                        <label for="id_realm_waiting_period_threshold_custom_input" class="inline-block">{{t "Waiting period (days)" }}:</label>
-                        <input type="text" id="id_realm_waiting_period_threshold_custom_input"
-                          name="realm_waiting_period_threshold_custom_input"
-                          class="time-limit-custom-input"
-                          value="{{ realm_waiting_period_threshold }}"/>
-                    </div>
+            </div>
+            <div class="input-group time-limit-setting">
+                <label for="id_realm_waiting_period_threshold" class="settings-field-label">
+                    {{t "Waiting period before new members turn into full members" }}
+                    {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
+                </label>
+                <select name="realm_waiting_period_threshold" id="id_realm_waiting_period_threshold" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="time-limit">
+                    {{> dropdown_options_widget option_values=waiting_period_threshold_dropdown_values}}
+                </select>
+                {{!-- This setting is hidden unless `custom_period` --}}
+                <div class="dependent-settings-block">
+                    <label for="id_realm_waiting_period_threshold_custom_input" class="inline-block">{{t "Waiting period (days)" }}:</label>
+                    <input type="text" id="id_realm_waiting_period_threshold_custom_input"
+                      name="realm_waiting_period_threshold_custom_input"
+                      class="time-limit-custom-input"
+                      value="{{ realm_waiting_period_threshold }}"/>
                 </div>
             </div>
         </div>
@@ -67,44 +65,42 @@
                 </h3>
                 {{> settings_save_discard_widget section_name="stream-permissions" show_save_discard_buttons=true }}
             </div>
-            <div class="m-10 organization-permissions-parent">
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_create_public_channel_group"
-                  label=group_setting_labels.can_create_public_channel_group}}
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_create_public_channel_group"
+              label=group_setting_labels.can_create_public_channel_group}}
 
-                {{> upgrade_tip_widget . }}
-                {{> settings_checkbox
-                  setting_name="realm_enable_spectator_access"
-                  prefix="id_"
-                  is_checked=realm_enable_spectator_access
-                  label=admin_settings_label.realm_enable_spectator_access
-                  is_disabled=disable_enable_spectator_access_setting
-                  help_link="/help/public-access-option"}}
+            {{> upgrade_tip_widget . }}
+            {{> settings_checkbox
+              setting_name="realm_enable_spectator_access"
+              prefix="id_"
+              is_checked=realm_enable_spectator_access
+              label=admin_settings_label.realm_enable_spectator_access
+              is_disabled=disable_enable_spectator_access_setting
+              help_link="/help/public-access-option"}}
 
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_can_create_web_public_channel_group"
-                  label=group_setting_labels.can_create_web_public_channel_group
-                  value_type="number"}}
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_can_create_web_public_channel_group"
+              label=group_setting_labels.can_create_web_public_channel_group
+              value_type="number"}}
 
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_create_private_channel_group"
-                  label=group_setting_labels.can_create_private_channel_group}}
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_create_private_channel_group"
+              label=group_setting_labels.can_create_private_channel_group}}
 
 
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_add_subscribers_group"
-                  label=group_setting_labels.can_add_subscribers_group}}
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_add_subscribers_group"
+              label=group_setting_labels.can_add_subscribers_group}}
 
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_mention_many_users_group"
-                  label=group_setting_labels.can_mention_many_users_group
-                  help_link="/help/restrict-wildcard-mentions"}}
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_mention_many_users_group"
+              label=group_setting_labels.can_mention_many_users_group
+              help_link="/help/restrict-wildcard-mentions"}}
 
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_set_topics_policy_group"
-                  label=group_setting_labels.can_set_topics_policy_group
-                  help_link="/help/require-topics"}}
-            </div>
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_set_topics_policy_group"
+              label=group_setting_labels.can_set_topics_policy_group
+              help_link="/help/require-topics"}}
         </div>
 
         <div id="org-group-permissions" class="settings-subsection-parent">
@@ -114,15 +110,13 @@
                 </h3>
                 {{> settings_save_discard_widget section_name="group-permissions" show_save_discard_buttons=true }}
             </div>
-            <div class="m-10 organization-permissions-parent">
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_manage_all_groups"
-                  label=group_setting_labels.can_manage_all_groups}}
-                {{> upgrade_tip_widget . }}
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_create_groups"
-                  label=group_setting_labels.can_create_groups}}
-            </div>
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_manage_all_groups"
+              label=group_setting_labels.can_manage_all_groups}}
+            {{> upgrade_tip_widget . }}
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_create_groups"
+              label=group_setting_labels.can_create_groups}}
         </div>
 
         <div id="org-direct-message-permissions" class="settings-subsection-parent">
@@ -149,43 +143,41 @@
                 </h3>
                 {{> settings_save_discard_widget section_name="msg-editing" show_save_discard_buttons=true }}
             </div>
-            <div class="inline-block organization-settings-parent">
-                {{> settings_checkbox
-                  setting_name="realm_allow_message_editing"
-                  prefix="id_"
-                  is_checked=realm_allow_message_editing
-                  label=admin_settings_label.realm_allow_message_editing}}
+            {{> settings_checkbox
+              setting_name="realm_allow_message_editing"
+              prefix="id_"
+              is_checked=realm_allow_message_editing
+              label=admin_settings_label.realm_allow_message_editing}}
 
-                <div class="input-group">
-                    <label for="id_realm_message_edit_history_visibility_policy" class="settings-field-label">{{t "Allow viewing the history of a message?"}}</label>
-                    <select name="realm_message_edit_history_visibility_policy" id="id_realm_message_edit_history_visibility_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
-                        {{> dropdown_options_widget option_values=(object_values message_edit_history_visibility_policy_values)}}
-                    </select>
-                </div>
+            <div class="input-group">
+                <label for="id_realm_message_edit_history_visibility_policy" class="settings-field-label">{{t "Allow viewing the history of a message?"}}</label>
+                <select name="realm_message_edit_history_visibility_policy" id="id_realm_message_edit_history_visibility_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
+                    {{> dropdown_options_widget option_values=(object_values message_edit_history_visibility_policy_values)}}
+                </select>
+            </div>
 
-                <div class="input-group time-limit-setting">
-                    <label for="id_realm_message_content_edit_limit_seconds" class="settings-field-label">{{t "Time limit for editing messages" }}</label>
-                    <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element settings_select bootstrap-focus-style" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
-                        {{#each msg_edit_limit_dropdown_values}}
-                            <option value="{{value}}">{{text}}</option>
-                        {{/each}}
-                    </select>
-                    <div class="dependent-settings-block">
-                        <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t 'Time limit'}}:&nbsp;
-                        </label>
-                        <input type="text" id="id_realm_message_content_edit_limit_minutes"
-                          name="realm_message_content_edit_limit_minutes"
-                          class="time-limit-custom-input"
-                          autocomplete="off"
-                          value="{{ realm_message_content_edit_limit_minutes }}"
-                          {{#unless realm_allow_message_editing}}disabled{{/unless}}/>&nbsp;
-                        <span class="time-unit-text">
-                            {{t "{realm_message_content_edit_limit_minutes, plural, one {minute} other {minutes}}"}}
-                        </span>
+            <div class="input-group time-limit-setting">
+                <label for="id_realm_message_content_edit_limit_seconds" class="settings-field-label">{{t "Time limit for editing messages" }}</label>
+                <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element settings_select bootstrap-focus-style" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
+                    {{#each msg_edit_limit_dropdown_values}}
+                        <option value="{{value}}">{{text}}</option>
+                    {{/each}}
+                </select>
+                <div class="dependent-settings-block">
+                    <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
+                        {{t 'Time limit'}}:&nbsp;
+                    </label>
+                    <input type="text" id="id_realm_message_content_edit_limit_minutes"
+                      name="realm_message_content_edit_limit_minutes"
+                      class="time-limit-custom-input"
+                      autocomplete="off"
+                      value="{{ realm_message_content_edit_limit_minutes }}"
+                      {{#unless realm_allow_message_editing}}disabled{{/unless}}/>&nbsp;
+                    <span class="time-unit-text">
+                        {{t "{realm_message_content_edit_limit_minutes, plural, one {minute} other {minutes}}"}}
+                    </span>
 
 
-                    </div>
                 </div>
             </div>
         </div>
@@ -260,41 +252,39 @@
                 </h3>
                 {{> settings_save_discard_widget section_name="msg-deletion" show_save_discard_buttons=true }}
             </div>
-            <div class="inline-block organization-settings-parent">
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_delete_any_message_group"
-                  label=group_setting_labels.can_delete_any_message_group}}
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_delete_any_message_group"
+              label=group_setting_labels.can_delete_any_message_group}}
 
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_delete_own_message_group"
-                  label=group_setting_labels.can_delete_own_message_group}}
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_delete_own_message_group"
+              label=group_setting_labels.can_delete_own_message_group}}
 
-                <div class="input-group time-limit-setting">
-                    <label for="id_realm_message_content_delete_limit_seconds" class="settings-field-label">
-                        {{t "Time limit for deleting messages" }} <i>({{t "does not apply to users who can delete any message" }})</i>
+            <div class="input-group time-limit-setting">
+                <label for="id_realm_message_content_delete_limit_seconds" class="settings-field-label">
+                    {{t "Time limit for deleting messages" }} <i>({{t "does not apply to users who can delete any message" }})</i>
+                </label>
+                <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
+                    {{#each msg_delete_limit_dropdown_values}}
+                        <option value="{{value}}">{{text}}</option>
+                    {{/each}}
+                </select>
+                <div class="dependent-settings-block">
+                    <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
+                        {{t "Time limit" }}:&nbsp;
                     </label>
-                    <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
-                        {{#each msg_delete_limit_dropdown_values}}
-                            <option value="{{value}}">{{text}}</option>
-                        {{/each}}
-                    </select>
-                    <div class="dependent-settings-block">
-                        <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t "Time limit" }}:&nbsp;
-                        </label>
-                        <input type="text" id="id_realm_message_content_delete_limit_minutes"
-                          name="realm_message_content_delete_limit_minutes"
-                          class="time-limit-custom-input"
-                          autocomplete="off"
-                          value="{{ realm_message_content_delete_limit_minutes }}"/>&nbsp;
-                        <span class="time-unit-text">{{t "{realm_message_content_delete_limit_minutes, plural, one {minute} other {minutes}}"}}</span>
-                    </div>
+                    <input type="text" id="id_realm_message_content_delete_limit_minutes"
+                      name="realm_message_content_delete_limit_minutes"
+                      class="time-limit-custom-input"
+                      autocomplete="off"
+                      value="{{ realm_message_content_delete_limit_minutes }}"/>&nbsp;
+                    <span class="time-unit-text">{{t "{realm_message_content_delete_limit_minutes, plural, one {minute} other {minutes}}"}}</span>
                 </div>
-
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_set_delete_message_policy_group"
-                  label=group_setting_labels.can_set_delete_message_policy_group}}
             </div>
+
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_set_delete_message_policy_group"
+              label=group_setting_labels.can_set_delete_message_policy_group}}
         </div>
 
         <div id="org-user-identity" class="settings-subsection-parent">
@@ -304,34 +294,32 @@
                 </h3>
                 {{> settings_save_discard_widget section_name="user-identity" show_save_discard_buttons=true }}
             </div>
-            <div class="inline-block organization-permissions-parent">
-                {{> settings_checkbox
-                  setting_name="realm_require_unique_names"
-                  prefix="id_"
-                  is_checked=realm_require_unique_names
-                  label=admin_settings_label.realm_require_unique_names}}
+            {{> settings_checkbox
+              setting_name="realm_require_unique_names"
+              prefix="id_"
+              is_checked=realm_require_unique_names
+              label=admin_settings_label.realm_require_unique_names}}
 
-                {{> settings_checkbox
-                  setting_name="realm_name_changes_disabled"
-                  prefix="id_"
-                  is_checked=(or realm_name_changes_disabled server_name_changes_disabled)
-                  label=admin_settings_label.realm_name_changes_disabled
-                  is_disabled=server_name_changes_disabled}}
+            {{> settings_checkbox
+              setting_name="realm_name_changes_disabled"
+              prefix="id_"
+              is_checked=(or realm_name_changes_disabled server_name_changes_disabled)
+              label=admin_settings_label.realm_name_changes_disabled
+              is_disabled=server_name_changes_disabled}}
 
-                {{> settings_checkbox
-                  setting_name="realm_email_changes_disabled"
-                  prefix="id_"
-                  is_checked=realm_email_changes_disabled
-                  label=admin_settings_label.realm_email_changes_disabled}}
+            {{> settings_checkbox
+              setting_name="realm_email_changes_disabled"
+              prefix="id_"
+              is_checked=realm_email_changes_disabled
+              label=admin_settings_label.realm_email_changes_disabled}}
 
-                {{> settings_checkbox
-                  setting_name="realm_avatar_changes_disabled"
-                  prefix="id_"
-                  is_checked=(or realm_avatar_changes_disabled server_avatar_changes_disabled)
-                  label=admin_settings_label.realm_avatar_changes_disabled
-                  is_disabled=server_avatar_changes_disabled}}
+            {{> settings_checkbox
+              setting_name="realm_avatar_changes_disabled"
+              prefix="id_"
+              is_checked=(or realm_avatar_changes_disabled server_avatar_changes_disabled)
+              label=admin_settings_label.realm_avatar_changes_disabled
+              is_disabled=server_avatar_changes_disabled}}
 
-            </div>
         </div>
 
         <div id="org-guest-settings" class="settings-subsection-parent">
@@ -340,25 +328,23 @@
                 {{> settings_save_discard_widget section_name="guest-settings" show_save_discard_buttons=true }}
             </div>
 
-            <div class="inline-block organization-permissions-parent">
-                {{> settings_checkbox
-                  setting_name="realm_enable_guest_user_indicator"
-                  prefix="id_"
-                  is_checked=realm_enable_guest_user_indicator
-                  label=admin_settings_label.realm_enable_guest_user_indicator}}
+            {{> settings_checkbox
+              setting_name="realm_enable_guest_user_indicator"
+              prefix="id_"
+              is_checked=realm_enable_guest_user_indicator
+              label=admin_settings_label.realm_enable_guest_user_indicator}}
 
-                {{> settings_checkbox
-                  setting_name="realm_enable_guest_user_dm_warning"
-                  prefix="id_"
-                  is_checked=realm_enable_guest_user_dm_warning
-                  label=admin_settings_label.realm_enable_guest_user_dm_warning}}
+            {{> settings_checkbox
+              setting_name="realm_enable_guest_user_dm_warning"
+              prefix="id_"
+              is_checked=realm_enable_guest_user_dm_warning
+              label=admin_settings_label.realm_enable_guest_user_dm_warning}}
 
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_can_access_all_users_group"
-                  label=group_setting_labels.can_access_all_users_group
-                  value_type="number"
-                  help_link="/help/guest-users#configure-whether-guests-can-see-all-other-users"}}
-            </div>
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_can_access_all_users_group"
+              label=group_setting_labels.can_access_all_users_group
+              value_type="number"
+              help_link="/help/guest-users#configure-whether-guests-can-see-all-other-users"}}
         </div>
 
         <div id="org-other-permissions" class="settings-subsection-parent">
@@ -366,35 +352,33 @@
                 <h3>{{t "Other permissions" }}</h3>
                 {{> settings_save_discard_widget section_name="other-permissions" show_save_discard_buttons=true }}
             </div>
-            <div class="m-10 inline-block organization-permissions-parent">
-                <div class="disabled-unfinished-feature"
-                  {{#unless server_can_summarize_topics}}style="display: none"{{/unless}}>
-                    {{#unless server_can_summarize_topics}}
-                        <div class="tip">
-                            {{#if is_plan_self_hosted}}
-                            {{t "AI summaries are not enabled on this server."}}
-                            {{else}}
-                            {{t "AI summaries are not available on Zulip Cloud yet."}}
-                            {{/if}}
-                        </div>
-                    {{/unless}}
-                    {{> group_setting_value_pill_input
-                      setting_name="realm_can_summarize_topics_group"
-                      label=group_setting_labels.can_summarize_topics_group}}
-                </div>
-
+            <div class="disabled-unfinished-feature"
+              {{#unless server_can_summarize_topics}}style="display: none"{{/unless}}>
+                {{#unless server_can_summarize_topics}}
+                    <div class="tip">
+                        {{#if is_plan_self_hosted}}
+                        {{t "AI summaries are not enabled on this server."}}
+                        {{else}}
+                        {{t "AI summaries are not available on Zulip Cloud yet."}}
+                        {{/if}}
+                    </div>
+                {{/unless}}
                 {{> group_setting_value_pill_input
-                  setting_name="realm_can_create_write_only_bots_group"
-                  label=group_setting_labels.can_create_write_only_bots_group}}
-
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_create_bots_group"
-                  label=group_setting_labels.can_create_bots_group}}
-
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_add_custom_emoji_group"
-                  label=group_setting_labels.can_add_custom_emoji_group}}
+                  setting_name="realm_can_summarize_topics_group"
+                  label=group_setting_labels.can_summarize_topics_group}}
             </div>
+
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_create_write_only_bots_group"
+              label=group_setting_labels.can_create_write_only_bots_group}}
+
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_create_bots_group"
+              label=group_setting_labels.can_create_bots_group}}
+
+            {{> group_setting_value_pill_input
+              setting_name="realm_can_add_custom_emoji_group"
+              label=group_setting_labels.can_add_custom_emoji_group}}
         </div>
     </form>
 </div>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -4,7 +4,7 @@
 
         <div id="org-org-profile" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Organization profile" }}
+                <h3 class="settings-subsection-title">{{t "Organization profile" }}
                     {{> ../help_link_widget link="/help/create-your-organization-profile" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="org-profile" show_save_discard_buttons=true }}
@@ -52,7 +52,7 @@
           intent="brand"
           }}
         <div class="subsection-header">
-            <h3>{{t "Organization logo" }}
+            <h3 class="settings-subsection-title">{{t "Organization logo" }}
                 {{> ../help_link_widget link="/help/create-your-organization-profile#add-a-wide-logo" }}
             </h3>
         </div>
@@ -81,7 +81,7 @@
         </div>
         <div class="deactivate-realm-section">
             <div class="subsection-header">
-                <h3>
+                <h3 class="settings-subsection-title">
                     {{t "Deactivate organization" }}
                     {{> ../help_link_widget link="/help/deactivate-your-organization" }}
                 </h3>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -82,10 +82,12 @@
             </div>
         </div>
         <div class="deactivate-realm-section">
-            <h3>
-                {{t "Deactivate organization" }}
-                {{> ../help_link_widget link="/help/deactivate-your-organization" }}
-            </h3>
+            <div class="subsection-header">
+                <h3>
+                    {{t "Deactivate organization" }}
+                    {{> ../help_link_widget link="/help/deactivate-your-organization" }}
+                </h3>
+            </div>
             <div class="input-group">
                 <div id="deactivate_realm_button_container" class="inline-block">
                     {{> ../components/action_button

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -10,30 +10,28 @@
                 {{> settings_save_discard_widget section_name="org-profile" show_save_discard_buttons=true }}
             </div>
 
-            <div class="organization-settings-parent">
-                <div class="input-group admin-realm">
-                    <label for="id_realm_name" class="settings-field-label">{{t "Organization name" }}</label>
-                    <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name setting-widget prop-element settings_text_input"
-                      autocomplete="off" data-setting-widget-type="string"
-                      value="{{ realm_name }}" maxlength="40" />
-                </div>
-                <div class="input-group admin-realm">
-                    <label for="id_realm_org_type" class="settings-field-label">{{t "Organization type" }}
-                        {{> ../help_link_widget link="/help/organization-type" }}
-                    </label>
-                    <select name="realm_org_type" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_org_type" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=(object_values realm_org_type_values)}}
-                    </select>
-                </div>
-                {{> settings_checkbox
-                  setting_name="realm_want_advertise_in_communities_directory"
-                  prefix="id_"
-                  is_checked=realm_want_advertise_in_communities_directory
-                  is_disabled=disable_want_advertise_in_communities_directory
-                  label=admin_settings_label.realm_want_advertise_in_communities_directory
-                  help_link="/help/communities-directory"}}
-                {{> realm_description . }}
+            <div class="input-group admin-realm">
+                <label for="id_realm_name" class="settings-field-label">{{t "Organization name" }}</label>
+                <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name setting-widget prop-element settings_text_input"
+                  autocomplete="off" data-setting-widget-type="string"
+                  value="{{ realm_name }}" maxlength="40" />
             </div>
+            <div class="input-group admin-realm">
+                <label for="id_realm_org_type" class="settings-field-label">{{t "Organization type" }}
+                    {{> ../help_link_widget link="/help/organization-type" }}
+                </label>
+                <select name="realm_org_type" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_org_type" data-setting-widget-type="number">
+                    {{> dropdown_options_widget option_values=(object_values realm_org_type_values)}}
+                </select>
+            </div>
+            {{> settings_checkbox
+              setting_name="realm_want_advertise_in_communities_directory"
+              prefix="id_"
+              is_checked=realm_want_advertise_in_communities_directory
+              is_disabled=disable_want_advertise_in_communities_directory
+              label=admin_settings_label.realm_want_advertise_in_communities_directory
+              help_link="/help/communities-directory"}}
+            {{> realm_description . }}
         </div>
 
         <div>{{t "Organization profile picture" }}</div>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -82,7 +82,7 @@
             </div>
         </div>
         <div class="deactivate-realm-section">
-            <h3 class="light">
+            <h3>
                 {{t "Deactivate organization" }}
                 {{> ../help_link_widget link="/help/deactivate-your-organization" }}
             </h3>

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -3,7 +3,7 @@
 
         <div id="org-billing" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Billing" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Billing" }}</h3>
                 {{> settings_save_discard_widget section_name="onboarding" show_save_discard_buttons=true }}
             </div>
             {{#if show_two_tier_billing_settings}}
@@ -35,7 +35,7 @@
         </div>
         <div id="org-notifications" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Automated messages and emails" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Automated messages and emails" }}</h3>
                 {{> settings_save_discard_widget section_name="notifications" show_save_discard_buttons=true }}
             </div>
             {{> ../dropdown_widget_with_label
@@ -103,7 +103,7 @@
 
         <div id="org-onboarding" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Onboarding" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Onboarding" }}</h3>
                 {{> settings_save_discard_widget section_name="onboarding" show_save_discard_buttons=true }}
             </div>
             <div class="input-group">
@@ -163,7 +163,7 @@
 
         <div class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Notifications security" }}</h3>
+                <h3 class="settings-subsection-title">{{t "Notifications security" }}</h3>
                 {{> settings_save_discard_widget section_name="notifications-security" show_save_discard_buttons=true }}
             </div>
             {{> settings_checkbox
@@ -182,7 +182,7 @@
 
         <div id="org-compose-settings" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Compose settings"}}</h3>
+                <h3 class="settings-subsection-title">{{t "Compose settings"}}</h3>
                 {{> settings_save_discard_widget section_name="compose-settings" show_save_discard_buttons=true }}
             </div>
             <div class="input-group">
@@ -245,7 +245,7 @@
 
         <div id="org-msg-feed-settings" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Message feed settings"}}</h3>
+                <h3 class="settings-subsection-title">{{t "Message feed settings"}}</h3>
                 {{> settings_save_discard_widget section_name="msg-feed-settings" show_save_discard_buttons=true }}
             </div>
             {{> ../dropdown_widget_with_label
@@ -288,7 +288,7 @@
 
         <div id="org-message-retention" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Message retention period" }}
+                <h3 class="settings-subsection-title">{{t "Message retention period" }}
                     {{> ../help_link_widget link="/help/message-retention-policy" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="message-retention" show_save_discard_buttons=true }}

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -6,103 +6,99 @@
                 <h3>{{t "Billing" }}</h3>
                 {{> settings_save_discard_widget section_name="onboarding" show_save_discard_buttons=true }}
             </div>
-            <div class="organization-settings-parent">
-                {{#if show_two_tier_billing_settings}}
-                {{> settings_checkbox
-                  setting_name="realm_enable_two_tier_billing"
-                  prefix="id_"
-                  is_checked=realm_enable_two_tier_billing
-                  label=admin_settings_label.realm_enable_two_tier_billing
-                  skip_prop_element=true}}
+            {{#if show_two_tier_billing_settings}}
+            {{> settings_checkbox
+              setting_name="realm_enable_two_tier_billing"
+              prefix="id_"
+              is_checked=realm_enable_two_tier_billing
+              label=admin_settings_label.realm_enable_two_tier_billing
+              skip_prop_element=true}}
 
+            {{> group_setting_value_pill_input
+              setting_name="realm_workplace_users_group"
+              label=group_setting_labels.workplace_users_group}}
+            {{/if}}
+
+            {{#if is_plan_self_hosted}}
                 {{> group_setting_value_pill_input
-                  setting_name="realm_workplace_users_group"
-                  label=group_setting_labels.workplace_users_group}}
-                {{/if}}
-
-                {{#if is_plan_self_hosted}}
-                    {{> group_setting_value_pill_input
-                      setting_name="realm_can_manage_billing_group"
-                      label=group_setting_labels.can_manage_billing_group
-                      help_link="https://zulip.com//help/self-hosted-billing"
-                      }}
-                {{else}}
-                    {{> group_setting_value_pill_input
-                      setting_name="realm_can_manage_billing_group"
-                      label=group_setting_labels.can_manage_billing_group
-                      help_link="/help/zulip-cloud-billing"
-                      }}
-                {{/if}}
-            </div>
+                  setting_name="realm_can_manage_billing_group"
+                  label=group_setting_labels.can_manage_billing_group
+                  help_link="https://zulip.com//help/self-hosted-billing"
+                  }}
+            {{else}}
+                {{> group_setting_value_pill_input
+                  setting_name="realm_can_manage_billing_group"
+                  label=group_setting_labels.can_manage_billing_group
+                  help_link="/help/zulip-cloud-billing"
+                  }}
+            {{/if}}
         </div>
         <div id="org-notifications" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Automated messages and emails" }}</h3>
                 {{> settings_save_discard_widget section_name="notifications" show_save_discard_buttons=true }}
             </div>
-            <div class="inline-block organization-settings-parent">
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_default_language"
-                  label=admin_settings_label.realm_default_language
-                  value_type="string"
-                  help_link="/help/configure-organization-language"}}
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_default_language"
+              label=admin_settings_label.realm_default_language
+              value_type="string"
+              help_link="/help/configure-organization-language"}}
 
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_moderation_request_channel_id"
-                  label=admin_settings_label.realm_moderation_request_channel
-                  value_type="number"
-                  help_link="/help/enable-moderation-requests"
-                  }}
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_moderation_request_channel_id"
+              label=admin_settings_label.realm_moderation_request_channel
+              value_type="number"
+              help_link="/help/enable-moderation-requests"
+              }}
 
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_new_stream_announcements_stream_id"
-                  label=admin_settings_label.realm_new_stream_announcements_stream
-                  value_type="number"
-                  custom_classes="decorated-stream-name-dropdown-widget"}}
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_new_stream_announcements_stream_id"
+              label=admin_settings_label.realm_new_stream_announcements_stream
+              value_type="number"
+              custom_classes="decorated-stream-name-dropdown-widget"}}
 
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_signup_announcements_stream_id"
-                  label=admin_settings_label.realm_signup_announcements_stream
-                  value_type="number"
-                  custom_classes="decorated-stream-name-dropdown-widget"}}
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_signup_announcements_stream_id"
+              label=admin_settings_label.realm_signup_announcements_stream
+              value_type="number"
+              custom_classes="decorated-stream-name-dropdown-widget"}}
 
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_zulip_update_announcements_stream_id"
-                  label=admin_settings_label.realm_zulip_update_announcements_stream
-                  value_type="number"
-                  custom_classes="decorated-stream-name-dropdown-widget"}}
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_zulip_update_announcements_stream_id"
+              label=admin_settings_label.realm_zulip_update_announcements_stream
+              value_type="number"
+              custom_classes="decorated-stream-name-dropdown-widget"}}
 
-                {{> settings_checkbox
-                  setting_name="realm_send_channel_events_messages"
-                  prefix="id_"
-                  is_checked=realm_send_channel_events_messages
-                  label=admin_settings_label.realm_send_channel_events_messages
-                  help_link="/help/configure-automated-notices#notices-about-channels"}}
+            {{> settings_checkbox
+              setting_name="realm_send_channel_events_messages"
+              prefix="id_"
+              is_checked=realm_send_channel_events_messages
+              label=admin_settings_label.realm_send_channel_events_messages
+              help_link="/help/configure-automated-notices#notices-about-channels"}}
 
-                {{#if settings_send_digest_emails }}
-                {{> settings_checkbox
-                  setting_name="realm_digest_emails_enabled"
-                  prefix="id_"
-                  is_checked=realm_digest_emails_enabled
-                  label=admin_settings_label.realm_digest_emails_enabled}}
-                {{/if}}
-                <div class="input-group">
-                    <label for="id_realm_digest_weekday" class="settings-field-label">{{t "Day of the week to send digests" }}</label>
-                    <select name="realm_digest_weekday"
-                      id="id_realm_digest_weekday"
-                      class="setting-widget prop-element settings_select bootstrap-focus-style"
-                      data-setting-widget-type="number">
-                        <option value="0">{{t "Monday" }}</option>
-                        <option value="1">{{t "Tuesday" }}</option>
-                        <option value="2">{{t "Wednesday" }}</option>
-                        <option value="3">{{t "Thursday" }}</option>
-                        <option value="4">{{t "Friday" }}</option>
-                        <option value="5">{{t "Saturday" }}</option>
-                        <option value="6">{{t "Sunday" }}</option>
-                    </select>
-                </div>
-
+            {{#if settings_send_digest_emails }}
+            {{> settings_checkbox
+              setting_name="realm_digest_emails_enabled"
+              prefix="id_"
+              is_checked=realm_digest_emails_enabled
+              label=admin_settings_label.realm_digest_emails_enabled}}
+            {{/if}}
+            <div class="input-group">
+                <label for="id_realm_digest_weekday" class="settings-field-label">{{t "Day of the week to send digests" }}</label>
+                <select name="realm_digest_weekday"
+                  id="id_realm_digest_weekday"
+                  class="setting-widget prop-element settings_select bootstrap-focus-style"
+                  data-setting-widget-type="number">
+                    <option value="0">{{t "Monday" }}</option>
+                    <option value="1">{{t "Tuesday" }}</option>
+                    <option value="2">{{t "Wednesday" }}</option>
+                    <option value="3">{{t "Thursday" }}</option>
+                    <option value="4">{{t "Friday" }}</option>
+                    <option value="5">{{t "Saturday" }}</option>
+                    <option value="6">{{t "Sunday" }}</option>
+                </select>
             </div>
+
         </div>
 
         <div id="org-onboarding" class="settings-subsection-parent">
@@ -110,61 +106,59 @@
                 <h3>{{t "Onboarding" }}</h3>
                 {{> settings_save_discard_widget section_name="onboarding" show_save_discard_buttons=true }}
             </div>
-            <div class="organization-settings-parent">
-                <div class="input-group">
-                    <label class="settings-field-label">
-                        {{admin_settings_label.realm_default_avatar_source}}
-                        {{> ../help_link_widget link="/help/configure-default-profile-pictures" }}
-                    </label>
-                    <div class="default_avatar_source_values settings-highlight-box prop-element" id="id_realm_default_avatar_source" data-setting-widget-type="radio-group" data-setting-choice-type="string">
-                        {{#each (object_values default_avatar_source_values)}}
-                            <label class="preferences-radio-choice-label">
-                                <span class="radio-choice-controls">
-                                    <input type="radio" name="default_avatar_source" value="{{this.code}}"/>
-                                    <span class="preferences-radio-choice-text">{{this.description}}</span>
-                                </span>
-                                <span class="right">
-                                    {{#if (eq this.code "J") }}
-                                    <img class="avatar" src="/static/images/jdenticon-1.png" />
-                                    <img class="avatar" src="/static/images/jdenticon-2.png" />
-                                    <img class="avatar" src="/static/images/jdenticon-3.png" />
-                                    <img class="avatar" src="/static/images/jdenticon-4.png" />
-                                    {{else}}
-                                    <img class="avatar" src="/static/images/gravatar-1.png" />
-                                    <img class="avatar" src="/static/images/gravatar-2.png" />
-                                    <img class="avatar" src="/static/images/gravatar-3.png" />
-                                    <img class="avatar" src="/static/images/gravatar-4.png" />
-                                    {{/if}}
-                                </span>
-                            </label>
-                        {{/each}}
-                    </div>
+            <div class="input-group">
+                <label class="settings-field-label">
+                    {{admin_settings_label.realm_default_avatar_source}}
+                    {{> ../help_link_widget link="/help/configure-default-profile-pictures" }}
+                </label>
+                <div class="default_avatar_source_values settings-highlight-box prop-element" id="id_realm_default_avatar_source" data-setting-widget-type="radio-group" data-setting-choice-type="string">
+                    {{#each (object_values default_avatar_source_values)}}
+                        <label class="preferences-radio-choice-label">
+                            <span class="radio-choice-controls">
+                                <input type="radio" name="default_avatar_source" value="{{this.code}}"/>
+                                <span class="preferences-radio-choice-text">{{this.description}}</span>
+                            </span>
+                            <span class="right">
+                                {{#if (eq this.code "J") }}
+                                <img class="avatar" src="/static/images/jdenticon-1.png" />
+                                <img class="avatar" src="/static/images/jdenticon-2.png" />
+                                <img class="avatar" src="/static/images/jdenticon-3.png" />
+                                <img class="avatar" src="/static/images/jdenticon-4.png" />
+                                {{else}}
+                                <img class="avatar" src="/static/images/gravatar-1.png" />
+                                <img class="avatar" src="/static/images/gravatar-2.png" />
+                                <img class="avatar" src="/static/images/gravatar-3.png" />
+                                <img class="avatar" src="/static/images/gravatar-4.png" />
+                                {{/if}}
+                            </span>
+                        </label>
+                    {{/each}}
                 </div>
-
-                {{> settings_checkbox
-                  setting_name="realm_enable_welcome_message_custom_text"
-                  prefix="id_"
-                  is_checked=realm_enable_welcome_message_custom_text
-                  label=admin_settings_label.realm_enable_welcome_message_custom_text
-                  skip_prop_element=true}}
-                <div class="input-group" id="welcome_message_custom_text_container">
-                    <label for="id_realm_welcome_message_custom_text" class="settings-field-label">
-                        {{t "Message text" }}
-                    </label>
-                    <textarea id="id_realm_welcome_message_custom_text" name="welcome_message_custom_text"
-                      class="admin-realm-welcome-message-custom-text setting-widget prop-element settings-textarea display-block" maxlength="8000"
-                      data-setting-widget-type="string">{{ realm_welcome_message_custom_text }}</textarea>
-                    <div id="welcome_message_custom_text_buttons_container">
-                        {{> ../components/action_button variant="subtle" intent="neutral" label=(t "Send me a test message") id="send_test_welcome_bot_custom_message"}}
-                    </div>
-                </div>
-
-                {{> settings_checkbox
-                  setting_name="realm_send_welcome_emails"
-                  prefix="id_"
-                  is_checked=realm_send_welcome_emails
-                  label=admin_settings_label.realm_send_welcome_emails}}
             </div>
+
+            {{> settings_checkbox
+              setting_name="realm_enable_welcome_message_custom_text"
+              prefix="id_"
+              is_checked=realm_enable_welcome_message_custom_text
+              label=admin_settings_label.realm_enable_welcome_message_custom_text
+              skip_prop_element=true}}
+            <div class="input-group" id="welcome_message_custom_text_container">
+                <label for="id_realm_welcome_message_custom_text" class="settings-field-label">
+                    {{t "Message text" }}
+                </label>
+                <textarea id="id_realm_welcome_message_custom_text" name="welcome_message_custom_text"
+                  class="admin-realm-welcome-message-custom-text setting-widget prop-element settings-textarea display-block" maxlength="8000"
+                  data-setting-widget-type="string">{{ realm_welcome_message_custom_text }}</textarea>
+                <div id="welcome_message_custom_text_buttons_container">
+                    {{> ../components/action_button variant="subtle" intent="neutral" label=(t "Send me a test message") id="send_test_welcome_bot_custom_message"}}
+                </div>
+            </div>
+
+            {{> settings_checkbox
+              setting_name="realm_send_welcome_emails"
+              prefix="id_"
+              is_checked=realm_send_welcome_emails
+              label=admin_settings_label.realm_send_welcome_emails}}
         </div>
 
         <div class="settings-subsection-parent">
@@ -172,20 +166,18 @@
                 <h3>{{t "Notifications security" }}</h3>
                 {{> settings_save_discard_widget section_name="notifications-security" show_save_discard_buttons=true }}
             </div>
-            <div class="inline-block organization-settings-parent">
-                {{> settings_checkbox
-                  setting_name="realm_require_e2ee_push_notifications"
-                  prefix="id_"
-                  is_checked=realm_require_e2ee_push_notifications
-                  label=admin_settings_label.realm_require_e2ee_push_notifications
-                  help_link="/help/mobile-notifications"}}
+            {{> settings_checkbox
+              setting_name="realm_require_e2ee_push_notifications"
+              prefix="id_"
+              is_checked=realm_require_e2ee_push_notifications
+              label=admin_settings_label.realm_require_e2ee_push_notifications
+              help_link="/help/mobile-notifications"}}
 
-                {{> settings_checkbox
-                  setting_name="realm_message_content_allowed_in_email_notifications"
-                  prefix="id_"
-                  is_checked=realm_message_content_allowed_in_email_notifications
-                  label=admin_settings_label.realm_message_content_allowed_in_email_notifications}}
-            </div>
+            {{> settings_checkbox
+              setting_name="realm_message_content_allowed_in_email_notifications"
+              prefix="id_"
+              is_checked=realm_message_content_allowed_in_email_notifications
+              label=admin_settings_label.realm_message_content_allowed_in_email_notifications}}
         </div>
 
         <div id="org-compose-settings" class="settings-subsection-parent">
@@ -193,63 +185,61 @@
                 <h3>{{t "Compose settings"}}</h3>
                 {{> settings_save_discard_widget section_name="compose-settings" show_save_discard_buttons=true }}
             </div>
-            <div class="inline-block organization-settings-parent">
-                <div class="input-group">
-                    <label for="id_realm_video_chat_provider" class="settings-field-label">
-                        {{t 'Call provider' }}
-                        {{> ../help_link_widget link="/help/configure-call-provider" }}
-                    </label>
-                    <select name="realm_video_chat_provider" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_video_chat_provider" data-setting-widget-type="number">
-                        {{#each (object_values realm_available_video_chat_providers)}}
-                            <option value='{{this.id}}'>{{this.name}}</option>
-                        {{/each}}
-                    </select>
+            <div class="input-group">
+                <label for="id_realm_video_chat_provider" class="settings-field-label">
+                    {{t 'Call provider' }}
+                    {{> ../help_link_widget link="/help/configure-call-provider" }}
+                </label>
+                <select name="realm_video_chat_provider" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_video_chat_provider" data-setting-widget-type="number">
+                    {{#each (object_values realm_available_video_chat_providers)}}
+                        <option value='{{this.id}}'>{{this.name}}</option>
+                    {{/each}}
+                </select>
 
-                    <div class="dependent-settings-block" id="realm_jitsi_server_url_setting">
-                        <div>
-                            <label for="id_realm_jitsi_server_url" class="settings-field-label">
-                                {{t "Jitsi server URL" }}
-                                {{> ../help_link_widget link="/help/configure-call-provider#use-a-self-hosted-instance-of-jitsi-meet" }}
-                            </label>
-                            <select name="realm_jitsi_server_url" id="id_realm_jitsi_server_url" class="setting-widget prop-element settings_select bootstrap-focus-style" data-setting-widget-type="jitsi-server-url-setting">
-                                {{#if server_jitsi_server_url}}
-                                    <option value="server_default">
-                                        {{#tr}}{server_jitsi_server_url} (default){{/tr}}
-                                    </option>
-                                {{else}}
-                                    <option value="server_default">{{t 'Disabled' }}</option>
-                                {{/if}}
-                                <option value="custom">{{t 'Custom URL' }}</option>
-                            </select>
-                        </div>
+                <div class="dependent-settings-block" id="realm_jitsi_server_url_setting">
+                    <div>
+                        <label for="id_realm_jitsi_server_url" class="settings-field-label">
+                            {{t "Jitsi server URL" }}
+                            {{> ../help_link_widget link="/help/configure-call-provider#use-a-self-hosted-instance-of-jitsi-meet" }}
+                        </label>
+                        <select name="realm_jitsi_server_url" id="id_realm_jitsi_server_url" class="setting-widget prop-element settings_select bootstrap-focus-style" data-setting-widget-type="jitsi-server-url-setting">
+                            {{#if server_jitsi_server_url}}
+                                <option value="server_default">
+                                    {{#tr}}{server_jitsi_server_url} (default){{/tr}}
+                                </option>
+                            {{else}}
+                                <option value="server_default">{{t 'Disabled' }}</option>
+                            {{/if}}
+                            <option value="custom">{{t 'Custom URL' }}</option>
+                        </select>
+                    </div>
 
-                        <div>
-                            <label for="id_realm_jitsi_server_url_custom_input" class="jitsi_server_url_custom_input_label">
-                                {{t 'URL' }}
-                            </label>
-                            <input type="text" id="id_realm_jitsi_server_url_custom_input" autocomplete="off"
-                              name="realm_jitsi_server_url_custom_input" class="realm_jitsi_server_url_custom_input settings_url_input" maxlength="200" />
-                        </div>
+                    <div>
+                        <label for="id_realm_jitsi_server_url_custom_input" class="jitsi_server_url_custom_input_label">
+                            {{t 'URL' }}
+                        </label>
+                        <input type="text" id="id_realm_jitsi_server_url_custom_input" autocomplete="off"
+                          name="realm_jitsi_server_url_custom_input" class="realm_jitsi_server_url_custom_input settings_url_input" maxlength="200" />
                     </div>
                 </div>
-                <div class="input-group">
-                    <label for="id_realm_gif_rating_policy" class="settings-field-label">
-                        {{t 'GIF picker' }}
-                        {{> ../help_link_widget link=gif_help_link }}
-                    </label>
-                    <select name="realm_gif_rating_policy" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_gif_rating_policy" data-setting-widget-type="number" {{#if gif_api_key_empty}}disabled{{/if}}>
-                        {{#each (object_values gif_rating_policy_options)}}
-                            <option value='{{this.id}}'>{{this.name}}</option>
-                        {{/each}}
-                    </select>
-                </div>
+            </div>
+            <div class="input-group">
+                <label for="id_realm_gif_rating_policy" class="settings-field-label">
+                    {{t 'GIF picker' }}
+                    {{> ../help_link_widget link=gif_help_link }}
+                </label>
+                <select name="realm_gif_rating_policy" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_gif_rating_policy" data-setting-widget-type="number" {{#if gif_api_key_empty}}disabled{{/if}}>
+                    {{#each (object_values gif_rating_policy_options)}}
+                        <option value='{{this.id}}'>{{this.name}}</option>
+                    {{/each}}
+                </select>
+            </div>
 
-                <div class="input-group">
-                    <label for="id_realm_topics_policy" class="settings-field-label">{{> realm_topics_policy_label .}}</label>
-                    <select name="realm_topics_policy" id="id_realm_topics_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
-                        {{> dropdown_options_widget option_values=(object_values realm_topics_policy_values)}}
-                    </select>
-                </div>
+            <div class="input-group">
+                <label for="id_realm_topics_policy" class="settings-field-label">{{> realm_topics_policy_label .}}</label>
+                <select name="realm_topics_policy" id="id_realm_topics_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
+                    {{> dropdown_options_widget option_values=(object_values realm_topics_policy_values)}}
+                </select>
             </div>
         </div>
 
@@ -258,44 +248,42 @@
                 <h3>{{t "Message feed settings"}}</h3>
                 {{> settings_save_discard_widget section_name="msg-feed-settings" show_save_discard_buttons=true }}
             </div>
-            <div class="inline-block organization-settings-parent">
-                {{> ../dropdown_widget_with_label
-                  widget_name="realm_default_code_block_language"
-                  label=admin_settings_label.realm_default_code_block_language
-                  value_type="string"}}
+            {{> ../dropdown_widget_with_label
+              widget_name="realm_default_code_block_language"
+              label=admin_settings_label.realm_default_code_block_language
+              value_type="string"}}
 
-                {{> settings_checkbox
-                  setting_name="realm_enable_read_receipts"
-                  prefix="id_"
-                  is_checked=realm_enable_read_receipts
-                  label=admin_settings_label.realm_enable_read_receipts
-                  label_parens_text=admin_settings_label.realm_enable_read_receipts_parens_text}}
+            {{> settings_checkbox
+              setting_name="realm_enable_read_receipts"
+              prefix="id_"
+              is_checked=realm_enable_read_receipts
+              label=admin_settings_label.realm_enable_read_receipts
+              label_parens_text=admin_settings_label.realm_enable_read_receipts_parens_text}}
 
-                <div class="input-group">
-                    <label for="id_realm_media_preview_size" class="settings-field-label">{{admin_settings_label.realm_media_preview_size}}</label>
-                    <select name="realm_media_preview_size" id="id_realm_media_preview_size" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=realm_media_preview_size_values}}
-                    </select>
-                </div>
-
-                {{#if server_inline_image_preview}}
-                {{> settings_checkbox
-                  setting_name="realm_inline_image_preview"
-                  prefix="id_"
-                  is_checked=realm_inline_image_preview
-                  label=admin_settings_label.realm_inline_image_preview
-                  help_link="/help/image-video-and-website-previews"}}
-                {{/if}}
-
-                {{#if server_inline_url_embed_preview}}
-                {{> settings_checkbox
-                  setting_name="realm_inline_url_embed_preview"
-                  prefix="id_"
-                  is_checked=realm_inline_url_embed_preview
-                  label=admin_settings_label.realm_inline_url_embed_preview
-                  help_link="/help/image-video-and-website-previews"}}
-                {{/if}}
+            <div class="input-group">
+                <label for="id_realm_media_preview_size" class="settings-field-label">{{admin_settings_label.realm_media_preview_size}}</label>
+                <select name="realm_media_preview_size" id="id_realm_media_preview_size" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
+                    {{> dropdown_options_widget option_values=realm_media_preview_size_values}}
+                </select>
             </div>
+
+            {{#if server_inline_image_preview}}
+            {{> settings_checkbox
+              setting_name="realm_inline_image_preview"
+              prefix="id_"
+              is_checked=realm_inline_image_preview
+              label=admin_settings_label.realm_inline_image_preview
+              help_link="/help/image-video-and-website-previews"}}
+            {{/if}}
+
+            {{#if server_inline_url_embed_preview}}
+            {{> settings_checkbox
+              setting_name="realm_inline_url_embed_preview"
+              prefix="id_"
+              is_checked=realm_inline_url_embed_preview
+              label=admin_settings_label.realm_inline_url_embed_preview
+              help_link="/help/image-video-and-website-previews"}}
+            {{/if}}
         </div>
 
         <div id="org-message-retention" class="settings-subsection-parent">
@@ -308,28 +296,26 @@
 
             {{> upgrade_tip_widget . }}
 
-            <div class="inline-block organization-settings-parent">
-                <div class="input-group time-limit-setting">
-                    <label for="id_realm_message_retention_days" class="settings-field-label">{{t "Message retention period" }}
-                    </label>
-                    <select name="realm_message_retention_days"
-                      id="id_realm_message_retention_days" class="prop-element settings_select bootstrap-focus-style"
-                      data-setting-widget-type="message-retention-setting"
-                      {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
-                        <option value="unlimited">{{t 'Retain forever' }}</option>
-                        <option value="custom_period">{{t 'Custom' }}</option>
-                    </select>
+            <div class="input-group time-limit-setting">
+                <label for="id_realm_message_retention_days" class="settings-field-label">{{t "Message retention period" }}
+                </label>
+                <select name="realm_message_retention_days"
+                  id="id_realm_message_retention_days" class="prop-element settings_select bootstrap-focus-style"
+                  data-setting-widget-type="message-retention-setting"
+                  {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
+                    <option value="unlimited">{{t 'Retain forever' }}</option>
+                    <option value="custom_period">{{t 'Custom' }}</option>
+                </select>
 
-                    <div class="dependent-settings-block">
-                        <label for="id_realm_message_retention_custom_input" class="inline-block realm-time-limit-label">
-                            {{t 'Retention period (days)' }}:
-                        </label>
-                        <input type="text" id="id_realm_message_retention_custom_input" autocomplete="off"
-                          name="realm_message_retention_custom_input"
-                          class="admin-realm-message-retention-days message-retention-setting-custom-input time-limit-custom-input"
-                          data-setting-widget-type="number"
-                          {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}/>
-                    </div>
+                <div class="dependent-settings-block">
+                    <label for="id_realm_message_retention_custom_input" class="inline-block realm-time-limit-label">
+                        {{t 'Retention period (days)' }}:
+                    </label>
+                    <input type="text" id="id_realm_message_retention_custom_input" autocomplete="off"
+                      name="realm_message_retention_custom_input"
+                      class="admin-realm-message-retention-days message-retention-setting-custom-input time-limit-custom-input"
+                      data-setting-widget-type="number"
+                      {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}/>
                 </div>
             </div>
         </div>

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -67,7 +67,7 @@
         {{/if}}
 
         <div class="settings_panel_list_header">
-            <h3>{{t "Code playgrounds"}}</h3>
+            <h3 class="settings-table-title">{{t "Code playgrounds"}}</h3>
             {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter code playgrounds')}}
         </div>
 

--- a/web/templates/settings/preferences_emoji.hbs
+++ b/web/templates/settings/preferences_emoji.hbs
@@ -1,6 +1,6 @@
 <div class="emoji-preferences {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3 class="light">{{t "Emoji" }}</h3>
+        <h3>{{t "Emoji" }}</h3>
         {{> settings_save_discard_widget section_name="emoji-preferences-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/preferences_emoji.hbs
+++ b/web/templates/settings/preferences_emoji.hbs
@@ -1,6 +1,6 @@
 <div class="emoji-preferences {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3>{{t "Emoji" }}</h3>
+        <h3 class="settings-subsection-title">{{t "Emoji" }}</h3>
         {{> settings_save_discard_widget section_name="emoji-preferences-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -2,7 +2,7 @@
     <!-- this is inline block so that the alert notification can sit beside
     it. If there's not an alert, don't make it inline-block.-->
     <div class="subsection-header">
-        <h3>{{t "General" }}</h3>
+        <h3 class="settings-subsection-title">{{t "General" }}</h3>
         {{> settings_save_discard_widget section_name="general-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
     {{#unless for_realm_settings}}

--- a/web/templates/settings/preferences_information.hbs
+++ b/web/templates/settings/preferences_information.hbs
@@ -1,6 +1,6 @@
 <div class="information-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3 class="light">{{t "Information" }}</h3>
+        <h3>{{t "Information" }}</h3>
         {{> settings_save_discard_widget section_name="information-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/preferences_information.hbs
+++ b/web/templates/settings/preferences_information.hbs
@@ -1,6 +1,6 @@
 <div class="information-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3>{{t "Information" }}</h3>
+        <h3 class="settings-subsection-title">{{t "Information" }}</h3>
         {{> settings_save_discard_widget section_name="information-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/preferences_left_sidebar.hbs
+++ b/web/templates/settings/preferences_left_sidebar.hbs
@@ -1,6 +1,6 @@
 <div class="left-sidebar-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3 class="light">{{t "Left sidebar" }}</h3>
+        <h3>{{t "Left sidebar" }}</h3>
         {{> settings_save_discard_widget section_name="left-sidebar-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/preferences_left_sidebar.hbs
+++ b/web/templates/settings/preferences_left_sidebar.hbs
@@ -1,6 +1,6 @@
 <div class="left-sidebar-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3>{{t "Left sidebar" }}</h3>
+        <h3 class="settings-subsection-title">{{t "Left sidebar" }}</h3>
         {{> settings_save_discard_widget section_name="left-sidebar-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/preferences_navigation.hbs
+++ b/web/templates/settings/preferences_navigation.hbs
@@ -1,6 +1,6 @@
 <div class="navigation-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3 class="light">{{t "Navigation" }}</h3>
+        <h3>{{t "Navigation" }}</h3>
         {{> settings_save_discard_widget section_name="navigation-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/preferences_navigation.hbs
+++ b/web/templates/settings/preferences_navigation.hbs
@@ -1,6 +1,6 @@
 <div class="navigation-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <div class="subsection-header">
-        <h3>{{t "Navigation" }}</h3>
+        <h3 class="settings-subsection-title">{{t "Navigation" }}</h3>
         {{> settings_save_discard_widget section_name="navigation-settings" show_save_discard_buttons=for_realm_settings }}
     </div>
 

--- a/web/templates/settings/privacy_settings.hbs
+++ b/web/templates/settings/privacy_settings.hbs
@@ -1,11 +1,11 @@
 <div {{#if for_realm_settings}}class="privacy_settings settings-subsection-parent" {{else}} id="privacy_settings_box"
   {{/if}}>
-    <div class="subsection-header inline-block">
+    <div class="subsection-header">
         {{#if for_realm_settings}}
-        <h3 class="inline-block">{{t "Privacy settings"}}</h3>
+        <h3>{{t "Privacy settings"}}</h3>
         {{> settings_save_discard_widget section_name="privacy-setting" show_save_discard_buttons=true }}
         {{else}}
-        <h3 class="inline-block">{{t "Privacy"}}</h3>
+        <h3>{{t "Privacy"}}</h3>
         {{> settings_save_discard_widget section_name="privacy-setting" }}
         {{/if}}
     </div>

--- a/web/templates/settings/privacy_settings.hbs
+++ b/web/templates/settings/privacy_settings.hbs
@@ -2,10 +2,10 @@
   {{/if}}>
     <div class="subsection-header">
         {{#if for_realm_settings}}
-        <h3>{{t "Privacy settings"}}</h3>
+        <h3 class="settings-subsection-title">{{t "Privacy settings"}}</h3>
         {{> settings_save_discard_widget section_name="privacy-setting" show_save_discard_buttons=true }}
         {{else}}
-        <h3>{{t "Privacy"}}</h3>
+        <h3 class="settings-subsection-title">{{t "Privacy"}}</h3>
         {{> settings_save_discard_widget section_name="privacy-setting" }}
         {{/if}}
     </div>

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -1,6 +1,6 @@
 <div id="profile-field-settings" class="settings-section" data-name="profile-field-settings">
     <div class="settings_panel_list_header">
-        <h3>{{t "Custom profile fields"}}</h3>
+        <h3 class="settings-table-title">{{t "Custom profile fields"}}</h3>
         <div class="alert-notification" id="admin-profile-field-status"></div>
         {{#if is_admin}}
             {{> ../components/action_button

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -2,7 +2,7 @@
     <div class="profile-settings-form">
         <div class="profile-main-panel inline-block">
             <div class="subsection-header">
-                <h3 id="user-profile-header">{{t "Profile" }}</h3>
+                <h3 id="user-profile-header" class="settings-subsection-title">{{t "Profile" }}</h3>
             </div>
             <div id="user_details_section">
                 <div class="full-name-change-container">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -1,7 +1,9 @@
 <div id="profile-settings" class="settings-section" data-name="profile">
     <div class="profile-settings-form">
         <div class="profile-main-panel inline-block">
-            <h3 class="inline-block" id="user-profile-header">{{t "Profile" }}</h3>
+            <div class="subsection-header">
+                <h3 id="user-profile-header">{{t "Profile" }}</h3>
+            </div>
             <div id="user_details_section">
                 <div class="full-name-change-container">
                     <div class="input-group inline-block grid user-name-parent">

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -8,7 +8,7 @@
         {{/tr}}
     </p>
     <div class="settings_panel_list_header">
-        <h3>{{t "Topic settings"}}
+        <h3 class="settings-table-title">{{t "Topic settings"}}
             {{> ../help_link_widget link="/help/topic-notifications" }}
         </h3>
         {{> settings_save_discard_widget section_name="user-topics-settings" }}

--- a/web/templates/stream_settings/channel_permissions.hbs
+++ b/web/templates/stream_settings/channel_permissions.hbs
@@ -1,5 +1,5 @@
 <div id="channel-subscription-permissions" class="settings-subsection-parent">
-    <div class="channel-subscription-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
+    <div class="subsection-header">
         <h3 class="stream_setting_subsection_title">{{t "Subscription management"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="subscription-permissions" show_save_discard_buttons=true}}
@@ -54,7 +54,7 @@
 </div>
 
 <div id="channel-messaging-permissions" class="settings-subsection-parent">
-    <div class="channel-messaging-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
+    <div class="subsection-header">
         <h3 class="stream_setting_subsection_title">{{t "Messaging permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="messaging-permissions" show_save_discard_buttons=true}}
@@ -83,7 +83,7 @@
 </div>
 
 <div id="channel-moderation-permissions" class="settings-subsection-parent">
-    <div class="channel-moderation-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
+    <div class="subsection-header">
         <h3 class="stream_setting_subsection_title">{{t "Moderation permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="moderation-permissions" show_save_discard_buttons=true}}
@@ -117,7 +117,7 @@
 </div>
 
 <div id="channel-administrative-permissions" class="settings-subsection-parent">
-    <div class="channel-administrative-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
+    <div class="subsection-header">
         <h3 class="stream_setting_subsection_title">{{t "Administrative permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="administrative-permissions" show_save_discard_buttons=true}}

--- a/web/templates/stream_settings/channel_permissions.hbs
+++ b/web/templates/stream_settings/channel_permissions.hbs
@@ -1,6 +1,6 @@
 <div id="channel-subscription-permissions" class="settings-subsection-parent">
     <div class="channel-subscription-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
-        <h4 class="stream_setting_subsection_title">{{t "Subscription management"}}</h4>
+        <h3 class="stream_setting_subsection_title">{{t "Subscription management"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="subscription-permissions" show_save_discard_buttons=true}}
         {{/if}}
@@ -55,7 +55,7 @@
 
 <div id="channel-messaging-permissions" class="settings-subsection-parent">
     <div class="channel-messaging-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
-        <h4 class="stream_setting_subsection_title">{{t "Messaging permissions"}}</h4>
+        <h3 class="stream_setting_subsection_title">{{t "Messaging permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="messaging-permissions" show_save_discard_buttons=true}}
         {{/if}}
@@ -84,7 +84,7 @@
 
 <div id="channel-moderation-permissions" class="settings-subsection-parent">
     <div class="channel-moderation-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
-        <h4 class="stream_setting_subsection_title">{{t "Moderation permissions"}}</h4>
+        <h3 class="stream_setting_subsection_title">{{t "Moderation permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="moderation-permissions" show_save_discard_buttons=true}}
         {{/if}}
@@ -118,7 +118,7 @@
 
 <div id="channel-administrative-permissions" class="settings-subsection-parent">
     <div class="channel-administrative-permissions-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
-        <h4 class="stream_setting_subsection_title">{{t "Administrative permissions"}}</h4>
+        <h3 class="stream_setting_subsection_title">{{t "Administrative permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="administrative-permissions" show_save_discard_buttons=true}}
         {{/if}}

--- a/web/templates/stream_settings/channel_permissions.hbs
+++ b/web/templates/stream_settings/channel_permissions.hbs
@@ -1,6 +1,6 @@
 <div id="channel-subscription-permissions" class="settings-subsection-parent">
     <div class="subsection-header">
-        <h3 class="stream_setting_subsection_title">{{t "Subscription management"}}</h3>
+        <h3 class="settings-subsection-title">{{t "Subscription management"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="subscription-permissions" show_save_discard_buttons=true}}
         {{/if}}
@@ -55,7 +55,7 @@
 
 <div id="channel-messaging-permissions" class="settings-subsection-parent">
     <div class="subsection-header">
-        <h3 class="stream_setting_subsection_title">{{t "Messaging permissions"}}</h3>
+        <h3 class="settings-subsection-title">{{t "Messaging permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="messaging-permissions" show_save_discard_buttons=true}}
         {{/if}}
@@ -84,7 +84,7 @@
 
 <div id="channel-moderation-permissions" class="settings-subsection-parent">
     <div class="subsection-header">
-        <h3 class="stream_setting_subsection_title">{{t "Moderation permissions"}}</h3>
+        <h3 class="settings-subsection-title">{{t "Moderation permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="moderation-permissions" show_save_discard_buttons=true}}
         {{/if}}
@@ -118,7 +118,7 @@
 
 <div id="channel-administrative-permissions" class="settings-subsection-parent">
     <div class="subsection-header">
-        <h3 class="stream_setting_subsection_title">{{t "Administrative permissions"}}</h3>
+        <h3 class="settings-subsection-title">{{t "Administrative permissions"}}</h3>
         {{#if is_stream_edit}}
             {{> ../settings/settings_save_discard_widget section_name="administrative-permissions" show_save_discard_buttons=true}}
         {{/if}}

--- a/web/templates/stream_settings/new_stream_configuration.hbs
+++ b/web/templates/stream_settings/new_stream_configuration.hbs
@@ -25,7 +25,7 @@
     <div class="advance-config-title-container">
         <div class="advance-config-toggle-area">
             <i class="fa fa-sm fa-caret-right toggle-advanced-configurations-icon" aria-hidden="true"></i>
-            <h3 class="stream_setting_subsection_title"><span>{{t 'Advanced configuration' }}</span></h3>
+            <h3 class="settings-subsection-title"><span>{{t 'Advanced configuration' }}</span></h3>
         </div>
     </div>
     <div class="advanced-configurations-collapase-view hide">

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -11,13 +11,15 @@
     {{/tr}}
 </div>
 
-<div class="create_stream_subscriber_list_header">
+<div class="settings_panel_list_header create_stream_subscriber_list_header">
     <div class="subscribers-heading">
         <h3 class="stream_setting_subsection_title">{{t 'Subscribers preview' }}</h3>
         <div class="add-subscriber-loading-spinner"></div>
     </div>
-    <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
-      autocomplete="off" placeholder="{{t 'Filter' }}" />
+    <div class="user_filters">
+        <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
+          autocomplete="off" placeholder="{{t 'Filter' }}" />
+    </div>
 </div>
 
 <div class="subscriber-list-box">

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -13,7 +13,7 @@
 
 <div class="settings_panel_list_header">
     <div class="subscribers-heading">
-        <h3 class="stream_setting_subsection_title">{{t 'Subscribers preview' }}</h3>
+        <h3 class="settings-table-title">{{t 'Subscribers preview' }}</h3>
         <div class="add-subscriber-loading-spinner"></div>
     </div>
     <div class="user_filters">

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -17,8 +17,7 @@
         <div class="add-subscriber-loading-spinner"></div>
     </div>
     <div class="user_filters">
-        <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
-          autocomplete="off" placeholder="{{t 'Filter' }}" />
+        {{> ../settings/filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter subscribers') }}
     </div>
 </div>
 

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -11,7 +11,7 @@
     {{/tr}}
 </div>
 
-<div class="settings_panel_list_header create_stream_subscriber_list_header">
+<div class="settings_panel_list_header">
     <div class="subscribers-heading">
         <h3 class="stream_setting_subsection_title">{{t 'Subscribers preview' }}</h3>
         <div class="add-subscriber-loading-spinner"></div>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -13,7 +13,7 @@
 
 <div class="create_stream_subscriber_list_header">
     <div class="subscribers-heading">
-        <h4 class="stream_setting_subsection_title">{{t 'Subscribers preview' }}</h4>
+        <h3 class="stream_setting_subsection_title">{{t 'Subscribers preview' }}</h3>
         <div class="add-subscriber-loading-spinner"></div>
     </div>
     <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -33,7 +33,7 @@
                 <div class="subscribers_container stream_creation_container">
                     <section class="stream_create_add_subscriber_container">
                         <div class="subsection-header">
-                            <h3 class="stream_setting_subsection_title new-stream-subscribers-title">
+                            <h3 class="stream_setting_subsection_title">
                                 <label class="choose-subscribers-label">{{t "Choose subscribers" }}</label>
                             </h3>
                         </div>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -32,9 +32,9 @@
                 </div>
                 <div class="subscribers_container stream_creation_container">
                     <section class="stream_create_add_subscriber_container">
-                        <h4 class="stream_setting_subsection_title new-stream-subscribers-title">
+                        <h3 class="stream_setting_subsection_title new-stream-subscribers-title">
                             <label class="choose-subscribers-label">{{t "Choose subscribers" }}</label>
-                        </h4>
+                        </h3>
                         <div id="stream_subscription_error" class="stream_creation_error"></div>
                         <div class="controls" id="people_to_add"></div>
                     </section>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -33,7 +33,7 @@
                 <div class="subscribers_container stream_creation_container">
                     <section class="stream_create_add_subscriber_container">
                         <div class="subsection-header">
-                            <h3 class="stream_setting_subsection_title">
+                            <h3 class="settings-subsection-title">
                                 <label class="choose-subscribers-label">{{t "Choose subscribers" }}</label>
                             </h3>
                         </div>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -32,9 +32,11 @@
                 </div>
                 <div class="subscribers_container stream_creation_container">
                     <section class="stream_create_add_subscriber_container">
-                        <h3 class="stream_setting_subsection_title new-stream-subscribers-title">
-                            <label class="choose-subscribers-label">{{t "Choose subscribers" }}</label>
-                        </h3>
+                        <div class="subsection-header">
+                            <h3 class="stream_setting_subsection_title new-stream-subscribers-title">
+                                <label class="choose-subscribers-label">{{t "Choose subscribers" }}</label>
+                            </h3>
+                        </div>
                         <div id="stream_subscription_error" class="stream_creation_error"></div>
                         <div class="controls" id="people_to_add"></div>
                     </section>

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -1,7 +1,7 @@
 <div class="subscriber_list_settings_container no-display">
-    <h4 class="stream_setting_subsection_title add-subscribers-heading">
+    <h3 class="stream_setting_subsection_title add-subscribers-heading">
         {{t "Add subscribers" }}
-    </h4>
+    </h3>
     <div class="stream_subscription_request_result banner-wrapper"></div>
     {{> add_subscribers_form .}}
     <div class="add-subscribers-subtitle">
@@ -23,7 +23,7 @@
     </div>
     <div class="subscribers-list-header">
         <div class="subscribers-heading">
-            <h4 class="inline-block stream_setting_subsection_title">{{t "Subscribers"}}</h4>
+            <h3 class="inline-block stream_setting_subsection_title">{{t "Subscribers"}}</h3>
             <div class="add-subscriber-loading-spinner"></div>
         </div>
         <span class="subscriber-search float-right">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -1,7 +1,9 @@
 <div class="subscriber_list_settings_container no-display">
-    <h3 class="stream_setting_subsection_title add-subscribers-heading">
-        {{t "Add subscribers" }}
-    </h3>
+    <div class="subsection-header add-subscribers-heading">
+        <h3 class="stream_setting_subsection_title">
+            {{t "Add subscribers" }}
+        </h3>
+    </div>
     <div class="stream_subscription_request_result banner-wrapper"></div>
     {{> add_subscribers_form .}}
     <div class="add-subscribers-subtitle">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -23,14 +23,14 @@
           label=(t "Send notification message to newly subscribed users")
           }}
     </div>
-    <div class="subscribers-list-header">
+    <div class="settings_panel_list_header subscribers-list-header">
         <div class="subscribers-heading">
             <h3 class="stream_setting_subsection_title">{{t "Subscribers"}}</h3>
             <div class="add-subscriber-loading-spinner"></div>
         </div>
-        <span class="subscriber-search float-right">
+        <div class="user_filters">
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
-        </span>
+        </div>
     </div>
     <div class="subscriber-list-box">
         {{> stream_members_table .}}

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -23,7 +23,7 @@
           label=(t "Send notification message to newly subscribed users")
           }}
     </div>
-    <div class="settings_panel_list_header subscribers-list-header">
+    <div class="settings_panel_list_header">
         <div class="subscribers-heading">
             <h3 class="stream_setting_subsection_title">{{t "Subscribers"}}</h3>
             <div class="add-subscriber-loading-spinner"></div>

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -23,7 +23,7 @@
     </div>
     <div class="subscribers-list-header">
         <div class="subscribers-heading">
-            <h3 class="inline-block stream_setting_subsection_title">{{t "Subscribers"}}</h3>
+            <h3 class="stream_setting_subsection_title">{{t "Subscribers"}}</h3>
             <div class="add-subscriber-loading-spinner"></div>
         </div>
         <span class="subscriber-search float-right">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -1,6 +1,6 @@
 <div class="subscriber_list_settings_container no-display">
     <div class="subsection-header add-subscribers-heading">
-        <h3 class="stream_setting_subsection_title">
+        <h3 class="settings-subsection-title">
             {{t "Add subscribers" }}
         </h3>
     </div>
@@ -25,7 +25,7 @@
     </div>
     <div class="settings_panel_list_header">
         <div class="subscribers-heading">
-            <h3 class="stream_setting_subsection_title">{{t "Subscribers"}}</h3>
+            <h3 class="settings-table-title">{{t "Subscribers"}}</h3>
             <div class="add-subscriber-loading-spinner"></div>
         </div>
         <div class="user_filters">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -29,7 +29,7 @@
             <div class="add-subscriber-loading-spinner"></div>
         </div>
         <div class="user_filters">
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
+            {{> ../settings/filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter subscribers') }}
         </div>
     </div>
     <div class="subscriber-list-box">

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -109,7 +109,7 @@
             </div>
             <div class="subsection-parent">
                 <div class="subsection-header">
-                    <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
+                    <h3 class="stream_setting_subsection_title">{{t "Notification settings" }}</h3>
                     <div class="stream_change_property_status alert-notification"></div>
                 </div>
                 <div class="input-group">

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -42,7 +42,7 @@
 
             <div class="stream-settings-subsection settings-subsection-parent">
                 <div class="subsection-header">
-                    <h3 class="stream_setting_subsection_title">
+                    <h3 class="settings-subsection-title">
                         {{t "Settings" }}
                     </h3>
                     {{> ../settings/settings_save_discard_widget section_name="channel-general-settings" show_save_discard_buttons=true}}
@@ -83,7 +83,7 @@
         <div id="personal-stream-settings" class="stream_section" data-stream-section="personal">
             <div class="subsection-parent">
                 <div class="subsection-header">
-                    <h3 class="stream_setting_subsection_title">{{t "Personal settings" }}</h3>
+                    <h3 class="settings-subsection-title">{{t "Personal settings" }}</h3>
                     <div class="stream_change_property_status alert-notification"></div>
                 </div>
                 {{#each other_settings}}
@@ -109,7 +109,7 @@
             </div>
             <div class="subsection-parent">
                 <div class="subsection-header">
-                    <h3 class="stream_setting_subsection_title">{{t "Notification settings" }}</h3>
+                    <h3 class="settings-subsection-title">{{t "Notification settings" }}</h3>
                     <div class="stream_change_property_status alert-notification"></div>
                 </div>
                 <div class="input-group">

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -83,7 +83,7 @@
         <div id="personal-stream-settings" class="stream_section" data-stream-section="personal">
             <div class="subsection-parent">
                 <div class="subsection-header">
-                    <h3 class="stream_setting_subsection_title inline-block">{{t "Personal settings" }}</h3>
+                    <h3 class="stream_setting_subsection_title">{{t "Personal settings" }}</h3>
                     <div class="stream_change_property_status alert-notification"></div>
                 </div>
                 {{#each other_settings}}

--- a/web/templates/user_group_settings/group_permission_settings.hbs
+++ b/web/templates/user_group_settings/group_permission_settings.hbs
@@ -5,7 +5,7 @@
         {{#each group_assigned_realm_permissions}}
             <div class="settings-subsection-parent {{subsection_key}} {{#if (eq assigned_permissions.length 0)}}hide{{/if}}">
                 <div class="subsection-header">
-                    <h3>{{subsection_heading}}</h3>
+                    <h3 class="settings-subsection-title">{{subsection_heading}}</h3>
                     {{> ../settings/settings_save_discard_widget show_save_discard_buttons=true }}
                 </div>
 

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -12,10 +12,12 @@
     {{/tr}}
 </div>
 
-<div class="create_user_group_member_list_header">
+<div class="settings_panel_list_header create_user_group_member_list_header">
     <h3 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h3>
-    <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
-      autocomplete="off" placeholder="{{t 'Filter' }}" />
+    <div class="user_filters">
+        <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
+          autocomplete="off" placeholder="{{t 'Filter' }}" />
+    </div>
 </div>
 
 <div class="add-group-member-loading-spinner"></div>

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -13,7 +13,7 @@
 </div>
 
 <div class="create_user_group_member_list_header">
-    <h4 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h4>
+    <h3 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h3>
     <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter' }}" />
 </div>

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -13,7 +13,7 @@
 </div>
 
 <div class="settings_panel_list_header create_user_group_member_list_header">
-    <h3 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h3>
+    <h3 class="settings-table-title">{{t 'Members preview' }}</h3>
     <div class="user_filters">
         {{> ../settings/filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter members') }}
     </div>

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -15,8 +15,7 @@
 <div class="settings_panel_list_header create_user_group_member_list_header">
     <h3 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h3>
     <div class="user_filters">
-        <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
-          autocomplete="off" placeholder="{{t 'Filter' }}" />
+        {{> ../settings/filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter members') }}
     </div>
 </div>
 

--- a/web/templates/user_group_settings/stream_group_permission_settings.hbs
+++ b/web/templates/user_group_settings/stream_group_permission_settings.hbs
@@ -1,6 +1,6 @@
 <div class="settings-subsection-parent" data-stream-id="{{stream.stream_id}}">
     <div class="subsection-header">
-        <h3>
+        <h3 class="settings-subsection-title">
             {{> ../decorated_channel_name stream=stream }}
         </h3>
         {{> ../settings/settings_save_discard_widget show_save_discard_buttons=true }}

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -25,7 +25,7 @@
                     <section id="user-group-permission-container">
                         <div class="group-permissions settings-subsection-parent" id="new_group_permission_settings">
                             <div class="subsection-header">
-                                <h3 class="user_group_setting_subsection_title">{{t "Group permissions" }}
+                                <h3 class="settings-subsection-title">{{t "Group permissions" }}
                                 </h3>
                             </div>
 
@@ -36,7 +36,7 @@
                 <div class="user_group_members_container user_group_creation">
                     <section id="choose_member_section">
                         <div class="subsection-header">
-                            <h3 class="user_group_setting_subsection_title">
+                            <h3 class="settings-subsection-title">
                                 <label for="people_to_add_in_group">{{t "Choose members" }}</label>
                             </h3>
                         </div>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -35,9 +35,9 @@
                 </div>
                 <div class="user_group_members_container user_group_creation">
                     <section id="choose_member_section">
-                        <h4 class="user_group_setting_subsection_title">
+                        <h3 class="user_group_setting_subsection_title">
                             <label for="people_to_add_in_group">{{t "Choose members" }}</label>
-                        </h4>
+                        </h3>
                         <div id="user_group_membership_error" class="user_group_creation_error"></div>
                         <div class="controls" id="people_to_add_in_group"></div>
                     </section>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -35,9 +35,11 @@
                 </div>
                 <div class="user_group_members_container user_group_creation">
                     <section id="choose_member_section">
-                        <h3 class="user_group_setting_subsection_title">
-                            <label for="people_to_add_in_group">{{t "Choose members" }}</label>
-                        </h3>
+                        <div class="subsection-header">
+                            <h3 class="user_group_setting_subsection_title">
+                                <label for="people_to_add_in_group">{{t "Choose members" }}</label>
+                            </h3>
+                        </div>
                         <div id="user_group_membership_error" class="user_group_creation_error"></div>
                         <div class="controls" id="people_to_add_in_group"></div>
                     </section>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -3,9 +3,11 @@
         {{> user_group_membership_status .}}
     </div>
     {{#unless group.is_system_group}}
-        <h3 class="user_group_setting_subsection_title">
-            {{t "Add members" }}
-        </h3>
+        <div class="subsection-header">
+            <h3 class="user_group_setting_subsection_title">
+                {{t "Add members" }}
+            </h3>
+        </div>
         <div class="user_group_subscription_request_result banner-wrapper"></div>
         {{> add_members_form .}}
         <div class="add-members-subtitle">

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -4,7 +4,7 @@
     </div>
     {{#unless group.is_system_group}}
         <div class="subsection-header">
-            <h3 class="user_group_setting_subsection_title">
+            <h3 class="settings-subsection-title">
                 {{t "Add members" }}
             </h3>
         </div>
@@ -23,7 +23,7 @@
         </div>
     {{/unless}}
     <div class="settings_panel_list_header members-list-header">
-        <h3 class="user_group_setting_subsection_title">{{t "Members"}}</h3>
+        <h3 class="settings-table-title">{{t "Members"}}</h3>
         <div class="user_filters">
             {{> ../settings/filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter members') }}
         </div>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -25,7 +25,7 @@
     <div class="settings_panel_list_header members-list-header">
         <h3 class="user_group_setting_subsection_title">{{t "Members"}}</h3>
         <div class="user_filters">
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
+            {{> ../settings/filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter members') }}
         </div>
     </div>
     <div class="add-group-member-loading-spinner"></div>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -3,9 +3,9 @@
         {{> user_group_membership_status .}}
     </div>
     {{#unless group.is_system_group}}
-        <h4 class="user_group_setting_subsection_title">
+        <h3 class="user_group_setting_subsection_title">
             {{t "Add members" }}
-        </h4>
+        </h3>
         <div class="user_group_subscription_request_result banner-wrapper"></div>
         {{> add_members_form .}}
         <div class="add-members-subtitle">
@@ -21,7 +21,7 @@
         </div>
     {{/unless}}
     <div>
-        <h4 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h4>
+        <h3 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h3>
         <span class="member-search float-right">
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
         </span>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -21,7 +21,7 @@
         </div>
     {{/unless}}
     <div class="members-list-header">
-        <h3 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h3>
+        <h3 class="user_group_setting_subsection_title">{{t "Members"}}</h3>
         <span class="member-search float-right">
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
         </span>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -20,7 +20,7 @@
             {{/tr}}
         </div>
     {{/unless}}
-    <div>
+    <div class="members-list-header">
         <h3 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h3>
         <span class="member-search float-right">
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -22,11 +22,11 @@
             {{/tr}}
         </div>
     {{/unless}}
-    <div class="members-list-header">
+    <div class="settings_panel_list_header members-list-header">
         <h3 class="user_group_setting_subsection_title">{{t "Members"}}</h3>
-        <span class="member-search float-right">
+        <div class="user_filters">
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
-        </span>
+        </div>
     </div>
     <div class="add-group-member-loading-spinner"></div>
     <div class="member-list-box">

--- a/web/templates/user_group_settings/user_group_permission_settings.hbs
+++ b/web/templates/user_group_settings/user_group_permission_settings.hbs
@@ -1,6 +1,6 @@
 <div class="settings-subsection-parent" data-group-id="{{group_id}}">
     <div class="subsection-header">
-        <h3>{{group_name}}</h3>
+        <h3 class="settings-subsection-title">{{group_name}}</h3>
         {{> ../settings/settings_save_discard_widget show_save_discard_buttons=true }}
     </div>
 

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -27,7 +27,7 @@
             {{#unless group.is_system_group}}
                 <div class="group-permissions settings-subsection-parent" id="group_permission_settings">
                     <div class="subsection-header">
-                        <h3 class="user_group_setting_subsection_title">
+                        <h3 class="settings-subsection-title">
                             {{t "Group permissions" }}
                             {{> ../help_link_widget link="/help/manage-user-groups#configure-group-permissions"}}
                         </h3>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First two commits are to remove redundant classes.
- Make margin consistent for all the headings in the Settings overlay.
- Fix tooltip appearing when hovering outisde the `invite_required` setting input.
- Fix the inconsistency in some subsections due to settings wrapped in a `div` element. The wrapper element is removed.
- Make all the `h4` headings `h3` in stream and group settings UI.
- Make margins on headings in stream and group settings UI same with what we have for main settings UI.
- Remove extra space between the "Add subscribers" heading and the pill input due to result banner margin occupying space even when the banner is hidden. And same thing is fixed for group settings as well.
- Drop redundant `inline-block` class.
- Remove margin CSS rules.
-  Make all non-table headings in stream and group settings UI wrap in `subsection-header`.
- Make table headings in stream and group settings same as what we have in main settings UI.
- Add clear button in search in stream and group settings UI.

https://chat.zulip.org/#narrow/channel/101-design/topic/inconsistency.20in.20headings.20channel.20and.20group.20settings/with/2482187

 <!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Main settings overlay</summary>

| Before | After |
| ------ | ------ |
| <img width="1712" height="1636" alt="image" src="https://github.com/user-attachments/assets/dd39b4eb-72dd-481b-946d-65be1246506e" /> | <img width="1712" height="1636" alt="image" src="https://github.com/user-attachments/assets/56a001e5-2eef-401c-b53a-44c4db654ded" /> |
| <img width="1712" height="1354" alt="image" src="https://github.com/user-attachments/assets/1dbab1bd-80cf-4981-aa3e-e14eef36758f" /> | <img width="1712" height="1354" alt="image" src="https://github.com/user-attachments/assets/4a3747e0-6b3b-4d10-b22d-9d88fd457aa9" /> |
| <img width="1712" height="1652" alt="image" src="https://github.com/user-attachments/assets/a968b7c0-89df-4143-b23a-8bdcc72ea798" /> | <img width="1712" height="1652" alt="image" src="https://github.com/user-attachments/assets/afb47b99-0c83-4bf3-b3c2-5e51df4183f4" /> |
| <img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/fe0b277e-d016-4b7e-b326-62152e3986d8" /> | <img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/89adc346-9c6f-46ed-8ba3-0691f88eb205" /> |
| <img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/a13a81c6-7af6-4a34-95eb-44833fb9aa06" /> | <img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/2e74ca50-5034-4a06-bfb7-71d7398edecb" /> |
| <img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/90369589-d651-495d-97d0-718ca70400cb" /> | <img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/6aeef7d7-0f65-49d0-bcdc-f6777ea1d0d0" /> |
|<img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/270b5ad7-bea3-42a8-aa67-11a6510be123" /> | <img width="1702" height="1728" alt="image" src="https://github.com/user-attachments/assets/b10b7040-9f35-44cb-9ec5-56f8e80601e7" /> |
</details>

<details>
<summary>Channel settings overlay</summary>

| Before | After |
| ------ | ------ |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/217e4d94-e299-4be9-bf33-29cdb12ed81b" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/28d0b12a-edfb-48fa-b970-0ee9a239b9d5" /> |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/0dbafc34-8086-495f-a1ce-12f39c2f6262" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/8dcd45de-a69d-444c-b6c2-e3f08f10e691" /> |
|<img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/7ea36c38-df17-41c9-839c-b53117acbc75" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/54a7fd2b-0340-4c51-94a5-5c06d4d1f8be" />
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/58e95f8d-388b-456f-88aa-6a8b6aca31cf" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/843c5b64-1662-4f0e-b9a2-6e97dcdbb049" /> |
|<img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/f7093530-af7a-4697-8721-e6d24085c2e9" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/6b4c332a-1ad1-464f-9b82-098f64ed488b" /> |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/5a5e9640-f0bd-45de-8b01-5e94c0d2a547" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/4d61a6f4-673c-49c4-8828-ce52832e6aa1" /> |

</details>

<details>
<summary>Group settings overlay</summary>

| Before | After |
| ------ | ------ |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/11c9fd96-cfce-4f91-b9e1-f49ffbad6501" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/c15d5119-006e-48a3-808f-d518ec1ebfc2" /> |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/66f687b3-575e-42ea-b95f-a229388c1323" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/1b065e15-3f5e-4e44-9ec1-f7b2d89c1ec2" /> |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/50858e25-f9b0-4243-a26b-9bbc83941dda" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/99f532bb-426c-4701-8491-bdf8b71500ce" /> |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/a728a3a9-e25a-4587-b56b-e0d1f8e6fd0c" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/0c1a8511-f435-4fd6-9acb-27f3dc8e085a" /> |
| <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/8637951e-9535-4069-87f8-3804b26273ed" /> | <img width="1474" height="1732" alt="image" src="https://github.com/user-attachments/assets/13739293-eaef-4665-b625-ccdde9cfb4bd" /> |

</details>

























<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
