### PR TITLE
drafts: Prepare drafts overlay for an Outbox tab.

### DIFF
--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -604,6 +604,7 @@ export function get_last_restorable_draft_based_on_compose_state():
 export type FormattedDraft =
     | {
           is_stream: true;
+          is_sending_saving: boolean;
           draft_id: string;
           stream_name?: string | undefined;
           recipient_bar_color: string;
@@ -618,6 +619,7 @@ export type FormattedDraft =
       }
     | {
           is_stream: false;
+          is_sending_saving: boolean;
           is_dm_with_self?: boolean;
           draft_id: string;
           recipients: string;
@@ -692,6 +694,7 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
         return {
             draft_id: draft.id,
             is_stream: true,
+            is_sending_saving: draft.is_sending_saving,
             stream_name,
             recipient_bar_color: stream_color.get_recipient_bar_color(draft_stream_color),
             stream_privacy_icon_color:
@@ -712,6 +715,7 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
         return {
             draft_id: draft.id,
             is_stream: false,
+            is_sending_saving: draft.is_sending_saving,
             has_recipient_data: false,
             recipients: "",
             raw_content: draft.content,
@@ -727,6 +731,7 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
     return {
         draft_id: draft.id,
         is_stream: false,
+        is_sending_saving: draft.is_sending_saving,
         is_dm_with_self,
         recipients,
         raw_content: draft.content,

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -141,8 +141,8 @@ function remove_drafts($draft_rows: JQuery): void {
         show_delete_banner();
     }
 
-    if ($("#drafts_table .overlay-message-row").length === 0) {
-        $("#drafts_table .no-drafts").show();
+    if ($(".drafts-tab-pane .overlay-message-row").length === 0) {
+        $(".drafts-tab-pane .no-drafts").show();
     }
     update_rendered_drafts(
         $("#drafts-from-conversation .overlay-message-row").length > 0,
@@ -171,7 +171,7 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
     get_items_ids() {
         const draft_ids: string[] = [];
         for (const row of document.querySelectorAll<HTMLElement>(
-            "#drafts_table .overlay-message-row",
+            ".drafts-tab-pane .overlay-message-row",
         )) {
             const id = row.dataset["draftId"];
             assert(id !== undefined);
@@ -330,8 +330,8 @@ function render_widgets(
         });
         $(".drafts-list").replaceWith($(rendered));
     }
-    if ($("#drafts_table .overlay-message-row").length > 0) {
-        $("#drafts_table .no-drafts").hide();
+    if ($(".drafts-tab-pane .overlay-message-row").length > 0) {
+        $(".drafts-tab-pane .no-drafts").hide();
         // Update possible dynamic elements.
         const $rendered_drafts = $drafts_table.find(
             ".message_content.rendered_markdown.restore-overlay-message",

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -889,13 +889,21 @@ input.settings_text_input {
     display: grid;
     grid-template-rows: auto minmax(0, 1fr);
 
+    /* min-height: 0 lets the tab pane shrink inside the 1fr grid row
+       (grid items default to min-height: auto). */
+    .drafts-tab-pane {
+        min-height: 0;
+    }
+
     .overlay-messages-list {
         /* We unset the `overflow` value so SimpleBar
            can manage scrolling. */
         overflow: unset;
-        /* We don't need to set a height value; the
-           1fr grid row will occupy the available height. */
-        height: auto;
+        /* border-box + height: 100% makes the list fill (not overflow) the
+           tab pane, which the 1fr grid row bounds, so SimpleBar has a
+           definite height to scroll within. */
+        box-sizing: border-box;
+        height: 100%;
         /* And therefore we don't need to worry about padding,
            so that the scrollbar appears to reach all the way
            to the bottom of the content. */

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -28,7 +28,9 @@
                     </div>
                 </div>
             </div>
-            {{> drafts_list context }}
+            <div class="drafts-tab-pane">
+                {{> drafts_list context }}
+            </div>
         </div>
     </div>
 </div>

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -657,7 +657,7 @@ test("format_drafts", ({override, mock_template}) => {
     override(messages_overlay_ui, "get_and_clear_pending_restore_element_id", () => undefined);
 
     $.set_results(".drafts-list", []);
-    $.set_results("#drafts_table .overlay-message-row", []);
+    $.set_results(".drafts-tab-pane .overlay-message-row", []);
     $.set_results(".draft-selection-checkbox", []);
     drafts_overlay_ui.launch();
 });
@@ -804,7 +804,7 @@ test("filter_drafts", ({override, mock_template}) => {
     compose_state.set_message_type("private");
 
     $.set_results(".drafts-list", []);
-    $.set_results("#drafts_table .overlay-message-row", []);
+    $.set_results(".drafts-tab-pane .overlay-message-row", []);
     $.set_results(".draft-selection-checkbox", []);
     drafts_overlay_ui.launch();
 });
@@ -860,7 +860,7 @@ test("server_rendering_for_backend_only_syntax", ({override, mock_template}) => 
     // These selectors are accessed during render_widgets() and
     // update_bulk_delete_ui() inside launch().
     $.set_results(".drafts-list", []);
-    $.set_results("#drafts_table .overlay-message-row", []);
+    $.set_results(".drafts-tab-pane .overlay-message-row", []);
     $.set_results(".draft-selection-checkbox", []);
 
     override(channel, "post", (payload) => {

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -555,6 +555,7 @@ test("format_drafts", ({override, mock_template}) => {
             time_stamp: "7:55 AM",
             invite_only: stream_1.invite_only,
             is_web_public: stream_1.is_web_public,
+            is_sending_saving: false,
         },
         {
             draft_id: "id2",
@@ -564,6 +565,7 @@ test("format_drafts", ({override, mock_template}) => {
             recipients: "Aaron",
             raw_content: "Test direct message",
             time_stamp: "Jan 30",
+            is_sending_saving: false,
         },
         {
             draft_id: "id5",
@@ -573,6 +575,7 @@ test("format_drafts", ({override, mock_template}) => {
             has_recipient_data: true,
             raw_content: "Test direct message 3",
             time_stamp: "Jan 29",
+            is_sending_saving: false,
         },
         {
             draft_id: "id4",
@@ -582,6 +585,7 @@ test("format_drafts", ({override, mock_template}) => {
             has_recipient_data: true,
             raw_content: "Test direct message 2",
             time_stamp: "Jan 26",
+            is_sending_saving: false,
         },
         {
             draft_id: "id3",
@@ -596,6 +600,7 @@ test("format_drafts", ({override, mock_template}) => {
             time_stamp: "Jan 21",
             invite_only: stream_2.invite_only,
             is_web_public: stream_2.is_web_public,
+            is_sending_saving: false,
         },
         {
             draft_id: "id6",
@@ -610,6 +615,7 @@ test("format_drafts", ({override, mock_template}) => {
             time_stamp: "Jan 20",
             invite_only: stream_2.invite_only,
             is_web_public: stream_2.is_web_public,
+            is_sending_saving: false,
         },
         {
             draft_id: "id7",
@@ -618,6 +624,7 @@ test("format_drafts", ({override, mock_template}) => {
             recipients: "",
             raw_content: "Test direct message 4",
             time_stamp: "Jan 19",
+            is_sending_saving: false,
         },
     ];
 
@@ -724,6 +731,7 @@ test("filter_drafts", ({override, mock_template}) => {
             recipients: "Aaron",
             raw_content: "Test direct message",
             time_stamp: "Jan 30",
+            is_sending_saving: false,
         },
         {
             draft_id: "id5",
@@ -733,6 +741,7 @@ test("filter_drafts", ({override, mock_template}) => {
             recipients: "Aaron",
             raw_content: "Test direct message 3",
             time_stamp: "Jan 29",
+            is_sending_saving: false,
         },
         {
             draft_id: "id4",
@@ -742,6 +751,7 @@ test("filter_drafts", ({override, mock_template}) => {
             recipients: "Aaron",
             raw_content: "Test direct message 2",
             time_stamp: "Jan 26",
+            is_sending_saving: false,
         },
     ];
 
@@ -759,6 +769,7 @@ test("filter_drafts", ({override, mock_template}) => {
             time_stamp: "7:55 AM",
             invite_only: stream_1.invite_only,
             is_web_public: stream_1.is_web_public,
+            is_sending_saving: false,
         },
         {
             draft_id: "id3",
@@ -773,6 +784,7 @@ test("filter_drafts", ({override, mock_template}) => {
             time_stamp: "Jan 21",
             invite_only: stream_2.invite_only,
             is_web_public: stream_2.is_web_public,
+            is_sending_saving: false,
         },
     ];
 


### PR DESCRIPTION
Fixes part of #32999.

Non-functional groundwork for the Outbox tab, split out of #38356. It makes no user-visible change on its own: it prepares the drafts overlay to host a second tab - the drafts list moves into its own container (with the styling to keep it scrolling), the existing `is_sending_saving` flag is exposed to templates, and the outbox tab's markup and styles are added but kept `display: none`. The logic that fills the outbox and turns the tab on lands with the feature in #38356.

No user-visible change: the Drafts overlay looks and scrolls exactly as before.
| Before (main) | After (this PR) |
| --- | --- |
| <img width="1200" height="760" alt="Screen Shot 2026-07-06 at 22 25 45" src="https://github.com/user-attachments/assets/aff05b07-bb67-4374-87c3-1f44a553d1e5" /> | <img width="1200" height="760" alt="Screen Shot 2026-07-06 at 22 25 45" src="https://github.com/user-attachments/assets/b107d891-b7bf-40be-8362-e7a94702a2a0" />|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
