### PR TITLE
settings: Compute time zone UTC offsets on the client

### DIFF
--- a/tools/setup/build_timezone_values
+++ b/tools/setup/build_timezone_values
@@ -3,7 +3,6 @@ import json
 import os
 import sys
 import zoneinfo
-from datetime import datetime, timedelta
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 sys.path.insert(0, ZULIP_PATH)
@@ -12,35 +11,14 @@ from zerver.lib.timezone import get_canonical_timezone_map
 
 OUT_PATH = os.path.join(ZULIP_PATH, "web", "generated", "timezones.json")
 
-
-def get_utc_offset(tz_name: str) -> str:
-    """Get UTC offset for a timezone in the format UTC(+HH:MM)."""
-    try:
-        now = datetime.now(zoneinfo.ZoneInfo(tz_name))
-        offset: timedelta | None = now.utcoffset()
-
-        if offset is None:
-            return "UTC(+00:00)"
-
-        offset_seconds = offset.total_seconds()
-        hours, remainder = divmod(offset_seconds, 3600)
-        minutes = remainder // 60
-        if minutes == 0:
-            return f"UTC{int(hours):+d}"
-        return f"UTC{int(hours):+d}:{int(minutes):02d}"
-
-    except Exception as e:
-        print(f"Error processing {tz_name}: {e}")
-        return "UTC(?)"
-
-
-timezones = sorted(
-    zoneinfo.available_timezones() - {"Factory", "localtime"} - set(get_canonical_timezone_map())
-)
-
-
-timezone_data = [{"name": tz, "utc_offset": get_utc_offset(tz)} for tz in timezones]
-
-
 with open(OUT_PATH, "w") as f:
-    json.dump({"timezones": timezone_data}, f)
+    json.dump(
+        {
+            "timezones": sorted(
+                zoneinfo.available_timezones()
+                - {"Factory", "localtime"}
+                - set(get_canonical_timezone_map())
+            )
+        },
+        f,
+    )

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 506
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (383, 0)  # bumped 2026-07-03 to upgrade Python requirements
+PROVISION_VERSION = (384, 0)  # bumped 2026-07-04 to update build_timezone_values

--- a/web/src/settings.ts
+++ b/web/src/settings.ts
@@ -2,7 +2,6 @@ import {parseISO} from "date-fns";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
-import timezones from "../generated/timezones.json";
 import render_settings_overlay from "../templates/settings_overlay.hbs";
 import render_settings_tab from "../templates/settings_tab.hbs";
 
@@ -109,7 +108,6 @@ export function build_page(): void {
             user_settings.enable_sounds || user_settings.enable_stream_audible_notifications,
         zuliprc: "zuliprc",
         botserverrc: "botserverrc",
-        timezones: timezones.timezones,
         can_create_new_bots: settings_bots.can_create_incoming_webhooks(),
         settings_label,
         demote_inactive_streams_values: settings_config.demote_inactive_streams_values,

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -32,6 +32,7 @@ import * as settings_data from "./settings_data.ts";
 import * as settings_org from "./settings_org.ts";
 import * as settings_ui from "./settings_ui.ts";
 import {current_user, realm} from "./state_data.ts";
+import * as timerender from "./timerender.ts";
 import * as ui_report from "./ui_report.ts";
 import * as ui_util from "./ui_util.ts";
 import * as user_deactivation_ui from "./user_deactivation_ui.ts";
@@ -309,9 +310,10 @@ export function update_privacy_settings_box(property: PrivacySettingName): void 
 }
 
 export function render_user_timezone_dropdown_widget(): void {
-    const timezone_items = timezones.timezones.map((tz: {name: string; utc_offset: string}) => ({
-        name: `${tz.name} (${tz.utc_offset})`,
-        unique_id: tz.name,
+    const now = new Date();
+    const timezone_items = timezones.timezones.map((tz) => ({
+        name: `${tz} (${timerender.get_utc_offset_string(tz, now)})`,
+        unique_id: tz,
     }));
 
     const opts: dropdown_widget.DropdownWidgetOptions = {

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -158,6 +158,15 @@ export function get_localized_date_or_time_for_format(
     return formatter_map.get(format_key)!.format(date);
 }
 
+// Returns the UTC offset of the given time zone at the given time,
+// formatted like "UTC+05:30".
+export function get_utc_offset_string(time_zone: string, time: Date): string {
+    const offset_minutes = tzOffset(time_zone, time);
+    return `UTC${offset_minutes < 0 ? "-" : "+"}${String(
+        Math.floor(Math.abs(offset_minutes) / 60),
+    ).padStart(2, "0")}:${String(Math.abs(offset_minutes) % 60).padStart(2, "0")}`;
+}
+
 // Exported for tests only.
 export function get_tz_with_UTC_offset(time: Date): string {
     let timezone = new Intl.DateTimeFormat(user_settings.default_language, {
@@ -176,10 +185,7 @@ export function get_tz_with_UTC_offset(time: Date): string {
     // show that along with (UTC+x:y)
     timezone = /GMT[+-][\d:]*/.test(timezone ?? "") ? "" : timezone;
 
-    const offset_minutes = tzOffset(display_time_zone, time);
-    const tz_UTC_offset = `(UTC${offset_minutes < 0 ? "-" : "+"}${String(
-        Math.floor(Math.abs(offset_minutes) / 60),
-    ).padStart(2, "0")}:${String(Math.abs(offset_minutes) % 60).padStart(2, "0")})`;
+    const tz_UTC_offset = `(${get_utc_offset_string(display_time_zone, time)})`;
 
     if (timezone) {
         return timezone + " " + tz_UTC_offset;

--- a/web/tests/timerender.test.cjs
+++ b/web/tests/timerender.test.cjs
@@ -193,6 +193,19 @@ run_test("get_tz_with_UTC_offset", () => {
     timerender.set_display_time_zone("UTC");
 });
 
+run_test("get_utc_offset_string", () => {
+    // Offsets depend on the date: standard time vs. daylight saving time.
+    assert.equal(timerender.get_utc_offset_string("America/New_York", date_2025), "UTC-05:00");
+    assert.equal(timerender.get_utc_offset_string("America/New_York", date_2019), "UTC-04:00");
+
+    // Fractional-hour offsets, positive and negative.
+    assert.equal(timerender.get_utc_offset_string("Asia/Kolkata", date_2025), "UTC+05:30");
+    assert.equal(timerender.get_utc_offset_string("America/St_Johns", date_2025), "UTC-03:30");
+    assert.equal(timerender.get_utc_offset_string("America/St_Johns", date_2019), "UTC-02:30");
+
+    assert.equal(timerender.get_utc_offset_string("UTC", date_2025), "UTC+00:00");
+});
+
 run_test("render_now_returns_today", () => {
     clock.setSystemTime(date_2019.getTime());
 


### PR DESCRIPTION
Commit b0844109ca67f6e2385874620b74ad5c7f5b006f “settings: Show UTC offsets in timezone dropdown” (#33609) baked a fixed UTC offset for each time zone into the generated `timezones.json` at installation time. UTC offsets are not constants: they change with daylight saving time (and tzdata updates), so the baked values were wrong for much of the year. The Python formatting was also incorrect for zones with negative fractional-hour offsets (`divmod` rounds toward negative infinity, so America/St_Johns at UTC-03:30 rendered as UTC-4:30).

Revert the generated file to a plain list of names, and compute each offset in the web app when the picker is rendered, reusing the UTC±HH:MM formatting that message timestamp tooltips use. Computing all 446 offsets takes ~50ms the first time and ~1ms once `@date-fns/tz` has cached its formatters.