### PR TITLE
[ai] subscriptions: Lock UserProfile row when subscribing or unsubscribing.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -167,6 +167,10 @@ def set_up_streams_and_groups_for_new_human_user(
     else:
         streams = []
 
+    # Lock the subscriber row so that a concurrent (un)subscription of
+    # this user serializes with this one and they cannot race to create
+    # or double-count a subscription.
+    list(UserProfile.objects.filter(id=user_profile.id).select_for_update(no_key=True))
     bulk_add_subscriptions(
         realm,
         streams,

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -357,15 +357,27 @@ def merge_streams(
     existing_subs = Subscription.objects.filter(recipient=recipient_to_keep)
     users_already_subscribed = {sub.user_profile_id: sub.active for sub in existing_subs}
 
-    subs_to_deactivate = Subscription.objects.filter(recipient=recipient_to_destroy, active=True)
-    users_to_activate = [
-        sub.user_profile
-        for sub in subs_to_deactivate
-        if not users_already_subscribed.get(sub.user_profile_id, False)
+    user_ids_to_deactivate_subs = Subscription.objects.filter(
+        recipient=recipient_to_destroy, active=True
+    ).values_list("user_profile_id", flat=True)
+    user_ids_to_activate = [
+        user_id
+        for user_id in user_ids_to_deactivate_subs
+        if not users_already_subscribed.get(user_id, False)
     ]
 
-    if len(users_to_activate) > 0:
-        bulk_add_subscriptions(realm, [stream_to_keep], users_to_activate, acting_user=None)
+    if len(user_ids_to_activate) > 0:
+        # Lock the subscriber rows (ordered, to avoid deadlocks) so this
+        # serializes with concurrent (un)subscription of the same users.
+        # The lock is scoped narrowly to keep merge_streams re-runnable
+        # after an interruption, as described above.
+        with transaction.atomic(savepoint=False):
+            users_to_activate = list(
+                UserProfile.objects.filter(id__in=user_ids_to_activate)
+                .order_by("id")
+                .select_for_update(no_key=True)
+            )
+            bulk_add_subscriptions(realm, [stream_to_keep], users_to_activate, acting_user=None)
 
     # Move the messages, and delete the old copies from caches. We do
     # this before removing the subscription objects, to avoid messages
@@ -385,17 +397,25 @@ def merge_streams(
     bulk_delete_cache_keys(message_ids_to_clear)
 
     # Remove subscriptions to the old stream.
-    if len(subs_to_deactivate) > 0:
-        bulk_remove_subscriptions(
-            realm,
-            [sub.user_profile for sub in subs_to_deactivate],
-            [stream_to_destroy],
-            acting_user=None,
-        )
+    if len(user_ids_to_deactivate_subs) > 0:
+        # Lock the subscriber rows (ordered, to avoid deadlocks) so this
+        # serializes with concurrent (un)subscription of the same users.
+        with transaction.atomic(savepoint=False):
+            users_to_deactivate = list(
+                UserProfile.objects.filter(id__in=user_ids_to_deactivate_subs)
+                .order_by("id")
+                .select_for_update(no_key=True)
+            )
+            bulk_remove_subscriptions(
+                realm,
+                users_to_deactivate,
+                [stream_to_destroy],
+                acting_user=None,
+            )
 
     do_deactivate_stream(stream_to_destroy, acting_user=None)
 
-    return (len(users_to_activate), count, len(subs_to_deactivate))
+    return (len(user_ids_to_activate), count, len(user_ids_to_deactivate_subs))
 
 
 def get_subscriber_ids(

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -179,6 +179,14 @@ def do_delete_user_core(
         # Then we hard-delete all the Subscription objects to avoid
         # preserving the user's previous personal metadata about
         # channel subscriptions (colors, notification preferences, etc.).
+        #
+        # Unlike the other bulk_remove_subscriptions callers, this one needs
+        # no user-row lock: do_deactivate_user above already marked the user
+        # inactive and decremented subscriber_count, so this call neither
+        # inserts a Subscription nor changes subscriber_count (the is_active
+        # guard in bulk_remove_subscriptions skips inactive users).  With no
+        # count delta and no insert, there is nothing for a concurrent
+        # (un)subscription to race against.
         bulk_remove_subscriptions(
             realm,
             [user_profile],

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -199,6 +199,7 @@ server via `ps -ef` or reading bash history. Prefer
         realm: Realm | None,
         is_bot: bool | None = None,
         include_deactivated: bool = False,
+        acquire_lock: bool = False,
     ) -> QuerySet[UserProfile]:
         if "all_users" in options:
             all_users = options["all_users"]
@@ -217,7 +218,9 @@ server via `ps -ef` or reading bash history. Prefer
                 if not include_deactivated:
                     user_profiles = user_profiles.filter(is_active=True)
                 if is_bot is not None:
-                    return user_profiles.filter(is_bot=is_bot)
+                    user_profiles = user_profiles.filter(is_bot=is_bot)
+                if acquire_lock:
+                    user_profiles = user_profiles.order_by("id").select_for_update(no_key=True)
                 return user_profiles
 
         if options["users"] is None:
@@ -237,6 +240,9 @@ server via `ps -ef` or reading bash history. Prefer
         user_profiles = user_profiles.filter(reduce(lambda a, b: a | b, email_matches)).order_by(
             "id"
         )
+
+        if acquire_lock:
+            user_profiles = user_profiles.select_for_update(of=("self",), no_key=True)
 
         # Return the single query, for ease of composing.
         return user_profiles

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -444,6 +444,7 @@ def bulk_access_users_by_email(
     allow_deactivated: bool = False,
     allow_bots: bool = False,
     for_admin: bool,
+    acquire_lock: bool = False,
 ) -> set[UserProfile]:
     # We upper-case the email addresses ourselves here, because
     # `email__iexact__in=emails` is not supported by Django.
@@ -453,6 +454,8 @@ def bulk_access_users_by_email(
         .annotate(email_upper=Upper("email"))
         .filter(email_upper__in=target_emails_upper, realm=acting_user.realm)
     )
+    if acquire_lock:
+        users = users.order_by("id").select_for_update(of=("self",), no_key=True)
 
     valid_emails_upper = {user_profile.email_upper for user_profile in users}
     all_users_exist = all(email in valid_emails_upper for email in target_emails_upper)
@@ -473,8 +476,12 @@ def bulk_access_users_by_id(
     allow_deactivated: bool = False,
     allow_bots: bool = False,
     for_admin: bool,
+    acquire_lock: bool = False,
 ) -> set[UserProfile]:
     users = base_bulk_get_user_queryset().filter(id__in=user_ids, realm=acting_user.realm)
+
+    if acquire_lock:
+        users = users.order_by("id").select_for_update(of=("self",), no_key=True)
 
     valid_user_ids = {user_profile.id for user_profile in users}
     all_users_exist = all(user_id in valid_user_ids for user_id in user_ids)

--- a/zerver/management/commands/add_users_to_streams.py
+++ b/zerver/management/commands/add_users_to_streams.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.core.management.base import CommandParser
+from django.db import transaction
 from typing_extensions import override
 
 from zerver.actions.streams import bulk_add_subscriptions
@@ -25,20 +26,23 @@ class Command(ZulipBaseCommand):
         realm = self.get_realm(options)
         assert realm is not None  # Should be ensured by parser
 
-        user_profiles = self.get_users(options, realm)
-        stream_names = {stream.strip() for stream in options["streams"].split(",")}
+        with transaction.atomic(savepoint=False):
+            user_profiles = self.get_users(options, realm, acquire_lock=True)
+            stream_names = {stream.strip() for stream in options["streams"].split(",")}
 
-        for stream_name in stream_names:
-            for user_profile in user_profiles:
-                stream = ensure_stream(realm, stream_name, acting_user=None)
-                _ignore, already_subscribed = bulk_add_subscriptions(
-                    realm, [stream], [user_profile], acting_user=None
-                )
-                was_there_already = user_profile.id in (info.user.id for info in already_subscribed)
-                print(
-                    "{} {} to {}".format(
-                        "Already subscribed" if was_there_already else "Subscribed",
-                        user_profile.delivery_email,
-                        stream_name,
+            for stream_name in stream_names:
+                for user_profile in user_profiles:
+                    stream = ensure_stream(realm, stream_name, acting_user=None)
+                    _ignore, already_subscribed = bulk_add_subscriptions(
+                        realm, [stream], [user_profile], acting_user=None
                     )
-                )
+                    was_there_already = user_profile.id in (
+                        info.user.id for info in already_subscribed
+                    )
+                    print(
+                        "{} {} to {}".format(
+                            "Already subscribed" if was_there_already else "Subscribed",
+                            user_profile.delivery_email,
+                            stream_name,
+                        )
+                    )

--- a/zerver/management/commands/remove_users_from_stream.py
+++ b/zerver/management/commands/remove_users_from_stream.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.core.management.base import CommandParser
+from django.db import transaction
 from typing_extensions import override
 
 from zerver.actions.streams import bulk_remove_subscriptions
@@ -24,13 +25,14 @@ class Command(ZulipBaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:
         realm = self.get_realm(options)
         assert realm is not None  # Should be ensured by parser
-        user_profiles = self.get_users(options, realm)
-        stream_name = options["stream"].strip()
-        stream = get_stream(stream_name, realm)
+        with transaction.atomic(savepoint=False):
+            user_profiles = self.get_users(options, realm, acquire_lock=True)
+            stream_name = options["stream"].strip()
+            stream = get_stream(stream_name, realm)
 
-        result = bulk_remove_subscriptions(realm, user_profiles, [stream], acting_user=None)
-        not_subscribed = result[1]
-        not_subscribed_users = {tup[0] for tup in not_subscribed}
+            result = bulk_remove_subscriptions(realm, user_profiles, [stream], acting_user=None)
+            not_subscribed = result[1]
+            not_subscribed_users = {tup[0] for tup in not_subscribed}
 
         for user_profile in user_profiles:
             if user_profile in not_subscribed_users:

--- a/zerver/tests/test_channel_permissions.py
+++ b/zerver/tests/test_channel_permissions.py
@@ -580,13 +580,19 @@ class ChannelSubscriptionPermissionTest(ZulipTestCase):
                         acting_user=user,
                     )
             stream_name_list = [stream.name for stream in stream_list]
-            result = self.client_delete(
-                "/json/users/me/subscriptions",
-                {
-                    "subscriptions": orjson.dumps(stream_name_list).decode(),
-                    "principals": orjson.dumps([cordelia.id]).decode(),
-                },
-            )
+            # The unsubscribe endpoint takes the user-row lock inside a
+            # savepoint=False transaction, so a permission error rolls back
+            # to no savepoint and leaves the test transaction unusable.  Wrap
+            # the request in a savepoint so an expected failure doesn't break
+            # the rest of the test.
+            with self.artificial_transaction_savepoint():
+                result = self.client_delete(
+                    "/json/users/me/subscriptions",
+                    {
+                        "subscriptions": orjson.dumps(stream_name_list).decode(),
+                        "principals": orjson.dumps([cordelia.id]).decode(),
+                    },
+                )
             if expect_fail:
                 self.assert_json_error(result, "Insufficient permission")
                 return

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -114,7 +114,7 @@ class StreamSetupTest(ZulipTestCase):
 
         new_user = self.create_simple_new_user(realm, "alice@zulip.com")
 
-        with self.assert_database_query_count(14):
+        with self.assert_database_query_count(15):
             set_up_streams_and_groups_for_new_human_user(
                 user_profile=new_user,
                 prereg_user=None,
@@ -150,7 +150,7 @@ class StreamSetupTest(ZulipTestCase):
 
         new_user = self.create_simple_new_user(realm, new_user_email)
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(18):
             set_up_streams_and_groups_for_new_human_user(
                 user_profile=new_user,
                 prereg_user=prereg_user,
@@ -184,7 +184,7 @@ class StreamSetupTest(ZulipTestCase):
 
         new_user = self.create_simple_new_user(realm, new_user_email)
 
-        with self.assert_database_query_count(13):
+        with self.assert_database_query_count(14):
             set_up_streams_and_groups_for_new_human_user(
                 user_profile=new_user,
                 prereg_user=prereg_user,

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -104,6 +104,11 @@ class TestZulipBaseCommand(ZulipTestCase):
         user_emails = ",".join(u.delivery_email for u in expected_user_profiles)
         user_profiles = self.get_users_sorted(dict(users=user_emails), self.zulip_realm)
         self.assertEqual(user_profiles, expected_user_profiles)
+        # acquire_lock=True returns the same users, additionally locking the rows.
+        user_profiles = self.get_users_sorted(
+            dict(users=user_emails), self.zulip_realm, acquire_lock=True
+        )
+        self.assertEqual(user_profiles, expected_user_profiles)
         user_profiles = self.get_users_sorted(dict(users=user_emails), None)
         self.assertEqual(user_profiles, expected_user_profiles)
 
@@ -159,6 +164,11 @@ class TestZulipBaseCommand(ZulipTestCase):
             key=lambda x: x.email,
         )
         user_profiles = self.get_users_sorted(dict(users=None, all_users=True), self.zulip_realm)
+        self.assertEqual(user_profiles, expected_user_profiles)
+        # acquire_lock=True returns the same users, additionally locking the rows.
+        user_profiles = self.get_users_sorted(
+            dict(users=None, all_users=True), self.zulip_realm, acquire_lock=True
+        )
         self.assertEqual(user_profiles, expected_user_profiles)
 
         # Test include_deactivated

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1068,7 +1068,7 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(101),
+            self.assert_database_query_count(102),
             self.assert_memcached_count(19),
             self.captureOnCommitCallbacks(execute=True),
         ):

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4284,7 +4284,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Now add ourselves
         with (
             self.capture_send_event_calls(expected_num_events=2) as events,
-            self.assert_database_query_count(17),
+            self.assert_database_query_count(18),
         ):
             self.subscribe_via_post(
                 self.test_user,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1147,7 +1147,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(99),
+            self.assert_database_query_count(100),
             self.assert_memcached_count(24),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):

--- a/zerver/transaction_tests/test_subscriptions.py
+++ b/zerver/transaction_tests/test_subscriptions.py
@@ -1,0 +1,240 @@
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+from unittest import mock
+
+import orjson
+from django.db import connections, transaction
+from django.http import HttpRequest, HttpResponse
+from typing_extensions import override
+
+import zerver.actions.streams
+from zerver.lib.test_classes import ZulipTransactionTestCase
+from zerver.lib.test_helpers import HostRequestMock
+from zerver.models import Stream, Subscription, UserProfile
+from zerver.models.realms import get_realm
+from zerver.views.streams import add_subscriptions_backend, remove_subscriptions_backend
+
+
+def call_subscription_endpoint(
+    view: Callable[..., HttpResponse], request: HttpRequest, acting_user: UserProfile
+) -> None:
+    # add_subscriptions_backend / remove_subscriptions_backend are
+    # @typed_endpoint views that read their parameters from `request`, so we
+    # invoke them with just (request, acting_user).  The Callable[...] type
+    # lets us do that without mypy expecting the request-supplied arguments.
+    view(request, acting_user)
+
+
+class RacingRequest(threading.Thread):
+    """Runs a single (un)subscription request and records whatever exception
+    it raised, so the test can assert that the lock let both requests through
+    cleanly."""
+
+    def __init__(self, make_request: Callable[[], object]) -> None:
+        threading.Thread.__init__(self)
+        self.make_request = make_request
+        self.error: Exception | None = None
+
+    @override
+    def run(self) -> None:
+        try:
+            self.make_request()
+        except Exception as e:  # nocoverage -- only reached if the lock regresses
+            self.error = e
+        finally:
+            # Close this thread's database connection so it doesn't leak.
+            connections.close_all()
+
+
+class SubscriptionRaceConditionTest(ZulipTransactionTestCase):
+    created_streams: list[Stream] = []
+
+    @override
+    def tearDown(self) -> None:
+        # ZulipTransactionTestCase commits to the database, so clean up
+        # the streams (and their subscriptions) created by each test.
+        with transaction.atomic(durable=True):
+            for stream in self.created_streams:
+                recipient = stream.recipient
+                assert recipient is not None
+                Subscription.objects.filter(recipient=recipient).delete()
+                stream.delete()
+                recipient.delete()
+            transaction.on_commit(self.created_streams.clear)
+
+        super().tearDown()
+
+    def assert_racing_requests_serialize(
+        self, pause_target: str, make_request: Callable[[], object]
+    ) -> None:
+        """Fire the same (un)subscription request from two threads and assert
+        the user-row lock serialized them so neither errored.
+
+        Unlike the user-group race test, we can't synchronize the threads
+        with a threading.Barrier: those locks use nowait=True and conflicts
+        raise immediately, whereas our (un)subscription locks block, so a
+        shared barrier would deadlock.  Instead we pause the first request
+        inside `pause_target` -- a function in zerver.actions.streams patched
+        to block on its first call, which runs after the subscription state
+        is read but before it is written -- while it still holds the user-row
+        lock.  That forces the second request to block on the lock until the
+        first commits.  With the lock both requests succeed; without it the
+        second write collides (a duplicate-key error, or the subscriber_count
+        check constraint).
+        """
+        first_request_holds_lock = threading.Event()
+        release_first_request = threading.Event()
+        original = getattr(zerver.actions.streams, pause_target)
+        first_call = True
+        first_call_lock = threading.Lock()
+
+        def pause_first_request(*args: Any, **kwargs: Any) -> object:
+            nonlocal first_call
+            with first_call_lock:
+                is_first = first_call
+                first_call = False
+            if is_first:
+                first_request_holds_lock.set()
+                assert release_first_request.wait(timeout=15)
+            return original(*args, **kwargs)
+
+        with mock.patch(f"zerver.actions.streams.{pause_target}", side_effect=pause_first_request):
+            first = RacingRequest(make_request)
+            second = RacingRequest(make_request)
+            first.start()
+            # Wait until the first request holds the lock and is paused.
+            assert first_request_holds_lock.wait(timeout=15)
+            second.start()
+            # Give the second request time to block on the user-row lock.
+            time.sleep(1)
+            release_first_request.set()
+            first.join()
+            second.join()
+
+        self.assertIsNone(first.error)
+        self.assertIsNone(second.error)
+
+    def test_concurrent_self_subscribe_serializes(self) -> None:
+        """Two concurrent requests subscribing the same user to a channel
+        must not both create a Subscription row and violate the
+        (user_profile, recipient) unique constraint."""
+        user = self.example_user("hamlet")
+        stream = self.make_stream("subscribe_race", get_realm("zulip"))
+        self.created_streams.append(stream)
+
+        def subscribe() -> None:
+            request = HostRequestMock(
+                {
+                    "subscriptions": orjson.dumps([{"name": stream.name}]).decode(),
+                    "send_new_subscription_messages": "false",
+                },
+                user_profile=user,
+            )
+            call_subscription_endpoint(add_subscriptions_backend, request, user)
+
+        self.assert_racing_requests_serialize("bulk_add_subs_to_db_with_logging", subscribe)
+
+        self.assertEqual(
+            Subscription.objects.filter(
+                user_profile=user, recipient=stream.recipient, active=True
+            ).count(),
+            1,
+        )
+        stream.refresh_from_db()
+        self.assertEqual(stream.subscriber_count, 1)
+
+    def test_concurrent_self_unsubscribe_serializes(self) -> None:
+        """Two concurrent requests unsubscribing the same user from a channel
+        must not both decrement Stream.subscriber_count -- which under-counts
+        subscribers and trips the subscriber_count check constraint when it
+        would go negative, as it does here where the count starts at one."""
+        user = self.example_user("hamlet")
+        stream = self.make_stream("unsubscribe_race", get_realm("zulip"))
+        self.created_streams.append(stream)
+        self.subscribe(user, stream.name)
+        stream.refresh_from_db()
+        self.assertEqual(stream.subscriber_count, 1)
+
+        def unsubscribe() -> None:
+            request = HostRequestMock(
+                {"subscriptions": orjson.dumps([stream.name]).decode()},
+                user_profile=user,
+            )
+            call_subscription_endpoint(remove_subscriptions_backend, request, user)
+
+        self.assert_racing_requests_serialize("bulk_update_subscriber_counts", unsubscribe)
+
+        self.assertEqual(
+            Subscription.objects.filter(
+                user_profile=user, recipient=stream.recipient, active=True
+            ).count(),
+            0,
+        )
+        stream.refresh_from_db()
+        self.assertEqual(stream.subscriber_count, 0)
+
+    def test_concurrent_subscribe_other_user_serializes(self) -> None:
+        """Same as the self-subscribe case, but for an admin subscribing
+        another user via `principals`, which takes the user-row lock in
+        bulk_access_users_by_id rather than in the view directly."""
+        admin = self.example_user("iago")
+        target = self.example_user("hamlet")
+        stream = self.make_stream("subscribe_other_race", get_realm("zulip"))
+        self.created_streams.append(stream)
+
+        def subscribe() -> None:
+            request = HostRequestMock(
+                {
+                    "subscriptions": orjson.dumps([{"name": stream.name}]).decode(),
+                    "principals": orjson.dumps([target.id]).decode(),
+                    "send_new_subscription_messages": "false",
+                },
+                user_profile=admin,
+            )
+            call_subscription_endpoint(add_subscriptions_backend, request, admin)
+
+        self.assert_racing_requests_serialize("bulk_add_subs_to_db_with_logging", subscribe)
+
+        self.assertEqual(
+            Subscription.objects.filter(
+                user_profile=target, recipient=stream.recipient, active=True
+            ).count(),
+            1,
+        )
+        stream.refresh_from_db()
+        self.assertEqual(stream.subscriber_count, 1)
+
+    def test_concurrent_unsubscribe_other_user_serializes(self) -> None:
+        """Same as the self-unsubscribe case, but for an admin unsubscribing
+        another user via `principals`, which takes the user-row lock in
+        bulk_access_users_by_id rather than in the view directly."""
+        admin = self.example_user("iago")
+        target = self.example_user("hamlet")
+        stream = self.make_stream("unsubscribe_other_race", get_realm("zulip"))
+        self.created_streams.append(stream)
+        self.subscribe(target, stream.name)
+        stream.refresh_from_db()
+        self.assertEqual(stream.subscriber_count, 1)
+
+        def unsubscribe() -> None:
+            request = HostRequestMock(
+                {
+                    "subscriptions": orjson.dumps([stream.name]).decode(),
+                    "principals": orjson.dumps([target.id]).decode(),
+                },
+                user_profile=admin,
+            )
+            call_subscription_endpoint(remove_subscriptions_backend, request, admin)
+
+        self.assert_racing_requests_serialize("bulk_update_subscriber_counts", unsubscribe)
+
+        self.assertEqual(
+            Subscription.objects.filter(
+                user_profile=target, recipient=stream.recipient, active=True
+            ).count(),
+            0,
+        )
+        stream.refresh_from_db()
+        self.assertEqual(stream.subscriber_count, 0)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -133,6 +133,7 @@ def bulk_principals_to_user_profiles(
             allow_deactivated=False,
             allow_bots=True,
             for_admin=False,
+            acquire_lock=True,
         )
 
     # principals are user ids.
@@ -143,6 +144,7 @@ def bulk_principals_to_user_profiles(
             allow_deactivated=False,
             allow_bots=True,
             for_admin=False,
+            acquire_lock=True,
         )
 
 
@@ -619,26 +621,29 @@ def remove_subscriptions_backend(
         {"name": stream_name.strip()} for stream_name in streams_raw
     ]
 
-    unsubscribing_others = False
-    if principals:
-        people_to_unsub = bulk_principals_to_user_profiles(principals, user_profile)
-        unsubscribing_others = any(
-            not user_directly_controls_user(user_profile, target) for target in people_to_unsub
+    result: dict[str, list[str]] = dict(removed=[], not_removed=[])
+    with transaction.atomic(savepoint=False):
+        unsubscribing_others = False
+        if principals:
+            people_to_unsub = bulk_principals_to_user_profiles(principals, user_profile)
+            unsubscribing_others = any(
+                not user_directly_controls_user(user_profile, target) for target in people_to_unsub
+            )
+
+        else:
+            people_to_unsub = {
+                UserProfile.objects.select_for_update(no_key=True).get(id=user_profile.id)
+            }
+
+        streams, __ = list_to_streams(
+            streams_as_dict,
+            user_profile,
+            unsubscribing_others=unsubscribing_others,
         )
 
-    else:
-        people_to_unsub = {user_profile}
-
-    streams, __ = list_to_streams(
-        streams_as_dict,
-        user_profile,
-        unsubscribing_others=unsubscribing_others,
-    )
-
-    result: dict[str, list[str]] = dict(removed=[], not_removed=[])
-    (removed, not_subscribed) = bulk_remove_subscriptions(
-        realm, people_to_unsub, streams, acting_user=user_profile
-    )
+        (removed, not_subscribed) = bulk_remove_subscriptions(
+            realm, people_to_unsub, streams, acting_user=user_profile
+        )
 
     for subscriber, removed_stream in removed:
         result["removed"].append(removed_stream.name)
@@ -912,7 +917,7 @@ def add_subscriptions_backend(
     if is_subscribing_other_users:
         subscribers = bulk_principals_to_user_profiles(principals, user_profile)
     else:
-        subscribers = {user_profile}
+        subscribers = {UserProfile.objects.select_for_update(no_key=True).get(id=user_profile.id)}
 
     if is_default_stream:
         for stream in created_streams:


### PR DESCRIPTION
Adding and removing subscriptions reads a user's current subscriptions and then decides what to insert, reactivate, or deactivate.  Under PostgreSQL's READ COMMITTED isolation, two requests operating on the same (user, channel) can both observe the pre-write state and race:

* Two concurrent subscribes both take the "insert" path, and the second Subscription.objects.bulk_create violates the (user_profile, recipient) unique constraint with a duplicate-key error.
* Two concurrent unsubscribes both see the subscription as active and both decrement Stream.subscriber_count, under-counting subscribers -- and tripping the subscriber_count >= 0 check constraint when the count would otherwise go negative.

Serialize these by taking a FOR NO KEY UPDATE lock on the affected user rows before reading their subscriptions, so operations on the same user cannot interleave; distinct users lock distinct rows and still proceed concurrently.  The lock is taken in the callers of bulk_add_subscriptions / bulk_remove_subscriptions:

* Requests that resolve principals fold it into the existing user lookup, via a new acquire_lock option on bulk_access_users_by_id / bulk_access_users_by_email and Command.get_users, so no extra query is added.
* Self-service (un)subscription, new-user creation, and merge_streams take an explicit select_for_update.  These queries order by id to avoid deadlocks and use of=("self",) so they lock only the user row, not the joined realm row.

do_delete_user_core needs no lock: it deactivates the user first, so its bulk_remove_subscriptions neither inserts a Subscription nor changes subscriber_count.

Add transaction-level regression tests that drive the subscribe and unsubscribe endpoints from two threads, for both self-service and admin-initiated (principals) requests, and confirm the second request blocks on the lock instead of racing; with the lock removed they reproduce the duplicate-key and check-constraint failures.  The new lock query on the self-subscription and user-creation paths bumps a few assert_database_query_count expectations by one.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
