### PR TITLE
compose: Block sending and saving messages that render blank.

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -20,6 +20,7 @@ import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
+import * as markdown from "./markdown.ts";
 import * as message_store from "./message_store.ts";
 import * as message_util from "./message_util.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -1053,6 +1054,27 @@ export function validate_private_message(show_banner = true): boolean {
     return true;
 }
 
+export function message_renders_blank(message_content: string): boolean {
+    // A blank textarea is an empty message, handled separately.
+    if (message_content.trim() === "") {
+        return false;
+    }
+    // Parse the rendered HTML into an inert document (parseFromString never
+    // runs scripts) and inspect it, since only the parser knows e.g. that
+    // `    $$ $$` is a code block rather than empty math.
+    const rendered = markdown.render(message_content).content;
+    const {body} = new DOMParser().parseFromString(rendered, "text/html");
+    // Not blank if any text survives collapsing ASCII whitespace (a
+    // non-breaking space does not collapse, so it counts as text).
+    if ((body.textContent ?? "").replaceAll(/[ \t\r\n]+/g, "") !== "") {
+        return false;
+    }
+    // With no text, it's blank unless a container or media element renders.
+    return (
+        body.querySelector("img, hr, table, video, audio, pre, blockquote, .spoiler-block") === null
+    );
+}
+
 export function check_overflow_text($container: JQuery): number {
     // This function is called when typing every character in the
     // compose box, so it's important that it not doing anything
@@ -1213,7 +1235,10 @@ export let validate = (scheduling_message: boolean, show_banner = true): boolean
 
     const no_message_content = /^\s*$/.test(message_content);
     set_no_message_content(no_message_content);
-    if (no_message_content) {
+    // A message that renders to nothing visible (e.g. empty math or an empty
+    // fenced block) is blocked too, but it isn't tracked in no_message_content
+    // since the compose box isn't actually empty.
+    if (no_message_content || message_renders_blank(message_content)) {
         if (show_banner) {
             // If you tried actually sending a message with empty
             // compose, flash the textarea as invalid.

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -44,6 +44,10 @@ let user_acknowledged_stream_wildcard = false;
 let upload_in_progress = false;
 let no_message_content = false;
 let message_too_long = false;
+// Whether the compose box renders to nothing visible. Like message_too_long,
+// this disables the send button, but it is not part of no_message_content,
+// which means specifically an empty textarea.
+let renders_blank = false;
 // Since same functions are used for both compose and message edit,
 //  we need to track when we are validating compose box.
 let is_validating_compose_box = false;
@@ -1053,6 +1057,27 @@ export function validate_private_message(show_banner = true): boolean {
     return true;
 }
 
+export function message_renders_blank(message_content: string): boolean {
+    // Whether a non-empty message renders to nothing a reader can see. We
+    // only block syntax that shows no element at all -- empty math and an
+    // empty strikethrough. Empty code/quote/spoiler blocks still show a
+    // visible container, so they're allowed. Empty/whitespace input returns
+    // false (that's an empty message, handled separately).
+    if (message_content.trim() === "") {
+        return false;
+    }
+    // `[^\S\n]` matches whitespace other than a newline, so a pasted
+    // non-breaking space is treated like a plain space.
+    const stripped = message_content
+        // Empty math block: ```math with a whitespace-only body.
+        .replaceAll(/(`{3,}|~{3,})[^\S\n]*math[^\S\n]*\n[^\S\n]*(?:\n[^\S\n]*)*?\1/g, "")
+        // Empty inline math: `$$` with a whitespace-only body.
+        .replaceAll(/\$\$[^\S\n]+\$\$/g, "")
+        // Empty strikethrough: renders an empty <del>.
+        .replaceAll(/~~[^\S\n]+~~/g, "");
+    return stripped.trim() === "";
+}
+
 export function check_overflow_text($container: JQuery): number {
     // This function is called when typing every character in the
     // compose box, so it's important that it not doing anything
@@ -1067,6 +1092,7 @@ export function check_overflow_text($container: JQuery): number {
 
     const old_no_message_content = no_message_content;
     const old_message_too_long = message_too_long;
+    const old_renders_blank = renders_blank;
 
     if (text.length > max_length) {
         $indicator.removeClass("textarea-approaching-limit");
@@ -1111,11 +1137,14 @@ export function check_overflow_text($container: JQuery): number {
     }
 
     if (!is_edit_container) {
-        // Update the state for whether the message is empty.
+        // Update the state for whether the message is empty, and (separately)
+        // whether it renders to nothing visible.
         set_no_message_content(text.length === 0);
+        renders_blank = message_renders_blank(text);
         if (
             message_too_long !== old_message_too_long ||
-            old_no_message_content !== no_message_content
+            old_no_message_content !== no_message_content ||
+            old_renders_blank !== renders_blank
         ) {
             // If this keystroke changed the truth status for whether
             // the message is empty or too long, then we need to
@@ -1213,7 +1242,10 @@ export let validate = (scheduling_message: boolean, show_banner = true): boolean
 
     const no_message_content = /^\s*$/.test(message_content);
     set_no_message_content(no_message_content);
-    if (no_message_content) {
+    // A message that renders to nothing visible (e.g. empty math or an empty
+    // fenced block) is blocked too, but it isn't tracked in no_message_content
+    // since the compose box isn't actually empty.
+    if (no_message_content || message_renders_blank(message_content)) {
         if (show_banner) {
             // If you tried actually sending a message with empty
             // compose, flash the textarea as invalid.

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1317,6 +1317,23 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
         changed = old_content !== new_content;
     }
 
+    if (
+        changed &&
+        new_content !== undefined &&
+        compose_validate.message_renders_blank(new_content)
+    ) {
+        // Block edits whose new content would render to nothing visible (an
+        // empty math or fenced block); the backend only rejects truly empty
+        // content. We only check changed content so an unchanged save still
+        // cancels cleanly below.
+        compose_banner.show_error_message(
+            $t({defaultMessage: "Message must not be empty."}),
+            compose_banner.CLASSNAMES.generic_compose_error,
+            $banner_container,
+        );
+        return;
+    }
+
     const already_has_stream_wildcard_mention = message.stream_wildcard_mentioned;
     if (stream_id !== undefined && !already_has_stream_wildcard_mention) {
         const stream_wildcard_mention = util.find_stream_wildcard_mentions(new_content ?? "");

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -41,7 +41,9 @@ const compose_fade = mock_esm("../src/compose_fade");
 const compose_notifications = mock_esm("../src/compose_notifications");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 const loading = mock_esm("../src/loading");
-const markdown = mock_esm("../src/markdown");
+const markdown = mock_esm("../src/markdown", {
+    render: () => ({content: "<p>x</p>"}),
+});
 const narrow_state = mock_esm("../src/narrow_state");
 const rendered_markdown = mock_esm("../src/rendered_markdown");
 const resize = mock_esm("../src/resize");

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -554,6 +554,34 @@ test_ui("test_check_overflow_text", ({override, override_rewire}) => {
     }
 });
 
+test_ui("message_renders_blank", () => {
+    // Syntax that renders no visible element: empty math and strikethrough.
+    // A pasted non-breaking space counts as a whitespace-only body.
+    assert.ok(compose_validate.message_renders_blank("$$ $$"));
+    assert.ok(compose_validate.message_renders_blank("$$\u{00A0}$$"));
+    assert.ok(compose_validate.message_renders_blank("```math\n\n```"));
+    assert.ok(compose_validate.message_renders_blank("```math\n \n```"));
+    assert.ok(compose_validate.message_renders_blank("~~ ~~"));
+    assert.ok(compose_validate.message_renders_blank("~~\u{00A0}~~"));
+
+    // Real content, or syntax that still shows a visible container (code,
+    // quote, spoiler), is not blank.
+    assert.ok(!compose_validate.message_renders_blank("hello world"));
+    assert.ok(!compose_validate.message_renders_blank("$$a$$"));
+    assert.ok(!compose_validate.message_renders_blank("```math\na^2\n```"));
+    assert.ok(!compose_validate.message_renders_blank("$$ $$ and some text"));
+    assert.ok(!compose_validate.message_renders_blank("~~struck~~"));
+    assert.ok(!compose_validate.message_renders_blank("[]()"));
+    assert.ok(!compose_validate.message_renders_blank("```\n```"));
+    assert.ok(!compose_validate.message_renders_blank("```js\n \n```"));
+    assert.ok(!compose_validate.message_renders_blank("```quote\n\n```"));
+    assert.ok(!compose_validate.message_renders_blank("```spoiler\n\n```"));
+    assert.ok(!compose_validate.message_renders_blank("```spoiler Header\n```"));
+    assert.ok(!compose_validate.message_renders_blank("~~~~"));
+    assert.ok(!compose_validate.message_renders_blank(""));
+    assert.ok(!compose_validate.message_renders_blank("   \n\n"));
+});
+
 test_ui("needs_subscribe_warning", async () => {
     const invalid_user_id = 999;
 

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -16,6 +16,11 @@ const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 
 const channel = mock_esm("../src/channel");
+const markdown = mock_esm("../src/markdown", {
+    // Non-blank by default so ordinary messages validate; the
+    // message_renders_blank test overrides this per case.
+    render: () => ({content: "<p>x</p>"}),
+});
 
 const compose_banner = zrequire("compose_banner");
 const compose_pm_pill = zrequire("compose_pm_pill");
@@ -552,6 +557,47 @@ test_ui("test_check_overflow_text", ({override, override_rewire}) => {
         compose_validate.check_overflow_text(fake_compose_box.$send_message_form);
         fake_compose_box.assert_message_size_is_under_the_limit();
     }
+});
+
+test_ui("message_renders_blank", ({override}) => {
+    // message_renders_blank inspects rendered HTML, so drive it with
+    // representative renderer output.
+    let renders = "";
+    override(markdown, "render", () => ({content: renders}));
+    function blank(html) {
+        renders = html;
+        return compose_validate.message_renders_blank("x");
+    }
+
+    // Empty math: an invisible KaTeX element (empty katex-html).
+    assert.ok(
+        blank(
+            '<p><span class="katex"><span class="katex-mathml">' +
+                "<annotation> </annotation></span>" +
+                '<span class="katex-html" aria-hidden="true"></span></span></p>',
+        ),
+    );
+    // Empty strikethrough with a collapsing space.
+    assert.ok(blank("<p><del> </del></p>"));
+
+    // A non-breaking space stays visible in HTML, so it is not blank.
+    assert.ok(!blank("<p><del>\u{00A0}</del></p>"));
+    // Real text.
+    assert.ok(!blank("<p>hello</p>"));
+    // Real math keeps its source in the annotation and glyphs in katex-html.
+    assert.ok(!blank('<p><span class="katex"><annotation>a</annotation></span></p>'));
+    // Indented `$$ $$` and empty fenced blocks still render a visible box.
+    assert.ok(!blank('<div class="codehilite"><pre><code>$$ $$\n</code></pre></div>'));
+    assert.ok(!blank('<div class="codehilite"><pre><code>\n</code></pre></div>'));
+    // A quote or spoiler container is visible even when empty.
+    assert.ok(!blank("<blockquote>\n</blockquote>"));
+    assert.ok(!blank('<div class="spoiler-block"><div class="spoiler-header"></div></div>'));
+    // Non-text content like an image is visible.
+    assert.ok(!blank('<p><img src="/x"></p>'));
+
+    // Genuinely empty input is an empty message, handled separately.
+    assert.ok(!compose_validate.message_renders_blank(""));
+    assert.ok(!compose_validate.message_renders_blank("   \n\n"));
 });
 
 test_ui("needs_subscribe_warning", async () => {

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -6,6 +6,22 @@ const {make_realm} = require("./lib/example_realm.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
+const compose_banner = mock_esm("../src/compose_banner", {
+    CLASSNAMES: {generic_compose_error: "generic_compose_error"},
+    get_compose_banner_container: () => ({}),
+    show_error_message() {},
+});
+mock_esm("../src/compose_tooltips", {
+    hide_compose_control_button_tooltips() {},
+});
+mock_esm("../src/markdown", {
+    // message_renders_blank renders the content; return an empty math element
+    // (no visible text or container) so the blank-render guard fires.
+    render: () => ({content: '<p><span class="katex"></span></p>'}),
+});
+const message_lists = mock_esm("../src/message_lists");
+const rows = mock_esm("../src/rows");
+
 const message_edit = zrequire("message_edit");
 const {set_current_user, set_realm} = zrequire("state_data");
 
@@ -303,4 +319,39 @@ run_test("stream_and_topic_exist_in_edit_history", () => {
         ),
         false,
     );
+});
+
+run_test("save_message_row_edit blank-render guard", async ({override}) => {
+    const message = {raw_content: "old content", stream_wildcard_mentioned: false};
+    message_lists.current = {get: () => message};
+    override(rows, "id", () => 42);
+    override(rows, "get_message_recipient_header", () => ({attr: () => undefined}));
+
+    let content = "";
+    const $textarea = {val: () => content, attr: () => undefined};
+    const $row = {
+        find: (selector) => (selector === "textarea.message_edit_content" ? $textarea : {}),
+    };
+
+    let error_count = 0;
+    override(compose_banner, "show_error_message", (html) => {
+        error_count += 1;
+        assert.equal(html, "translated: Message must not be empty.");
+    });
+
+    // Content that renders to nothing visible is blocked with an error.
+    content = "```math\n\n```";
+    await message_edit.save_message_row_edit($row);
+    assert.equal(error_count, 1);
+
+    // Clearing all text is a valid edit (the backend turns it into
+    // "(deleted)"), so the guard is skipped; execution continues past it to
+    // the (unmocked) save path, which throws harmlessly here.
+    content = "";
+    try {
+        await message_edit.save_message_row_edit($row);
+    } catch {
+        // Downstream save path isn't mocked.
+    }
+    assert.equal(error_count, 1);
 });

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -6,6 +6,17 @@ const {make_realm} = require("./lib/example_realm.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
+const compose_banner = mock_esm("../src/compose_banner", {
+    CLASSNAMES: {generic_compose_error: "generic_compose_error"},
+    get_compose_banner_container: () => ({}),
+    show_error_message() {},
+});
+mock_esm("../src/compose_tooltips", {
+    hide_compose_control_button_tooltips() {},
+});
+const message_lists = mock_esm("../src/message_lists");
+const rows = mock_esm("../src/rows");
+
 const message_edit = zrequire("message_edit");
 const {set_current_user, set_realm} = zrequire("state_data");
 
@@ -303,4 +314,39 @@ run_test("stream_and_topic_exist_in_edit_history", () => {
         ),
         false,
     );
+});
+
+run_test("save_message_row_edit blank-render guard", async ({override}) => {
+    const message = {raw_content: "old content", stream_wildcard_mentioned: false};
+    message_lists.current = {get: () => message};
+    override(rows, "id", () => 42);
+    override(rows, "get_message_recipient_header", () => ({attr: () => undefined}));
+
+    let content = "";
+    const $textarea = {val: () => content, attr: () => undefined};
+    const $row = {
+        find: (selector) => (selector === "textarea.message_edit_content" ? $textarea : {}),
+    };
+
+    let error_count = 0;
+    override(compose_banner, "show_error_message", (html) => {
+        error_count += 1;
+        assert.equal(html, "translated: Message must not be empty.");
+    });
+
+    // Content that renders to nothing visible is blocked with an error.
+    content = "```math\n\n```";
+    await message_edit.save_message_row_edit($row);
+    assert.equal(error_count, 1);
+
+    // Clearing all text is a valid edit (the backend turns it into
+    // "(deleted)"), so the guard is skipped; execution continues past it to
+    // the (unmocked) save path, which throws harmlessly here.
+    content = "";
+    try {
+        await message_edit.save_message_row_edit($row);
+    } catch {
+        // Downstream save path isn't mocked.
+    }
+    assert.equal(error_count, 1);
 });


### PR DESCRIPTION
Some Markdown that is non-empty as text still renders to nothing visible: an empty math span (`$$ $$`), or a block (math, code, quote, spoiler) with a whitespace-only body. Sending these created a blank, empty-looking message in the feed.

This blocks sending/saving such messages, treating them like an empty message

Fixes: [#issues > send message with empty Math block.](https://chat.zulip.org/#narrow/channel/9-issues/topic/send.20message.20with.20empty.20Math.20block.2E/with/2486579)

<details>

<summary><b><i> Note </b></i> </summary>

&rarr; I added a banner for an empty message when editing a message instead of the default Compose box red border (experiment, also in favour of reverting it if this does not fit here)

<img width="1018" height="307" alt="image" src="https://github.com/user-attachments/assets/56efb635-f8a5-4129-9c61-ed8d9894ec48" />

</details>

<hr>
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/9733ee3f-6ed5-4ad7-80ec-afaaa1cad2ba" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/53b1652d-559e-47ed-bbe0-03179a050f79" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
