### PR TITLE
compose: Add autosave for drafts while typing.

### DIFF
--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -48,6 +48,8 @@ import * as user_topics from "./user_topics.ts";
 import * as util from "./util.ts";
 import * as widget_modal from "./widget_modal.ts";
 
+const AUTOSAVE_DRAFT_THROTTLE_IN_MILLISECONDS = 60 * 1000;
+
 export function abort_xhr(): void {
     upload.compose_upload_cancel();
 }
@@ -62,6 +64,30 @@ function setup_compose_actions_hooks(): void {
         compose_call_session_manager.abandon_session("");
     });
 }
+
+// This autosave callback does not track the compose_draft_id that was
+// active when scheduled; it simply calls update_draft() on whatever
+// compose state is current when it fires, as long as compose is still
+// open.
+//
+// This is safe because compose context transitions (send, close,
+// switching/restoring drafts) already perform explicit draft saves, and
+// compose_draft_id is only changed through those controlled flows.
+//
+// At worst, a delayed call results in an extra save of the current draft,
+// which is harmless. Adding draft_id tracking here would introduce
+// significant complexity without meaningful benefit.
+export function update_draft_if_composing(): void {
+    if (compose_state.composing()) {
+        drafts.update_draft({no_notify: true});
+    }
+}
+
+const throttled_update_draft = _.throttle(
+    update_draft_if_composing,
+    AUTOSAVE_DRAFT_THROTTLE_IN_MILLISECONDS,
+    {leading: false, trailing: true},
+);
 
 export function initialize(): void {
     // Register hooks for compose_actions.
@@ -125,6 +151,9 @@ export function initialize(): void {
             if (compose_state.get_is_content_unedited_restored_draft()) {
                 compose_state.set_is_content_unedited_restored_draft(false);
             }
+
+            // We occasionally update the saved draft while the user is typing to minimize data loss risk.
+            throttled_update_draft();
         }, 25),
     );
 

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -616,6 +616,28 @@ test_ui("initialize", ({override}) => {
     })();
 });
 
+test_ui("update_draft_if_composing", ({override_rewire}) => {
+    let update_draft_call_count = 0;
+    override_rewire(drafts, "update_draft", (opts) => {
+        assert.deepEqual(opts, {no_notify: true});
+        update_draft_call_count += 1;
+        return "draft-id";
+    });
+
+    // Autosave does nothing once the compose box has closed, so a
+    // delayed call can't resurrect a draft the user is done with.
+    compose_state.set_message_type(undefined);
+    assert.ok(!compose_state.composing());
+    compose_setup.update_draft_if_composing();
+    assert.equal(update_draft_call_count, 0);
+
+    // While the user is still composing, autosave persists the draft.
+    compose_state.set_message_type("stream");
+    assert.ok(compose_state.composing());
+    compose_setup.update_draft_if_composing();
+    assert.equal(update_draft_call_count, 1);
+});
+
 test_ui("update_fade", ({override, override_rewire}) => {
     mock_banners();
     initialize_handlers({override});


### PR DESCRIPTION
Continuation of #37935.

This PR adds throttled auto-save for compose drafts that triggers at most once every 60 seconds while the user is actively composing. The implementation uses Lodash's throttle function with leading: false and trailing: true to ensure the draft is saved after the user pauses typing.

The save is skipped if the compose box has closed by the time the throttled call fires, since compose context transitions already persist the draft explicitly.

Fixes: #36102
Addresses : https://github.com/zulip/zulip/pull/36222#issuecomment-3572322205

### screencapture tests

_These were done with the interval set to 5s instead of 60s, and with a console.log beside the call to `update_draft`._

**Saves while composing**
Type >2 chars, wait the interval without closing; draft appears in Drafts view, count updates, no "Saved as draft" tooltip.

<img width="3370" height="2026" alt="Kapture 2026-06-29 at 13 13 02" src="https://github.com/user-attachments/assets/d5da7408-d9c2-4eb8-b08f-9bed2f1326a2" />

**Closing composebox stops the save call**
Type, then close the compose box before the interval elapses. The explicit close already saves the draft; verify the trailing autosave that fires afterward does not create a second/phantom draft (count stays correct). 

<img width="1112" height="669" alt="Kapture 2026-06-29 at 13 15 16" src="https://github.com/user-attachments/assets/997da85a-50e7-4529-9250-35508235926d" />

**Short content doesn't save**
Type 1–2 chars; confirm nothing is saved.

<img width="1685" height="1013" alt="Kapture 2026-06-29 at 13 16 49" src="https://github.com/user-attachments/assets/9f2c675d-e4ee-4dbd-a1f9-a2123a40d39a" />

**Deleting content removes draft**
Type, let it autosave, then delete all content; confirm the draft is removed (count back to 0).

<img width="1685" height="1013" alt="Kapture 2026-06-29 at 13 19 05" src="https://github.com/user-attachments/assets/97c93bf7-0dd0-4336-8c5d-f23617fb52e0" />

**No regressions**
I didn't screen capture this, but saw no regressions to existing flows: send clears drafts, reopening composebox restores the draft, and a restored draft autosaves into the same draft (not a duplicate). Also checked that DMs autosave, though I didn't check every single case for them too.