### PR TITLE
rabbitmq: Disable consumer_timeout to avoid event redelivery.

### DIFF
--- a/puppet/zulip/files/rabbitmq/rabbitmq.config
+++ b/puppet/zulip/files/rabbitmq/rabbitmq.config
@@ -1,3 +1,9 @@
 [{kernel, [{inet_dist_use_interface, {127,0,0,1}}]},
- {rabbit, [{tcp_listeners, [{"127.0.0.1", 5672}]}]},
+ {rabbit, [{tcp_listeners, [{"127.0.0.1", 5672}]},
+           %% We disable consumer_timeout. Our queue workers ACK an
+           %% event only after consume() finishes; consumer_timeout doesn't
+           %% abort a slow job, it just requeues it for a redundant,
+           %% duplicate run. This mechanism doesn't provide anything helpful
+           %% for us.
+           {consumer_timeout, undefined}]},
  {rabbitmq_prometheus, [{tcp_config, [{ip, {127,0,0,1}}, {port, 15692}]}]}].


### PR DESCRIPTION
Note: Requires a careful deployment strategy on Zulip Cloud to avoid a restart of rabbitmq by puppet.

Since 3.8.15, RabbitMQ enforces a consumer_timeout (30 minutes by default): if a delivery is not acknowledged within it, the broker requeues the event and closes the channel. Because our queue workers acknowledge only after consume() returns, any task that runs longer causes the event to be redelivered and processed a second time.

This timeout does nothing useful for us. It does not abort an overlong job, it merely re-runs it; and we already have our own mechanism (MAX_CONSUME_SECONDS) for bounding worker runtime, which we deliberately disable on deferred_work precisely because its jobs have no time bound.

Self-serve Slack imports routinely exceed 30 minutes, so in practice this just redelivers the import for a duplicate, harmful run. Disable consumer_timeout globally.

