### PR TITLE
api docs: Document POST, DELETE and GET `/realm/icon` and `/realm/logo`.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -163,6 +163,9 @@
 * [Upload an organization icon](/api/upload-realm-icon)
 * [Delete an organization icon](/api/delete-realm-icon)
 * [Get an organization icon](/api/get-realm-icon)
+* [Upload an organization logo](/api/upload-realm-logo)
+* [Delete an organization logo](/api/delete-realm-logo)
+* [Get an organization logo](/api/get-realm-logo)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -160,6 +160,9 @@
 * [Create a data export](/api/export-realm)
 * [Get data export consent state](/api/get-realm-export-consents)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
+* [Upload an organization icon](/api/upload-realm-icon)
+* [Delete an organization icon](/api/delete-realm-icon)
+* [Get an organization icon](/api/get-realm-icon)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -167,6 +167,9 @@
 * [Upload an organization icon](/api/upload-realm-icon)
 * [Delete an organization icon](/api/delete-realm-icon)
 * [Get an organization icon](/api/get-realm-icon)
+* [Upload an organization logo](/api/upload-realm-logo)
+* [Delete an organization logo](/api/delete-realm-logo)
+* [Get an organization logo](/api/get-realm-logo)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -164,6 +164,9 @@
 * [Delete a data export](/api/delete-realm-export)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate an organization](/api/deactivate-realm)
+* [Upload an organization icon](/api/upload-realm-icon)
+* [Delete an organization icon](/api/delete-realm-icon)
+* [Get an organization icon](/api/get-realm-icon)
 
 ## Real-time events
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -223,7 +223,11 @@ def curl_method_arguments(endpoint: str, method: str, api_url: str) -> list[str]
 
 
 def get_openapi_param_example_value_as_string(
-    endpoint: str, method: str, parameter: Parameter, curl_argument: bool = False
+    endpoint: str,
+    method: str,
+    parameter: Parameter,
+    curl_argument: bool = False,
+    use_multipart: bool = False,
 ) -> str:
     if "type" in parameter.value_schema:
         param_type = parameter.value_schema["type"]
@@ -245,7 +249,8 @@ cURL example."""
         # We currently don't have any non-JSON encoded arrays.
         assert parameter.json_encoded
         if curl_argument:
-            return "    --data-urlencode " + shlex.quote(f"{parameter.name}={ordered_ex_val_str}")
+            flag = "-F" if use_multipart else "--data-urlencode"
+            return f"    {flag} " + shlex.quote(f"{parameter.name}={ordered_ex_val_str}")
         return ordered_ex_val_str  # nocoverage
     else:
         if parameter.example is NO_EXAMPLE:
@@ -261,7 +266,8 @@ cURL example."""
             assert isinstance(example_value, str)
 
         if curl_argument:
-            return "    --data-urlencode " + shlex.quote(f"{parameter.name}={example_value}")
+            flag = "-F" if use_multipart else "--data-urlencode"
+            return f"    {flag} " + shlex.quote(f"{parameter.name}={example_value}")
         return example_value
 
 
@@ -339,6 +345,10 @@ def generate_curl_example(
         auth_api_key = "ZULIP_ORG_KEY" if is_zilencer_endpoint else DEFAULT_AUTH_API_KEY
         lines.append("    -u " + shlex.quote(f"{auth_email}:{auth_api_key}"))
 
+    content = (operation_request_body or {}).get("content", {})
+    multipart_schema = content.get("multipart/form-data", {}).get("schema")
+    is_multipart = multipart_schema is not None
+
     for parameter in parameters:
         if parameter.kind == "path":
             continue
@@ -350,15 +360,16 @@ def generate_curl_example(
             continue
 
         example_value = get_openapi_param_example_value_as_string(
-            endpoint, method, parameter, curl_argument=True
+            endpoint, method, parameter, curl_argument=True, use_multipart=is_multipart
         )
         lines.append(example_value)
 
-    if "requestBody" in operation_entry and "multipart/form-data" in (
-        content := operation_entry["requestBody"]["content"]
-    ):
-        properties = content["multipart/form-data"]["schema"]["properties"]
-        for key, property in properties.items():
+    if is_multipart:
+        for key, property in multipart_schema["properties"].items():
+            if property.get("format") != "binary":
+                # Non-file properties are already rendered above, from
+                # get_openapi_parameters.
+                continue
             lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
 
     for i in range(1, len(lines) - 1):

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -224,7 +224,11 @@ def curl_method_arguments(endpoint: str, method: str, api_url: str) -> list[str]
 
 
 def get_openapi_param_example_value_as_string(
-    endpoint: str, method: str, parameter: Parameter, curl_argument: bool = False
+    endpoint: str,
+    method: str,
+    parameter: Parameter,
+    curl_argument: bool = False,
+    use_multipart: bool = False,
 ) -> str:
     if "type" in parameter.value_schema:
         param_type = parameter.value_schema["type"]
@@ -234,6 +238,8 @@ def get_openapi_param_example_value_as_string(
         # union type.  But for this logic's purpose, it's good enough
         # to just check the first parameter.
         param_type = parameter.value_schema["oneOf"][0]["type"]
+
+    flag = "-F" if use_multipart else "--data-urlencode"
 
     if param_type in ["object", "array"]:
         if parameter.example is NO_EXAMPLE:
@@ -246,7 +252,7 @@ cURL example."""
         # We currently don't have any non-JSON encoded arrays.
         assert parameter.json_encoded
         if curl_argument:
-            return "    --data-urlencode " + shlex.quote(f"{parameter.name}={ordered_ex_val_str}")
+            return f"    {flag} " + shlex.quote(f"{parameter.name}={ordered_ex_val_str}")
         return ordered_ex_val_str  # nocoverage
     else:
         if parameter.example is NO_EXAMPLE:
@@ -262,7 +268,7 @@ cURL example."""
             assert isinstance(example_value, str)
 
         if curl_argument:
-            return "    --data-urlencode " + shlex.quote(f"{parameter.name}={example_value}")
+            return f"    {flag} " + shlex.quote(f"{parameter.name}={example_value}")
         return example_value
 
 
@@ -340,6 +346,10 @@ def generate_curl_example(
         auth_api_key = "ZULIP_ORG_KEY" if is_zilencer_endpoint else DEFAULT_AUTH_API_KEY
         lines.append("    -u " + shlex.quote(f"{auth_email}:{auth_api_key}"))
 
+    content = (operation_request_body or {}).get("content", {})
+    multipart_schema = content.get("multipart/form-data", {}).get("schema")
+    is_multipart = multipart_schema is not None
+
     for parameter in parameters:
         if parameter.kind == "path":
             continue
@@ -351,15 +361,16 @@ def generate_curl_example(
             continue
 
         example_value = get_openapi_param_example_value_as_string(
-            endpoint, method, parameter, curl_argument=True
+            endpoint, method, parameter, curl_argument=True, use_multipart=is_multipart
         )
         lines.append(example_value)
 
-    if "requestBody" in operation_entry and "multipart/form-data" in (
-        content := operation_entry["requestBody"]["content"]
-    ):
-        properties = content["multipart/form-data"]["schema"]["properties"]
-        for key, property in properties.items():
+    if is_multipart:
+        for key, property in multipart_schema["properties"].items():
+            if property.get("format") != "binary":
+                # Non-file properties are already rendered above, from
+                # get_openapi_parameters.
+                continue
             lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
 
     for i in range(1, len(lines) - 1):

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -414,6 +414,33 @@ def get_openapi_parameters(
                 )
             )
 
+    if "requestBody" in operation and "multipart/form-data" in (
+        content := operation["requestBody"]["content"]
+    ):
+        media_type = content["multipart/form-data"]
+        required = media_type["schema"].get("required", [])
+        for key, schema in media_type["schema"]["properties"].items():
+            if schema.get("format") == "binary":
+                # File upload properties aren't typed_endpoint arguments.
+                continue
+            json_encoded = (
+                media_type.get("encoding", {}).get(key, {}).get("contentType") == "application/json"
+                or schema.get("type") == "object"
+            )
+
+            parameters.append(
+                Parameter(
+                    kind="formData",
+                    name=key,
+                    description=schema["description"],
+                    json_encoded=json_encoded,
+                    value_schema=schema,
+                    example=schema.get("example"),
+                    required=key in required,
+                    deprecated=schema.get("deprecated", False),
+                )
+            )
+
     return parameters
 
 

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -5,6 +5,7 @@
 # definitions and validate that Zulip's implementation matches what is
 # described in our documentation.
 
+import http.client
 import json
 import os
 import re
@@ -271,17 +272,21 @@ def generate_openapi_fixture(endpoint: str, method: str) -> list[str]:
     for status_code in sorted(
         openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"]
     ):
-        if (
-            "oneOf"
-            in openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][status_code][
-                "content"
-            ]["application/json"]["schema"]
-        ):
-            subschema_count = len(
-                openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][status_code][
-                    "content"
-                ]["application/json"]["schema"]["oneOf"]
-            )
+        response = openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][
+            status_code
+        ]
+        if "content" not in response:
+            # Redirect responses have no JSON body; render the status
+            # line and headers instead of a JSON fixture.
+            reason = http.client.responses.get(int(status_code), "")
+            fixture.append("``` http")
+            fixture.append(f"HTTP/1.1 {status_code} {reason}")
+            for header_name, header in response.get("headers", {}).items():
+                fixture.append(f"{header_name}: {header['example']}")
+            fixture.append("```")
+            continue
+        if "oneOf" in response["content"]["application/json"]["schema"]:
+            subschema_count = len(response["content"]["application/json"]["schema"]["oneOf"])
         else:
             subschema_count = 1
         for subschema_index in range(subschema_count):
@@ -414,7 +419,12 @@ def get_openapi_parameters(
 
 def get_openapi_return_values(endpoint: str, method: str) -> dict[str, Any]:
     operation = openapi_spec.openapi()["paths"][endpoint][method.lower()]
-    schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
+    response = operation["responses"].get("200")
+    if response is None or "content" not in response:
+        # No documented JSON success response (e.g., a redirect) means
+        # there are no return values to describe.
+        return {}
+    schema = response["content"]["application/json"]["schema"]
     # We do not currently have documented endpoints that have multiple schemas
     # ("oneOf", "anyOf", "allOf") for success ("200") responses. If this changes,
     # then the assertion below will need to be removed, and this function updated

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -5,6 +5,7 @@
 # definitions and validate that Zulip's implementation matches what is
 # described in our documentation.
 
+import http.client
 import json
 import os
 import re
@@ -278,17 +279,21 @@ def generate_openapi_fixture(endpoint: str, method: str) -> list[str]:
     for status_code in sorted(
         openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"]
     ):
-        if (
-            "oneOf"
-            in openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][status_code][
-                "content"
-            ]["application/json"]["schema"]
-        ):
-            subschema_count = len(
-                openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][status_code][
-                    "content"
-                ]["application/json"]["schema"]["oneOf"]
-            )
+        response = openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][
+            status_code
+        ]
+        if "content" not in response:
+            # Redirect responses have no JSON body; render the status
+            # line and headers instead of a JSON fixture.
+            reason = http.client.responses.get(int(status_code), "")
+            fixture.append("``` http")
+            fixture.append(f"HTTP/1.1 {status_code} {reason}")
+            for header_name, header in response.get("headers", {}).items():
+                fixture.append(f"{header_name}: {header['example']}")
+            fixture.append("```")
+            continue
+        if "oneOf" in response["content"]["application/json"]["schema"]:
+            subschema_count = len(response["content"]["application/json"]["schema"]["oneOf"])
         else:
             subschema_count = 1
         for subschema_index in range(subschema_count):
@@ -421,7 +426,12 @@ def get_openapi_parameters(
 
 def get_openapi_return_values(endpoint: str, method: str) -> dict[str, Any]:
     operation = openapi_spec.openapi()["paths"][endpoint][method.lower()]
-    schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
+    response = operation["responses"].get("200")
+    if response is None or "content" not in response:
+        # No documented JSON success response (e.g., a redirect) means
+        # there are no return values to describe.
+        return {}
+    schema = response["content"]["application/json"]["schema"]
     # We do not currently have documented endpoints that have multiple schemas
     # ("oneOf", "anyOf", "allOf") for success ("200") responses. If this changes,
     # then the assertion below will need to be removed, and this function updated

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -396,17 +396,20 @@ def get_openapi_parameters(
             )
         )
 
-    if "requestBody" in operation and "application/x-www-form-urlencoded" in (
-        content := operation["requestBody"]["content"]
-    ):
-        media_type = content["application/x-www-form-urlencoded"]
+    request_body = operation.get("requestBody", {})
+    for content_type in ("application/x-www-form-urlencoded", "multipart/form-data"):
+        if content_type not in request_body.get("content", {}):
+            continue
+        media_type = request_body["content"][content_type]
         required = media_type["schema"].get("required", [])
         for key, schema in media_type["schema"]["properties"].items():
+            if schema.get("format") == "binary":
+                # File upload properties aren't typed_endpoint arguments.
+                continue
             json_encoded = (
-                "encoding" in media_type
-                and key in (encodings := media_type["encoding"])
-                and encodings[key].get("contentType") == "application/json"
-            ) or schema.get("type") == "object"
+                media_type.get("encoding", {}).get(key, {}).get("contentType") == "application/json"
+                or schema.get("type") == "object"
+            )
 
             parameters.append(
                 Parameter(

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -40,6 +40,8 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "create-constructor-groups-video-call",
     "create-nextcloud-talk-video-call",
     "create-webex-video-call",
+    # Redirects to the organization's icon rather than returning JSON.
+    "get-realm-icon",
 }
 
 

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -42,6 +42,8 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "create-webex-video-call",
     # Redirects to the organization's icon rather than returning JSON.
     "get-realm-icon",
+    # Redirects to the organization's logo rather than returning JSON.
+    "get-realm-logo",
 }
 
 

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -44,6 +44,8 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     # realm used by the test server, breaking the curl examples that
     # run after it.
     "deactivate-realm",
+    # Redirects to the organization's icon rather than returning JSON.
+    "get-realm-icon",
 }
 
 

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -46,6 +46,8 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "deactivate-realm",
     # Redirects to the organization's icon rather than returning JSON.
     "get-realm-icon",
+    # Redirects to the organization's logo rather than returning JSON.
+    "get-realm-logo",
 }
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15188,6 +15188,177 @@ paths:
               schema:
                 type: string
               example: "/user_avatars/2/realm/icon.png?version=2"
+  /realm/logo:
+    post:
+      operationId: upload-realm-logo
+      summary: Upload an organization logo
+      tags: ["server_and_organizations"]
+      description: |
+        [Change the organization's wide logo](/help/create-your-organization-profile#add-a-wide-logo).
+
+        The maximum allowed file size is available in the `max_logo_file_size_mib`
+        field in the [`POST /register`](/api/register-queue) response.
+
+        On Zulip Cloud, this endpoint requires an organization to be on a
+        [Zulip Cloud Standard](https://zulip.com/plans/) plan or higher.
+      x-requires-administrator: true
+      x-parameter-description: |
+        The logo image file must be provided in the request's body as
+        multipart form data.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  example: "zerver/tests/images/img.png"
+                night:
+                  allOf:
+                    - $ref: "#/components/schemas/Night"
+                  description: |
+                    Whether to change the organization's dark theme wide logo,
+                    instead of its default (light theme) wide logo.
+              required:
+                - file
+                - night
+            encoding:
+              night:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the organization's plan does
+                          not support a custom wide logo:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Available on Zulip Cloud Standard. Upgrade to access.",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the request did not include
+                          exactly one file:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "You must upload exactly one logo.",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file exceeds the
+                          maximum allowed size:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Uploaded file is larger than the allowed limit of 5 MiB",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file has an
+                          unsupported format:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Invalid image format",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file cannot be
+                          decoded as an image:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Could not decode image; did you upload an image file?",
+                            "result": "error",
+                          }
+    delete:
+      operationId: delete-realm-logo
+      summary: Delete an organization logo
+      tags: ["server_and_organizations"]
+      description: |
+        Delete the organization's uploaded
+        [wide logo](/help/create-your-organization-profile#add-a-wide-logo),
+        reverting it to the default Zulip logo.
+      x-requires-administrator: true
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                night:
+                  allOf:
+                    - $ref: "#/components/schemas/Night"
+                  description: |
+                    Whether to delete the organization's dark theme wide logo,
+                    instead of its default (light theme) wide logo.
+              required:
+                - night
+            encoding:
+              night:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+    get:
+      operationId: get-realm-logo
+      summary: Get an organization logo
+      tags: ["server_and_organizations"]
+      description: |
+        Get the organization's current
+        [wide logo](/help/create-your-organization-profile#add-a-wide-logo).
+
+        Redirects to the logo's current image URL. Any authenticated user in
+        the organization can use this endpoint.
+      x-response-description: |
+        This endpoint responds with an HTTP 302 redirect to the logo's
+        current image URL, provided in the `Location` header, rather than
+        a JSON body.
+      parameters:
+        - name: night
+          in: query
+          description: |
+            Whether to fetch the organization's dark theme wide logo,
+            instead of its default (light theme) wide logo.
+          schema:
+            type: boolean
+          example: false
+          required: true
+      responses:
+        "302":
+          description: |
+            Found. Redirects to the organization's current wide logo image.
+          headers:
+            Location:
+              description: |
+                The URL of the organization's current wide logo image.
+              schema:
+                type: string
+              example: "/user_avatars/2/realm/logo.png?version=2&night=false"
   /realm/profile_fields:
     get:
       operationId: get-custom-profile-fields
@@ -30991,6 +31162,9 @@ components:
 
         **Changes**: New in Zulip 13.0 (feature level 507).
       example: true
+    Night:
+      type: boolean
+      example: false
     TopicsPolicy:
       type: string
       enum:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15032,6 +15032,162 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /realm/icon:
+    post:
+      operationId: upload-realm-icon
+      summary: Upload an organization icon
+      tags: ["server_and_organizations"]
+      description: |
+        [Change the organization's icon](/help/create-your-organization-profile#edit-organization-profile).
+
+        The maximum allowed file size is available in the `max_icon_file_size_mib`
+        field in the [`POST /register`](/api/register-queue) response.
+      x-requires-administrator: true
+      x-parameter-description: |
+        The icon image file must be provided in the request's body as
+        multipart form data.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  example: "zerver/tests/images/img.png"
+              required:
+                - file
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      icon_url:
+                        type: string
+                        description: |
+                          The URL of the organization's new icon.
+                example:
+                  {
+                    "icon_url": "/user_avatars/2/realm/icon.png?version=2",
+                    "msg": "",
+                    "result": "success",
+                  }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the request did not include
+                          exactly one file:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "You must upload exactly one icon.",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file exceeds the
+                          maximum allowed size:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Uploaded file is larger than the allowed limit of 5 MiB",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file has an
+                          unsupported format:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Invalid image format",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file cannot be
+                          decoded as an image:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Could not decode image; did you upload an image file?",
+                            "result": "error",
+                          }
+    delete:
+      operationId: delete-realm-icon
+      summary: Delete an organization icon
+      tags: ["server_and_organizations"]
+      description: |
+        Delete the organization's uploaded
+        [icon](/help/create-your-organization-profile#edit-organization-profile),
+        reverting it to its default icon.
+      x-requires-administrator: true
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      icon_url:
+                        type: string
+                        description: |
+                          The URL of the organization's default icon.
+                example:
+                  {
+                    "icon_url": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
+                    "msg": "",
+                    "result": "success",
+                  }
+    get:
+      operationId: get-realm-icon
+      summary: Get an organization icon
+      tags: ["server_and_organizations"]
+      description: |
+        Get the organization's current
+        [icon](/help/create-your-organization-profile#edit-organization-profile).
+
+        Redirects to the icon's current image URL. Any authenticated user in
+        the organization can use this endpoint.
+      x-response-description: |
+        This endpoint responds with an HTTP 302 redirect to the icon's
+        current image URL, provided in the `Location` header, rather than
+        a JSON body.
+      responses:
+        "302":
+          description: |
+            Found. Redirects to the organization's current icon image.
+          headers:
+            Location:
+              description: |
+                The URL of the organization's current icon image.
+              schema:
+                type: string
+              example: "/user_avatars/2/realm/icon.png?version=2"
   /realm/profile_fields:
     get:
       operationId: get-custom-profile-fields

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15373,6 +15373,176 @@ paths:
               schema:
                 type: string
               example: "/user_avatars/2/realm/icon.png?version=2"
+  /realm/logo:
+    post:
+      operationId: upload-realm-logo
+      summary: Upload an organization logo
+      tags: ["server_and_organizations"]
+      description: |
+        [Change the organization's wide logo](/help/create-your-organization-profile#add-a-wide-logo).
+
+        The maximum allowed file size is available in the `max_logo_file_size_mib`
+        field in the [`POST /register`](/api/register-queue) response.
+
+        On Zulip Cloud, this endpoint requires an organization to be on a
+        [Zulip Cloud Standard](https://zulip.com/plans/) plan or higher.
+      x-requires-administrator: true
+      x-parameter-description: |
+        The logo image file must be provided in the request's body as
+        multipart form data.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  example: "zerver/tests/images/img.png"
+                night:
+                  type: boolean
+                  description: |
+                    Whether to change the organization's dark theme wide logo,
+                    instead of its default (light theme) wide logo.
+                  example: false
+              required:
+                - file
+                - night
+            encoding:
+              night:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the organization's plan does
+                          not support a custom wide logo:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Available on Zulip Cloud Standard. Upgrade to access.",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the request did not include
+                          exactly one file:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "You must upload exactly one logo.",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file exceeds the
+                          maximum allowed size:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Uploaded file is larger than the allowed limit of 5 MiB",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file has an
+                          unsupported format:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Invalid image format",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file cannot be
+                          decoded as an image:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Could not decode image; did you upload an image file?",
+                            "result": "error",
+                          }
+    delete:
+      operationId: delete-realm-logo
+      summary: Delete an organization logo
+      tags: ["server_and_organizations"]
+      description: |
+        Delete the organization's uploaded
+        [wide logo](/help/create-your-organization-profile#add-a-wide-logo),
+        reverting it to the default Zulip logo.
+      x-requires-administrator: true
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                night:
+                  type: boolean
+                  description: |
+                    Whether to delete the organization's dark theme wide logo,
+                    instead of its default (light theme) wide logo.
+                  example: false
+              required:
+                - night
+            encoding:
+              night:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+    get:
+      operationId: get-realm-logo
+      summary: Get an organization logo
+      tags: ["server_and_organizations"]
+      description: |
+        Get the organization's current
+        [wide logo](/help/create-your-organization-profile#add-a-wide-logo).
+
+        Redirects to the logo's current image URL.
+      x-response-description: |
+        This endpoint responds with an HTTP 302 redirect to the logo's
+        current image URL, provided in the `Location` header, rather than
+        a JSON body.
+      parameters:
+        - name: night
+          in: query
+          description: |
+            Whether to fetch the organization's dark theme wide logo,
+            instead of its default (light theme) wide logo.
+          schema:
+            type: boolean
+          example: false
+          required: true
+      responses:
+        "302":
+          description: |
+            Found. Redirects to the organization's current wide logo image.
+          headers:
+            Location:
+              description: |
+                The URL of the organization's current wide logo image.
+              schema:
+                type: string
+              example: "/user_avatars/2/realm/logo.png?version=2&night=false"
   /realm/profile_fields:
     get:
       operationId: get-custom-profile-fields

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15218,6 +15218,161 @@ paths:
                             "msg": "Invalid data deletion time for demo organization.",
                             "result": "error",
                           }
+  /realm/icon:
+    post:
+      operationId: upload-realm-icon
+      summary: Upload an organization icon
+      tags: ["server_and_organizations"]
+      description: |
+        [Change the organization's icon](/help/create-your-organization-profile#edit-organization-profile).
+
+        The maximum allowed file size is available in the `max_icon_file_size_mib`
+        field in the [`POST /register`](/api/register-queue) response.
+      x-requires-administrator: true
+      x-parameter-description: |
+        The icon image file must be provided in the request's body as
+        multipart form data.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  example: "zerver/tests/images/img.png"
+              required:
+                - file
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      icon_url:
+                        type: string
+                        description: |
+                          The URL of the organization's new icon.
+                example:
+                  {
+                    "icon_url": "/user_avatars/2/realm/icon.png?version=2",
+                    "msg": "",
+                    "result": "success",
+                  }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the request did not include
+                          exactly one file:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "You must upload exactly one icon.",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file exceeds the
+                          maximum allowed size:
+                        example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Uploaded file is larger than the allowed limit of 5 MiB",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file has an
+                          unsupported format:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Invalid image format",
+                            "result": "error",
+                          }
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - description: |
+                          An example JSON response for when the uploaded file cannot be
+                          decoded as an image:
+                        example:
+                          {
+                            "code": "BAD_IMAGE",
+                            "msg": "Could not decode image; did you upload an image file?",
+                            "result": "error",
+                          }
+    delete:
+      operationId: delete-realm-icon
+      summary: Delete an organization icon
+      tags: ["server_and_organizations"]
+      description: |
+        Delete the organization's uploaded
+        [icon](/help/create-your-organization-profile#edit-organization-profile),
+        reverting it to its default icon.
+      x-requires-administrator: true
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      icon_url:
+                        type: string
+                        description: |
+                          The URL of the organization's default icon.
+                example:
+                  {
+                    "icon_url": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
+                    "msg": "",
+                    "result": "success",
+                  }
+    get:
+      operationId: get-realm-icon
+      summary: Get an organization icon
+      tags: ["server_and_organizations"]
+      description: |
+        Get the organization's current
+        [icon](/help/create-your-organization-profile#edit-organization-profile).
+
+        Redirects to the icon's current image URL.
+      x-response-description: |
+        This endpoint responds with an HTTP 302 redirect to the icon's
+        current image URL, provided in the `Location` header, rather than
+        a JSON body.
+      responses:
+        "302":
+          description: |
+            Found. Redirects to the organization's current icon image.
+          headers:
+            Location:
+              description: |
+                The URL of the organization's current icon image.
+              schema:
+                type: string
+              example: "/user_avatars/2/realm/icon.png?version=2"
   /realm/profile_fields:
     get:
       operationId: get-custom-profile-fields

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -231,7 +231,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
         "/realm/profile_fields/{field_id}",
-        "/realm/icon",
         "/realm/logo",
         "/realm/deactivate",
         "/realm/subdomain/{subdomain}",
@@ -940,6 +939,11 @@ class OpenAPIAttributesTest(ZulipTestCase):
                 tag = operation["tags"][0]
                 assert tag in VALID_TAGS
                 for status_code, response in operation["responses"].items():
+                    if status_code.startswith("3"):
+                        # Redirect responses only set a Location header;
+                        # they have no JSON body to validate.
+                        assert "content" not in response
+                        continue
                     schema = response["content"]["application/json"]["schema"]
                     # Validate the documented examples for each event type
                     # in api/get-events for the documented event schemas.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -231,7 +231,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
         "/realm/profile_fields/{field_id}",
-        "/realm/logo",
         "/realm/deactivate",
         "/realm/subdomain/{subdomain}",
         # API for Zoom video calls.  Unclear if this can support other apps.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -627,6 +627,46 @@ class TestCurlExampleGeneration(ZulipTestCase):
         },
     }
 
+    spec_mock_with_multipart_and_extra_param = {
+        "security": [{"basicAuth": []}],
+        "paths": {
+            "/endpoint": {
+                "post": {
+                    "description": "Upload something, with an extra parameter.",
+                    "parameters": [
+                        {
+                            "name": "night",
+                            "in": "query",
+                            "description": "Whether to use the night version.",
+                            "schema": {
+                                "type": "boolean",
+                            },
+                            "example": False,
+                            "required": True,
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "file": {
+                                            "type": "string",
+                                            "format": "binary",
+                                            "example": "path/to/file.png",
+                                        },
+                                    },
+                                    "required": ["file"],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
     spec_mock_with_invalid_method: dict[str, object] = {
         "security": [{"basicAuth": []}],
         "paths": {
@@ -784,6 +824,22 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream_id=1 \\",
             "    --data-urlencode bool_param=false",
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+    @patch("zerver.openapi.openapi.OpenAPISpec.openapi")
+    def test_generate_and_render_curl_with_multipart_and_extra_param(
+        self, spec_mock: MagicMock
+    ) -> None:
+        spec_mock.return_value = self.spec_mock_with_multipart_and_extra_param
+        generated_curl_example = self.curl_example("/endpoint", "POST")
+        expected_curl_example = [
+            "```curl",
+            "curl -sSX POST http://localhost:9991/api/v1/endpoint \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    -F night=false \\",
+            "    -F file=@path/to/file.png",
             "```",
         ]
         self.assertEqual(generated_curl_example, expected_curl_example)

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -228,7 +228,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots",
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
-        "/realm/logo",
         "/realm/subdomain/{subdomain}",
         # API for Zoom video calls.  Unclear if this can support other apps.
         "/calls/zoom/create",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -228,7 +228,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/bots",
         "/bots/{bot_id}",
         #### These "organization settings" endpoints have low value to document:
-        "/realm/icon",
         "/realm/logo",
         "/realm/subdomain/{subdomain}",
         # API for Zoom video calls.  Unclear if this can support other apps.
@@ -936,6 +935,11 @@ class OpenAPIAttributesTest(ZulipTestCase):
                 tag = operation["tags"][0]
                 assert tag in VALID_TAGS
                 for status_code, response in operation["responses"].items():
+                    if status_code.startswith("3"):
+                        # Redirect responses only set a Location header;
+                        # they have no JSON body to validate.
+                        assert "content" not in response
+                        continue
                     schema = response["content"]["application/json"]["schema"]
                     # Validate the documented examples for each event type
                     # in api/get-events for the documented event schemas.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -623,6 +623,42 @@ class TestCurlExampleGeneration(ZulipTestCase):
         },
     }
 
+    spec_mock_with_multipart_and_extra_param = {
+        "security": [{"basicAuth": []}],
+        "paths": {
+            "/endpoint": {
+                "post": {
+                    "description": "Upload something, with an extra parameter.",
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "night": {
+                                            "type": "boolean",
+                                            "description": "Whether to use the night version.",
+                                            "example": False,
+                                        },
+                                        "file": {
+                                            "type": "string",
+                                            "format": "binary",
+                                            "example": "path/to/file.png",
+                                        },
+                                    },
+                                    "required": ["file", "night"],
+                                },
+                                "encoding": {
+                                    "night": {"contentType": "application/json"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
     spec_mock_with_invalid_method: dict[str, object] = {
         "security": [{"basicAuth": []}],
         "paths": {
@@ -780,6 +816,22 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "    -u EMAIL_ADDRESS:API_KEY \\",
             "    --data-urlencode stream_id=1 \\",
             "    --data-urlencode bool_param=false",
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+    @patch("zerver.openapi.openapi.OpenAPISpec.openapi")
+    def test_generate_and_render_curl_with_multipart_and_extra_param(
+        self, spec_mock: MagicMock
+    ) -> None:
+        spec_mock.return_value = self.spec_mock_with_multipart_and_extra_param
+        generated_curl_example = self.curl_example("/endpoint", "POST")
+        expected_curl_example = [
+            "```curl",
+            "curl -sSX POST http://localhost:9991/api/v1/endpoint \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    -F night=false \\",
+            "    -F file=@path/to/file.png",
             "```",
         ]
         self.assertEqual(generated_curl_example, expected_curl_example)


### PR DESCRIPTION
Documents the `/realm/icon` and `/realm/logo` endpoints (POST, DELETE, and GET for each) in the OpenAPI spec and removes them from `pending_endpoints`.

**Note to maintainers:**

- `night` is declared three different ways on `/realm/logo` (query param for GET, multipart property for POST, x-www-form-urlencoded property for DELETE) to match how each method actually sends it on the wire -- `client_delete` always sends form-urlencoded regardless of what's passed to it. Needed a small prep commit teaching `get_openapi_parameters`/the curl generator about a parameter alongside a file upload, since no multipart endpoint needed one before.
- POST's and DELETE's `night` share a shape, so that part's deduped into a `components.schemas.Night` fragment via `allOf` (keeps each operation's own wording). GET's stays inline -- it's the only query-param instance, nothing to dedupe against yet.
- Fixed a wrong error code: icon/logo's 400 examples said `BAD_REQUEST` for "invalid format"/"can't decode", but `BadImageError` actually returns `BAD_IMAGE` (matches avatar's docs). Slipped through since `code` has no `enum` and our tests only assert on `msg`.
- Touches three spots in `openapi.py`/`test_openapi.py` that assumed every response has a JSON body -- not true for these two GET endpoints (302 redirects instead). Shared code, worth a second look.



**How changes were tested:**

- [x] `./tools/test-backend zerver.tests.test_openapi`
- [x] `./tools/test-backend` 
- [x] `./tools/lint`
- [x] `./tools/test-api`
- [x] Rendered all six pages locally (screenshots below)

<details>
<summary>Screenshots and screen captures</summary>

Upload an organization icon:

<img width="1400" height="1881" alt="upload-realm-icon-api-doc" src="https://github.com/user-attachments/assets/37d5ba38-ba6b-4275-a951-6464049ab295" />

Delete an organization icon:

<img width="1400" height="1123" alt="delete-realm-icon-api-doc" src="https://github.com/user-attachments/assets/cf123c3e-6504-4d1b-b103-f46e2d2f87ef" />

Get an organization icon:

<img width="1400" height="937" alt="get-realm-icon-api-doc" src="https://github.com/user-attachments/assets/b7996370-85aa-4cc0-a866-9a8bf3fcb4b2" />

Upload an organization logo:

<img width="1400" height="2120" alt="upload-realm-logo-api-doc" src="https://github.com/user-attachments/assets/bfe94636-8459-451a-9d18-b516db46fbb5" />
Delete an organization logo:

<img width="1400" height="1089" alt="delete-realm-logo-api-doc" src="https://github.com/user-attachments/assets/1616552c-5802-40b4-97f3-ee99068853c6" />

Get an organization logo:

<img width="1400" height="1022" alt="get-realm-logo-api-doc" src="https://github.com/user-attachments/assets/cacd235b-e830-4d79-9c0f-21e35011ba18" />

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
