### PR TITLE
upload: Strip control characters from uploaded filenames.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -67,6 +67,7 @@ from zerver.lib.upload import (
     ensure_avatar_image,
     generate_message_upload_path,
     get_avatar_path,
+    remove_control_characters,
     sanitize_name,
     upload_emoji_image,
 )
@@ -698,6 +699,12 @@ def sanitize_attachment_data(attachment_data: ImportedTableData, import_dir: Pat
     for attachment in attachment_data["zerver_attachment"]:
         assert attachment["file_name"] and attachment["path_id"]
         attachment["file_name"] = sanitize_name(attachment["file_name"])
+        # We serve this back as Content-Type, where a control
+        # character is not valid; NULL is how we record not knowing
+        # the type.
+        content_type = attachment.get("content_type")
+        if content_type is not None:
+            attachment["content_type"] = remove_control_characters(content_type) or None
         attachment["path_id"], _ = validate_and_resolve_relative_path(
             attachment["path_id"],
             base_dir=uploads_import_dir,
@@ -1359,16 +1366,21 @@ def import_uploads(
             metadata["orig_last_modified"] = str(sanitized_record.raw_record["last_modified"])
         metadata["realm_id"] = str(sanitized_record.raw_record["realm_id"])
 
-        # Zulip exports will always have a content-type, but third-party exports might not.
-        content_type = sanitized_record.raw_record.get("content_type")
-        if content_type is None:
-            content_type = guess_type(sanitized_record.safe_resolved_source_path)[0]
-            if content_type is None:
-                # This is the default for unknown data.  Note that
-                # for `.original` files, this is the value we'll
-                # set; that is OK, because those are never served
-                # directly anyway.
-                content_type = "application/octet-stream"
+        # Zulip exports will always have a content-type, but
+        # third-party exports might not; either way it becomes the S3
+        # object's ContentType, so it needs the same cleaning.
+        content_type = remove_control_characters(
+            sanitized_record.raw_record.get("content_type") or ""
+        )
+        if not content_type:
+            # application/octet-stream is the default for unknown
+            # data. Note that for `.original` files, this is the value
+            # we'll set; that is OK, because those are never served
+            # directly anyway.
+            content_type = (
+                guess_type(sanitized_record.safe_resolved_source_path)[0]
+                or "application/octet-stream"
+            )
 
         return UploadPlan(
             source_path=sanitized_record.safe_resolved_source_path,

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -256,18 +256,17 @@ def sanitize_name(value: str, *, strict: bool = False) -> str:
     return value
 
 
-def remove_control_characters(filename: str) -> str:
+def remove_control_characters(value: str) -> str:
     """Strips ASCII control characters -- RFC 5234's CTL set, %x00-1F and
-    %x7F -- from a filename.
+    %x7F -- from a client-supplied filename or content type.
     https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1
 
-    NULL bytes can't be stored in the "file_name" column, and a
-    trailing newline yields a Content-Disposition header that S3, like
-    any HTTP recipient, rejects as an illegal field value (RFC 9110
-    section 5.5).
+    NULL bytes can't be stored in the "file_name" column, and a CR or
+    LF yields a header that S3, Django, and Python's email module all
+    reject as an illegal field value (RFC 9110 section 5.5).
 
     """
-    return re.sub(r"[\x00-\x1f\x7f]", "", filename)
+    return re.sub(r"[\x00-\x1f\x7f]", "", value)
 
 
 def clean_uploaded_file_name(file_name: str) -> str:
@@ -281,6 +280,18 @@ def clean_uploaded_file_name(file_name: str) -> str:
     if file_name in {"", ".", ".."}:
         return "uploaded-file"
     return file_name
+
+
+def clean_uploaded_content_type(content_type: str, file_name: str) -> str:
+    """The content type we store in Attachment.content_type and serve in
+    Content-Type, guessed from the cleaned filename when the client
+    leaves us nothing usable.
+
+    """
+    content_type = remove_control_characters(content_type)
+    if not content_type:
+        content_type = guess_type(file_name)[0] or "application/octet-stream"
+    return content_type
 
 
 def upload_message_attachment(
@@ -298,6 +309,7 @@ def upload_message_attachment(
     path_id = get_upload_backend().generate_message_upload_path(
         str(target_realm.id), sanitize_name(uploaded_file_name)
     )
+    content_type = clean_uploaded_content_type(content_type, uploaded_file_name)
     if needs_charset_detection(content_type):
         content_type = maybe_add_charset(content_type, file_data)
 

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -256,6 +256,33 @@ def sanitize_name(value: str, *, strict: bool = False) -> str:
     return value
 
 
+def remove_control_characters(filename: str) -> str:
+    """Strips ASCII control characters -- RFC 5234's CTL set, %x00-1F and
+    %x7F -- from a filename.
+    https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1
+
+    NULL bytes can't be stored in the "file_name" column, and a
+    trailing newline yields a Content-Disposition header that S3, like
+    any HTTP recipient, rejects as an illegal field value (RFC 9110
+    section 5.5).
+
+    """
+    return re.sub(r"[\x00-\x1f\x7f]", "", filename)
+
+
+def clean_uploaded_file_name(file_name: str) -> str:
+    """The filename we store in Attachment.file_name and serve in
+    Content-Disposition. Unlike sanitize_name, which builds the path
+    component, this stays close to what the client sent, so that
+    "Save as..." offers a sensible name.
+
+    """
+    file_name = remove_control_characters(file_name)
+    if file_name in {"", ".", ".."}:
+        return "uploaded-file"
+    return file_name
+
+
 def upload_message_attachment(
     uploaded_file_name: str,
     content_type: str,
@@ -265,15 +292,14 @@ def upload_message_attachment(
 ) -> tuple[str, str]:
     if target_realm is None:
         target_realm = user_profile.realm
+    # Clean the name first, so that path_id is derived from the same
+    # value we store.
+    uploaded_file_name = clean_uploaded_file_name(uploaded_file_name)
     path_id = get_upload_backend().generate_message_upload_path(
         str(target_realm.id), sanitize_name(uploaded_file_name)
     )
     if needs_charset_detection(content_type):
         content_type = maybe_add_charset(content_type, file_data)
-
-    # NULL bytes are the one thing we can't store in the original
-    # filename column, due to PostgreSQL limitations
-    uploaded_file_name = re.sub(r"\x00", "", uploaded_file_name)
 
     with transaction.atomic(durable=True):
         get_upload_backend().store_message_attachment(

--- a/zerver/migrations/0807_strip_control_characters_from_attachments.py
+++ b/zerver/migrations/0807_strip_control_characters_from_attachments.py
@@ -1,0 +1,83 @@
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import F, Func, Q, TextField, Value
+from django.db.models.functions import Coalesce, NullIf
+
+# Copied from zerver.lib.upload.remove_control_characters, less the
+# NUL byte: PostgreSQL cannot store NUL in a text column, so it can
+# never be present here, and it cannot be sent as a query parameter
+# either.
+CONTROL_CHARACTERS = r"[\x01-\x1f\x7f]"
+
+# The names clean_uploaded_file_name replaces, because they leave
+# nothing for "Save as..." to use.
+PLACEHOLDER_FILE_NAMES = ["", ".", ".."]
+
+
+def strip_control_characters(field_name: str) -> Func:
+    return Func(
+        F(field_name),
+        Value(CONTROL_CHARACTERS),
+        Value(""),
+        Value("g"),
+        function="regexp_replace",
+    )
+
+
+def stripped_file_name() -> Func:
+    file_name = strip_control_characters("file_name")
+    for placeholder in PLACEHOLDER_FILE_NAMES:
+        file_name = NullIf(file_name, Value(placeholder))
+    return Coalesce(file_name, Value("uploaded-file"), output_field=TextField())
+
+
+def stripped_content_type() -> Func:
+    # NULL is the "we don't know" value that both serving paths
+    # already handle by guessing from the file name.
+    return NullIf(strip_control_characters("content_type"), Value(""), output_field=TextField())
+
+
+def strip_control_characters_from_attachments(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    for model_name in ("Attachment", "ArchivedAttachment"):
+        model = apps.get_model("zerver", model_name)
+        count = model.objects.filter(
+            Q(file_name__regex=CONTROL_CHARACTERS) | Q(content_type__regex=CONTROL_CHARACTERS)
+        ).update(
+            file_name=stripped_file_name(),
+            content_type=stripped_content_type(),
+        )
+        if count > 0:
+            print(f"\nStripped control characters from {count} {model_name} rows.")
+
+
+class Migration(migrations.Migration):
+    """Uploads stored the client's filename and content type nearly
+    verbatim, so a control character in either could reach the
+    database; we now strip them on the way in, but existing rows keep
+    what was stored.
+
+    A CR or LF is the harmful case: serve_local rebuilds
+    Content-Disposition and Content-Type from these columns on every
+    read, and Django raises BadHeaderError on either, leaving the
+    attachment undownloadable until the row is repaired. The rest
+    serve correctly, and are cleaned up here only for tidiness.
+    """
+
+    # Each .update() is a single statement, so committing them
+    # separately avoids holding a transaction open across the scans.
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0806_stream_default_push_notifications"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            strip_control_characters_from_attachments,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -2622,6 +2622,41 @@ class RealmImportExportTest(ExportFile):
         self.assertEqual(imported_realm.night_logo_source, Realm.LOGO_UPLOADED)
 
     @use_s3_backend
+    def test_import_content_type_with_control_characters(self) -> None:
+        uploads_bucket = create_s3_buckets(
+            settings.S3_AUTH_UPLOADS_BUCKET, settings.S3_AVATAR_BUCKET
+        )[0]
+
+        user = self.example_user("hamlet")
+        realm = user.realm
+
+        self.upload_files_for_user(user)
+        self.export_realm_and_create_auditlog(realm)
+
+        # An export taken before we cleaned these values, or a
+        # third-party converter which copies the source service's MIME
+        # type, can carry control characters in the content type.
+        attachment_data = read_json("attachment.json")
+        for attachment in attachment_data["zerver_attachment"]:
+            attachment["content_type"] = "text/plain\n"
+        with open(export_fn("attachment.json"), "wb") as f:
+            f.write(orjson.dumps(attachment_data))
+
+        upload_records = read_json("uploads/records.json")
+        for record in upload_records:
+            record["content_type"] = "text/plain\n"
+        with open(export_fn("uploads/records.json"), "wb") as f:
+            f.write(orjson.dumps(upload_records))
+
+        with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"):
+            do_import_realm(get_output_dir(), "test-zulip")
+
+        imported_realm = Realm.objects.get(string_id="test-zulip")
+        uploaded_file = Attachment.objects.get(realm=imported_realm)
+        self.assertEqual(uploaded_file.content_type, "text/plain")
+        self.assertEqual(uploads_bucket.Object(uploaded_file.path_id).content_type, "text/plain")
+
+    @use_s3_backend
     def test_import_files_from_s3(self) -> None:
         uploads_bucket, avatar_bucket = create_s3_buckets(
             settings.S3_AUTH_UPLOADS_BUCKET, settings.S3_AVATAR_BUCKET

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1104,7 +1104,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
         # audio file extension.
         url = upload_message_attachment(
             "filename.mp3",
-            "",
+            "application/octet-stream",
             b"",
             self.example_user("othello"),
         )[0]

--- a/zerver/tests/test_migrations.py
+++ b/zerver/tests/test_migrations.py
@@ -22,45 +22,99 @@ from zerver.lib.test_classes import MigrationsTestCase
 #   "zerver_subscription" because it has pending trigger events
 
 
-class FixDeletedUserEmail(MigrationsTestCase):
-    migrate_from = "0804_backfill_user_created_audit_logs"
-    migrate_to = "0805_fix_deleteduser_email"
+class StripControlCharactersFromAttachments(MigrationsTestCase):
+    migrate_from = "0806_stream_default_push_notifications"
+    migrate_to = "0807_strip_control_characters_from_attachments"
+
+    # The migration reports what it repaired, which test-backend
+    # otherwise rejects as unexpected console output; pin the counts
+    # here, which also verifies that it touches only the dirty rows.
+    expected_console_output = """
+Stripped control characters from 5 Attachment rows.
+
+Stripped control characters from 1 ArchivedAttachment rows.
+"""
 
     @override
     def setUpBeforeMigration(self, apps: StateApps) -> None:
-        UserProfile = apps.get_model("zerver", "UserProfile")
+        Attachment = apps.get_model("zerver", "Attachment")
+        hamlet = self.example_user("hamlet")
+        self.attachment_ids: list[int] = []
 
-        # Simulate a user deleted before the fix in 208c0c303405,
-        # after 0439_fix_deleteduser_email repaired delivery_email.
-        deleted_user = self.example_user("hamlet")
-        UserProfile.objects.filter(id=deleted_user.id).update(
-            is_active=False,
-            email=f"deleteduser{deleted_user.id}@https://zulip.testserver",
-            delivery_email=f"deleteduser{deleted_user.id}@zulip.testserver",
+        def create_attachment(path_id: str, file_name: str, content_type: str | None) -> int:
+            attachment_id = Attachment.objects.create(
+                file_name=file_name,
+                path_id=path_id,
+                owner_id=hamlet.id,
+                realm_id=hamlet.realm_id,
+                size=6,
+                content_type=content_type,
+            ).id
+            self.attachment_ids.append(attachment_id)
+            return attachment_id
+
+        # A trailing newline in either column is the case that makes
+        # serve_local() raise BadHeaderError.
+        self.bad_file_name_id = create_attachment("1/aa/bb/one.txt", "one.txt\n", "text/plain")
+        self.bad_content_type_id = create_attachment("1/aa/bb/two.png", "two.png", "image/png\n")
+        # Other control characters are escaped correctly on the way
+        # out, but should still be cleaned up.
+        self.other_control_id = create_attachment(
+            "1/aa/bb/three.txt", "th\x01ree.txt", "text/plain"
         )
-        self.deleted_user_id = deleted_user.id
+        # A NULL content_type must survive the regexp_replace.
+        self.null_content_type_id = create_attachment("1/aa/bb/four.txt", "four.txt\n", None)
+        # Values which stripping empties get what a new upload would
+        # have stored, rather than an empty string.
+        self.all_control_id = create_attachment("1/aa/bb/uploaded-file", "\x01.\x02", "\x01")
+        # A clean row, as a control.
+        self.clean_id = create_attachment("1/aa/bb/five.txt", "five.txt", "text/plain")
 
-        # A normal active user, as a control.
-        control_user = self.example_user("cordelia")
-        self.control_user_id = control_user.id
-        self.control_user_email = control_user.email
+        # ArchivedAttachment rows get repaired too, since they can be
+        # restored into Attachment.
+        ArchivedAttachment = apps.get_model("zerver", "ArchivedAttachment")
+        self.archived_id = ArchivedAttachment.objects.create(
+            file_name="six.txt\n",
+            path_id="1/aa/bb/six.txt",
+            owner_id=hamlet.id,
+            realm_id=hamlet.realm_id,
+            size=6,
+            content_type="text/plain\n",
+        ).id
 
-        # A deactivated user with a valid email, as a control for the
-        # is_active=False part of the migration's filter.
-        deactivated_user = self.example_user("othello")
-        UserProfile.objects.filter(id=deactivated_user.id).update(is_active=False)
-        self.deactivated_user_id = deactivated_user.id
-        self.deactivated_user_email = deactivated_user.email
+    @override
+    def tearDown(self) -> None:
+        # MigrationsTestCase commits its changes, and its base class
+        # asserts that a test leaves the set of rows unchanged, so
+        # these have to go before that check runs.
+        Attachment = self.apps.get_model("zerver", "Attachment")
+        Attachment.objects.filter(id__in=self.attachment_ids).delete()
+        ArchivedAttachment = self.apps.get_model("zerver", "ArchivedAttachment")
+        ArchivedAttachment.objects.filter(id=self.archived_id).delete()
+        super().tearDown()
 
-    def test_deleted_user_email_fixed(self) -> None:
-        UserProfile = self.apps.get_model("zerver", "UserProfile")
+    def test_control_characters_stripped(self) -> None:
+        Attachment = self.apps.get_model("zerver", "Attachment")
 
-        deleted_user = UserProfile.objects.get(id=self.deleted_user_id)
-        self.assertEqual(deleted_user.email, f"deleteduser{deleted_user.id}@zulip.testserver")
-        self.assertEqual(deleted_user.email, deleted_user.delivery_email)
+        self.assertEqual(Attachment.objects.get(id=self.bad_file_name_id).file_name, "one.txt")
+        self.assertEqual(
+            Attachment.objects.get(id=self.bad_content_type_id).content_type, "image/png"
+        )
+        self.assertEqual(Attachment.objects.get(id=self.other_control_id).file_name, "three.txt")
 
-        control_user = UserProfile.objects.get(id=self.control_user_id)
-        self.assertEqual(control_user.email, self.control_user_email)
+        null_content_type_row = Attachment.objects.get(id=self.null_content_type_id)
+        self.assertEqual(null_content_type_row.file_name, "four.txt")
+        self.assertIsNone(null_content_type_row.content_type)
 
-        deactivated_user = UserProfile.objects.get(id=self.deactivated_user_id)
-        self.assertEqual(deactivated_user.email, self.deactivated_user_email)
+        all_control_row = Attachment.objects.get(id=self.all_control_id)
+        self.assertEqual(all_control_row.file_name, "uploaded-file")
+        self.assertIsNone(all_control_row.content_type)
+
+        clean_row = Attachment.objects.get(id=self.clean_id)
+        self.assertEqual(clean_row.file_name, "five.txt")
+        self.assertEqual(clean_row.content_type, "text/plain")
+
+        ArchivedAttachment = self.apps.get_model("zerver", "ArchivedAttachment")
+        archived_row = ArchivedAttachment.objects.get(id=self.archived_id)
+        self.assertEqual(archived_row.file_name, "six.txt")
+        self.assertEqual(archived_row.content_type, "text/plain")

--- a/zerver/tests/test_tusd.py
+++ b/zerver/tests/test_tusd.py
@@ -535,6 +535,67 @@ class TusdPreFinishTest(ZulipTestCase):
         self.assertTrue(os.path.exists(os.path.join(settings.LOCAL_FILES_DIR, path_id)))
         self.assertTrue(os.path.exists(os.path.join(settings.LOCAL_FILES_DIR, f"{path_id}.info")))
 
+    def test_content_type_with_control_characters(self) -> None:
+        # tusd passes the client's "filetype" through verbatim, and we
+        # store it and serve it back as Content-Type; a control
+        # character in it must not reach that header.
+        self.login("hamlet")
+        hamlet = self.example_user("hamlet")
+
+        path_id = generate_message_upload_path(str(hamlet.realm.id), sanitize_name("zulip.png"))
+        store_message_attachment(
+            path_id,
+            "zulip.png",
+            "image/png",
+            b"zulip!",
+            hamlet,
+            hamlet.realm,
+        )
+
+        info = TusUpload(
+            id=path_id,
+            size=len("zulip!"),
+            offset=0,
+            size_is_deferred=False,
+            meta_data={
+                "filename": "zulip.png",
+                "filetype": "image/png\n",
+                "name": "zulip.png",
+                "type": "image/png\n",
+            },
+            is_final=False,
+            is_partial=False,
+            partial_uploads=None,
+            storage=None,
+        )
+        store_message_attachment(
+            f"{path_id}.info",
+            "zulip.png.info",
+            "application/octet-stream",
+            info.model_dump_json().encode(),
+            hamlet,
+            hamlet.realm,
+        )
+
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request(info).model_dump(),
+            content_type="application/json",
+        )
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json()["HttpResponse"]["StatusCode"], 200)
+
+        attachment = Attachment.objects.get(path_id=path_id)
+        self.assertEqual(attachment.content_type, "image/png")
+
+        # Against the previous code the newline reached the stored
+        # content type, and serving the file then raised
+        # BadHeaderError -- leaving the attachment permanently
+        # undownloadable, since we compute this header on every read.
+        result = self.client_get(f"/user_uploads/{path_id}")
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.headers["Content-Type"], "image/png")
+
     def test_no_metadata(self) -> None:
         self.login("hamlet")
         hamlet = self.example_user("hamlet")
@@ -714,6 +775,51 @@ class TusdPreFinishTest(ZulipTestCase):
 
         content_disposition = bucket.Object(path_id).get()["ContentDisposition"]
         self.assertEqual(content_disposition, f'inline; filename="{clean_filename}"')
+
+    @use_s3_backend
+    def test_s3_upload_content_type_with_control_characters(self) -> None:
+        # The client's "filetype" is passed to S3 as the object's
+        # Content-Type; a control character in it must not reach that
+        # header.
+        hamlet = self.example_user("hamlet")
+        bucket = create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)[0]
+
+        upload_backend = S3UploadBackend()
+        path_id = upload_backend.generate_message_upload_path(
+            str(hamlet.realm.id), sanitize_name("report.png", strict=True)
+        )
+        info = TusUpload(
+            id=path_id,
+            size=len("zulip!"),
+            offset=0,
+            size_is_deferred=False,
+            meta_data={
+                "filename": "report.png",
+                "filetype": "image/png\n",
+                "name": "report.png",
+                "type": "image/png\n",
+            },
+            is_final=False,
+            is_partial=False,
+            partial_uploads=None,
+            storage=None,
+        )
+        bucket.Object(path_id).put(Body=b"zulip!", ContentType="application/octet-stream")
+        bucket.Object(f"{path_id}.info").put(Body=info.model_dump_json().encode())
+
+        self.login("hamlet")
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request(info).model_dump(),
+            content_type="application/json",
+        )
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json()["HttpResponse"]["StatusCode"], 200)
+
+        attachment = Attachment.objects.get(path_id=path_id)
+        self.assertEqual(attachment.content_type, "image/png")
+
+        self.assertEqual(bucket.Object(path_id).get()["ContentType"], "image/png")
 
     @use_s3_backend
     def test_s3_upload_streaming_chardet(self) -> None:

--- a/zerver/tests/test_tusd.py
+++ b/zerver/tests/test_tusd.py
@@ -664,6 +664,58 @@ class TusdPreFinishTest(ZulipTestCase):
         self.assertEqual(response["ContentType"], "binary/octet-stream")
 
     @use_s3_backend
+    def test_s3_upload_filename_with_control_characters(self) -> None:
+        # Some upload clients send filenames with a trailing newline,
+        # which must not reach the Content-Disposition header.
+        hamlet = self.example_user("hamlet")
+        bucket = create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)[0]
+
+        upload_backend = S3UploadBackend()
+        filename = "report.png\n"
+        clean_filename = "report.png"
+        path_id = upload_backend.generate_message_upload_path(
+            str(hamlet.realm.id), sanitize_name(filename, strict=True)
+        )
+        info = TusUpload(
+            id=path_id,
+            size=len("zulip!"),
+            offset=0,
+            size_is_deferred=False,
+            meta_data={
+                "filename": filename,
+                "filetype": "image/png",
+                "name": filename,
+                "type": "image/png",
+            },
+            is_final=False,
+            is_partial=False,
+            partial_uploads=None,
+            storage=None,
+        )
+        bucket.Object(path_id).put(Body=b"zulip!", ContentType="application/octet-stream")
+        bucket.Object(f"{path_id}.info").put(Body=info.model_dump_json().encode())
+
+        self.login("hamlet")
+        result = self.client_post(
+            "/api/internal/tusd",
+            self.request(info).model_dump(),
+            content_type="application/json",
+        )
+        self.assertEqual(result.status_code, 200)
+        result_json = result.json()
+        self.assertEqual(result_json["HttpResponse"]["StatusCode"], 200)
+        self.assertEqual(
+            orjson.loads(result_json["HttpResponse"]["Body"]),
+            {"url": f"/user_uploads/{path_id}", "filename": clean_filename},
+        )
+
+        attachment = Attachment.objects.get(path_id=path_id)
+        self.assertEqual(attachment.file_name, clean_filename)
+
+        content_disposition = bucket.Object(path_id).get()["ContentDisposition"]
+        self.assertEqual(content_disposition, f'inline; filename="{clean_filename}"')
+
+    @use_s3_backend
     def test_s3_upload_streaming_chardet(self) -> None:
         assert settings.LOCAL_FILES_DIR is None
         self.login("hamlet")

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -46,6 +46,7 @@ from zerver.lib.test_helpers import (
     ratelimit_rule,
 )
 from zerver.lib.upload import (
+    clean_uploaded_content_type,
     clean_uploaded_file_name,
     remove_control_characters,
     sanitize_name,
@@ -202,6 +203,28 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
                 self.assertEqual(result.status_code, 200)
                 self.assertEqual(result["Content-Disposition"], f'inline; filename="{stored_name}"')
                 consume_response(result)
+
+    def test_content_type_with_control_characters(self) -> None:
+        """
+        Django does not sanitize the content type of an uploaded part, so
+        control characters in it reach us here; one which is nothing
+        but them is guessed from the filename, as a missing one is.
+        """
+        self.login("hamlet")
+
+        uploaded_file = SimpleUploadedFile("zulip.png", b"zulip!", content_type="\x01")
+        result = self.api_post(
+            self.example_user("hamlet"), "/api/v1/user_uploads", {"file": uploaded_file}
+        )
+        url = self.assert_json_success(result)["url"]
+
+        attachment = Attachment.objects.get(path_id=url.removeprefix("/user_uploads/"))
+        self.assertEqual(attachment.content_type, "image/png")
+
+        result = self.client_get(url)
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result["Content-Type"], "image/png")
+        consume_response(result)
 
     def test_guess_content_type_from_filename(self) -> None:
         """
@@ -2307,6 +2330,12 @@ class RemoveControlCharactersTests(ZulipTestCase):
         # fails to escape.
         self.assertEqual(remove_control_characters("report.pdf\n"), "report.pdf")
         self.assertEqual(remove_control_characters("\n"), "")
+        # Content types get the same treatment; a CR or LF in one
+        # would otherwise be injected into the Content-Type header.
+        self.assertEqual(remove_control_characters("image/png\n"), "image/png")
+        self.assertEqual(
+            remove_control_characters("text/plain\r\nX-Foo: bar"), "text/plainX-Foo: bar"
+        )
 
 
 class CleanUploadedFileNameTests(ZulipTestCase):
@@ -2318,6 +2347,21 @@ class CleanUploadedFileNameTests(ZulipTestCase):
         self.assertEqual(clean_uploaded_file_name("\n\n"), "uploaded-file")
         self.assertEqual(clean_uploaded_file_name("\x01.\x02"), "uploaded-file")
         self.assertEqual(clean_uploaded_file_name(".."), "uploaded-file")
+
+
+class CleanUploadedContentTypeTests(ZulipTestCase):
+    def test_clean_uploaded_content_type(self) -> None:
+        self.assertEqual(clean_uploaded_content_type("image/png\n", "zulip.png"), "image/png")
+        self.assertEqual(
+            clean_uploaded_content_type("text/plain; charset=utf-8", "zulip.txt"),
+            "text/plain; charset=utf-8",
+        )
+        # A type which stripping leaves empty is guessed from the
+        # filename, exactly as a missing one is.
+        self.assertEqual(clean_uploaded_content_type("\x01", "zulip.png"), "image/png")
+        self.assertEqual(
+            clean_uploaded_content_type("", "uploaded-file"), "application/octet-stream"
+        )
 
 
 class UploadSpaceTests(UploadSerializeMixin, ZulipTestCase):

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -245,15 +245,19 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         consume_response(result)
 
         # Old files may be stored without a content-type in the
-        # database, in which case we try to guess at download time.
+        # database -- as NULL, or as the empty string that a
+        # third-party import can carry over -- in which case we try to
+        # guess at download time.
         attachment = Attachment.objects.get(file_name="somefile")
         self.assertEqual(attachment.content_type, "application/octet-stream")
-        attachment.content_type = None
-        attachment.save(update_fields=["content_type"])
-        result = self.client_get(url)
-        self.assertEqual(result.status_code, 200)
-        self.assertEqual(result["Content-Type"], "application/octet-stream")
-        consume_response(result)
+        for stored_content_type in [None, ""]:
+            with self.subTest(content_type=stored_content_type):
+                attachment.content_type = stored_content_type
+                attachment.save(update_fields=["content_type"])
+                result = self.client_get(url)
+                self.assertEqual(result.status_code, 200)
+                self.assertEqual(result["Content-Type"], "application/octet-stream")
+                consume_response(result)
 
         uploaded_file = SimpleUploadedFile("somefile.txt", b"zulip!", content_type="")
         result = self.api_post(

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -45,7 +45,12 @@ from zerver.lib.test_helpers import (
     get_test_image_file,
     ratelimit_rule,
 )
-from zerver.lib.upload import sanitize_name, upload_message_attachment
+from zerver.lib.upload import (
+    clean_uploaded_file_name,
+    remove_control_characters,
+    sanitize_name,
+    upload_message_attachment,
+)
 from zerver.lib.upload.base import ZulipUploadBackend
 from zerver.lib.upload.local import LocalUploadBackend
 from zerver.lib.upload.s3 import S3UploadBackend
@@ -170,6 +175,33 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         result = self.client_post("/json/user_uploads")
         self.assert_json_error(result, "You must specify a file to upload")
+
+    def test_file_name_with_control_characters(self) -> None:
+        """
+        Django's multipart parser drops non-printable characters from the
+        filename, but we percent-decode it afterwards, so they can
+        still reach us here.
+        """
+        self.login("hamlet")
+
+        for sent_name, stored_name in [("a%0Ab.txt", "ab.txt"), ("%0A%0A", "uploaded-file")]:
+            with self.subTest(file_name=sent_name):
+                uploaded_file = SimpleUploadedFile(sent_name, b"zulip!", content_type="text/plain")
+                result = self.api_post(
+                    self.example_user("hamlet"), "/api/v1/user_uploads", {"file": uploaded_file}
+                )
+                url = self.assert_json_success(result)["url"]
+
+                path_id = url.removeprefix("/user_uploads/")
+                attachment = Attachment.objects.get(path_id=path_id)
+                self.assertEqual(attachment.file_name, stored_name)
+                # path_id is derived from the same cleaned name.
+                self.assertTrue(path_id.endswith(stored_name))
+
+                result = self.client_get(url)
+                self.assertEqual(result.status_code, 200)
+                self.assertEqual(result["Content-Disposition"], f'inline; filename="{stored_name}"')
+                consume_response(result)
 
     def test_guess_content_type_from_filename(self) -> None:
         """
@@ -2263,6 +2295,29 @@ class SanitizeNameTests(ZulipTestCase):
         self.assertEqual(
             sanitize_name('~/."\\`\\?*"u0`000ssh/test.t**{}ar.gz'), ".u0000sshtest.tar.gz"
         )
+
+
+class RemoveControlCharactersTests(ZulipTestCase):
+    def test_remove_control_characters(self) -> None:
+        self.assertEqual(remove_control_characters("a\x00b.txt"), "ab.txt")
+        self.assertEqual(remove_control_characters("a\tb\x1f\x7f.txt"), "ab.txt")
+        self.assertEqual(remove_control_characters("my report.png"), "my report.png")
+        self.assertEqual(remove_control_characters("테스트.txt"), "테스트.txt")
+        # A trailing newline is the case Django's content_disposition_header
+        # fails to escape.
+        self.assertEqual(remove_control_characters("report.pdf\n"), "report.pdf")
+        self.assertEqual(remove_control_characters("\n"), "")
+
+
+class CleanUploadedFileNameTests(ZulipTestCase):
+    def test_clean_uploaded_file_name(self) -> None:
+        self.assertEqual(clean_uploaded_file_name("report.pdf\n"), "report.pdf")
+        self.assertEqual(clean_uploaded_file_name("테스트.txt"), "테스트.txt")
+        # Names which stripping leaves unusable get the placeholder
+        # that sanitize_name uses for them.
+        self.assertEqual(clean_uploaded_file_name("\n\n"), "uploaded-file")
+        self.assertEqual(clean_uploaded_file_name("\x01.\x02"), "uploaded-file")
+        self.assertEqual(clean_uploaded_file_name(".."), "uploaded-file")
 
 
 class UploadSpaceTests(UploadSerializeMixin, ZulipTestCase):

--- a/zerver/tests/test_upload_s3.py
+++ b/zerver/tests/test_upload_s3.py
@@ -72,6 +72,25 @@ class S3Test(ZulipTestCase):
         self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
 
     @use_s3_backend
+    def test_upload_message_attachment_filename_with_control_characters(self) -> None:
+        bucket = create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)[0]
+        user_profile = self.example_user("hamlet")
+
+        # Some email clients send attachment filenames with a trailing
+        # newline, which must not reach the Content-Disposition header.
+        url, returned_filename = upload_message_attachment(
+            "quotes.txt\n", "text/plain", b"zulip!", user_profile
+        )
+        self.assertEqual(returned_filename, "quotes.txt")
+
+        path_id = url.removeprefix("/user_uploads/")
+        attachment = Attachment.objects.get(owner=user_profile, path_id=path_id)
+        self.assertEqual(attachment.file_name, "quotes.txt")
+
+        content_disposition = bucket.Object(path_id).get()["ContentDisposition"]
+        self.assertEqual(content_disposition, 'inline; filename="quotes.txt"')
+
+    @use_s3_backend
     def test_upload_message_attachment_thumbnail(self) -> None:
         bucket = create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)[0]
         user_profile = self.example_user("hamlet")

--- a/zerver/tests/test_upload_s3.py
+++ b/zerver/tests/test_upload_s3.py
@@ -91,6 +91,22 @@ class S3Test(ZulipTestCase):
         self.assertEqual(content_disposition, 'inline; filename="quotes.txt"')
 
     @use_s3_backend
+    def test_upload_message_attachment_content_type_with_control_characters(self) -> None:
+        bucket = create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)[0]
+        user_profile = self.example_user("hamlet")
+
+        # Against the previous code, a newline in the content type
+        # made maybe_add_charset raise ValueError, before the value
+        # could even reach the S3 Content-Type header.
+        url, _ = upload_message_attachment("quotes.txt", "text/plain\n", b"zulip!", user_profile)
+
+        path_id = url.removeprefix("/user_uploads/")
+        attachment = Attachment.objects.get(owner=user_profile, path_id=path_id)
+        self.assertEqual(attachment.content_type, 'text/plain; charset="ascii"')
+
+        self.assertEqual(bucket.Object(path_id).get()["ContentType"], 'text/plain; charset="ascii"')
+
+    @use_s3_backend
     def test_upload_message_attachment_thumbnail(self) -> None:
         bucket = create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)[0]
         user_profile = self.example_user("hamlet")

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -14,13 +14,14 @@ from pydantic.alias_generators import to_pascal
 from confirmation.models import Confirmation, ConfirmationKeyError, get_object_from_key
 from zerver.decorator import get_basic_credentials, validate_api_key
 from zerver.lib.exceptions import AccessDeniedError, JsonableError
-from zerver.lib.mime_types import INLINE_MIME_TYPES, bare_content_type, guess_type
+from zerver.lib.mime_types import INLINE_MIME_TYPES, bare_content_type
 from zerver.lib.rate_limiter import is_local_addr
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
 from zerver.lib.upload import (
     RealmUploadQuotaError,
     attachment_source,
     check_upload_within_quota,
+    clean_uploaded_content_type,
     clean_uploaded_file_name,
     create_attachment,
     delete_message_attachment,
@@ -147,12 +148,7 @@ def handle_upload_pre_finish_hook(
 
     tus_metadata = data.meta_data
     filename = clean_uploaded_file_name(tus_metadata.get("filename", ""))
-
-    content_type = tus_metadata.get("filetype")
-    if not content_type:
-        content_type = guess_type(filename)[0]
-        if content_type is None:
-            content_type = "application/octet-stream"
+    content_type = clean_uploaded_content_type(tus_metadata.get("filetype", ""), filename)
 
     # Only open the object at all when charset detection actually needs to
     # inspect its bytes. With the S3 backend, opening it starts a

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -21,6 +21,7 @@ from zerver.lib.upload import (
     RealmUploadQuotaError,
     attachment_source,
     check_upload_within_quota,
+    clean_uploaded_file_name,
     create_attachment,
     delete_message_attachment,
     generate_message_upload_path,
@@ -145,12 +146,7 @@ def handle_upload_pre_finish_hook(
     path_id = data.id.partition("+")[0]
 
     tus_metadata = data.meta_data
-    filename = tus_metadata.get("filename", "")
-
-    # We want to store as the filename a version that clients are
-    # likely to be able to accept via "Save as..."
-    if filename in {"", ".", ".."}:
-        filename = "uploaded-file"
+    filename = clean_uploaded_file_name(tus_metadata.get("filename", ""))
 
     content_type = tus_metadata.get("filetype")
     if not content_type:

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -153,7 +153,9 @@ def serve_local(
     if not os.path.isfile(local_path):
         return HttpResponseNotFound("<p>File not found</p>")
 
-    if content_type is None:
+    # An empty stored content type is as unusable as a missing one;
+    # serve_s3 falls back for both.
+    if not content_type:
         content_type = guess_type(filename)[0] or "application/octet-stream"
 
     if needs_charset_detection(content_type):


### PR DESCRIPTION
A filename ending in a newline produces an invalid S3 Content-Disposition header, and the upload then fails with an uncaught HTTPClientError ("Invalid header value ..."). This is reached from two client-controlled paths: the tusd pre-finish hook, for web uploads, and upload_message_attachment, for the email mirror and other attachment uploads.

The header is built by Django's content_disposition_header(), which falls back to the RFC 6266 "filename*=utf-8''" encoding for any filename that is not a valid quoted-string. It detects that with re.match(r"^[\t \x21-\x7e]*$", filename); but in Python "$" also matches just before a trailing "\n", so a filename made of quotable characters plus a trailing newline slips into the quoted-string branch and is emitted verbatim, newline included. A newline elsewhere in the filename is escaped correctly. This is a residual bug in the fix for Django ticket 36023
(https://code.djangoproject.com/ticket/36023); the upstream fix is "\Z" in place of "$", reported upstream as Django ticket 37198 (https://code.djangoproject.com/ticket/37198).

Rather than work around Django's escaping, strip control characters from the filename as it enters the system. That is correct regardless: a control character is never valid in a filename, we already stripped NUL bytes here because PostgreSQL cannot store them, and it keeps the stored filename clean in the database and on the download path.

moto does not reproduce the HTTP-layer header rejection, so the regression tests instead assert that the resulting Content-Disposition header and stored filename contain no newline, which fails against the previous code.


---

Asked Claude to fix a sentry trace. 