### PR TITLE
slack: Pass convert_slack_threads=True in self-serve flow.

### DIFF
--- a/zerver/actions/data_import.py
+++ b/zerver/actions/data_import.py
@@ -112,6 +112,7 @@ def import_slack_data(event: dict[str, Any]) -> None:
                 fh.name,
                 output_dir,
                 event["slack_access_token"],
+                convert_slack_threads=True,
             )
             attachment_size = sum(
                 os.path.getsize(os.path.join(dirpath, filename))

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -2767,7 +2767,7 @@ To Do
 
         mock_save_attachment_contents.assert_called_once()
         mock_do_convert_zipfile.assert_called_once_with(
-            mock.ANY, mock.ANY, event["slack_access_token"]
+            mock.ANY, mock.ANY, event["slack_access_token"], convert_slack_threads=True
         )
         mock_do_import_realm.assert_called_once_with(
             mock.ANY, prereg_realm.string_id, on_realm_created=mock.ANY
@@ -2935,7 +2935,7 @@ To Do
 
         mock_save_attachment_contents.assert_called_once()
         mock_do_convert_zipfile.assert_called_once_with(
-            mock.ANY, mock.ANY, event["slack_access_token"]
+            mock.ANY, mock.ANY, event["slack_access_token"], convert_slack_threads=True
         )
         mock_do_import_realm.assert_called_once_with(
             mock.ANY, prereg_realm.string_id, on_realm_created=mock.ANY


### PR DESCRIPTION
We missed to set this flag in the original implementation of the self-serve flow - but there's no reason not to enable the conversion of threads.

@amanagr @PieterCK Any thoughts on whether the default for this in `do_convert_zipfile` shouldn't actually be `True`? If the self-serve flow enabled this and the management command enables it unless explicitly disables it with `--no-convert-slack-threads`, why default to `False`.