### PR TITLE
corporate: Improve `communities_view`.

### DIFF
--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -353,7 +353,6 @@ def communities_view(request: HttpRequest) -> HttpResponse:
             )
             eligible_realms.append(
                 {
-                    "id": realm.id,
                     "name": realm.name,
                     "realm_url": realm.url,
                     "logo_url": get_realm_icon_url(realm),

--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -375,8 +375,8 @@ def communities_view(request: HttpRequest) -> HttpResponse:
         if Realm.ORG_TYPES[org_type]["id"] in unique_org_type_ids:
             org_types[org_type] = Realm.ORG_TYPES[org_type]
 
-    # This code is not required right bot could be useful in future.
-    # If we ever decided to show all the ORG_TYPES.
+    # This code is not required right now, but could be useful in the
+    # future if we ever decide to show all the ORG_TYPES.
     # Remove `Unspecified` ORG_TYPE
     # org_types.pop("unspecified", None)
 

--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -372,8 +372,9 @@ def communities_view(request: HttpRequest) -> HttpResponse:
     # Remove org_types for which there are no open organizations.
     org_types = dict()
     for org_type in CATEGORIES_TO_OFFER:
-        if Realm.ORG_TYPES[org_type]["id"] in unique_org_type_ids:
-            org_types[org_type] = Realm.ORG_TYPES[org_type]
+        org_type_info = Realm.ORG_TYPES[org_type]
+        if org_type_info["id"] in unique_org_type_ids:
+            org_types[org_type] = {"name": org_type_info["name"]}
 
     # This code is not required right now, but could be useful in the
     # future if we ever decide to show all the ORG_TYPES.


### PR DESCRIPTION
While working on #23419, noticed some small cleanups we can make in `communities_view`

**How changes were tested:**

We have tests in `test_open_organizations_endpoint` and there is no behavioral change in this PR.

**Screenshot**

Works fine:
<img width="646" height="543" alt="Screenshot 2026-07-01 at 3 29 24 PM" src="https://github.com/user-attachments/assets/0e6229f4-2010-4472-be86-9b1067e22b5c" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
