### PR TITLE
docs: Fix incorrect header name in SCIM setup instructions.

### DIFF
--- a/docs/production/scim.md
+++ b/docs/production/scim.md
@@ -50,8 +50,8 @@ The Zulip server-side configuration is straightforward:
    `/home/zulip/deployments/current/scripts/restart-server`.
 
    The SCIM IdP will authenticate its requests to your Zulip server by
-   sending a `WWW-Authenticate` header like this:
-   `WWW-Authenticate: Bearer <secret token>`. `name_formatted_included` needs to be set
+   sending an `Authorization` header like this:
+   `Authorization: Bearer <secret token>`. `name_formatted_included` needs to be set
    to `False` for Okta. It tells Zulip whether the IdP includes
    `name.formatted` in its `User` representation.
 


### PR DESCRIPTION
The SCIM setup instructions described the IdP as authenticating by sending a `WWW-Authenticate` header. That is a response header used by a server to challenge a client; the credential is actually sent by the client in the `Authorization` header, which is what Zulip reads in validate_scim_bearer_token.



