### PR TITLE
compose: Quote partial content at multi-message selection bookends.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -174,6 +174,7 @@ EXEMPT_FILES = make_set(
         "web/src/message_report.ts",
         "web/src/message_scroll.ts",
         "web/src/message_scroll_state.ts",
+        "web/src/message_selection_content.ts",
         "web/src/message_summary.ts",
         "web/src/message_util.ts",
         "web/src/message_view.ts",

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -245,7 +245,7 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
         // w/o partial selection: "copy paste test B",
-        "...paste test B",
+        "[...]paste test B",
         "Verona > copy-paste-topic #2 | Today",
         "Desdemona:",
         "copy paste test C",
@@ -256,7 +256,7 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
         "Verona > copy-paste-topic #3 | Today",
         "Desdemona:",
         // w/o partial selection: "copy paste test F",
-        "copy paste...",
+        "copy paste[...]",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -248,7 +248,7 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
         // w/o partial selection: "copy paste test B",
-        "...paste test B",
+        "[...]paste test B",
         "Verona > copy-paste-topic #2 | Today",
         "Desdemona:",
         "copy paste test C",
@@ -259,7 +259,7 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
         "Verona > copy-paste-topic #3 | Today",
         "Desdemona:",
         // w/o partial selection: "copy paste test F",
-        "copy paste...",
+        "copy paste[...]",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
@@ -313,7 +313,7 @@ async function test_copying_selection_with_no_message_content(page: Page): Promi
 
 async function test_partial_me_bookend_copy_includes_ellipsis(page: Page): Promise<void> {
     // A partial `/me` bookend should copy the selected status text with
-    // the same `...` marker as a normal bookend.
+    // the same `[...]` marker as a normal bookend.
     const actual_first = await copy_messages(
         page,
         "waves at the camera for status bookend",
@@ -328,9 +328,9 @@ async function test_partial_me_bookend_copy_includes_ellipsis(page: Page): Promi
     );
     assert.deepStrictEqual(actual_first, [
         "Desdemona:",
-        "...camera for status bookend",
+        "[...]camera for status bookend",
         "Desdemona:",
-        "BBB after first status message brav...",
+        "BBB after first status message brav[...]",
     ]);
 
     const actual_last = await copy_messages(
@@ -347,9 +347,9 @@ async function test_partial_me_bookend_copy_includes_ellipsis(page: Page): Promi
     );
     assert.deepStrictEqual(actual_last, [
         "Desdemona:",
-        "...start normal message alpha",
+        "[...]start normal message alpha",
         "Desdemona:",
-        "waves at the camera for status...",
+        "waves at the camera for status[...]",
     ]);
 }
 

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -245,7 +245,7 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
         // w/o partial selection: "copy paste test B",
-        "[...]paste test B",
+        "[...]\u{200B}paste test B",
         "Verona > copy-paste-topic #2 | Today",
         "Desdemona:",
         "copy paste test C",
@@ -257,6 +257,31 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
         "Desdemona:",
         // w/o partial selection: "copy paste test F",
         "copy paste[...]",
+    ];
+    assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
+}
+
+async function test_partial_bookend_before_url_keeps_raw_link(page: Page): Promise<void> {
+    // Selection starts at the "(" before an auto-linked URL. Without a
+    // zero-width space after the start ellipsis, the bookend would look
+    // like a markdown link labeled "...".
+    const actual_copied_lines = await copy_messages(
+        page,
+        "Prefix before paren (https://example.com) trailing words",
+        "Second message after partial URL bookend",
+        {
+            select_start_message_partially: true,
+            select_end_message_partially: false,
+            // Offset of "(" in the leading text node.
+            start_text_node_offset: 20,
+        },
+    );
+    const expected_copied_lines = [
+        "Desdemona:",
+        // without ZWSP: [...](https://example.com) trailing words
+        "[...]\u{200B}(https://example.com) trailing words",
+        "Desdemona:",
+        "Second message after partial URL bookend",
     ];
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
@@ -283,6 +308,18 @@ async function copy_paste_test(page: Page): Promise<void> {
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test F"},
 
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test G"},
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "Prefix before paren (https://example.com) trailing words",
+        },
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "Second message after partial URL bookend",
+        },
     ]);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
@@ -295,6 +332,13 @@ async function copy_paste_test(page: Page): Promise<void> {
             ["copy paste test C", "copy paste test D", "copy paste test E"],
         ],
         ["Verona > copy-paste-topic #3", ["copy paste test F", "copy paste test G"]],
+        [
+            "Verona > copy-paste-topic #4",
+            [
+                "Prefix before paren (https://example.com) trailing words",
+                "Second message after partial URL bookend",
+            ],
+        ],
     ]);
     console.log("Messages were sent successfully");
 
@@ -308,6 +352,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_messages_from_several_topics(page);
     await test_timestamp_clipboard_has_datetime(page);
     await test_multiple_message_selection_with_partially_selected_bookend_messages(page);
+    await test_partial_bookend_before_url_keeps_raw_link(page);
 }
 
 await common.run_test(copy_paste_test);

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -261,6 +261,53 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
+async function test_copying_selection_with_no_message_content(page: Page): Promise<void> {
+    // A recipient header plus the first message's sender name has no
+    // `.message_content`.
+    const result = await page.evaluate(() => {
+        const header = document.querySelector(
+            '.message-list .message_header[data-topic-name="copy-paste-topic #2"]',
+        );
+        const sender_name = header
+            ?.closest(".recipient_row")
+            ?.querySelector(":scope .message_row .sender_name");
+        if (header === null || sender_name === null || sender_name === undefined) {
+            throw new Error("Expected topic header and sender name");
+        }
+
+        const range = document.createRange();
+        range.setStartBefore(header);
+        range.setEndAfter(sender_name);
+        window.getSelection()!.removeAllRanges();
+        window.getSelection()!.addRange(range);
+
+        const clipboard_data = new DataTransfer();
+        const copy_event = new ClipboardEvent("copy", {
+            bubbles: true,
+            cancelable: true,
+            clipboardData: clipboard_data,
+        });
+        document.dispatchEvent(copy_event);
+
+        return {
+            default_prevented: copy_event.defaultPrevented,
+            copied_html: clipboard_data.getData("text/html"),
+            copied_text: clipboard_data.getData("text/plain"),
+            selection_text: window.getSelection()!.toString(),
+        };
+    });
+
+    // This is a synthetic ClipboardEvent. The browser does not copy the
+    // selection into `clipboard_data`. Empty html/text means our handler
+    // returned false and did not call setData, so a real copy would use
+    // the native selection. `selection_text` checks that there was
+    // something to copy.
+    assert.equal(result.default_prevented, false);
+    assert.equal(result.copied_html, "");
+    assert.equal(result.copied_text, "");
+    assert.ok(result.selection_text.length > 0);
+}
+
 async function copy_paste_test(page: Page): Promise<void> {
     await common.log_in(page);
     await common.send_multiple_messages(page, [
@@ -307,6 +354,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_all_from_prev_first_from_next(page);
     await test_copying_messages_from_several_topics(page);
     await test_timestamp_clipboard_has_datetime(page);
+    await test_copying_selection_with_no_message_content(page);
     await test_multiple_message_selection_with_partially_selected_bookend_messages(page);
 }
 

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -28,26 +28,29 @@ async function copy_messages(
                 )!;
             }
 
+            // Normal messages put the body in a `<p>`; /me status lines
+            // keep the text directly in `.status-message`.
+            function first_text_node(message_content: Element): Text {
+                const p = message_content.querySelector("p");
+                const node = p?.firstChild ?? message_content.firstChild;
+                if (!(node instanceof Text)) {
+                    throw new TypeError("Expected a Text node");
+                }
+                return node;
+            }
+
             // select messages from start_message to end_message
             const selectedRange = document.createRange();
             if (partial_selection_config?.select_start_message_partially) {
                 const offset = partial_selection_config.start_text_node_offset!;
-                const start_message_text_node =
-                    get_message_node(start_message).querySelector("p")?.firstChild;
-                if (!(start_message_text_node instanceof Text)) {
-                    throw new TypeError("Expected a Text node");
-                }
+                const start_message_text_node = first_text_node(get_message_node(start_message));
                 selectedRange.setStart(start_message_text_node, offset);
             } else {
                 selectedRange.setStartBefore(get_message_node(start_message));
             }
             if (partial_selection_config?.select_end_message_partially) {
                 const offset = partial_selection_config.end_text_node_offset!;
-                const end_message_text_node =
-                    get_message_node(end_message).querySelector("p")?.firstChild;
-                if (!(end_message_text_node instanceof Text)) {
-                    throw new TypeError("Expected a Text node");
-                }
+                const end_message_text_node = first_text_node(get_message_node(end_message));
                 // For the last message, the offset will be from the end of the message,
                 // just like how selecting text in the browser would work.
                 selectedRange.setEnd(end_message_text_node, end_message_text_node.length - offset);
@@ -308,6 +311,48 @@ async function test_copying_selection_with_no_message_content(page: Page): Promi
     assert.ok(result.selection_text.length > 0);
 }
 
+async function test_partial_me_bookend_copy_includes_ellipsis(page: Page): Promise<void> {
+    // A partial `/me` bookend should copy the selected status text with
+    // the same `...` marker as a normal bookend.
+    const actual_first = await copy_messages(
+        page,
+        "waves at the camera for status bookend",
+        "BBB after first status message bravo",
+        {
+            select_start_message_partially: true,
+            select_end_message_partially: true,
+            // Offset of "camera" in the status line.
+            start_text_node_offset: 13,
+            end_text_node_offset: 1,
+        },
+    );
+    assert.deepStrictEqual(actual_first, [
+        "Desdemona:",
+        "...camera for status bookend",
+        "Desdemona:",
+        "BBB after first status message brav...",
+    ]);
+
+    const actual_last = await copy_messages(
+        page,
+        "AAA start normal message alpha",
+        "waves at the camera for status bookend",
+        {
+            select_start_message_partially: true,
+            select_end_message_partially: true,
+            start_text_node_offset: 4,
+            // Drop " bookend" (8 chars) from the status line.
+            end_text_node_offset: 8,
+        },
+    );
+    assert.deepStrictEqual(actual_last, [
+        "Desdemona:",
+        "...start normal message alpha",
+        "Desdemona:",
+        "waves at the camera for status...",
+    ]);
+}
+
 async function copy_paste_test(page: Page): Promise<void> {
     await common.log_in(page);
     await common.send_multiple_messages(page, [
@@ -330,6 +375,24 @@ async function copy_paste_test(page: Page): Promise<void> {
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test F"},
 
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test G"},
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #5",
+            content: "AAA start normal message alpha",
+        },
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #5",
+            content: "/me waves at the camera for status bookend",
+        },
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #5",
+            content: "BBB after first status message bravo",
+        },
     ]);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
@@ -342,6 +405,14 @@ async function copy_paste_test(page: Page): Promise<void> {
             ["copy paste test C", "copy paste test D", "copy paste test E"],
         ],
         ["Verona > copy-paste-topic #3", ["copy paste test F", "copy paste test G"]],
+        [
+            "Verona > copy-paste-topic #5",
+            [
+                "AAA start normal message alpha",
+                "waves at the camera for status bookend",
+                "BBB after first status message bravo",
+            ],
+        ],
     ]);
     console.log("Messages were sent successfully");
 
@@ -356,6 +427,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_timestamp_clipboard_has_datetime(page);
     await test_copying_selection_with_no_message_content(page);
     await test_multiple_message_selection_with_partially_selected_bookend_messages(page);
+    await test_partial_me_bookend_copy_includes_ellipsis(page);
 }
 
 await common.run_test(copy_paste_test);

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -248,7 +248,7 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
         "Verona > copy-paste-topic #1 | Today",
         "Desdemona:",
         // w/o partial selection: "copy paste test B",
-        "[...]paste test B",
+        "[...]\u{200B}paste test B",
         "Verona > copy-paste-topic #2 | Today",
         "Desdemona:",
         "copy paste test C",
@@ -311,6 +311,30 @@ async function test_copying_selection_with_no_message_content(page: Page): Promi
     assert.ok(result.selection_text.length > 0);
 }
 
+async function test_partial_bookend_before_url_keeps_raw_link(page: Page): Promise<void> {
+    // Selection starts at the "(" before an auto-linked URL. Without a
+    // zero-width space after the start ellipsis, the bookend would look
+    // like a markdown link labeled "...".
+    const actual_copied_lines = await copy_messages(
+        page,
+        "Prefix before paren (https://example.com) trailing words",
+        "Second message after partial URL bookend",
+        {
+            select_start_message_partially: true,
+            select_end_message_partially: false,
+            // Offset of "(" in the leading text node.
+            start_text_node_offset: 20,
+        },
+    );
+    const expected_copied_lines = [
+        "Desdemona:",
+        "[...]\u{200B}(https://example.com) trailing words",
+        "Desdemona:",
+        "Second message after partial URL bookend",
+    ];
+    assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
+}
+
 async function test_partial_me_bookend_copy_includes_ellipsis(page: Page): Promise<void> {
     // A partial `/me` bookend should copy the selected status text with
     // the same `[...]` marker as a normal bookend.
@@ -328,7 +352,7 @@ async function test_partial_me_bookend_copy_includes_ellipsis(page: Page): Promi
     );
     assert.deepStrictEqual(actual_first, [
         "Desdemona:",
-        "[...]camera for status bookend",
+        "[...]\u{200B}camera for status bookend",
         "Desdemona:",
         "BBB after first status message brav[...]",
     ]);
@@ -347,7 +371,7 @@ async function test_partial_me_bookend_copy_includes_ellipsis(page: Page): Promi
     );
     assert.deepStrictEqual(actual_last, [
         "Desdemona:",
-        "[...]start normal message alpha",
+        "[...]\u{200B}start normal message alpha",
         "Desdemona:",
         "waves at the camera for status[...]",
     ]);
@@ -375,6 +399,18 @@ async function copy_paste_test(page: Page): Promise<void> {
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test F"},
 
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test G"},
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "Prefix before paren (https://example.com) trailing words",
+        },
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "Second message after partial URL bookend",
+        },
 
         {
             stream_name: "Verona",
@@ -406,6 +442,13 @@ async function copy_paste_test(page: Page): Promise<void> {
         ],
         ["Verona > copy-paste-topic #3", ["copy paste test F", "copy paste test G"]],
         [
+            "Verona > copy-paste-topic #4",
+            [
+                "Prefix before paren (https://example.com) trailing words",
+                "Second message after partial URL bookend",
+            ],
+        ],
+        [
             "Verona > copy-paste-topic #5",
             [
                 "AAA start normal message alpha",
@@ -427,6 +470,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_timestamp_clipboard_has_datetime(page);
     await test_copying_selection_with_no_message_content(page);
     await test_multiple_message_selection_with_partially_selected_bookend_messages(page);
+    await test_partial_bookend_before_url_keeps_raw_link(page);
     await test_partial_me_bookend_copy_includes_ellipsis(page);
 }
 

--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -246,6 +246,26 @@ function get_code_block_language(
     return language;
 }
 
+// Whether the link text is the same as the URL, so we can paste it as bare
+// markdown rather than as a labeled markdown link.
+function is_raw_url_link_text(content: string, node: HTMLAnchorElement): boolean {
+    const href_attr = node.getAttribute("href") ?? "";
+    if (content === href_attr || content === node.href) {
+        return true;
+    }
+    // node.href is a serialized URL and may include a trailing slash that the
+    // attribute and link text do not.
+    // https://url.spec.whatwg.org/#path-state
+    // https://url.spec.whatwg.org/#url-path-serializer
+    // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href
+    const without_trailing_slashes = (url: string): string => url.replace(/\/+$/, "");
+    const normalized_content = without_trailing_slashes(content);
+    return (
+        normalized_content === without_trailing_slashes(href_attr) ||
+        normalized_content === without_trailing_slashes(node.href)
+    );
+}
+
 export function paste_handler_converter(
     paste_html: string,
     $textarea?: JQuery<HTMLTextAreaElement>,
@@ -332,8 +352,8 @@ export function paste_handler_converter(
         filter: ["a"],
         replacement(content, node) {
             assert(node instanceof HTMLAnchorElement);
-            if (node.href === content) {
-                // Checks for raw links without custom text.
+            // Checks for raw links without custom text.
+            if (is_raw_url_link_text(content, node)) {
                 return content;
             }
             if (node.childNodes.length === 1 && node.firstChild!.nodeName === "IMG") {

--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -249,6 +249,26 @@ function get_code_block_language(
 
 export const MENTION_SELECTOR = ".user-mention, .user-group-mention, .topic-mention";
 
+// Whether the link text is the same as the URL, so we can paste it as bare
+// markdown rather than as a labeled markdown link.
+function is_raw_url_link_text(content: string, node: HTMLAnchorElement): boolean {
+    const href_attr = node.getAttribute("href") ?? "";
+    if (content === href_attr || content === node.href) {
+        return true;
+    }
+    // node.href is a serialized URL and may include a trailing slash that the
+    // attribute and link text do not.
+    // https://url.spec.whatwg.org/#path-state
+    // https://url.spec.whatwg.org/#url-path-serializer
+    // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href
+    const without_trailing_slashes = (url: string): string => url.replace(/\/+$/, "");
+    const normalized_content = without_trailing_slashes(content);
+    return (
+        normalized_content === without_trailing_slashes(href_attr) ||
+        normalized_content === without_trailing_slashes(node.href)
+    );
+}
+
 export function paste_handler_converter(
     paste_html: string,
     $textarea?: JQuery<HTMLTextAreaElement>,
@@ -394,8 +414,8 @@ export function paste_handler_converter(
         filter: ["a"],
         replacement(content, node) {
             assert(node instanceof HTMLAnchorElement);
-            if (node.href === content) {
-                // Checks for raw links without custom text.
+            // Checks for raw links without custom text.
+            if (is_raw_url_link_text(content, node)) {
                 return content;
             }
             if (node.childNodes.length === 1 && node.firstChild!.nodeName === "IMG") {

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -15,6 +15,7 @@ import * as inbox_ui from "./inbox_ui.ts";
 import * as inbox_util from "./inbox_util.ts";
 import * as message_fetch_raw_content from "./message_fetch_raw_content.ts";
 import * as message_lists from "./message_lists.ts";
+import * as message_selection_content from "./message_selection_content.ts";
 import * as message_store from "./message_store.ts";
 import {type Message} from "./message_store.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -616,6 +617,7 @@ type QuoteAsset = {
 export function build_and_process_quote_assets_for_messages(
     message_ids: number[],
     callback: (quote_assets: QuoteAsset[]) => void,
+    known_quote_content_by_message_id: ReadonlyMap<number, string> = new Map(),
 ): void {
     const messages: Message[] = [];
     for (const id of message_ids) {
@@ -624,38 +626,114 @@ export function build_and_process_quote_assets_for_messages(
         messages.push(message);
     }
 
-    const quote_assets: QuoteAsset[] = [];
+    const quote_content_by_id = new Map(known_quote_content_by_message_id);
+    const ids_needing_raw_content = message_ids.filter((id) => !quote_content_by_id.has(id));
+
+    const finish = (): void => {
+        const quote_assets: QuoteAsset[] = [];
+        for (const message of messages) {
+            const quote_content = quote_content_by_id.get(message.id);
+            assert(quote_content !== undefined);
+            quote_assets.push({message, quote_content});
+        }
+        callback(quote_assets);
+    };
+
+    if (ids_needing_raw_content.length === 0) {
+        finish();
+        return;
+    }
+
     message_fetch_raw_content.get_raw_content_for_messages({
-        message_ids,
+        message_ids: ids_needing_raw_content,
         on_success(raw_content_arr) {
-            for (const [i, message] of messages.entries()) {
+            for (const [i, id] of ids_needing_raw_content.entries()) {
                 const raw_content = raw_content_arr[i];
                 assert(raw_content !== undefined);
-                quote_assets.push({message, quote_content: raw_content});
+                quote_content_by_id.set(id, raw_content);
             }
-            callback(quote_assets);
+            finish();
         },
         on_error() {
-            for (const message of messages) {
-                const fallback_markdown_content = compose_paste.paste_handler_converter(
-                    message.content,
+            // Prefer locally cached raw_content; otherwise convert the
+            // already-rendered HTML (e.g. when the client is offline).
+            for (const id of ids_needing_raw_content) {
+                const message = message_store.get(id);
+                assert(message !== undefined);
+                quote_content_by_id.set(
+                    id,
+                    message.raw_content ?? compose_paste.paste_handler_converter(message.content),
                 );
-                quote_assets.push({
-                    message,
-                    quote_content: message.raw_content ?? fallback_markdown_content,
-                });
             }
-            callback(quote_assets);
+            finish();
         },
         timeout_ms: 1000,
     });
 }
 
+// Convert bookend HTML to markdown when the selection is partial.
+export function partial_bookend_markdown(
+    selection_content: message_selection_content.MultiMessageSelectionContent,
+): {
+    first: string | undefined;
+    last: string | undefined;
+} {
+    const {message_ids, first_bookend, last_bookend} = selection_content;
+    assert(message_ids.length > 0);
+    const first =
+        first_bookend?.is_partial === true
+            ? compose_paste.paste_handler_converter(first_bookend.html)
+            : undefined;
+    const last =
+        last_bookend?.is_partial === true
+            ? compose_paste.paste_handler_converter(last_bookend.html)
+            : undefined;
+    return {first, last};
+}
+
 function quote_multiple_messages(opts: QuoteMessageOpts): void {
     const highlighted_message_ids = opts.highlighted_message_ids;
     assert(highlighted_message_ids !== undefined && highlighted_message_ids.length > 1);
+
+    const start_id = highlighted_message_ids[0]!;
+    const end_id = highlighted_message_ids.at(-1)!;
+    const selection_content = message_selection_content.get_multi_message_selection_content(
+        start_id,
+        end_id,
+    );
+    const selected_contentful_message_ids =
+        selection_content?.message_ids ?? highlighted_message_ids;
+
+    // Capture partial bookends before any async raw_content fetch.
+    const partial_bookends =
+        selection_content !== undefined
+            ? partial_bookend_markdown(selection_content)
+            : {first: undefined, last: undefined};
+
+    if (selected_contentful_message_ids.length === 1) {
+        const only_id = selected_contentful_message_ids[0]!;
+        opts.quote_content = partial_bookends.first;
+        opts.message_id = only_id;
+        quote_single_message(opts);
+        return;
+    }
+
+    const known_quote_content_by_message_id = new Map<number, string>();
+    if (partial_bookends.first !== undefined) {
+        known_quote_content_by_message_id.set(
+            selected_contentful_message_ids[0]!,
+            partial_bookends.first,
+        );
+    }
+    if (partial_bookends.last !== undefined) {
+        known_quote_content_by_message_id.set(
+            selected_contentful_message_ids.at(-1)!,
+            partial_bookends.last,
+        );
+    }
+
     build_and_process_quote_assets_for_messages(
-        highlighted_message_ids,
+        selected_contentful_message_ids,
         (quote_assets: QuoteAsset[]) => {
             const msg_for_compose_box = quote_assets[0]!.message;
             const messages = quote_assets.map((asset) => asset.message);
@@ -712,6 +790,7 @@ function quote_multiple_messages(opts: QuoteMessageOpts): void {
                 forward_message: opts.forward_message,
             });
         },
+        known_quote_content_by_message_id,
     );
 }
 

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -15,6 +15,7 @@ import * as inbox_ui from "./inbox_ui.ts";
 import * as inbox_util from "./inbox_util.ts";
 import * as message_fetch_raw_content from "./message_fetch_raw_content.ts";
 import * as message_lists from "./message_lists.ts";
+import * as message_selection_content from "./message_selection_content.ts";
 import * as message_store from "./message_store.ts";
 import {type Message} from "./message_store.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -616,6 +617,7 @@ type QuoteAsset = {
 export function build_and_process_quote_assets_for_messages(
     message_ids: number[],
     callback: (quote_assets: QuoteAsset[]) => void,
+    known_quote_content_by_message_id: ReadonlyMap<number, string> = new Map(),
 ): void {
     const messages: Message[] = [];
     for (const id of message_ids) {
@@ -624,38 +626,112 @@ export function build_and_process_quote_assets_for_messages(
         messages.push(message);
     }
 
-    const quote_assets: QuoteAsset[] = [];
+    const quote_content_by_id = new Map(known_quote_content_by_message_id);
+    const ids_needing_raw_content = message_ids.filter((id) => !quote_content_by_id.has(id));
+
+    const finish = (): void => {
+        const quote_assets: QuoteAsset[] = [];
+        for (const message of messages) {
+            const quote_content = quote_content_by_id.get(message.id);
+            assert(quote_content !== undefined);
+            quote_assets.push({message, quote_content});
+        }
+        callback(quote_assets);
+    };
+
+    if (ids_needing_raw_content.length === 0) {
+        finish();
+        return;
+    }
+
     message_fetch_raw_content.get_raw_content_for_messages({
-        message_ids,
+        message_ids: ids_needing_raw_content,
         on_success(raw_content_arr) {
-            for (const [i, message] of messages.entries()) {
+            for (const [i, id] of ids_needing_raw_content.entries()) {
                 const raw_content = raw_content_arr[i];
                 assert(raw_content !== undefined);
-                quote_assets.push({message, quote_content: raw_content});
+                quote_content_by_id.set(id, raw_content);
             }
-            callback(quote_assets);
+            finish();
         },
         on_error() {
-            for (const message of messages) {
-                const fallback_markdown_content = compose_paste.paste_handler_converter(
-                    message.content,
-                );
-                quote_assets.push({
-                    message,
-                    quote_content: message.raw_content ?? fallback_markdown_content,
-                });
+            // Prefer locally cached raw_content; otherwise convert the
+            // already-rendered HTML (e.g. when the client is offline).
+            for (const id of ids_needing_raw_content) {
+                const message = message_store.get(id);
+                assert(message !== undefined);
+                const from_rendered_html = compose_paste.paste_handler_converter(message.content);
+                quote_content_by_id.set(id, message.raw_content ?? from_rendered_html);
             }
-            callback(quote_assets);
+            finish();
         },
         timeout_ms: 1000,
     });
 }
 
+// Partial first/last bookend selection as markdown
+// Saved as undefined when we decide to use the full message
+// content, when the entirety of the message content is
+// highlighted or for /me messages at the bookends.
+function partial_bookend_markdown(
+    selection_content: message_selection_content.MultiMessageSelectionContent,
+): {
+    first: string | undefined;
+    last: string | undefined;
+} {
+    const {message_ids, first: first_bookend, last: last_bookend} = selection_content;
+    assert(message_ids.length > 0);
+    const first =
+        first_bookend?.is_partial === true
+            ? compose_paste.paste_handler_converter(first_bookend.html)
+            : undefined;
+    const last =
+        last_bookend?.is_partial === true && message_ids.at(-1) !== message_ids[0]
+            ? compose_paste.paste_handler_converter(last_bookend.html)
+            : undefined;
+    return {first, last};
+}
+
 function quote_multiple_messages(opts: QuoteMessageOpts): void {
     const highlighted_message_ids = opts.highlighted_message_ids;
     assert(highlighted_message_ids !== undefined && highlighted_message_ids.length > 1);
+
+    const start_id = highlighted_message_ids[0]!;
+    const end_id = highlighted_message_ids.at(-1)!;
+    const selection_content = message_selection_content.get_multi_message_selection_content(
+        start_id,
+        end_id,
+    );
+    const selected_contentful_message_ids =
+        selection_content?.message_ids ?? highlighted_message_ids;
+
+    // Capture partial bookends before any async raw_content fetch.
+    const partial_bookends =
+        selection_content !== undefined
+            ? partial_bookend_markdown(selection_content)
+            : {first: undefined, last: undefined};
+
+    if (selected_contentful_message_ids.length === 1) {
+        const only_id = selected_contentful_message_ids[0]!;
+        opts.quote_content = partial_bookends.first;
+        opts.message_id = only_id;
+        quote_single_message(opts);
+        return;
+    }
+
+    const known_quote_content_by_id = new Map<number, string>();
+    if (partial_bookends.first !== undefined) {
+        known_quote_content_by_id.set(selected_contentful_message_ids[0]!, partial_bookends.first);
+    }
+    if (partial_bookends.last !== undefined) {
+        known_quote_content_by_id.set(
+            selected_contentful_message_ids.at(-1)!,
+            partial_bookends.last,
+        );
+    }
+
     build_and_process_quote_assets_for_messages(
-        highlighted_message_ids,
+        selected_contentful_message_ids,
         (quote_assets: QuoteAsset[]) => {
             const msg_for_compose_box = quote_assets[0]!.message;
             const messages = quote_assets.map((asset) => asset.message);
@@ -712,6 +788,7 @@ function quote_multiple_messages(opts: QuoteMessageOpts): void {
                 forward_message: opts.forward_message,
             });
         },
+        known_quote_content_by_id,
     );
 }
 

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -187,9 +187,9 @@ Do not be afraid to change this code if you understand
 how modern browsers deal with copy/paste.  Just test
 your changes carefully.
 */
-function construct_copy_div($div: JQuery, start_id: number, end_id: number): void {
+function construct_copy_div($div: JQuery, start_id: number, end_id: number): boolean {
     if (message_lists.current === undefined) {
-        return;
+        return false;
     }
     let $first_message_element;
     let $last_message_element;
@@ -223,7 +223,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
             copy_rows.splice(-1, 1);
             if (copy_rows.length === 0) {
                 // In case this just involved selecting the username of a message.
-                return;
+                return false;
             }
         }
         assert(copy_rows[0] && copy_rows.at(-1));
@@ -319,6 +319,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
     if (should_include_start_recipient_header) {
         construct_recipient_header($start_row).prependTo($div);
     }
+    return true;
 }
 
 // We want to grab the closest katex span up the tree
@@ -603,7 +604,11 @@ export function copy_handler(ev: ClipboardEvent): boolean {
     // more difficult since we can get a range (start_id and end_id) for
     // each selection `Range`.
     const $div = $("<div>");
-    construct_copy_div($div, start_id, end_id);
+    if (!construct_copy_div($div, start_id, end_id)) {
+        // No message content in the selection; let the browser copy
+        // the highlighted text natively.
+        return false;
+    }
 
     const html_content = $div.html().trim();
     const plain_text = $div.text().trim();

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -9,10 +9,10 @@ import render_copied_recipient_header from "../templates/copied_recipient_header
 import * as blueslip from "./blueslip.ts";
 import {MENTION_SELECTOR} from "./compose_paste.ts";
 import * as message_lists from "./message_lists.ts";
+import * as message_selection_content from "./message_selection_content.ts";
+import type {RangeContainer} from "./message_selection_content.ts";
 import * as rows from "./rows.ts";
 import {the} from "./util.ts";
-
-type RangeContainer = "start" | "end";
 
 function find_boundary_tr(
     $initial_tr: JQuery,
@@ -60,73 +60,6 @@ function construct_recipient_header($message_row: JQuery): JQuery {
     const recipient_text = $header_without_date.text().replaceAll(/\s+/g, " ").trim();
 
     return $(render_copied_recipient_header({recipient_text, date_text}));
-}
-
-// Returns the selected `.message_content`s in the current range.
-function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
-    return document
-        .getSelection()
-        ?.getRangeAt(0)
-        .cloneContents()
-        .querySelectorAll(".message_content");
-}
-
-// Returns the the inner HTML of the `.message_content` element
-// for the first or last message of a single range selection.
-// The caller is expected to only pass the first or last message
-// from a selection range, as the intermediate selected messages
-// anyways contain the entire `.message_content` HTML.
-function get_html_for_bookend_message_content(
-    type: RangeContainer,
-    original_message_content_element: Element,
-    selected_message_content_element: Node | undefined,
-): string {
-    assert(window.getSelection()?.rangeCount === 1);
-    assert(
-        selected_message_content_element !== undefined &&
-            selected_message_content_element instanceof HTMLElement,
-    );
-
-    // Special case for /me messages.
-    // We wrap the /me message content in a `div` to ensure newlines are
-    // inserted before and after the message content, which is important
-    // when copy pasting multiple messages.
-    if (selected_message_content_element.classList.contains("status-message")) {
-        return `<div>` + selected_message_content_element.outerHTML + `</div>`;
-    }
-
-    // If the selected `.message_content` HTML is same as the complete `.message_content` HTML,
-    // we return early and don't append/prepend ellipsis text.
-    if (
-        selected_message_content_element.innerHTML.trim() ===
-        original_message_content_element.innerHTML.trim()
-    ) {
-        return selected_message_content_element.innerHTML;
-    }
-
-    // The ellipsis marks where the partial selection was truncated, so it
-    // belongs within the text flow of the truncated paragraph. Inserting it
-    // inside the first/last paragraph (rather than as a sibling of it) keeps
-    // turndown from rendering it on its own line, separated from the text by
-    // a blank line.
-    const $ellipsis_span = $("<span>").text("...");
-    const $content_children = $(selected_message_content_element).children();
-    if (type === "start") {
-        const $first_child = $content_children.first();
-        if ($first_child.is("p")) {
-            the($first_child).prepend(the($ellipsis_span));
-        } else {
-            selected_message_content_element.prepend(the($ellipsis_span));
-        }
-    } else {
-        const $last_child = $content_children.last();
-        if ($last_child.is("p")) {
-            the($last_child).append(the($ellipsis_span));
-        } else {
-            selected_message_content_element.append(the($ellipsis_span));
-        }
-    }
-    return selected_message_content_element.innerHTML;
 }
 
 function is_container_within_message_row(type: RangeContainer): boolean {
@@ -211,7 +144,8 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
         // we only use the content that is part of the selection.
         // This is only done on Chrome for now, because of the behavior of having
         // a single range for a multi-message selection.
-        const selected_message_content_elements = get_selected_message_content_elements();
+        const selected_message_content_elements =
+            message_selection_content.get_selected_message_content_elements();
         assert(selected_message_content_elements !== undefined);
         // Case where the last message doesn't have any highlighted `.message_content`.
         // Here, end_id is set to id of the message whose username at the top
@@ -235,7 +169,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
         );
         assert(first_selected_message_content_element && last_selected_message_content_element);
         $first_message_element = $(
-            get_html_for_bookend_message_content(
+            message_selection_content.get_html_for_bookend_message_content(
                 "start",
                 first_selected_message_content_element,
                 selected_message_content_elements[0],
@@ -248,7 +182,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
         if (selected_message_content_elements.length > 1) {
             const len = selected_message_content_elements.length;
             $last_message_element = $(
-                get_html_for_bookend_message_content(
+                message_selection_content.get_html_for_bookend_message_content(
                     "end",
                     last_selected_message_content_element,
                     selected_message_content_elements[len - 1],

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -124,9 +124,6 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
     if (message_lists.current === undefined) {
         return false;
     }
-    let $first_message_element;
-    let $last_message_element;
-    const copy_rows = rows.visible_range(start_id, end_id);
     const range_count = window.getSelection()?.rangeCount;
     if (range_count && range_count > 1) {
         // Expand selection to select content from all the messages
@@ -138,57 +135,33 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
         // the selection into multiple ranges for non-selectable elements.
         // We should get rid of this when that becomes the baseline.
         // Details: https://github.com/zulip/zulip/pull/35100#issuecomment-4683858639
-        maybe_expand_selection_for_first_and_last_messages(copy_rows, range_count);
-    } else {
-        // Instead of copying the entire content of the first and last message,
-        // we only use the content that is part of the selection.
-        // This is only done on Chrome for now, because of the behavior of having
-        // a single range for a multi-message selection.
-        const selected_message_content_elements =
-            message_selection_content.get_selected_message_content_elements();
-        assert(selected_message_content_elements !== undefined);
-        // Case where the last message doesn't have any highlighted `.message_content`.
-        // Here, end_id is set to id of the message whose username at the top
-        // was highlighted, but has no highlighted `.message_content`.
-        // (See analyze_selection for details.)
-        // So the actually useful/contentful last message of this selection is
-        // at copy_rows[copy_rows.length - 2]
-        if (selected_message_content_elements.length === copy_rows.length - 1) {
-            copy_rows.splice(-1, 1);
-            if (copy_rows.length === 0) {
-                // In case this just involved selecting the username of a message.
-                return false;
-            }
-        }
-        assert(copy_rows[0] && copy_rows.at(-1));
-        const first_selected_message_content_element = the(copy_rows[0]).querySelector(
-            ".message_content",
-        );
-        const last_selected_message_content_element = the(copy_rows.at(-1)!).querySelector(
-            ".message_content",
-        );
-        assert(first_selected_message_content_element && last_selected_message_content_element);
-        $first_message_element = $(
-            message_selection_content.get_html_for_bookend_message_content(
-                "start",
-                first_selected_message_content_element,
-                selected_message_content_elements[0],
-            ),
-        );
+        const expand_rows = rows.visible_range(start_id, end_id);
+        maybe_expand_selection_for_first_and_last_messages(expand_rows, range_count);
+    }
 
-        // We don't want to append the same content as the first message in the selection
-        // if we are trying to get the `.message_content` HTML for the last
-        // message when there is only one `.message_content` in the selected range.
-        if (selected_message_content_elements.length > 1) {
-            const len = selected_message_content_elements.length;
-            $last_message_element = $(
-                message_selection_content.get_html_for_bookend_message_content(
-                    "end",
-                    last_selected_message_content_element,
-                    selected_message_content_elements[len - 1],
-                ),
-            );
-        }
+    const selection_content = message_selection_content.get_multi_message_selection_content(
+        start_id,
+        end_id,
+    );
+    if (selection_content === undefined) {
+        return false;
+    }
+
+    const {message_ids, first_bookend, last_bookend} = selection_content;
+
+    const copy_rows = message_ids.map((id) => {
+        const $row = message_lists.current!.get_row(id);
+        assert($row.length > 0);
+        return $row;
+    });
+
+    let $first_message_element;
+    let $last_message_element;
+    if (first_bookend !== undefined) {
+        $first_message_element = $(first_bookend.html);
+    }
+    if (last_bookend !== undefined) {
+        $last_message_element = $(last_bookend.html);
     }
 
     const $start_row = copy_rows[0];

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -8,10 +8,10 @@ import render_copied_recipient_header from "../templates/copied_recipient_header
 
 import * as blueslip from "./blueslip.ts";
 import * as message_lists from "./message_lists.ts";
+import * as message_selection_content from "./message_selection_content.ts";
+import type {RangeContainer} from "./message_selection_content.ts";
 import * as rows from "./rows.ts";
 import {the} from "./util.ts";
-
-type RangeContainer = "start" | "end";
 
 function find_boundary_tr(
     $initial_tr: JQuery,
@@ -58,73 +58,6 @@ function construct_recipient_header($message_row: JQuery): JQuery {
     const recipient_text = $header_without_date.text().replaceAll(/\s+/g, " ").trim();
 
     return $(render_copied_recipient_header({recipient_text, date_text}));
-}
-
-// Returns the selected `.message_content`s in the current range.
-function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
-    return document
-        .getSelection()
-        ?.getRangeAt(0)
-        .cloneContents()
-        .querySelectorAll(".message_content");
-}
-
-// Returns the the inner HTML of the `.message_content` element
-// for the first or last message of a single range selection.
-// The caller is expected to only pass the first or last message
-// from a selection range, as the intermediate selected messages
-// anyways contain the entire `.message_content` HTML.
-function get_html_for_bookend_message_content(
-    type: RangeContainer,
-    original_message_content_element: Element,
-    selected_message_content_element: Node | undefined,
-): string {
-    assert(window.getSelection()?.rangeCount === 1);
-    assert(
-        selected_message_content_element !== undefined &&
-            selected_message_content_element instanceof HTMLElement,
-    );
-
-    // Special case for /me messages.
-    // We wrap the /me message content in a `div` to ensure newlines are
-    // inserted before and after the message content, which is important
-    // when copy pasting multiple messages.
-    if (selected_message_content_element.classList.contains("status-message")) {
-        return `<div>` + selected_message_content_element.outerHTML + `</div>`;
-    }
-
-    // If the selected `.message_content` HTML is same as the complete `.message_content` HTML,
-    // we return early and don't append/prepend ellipsis text.
-    if (
-        selected_message_content_element.innerHTML.trim() ===
-        original_message_content_element.innerHTML.trim()
-    ) {
-        return selected_message_content_element.innerHTML;
-    }
-
-    // The ellipsis marks where the partial selection was truncated, so it
-    // belongs within the text flow of the truncated paragraph. Inserting it
-    // inside the first/last paragraph (rather than as a sibling of it) keeps
-    // turndown from rendering it on its own line, separated from the text by
-    // a blank line.
-    const $ellipsis_span = $("<span>").text("...");
-    const $content_children = $(selected_message_content_element).children();
-    if (type === "start") {
-        const $first_child = $content_children.first();
-        if ($first_child.is("p")) {
-            the($first_child).prepend(the($ellipsis_span));
-        } else {
-            selected_message_content_element.prepend(the($ellipsis_span));
-        }
-    } else {
-        const $last_child = $content_children.last();
-        if ($last_child.is("p")) {
-            the($last_child).append(the($ellipsis_span));
-        } else {
-            selected_message_content_element.append(the($ellipsis_span));
-        }
-    }
-    return selected_message_content_element.innerHTML;
 }
 
 function is_container_within_message_row(type: RangeContainer): boolean {
@@ -209,7 +142,8 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
         // we only use the content that is part of the selection.
         // This is only done on Chrome for now, because of the behavior of having
         // a single range for a multi-message selection.
-        const selected_message_content_elements = get_selected_message_content_elements();
+        const selected_message_content_elements =
+            message_selection_content.get_selected_message_content_elements();
         assert(selected_message_content_elements !== undefined);
         // Case where the last message doesn't have any highlighted `.message_content`.
         // Here, end_id is set to id of the message whose username at the top
@@ -233,7 +167,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
         );
         assert(first_selected_message_content_element && last_selected_message_content_element);
         $first_message_element = $(
-            get_html_for_bookend_message_content(
+            message_selection_content.get_html_for_bookend_message_content(
                 "start",
                 first_selected_message_content_element,
                 selected_message_content_elements[0],
@@ -246,7 +180,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
         if (selected_message_content_elements.length > 1) {
             const len = selected_message_content_elements.length;
             $last_message_element = $(
-                get_html_for_bookend_message_content(
+                message_selection_content.get_html_for_bookend_message_content(
                     "end",
                     last_selected_message_content_element,
                     selected_message_content_elements[len - 1],

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -122,9 +122,6 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
     if (message_lists.current === undefined) {
         return;
     }
-    let $first_message_element;
-    let $last_message_element;
-    const copy_rows = rows.visible_range(start_id, end_id);
     const range_count = window.getSelection()?.rangeCount;
     if (range_count && range_count > 1) {
         // Expand selection to select content from all the messages
@@ -136,57 +133,34 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
         // the selection into multiple ranges for non-selectable elements.
         // We should get rid of this when that becomes the baseline.
         // Details: https://github.com/zulip/zulip/pull/35100#issuecomment-4683858639
-        maybe_expand_selection_for_first_and_last_messages(copy_rows, range_count);
-    } else {
-        // Instead of copying the entire content of the first and last message,
-        // we only use the content that is part of the selection.
-        // This is only done on Chrome for now, because of the behavior of having
-        // a single range for a multi-message selection.
-        const selected_message_content_elements =
-            message_selection_content.get_selected_message_content_elements();
-        assert(selected_message_content_elements !== undefined);
-        // Case where the last message doesn't have any highlighted `.message_content`.
-        // Here, end_id is set to id of the message whose username at the top
-        // was highlighted, but has no highlighted `.message_content`.
-        // (See analyze_selection for details.)
-        // So the actually useful/contentful last message of this selection is
-        // at copy_rows[copy_rows.length - 2]
-        if (selected_message_content_elements.length === copy_rows.length - 1) {
-            copy_rows.splice(-1, 1);
-            if (copy_rows.length === 0) {
-                // In case this just involved selecting the username of a message.
-                return;
-            }
-        }
-        assert(copy_rows[0] && copy_rows.at(-1));
-        const first_selected_message_content_element = the(copy_rows[0]).querySelector(
-            ".message_content",
-        );
-        const last_selected_message_content_element = the(copy_rows.at(-1)!).querySelector(
-            ".message_content",
-        );
-        assert(first_selected_message_content_element && last_selected_message_content_element);
-        $first_message_element = $(
-            message_selection_content.get_html_for_bookend_message_content(
-                "start",
-                first_selected_message_content_element,
-                selected_message_content_elements[0],
-            ),
-        );
+        const expand_rows = rows.visible_range(start_id, end_id);
+        maybe_expand_selection_for_first_and_last_messages(expand_rows, range_count);
+    }
 
-        // We don't want to append the same content as the first message in the selection
-        // if we are trying to get the `.message_content` HTML for the last
-        // message when there is only one `.message_content` in the selected range.
-        if (selected_message_content_elements.length > 1) {
-            const len = selected_message_content_elements.length;
-            $last_message_element = $(
-                message_selection_content.get_html_for_bookend_message_content(
-                    "end",
-                    last_selected_message_content_element,
-                    selected_message_content_elements[len - 1],
-                ),
-            );
-        }
+    const selection_content = message_selection_content.get_multi_message_selection_content(
+        start_id,
+        end_id,
+    );
+    if (selection_content === undefined) {
+        // See get_multi_message_selection_content for when this is applicable.
+        return;
+    }
+
+    const {message_ids, first: first_bookend, last: last_bookend} = selection_content;
+
+    const copy_rows = message_ids.map((id) => {
+        const $row = message_lists.current!.get_row(id);
+        assert($row.length > 0);
+        return $row;
+    });
+
+    let $first_message_element;
+    let $last_message_element;
+    if (first_bookend !== undefined) {
+        $first_message_element = $(first_bookend.html);
+    }
+    if (last_bookend !== undefined) {
+        $last_message_element = $(last_bookend.html);
     }
 
     const $start_row = copy_rows[0];

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -1,12 +1,34 @@
+// Helpers for multi-message selection body coverage (first/last bookends and
+// which rows contribute message content).
+//
+// Partial bookends are only resolved for a single selection range (Chrome and
+// modern Firefox). When the browser splits a multi-message selection into
+// multiple ranges (older Firefox), partial first/last content is not recovered
+// and callers use full message bodies:
+// https://chat.zulip.org/#narrow/channel/101-design/topic/Improve.20the.20message.20copying.20experience.20.236316/with/681915
+
 import {$} from "jquery";
 import assert from "minimalistic-assert";
 
+import * as message_lists from "./message_lists.ts";
+import * as rows from "./rows.ts";
 import {the} from "./util.ts";
 
 export type RangeContainer = "start" | "end";
 
+type BookendContentHtml = {
+    html: string;
+};
+
+export type MultiMessageSelectionContent = {
+    message_ids: number[];
+    // Undefined means the caller should use the full message body.
+    first_bookend: BookendContentHtml | undefined;
+    last_bookend: BookendContentHtml | undefined;
+};
+
 // Returns the selected `.message_content`s in the current range.
-export function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
+function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
     return document
         .getSelection()
         ?.getRangeAt(0)
@@ -19,12 +41,12 @@ export function get_selected_message_content_elements(): NodeListOf<HTMLElement>
 // The caller is expected to only pass the first or last message
 // from a selection range, as the intermediate selected messages
 // anyways contain the entire `.message_content` HTML.
-export function get_html_for_bookend_message_content(
+// Mutates `selected_message_content_element` when inserting ellipsis text.
+function get_html_for_bookend_message_content(
     type: RangeContainer,
     original_message_content_element: Element,
     selected_message_content_element: Node | undefined,
-): string {
-    assert(window.getSelection()?.rangeCount === 1);
+): BookendContentHtml {
     assert(
         selected_message_content_element !== undefined &&
             selected_message_content_element instanceof HTMLElement,
@@ -35,7 +57,9 @@ export function get_html_for_bookend_message_content(
     // inserted before and after the message content, which is important
     // when copy pasting multiple messages.
     if (selected_message_content_element.classList.contains("status-message")) {
-        return `<div>` + selected_message_content_element.outerHTML + `</div>`;
+        return {
+            html: `<div>` + selected_message_content_element.outerHTML + `</div>`,
+        };
     }
 
     // If the selected `.message_content` HTML is same as the complete `.message_content` HTML,
@@ -44,7 +68,9 @@ export function get_html_for_bookend_message_content(
         selected_message_content_element.innerHTML.trim() ===
         original_message_content_element.innerHTML.trim()
     ) {
-        return selected_message_content_element.innerHTML;
+        return {
+            html: selected_message_content_element.innerHTML,
+        };
     }
 
     // The ellipsis marks where the partial selection was truncated, so it
@@ -69,5 +95,97 @@ export function get_html_for_bookend_message_content(
             selected_message_content_element.append(the($ellipsis_span));
         }
     }
-    return selected_message_content_element.innerHTML;
+    return {
+        html: selected_message_content_element.innerHTML,
+    };
+}
+
+function message_content_element_for_id(message_id: number): Element {
+    assert(message_lists.current !== undefined);
+    const $row = message_lists.current.get_row(message_id);
+    assert($row.length > 0);
+    const content = the($row).querySelector(".message_content");
+    assert(content !== null);
+    return content;
+}
+
+// Returns contentful message ids for the selection from start_id through end_id, plus
+// first/last bookend HTML when a single range allows partial recovery.
+//
+// Returns undefined when there are no contentful messages (e.g. empty visible
+// range, or username-only / no `.message_content` in a single-range selection).
+//
+// Multi-range selections (older Firefox): returns all visible row ids between
+// the endpoints and leaves first_bookend/last_bookend undefined so callers use full bodies.
+export function get_multi_message_selection_content(
+    start_id: number,
+    end_id: number,
+): MultiMessageSelectionContent | undefined {
+    const message_ids = rows.get_ids_in_range(start_id, end_id);
+    if (message_ids.length === 0) {
+        return undefined;
+    }
+
+    const range_count = window.getSelection()?.rangeCount ?? 0;
+    // Multi-range selections do not attempt the trailing username-only
+    // drop or partial bookends; callers use full bodies for every message.
+    if (range_count !== 1) {
+        return {
+            message_ids,
+            first_bookend: undefined,
+            last_bookend: undefined,
+        };
+    }
+
+    const selected_message_content_elements = get_selected_message_content_elements();
+    assert(selected_message_content_elements !== undefined);
+
+    // This is the case where there is no `.message_content` anywhere in
+    // the selection. /me messages are currently the only place where
+    // that can happen. Highlighting the timestamp from a /me message,
+    // followed by the username of the following message, does not
+    // include either message's `.message_content`.
+    if (selected_message_content_elements.length === 0) {
+        return undefined;
+    }
+
+    // Case where the last message doesn't have any highlighted `.message_content`.
+    // Here, end_id is set to id of the message whose username at the top
+    // was highlighted, but has no highlighted `.message_content`.
+    // (See analyze_selection for details.)
+    // So the actually useful/contentful last message of this selection is
+    // at message_ids[message_ids.length - 2]
+    if (selected_message_content_elements.length === message_ids.length - 1) {
+        message_ids.pop();
+        if (message_ids.length === 0) {
+            // In case this just involved selecting the username of a message.
+            return undefined;
+        }
+    }
+
+    assert(message_ids.length > 0);
+
+    const first_id = message_ids[0]!;
+    const last_id = message_ids.at(-1)!;
+    const first_original = message_content_element_for_id(first_id);
+    const last_original = message_content_element_for_id(last_id);
+
+    const first_bookend = get_html_for_bookend_message_content(
+        "start",
+        first_original,
+        selected_message_content_elements[0],
+    );
+
+    // Avoid treating a single selected fragment as both first and last.
+    let last_bookend: BookendContentHtml | undefined;
+    if (message_ids.length > 1 && selected_message_content_elements.length > 1) {
+        const len = selected_message_content_elements.length;
+        last_bookend = get_html_for_bookend_message_content(
+            "end",
+            last_original,
+            selected_message_content_elements[len - 1],
+        );
+    }
+
+    return {message_ids, first_bookend, last_bookend};
 }

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -84,7 +84,7 @@ function get_html_for_bookend_message_content(
     // inside the first/last paragraph (rather than as a sibling of it) keeps
     // turndown from rendering it on its own line, separated from the text by
     // a blank line.
-    const $ellipsis_span = $("<span>").text("...");
+    const $ellipsis_span = $("<span>").text("[...]");
     const $content_children = $(selected_message_content_element).children();
     if (type === "start") {
         const $first_child = $content_children.first();

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -58,7 +58,7 @@ function get_html_for_bookend_message_content(
     const is_partial =
         selected_message_content_element.innerHTML.trim() !==
         original_message_content_element.innerHTML.trim();
-    const $ellipsis_span = $("<span>").text("...");
+    const $ellipsis_span = $("<span>").text("[...]");
 
     // Special case for /me messages.
     // We wrap the /me message content in a `div` to ensure newlines are

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -18,6 +18,7 @@ export type RangeContainer = "start" | "end";
 
 type BookendContentHtml = {
     html: string;
+    is_partial: boolean;
 };
 
 export type MultiMessageSelectionContent = {
@@ -41,6 +42,8 @@ function get_selected_message_content_elements(): NodeListOf<HTMLElement> | unde
 // The caller is expected to only pass the first or last message
 // from a selection range, as the intermediate selected messages
 // anyways contain the entire `.message_content` HTML.
+//
+// Also reports whether the selection is partial (`is_partial`).
 // Mutates `selected_message_content_element` when inserting ellipsis text.
 function get_html_for_bookend_message_content(
     type: RangeContainer,
@@ -59,6 +62,8 @@ function get_html_for_bookend_message_content(
     if (selected_message_content_element.classList.contains("status-message")) {
         return {
             html: `<div>` + selected_message_content_element.outerHTML + `</div>`,
+            // Status messages are treated as whole units for selection.
+            is_partial: false,
         };
     }
 
@@ -70,6 +75,7 @@ function get_html_for_bookend_message_content(
     ) {
         return {
             html: selected_message_content_element.innerHTML,
+            is_partial: false,
         };
     }
 
@@ -97,6 +103,7 @@ function get_html_for_bookend_message_content(
     }
     return {
         html: selected_message_content_element.innerHTML,
+        is_partial: true,
     };
 }
 

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -1,12 +1,35 @@
+// Helpers for multi-message selection body coverage (first/last bookends and
+// which rows contribute message content).
+//
+// Partial bookends are only resolved for a single selection range (Chrome and
+// modern Firefox). When the browser splits a multi-message selection into
+// multiple ranges (older Firefox), partial first/last content is not recovered
+// and callers use full message bodies:
+// https://chat.zulip.org/#narrow/channel/101-design/topic/Improve.20the.20message.20copying.20experience.20.236316/with/681915
+
 import {$} from "jquery";
 import assert from "minimalistic-assert";
 
+import * as message_lists from "./message_lists.ts";
+import * as rows from "./rows.ts";
 import {the} from "./util.ts";
 
 export type RangeContainer = "start" | "end";
 
+export type BookendContentHtml = {
+    html: string;
+    is_partial: boolean;
+};
+
+export type MultiMessageSelectionContent = {
+    message_ids: number[];
+    // Undefined means the caller should use the full message body.
+    first: BookendContentHtml | undefined;
+    last: BookendContentHtml | undefined;
+};
+
 // Returns the selected `.message_content`s in the current range.
-export function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
+function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
     return document
         .getSelection()
         ?.getRangeAt(0)
@@ -19,12 +42,14 @@ export function get_selected_message_content_elements(): NodeListOf<HTMLElement>
 // The caller is expected to only pass the first or last message
 // from a selection range, as the intermediate selected messages
 // anyways contain the entire `.message_content` HTML.
-export function get_html_for_bookend_message_content(
+//
+// Also reports whether the selection is partial (`is_partial`).
+// Mutates `selected_message_content_element` when inserting ellipsis text.
+function get_html_for_bookend_message_content(
     type: RangeContainer,
     original_message_content_element: Element,
     selected_message_content_element: Node | undefined,
-): string {
-    assert(window.getSelection()?.rangeCount === 1);
+): BookendContentHtml {
     assert(
         selected_message_content_element !== undefined &&
             selected_message_content_element instanceof HTMLElement,
@@ -35,7 +60,11 @@ export function get_html_for_bookend_message_content(
     // inserted before and after the message content, which is important
     // when copy pasting multiple messages.
     if (selected_message_content_element.classList.contains("status-message")) {
-        return `<div>` + selected_message_content_element.outerHTML + `</div>`;
+        return {
+            html: `<div>` + selected_message_content_element.outerHTML + `</div>`,
+            // Status messages are treated as whole units for selection.
+            is_partial: false,
+        };
     }
 
     // If the selected `.message_content` HTML is same as the complete `.message_content` HTML,
@@ -44,7 +73,10 @@ export function get_html_for_bookend_message_content(
         selected_message_content_element.innerHTML.trim() ===
         original_message_content_element.innerHTML.trim()
     ) {
-        return selected_message_content_element.innerHTML;
+        return {
+            html: selected_message_content_element.innerHTML,
+            is_partial: false,
+        };
     }
 
     // The ellipsis marks where the partial selection was truncated, so it
@@ -69,5 +101,101 @@ export function get_html_for_bookend_message_content(
             selected_message_content_element.append(the($ellipsis_span));
         }
     }
-    return selected_message_content_element.innerHTML;
+    return {
+        html: selected_message_content_element.innerHTML,
+        is_partial: true,
+    };
+}
+
+function message_content_element_for_id(message_id: number): Element {
+    assert(message_lists.current !== undefined);
+    const $row = message_lists.current.get_row(message_id);
+    assert($row.length > 0);
+    const content = the($row).querySelector(".message_content");
+    assert(content !== null);
+    return content;
+}
+
+// Returns contentful message ids for the selection from start_id through end_id, plus
+// first/last bookend HTML when a single range allows partial recovery.
+//
+// Returns undefined when there are no contentful messages (e.g. empty visible
+// range, or username-only / no `.message_content` in a single-range selection).
+//
+// Multi-range selections (older Firefox): returns all visible row ids between
+// the endpoints and leaves first/last undefined so callers use full bodies.
+export function get_multi_message_selection_content(
+    start_id: number,
+    end_id: number,
+): MultiMessageSelectionContent | undefined {
+    const content_rows = rows.visible_range(start_id, end_id);
+    if (content_rows.length === 0) {
+        return undefined;
+    }
+
+    const range_count = window.getSelection()?.rangeCount ?? 0;
+    // Multi-range selections do not attempt the trailing username-only
+    // drop or partial bookends; callers use full bodies for every row.
+    if (range_count !== 1) {
+        return {
+            message_ids: content_rows.map(($row) => rows.id($row)),
+            first: undefined,
+            last: undefined,
+        };
+    }
+
+    const selected_message_content_elements = get_selected_message_content_elements();
+    assert(selected_message_content_elements !== undefined);
+
+    // Happens for a special case:
+    // Highlighting the timestamp from a /me message, followed by highlighting the
+    // username from the following message.
+    if (selected_message_content_elements.length === 0) {
+        return undefined;
+    }
+
+    // Case where the last message doesn't have any highlighted `.message_content`.
+    // Here, end_id is set to id of the message whose username at the top
+    // was highlighted, but has no highlighted `.message_content`.
+    // (See analyze_selection for details.)
+    // So the actually useful/contentful last message of this selection is
+    // at content_rows[content_rows.length - 2]
+    if (selected_message_content_elements.length === content_rows.length - 1) {
+        content_rows.splice(-1, 1);
+        if (content_rows.length === 0) {
+            // In case this just involved selecting the username of a message.
+            return undefined;
+        }
+    }
+
+    const message_ids = content_rows.map(($row) => rows.id($row));
+    assert(message_ids.length > 0);
+
+    const first_id = message_ids[0]!;
+    const last_id = message_ids.at(-1)!;
+    const first_original = message_content_element_for_id(first_id);
+    const last_original = message_content_element_for_id(last_id);
+
+    const first = get_html_for_bookend_message_content(
+        "start",
+        first_original,
+        selected_message_content_elements[0],
+    );
+
+    // Avoid treating a single selected fragment as both first and last when
+    // only one `.message_content` appears in the cloned selection across
+    // multiple rows (last then falls back to full body).
+    let last: BookendContentHtml | undefined;
+    if (message_ids.length === 1) {
+        last = first;
+    } else if (selected_message_content_elements.length > 1) {
+        const len = selected_message_content_elements.length;
+        last = get_html_for_bookend_message_content(
+            "end",
+            last_original,
+            selected_message_content_elements[len - 1],
+        );
+    }
+
+    return {message_ids, first, last};
 }

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -58,7 +58,11 @@ function get_html_for_bookend_message_content(
     const is_partial =
         selected_message_content_element.innerHTML.trim() !==
         original_message_content_element.innerHTML.trim();
-    const $ellipsis_span = $("<span>").text("[...]");
+    // For a start bookend, also insert a zero-width space after the marker.
+    // If the selection continues with "(", converting the HTML to markdown
+    // would otherwise treat the marker as the label of a link.
+    const ellipsis_text = type === "start" ? "[...]\u{200B}" : "[...]";
+    const $ellipsis_span = $("<span>").text(ellipsis_text);
 
     // Special case for /me messages.
     // We wrap the /me message content in a `div` to ensure newlines are

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -84,7 +84,12 @@ function get_html_for_bookend_message_content(
     // inside the first/last paragraph (rather than as a sibling of it) keeps
     // turndown from rendering it on its own line, separated from the text by
     // a blank line.
-    const $ellipsis_span = $("<span>").text("[...]");
+    //
+    // For a start bookend, also insert a zero-width space after the marker.
+    // If the selection continues with "(", converting the HTML to markdown
+    // would otherwise treat the marker as the label of a link.
+    const ellipsis_text = type === "start" ? "[...]\u{200B}" : "[...]";
+    const $ellipsis_span = $("<span>").text(ellipsis_text);
     const $content_children = $(selected_message_content_element).children();
     if (type === "start") {
         const $first_child = $content_children.first();

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -55,27 +55,35 @@ function get_html_for_bookend_message_content(
             selected_message_content_element instanceof HTMLElement,
     );
 
+    const is_partial =
+        selected_message_content_element.innerHTML.trim() !==
+        original_message_content_element.innerHTML.trim();
+    const $ellipsis_span = $("<span>").text("...");
+
     // Special case for /me messages.
     // We wrap the /me message content in a `div` to ensure newlines are
     // inserted before and after the message content, which is important
     // when copy pasting multiple messages.
     if (selected_message_content_element.classList.contains("status-message")) {
+        if (is_partial) {
+            if (type === "start") {
+                selected_message_content_element.prepend(the($ellipsis_span));
+            } else {
+                selected_message_content_element.append(the($ellipsis_span));
+            }
+        }
         return {
             html: `<div>` + selected_message_content_element.outerHTML + `</div>`,
-            // Status messages are treated as whole units for selection.
-            is_partial: false,
+            is_partial,
         };
     }
 
     // If the selected `.message_content` HTML is same as the complete `.message_content` HTML,
     // we return early and don't append/prepend ellipsis text.
-    if (
-        selected_message_content_element.innerHTML.trim() ===
-        original_message_content_element.innerHTML.trim()
-    ) {
+    if (!is_partial) {
         return {
             html: selected_message_content_element.innerHTML,
-            is_partial: false,
+            is_partial,
         };
     }
 
@@ -84,7 +92,6 @@ function get_html_for_bookend_message_content(
     // inside the first/last paragraph (rather than as a sibling of it) keeps
     // turndown from rendering it on its own line, separated from the text by
     // a blank line.
-    const $ellipsis_span = $("<span>").text("...");
     const $content_children = $(selected_message_content_element).children();
     if (type === "start") {
         const $first_child = $content_children.first();

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -1,0 +1,73 @@
+import {$} from "jquery";
+import assert from "minimalistic-assert";
+
+import {the} from "./util.ts";
+
+export type RangeContainer = "start" | "end";
+
+// Returns the selected `.message_content`s in the current range.
+export function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
+    return document
+        .getSelection()
+        ?.getRangeAt(0)
+        .cloneContents()
+        .querySelectorAll(".message_content");
+}
+
+// Returns the the inner HTML of the `.message_content` element
+// for the first or last message of a single range selection.
+// The caller is expected to only pass the first or last message
+// from a selection range, as the intermediate selected messages
+// anyways contain the entire `.message_content` HTML.
+export function get_html_for_bookend_message_content(
+    type: RangeContainer,
+    original_message_content_element: Element,
+    selected_message_content_element: Node | undefined,
+): string {
+    assert(window.getSelection()?.rangeCount === 1);
+    assert(
+        selected_message_content_element !== undefined &&
+            selected_message_content_element instanceof HTMLElement,
+    );
+
+    // Special case for /me messages.
+    // We wrap the /me message content in a `div` to ensure newlines are
+    // inserted before and after the message content, which is important
+    // when copy pasting multiple messages.
+    if (selected_message_content_element.classList.contains("status-message")) {
+        return `<div>` + selected_message_content_element.outerHTML + `</div>`;
+    }
+
+    // If the selected `.message_content` HTML is same as the complete `.message_content` HTML,
+    // we return early and don't append/prepend ellipsis text.
+    if (
+        selected_message_content_element.innerHTML.trim() ===
+        original_message_content_element.innerHTML.trim()
+    ) {
+        return selected_message_content_element.innerHTML;
+    }
+
+    // The ellipsis marks where the partial selection was truncated, so it
+    // belongs within the text flow of the truncated paragraph. Inserting it
+    // inside the first/last paragraph (rather than as a sibling of it) keeps
+    // turndown from rendering it on its own line, separated from the text by
+    // a blank line.
+    const $ellipsis_span = $("<span>").text("...");
+    const $content_children = $(selected_message_content_element).children();
+    if (type === "start") {
+        const $first_child = $content_children.first();
+        if ($first_child.is("p")) {
+            the($first_child).prepend(the($ellipsis_span));
+        } else {
+            selected_message_content_element.prepend(the($ellipsis_span));
+        }
+    } else {
+        const $last_child = $content_children.last();
+        if ($last_child.is("p")) {
+            the($last_child).append(the($ellipsis_span));
+        } else {
+            selected_message_content_element.append(the($ellipsis_span));
+        }
+    }
+    return selected_message_content_element.innerHTML;
+}

--- a/web/src/message_selection_content.ts
+++ b/web/src/message_selection_content.ts
@@ -1,0 +1,73 @@
+import {$} from "jquery";
+import assert from "minimalistic-assert";
+
+import {the} from "./util.ts";
+
+export type RangeContainer = "start" | "end";
+
+// Returns the selected `.message_content`s in the current range.
+export function get_selected_message_content_elements(): NodeListOf<HTMLElement> | undefined {
+    return document
+        .getSelection()
+        ?.getRangeAt(0)
+        .cloneContents()
+        .querySelectorAll(".message_content");
+}
+
+// Returns the inner HTML of the `.message_content` element
+// for the first or last message of a single range selection.
+// The caller is expected to only pass the first or last message
+// from a selection range, as the intermediate selected messages
+// anyways contain the entire `.message_content` HTML.
+export function get_html_for_bookend_message_content(
+    type: RangeContainer,
+    original_message_content_element: Element,
+    selected_message_content_element: Node | undefined,
+): string {
+    assert(window.getSelection()?.rangeCount === 1);
+    assert(
+        selected_message_content_element !== undefined &&
+            selected_message_content_element instanceof HTMLElement,
+    );
+
+    // Special case for /me messages.
+    // We wrap the /me message content in a `div` to ensure newlines are
+    // inserted before and after the message content, which is important
+    // when copy pasting multiple messages.
+    if (selected_message_content_element.classList.contains("status-message")) {
+        return `<div>` + selected_message_content_element.outerHTML + `</div>`;
+    }
+
+    // If the selected `.message_content` HTML is same as the complete `.message_content` HTML,
+    // we return early and don't append/prepend ellipsis text.
+    if (
+        selected_message_content_element.innerHTML.trim() ===
+        original_message_content_element.innerHTML.trim()
+    ) {
+        return selected_message_content_element.innerHTML;
+    }
+
+    // The ellipsis marks where the partial selection was truncated, so it
+    // belongs within the text flow of the truncated paragraph. Inserting it
+    // inside the first/last paragraph (rather than as a sibling of it) keeps
+    // turndown from rendering it on its own line, separated from the text by
+    // a blank line.
+    const $ellipsis_span = $("<span>").text("...");
+    const $content_children = $(selected_message_content_element).children();
+    if (type === "start") {
+        const $first_child = $content_children.first();
+        if ($first_child.is("p")) {
+            the($first_child).prepend(the($ellipsis_span));
+        } else {
+            selected_message_content_element.prepend(the($ellipsis_span));
+        }
+    } else {
+        const $last_child = $content_children.last();
+        if ($last_child.is("p")) {
+            the($last_child).append(the($ellipsis_span));
+        } else {
+            selected_message_content_element.append(the($ellipsis_span));
+        }
+    }
+    return selected_message_content_element.innerHTML;
+}

--- a/web/tests/compose_paste.test.cjs
+++ b/web/tests/compose_paste.test.cjs
@@ -412,6 +412,18 @@ run_test("paste_handler_converter", () => {
         "https://zulip.readthedocs.io/en/latest/subsystems/logging.html",
     );
 
+    // Raw link where node.href has a trailing slash the text does not.
+    // Without the fix this becomes a labeled markdown link.
+    input =
+        '<a href="https://google.com" target="_blank" rel="noopener noreferrer" title="https://google.com/">https://google.com</a>';
+    assert.equal(compose_paste.paste_handler_converter(input), "https://google.com");
+    input =
+        '<p>Check this link <a href="https://google.com" target="_blank" rel="noopener noreferrer" title="https://google.com/">https://google.com</a> please</p>';
+    assert.equal(
+        compose_paste.paste_handler_converter(input),
+        "Check this link https://google.com please",
+    );
+
     // Links with custom text
     input =
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><a class="reference external" href="https://zulip.readthedocs.io/en/latest/contributing/contributing.html" style="box-sizing: border-box; color: hsl(283, 39%, 53%); text-decoration: none; cursor: pointer; outline: 0px; font-family: Lato, proxima-nova, &quot;Helvetica Neue&quot;, Arial, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: hsl(0, 0%, 99%);">Contributing guide</a>';

--- a/web/tests/compose_paste.test.cjs
+++ b/web/tests/compose_paste.test.cjs
@@ -429,6 +429,18 @@ run_test("paste_handler_converter", () => {
         "https://zulip.readthedocs.io/en/latest/subsystems/logging.html",
     );
 
+    // Raw link where node.href has a trailing slash the text does not.
+    // Without the fix this becomes a labeled markdown link.
+    input =
+        '<a href="https://google.com" target="_blank" rel="noopener noreferrer" title="https://google.com/">https://google.com</a>';
+    assert.equal(compose_paste.paste_handler_converter(input), "https://google.com");
+    input =
+        '<p>Check this link <a href="https://google.com" target="_blank" rel="noopener noreferrer" title="https://google.com/">https://google.com</a> please</p>';
+    assert.equal(
+        compose_paste.paste_handler_converter(input),
+        "Check this link https://google.com please",
+    );
+
     // Links with custom text
     input =
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><a class="reference external" href="https://zulip.readthedocs.io/en/latest/contributing/contributing.html" style="box-sizing: border-box; color: hsl(283, 39%, 53%); text-decoration: none; cursor: pointer; outline: 0px; font-family: Lato, proxima-nova, &quot;Helvetica Neue&quot;, Arial, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: hsl(0, 0%, 99%);">Contributing guide</a>';

--- a/web/tests/compose_reply.test.cjs
+++ b/web/tests/compose_reply.test.cjs
@@ -389,4 +389,106 @@ run_test("build_and_process_quote_assets_for_messages", ({override}) => {
         {message: msg_unhydrated, quote_content: "converted_by_turndown: <p>unhydrated</p>"},
         "Fallback to using paste_handler_converter",
     );
+
+    // Case: partial bookend content via known_quote_content_by_id.
+    let fetched_ids;
+    override(
+        message_fetch_raw_content,
+        "get_raw_content_for_messages",
+        ({message_ids, on_success}) => {
+            fetched_ids = message_ids;
+            on_success(message_ids.map((id) => `fetched_${id}`));
+        },
+    );
+
+    const known_quote_content_by_id = new Map([[msg_hydrated.id, "...partial bookend A"]]);
+    compose_reply.build_and_process_quote_assets_for_messages(
+        [msg_hydrated.id, msg_unhydrated.id],
+        (assets) => {
+            result_assets = assets;
+        },
+        known_quote_content_by_id,
+    );
+
+    assert.deepEqual(fetched_ids, [msg_unhydrated.id]);
+    assert.deepEqual(
+        known_quote_content_by_id,
+        new Map([[msg_hydrated.id, "...partial bookend A"]]),
+    );
+    assert.deepEqual(result_assets[0], {
+        message: msg_hydrated,
+        quote_content: "...partial bookend A",
+    });
+    assert.deepEqual(result_assets[1], {
+        message: msg_unhydrated,
+        quote_content: `fetched_${msg_unhydrated.id}`,
+    });
+
+    // Case: every message already has known content; no fetch required.
+    fetched_ids = undefined;
+    const fully_known = new Map([
+        [msg_hydrated.id, "partial_1"],
+        [msg_unhydrated.id, "partial_2"],
+    ]);
+    compose_reply.build_and_process_quote_assets_for_messages(
+        [msg_hydrated.id, msg_unhydrated.id],
+        (assets) => {
+            result_assets = assets;
+        },
+        fully_known,
+    );
+
+    assert.equal(fetched_ids, undefined);
+    assert.deepEqual(result_assets[0], {message: msg_hydrated, quote_content: "partial_1"});
+    assert.deepEqual(result_assets[1], {message: msg_unhydrated, quote_content: "partial_2"});
+});
+
+run_test("partial_bookend_markdown", ({override}) => {
+    override(compose_paste, "paste_handler_converter", (html) => `md:${html}`);
+
+    assert.deepEqual(
+        compose_reply.partial_bookend_markdown({
+            message_ids: [10, 20],
+            first_bookend: {html: "<p>start</p>", is_partial: true},
+            last_bookend: {html: "<p>end</p>", is_partial: true},
+        }),
+        {first: "md:<p>start</p>", last: "md:<p>end</p>"},
+    );
+
+    assert.deepEqual(
+        compose_reply.partial_bookend_markdown({
+            message_ids: [10, 20],
+            first_bookend: {html: "<p>start</p>", is_partial: true},
+            last_bookend: {html: "<p>full</p>", is_partial: false},
+        }),
+        {first: "md:<p>start</p>", last: undefined},
+    );
+
+    assert.deepEqual(
+        compose_reply.partial_bookend_markdown({
+            message_ids: [10, 20],
+            first_bookend: {html: "<p>full</p>", is_partial: false},
+            last_bookend: {html: "<p>end</p>", is_partial: true},
+        }),
+        {first: undefined, last: "md:<p>end</p>"},
+    );
+
+    assert.deepEqual(
+        compose_reply.partial_bookend_markdown({
+            message_ids: [10, 20],
+            first_bookend: {html: "<p>full</p>", is_partial: false},
+            last_bookend: undefined,
+        }),
+        {first: undefined, last: undefined},
+    );
+
+    // Producer omits last when there is only one contentful id.
+    assert.deepEqual(
+        compose_reply.partial_bookend_markdown({
+            message_ids: [10],
+            first_bookend: {html: "<p>only</p>", is_partial: true},
+            last_bookend: undefined,
+        }),
+        {first: "md:<p>only</p>", last: undefined},
+    );
 });

--- a/web/tests/compose_reply.test.cjs
+++ b/web/tests/compose_reply.test.cjs
@@ -389,4 +389,60 @@ run_test("build_and_process_quote_assets_for_messages", ({override}) => {
         {message: msg_unhydrated, quote_content: "converted_by_turndown: <p>unhydrated</p>"},
         "Fallback to using paste_handler_converter",
     );
+
+    // Case: partial bookend content via known_quote_content_by_id.
+    let fetched_ids;
+    override(
+        message_fetch_raw_content,
+        "get_raw_content_for_messages",
+        ({message_ids, on_success, _on_error}) => {
+            fetched_ids = message_ids;
+            on_success(message_ids.map((id) => `fetched_${id}`));
+        },
+    );
+
+    const known_quote_content_by_id = new Map([[1, "...partial bookend A"]]);
+    compose_reply.build_and_process_quote_assets_for_messages(
+        [1, 2],
+        (assets) => {
+            result_assets = assets;
+        },
+        known_quote_content_by_id,
+    );
+
+    assert.deepEqual(fetched_ids, [2]);
+    assert.deepEqual(known_quote_content_by_id, new Map([[1, "...partial bookend A"]]));
+    assert.deepEqual(result_assets[0], {
+        message: msg_hydrated,
+        quote_content: "...partial bookend A",
+    });
+    assert.deepEqual(result_assets[1], {
+        message: msg_unhydrated,
+        quote_content: "fetched_2",
+    });
+
+    // Case: every message already has known content; no fetch required.
+    fetched_ids = undefined;
+    const fully_known = new Map([
+        [1, "partial_1"],
+        [2, "partial_2"],
+    ]);
+    compose_reply.build_and_process_quote_assets_for_messages(
+        [1, 2],
+        (assets) => {
+            result_assets = assets;
+        },
+        fully_known,
+    );
+
+    assert.equal(fetched_ids, undefined);
+    assert.deepEqual(
+        fully_known,
+        new Map([
+            [1, "partial_1"],
+            [2, "partial_2"],
+        ]),
+    );
+    assert.deepEqual(result_assets[0], {message: msg_hydrated, quote_content: "partial_1"});
+    assert.deepEqual(result_assets[1], {message: msg_unhydrated, quote_content: "partial_2"});
 });


### PR DESCRIPTION
Fixes #39129.


[#design > Quoting/Forwarding multiple messages #37878](https://chat.zulip.org/#narrow/channel/101-design/topic/Quoting.2FForwarding.20multiple.20messages.20.2337878/with/2380917)

When a contiguous text selection spans multiple messages, multi-message
quote (`>`) and forward (`<`) previously always inserted the **full** body of
every message in the range. That mismatched multi-message **copy** (#35100)
and the existing single-message partial-quote path.

This change uses shared bookend selection helpers so the first and last
messages in a multi-message selection contribute only the highlighted
portion (with the same leading/trailing `[...]` markers as copy), while
middle messages stay full. Fully covered bookends still prefer server
`raw_content`.

Truncation uses editorial `[...]` ([CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/Quoting.2FForwarding.20multiple.20messages.20.2337878/near/2490693)).

Partial bookends are supported for single-range selections (Chrome and
modern Firefox). Multi-range selections (older Firefox) keep using full
bodies for every message, matching existing copy tradeoffs.

## Screenshots and screen captures

### Full multi-message selection

| | selection | quote content |
| --- | --- | --- |
| Full first / full middle / full last; no ellipsis | ![Full multi before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/01-full-multi-before.png?v=7) | ![Full multi after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/01-full-multi-after.png?v=7) |

### Partial bookends

| | selection | quote content |
| --- | --- | --- |
| Partial first **and** last | ![Partial both before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/02-partial-both-before.png?v=7) | ![Partial both after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/02-partial-both-after.png?v=7) |
| Partial first only; **full** last | ![Partial first before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/03-partial-first-before.png?v=7) | ![Partial first after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/03-partial-first-after.png?v=7) |
| **Full** first; partial last | ![Partial last before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/04-partial-last-before.png?v=7) | ![Partial last after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/04-partial-last-after.png?v=7) |
| Two-message both partial | ![Two-message before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/05-two-message-before.png?v=7) | ![Two-message after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/05-two-message-after.png?v=7) |
| Four-message partial; middles full | ![Four-message before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/06-four-message-before.png?v=7) | ![Four-message after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/06-four-message-after.png?v=7) |
| Forward (`<`) partial both | ![Forward before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/07-forward-partial-before.png?v=7) | ![Forward after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/07-forward-partial-after.png?v=7) |

### Single-message partial (regression safety check)

| | selection | quote content |
| --- | --- | --- |
| Still quotes only the highlighted span | ![Single before](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/08-single-partial-before.png?v=7) | ![Single after](https://raw.githubusercontent.com/apoorvapendse/zulip/pr-39129-screenshot-assets/08-single-partial-after.png?v=7) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>



