### PR TITLE
soft_deactivation: Serialize per-user reactivation with a row lock.

### DIFF
--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -319,7 +319,22 @@ def do_auto_soft_deactivate_users(inactive_for_days: int, realm: Realm | None) -
 
 
 def reactivate_user_if_soft_deactivated(user_profile: UserProfile) -> UserProfile | None:
-    if user_profile.long_term_idle:
+    if not user_profile.long_term_idle:
+        return None
+
+    with transaction.atomic(savepoint=False):
+        # Lock the row and re-read the flag so concurrent reactivations of the
+        # same user run the expensive backfill at most once.
+        locked_user = (
+            UserProfile.objects.select_for_update(no_key=True)
+            .only("id", "long_term_idle")
+            .get(id=user_profile.id)
+        )
+        if not locked_user.long_term_idle:
+            # Another caller reactivated this user while we waited; sync our copy.
+            user_profile.long_term_idle = False
+            return None
+
         add_missing_messages(user_profile)
         user_profile.long_term_idle = False
         user_profile.save(update_fields=["long_term_idle"])
@@ -331,7 +346,6 @@ def reactivate_user_if_soft_deactivated(user_profile: UserProfile) -> UserProfil
         )
         logger.info("Soft reactivated user %s", user_profile.id)
         return user_profile
-    return None
 
 
 def get_users_for_soft_deactivation(

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -362,7 +362,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)
         self.assertNotEqual(idle_user_msg_list[-1].content, message)
-        with self.assert_database_query_count(7):
+        with self.assert_database_query_count(8):
             reactivate_user_if_soft_deactivated(long_term_idle_user)
         self.assertFalse(long_term_idle_user.long_term_idle)
         self.assertEqual(
@@ -374,6 +374,40 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         self.assertEqual(idle_user_msg_list[-1].content, message)
         long_term_idle_user.refresh_from_db()
         self.assertEqual(long_term_idle_user.last_active_message_id, message_id)
+
+    def test_reactivate_user_skips_backfill_if_already_reactivated(self) -> None:
+        # A stale in-memory long_term_idle must not trigger a second backfill:
+        # the lock re-read sees the flag already cleared and bails out.
+        user = self.example_user("hamlet")
+        self.subscribe(user, "Denmark")
+        self.send_stream_message(user, "Denmark")
+        with self.assertLogs(logger_string, level="INFO"):
+            do_soft_deactivate_users([user])
+        user.refresh_from_db()
+        self.assertTrue(user.long_term_idle)
+
+        # Clear the flag in the database directly, leaving our copy stale.
+        UserProfile.objects.filter(id=user.id).update(long_term_idle=False)
+        self.assertTrue(user.long_term_idle)
+
+        with mock.patch("zerver.lib.soft_deactivation.add_missing_messages") as mock_backfill:
+            result = reactivate_user_if_soft_deactivated(user)
+        mock_backfill.assert_not_called()
+        self.assertIsNone(result)
+        self.assertFalse(user.long_term_idle)
+
+    def test_reactivate_is_noop_for_active_user(self) -> None:
+        # A user who is not long-term-idle takes the fast path: no row lock,
+        # no backfill, and no database queries at all.
+        user = self.example_user("hamlet")
+        self.assertFalse(user.long_term_idle)
+        with (
+            mock.patch("zerver.lib.soft_deactivation.add_missing_messages") as mock_backfill,
+            self.assert_database_query_count(0),
+        ):
+            result = reactivate_user_if_soft_deactivated(user)
+        self.assertIsNone(result)
+        mock_backfill.assert_not_called()
 
     def test_add_missing_messages(self) -> None:
         recipient_list = [self.example_user("hamlet"), self.example_user("iago")]


### PR DESCRIPTION
A returning long-term-idle user can be reactivated from several paths at nearly the same time -- loading the app (register), an incoming notification, and a password reset all call
reactivate_user_if_soft_deactivated. Because the guard only checked the in-memory long_term_idle flag, concurrent calls for the same user could each run the expensive add_missing_messages backfill, wasting work and risking a deadlock on the concurrent UserMessage inserts.

Take a FOR NO KEY UPDATE row lock on the UserProfile and re-read long_term_idle inside a transaction before backfilling. Concurrent reactivations of the same user now serialize: the loser blocks until the winner commits, then sees the flag already cleared and returns without redoing the work. A fast path preserves the common not-idle case with no transaction or lock.

Fixes part of #22396.
