### PR TITLE
drafts: Create ClipboardJS instance once at initialize.

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -405,21 +405,6 @@ function setup_event_handlers(): void {
         toggle_checkbox_icon_state($(e.target), !is_checked);
         update_bulk_delete_ui();
     });
-
-    new ClipboardJS("#drafts_table .overlay_message_controls .copy-overlay-message", {
-        text(trigger): string {
-            const draft_id = $(trigger).attr("data-draft-id")!;
-            const draft = drafts.draft_model.getDraft(draft_id);
-            if (!draft) {
-                return "";
-            }
-            return draft.content ?? "";
-        },
-    }).on("success", (e) => {
-        show_copied_confirmation(e.trigger, {
-            show_check_icon: true,
-        });
-    });
 }
 
 function setup_bulk_actions_handlers(): void {
@@ -534,6 +519,21 @@ export function toggle_checkbox_icon_state($checkbox: JQuery, checked: boolean):
 }
 
 export function initialize(): void {
+    new ClipboardJS("#drafts_table .overlay_message_controls .copy-overlay-message", {
+        text(trigger): string {
+            const draft_id = $(trigger).attr("data-draft-id")!;
+            const draft = drafts.draft_model.getDraft(draft_id);
+            if (!draft) {
+                return "";
+            }
+            return draft.content ?? "";
+        },
+    }).on("success", (e) => {
+        show_copied_confirmation(e.trigger, {
+            show_check_icon: true,
+        });
+    });
+
     $("body").on("focus", "#drafts_table .overlay-message-info-box", function (this: HTMLElement) {
         messages_overlay_ui.activate_element(this, keyboard_handling_context);
     });


### PR DESCRIPTION


Noticed while working on the Outbox tab (#32999), but independent of it.

The drafts overlay builds its copy-to-clipboard support with a single ClipboardJS instance bound to a selector (`#drafts_table .overlay_message_controls .copy-overlay-message`). ClipboardJS uses event delegation, so one instance already handles every copy button, including rows added by later re-renders.

The instance was being constructed inside `setup_event_handlers()`, which re-runs on every `rerender_drafts()` (for example, deleting a draft or undoing the deletion). Each re-render added another copy handler without removing the previous one, so the handlers piled up - a single copy click eventually ran several times, and none were ever cleaned up. Move the construction into `initialize()`, which runs once at startup.

This is a pre-existing issue on `main`, unrelated to the Outbox feature, so it is split out as its own small change.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
