### PR TITLE
compose: Contextual Quote/Forward labels in message actions menu.

### DIFF
--- a/starlight_help/src/content/docs/keyboard-shortcuts.mdx
+++ b/starlight_help/src/content/docs/keyboard-shortcuts.mdx
@@ -106,8 +106,8 @@ reference in the Zulip app to add more to your repertoire as needed.
 * **Reply to message**: <kbd>R</kbd> or <kbd>Enter</kbd> — Reply to the
   selected message (outlined in blue). Same behavior as clicking on the
   message.
-* **Quote message**: <kbd>></kbd>
-* **Forward message**: <kbd>\<</kbd>
+* **Quote message or selection**: <kbd>></kbd>
+* **Forward message or selection**: <kbd>\<</kbd>
 * **Reply directly to sender**: <kbd>Shift</kbd> + <kbd>R</kbd>
 * **Reply @-mentioning sender**: <kbd>@</kbd>
 

--- a/starlight_help/src/content/docs/quote-or-forward-a-message.mdx
+++ b/starlight_help/src/content/docs/quote-or-forward-a-message.mdx
@@ -33,17 +33,18 @@ unnecessarily mentioning someone twice.
 <Tabs>
   <TabItem label="Desktop/Web">
     <FlattenedSteps>
-      1. *(optional)* To quote only part of a message, select the part that you want
-         to quote.
+      1. *(optional)* Select the text you want to quote. Your selection can be
+         part of a message, or can span several messages.
 
       <MessageActionsMenu />
 
-      1. Click **Quote message**.
+      1. Click **Quote message**. The label is **Quote selection** or **Quote
+         selected messages** if you made a selection.
       1. Send your message.
     </FlattenedSteps>
 
     <KeyboardTip>
-      You can also use <kbd>></kbd> to quote to the selected message or text,
+      You can also use <kbd>></kbd> to quote the selected message or text,
       including selections across several messages.
     </KeyboardTip>
   </TabItem>
@@ -71,12 +72,13 @@ unnecessarily mentioning someone twice.
 <Tabs>
   <TabItem label="Desktop/Web">
     <FlattenedSteps>
-      1. *(optional)* To forward only part of a message, select the part that you want
-         to forward.
+      1. *(optional)* Select the text you want to forward. Your selection can be
+         part of a message, or can span several messages.
 
       <MessageActionsMenu />
 
-      1. Click **Forward message**.
+      1. Click **Forward message**. The label is **Forward selection** or
+         **Forward selected messages** if you made a selection.
       1. Select the desired destination channel or **Direct message** from the dropdown
          in the top left of the compose box.
       1. Enter a topic name, or recipient names for a direct message.

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -227,6 +227,25 @@ export function rewire_get_highlighted_message_ids(
     get_highlighted_message_ids = value;
 }
 
+// Classification of the current DOM text selection, for quoting purposes.
+type HighlightedSelection =
+    | {type: "none"}
+    | {type: "single_message"; message_id: number}
+    | {type: "multi_message"; message_ids: number[]};
+
+function get_highlighted_selection(): HighlightedSelection {
+    const message_ids = get_highlighted_message_ids();
+    if (message_ids === undefined || message_ids.length === 0) {
+        return {type: "none"};
+    }
+    if (message_ids.length === 1) {
+        const message_id = message_ids[0];
+        assert(message_id !== undefined);
+        return {type: "single_message", message_id};
+    }
+    return {type: "multi_message", message_ids};
+}
+
 function get_quote_target_for_single_message(opts: {
     message_id?: number;
     quote_content?: string | undefined;
@@ -532,15 +551,19 @@ export function quote_messages(opts: QuoteMessageOpts): void {
         quote_single_message(opts);
         return;
     }
-    const highlighted_message_ids = get_highlighted_message_ids();
-    if (highlighted_message_ids === undefined || highlighted_message_ids.length === 0) {
-        quote_single_message(opts);
-    } else if (highlighted_message_ids.length === 1) {
-        opts.highlighted_message_ids = highlighted_message_ids;
-        quote_single_message(opts);
-    } else {
-        opts.highlighted_message_ids = highlighted_message_ids;
-        quote_multiple_messages(opts);
+    const selection = get_highlighted_selection();
+    switch (selection.type) {
+        case "none":
+            quote_single_message(opts);
+            return;
+        case "single_message":
+            opts.highlighted_message_ids = [selection.message_id];
+            quote_single_message(opts);
+            return;
+        case "multi_message":
+            opts.highlighted_message_ids = selection.message_ids;
+            quote_multiple_messages(opts);
+            return;
     }
 }
 

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -248,27 +248,35 @@ function get_highlighted_selection(): HighlightedSelection {
 
 // What the message actions menu opened on `message_id` should quote or
 // forward, given the text selection at the time the menu was opened.
-export type QuoteMenuSelection =
+export type QuoteMenuSelection = {
+    // Whether > and < would do the same thing as the menu item. They act on
+    // the selection wherever it is, so they disagree with a menu opened on a
+    // message the selection does not cover.
+    hotkeys_agree: boolean;
+} & (
     | {kind: "full_message"}
     | {kind: "message_selection"; quote_content: string}
-    | {kind: "selected_messages"; message_ids: number[]};
+    | {kind: "selected_messages"; message_ids: number[]}
+);
 
 export function get_quote_menu_selection(message_id: number): QuoteMenuSelection {
     const selection = get_highlighted_selection();
     if (selection.type === "multi_message" && selection.message_ids.includes(message_id)) {
-        return {kind: "selected_messages", message_ids: selection.message_ids};
+        return {kind: "selected_messages", message_ids: selection.message_ids, hotkeys_agree: true};
     }
     if (selection.type === "single_message" && selection.message_id === message_id) {
         const quote_content = get_message_selection();
         // Selecting only a sender name or timestamp lands outside
-        // `.message_content`, leaving nothing quotable to offer.
+        // `.message_content`, leaving nothing quotable to offer. The hotkeys
+        // fall back to the whole message too, so they still agree.
         if (quote_content.trim() !== "") {
-            return {kind: "message_selection", quote_content};
+            return {kind: "message_selection", quote_content, hotkeys_agree: true};
         }
+        return {kind: "full_message", hotkeys_agree: true};
     }
     // With no selection, or one that does not cover this message, the menu
     // acts on the message it was opened from.
-    return {kind: "full_message"};
+    return {kind: "full_message", hotkeys_agree: selection.type === "none"};
 }
 
 function get_quote_target_for_single_message(opts: {

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -246,17 +246,29 @@ function get_highlighted_selection(): HighlightedSelection {
     return {type: "multi_message", message_ids};
 }
 
-// Returns the selected text within `message_id`, if the entire current
-// selection is inside that message, and undefined otherwise. Selecting
-// only a message's sender name or timestamp yields no quotable content,
-// which we report the same way as having no selection at all.
-export function get_selection_within_message(message_id: number): string | undefined {
+// What the message actions menu opened on `message_id` should quote or
+// forward, given the text selection at the time the menu was opened.
+export type QuoteMenuSelection =
+    | {kind: "full_message"}
+    | {kind: "message_selection"; quote_content: string}
+    | {kind: "selected_messages"; message_ids: number[]};
+
+export function get_quote_menu_selection(message_id: number): QuoteMenuSelection {
     const selection = get_highlighted_selection();
-    if (selection.type !== "single_message" || selection.message_id !== message_id) {
-        return undefined;
+    if (selection.type === "multi_message" && selection.message_ids.includes(message_id)) {
+        return {kind: "selected_messages", message_ids: selection.message_ids};
     }
-    const content = get_message_selection();
-    return content.trim() === "" ? undefined : content;
+    if (selection.type === "single_message" && selection.message_id === message_id) {
+        const quote_content = get_message_selection();
+        // Selecting only a sender name or timestamp lands outside
+        // `.message_content`, leaving nothing quotable to offer.
+        if (quote_content.trim() !== "") {
+            return {kind: "message_selection", quote_content};
+        }
+    }
+    // With no selection, or one that does not cover this message, the menu
+    // acts on the message it was opened from.
+    return {kind: "full_message"};
 }
 
 function get_quote_target_for_single_message(opts: {
@@ -560,6 +572,13 @@ function replace_quoting_placeholder_with(info: {
 }
 
 export function quote_messages(opts: QuoteMessageOpts): void {
+    // The message actions menu passes the ids it recorded when the menu was
+    // opened, since the selection they came from no longer exists.
+    const selected_message_ids = opts.highlighted_message_ids;
+    if (selected_message_ids !== undefined && selected_message_ids.length > 1) {
+        quote_multiple_messages(opts);
+        return;
+    }
     if (opts.message_id) {
         quote_single_message(opts);
         return;

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -246,6 +246,19 @@ function get_highlighted_selection(): HighlightedSelection {
     return {type: "multi_message", message_ids};
 }
 
+// Returns the selected text within `message_id`, if the entire current
+// selection is inside that message, and undefined otherwise. Selecting
+// only a message's sender name or timestamp yields no quotable content,
+// which we report the same way as having no selection at all.
+export function get_selection_within_message(message_id: number): string | undefined {
+    const selection = get_highlighted_selection();
+    if (selection.type !== "single_message" || selection.message_id !== message_id) {
+        return undefined;
+    }
+    const content = get_message_selection();
+    return content.trim() === "" ? undefined : content;
+}
+
 function get_quote_target_for_single_message(opts: {
     message_id?: number;
     quote_content?: string | undefined;

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -27,6 +27,11 @@ import {the} from "./util.ts";
 
 let message_actions_popover_keyboard_toggle = false;
 
+// The text selected within the message whose ⋮ button was last pressed,
+// recorded on mousedown because the selection does not survive the click.
+let quote_content_at_button_mousedown:
+    {message_id: number; quote_content: string | undefined} | undefined;
+
 function get_action_menu_menu_items(): JQuery {
     return $("[data-tippy-root] #message-actions-menu-dropdown li:not(.divider) a");
 }
@@ -63,6 +68,9 @@ export function toggle_message_actions_menu(message: Message): boolean {
     message_viewport.maybe_scroll_to_show_message_top();
     const $popover_reference = $(".selected_message .actions_hover .message-actions-menu-button");
     message_actions_popover_keyboard_toggle = true;
+    // This synthetic click has no mousedown of its own, so make sure it
+    // cannot consume a stale selection left behind by an earlier ⋮ press.
+    quote_content_at_button_mousedown = undefined;
     $popover_reference.trigger("click");
     return true;
 }
@@ -75,6 +83,24 @@ export function initialize({
         target: tippy.ReferenceElement,
     ) => void;
 }): void {
+    // Pressing the ⋮ button collapses any text selection on mouseup, well
+    // before the popover opens, so we have to read the selection here.
+    $("#main_div").on(
+        "mousedown",
+        ".actions_hover .message-actions-menu-button",
+        function (this: HTMLElement) {
+            const $row = $(this).closest(".message_row");
+            if ($row.length === 0) {
+                return;
+            }
+            const message_id = rows.id($row);
+            quote_content_at_button_mousedown = {
+                message_id,
+                quote_content: compose_reply.get_selection_within_message(message_id),
+            };
+        },
+    );
+
     popover_menus.register_popover_menu(".actions_hover .message-actions-menu-button", {
         theme: "popover-menu",
         placement: "bottom",
@@ -101,19 +127,15 @@ export function initialize({
         onMount(instance) {
             const $row = $(instance.reference).closest(".message_row");
             const message_id = rows.id($row);
-            let quote_content: string | undefined;
-            const highlighted_message_ids = compose_reply.get_highlighted_message_ids();
-            if (
-                highlighted_message_ids &&
-                highlighted_message_ids?.length === 1 &&
-                highlighted_message_ids[0] === message_id
-            ) {
-                // If the user has selected text within this message, quote only that.
-                // We track the selection right now, before the popover option for Quote
-                // and reply is clicked, since by then the selection is lost, due to the
-                // change in focus.
-                quote_content = compose_reply.get_message_selection();
-            }
+            // If the user has selected text within this message, quote only
+            // that. Mouse opens rely on what we read on mousedown; keyboard
+            // opens have no mousedown, but do still have the live selection.
+            const at_mousedown = quote_content_at_button_mousedown;
+            quote_content_at_button_mousedown = undefined;
+            const quote_content =
+                at_mousedown?.message_id === message_id
+                    ? at_mousedown.quote_content
+                    : compose_reply.get_selection_within_message(message_id);
             if (message_actions_popover_keyboard_toggle) {
                 focus_first_action_popover_item();
                 message_actions_popover_keyboard_toggle = false;

--- a/web/src/message_actions_popover.ts
+++ b/web/src/message_actions_popover.ts
@@ -27,13 +27,51 @@ import {the} from "./util.ts";
 
 let message_actions_popover_keyboard_toggle = false;
 
-// The text selected within the message whose ⋮ button was last pressed,
+// What the message whose ⋮ button was last pressed should quote or forward,
 // recorded on mousedown because the selection does not survive the click.
-let quote_content_at_button_mousedown:
-    {message_id: number; quote_content: string | undefined} | undefined;
+let quote_menu_selection_at_button_mousedown:
+    {message_id: number; quote_menu_selection: compose_reply.QuoteMenuSelection} | undefined;
+
+// What each open menu was rendered to quote or forward. Keyed by instance so
+// that hiding one menu cannot disturb another that has since been opened.
+const quote_menu_selection_by_instance = new WeakMap<
+    tippy.Instance,
+    compose_reply.QuoteMenuSelection
+>();
 
 function get_action_menu_menu_items(): JQuery {
     return $("[data-tippy-root] #message-actions-menu-dropdown li:not(.divider) a");
+}
+
+function quote_from_menu(
+    message_id: number,
+    quote_menu_selection: compose_reply.QuoteMenuSelection,
+    forward_message: boolean,
+): void {
+    switch (quote_menu_selection.kind) {
+        case "full_message":
+            compose_reply.quote_messages({
+                trigger: "popover respond",
+                message_id,
+                forward_message,
+            });
+            return;
+        case "message_selection":
+            compose_reply.quote_messages({
+                trigger: "popover respond",
+                message_id,
+                quote_content: quote_menu_selection.quote_content,
+                forward_message,
+            });
+            return;
+        case "selected_messages":
+            compose_reply.quote_messages({
+                trigger: "popover respond",
+                highlighted_message_ids: quote_menu_selection.message_ids,
+                forward_message,
+            });
+            return;
+    }
 }
 
 function focus_first_action_popover_item(): void {
@@ -70,7 +108,7 @@ export function toggle_message_actions_menu(message: Message): boolean {
     message_actions_popover_keyboard_toggle = true;
     // This synthetic click has no mousedown of its own, so make sure it
     // cannot consume a stale selection left behind by an earlier ⋮ press.
-    quote_content_at_button_mousedown = undefined;
+    quote_menu_selection_at_button_mousedown = undefined;
     $popover_reference.trigger("click");
     return true;
 }
@@ -94,9 +132,9 @@ export function initialize({
                 return;
             }
             const message_id = rows.id($row);
-            quote_content_at_button_mousedown = {
+            quote_menu_selection_at_button_mousedown = {
                 message_id,
-                quote_content: compose_reply.get_selection_within_message(message_id),
+                quote_menu_selection: compose_reply.get_quote_menu_selection(message_id),
             };
         },
     );
@@ -120,22 +158,27 @@ export function initialize({
             popover_menus.on_show_prep(instance);
             const $row = $(instance.reference).closest(".message_row");
             const message_id = rows.id($row);
-            const args = popover_menus_data.get_actions_popover_content_context(message_id);
+            // Mouse opens rely on what we read on mousedown; keyboard opens
+            // have no mousedown, but do still have the live selection.
+            const at_mousedown = quote_menu_selection_at_button_mousedown;
+            quote_menu_selection_at_button_mousedown = undefined;
+            const quote_menu_selection =
+                at_mousedown?.message_id === message_id
+                    ? at_mousedown.quote_menu_selection
+                    : compose_reply.get_quote_menu_selection(message_id);
+            quote_menu_selection_by_instance.set(instance, quote_menu_selection);
+            const args = popover_menus_data.get_actions_popover_content_context(
+                message_id,
+                quote_menu_selection,
+            );
             instance.setContent(parse_html(render_message_actions_popover(args)));
             $row.addClass("has_actions_popover");
         },
         onMount(instance) {
             const $row = $(instance.reference).closest(".message_row");
             const message_id = rows.id($row);
-            // If the user has selected text within this message, quote only
-            // that. Mouse opens rely on what we read on mousedown; keyboard
-            // opens have no mousedown, but do still have the live selection.
-            const at_mousedown = quote_content_at_button_mousedown;
-            quote_content_at_button_mousedown = undefined;
-            const quote_content =
-                at_mousedown?.message_id === message_id
-                    ? at_mousedown.quote_content
-                    : compose_reply.get_selection_within_message(message_id);
+            const quote_menu_selection = quote_menu_selection_by_instance.get(instance);
+            assert(quote_menu_selection !== undefined);
             if (message_actions_popover_keyboard_toggle) {
                 focus_first_action_popover_item();
                 message_actions_popover_keyboard_toggle = false;
@@ -146,23 +189,14 @@ export function initialize({
             // instance.hide gets called.
             const $popper = $(instance.popper);
             $popper.one("click", ".respond_button", (e) => {
-                compose_reply.quote_messages({
-                    trigger: "popover respond",
-                    message_id,
-                    quote_content,
-                });
+                quote_from_menu(message_id, quote_menu_selection, false);
                 e.preventDefault();
                 e.stopPropagation();
                 popover_menus.hide_current_popover_if_visible(instance);
             });
 
             $popper.one("click", ".forward_button", (e) => {
-                compose_reply.quote_messages({
-                    trigger: "popover respond",
-                    message_id,
-                    quote_content,
-                    forward_message: true,
-                });
+                quote_from_menu(message_id, quote_menu_selection, true);
                 e.preventDefault();
                 e.stopPropagation();
                 popover_menus.hide_current_popover_if_visible(instance);

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -42,6 +42,8 @@ type ActionPopoverContext = {
     should_display_collapse: boolean;
     should_display_uncollapse: boolean;
     should_display_quote_message: boolean;
+    quote_message_menu_item: string;
+    forward_message_menu_item: string;
     conversation_time_url: string;
     should_display_delete_option: boolean;
     should_display_read_receipts_option: boolean;
@@ -205,6 +207,8 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         !message.locally_echoed && !message.is_me_message && message.collapsed;
 
     const should_display_quote_message = not_spectator;
+    const quote_message_menu_item = $t({defaultMessage: "Quote message"});
+    const forward_message_menu_item = $t({defaultMessage: "Forward message"});
 
     const conversation_time_url = hash_util.by_conversation_and_time_url(message);
 
@@ -255,6 +259,8 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         should_display_delete_option,
         should_display_read_receipts_option,
         should_display_quote_message,
+        quote_message_menu_item,
+        forward_message_menu_item,
         should_display_message_report_option: should_display_message_report_option(),
     };
 }

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -45,6 +45,7 @@ type ActionPopoverContext = {
     should_display_quote_message: boolean;
     quote_message_menu_item: string;
     forward_message_menu_item: string;
+    show_quote_and_forward_hotkey_hints: boolean;
     conversation_time_url: string;
     should_display_delete_option: boolean;
     should_display_read_receipts_option: boolean;
@@ -245,6 +246,9 @@ export function get_actions_popover_content_context(
     const {quote_message_menu_item, forward_message_menu_item} = get_quote_menu_labels(
         quote_menu_selection.kind,
     );
+    // Showing a hotkey next to a menu item that does something else would be
+    // a lie, so we drop the hint rather than the item.
+    const show_quote_and_forward_hotkey_hints = quote_menu_selection.hotkeys_agree;
 
     const conversation_time_url = hash_util.by_conversation_and_time_url(message);
 
@@ -297,6 +301,7 @@ export function get_actions_popover_content_context(
         should_display_quote_message,
         quote_message_menu_item,
         forward_message_menu_item,
+        show_quote_and_forward_hotkey_hints,
         should_display_message_report_option: should_display_message_report_option(),
     };
 }

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -4,6 +4,7 @@
 import assert from "minimalistic-assert";
 
 import * as buddy_data from "./buddy_data.ts";
+import type {QuoteMenuSelection} from "./compose_reply.ts";
 import * as gear_menu_util from "./gear_menu_util.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
@@ -147,7 +148,41 @@ type BillingInfo = {
     show_plans: boolean;
 };
 
-export function get_actions_popover_content_context(message_id: number): ActionPopoverContext {
+// The Quote and Forward labels spell out what the menu item will act on,
+// so that clicking it is not a surprise when there is a text selection.
+function get_quote_menu_labels(kind: QuoteMenuSelection["kind"]): {
+    quote_message_menu_item: string;
+    forward_message_menu_item: string;
+} {
+    switch (kind) {
+        case "full_message":
+            return {
+                quote_message_menu_item: $t({defaultMessage: "Quote message"}),
+                forward_message_menu_item: $t({defaultMessage: "Forward message"}),
+            };
+        case "message_selection":
+            return {
+                quote_message_menu_item: $t({defaultMessage: "Quote selection"}),
+                forward_message_menu_item: $t({defaultMessage: "Forward selection"}),
+            };
+        case "selected_messages":
+            return {
+                quote_message_menu_item: $t({defaultMessage: "Quote selected messages"}),
+                forward_message_menu_item: $t({defaultMessage: "Forward selected messages"}),
+            };
+        default: {
+            // Fail loudly rather than mislabel the menu item if a new kind
+            // of selection is added without wording to go with it.
+            const unexpected_kind: never = kind;
+            throw new Error(`Unexpected quote menu selection kind: ${String(unexpected_kind)}`);
+        }
+    }
+}
+
+export function get_actions_popover_content_context(
+    message_id: number,
+    quote_menu_selection: QuoteMenuSelection,
+): ActionPopoverContext {
     assert(message_lists.current !== undefined);
     const message = message_lists.current.get(message_id);
     assert(message !== undefined);
@@ -207,8 +242,9 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         !message.locally_echoed && !message.is_me_message && message.collapsed;
 
     const should_display_quote_message = not_spectator;
-    const quote_message_menu_item = $t({defaultMessage: "Quote message"});
-    const forward_message_menu_item = $t({defaultMessage: "Forward message"});
+    const {quote_message_menu_item, forward_message_menu_item} = get_quote_menu_labels(
+        quote_menu_selection.kind,
+    );
 
     const conversation_time_url = hash_util.by_conversation_and_time_url(message);
 

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -350,11 +350,11 @@
                     </td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Quote message' }}</td>
+                    <td class="definition">{{t 'Quote message or selection' }}</td>
                     <td><span class="hotkey"><kbd>></kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Forward message' }}</td>
+                    <td class="definition">{{t 'Forward message or selection' }}</td>
                     <td><span class="hotkey"><kbd>&lt;</kbd></span></td> <!-- &lt; is the HTML entity for < -->
                 </tr>
                 <tr>

--- a/web/templates/popovers/message_actions_popover.hbs
+++ b/web/templates/popovers/message_actions_popover.hbs
@@ -6,14 +6,18 @@
             <a role="menuitem" data-message-id="{{message_id}}" class="respond_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-quote-message" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{quote_message_menu_item}}</span>
+                {{#if show_quote_and_forward_hotkey_hints}}
                 {{popover_hotkey_hints ">"}}
+                {{/if}}
             </a>
         </li>
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" data-message-id="{{message_id}}" class="forward_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-forward-message" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{forward_message_menu_item}}</span>
+                {{#if show_quote_and_forward_hotkey_hints}}
                 {{popover_hotkey_hints "<"}}
+                {{/if}}
             </a>
         </li>
         {{/if}}

--- a/web/templates/popovers/message_actions_popover.hbs
+++ b/web/templates/popovers/message_actions_popover.hbs
@@ -5,14 +5,14 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" data-message-id="{{message_id}}" class="respond_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-quote-message" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Quote message" }}</span>
+                <span class="popover-menu-label">{{quote_message_menu_item}}</span>
                 {{popover_hotkey_hints ">"}}
             </a>
         </li>
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" data-message-id="{{message_id}}" class="forward_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-forward-message" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Forward message" }}</span>
+                <span class="popover-menu-label">{{forward_message_menu_item}}</span>
                 {{popover_hotkey_hints "<"}}
             </a>
         </li>

--- a/web/tests/compose_reply.test.cjs
+++ b/web/tests/compose_reply.test.cjs
@@ -393,22 +393,33 @@ run_test("build_and_process_quote_assets_for_messages", ({override}) => {
 
 run_test("get_quote_menu_selection", ({override_rewire}) => {
     override_rewire(compose_reply, "get_highlighted_message_ids", () => undefined);
-    assert.deepEqual(compose_reply.get_quote_menu_selection(10), {kind: "full_message"});
+    assert.deepEqual(compose_reply.get_quote_menu_selection(10), {
+        kind: "full_message",
+        hotkeys_agree: true,
+    });
 
     override_rewire(compose_reply, "get_highlighted_message_ids", () => [10]);
     override_rewire(compose_reply, "get_message_selection", () => "partial text");
     assert.deepEqual(compose_reply.get_quote_menu_selection(10), {
         kind: "message_selection",
         quote_content: "partial text",
+        hotkeys_agree: true,
     });
 
-    // The selection is inside a different message than the menu was opened on.
-    assert.deepEqual(compose_reply.get_quote_menu_selection(99), {kind: "full_message"});
+    // The selection is inside a different message than the menu was opened
+    // on, so > and < would act on the selection instead: hide their hints.
+    assert.deepEqual(compose_reply.get_quote_menu_selection(99), {
+        kind: "full_message",
+        hotkeys_agree: false,
+    });
 
     // Selecting only a sender name or timestamp lands outside
     // `.message_content`, so there is nothing quotable to offer.
     override_rewire(compose_reply, "get_message_selection", () => " ".repeat(3));
-    assert.deepEqual(compose_reply.get_quote_menu_selection(10), {kind: "full_message"});
+    assert.deepEqual(compose_reply.get_quote_menu_selection(10), {
+        kind: "full_message",
+        hotkeys_agree: true,
+    });
 
     // A selection spanning several messages, opened from inside the range;
     // we return early without consulting the selected text at all.
@@ -416,9 +427,13 @@ run_test("get_quote_menu_selection", ({override_rewire}) => {
     assert.deepEqual(compose_reply.get_quote_menu_selection(11), {
         kind: "selected_messages",
         message_ids: [10, 11, 12],
+        hotkeys_agree: true,
     });
 
     // ...and opened from a message outside the range, where the menu acts on
-    // that one message only.
-    assert.deepEqual(compose_reply.get_quote_menu_selection(99), {kind: "full_message"});
+    // that one message only and the hotkeys would not.
+    assert.deepEqual(compose_reply.get_quote_menu_selection(99), {
+        kind: "full_message",
+        hotkeys_agree: false,
+    });
 });

--- a/web/tests/compose_reply.test.cjs
+++ b/web/tests/compose_reply.test.cjs
@@ -391,24 +391,34 @@ run_test("build_and_process_quote_assets_for_messages", ({override}) => {
     );
 });
 
-run_test("get_selection_within_message", ({override_rewire}) => {
+run_test("get_quote_menu_selection", ({override_rewire}) => {
     override_rewire(compose_reply, "get_highlighted_message_ids", () => undefined);
-    assert.equal(compose_reply.get_selection_within_message(10), undefined, "no selection");
+    assert.deepEqual(compose_reply.get_quote_menu_selection(10), {kind: "full_message"});
 
     override_rewire(compose_reply, "get_highlighted_message_ids", () => [10]);
     override_rewire(compose_reply, "get_message_selection", () => "partial text");
-    assert.equal(compose_reply.get_selection_within_message(10), "partial text");
+    assert.deepEqual(compose_reply.get_quote_menu_selection(10), {
+        kind: "message_selection",
+        quote_content: "partial text",
+    });
 
-    // The selection is inside a different message than the one asked about.
-    assert.equal(compose_reply.get_selection_within_message(99), undefined);
+    // The selection is inside a different message than the menu was opened on.
+    assert.deepEqual(compose_reply.get_quote_menu_selection(99), {kind: "full_message"});
 
     // Selecting only a sender name or timestamp lands outside
-    // `.message_content`, so there is nothing quotable to return.
+    // `.message_content`, so there is nothing quotable to offer.
     override_rewire(compose_reply, "get_message_selection", () => " ".repeat(3));
-    assert.equal(compose_reply.get_selection_within_message(10), undefined);
+    assert.deepEqual(compose_reply.get_quote_menu_selection(10), {kind: "full_message"});
 
-    // A selection spanning several messages is not a within-message one;
+    // A selection spanning several messages, opened from inside the range;
     // we return early without consulting the selected text at all.
-    override_rewire(compose_reply, "get_highlighted_message_ids", () => [10, 11]);
-    assert.equal(compose_reply.get_selection_within_message(10), undefined);
+    override_rewire(compose_reply, "get_highlighted_message_ids", () => [10, 11, 12]);
+    assert.deepEqual(compose_reply.get_quote_menu_selection(11), {
+        kind: "selected_messages",
+        message_ids: [10, 11, 12],
+    });
+
+    // ...and opened from a message outside the range, where the menu acts on
+    // that one message only.
+    assert.deepEqual(compose_reply.get_quote_menu_selection(99), {kind: "full_message"});
 });

--- a/web/tests/compose_reply.test.cjs
+++ b/web/tests/compose_reply.test.cjs
@@ -390,3 +390,25 @@ run_test("build_and_process_quote_assets_for_messages", ({override}) => {
         "Fallback to using paste_handler_converter",
     );
 });
+
+run_test("get_selection_within_message", ({override_rewire}) => {
+    override_rewire(compose_reply, "get_highlighted_message_ids", () => undefined);
+    assert.equal(compose_reply.get_selection_within_message(10), undefined, "no selection");
+
+    override_rewire(compose_reply, "get_highlighted_message_ids", () => [10]);
+    override_rewire(compose_reply, "get_message_selection", () => "partial text");
+    assert.equal(compose_reply.get_selection_within_message(10), "partial text");
+
+    // The selection is inside a different message than the one asked about.
+    assert.equal(compose_reply.get_selection_within_message(99), undefined);
+
+    // Selecting only a sender name or timestamp lands outside
+    // `.message_content`, so there is nothing quotable to return.
+    override_rewire(compose_reply, "get_message_selection", () => " ".repeat(3));
+    assert.equal(compose_reply.get_selection_within_message(10), undefined);
+
+    // A selection spanning several messages is not a within-message one;
+    // we return early without consulting the selected text at all.
+    override_rewire(compose_reply, "get_highlighted_message_ids", () => [10, 11]);
+    assert.equal(compose_reply.get_selection_within_message(10), undefined);
+});

--- a/web/tests/i18n.test.cjs
+++ b/web/tests/i18n.test.cjs
@@ -14,6 +14,7 @@ const {page_params} = require("./lib/zpage_params.cjs");
 page_params.request_language = "en";
 page_params.translation_data = {
     "Quote message": "Citer le message",
+    "Copy link to message": "Copier le lien vers le message",
     "Notification triggers": "Déclencheurs de notification",
     "You subscribed to channel {name}": "Vous n'êtes pas abonnés au canal {name}",
     "<p>The channel <b>{name}</b> does not exist.</p><p>Manage your subscriptions <z-link>on your Channels page</z-link>.</p>":
@@ -58,9 +59,13 @@ run_test("$t_html", () => {
 });
 
 run_test("t_tag", ({mock_template}) => {
+    // The Quote/Forward labels reach this template already translated, so
+    // assert on a label the template still translates itself.
     const args = {
         message_id: "99",
         should_display_quote_message: true,
+        quote_message_menu_item: "Citer le message",
+        forward_message_menu_item: "Transférer le message",
         editability_menu_item: "Edit message",
         conversation_time_url:
             "http://zulip.zulipdev.com/#narrow/channel/101-devel/topic/testing/near/99",
@@ -68,7 +73,7 @@ run_test("t_tag", ({mock_template}) => {
 
     mock_template("popovers/message_actions_popover.hbs", true, (data, html) => {
         assert.equal(data, args);
-        assert.ok(html.includes("Citer le message"));
+        assert.ok(html.includes("Copier le lien vers le message"));
         return "<message-actions-popover-stub>";
     });
 

--- a/web/tests/i18n.test.cjs
+++ b/web/tests/i18n.test.cjs
@@ -66,6 +66,7 @@ run_test("t_tag", ({mock_template}) => {
         should_display_quote_message: true,
         quote_message_menu_item: "Citer le message",
         forward_message_menu_item: "Transférer le message",
+        show_quote_and_forward_hotkey_hints: true,
         editability_menu_item: "Edit message",
         conversation_time_url:
             "http://zulip.zulipdev.com/#narrow/channel/101-devel/topic/testing/near/99",

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -233,6 +233,7 @@ test("my_message_all_actions", ({override}) => {
     add_message_with_view(list, messages);
     const response = popover_menus_data.get_actions_popover_content_context(1, {
         kind: "full_message",
+        hotkeys_agree: true,
     });
     assert.equal(response.message_id, 1);
     assert.equal(response.stream_id, 1);
@@ -247,6 +248,15 @@ test("my_message_all_actions", ({override}) => {
     assert.equal(response.should_display_delete_option, true);
     assert.equal(response.should_display_read_receipts_option, true);
     assert.equal(response.should_display_quote_message, true);
+    assert.equal(response.show_quote_and_forward_hotkey_hints, true);
+
+    // A menu opened on a message the selection does not cover quotes just
+    // that message, which is not what > and < would do.
+    const diverging_response = popover_menus_data.get_actions_popover_content_context(1, {
+        kind: "full_message",
+        hotkeys_agree: false,
+    });
+    assert.equal(diverging_response.show_quote_and_forward_hotkey_hints, false);
     assert.equal(response.quote_message_menu_item, "translated: Quote message");
     assert.equal(response.forward_message_menu_item, "translated: Forward message");
 
@@ -303,6 +313,7 @@ test("not_my_message_view_actions", ({override}) => {
 
     const response = popover_menus_data.get_actions_popover_content_context(1, {
         kind: "full_message",
+        hotkeys_agree: true,
     });
 
     assert.equal(response.view_source_menu_item, "translated: View original message");
@@ -349,6 +360,7 @@ test("not_my_message_view_source_and_move", ({override}) => {
 
     const response = popover_menus_data.get_actions_popover_content_context(1, {
         kind: "full_message",
+        hotkeys_agree: true,
     });
     assert.equal(response.view_source_menu_item, "translated: View original message");
     assert.equal(response.editability_menu_item, undefined);

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -245,6 +245,8 @@ test("my_message_all_actions", ({override}) => {
     assert.equal(response.should_display_delete_option, true);
     assert.equal(response.should_display_read_receipts_option, true);
     assert.equal(response.should_display_quote_message, true);
+    assert.equal(response.quote_message_menu_item, "translated: Quote message");
+    assert.equal(response.forward_message_menu_item, "translated: Forward message");
 });
 
 test("not_my_message_view_actions", ({override}) => {

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -231,7 +231,9 @@ test("my_message_all_actions", ({override}) => {
     ];
 
     add_message_with_view(list, messages);
-    const response = popover_menus_data.get_actions_popover_content_context(1);
+    const response = popover_menus_data.get_actions_popover_content_context(1, {
+        kind: "full_message",
+    });
     assert.equal(response.message_id, 1);
     assert.equal(response.stream_id, 1);
     assert.equal(response.editability_menu_item, "translated: Edit message");
@@ -247,6 +249,24 @@ test("my_message_all_actions", ({override}) => {
     assert.equal(response.should_display_quote_message, true);
     assert.equal(response.quote_message_menu_item, "translated: Quote message");
     assert.equal(response.forward_message_menu_item, "translated: Forward message");
+
+    // The Quote/Forward labels spell out what a text selection will act on.
+    const selection_response = popover_menus_data.get_actions_popover_content_context(1, {
+        kind: "message_selection",
+        quote_content: "selected text",
+    });
+    assert.equal(selection_response.quote_message_menu_item, "translated: Quote selection");
+    assert.equal(selection_response.forward_message_menu_item, "translated: Forward selection");
+
+    const messages_response = popover_menus_data.get_actions_popover_content_context(1, {
+        kind: "selected_messages",
+        message_ids: [1, 2],
+    });
+    assert.equal(messages_response.quote_message_menu_item, "translated: Quote selected messages");
+    assert.equal(
+        messages_response.forward_message_menu_item,
+        "translated: Forward selected messages",
+    );
 });
 
 test("not_my_message_view_actions", ({override}) => {
@@ -281,7 +301,9 @@ test("not_my_message_view_actions", ({override}) => {
 
     add_message_with_view(list, messages);
 
-    const response = popover_menus_data.get_actions_popover_content_context(1);
+    const response = popover_menus_data.get_actions_popover_content_context(1, {
+        kind: "full_message",
+    });
 
     assert.equal(response.view_source_menu_item, "translated: View original message");
     assert.equal(response.editability_menu_item, undefined);
@@ -325,7 +347,9 @@ test("not_my_message_view_source_and_move", ({override}) => {
 
     add_message_with_view(list, messages);
 
-    const response = popover_menus_data.get_actions_popover_content_context(1);
+    const response = popover_menus_data.get_actions_popover_content_context(1, {
+        kind: "full_message",
+    });
     assert.equal(response.view_source_menu_item, "translated: View original message");
     assert.equal(response.editability_menu_item, undefined);
     assert.equal(response.move_message_menu_item, "translated: Move messages");


### PR DESCRIPTION
## Description

Makes the message actions **Quote** / **Forward** menu items follow the user's current text selection, so the mouse path matches multi-message and partial-selection behavior that already works with `>` / `<`.

When opening the actions menu on message M:

| Selection | Labels | Action |
| --- | --- | --- |
| ≥2 messages including M | Quote/Forward **selected messages** | Multi-message quote/forward (same as hotkeys) |
| Selection only within M | Quote/Forward **selection** | Partial content only |
| No selection, or selection does not include M | Quote/Forward **message** | Full message M |

`>` / `<` hotkey hints are shown only when the menu action matches what the hotkeys would do (hidden when the menu would full-quote a message **outside** a multi-message selection while the hotkeys would multi-quote the selection).

Related design discussion: [Quoting/Forwarding multiple messages #37878](https://chat.zulip.org/#narrow/channel/101-design/topic/Quoting.2FForwarding.20multiple.20messages.20.2337878/with/2488448).

## Screenshots and screen captures

### Message actions menu (Quote **and** Forward labels)

Each menu shot shows **both** the Quote and Forward rows for that selection state (with visible text selection where relevant).

| No selection | Partial selection in one message |
| --- | --- |
| **Quote message** / **Forward message** (hints shown) | **Quote selection** / **Forward selection** (hints shown) |
| ![No selection menu](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/01-ui-no-selection.png?v=8) | ![Partial selection menu with highlight](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/02-ui-partial.png?v=8) |

| Multi-message selection (menu on in-range message) | Multi-message selection (menu on out-of-range message) |
| --- | --- |
| **Quote selected messages** / **Forward selected messages** (hints shown) | **Quote message** / **Forward message** (hints hidden) |
| ![Multi in-range menu](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/03-ui-multi.png?v=8) | ![Multi out-of-range menu](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/04-ui-out-of-range.png?v=8) |

### In-app keyboard shortcuts (`?`)

| Updated cheatsheet copy |
| --- |
| **Quote message or selection** / **Forward message or selection** |
| ![In-app keyboard shortcuts](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/05-app-keyboard-shortcuts.png?v=8) |

### [Quote section](https://zulip.com/help/quote-or-forward-a-message#quote-a-message)

| Before ([zulip.com/help](https://zulip.com/help/quote-or-forward-a-message)) | After (this PR) |
| --- | --- |
| Fixed **Click Quote message** | Contextual quote labels + multi-message steps |
| ![Help quote before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/06-help-quote-before.png?v=8) | ![Help quote after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/07-help-quote-after.png?v=8) |

### [Forward section](https://zulip.com/help/quote-or-forward-a-message#forward-a-message)

| Before ([zulip.com/help](https://zulip.com/help/quote-or-forward-a-message)) | After (this PR) |
| --- | --- |
| Fixed **Click Forward message** | Contextual forward labels + multi-message steps |
| ![Help forward before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/10-help-forward-before.png?v=8) | ![Help forward after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/11-help-forward-after.png?v=8) |

### Help center: [Keyboard shortcuts](https://zulip.com/help/keyboard-shortcuts)

| Before ([zulip.com/help](https://zulip.com/help/keyboard-shortcuts)) | After (this PR) |
| --- | --- |
| **Quote message** / **Forward message** | **Quote message or selection** / **Forward message or selection** |
| ![Help keyboard before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/08-help-keyboard-shortcuts-before.png?v=8) | ![Help keyboard after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39669-screenshot-assets/09-help-keyboard-shortcuts-after.png?v=8) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>




