### PR TITLE
message_edit: Keep scroll arrows from overlapping the compose box.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -552,7 +552,13 @@
 }
 
 .formatting-control-scroller-button {
-    z-index: 5;
+    /* These buttons only need to layer above the horizontally
+       scrolling formatting buttons (z-index 0) they overlay, so a
+       z-index of 1 is sufficient. Keeping it below #compose's z-index
+       (4) also ensures that when the message edit box is resized over
+       the compose box, its scroll arrows--which share a stacking
+       context with #compose--don't paint on top of it. */
+    z-index: 1;
     display: flex;
     align-items: center;
 


### PR DESCRIPTION
When the message edit box is resized (via its resize handle) tall enough to overlap the fixed compose box at the bottom, the edit box's formatting-bar scroll arrows are painted on top of the compose box.


independent commit reduces the main compose box's scroller buttons from `z-index: 5` to `z-index: 1`, since they only need to layer above the horizontally scrolling formatting buttons (`z-index: 0`). The `5` was needlessly high

Fixes: [#issues > The resize handle overlaps the compose box during editing.](https://chat.zulip.org/#narrow/channel/9-issues/topic/The.20resize.20handle.20overlaps.20the.20compose.20box.20during.20editing.2E/with/2486986)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/9edf0ff3-85c0-4715-89d3-a081aa414c59" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/b4082f56-ddfb-4c48-8aca-7cdf149463f0" width="400" controls></video> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
