### PR TITLE
Empty topic only channel topic links

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1141,15 +1141,38 @@ export function get_candidates(
         const topic_shortcut_regex = /#(>)([^*\n]*)$/;
         // Matches '[#channel](url)>some text' at the end of a split.
         const partial_fallback_stream_topic_regex = /(\[#)([^*>]+)]\(#[^)]*\)>([^*\n]*)$/;
+        // Matches a complete '#**stream name**' link, optionally followed
+        // by a topic query; reopening the typeahead here offers topic
+        // completion. The trailing token excludes `>` to stay non-overlapping
+        // with the topic_jump trigger above.
+        const complete_stream_regex = /#\*\*([^*>]+)\*\*([^*>\n]*)$/;
+        // Matches the '[#channel](url)' fallback link for special characters.
+        const complete_fallback_stream_regex = /(\[#)([^*>]+)]\(#[^)]*\)([^*>\n]*)$/;
         const partial_fallback_stream_topic_tokens = partial_fallback_stream_topic_regex.exec(
             split[0],
         );
         const partial_stream_topic_tokens = partial_stream_topic_regex.exec(split[0]);
         const topic_shortcut_tokens = topic_shortcut_regex.exec(split[0]);
+        // A complete link is a valid final form, so only trigger topic
+        // completion while the typeahead is already open (the reopen flow
+        // after picking a channel), not when the cursor lands after an
+        // existing link.
+        const typeahead_already_shown = compose_ui.compose_textarea_typeahead?.shown ?? false;
+        const complete_channel_link_tokens = typeahead_already_shown
+            ? complete_stream_regex.exec(split[0])
+            : null;
+        const complete_fallback_link_tokens = typeahead_already_shown
+            ? complete_fallback_stream_regex.exec(split[0])
+            : null;
         const tokens =
             partial_stream_topic_tokens ?? // #**channel>topic
             topic_shortcut_tokens ?? // #>topic
-            partial_fallback_stream_topic_tokens; // [#channel](url)>topic
+            partial_fallback_stream_topic_tokens ?? // [#channel](url)>topic
+            complete_channel_link_tokens ?? // #**channel**
+            complete_fallback_link_tokens; // [#channel](url)
+        const is_complete_channel_link =
+            tokens !== null &&
+            (tokens === complete_channel_link_tokens || tokens === complete_fallback_link_tokens);
         const should_begin_typeahead = tokens !== null;
         if (should_begin_typeahead) {
             completing = "topic_list";
@@ -1189,6 +1212,15 @@ export function get_candidates(
             }
             // If we aren't composing to a channel, `sub` would be undefined.
             if (sub !== undefined) {
+                if (
+                    is_complete_channel_link &&
+                    stream_data.is_empty_topic_only_channel(sub.stream_id)
+                ) {
+                    // This channel only allows the empty topic, so the
+                    // complete channel link is the final form; don't offer
+                    // topic completion.
+                    return [];
+                }
                 // We always show topic suggestions after the user types a stream, and let them
                 // pick between just showing the stream (the first option, when nothing follows ">")
                 // or adding a topic.
@@ -1442,16 +1474,22 @@ export function content_typeahead_selected(
                 sub && stream_data.is_empty_topic_only_channel(sub.stream_id);
             const is_greater_than_key_pressed = event?.type === "keydown" && event.key === ">";
 
-            // For empty topic only channel, skip showing topic typeahead and
-            // insert direct channel link.
-            if (is_empty_topic_only_channel && !is_greater_than_key_pressed) {
-                beginning += topic_link_util.get_stream_link_syntax(item.name);
-            } else if (topic_link_util.will_produce_broken_stream_topic_link(item.name)) {
-                // for stream links, we use markdown link syntax if the #**stream** syntax
-                // will generate a broken url.
-                beginning += topic_link_util.get_fallback_markdown_link(item.name) + ">";
+            // For an empty-topic-only channel, the user pressed ">" to
+            // explicitly request a topic, so insert the partial syntax to
+            // open topic completion.
+            if (is_empty_topic_only_channel && is_greater_than_key_pressed) {
+                if (topic_link_util.will_produce_broken_stream_topic_link(item.name)) {
+                    // for stream links, we use markdown link syntax if the #**stream** syntax
+                    // will generate a broken url.
+                    beginning += topic_link_util.get_fallback_markdown_link(item.name) + ">";
+                } else {
+                    beginning += "#**" + item.name + ">";
+                }
             } else {
-                beginning += "#**" + item.name + ">";
+                // Insert a complete channel link; the topic typeahead reopens
+                // to offer topic completion, so dismissing it leaves a valid
+                // link rather than broken `#**channel>` syntax.
+                beginning += topic_link_util.get_stream_link_syntax(item.name);
             }
 
             void compose_validate.warn_if_private_stream_is_linked(item, $textbox);

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1488,11 +1488,12 @@ export function content_typeahead_selected(
         }
         case "topic_list": {
             // If we use "Escape" we would want `#**design>this is a design topic` to be
-            // resolved to `#**design** this is a design topic`
+            // resolved to `#**design** this is a design topic`, i.e. a link to the
+            // channel followed by the partially typed topic as plain text.
             if (event?.key === "Escape") {
-                const topic_start_index = beginning.lastIndexOf(">");
-                const topic = beginning.slice(topic_start_index + 1);
-                beginning = beginning.slice(0, topic_start_index) + "** " + topic;
+                const syntax_start_index = beginning.lastIndexOf(item.used_syntax_prefix);
+                const stream_link = topic_link_util.get_stream_link_syntax(item.stream_data.name);
+                beginning = beginning.slice(0, syntax_start_index) + stream_link + " " + token;
                 break;
             }
 

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1212,14 +1212,31 @@ export function get_candidates(
             }
             // If we aren't composing to a channel, `sub` would be undefined.
             if (sub !== undefined) {
-                if (
-                    is_complete_channel_link &&
-                    stream_data.is_empty_topic_only_channel(sub.stream_id)
-                ) {
-                    // This channel only allows the empty topic, so the
-                    // complete channel link is the final form; don't offer
-                    // topic completion.
-                    return [];
+                if (stream_data.is_empty_topic_only_channel(sub.stream_id)) {
+                    if (is_complete_channel_link) {
+                        // The complete channel link is the final form, so
+                        // don't open topic completion by default; the user
+                        // must press ">" to reach the empty topic.
+                        return [];
+                    }
+                    // The user asked for a topic with ">", but this channel
+                    // only allows the empty topic, so offer just that single
+                    // topic rather than offering or creating named ones.
+                    const empty_topic_suggestion: TopicSuggestion = {
+                        topic: "",
+                        topic_display_name: util.get_final_topic_display_name(""),
+                        is_empty_string_topic: true,
+                        type: "topic_list",
+                        is_channel_link: false,
+                        used_syntax_prefix,
+                        stream_data: {
+                            ...sub,
+                            type: "stream",
+                            rendered_description: "",
+                        },
+                        is_new_topic: false,
+                    };
+                    return [empty_topic_suggestion];
                 }
                 // We always show topic suggestions after the user types a stream, and let them
                 // pick between just showing the stream (the first option, when nothing follows ">")

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1131,19 +1131,25 @@ export function get_candidates(
             ];
         }
 
-        // Matches '#**stream name>some text' at the end of a split.
-        const stream_topic_regex = /#\*\*([^*>]+)>([^*\n]*)$/;
+        // Matches an in-progress (unterminated) '#**stream name>some text' mention
+        // where the closing '**' hasn't been typed yet.
+        const partial_stream_topic_regex = /#\*\*([^*>]+)>([^*\n]*)$/;
         // Matches '#>some text', which is a shortcut to
         // link to topics in the channel currently composing to.
         // `>` is enclosed in a capture group to use the below
         // code path for both syntaxes.
-        const shortcut_regex = /#(>)([^*\n]*)$/;
+        const topic_shortcut_regex = /#(>)([^*\n]*)$/;
         // Matches '[#channel](url)>some text' at the end of a split.
-        const fallback_stream_topic_regex = /(\[#)([^*>]+)]\(#[^)]*\)>([^*\n]*)$/;
-        const fallback_tokens = fallback_stream_topic_regex.exec(split[0]);
-        const stream_topic_tokens = stream_topic_regex.exec(split[0]);
-        const topic_shortcut_tokens = shortcut_regex.exec(split[0]);
-        const tokens = stream_topic_tokens ?? topic_shortcut_tokens ?? fallback_tokens;
+        const partial_fallback_stream_topic_regex = /(\[#)([^*>]+)]\(#[^)]*\)>([^*\n]*)$/;
+        const partial_fallback_stream_topic_tokens = partial_fallback_stream_topic_regex.exec(
+            split[0],
+        );
+        const partial_stream_topic_tokens = partial_stream_topic_regex.exec(split[0]);
+        const topic_shortcut_tokens = topic_shortcut_regex.exec(split[0]);
+        const tokens =
+            partial_stream_topic_tokens ?? // #**channel>topic
+            topic_shortcut_tokens ?? // #>topic
+            partial_fallback_stream_topic_tokens; // [#channel](url)>topic
         const should_begin_typeahead = tokens !== null;
         if (should_begin_typeahead) {
             completing = "topic_list";

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -79,6 +79,7 @@ export type MarkdownHelpers = {
 
     // stream hashes
     get_stream_by_name: (stream_name: string) => {stream_id: number; name: string} | undefined;
+    is_empty_topic_only_channel: (stream_id: number) => boolean;
     stream_hash: (stream_id: number) => string;
     stream_topic_hash: (stream_id: number, topic: string) => string;
 
@@ -615,6 +616,7 @@ function handleStreamTopic({
     stream_name,
     topic,
     get_stream_by_name,
+    is_empty_topic_only_channel,
     stream_topic_hash,
 }: {
     stream_name: string;
@@ -625,10 +627,16 @@ function handleStreamTopic({
               name: string;
           }
         | undefined;
+    is_empty_topic_only_channel: (stream_id: number) => boolean;
     stream_topic_hash: (stream_id: number, topic: string) => string;
 }): string | undefined {
     const stream = get_stream_by_name(stream_name);
     if (stream === undefined) {
+        return undefined;
+    }
+    if (topic !== "" && is_empty_topic_only_channel(stream.stream_id)) {
+        // This channel only allows the empty topic, so a non-empty topic
+        // can never exist in it; don't linkify it.
         return undefined;
     }
     const href = stream_topic_hash(stream.stream_id, topic);
@@ -647,6 +655,7 @@ function handleStreamTopicMessage({
     topic,
     message_id,
     get_stream_by_name,
+    is_empty_topic_only_channel,
     stream_topic_hash,
 }: {
     stream_name: string;
@@ -658,10 +667,16 @@ function handleStreamTopicMessage({
               name: string;
           }
         | undefined;
+    is_empty_topic_only_channel: (stream_id: number) => boolean;
     stream_topic_hash: (stream_id: number, topic: string) => string;
 }): string | undefined {
     const stream = get_stream_by_name(stream_name);
     if (stream === undefined) {
+        return undefined;
+    }
+    if (topic !== "" && is_empty_topic_only_channel(stream.stream_id)) {
+        // This channel only allows the empty topic, so a non-empty topic
+        // can never exist in it; don't linkify it.
         return undefined;
     }
     const href = stream_topic_hash(stream.stream_id, topic) + "/near/" + message_id;
@@ -778,6 +793,7 @@ export function parse({
             stream_name,
             topic,
             get_stream_by_name: helper_config.get_stream_by_name,
+            is_empty_topic_only_channel: helper_config.is_empty_topic_only_channel,
             stream_topic_hash: helper_config.stream_topic_hash,
         });
     }
@@ -792,6 +808,7 @@ export function parse({
             topic,
             message_id,
             get_stream_by_name: helper_config.get_stream_by_name,
+            is_empty_topic_only_channel: helper_config.is_empty_topic_only_channel,
             stream_topic_hash: helper_config.stream_topic_hash,
         });
     }

--- a/web/src/markdown_config.ts
+++ b/web/src/markdown_config.ts
@@ -76,6 +76,7 @@ export const get_helpers = (): MarkdownHelpers => ({
 
     // stream hashes
     get_stream_by_name: (name) => stream(stream_data.get_sub(name)),
+    is_empty_topic_only_channel: stream_data.is_empty_topic_only_channel,
     stream_hash: hash_util.channel_url_by_user_setting,
     stream_topic_hash: hash_util.by_stream_topic_url,
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1158,34 +1158,40 @@ test("content_typeahead_selected", ({override}) => {
         warned_for_stream_link = true;
     });
 
+    // Selecting a channel inserts a complete channel link; the topic
+    // typeahead then reopens to offer topic completion (see the
+    // get_candidates tests), so no broken `#**channel>` syntax is left
+    // behind if the user dismisses it without picking a topic.
     query = "#swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "#**Sweden>";
+    expected_value = "#**Sweden**";
     assert.equal(actual_value, expected_value);
 
     query = "Hello #swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "Hello #**Sweden>";
+    expected_value = "Hello #**Sweden**";
     assert.equal(actual_value, expected_value);
 
     query = "#**swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "#**Sweden>";
+    expected_value = "#**Sweden**";
     assert.equal(actual_value, expected_value);
 
+    // A channel name with special characters falls back to the markdown
+    // link syntax, still as a complete link.
     query = "#**A* al";
     ct.get_or_set_token_for_testing("A* al");
     actual_value = ct.content_typeahead_selected(broken_link_stream, query, input_element);
-    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>";
+    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)";
     assert.equal(actual_value, expected_value);
 
     query = "#>";
     ct.get_or_set_token_for_testing("#");
     actual_value = ct.content_typeahead_selected(broken_link_stream, query, input_element);
-    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>";
+    expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)";
     assert.equal(actual_value, expected_value);
 
     // A channel that only allows the empty topic gets a complete channel
@@ -2904,6 +2910,18 @@ test("begins_typeahead", ({override, override_rewire}) => {
     // rewrites the link into the partial-then-completed form. Typing after
     // the link filters topics just like the `>` syntax does.
     compose_ui.compose_textarea_typeahead = {shown: true};
+    assert_typeahead_equals(
+        "#**Sweden**",
+        typed_topics("Sweden", ["Sweden", ...sweden_topics_to_show]),
+    );
+    assert_typeahead_equals(
+        "#**Sweden**more ice",
+        typed_topics("Sweden", ["more ice", "even more ice"]),
+    );
+    assert_typeahead_equals(
+        "#**Sweden**totally new topic",
+        typed_topics("Sweden", ["totally new topic"], is_new_topic),
+    );
     // A space immediately after the complete link means the user has
     // moved on to the message body, so no topic typeahead is offered.
     assert_typeahead_equals("#**Sweden** more ice", []);

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -2928,6 +2928,27 @@ test("begins_typeahead", ({override, override_rewire}) => {
     // A channel that only allows the empty topic gets a complete channel
     // link with no topic completion offered.
     assert_typeahead_equals("#**Announce**", []);
+    // Once the user presses ">", completion is offered to just that
+    // single (empty) topic, and never to named ones.
+    const announce_empty_topic_suggestion = [
+        {
+            topic: "",
+            topic_display_name: get_final_topic_display_name(""),
+            is_empty_string_topic: true,
+            type: "topic_list",
+            is_channel_link: false,
+            used_syntax_prefix: "#**",
+            stream_data: {
+                ...stream_data.get_sub_by_name("Announce"),
+                rendered_description: "",
+            },
+            is_new_topic: false,
+        },
+    ];
+    assert_typeahead_equals("#**Announce>", announce_empty_topic_suggestion);
+    // Text typed after ">" cannot create a named topic; only the empty
+    // topic is still offered.
+    assert_typeahead_equals("#**Announce>random", announce_empty_topic_suggestion);
     compose_ui.compose_textarea_typeahead = undefined;
 
     // time_jump

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1448,6 +1448,50 @@ test("content_typeahead_selected", ({override}) => {
     expected_value = "Hello #**Sweden** plan";
     assert.equal(actual_value, expected_value);
 
+    // Escape with the shortcut syntax for the channel being composed to.
+    compose_state.set_stream_id(sweden_stream.stream_id);
+    query = "Hello #>plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "planning",
+            topic_display_name: "planning",
+            type: "topic_list",
+            used_syntax_prefix: "#>",
+            is_channel_link: false,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+        {key: "Escape"},
+    );
+    expected_value = "Hello #**Sweden** plan";
+    assert.equal(actual_value, expected_value);
+
+    // Escape with the fallback markdown link syntax used for channel
+    // names that would produce broken `#**channel**` links.
+    query = "Hello [#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>fast";
+    ct.get_or_set_token_for_testing("fast");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "fast",
+            topic_display_name: "fast",
+            type: "topic_list",
+            used_syntax_prefix: "[#",
+            is_channel_link: false,
+            stream_data: {
+                name: "A* Algorithm",
+            },
+        },
+        query,
+        input_element,
+        {key: "Escape"},
+    );
+    expected_value = "Hello [#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm) fast";
+    assert.equal(actual_value, expected_value);
+
     // syntax
     ct.get_or_set_completing_for_tests("syntax");
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -737,6 +737,18 @@ const broken_link_stream = stream_item(
         can_create_topic_group: members.id,
     }),
 );
+const empty_topic_only_stream = stream_item(
+    make_stream({
+        name: "Announce",
+        description: "A channel that only allows the empty topic",
+        stream_id: 7,
+        subscribed: true,
+        topics_policy: "empty_topic_only",
+        can_administer_channel_group: support.id,
+        can_add_subscribers_group: support.id,
+        can_create_topic_group: members.id,
+    }),
+);
 
 stream_data.add_sub_for_tests(sweden_stream);
 stream_data.add_sub_for_tests(denmark_stream);
@@ -744,6 +756,7 @@ stream_data.add_sub_for_tests(netherland_stream);
 stream_data.add_sub_for_tests(mobile_stream);
 stream_data.add_sub_for_tests(mobile_team_stream);
 stream_data.add_sub_for_tests(broken_link_stream);
+stream_data.add_sub_for_tests(empty_topic_only_stream);
 
 const make_emoji = (emoji_dict) => ({
     emoji_name: emoji_dict.name,
@@ -1137,7 +1150,11 @@ test("content_typeahead_selected", ({override}) => {
     ct.get_or_set_completing_for_tests("stream");
     let warned_for_stream_link = false;
     override(compose_validate, "warn_if_private_stream_is_linked", (linked_stream) => {
-        assert.ok(linked_stream === sweden_stream || linked_stream === broken_link_stream);
+        assert.ok(
+            linked_stream === sweden_stream ||
+                linked_stream === broken_link_stream ||
+                linked_stream === empty_topic_only_stream,
+        );
         warned_for_stream_link = true;
     });
 
@@ -1169,6 +1186,25 @@ test("content_typeahead_selected", ({override}) => {
     ct.get_or_set_token_for_testing("#");
     actual_value = ct.content_typeahead_selected(broken_link_stream, query, input_element);
     expected_value = "[#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)>";
+    assert.equal(actual_value, expected_value);
+
+    // A channel that only allows the empty topic gets a complete channel
+    // link, and no topic typeahead is reopened for it.
+    query = "#Announ";
+    ct.get_or_set_token_for_testing("Announ");
+    actual_value = ct.content_typeahead_selected(empty_topic_only_stream, query, input_element);
+    expected_value = "#**Announce**";
+    assert.equal(actual_value, expected_value);
+
+    // Pressing ">" on such a channel still opens topic completion via the
+    // partial syntax, for the user who explicitly wants a topic link.
+    query = "#Announ";
+    ct.get_or_set_token_for_testing("Announ");
+    actual_value = ct.content_typeahead_selected(empty_topic_only_stream, query, input_element, {
+        type: "keydown",
+        key: ">",
+    });
+    expected_value = "#**Announce>";
     assert.equal(actual_value, expected_value);
 
     // topic_list
@@ -1322,6 +1358,94 @@ test("content_typeahead_selected", ({override}) => {
     );
     expected_value =
         "Hello [#A&#42; Algorithm > fast](#narrow/channel/6-A.2A-Algorithm/topic/fast) ";
+    assert.equal(actual_value, expected_value);
+
+    // Selecting a topic from the complete channel link form (the link
+    // inserted on channel selection, followed by the partially typed
+    // topic) rewrites the whole span into the full stream+topic link.
+    query = "Hello #**Sweden**plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "planning",
+            topic_display_name: "planning",
+            type: "topic_list",
+            used_syntax_prefix: "#**",
+            is_channel_link: false,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+    );
+    expected_value = "Hello #**Sweden>planning** ";
+    assert.equal(actual_value, expected_value);
+
+    // The same, but for the complete fallback markdown link form used
+    // for channel names with special characters.
+    query = "Hello [#A&#42; Algorithm](#narrow/channel/6-A.2A-Algorithm)fas";
+    ct.get_or_set_token_for_testing("fas");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "fast",
+            topic_display_name: "fast",
+            type: "topic_list",
+            used_syntax_prefix: "[#",
+            is_channel_link: false,
+            stream_data: {
+                name: "A* Algorithm",
+            },
+        },
+        query,
+        input_element,
+    );
+    expected_value =
+        "Hello [#A&#42; Algorithm > fast](#narrow/channel/6-A.2A-Algorithm/topic/fast) ";
+    assert.equal(actual_value, expected_value);
+
+    // Selecting the "(link to channel)" option from the complete link
+    // form keeps the channel link as-is, dropping any partially typed
+    // topic text.
+    query = "Hello #**Sweden**plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "Sweden",
+            topic_display_name: "Sweden",
+            type: "topic_list",
+            used_syntax_prefix: "#**",
+            is_channel_link: true,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+    );
+    expected_value = "Hello #**Sweden** ";
+    assert.equal(actual_value, expected_value);
+
+    // Escape resolves the partial stream+topic syntax to a channel
+    // link, keeping any partially typed topic as plain text.
+    query = "Hello #**Sweden>plan";
+    ct.get_or_set_token_for_testing("plan");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "planning",
+            topic_display_name: "planning",
+            type: "topic_list",
+            used_syntax_prefix: "#**",
+            is_channel_link: false,
+            stream_data: {
+                name: "Sweden",
+            },
+        },
+        query,
+        input_element,
+        {key: "Escape"},
+    );
+    expected_value = "Hello #**Sweden** plan";
     assert.equal(actual_value, expected_value);
 
     // syntax
@@ -2724,6 +2848,25 @@ test("begins_typeahead", ({override, override_rewire}) => {
         typed_topics("Sweden", ["totally new topic"], is_new_topic),
     );
     assert_typeahead_equals("#**Sweden>\n\nmore ice", typed_topics("Sweden", []));
+
+    // A complete channel link is a valid final form, so it only triggers
+    // topic completion while the typeahead is already open (the state
+    // right after a channel is selected). With the typeahead closed, the
+    // cursor merely sitting after a channel link offers nothing.
+    assert_typeahead_equals("#**Sweden**", []);
+
+    // The complete channel link inserted on channel selection reopens the
+    // topic typeahead, so the user can still pick a topic; selecting one
+    // rewrites the link into the partial-then-completed form. Typing after
+    // the link filters topics just like the `>` syntax does.
+    compose_ui.compose_textarea_typeahead = {shown: true};
+    // A space immediately after the complete link means the user has
+    // moved on to the message body, so no topic typeahead is offered.
+    assert_typeahead_equals("#**Sweden** more ice", []);
+    // A channel that only allows the empty topic gets a complete channel
+    // link with no topic completion offered.
+    assert_typeahead_equals("#**Announce**", []);
+    compose_ui.compose_textarea_typeahead = undefined;
 
     // time_jump
     const time_jump = [

--- a/web/tests/markdown_parse.test.cjs
+++ b/web/tests/markdown_parse.test.cjs
@@ -5,11 +5,15 @@ const assert = require("node:assert/strict");
 const {RE2JS} = require("re2js");
 const Template = require("uri-template-lite");
 
+const {make_realm} = require("./lib/example_realm.cjs");
 const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 
 const markdown = zrequire("markdown");
 const linkifiers = zrequire("linkifiers");
+const {set_realm} = zrequire("state_data");
+
+set_realm(make_realm({realm_empty_topic_display_name: "general chat"}));
 
 const my_id = 101;
 
@@ -69,8 +73,14 @@ const social = {
 
 const sub_map = new Map([[social.name, social]]);
 
+const empty_topic_only_channel_ids = new Set();
+
 function get_stream_by_name(name) {
     return sub_map.get(name);
+}
+
+function is_empty_topic_only_channel(stream_id) {
+    return empty_topic_only_channel_ids.has(stream_id);
 }
 
 function stream_hash(stream_id) {
@@ -146,6 +156,7 @@ const helper_config = {
 
     // stream hashes
     get_stream_by_name,
+    is_empty_topic_only_channel,
     stream_hash,
     stream_topic_hash,
 
@@ -205,6 +216,30 @@ run_test("stream links", () => {
         "#**social>lunch**",
         '<p><a class="stream-topic" data-stream-id="301" href="stream-301-topic-lunch">#social &gt; lunch</a></p>',
     );
+});
+
+run_test("empty-topic-only channel topic links", () => {
+    // A channel that only allows the empty topic can never contain a
+    // non-empty topic, so a non-empty topic link is left as plain text
+    // rather than linkified.
+    empty_topic_only_channel_ids.add(social.stream_id);
+    try {
+        assert_parse("#**social>lunch**", "<p>#**social&gt;lunch**</p>");
+        assert_parse("#**social>lunch@12**", "<p>#**social&gt;lunch@12**</p>");
+        // The empty topic is still linkified, since it's the one topic
+        // such a channel can contain.
+        assert_parse(
+            "#**social>**",
+            '<p><a class="stream-topic" data-stream-id="301" href="stream-301-topic-">#social &gt; <span class="empty-topic-display">translated: general chat</span></a></p>',
+        );
+        // The channel link itself is still linkified.
+        assert_parse(
+            "#**social**",
+            '<p><a class="stream" data-stream-id="301" href="/stream-301">#social</a></p>',
+        );
+    } finally {
+        empty_topic_only_channel_ids.delete(social.stream_id);
+    }
 });
 
 run_test("emojis", () => {

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -67,6 +67,7 @@ from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
 from zerver.models import Message, Realm, UserProfile
 from zerver.models.linkifiers import linkifiers_for_realm
 from zerver.models.realm_emoji import EmojiInfo, get_name_keyed_dict_for_active_realm_emoji
+from zerver.models.streams import StreamTopicsPolicyEnum
 
 ReturnT = TypeVar("ReturnT")
 
@@ -135,6 +136,7 @@ class DbData:
     active_realm_emoji: dict[str, EmojiInfo]
     sent_by_bot: bool
     stream_names: dict[str, int]
+    stream_topics_policy: dict[str, int]
     topic_info: dict[ChannelTopicInfo, int | None]
     translate_emoticons: bool
     user_upload_previews: AttachmentData
@@ -1818,6 +1820,13 @@ class StreamTopicMessageProcessor(CompiledInlineProcessor):
         stream_id = db_data.stream_names.get(name)
         return stream_id
 
+    def is_empty_topic_only_channel(self, name: str) -> bool:
+        db_data: DbData | None = self.zmd.zulip_db_data
+        if db_data is None:
+            return False
+        topics_policy = db_data.stream_topics_policy.get(name)
+        return topics_policy == StreamTopicsPolicyEnum.empty_topic_only.value
+
 
 class StreamPattern(StreamTopicMessageProcessor):
     @override
@@ -1862,6 +1871,10 @@ class StreamTopicPattern(StreamTopicMessageProcessor):
         stream_id = self.find_stream_id(stream_name)
         if stream_id is None or topic_name is None:
             return None, None, None
+        if topic_name != "" and self.is_empty_topic_only_channel(stream_name):
+            # This channel only allows the empty topic, so a non-empty
+            # topic can never exist in it; don't linkify it.
+            return None, None, None
         el = Element("a")
         el.set("class", "stream-topic")
         el.set("data-stream-id", str(stream_id))
@@ -1901,6 +1914,10 @@ class StreamTopicMessagePattern(StreamTopicMessageProcessor):
 
         stream_id = self.find_stream_id(stream_name)
         if stream_id is None or topic_name is None:
+            return None, None, None
+        if topic_name != "" and self.is_empty_topic_only_channel(stream_name):
+            # This channel only allows the empty topic, so a non-empty
+            # topic can never exist in it; don't linkify it.
             return None, None, None
         el = Element("a")
         el.set("class", "message-link")
@@ -2672,6 +2689,15 @@ def do_convert(
 
         stream_names = possible_linked_stream_names(content)
         stream_name_info = mention_data.get_stream_name_map(stream_names, acting_user=acting_user)
+        # Resolve each linked channel's effective topics_policy, mapping
+        # `inherit` to the realm's policy, so the stream-topic handlers can
+        # avoid linkifying non-empty topics in empty-topic-only channels.
+        stream_topics_policy: dict[str, int] = {}
+        for channel_name, channel_info in mention_data.get_channel_info_map().items():
+            topics_policy = channel_info.topics_policy
+            if topics_policy == StreamTopicsPolicyEnum.inherit.value:
+                topics_policy = message_realm.topics_policy
+            stream_topics_policy[channel_name] = topics_policy
 
         linked_stream_topic_data = possible_linked_topics(content)
         topic_info = mention_data.get_topic_info_map(
@@ -2691,6 +2717,7 @@ def do_convert(
             realm_url=message_realm.url,
             sent_by_bot=sent_by_bot,
             stream_names=stream_name_info,
+            stream_topics_policy=stream_topics_policy,
             topic_info=topic_info,
             translate_emoticons=translate_emoticons,
             user_upload_previews=user_upload_previews,

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -90,6 +90,7 @@ class ChannelInfo:
     channel_id: int
     recipient_id: int
     history_public_to_subscribers: bool
+    topics_policy: int
     # TODO: Track whether the current user has only metadata access or
     # content access, so that we can allow mentioning channels with
     # only metadata access, while still enforcing content access to
@@ -203,11 +204,15 @@ class MentionBackend:
                     "name",
                     "recipient_id",
                     "history_public_to_subscribers",
+                    "topics_policy",
                 )
             )
             for row in rows:
                 self.stream_cache[row["name"]] = ChannelInfo(
-                    row["id"], row["recipient_id"], row["history_public_to_subscribers"]
+                    row["id"],
+                    row["recipient_id"],
+                    row["history_public_to_subscribers"],
+                    row["topics_policy"],
                 )
                 result[row["name"]] = row["id"]
         else:
@@ -227,7 +232,10 @@ class MentionBackend:
             for stream in content_access_streams:
                 assert stream.recipient_id is not None
                 self.stream_cache[stream.name] = ChannelInfo(
-                    stream.id, stream.recipient_id, stream.history_public_to_subscribers
+                    stream.id,
+                    stream.recipient_id,
+                    stream.history_public_to_subscribers,
+                    stream.topics_policy,
                 )
                 result[stream.name] = stream.id
 
@@ -461,6 +469,9 @@ class MentionData:
         self, stream_names: set[str], acting_user: UserProfile | None
     ) -> dict[str, int]:
         return self.mention_backend.get_stream_name_map(stream_names, acting_user=acting_user)
+
+    def get_channel_info_map(self) -> dict[str, ChannelInfo]:
+        return self.mention_backend.stream_cache
 
     def get_topic_info_map(
         self, channel_topics: set[ChannelTopicInfo], acting_user: UserProfile | None

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -75,7 +75,7 @@ from zerver.models.clients import get_client
 from zerver.models.groups import SystemGroups
 from zerver.models.linkifiers import linkifiers_for_realm
 from zerver.models.realms import get_realm
-from zerver.models.streams import get_stream
+from zerver.models.streams import StreamTopicsPolicyEnum, get_stream
 from zerver.models.users import get_system_bot
 
 
@@ -3344,6 +3344,41 @@ class MarkdownStreamTopicMentionTests(ZulipTestCase):
             f'<p><a class="stream-topic" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark/topic/some.20topic">#{denmark.name} &gt; some topic</a></p>',
         )
         # Empty string as topic name.
+        content = "#**Denmark>**"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a class="stream-topic" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark/topic/">#{denmark.name} &gt; <em>{Message.EMPTY_TOPIC_FALLBACK_NAME}</em></a></p>',
+        )
+
+    def test_topic_link_in_empty_topic_only_channel(self) -> None:
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        denmark.topics_policy = StreamTopicsPolicyEnum.empty_topic_only.value
+        denmark.save(update_fields=["topics_policy"])
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        # A non-empty topic can never exist in this channel, so its link
+        # is not formed (the leftover `**` then renders as bold).
+        content = "#**Denmark>some topic**"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            "<p>#<strong>Denmark&gt;some topic</strong></p>",
+        )
+        # The message permalink variant is likewise not linkified.
+        content = "#**Denmark>some topic@12**"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            "<p>#<strong>Denmark&gt;some topic@12</strong></p>",
+        )
+        # The channel link and the empty-topic link are still valid.
+        content = "#**Denmark**"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a class="stream" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark">#{denmark.name}</a></p>',
+        )
         content = "#**Denmark>**"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,


### PR DESCRIPTION
Fixes: [#design > Empty topic only channel - topic completion](https://chat.zulip.org/#narrow/channel/101-design/topic/Empty.20topic.20only.20channel.20-.20topic.20completion/with/2487669)


In empty topic only channel, creating `#**channel>topic**` link with any topic name would get linkified. Clicking it narrowed to a topic that can never have messages. In that case the left sidebar showed this random topic while the compose box showed "general chat".

Now:

- The compose typeahead no longer offers named topics for these channels. Selecting the channel inserts the complete `#**channel**` link without reopening the topic typeahead; pressing ">" explicitly opens topic completion, which offers just the single empty topic.
- The backend markdown leaves `#**channel>topic**` (and the `@message-id` permalink form) as plain text for non-empty topics in these channels. The channel link and the empty-topic link still render as before. The channel's effective `topics_policy` (resolving `inherit` to the realm's policy) is threaded into the markdown `DbData` for this.
- The web app's local echo markdown does the same check via a new `is_empty_topic_only_channel` helper on `MarkdownHelpers`, so the local render matches the server's.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="928" height="704" alt="empty topic channel" src="https://github.com/user-attachments/assets/b6def0b3-fdad-4cf4-bf79-30e0188b7dc0" />
Invalid topic name:
<img width="925" height="135" alt="Screenshot 2026-07-02 at 11 43 25 AM" src="https://github.com/user-attachments/assets/b1eeea43-9e63-4921-bc92-3f449cbd7cad" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
