### PR TITLE
edit-history: Fix server message edit history schema in web app.

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -50,8 +50,8 @@ type EditHistoryEntry = {
 const server_message_history_schema = z.object({
     message_history: z.array(
         z.object({
-            content: z.string(),
-            rendered_content: z.string(),
+            content: z.optional(z.string()),
+            rendered_content: z.optional(z.string()),
             timestamp: z.number(),
             topic: z.string(),
             user_id: z.nullable(z.number()),


### PR DESCRIPTION
In commit c7ddd7884a, the server stopped sending the `content` and `rendered_content` fields for realms that had set the visibility policy for message edits to show message moves only (`message_edit_history_visibility_policy.moves_only`) in a message's edit history object.

This updates the web app code so that the schema expected from the server has those fields marked as optional.

**Notes**:
- Did a `git-bisect` to confirm the commit where the message edit history modal stopped working in the web app.
- We should also update the API documentation for the change in  commit c7ddd7884a, but I'm planning on doing that in a separate pull request as I'm not sure what feature level to put that in and I don't want to delay getting this bug fix merged.

*Manual testing notes*:
- Switch Zulip dev organization's "Allow viewing the history of a message?" setting to "Moves only"
- Send a message in dev
- Move the message to a new channel
- Open the message edit history

---

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="2264" height="928" alt="Screenshot From 2026-07-03 20-48-48" src="https://github.com/user-attachments/assets/530c8aa9-bde0-4043-a0d5-55321a5d4d52" /> | <img width="2264" height="928" alt="Screenshot From 2026-07-03 20-49-01" src="https://github.com/user-attachments/assets/353a8e8d-9fd2-421f-bef2-120997d6afb3" /> |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
