### PR TITLE
sentry: Move /error_tracing event forwarding to a queue worker.

### DIFF
--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -233,7 +233,13 @@ You can enable it by:
     ```
 3.  If you wish to [sample][sentry-sample] some fraction of the errors, you
     should adjust `SENTRY_FRONTEND_SAMPLE_RATE` down from `1.0`.
-4.  As the `zulip` user, restart Zulip by running:
+4.  As root, run:
+    ```shell
+        /home/zulip/deployments/current/scripts/zulip-puppet-apply
+    ```
+    This installs the `sentry_events` queue worker, which handles
+    forwarding browser errors to Sentry asynchronously.
+5.  As the `zulip` user, restart Zulip by running:
     ```shell
     /home/zulip/deployments/current/scripts/restart-server
     ```

--- a/docs/subsystems/queuing.md
+++ b/docs/subsystems/queuing.md
@@ -61,7 +61,7 @@ You can publish events to a RabbitMQ queue using the
 
 An interesting challenge with queue processors is what should happen
 when queued events in Zulip's backend tests. Our current solution is
-that in the tests, `queue_event_on_commit` will (by default) simple call
+that in the tests, `queue_event_on_commit` will (by default) simply call
 the `consume` method for the relevant queue processor. However,
 `queue_event_on_commit` also supports being passed a function that should
 be called in the tests instead of the queue processor's `consume`

--- a/puppet/kandra/files/nagios4/conf.d/services.cfg
+++ b/puppet/kandra/files/nagios4/conf.d/services.cfg
@@ -384,6 +384,12 @@ define service {
 
 define service {
         use                             rabbitmq-consumer-service
+        service_description             Check RabbitMQ sentry_events consumers
+        check_command                   check_rabbitmq_consumers!sentry_events
+}
+
+define service {
+        use                             rabbitmq-consumer-service
         service_description             Check RabbitMQ soft_reactivation consumers
         check_command                   check_rabbitmq_consumers!soft_reactivation
 }

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -161,6 +161,7 @@ class zulip::app_frontend_base {
     'missedmessage_emails',
     'missedmessage_mobile_notifications',
     'outgoing_webhooks',
+    'sentry_events',
     'thumbnail',
     'user_activity',
     'user_activity_interval',

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -127,8 +127,6 @@ not_yet_fully_covered = [
     "zerver/webhooks/greenhouse/view.py",
     "zerver/webhooks/teamcity/view.py",
     "zerver/webhooks/zapier/view.py",
-    # This is hard to get test coverage for, and low value to do so
-    "zerver/views/sentry.py",
     # Cannot have coverage, as tests run in a transaction
     "zerver/lib/safe_session_cached_db.py",
     "zerver/lib/singleton_bmemcached.py",

--- a/zerver/tests/test_sentry.py
+++ b/zerver/tests/test_sentry.py
@@ -1,15 +1,18 @@
+import base64
 from unittest import mock
 
 import orjson
 from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
 from pybreaker import CircuitBreakerError
-from requests.exceptions import Timeout
+from requests import HTTPError
+from requests.exceptions import ProxyError, Timeout
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.response import json_response_from_error
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.views.sentry import sentry_tunnel
+from zerver.worker.sentry_events import SentryEventsWorker, open_circuit_for
 
 TEST_USER_IP = "203.0.113.42"
 # We make this valid by overriding SENTRY_FRONTEND_DSN in the test class below.
@@ -71,10 +74,11 @@ def build_envelope(
 @override_settings(SENTRY_FRONTEND_DSN=TEST_VALID_DSN)
 class SentryTunnelTest(ZulipTestCase):
     """
-    Tests the current (synchronous) sentry_tunnel view, prior to
-    migrating Sentry submission to a queue worker per zulip#26229.
-    Tests call the view directly via RequestFactory to avoid depending
-    on conditional URL registration.
+    Tests for the sentry_tunnel view. The view validates the envelope,
+    injects the client IP, and publishes to the sentry_events queue;
+    the actual HTTP forwarding to Sentry happens in SentryEventsWorker.
+    Tests mock queue_event_on_commit to keep tests hermetic and assert
+    on exactly what gets enqueued.
     """
 
     def _post_envelope(
@@ -93,46 +97,48 @@ class SentryTunnelTest(ZulipTestCase):
         except JsonableError as e:
             return json_response_from_error(e)
 
-    def test_valid_envelope_is_forwarded_to_sentry(self) -> None:
+    def test_valid_envelope_is_enqueued(self) -> None:
         envelope = build_envelope()
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(envelope)
 
         self.assertEqual(response.status_code, 200)
-        mock_request.assert_called_once()
-        (called_url, _), _kwargs = mock_request.call_args
-        self.assertIn("/api/789/envelope/", called_url)
+        mock_queue.assert_called_once()
+        queue_name, event = mock_queue.call_args[0]
+        self.assertEqual(queue_name, "sentry_events")
+        self.assertIn("/api/789/envelope/", event["url"])
 
     def test_invalid_dsn_is_rejected(self) -> None:
         envelope = build_envelope(dsn=TEST_INVALID_DSN)
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(envelope)
 
         self.assert_json_error(response, "Invalid DSN", 400)
-        mock_request.assert_not_called()
+        mock_queue.assert_not_called()
 
     def test_malformed_envelope_is_rejected(self) -> None:
         # No newline at all -- the initial `request.body.split(b"\n", 1)`
         # will fail to produce two parts.
         malformed_envelope = b"not a real envelope"
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(malformed_envelope)
 
         self.assert_json_error(response, "Invalid request format", 400)
-        mock_request.assert_not_called()
+        mock_queue.assert_not_called()
 
     def test_ip_address_is_injected_into_user_payload(self) -> None:
         envelope = build_envelope(user_ip="should-be-overwritten")
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(envelope, remote_addr=TEST_USER_IP)
 
         self.assertEqual(response.status_code, 200)
-        mock_request.assert_called_once()
-        (_, called_body), _kwargs = mock_request.call_args
+        mock_queue.assert_called_once()
+        _, event = mock_queue.call_args[0]
+        called_body = base64.b64decode(event["body"])
         # The body is: header\n, item_header\n, item_body\n
         _header_line, rest = called_body.split(b"\n", 1)
         _item_header_line, item_body_and_rest = rest.split(b"\n", 1)
@@ -145,12 +151,13 @@ class SentryTunnelTest(ZulipTestCase):
         # but via the explicit-length parsing branch.
         envelope = build_envelope(user_ip="should-be-overwritten", explicit_length=True)
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(envelope, remote_addr=TEST_USER_IP)
 
         self.assertEqual(response.status_code, 200)
-        mock_request.assert_called_once()
-        (_, called_body), _kwargs = mock_request.call_args
+        mock_queue.assert_called_once()
+        _, event = mock_queue.call_args[0]
+        called_body = base64.b64decode(event["body"])
         _header_line, rest = called_body.split(b"\n", 1)
         item_header_line, item_body_and_rest = rest.split(b"\n", 1)
         item_header = orjson.loads(item_header_line)
@@ -177,12 +184,13 @@ class SentryTunnelTest(ZulipTestCase):
         item_header = orjson.dumps({"type": "event", "length": len(item_body_bytes)})
         envelope = envelope_header + b"\n" + item_header + b"\n" + item_body_bytes
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(envelope)
 
         self.assertEqual(response.status_code, 200)
-        mock_request.assert_called_once()
-        (_called_url, called_body), _kwargs = mock_request.call_args
+        mock_queue.assert_called_once()
+        _, event = mock_queue.call_args[0]
+        called_body = base64.b64decode(event["body"])
         _header_line, rest = called_body.split(b"\n", 1)
         item_header_line, item_body_and_rest = rest.split(b"\n", 1)
         parsed_header = orjson.loads(item_header_line)
@@ -200,14 +208,38 @@ class SentryTunnelTest(ZulipTestCase):
         item_body = b"arbitrary binary-ish payload, not even valid JSON"
         envelope = envelope_header + b"\n" + item_header + b"\n" + item_body + b"\n"
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(envelope, remote_addr=TEST_USER_IP)
 
         self.assertEqual(response.status_code, 200)
-        mock_request.assert_called_once()
-        (_called_url, called_body), _kwargs = mock_request.call_args
+        mock_queue.assert_called_once()
+        _, event = mock_queue.call_args[0]
+        called_body = base64.b64decode(event["body"])
         # Forwarded exactly as-is -- no parsing/mutation attempted for this item type.
         self.assertEqual(called_body, envelope)
+
+    def test_ip_address_is_injected_before_enqueueing(self) -> None:
+        # Verifies that the view enqueues via queue_event_on_commit
+        # rather than calling sentry_request directly, and that IP
+        # injection happens before enqueueing.
+        envelope = build_envelope(user_ip="should-be-overwritten")
+
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
+            response = self._post_envelope(envelope, remote_addr=TEST_USER_IP)
+
+        self.assertEqual(response.status_code, 200)
+        mock_queue.assert_called_once()
+        queue_name, event = mock_queue.call_args[0]
+        self.assertEqual(queue_name, "sentry_events")
+        self.assertIn("/api/789/envelope/", event["url"])
+
+        # Confirm IP injection happened before enqueueing.
+        decoded_body = base64.b64decode(event["body"])
+        _header_line, rest = decoded_body.split(b"\n", 1)
+        _item_header_line, item_body_and_rest = rest.split(b"\n", 1)
+        item_body = item_body_and_rest.split(b"\n", 1)[0]
+        payload = orjson.loads(item_body)
+        self.assertEqual(payload["user"]["ip_address"], TEST_USER_IP)
 
     def test_unparseable_item_body_is_forwarded_unmodified(self) -> None:
         # This is a valid DSN and header, but the payload is not a valid
@@ -222,12 +254,13 @@ class SentryTunnelTest(ZulipTestCase):
             + b"not valid JSON\n"
         )
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(garbage)
 
         self.assertEqual(response.status_code, 200)
-        mock_request.assert_called_once()
-        (_called_url, called_body), _kwargs = mock_request.call_args
+        mock_queue.assert_called_once()
+        _, event = mock_queue.call_args[0]
+        called_body = base64.b64decode(event["body"])
         # The key assertion: the fallback forwards the *original* body
         # byte-for-byte, not a partially-mutated or truncated version.
         self.assertEqual(called_body, garbage)
@@ -243,63 +276,93 @@ class SentryTunnelTest(ZulipTestCase):
             length_override=5,
         )
 
-        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+        with mock.patch("zerver.views.sentry.queue_event_on_commit") as mock_queue:
             response = self._post_envelope(envelope)
 
         self.assertEqual(response.status_code, 200)
-        mock_request.assert_called_once()
-        (_called_url, called_body), _kwargs = mock_request.call_args
+        mock_queue.assert_called_once()
+        _, event = mock_queue.call_args[0]
+        called_body = base64.b64decode(event["body"])
         self.assertEqual(called_body, envelope)
 
-    def test_circuit_breaker_open_is_logged_and_swallowed(self) -> None:
-        envelope = build_envelope()
 
-        with mock.patch(
-            "zerver.views.sentry.sentry_request",
-            side_effect=CircuitBreakerError("Sentry tunnel"),
-        ):
-            with self.assertLogs(level="WARNING") as warning_logs:
-                response = self._post_envelope(envelope)
-            self.assertIn(
-                "WARNING:zerver.views.sentry:Dropped a client exception due to circuit-breaking",
-                warning_logs.output[0],
+class SentryEventsWorkerTest(ZulipTestCase):
+    """
+    Tests for SentryEventsWorker.consume(), which decodes the queued
+    event and forwards it to Sentry via sentry_request.
+    """
+
+    def test_consume_calls_sentry_request(self) -> None:
+        worker = SentryEventsWorker()
+        test_url = "https://o123456.ingest.sentry.io/api/789/envelope/"
+        test_body = b"some envelope bytes"
+
+        with mock.patch("zerver.worker.sentry_events.sentry_request") as mock_request:
+            worker.consume(
+                {
+                    "url": test_url,
+                    "body": base64.b64encode(test_body).decode("ascii"),
+                }
             )
-        # Per current behavior: even when the breaker is open, the
-        # client always gets a 200, since this is fire-and-forget.
-        self.assertEqual(response.status_code, 200)
+
+        mock_request.assert_called_once_with(test_url, test_body)
+
+    def test_circuit_breaker_open_is_logged_and_swallowed(self) -> None:
+        worker = SentryEventsWorker()
+
+        with (
+            mock.patch(
+                "zerver.worker.sentry_events.sentry_request",
+                side_effect=CircuitBreakerError("Sentry tunnel"),
+            ),
+            self.assertLogs(level="WARNING") as warning_logs,
+        ):
+            worker.consume(
+                {
+                    "url": "https://o123456.ingest.sentry.io/api/789/envelope/",
+                    "body": base64.b64encode(b"test").decode("ascii"),
+                }
+            )
+
+        self.assertIn(
+            "WARNING:zerver.worker.sentry_events:Dropped a client exception due to circuit-breaking",
+            warning_logs.output,
+        )
 
     def test_request_exception_is_logged_and_swallowed(self) -> None:
-        envelope = build_envelope()
+        worker = SentryEventsWorker()
 
-        with mock.patch(
-            "zerver.views.sentry.sentry_request",
-            side_effect=Timeout("simulated timeout"),
+        with (
+            mock.patch(
+                "zerver.worker.sentry_events.sentry_request",
+                side_effect=Timeout("simulated timeout"),
+            ),
+            self.assertLogs(level="ERROR") as error_logs,
         ):
-            with self.assertLogs(level="ERROR") as error_logs:
-                response = self._post_envelope(envelope)
-            self.assertIn(
-                "ERROR:zerver.views.sentry:simulated timeout",
-                error_logs.output[0],
+            worker.consume(
+                {
+                    "url": "https://o123456.ingest.sentry.io/api/789/envelope/",
+                    "body": base64.b64encode(b"test").decode("ascii"),
+                }
             )
-        self.assertEqual(response.status_code, 200)
+
+        self.assertIn(
+            "ERROR:zerver.worker.sentry_events:simulated timeout",
+            error_logs.output[0],
+        )
 
     def test_open_circuit_for(self) -> None:
-        from requests.exceptions import ProxyError, Timeout
-        from requests import HTTPError
-        from unittest.mock import MagicMock
-        from zerver.views.sentry import open_circuit_for
-
         self.assertTrue(open_circuit_for(ProxyError()))
         self.assertTrue(open_circuit_for(Timeout()))
 
         # 429 and 5xx trip the breaker
         for status_code in [429, 500, 503]:
-            response = MagicMock()
+            response = mock.MagicMock()
             response.status_code = status_code
             self.assertTrue(open_circuit_for(HTTPError(response=response)))
 
         # 4xx (other than 429) do not trip the breaker
-        response = MagicMock()
+        response = mock.MagicMock()
         response.status_code = 401
         self.assertFalse(open_circuit_for(HTTPError(response=response)))
 

--- a/zerver/tests/test_sentry.py
+++ b/zerver/tests/test_sentry.py
@@ -1,0 +1,307 @@
+from unittest import mock
+
+import orjson
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+from pybreaker import CircuitBreakerError
+from requests.exceptions import Timeout
+
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.response import json_response_from_error
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.views.sentry import sentry_tunnel
+
+TEST_USER_IP = "203.0.113.42"
+# We make this valid by overriding SENTRY_FRONTEND_DSN in the test class below.
+TEST_VALID_DSN = "https://abc123@o123456.ingest.sentry.io/789"
+# Doesn't match TEST_VALID_DSN/SENTRY_FRONTEND_DSN, so view will reject.
+TEST_INVALID_DSN = "https://other@o999999.ingest.sentry.io/000"
+
+
+def build_envelope(
+    dsn: str = TEST_VALID_DSN,
+    item_type: str = "event",
+    user_ip: str | None = None,
+    explicit_length: bool = False,
+    length_override: int | None = None,
+) -> bytes:
+    """
+    Builds a minimal, valid Sentry envelope with a single item.
+    See https://develop.sentry.dev/sdk/envelopes/ for the format:
+    a header JSON line, then for each item: an item-header JSON line,
+    then the item body.
+
+    By default the item header omits "length", so the item body is
+    delimited by a trailing newline (the length-less branch of the
+    parser). Pass explicit_length=True to instead declare the body's
+    exact byte length in the item header (the explicit-length branch),
+    which is parsed differently: no trailing newline is required or
+    consumed after the body.
+
+    length_override lets a caller declare a length that doesn't match
+    the actual body size, to exercise the parser's failure/fallback
+    behavior on a corrupt envelope.
+    """
+    envelope_header = orjson.dumps({"dsn": dsn})
+
+    item_body: dict[str, object] = {
+        "message": "test event from baseline test",
+    }
+    if user_ip is not None:
+        item_body["user"] = {"ip_address": user_ip}
+
+    item_body_bytes = orjson.dumps(item_body)
+
+    item_header_fields: dict[str, object] = {"type": item_type}
+    if explicit_length:
+        item_header_fields["length"] = (
+            length_override if length_override is not None else len(item_body_bytes)
+        )
+    item_header = orjson.dumps(item_header_fields)
+
+    if explicit_length:
+        # No trailing newline: the parser slices exactly `length`
+        # bytes for the body and treats whatever follows as the
+        # start of the next item (or the end of input).
+        return envelope_header + b"\n" + item_header + b"\n" + item_body_bytes
+    else:
+        return envelope_header + b"\n" + item_header + b"\n" + item_body_bytes + b"\n"
+
+
+@override_settings(SENTRY_FRONTEND_DSN=TEST_VALID_DSN)
+class SentryTunnelTest(ZulipTestCase):
+    """
+    Tests the current (synchronous) sentry_tunnel view, prior to
+    migrating Sentry submission to a queue worker per zulip#26229.
+    Tests call the view directly via RequestFactory to avoid depending
+    on conditional URL registration.
+    """
+
+    def _post_envelope(
+        self,
+        envelope: bytes,
+        remote_addr: str = TEST_USER_IP,
+    ) -> HttpResponse:
+        request = RequestFactory().post(
+            "/error_tracing",
+            data=envelope,
+            content_type="application/x-sentry-envelope",
+            REMOTE_ADDR=remote_addr,
+        )
+        try:
+            return sentry_tunnel(request)
+        except JsonableError as e:
+            return json_response_from_error(e)
+
+    def test_valid_envelope_is_forwarded_to_sentry(self) -> None:
+        envelope = build_envelope()
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(envelope)
+
+        self.assertEqual(response.status_code, 200)
+        mock_request.assert_called_once()
+        (called_url, _), _kwargs = mock_request.call_args
+        self.assertIn("/api/789/envelope/", called_url)
+
+    def test_invalid_dsn_is_rejected(self) -> None:
+        envelope = build_envelope(dsn=TEST_INVALID_DSN)
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(envelope)
+
+        self.assert_json_error(response, "Invalid DSN", 400)
+        mock_request.assert_not_called()
+
+    def test_malformed_envelope_is_rejected(self) -> None:
+        # No newline at all -- the initial `request.body.split(b"\n", 1)`
+        # will fail to produce two parts.
+        malformed_envelope = b"not a real envelope"
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(malformed_envelope)
+
+        self.assert_json_error(response, "Invalid request format", 400)
+        mock_request.assert_not_called()
+
+    def test_ip_address_is_injected_into_user_payload(self) -> None:
+        envelope = build_envelope(user_ip="should-be-overwritten")
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(envelope, remote_addr=TEST_USER_IP)
+
+        self.assertEqual(response.status_code, 200)
+        mock_request.assert_called_once()
+        (_, called_body), _kwargs = mock_request.call_args
+        # The body is: header\n, item_header\n, item_body\n
+        _header_line, rest = called_body.split(b"\n", 1)
+        _item_header_line, item_body_and_rest = rest.split(b"\n", 1)
+        item_body = item_body_and_rest.split(b"\n", 1)[0]
+        payload = orjson.loads(item_body)
+        self.assertEqual(payload["user"]["ip_address"], TEST_USER_IP)
+
+    def test_ip_address_is_injected_via_explicit_length(self) -> None:
+        # Same as test_ip_address_is_injected_into_user_payload,
+        # but via the explicit-length parsing branch.
+        envelope = build_envelope(user_ip="should-be-overwritten", explicit_length=True)
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(envelope, remote_addr=TEST_USER_IP)
+
+        self.assertEqual(response.status_code, 200)
+        mock_request.assert_called_once()
+        (_, called_body), _kwargs = mock_request.call_args
+        _header_line, rest = called_body.split(b"\n", 1)
+        item_header_line, item_body_and_rest = rest.split(b"\n", 1)
+        item_header = orjson.loads(item_header_line)
+        length = item_header["length"]
+        item_body = item_body_and_rest[:length]
+        payload = orjson.loads(item_body)
+        self.assertEqual(payload["user"]["ip_address"], TEST_USER_IP)
+
+    def test_explicit_length_handles_multibyte_utf8(self) -> None:
+        # "café" -- the "é" character is 2 bytes in UTF-8 but only
+        # 1 character, so a length computed from character count
+        # rather than byte count would mis-slice this body.
+        test_message = "café \u2603"  # also include a snowman (3 bytes in UTF-8)
+
+        envelope_header = orjson.dumps({"dsn": TEST_VALID_DSN})
+        item_body_bytes = orjson.dumps({"message": test_message})
+
+        # Sanity check our own test data: confirm this body actually
+        # has more bytes than characters, so the test would catch a
+        # char-count-vs-byte-count bug if one existed.
+        decoded_for_sanity_check = orjson.loads(item_body_bytes)
+        self.assertGreater(len(item_body_bytes), len(decoded_for_sanity_check["message"]))
+
+        item_header = orjson.dumps({"type": "event", "length": len(item_body_bytes)})
+        envelope = envelope_header + b"\n" + item_header + b"\n" + item_body_bytes
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(envelope)
+
+        self.assertEqual(response.status_code, 200)
+        mock_request.assert_called_once()
+        (_called_url, called_body), _kwargs = mock_request.call_args
+        _header_line, rest = called_body.split(b"\n", 1)
+        item_header_line, item_body_and_rest = rest.split(b"\n", 1)
+        parsed_header = orjson.loads(item_header_line)
+        length = parsed_header["length"]
+        item_body = item_body_and_rest[:length]
+        payload = orjson.loads(item_body)
+        self.assertEqual(payload["message"], test_message)
+
+    def test_non_event_item_type_skips_ip_injection(self) -> None:
+        # IP injection only applies to "transaction" and "event" items;
+        # other item types (e.g. "attachment") should pass through
+        # completely unmodified, with no attempt to parse/mutate the body.
+        envelope_header = orjson.dumps({"dsn": TEST_VALID_DSN})
+        item_header = orjson.dumps({"type": "attachment"})
+        item_body = b"arbitrary binary-ish payload, not even valid JSON"
+        envelope = envelope_header + b"\n" + item_header + b"\n" + item_body + b"\n"
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(envelope, remote_addr=TEST_USER_IP)
+
+        self.assertEqual(response.status_code, 200)
+        mock_request.assert_called_once()
+        (_called_url, called_body), _kwargs = mock_request.call_args
+        # Forwarded exactly as-is -- no parsing/mutation attempted for this item type.
+        self.assertEqual(called_body, envelope)
+
+    def test_unparseable_item_body_is_forwarded_unmodified(self) -> None:
+        # This is a valid DSN and header, but the payload is not a valid
+        # JSON object, so the `orjson.loads(item_body)` call inside the
+        # IP-injection block will raise, and `suppress(Exception)` should
+        # cause the view to fall back to forwarding the original,
+        # unmutated envelope bytes rather than dropping the report.
+        garbage = (
+            orjson.dumps({"dsn": TEST_VALID_DSN})
+            + b"\n"
+            + b'{"type": "event"}\n'
+            + b"not valid JSON\n"
+        )
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(garbage)
+
+        self.assertEqual(response.status_code, 200)
+        mock_request.assert_called_once()
+        (_called_url, called_body), _kwargs = mock_request.call_args
+        # The key assertion: the fallback forwards the *original* body
+        # byte-for-byte, not a partially-mutated or truncated version.
+        self.assertEqual(called_body, garbage)
+
+    def test_incorrect_length_falls_back_to_original_envelope(self) -> None:
+        # Declares a "length" shorter than the actual body, so the
+        # parser slices mid-JSON-object; orjson.loads should fail to
+        # parse the truncated bytes, triggering the suppress(Exception)
+        # fallback that forwards the original envelope unmodified.
+        envelope = build_envelope(
+            user_ip=TEST_USER_IP,
+            explicit_length=True,
+            length_override=5,
+        )
+
+        with mock.patch("zerver.views.sentry.sentry_request") as mock_request:
+            response = self._post_envelope(envelope)
+
+        self.assertEqual(response.status_code, 200)
+        mock_request.assert_called_once()
+        (_called_url, called_body), _kwargs = mock_request.call_args
+        self.assertEqual(called_body, envelope)
+
+    def test_circuit_breaker_open_is_logged_and_swallowed(self) -> None:
+        envelope = build_envelope()
+
+        with mock.patch(
+            "zerver.views.sentry.sentry_request",
+            side_effect=CircuitBreakerError("Sentry tunnel"),
+        ):
+            with self.assertLogs(level="WARNING") as warning_logs:
+                response = self._post_envelope(envelope)
+            self.assertIn(
+                "WARNING:zerver.views.sentry:Dropped a client exception due to circuit-breaking",
+                warning_logs.output[0],
+            )
+        # Per current behavior: even when the breaker is open, the
+        # client always gets a 200, since this is fire-and-forget.
+        self.assertEqual(response.status_code, 200)
+
+    def test_request_exception_is_logged_and_swallowed(self) -> None:
+        envelope = build_envelope()
+
+        with mock.patch(
+            "zerver.views.sentry.sentry_request",
+            side_effect=Timeout("simulated timeout"),
+        ):
+            with self.assertLogs(level="ERROR") as error_logs:
+                response = self._post_envelope(envelope)
+            self.assertIn(
+                "ERROR:zerver.views.sentry:simulated timeout",
+                error_logs.output[0],
+            )
+        self.assertEqual(response.status_code, 200)
+
+    def test_open_circuit_for(self) -> None:
+        from requests.exceptions import ProxyError, Timeout
+        from requests import HTTPError
+        from unittest.mock import MagicMock
+        from zerver.views.sentry import open_circuit_for
+
+        self.assertTrue(open_circuit_for(ProxyError()))
+        self.assertTrue(open_circuit_for(Timeout()))
+
+        # 429 and 5xx trip the breaker
+        for status_code in [429, 500, 503]:
+            response = MagicMock()
+            response.status_code = status_code
+            self.assertTrue(open_circuit_for(HTTPError(response=response)))
+
+        # 4xx (other than 429) do not trip the breaker
+        response = MagicMock()
+        response.status_code = 401
+        self.assertFalse(open_circuit_for(HTTPError(response=response)))
+
+        # Other exceptions do not trip the breaker
+        self.assertFalse(open_circuit_for(ValueError()))

--- a/zerver/views/sentry.py
+++ b/zerver/views/sentry.py
@@ -1,4 +1,4 @@
-import logging
+import base64
 from contextlib import suppress
 from urllib.parse import urlsplit
 
@@ -7,23 +7,10 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
-from pybreaker import CircuitBreaker, CircuitBreakerError
-from requests.exceptions import HTTPError, ProxyError, RequestException, Timeout
-from sentry_sdk.integrations.logging import ignore_logger
 
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.outgoing_http import OutgoingSession
+from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.validator import check_url, to_wild_value
-
-# In order to not overload Sentry if it's having a bad day, we tell
-# Sentry to ignore exceptions that we have when talking to Sentry.
-logger = logging.getLogger(__name__)
-ignore_logger(logger.name)
-
-
-class SentryTunnelSession(OutgoingSession):
-    def __init__(self) -> None: # nocoverage
-        super().__init__(role="sentry_tunnel", timeout=1)
 
 
 @csrf_exempt
@@ -83,42 +70,11 @@ def sentry_tunnel(
                 parts.append(b"\n")
         updated_body = b"".join(parts)
 
-    try:
-        sentry_request(url, updated_body)
-    except CircuitBreakerError:
-        logger.warning("Dropped a client exception due to circuit-breaking")
-    except RequestException as e:
-        # This logger has been configured, above, to not report to Sentry
-        logger.exception(e)
+    queue_event_on_commit(
+        "sentry_events",
+        {
+            "url": url,
+            "body": base64.b64encode(updated_body).decode("ascii"),
+        },
+    )
     return HttpResponse(status=200)
-
-
-# Circuit-break and temporarily stop trying to report to
-# Sentry if it keeps timing out.  We include ProxyError in
-# here because we are likely making our requests through
-# Smokescreen as a CONNECT proxy, so failures from Smokescreen
-# failing to connect at the TCP level will report as
-# ProxyErrors.
-def open_circuit_for(exc_value: Exception) -> bool:
-    if isinstance(exc_value, ProxyError | Timeout):
-        return True
-    if isinstance(exc_value, HTTPError):
-        response = exc_value.response
-        if response.status_code == 429 or response.status_code >= 500:
-            return True
-    return False
-
-
-# Open the circuit after 2 failures, and leave it open for 30s.
-@CircuitBreaker(
-    fail_max=2,
-    reset_timeout=30,
-    name="Sentry tunnel",
-    exclude=(open_circuit_for,),
-)
-def sentry_request(url: str, data: bytes) -> None: # nocoverage
-    SentryTunnelSession().post(
-        url=url,
-        data=data,
-        headers={"Content-Type": "application/x-sentry-envelope"},
-    ).raise_for_status()

--- a/zerver/views/sentry.py
+++ b/zerver/views/sentry.py
@@ -22,7 +22,7 @@ ignore_logger(logger.name)
 
 
 class SentryTunnelSession(OutgoingSession):
-    def __init__(self) -> None:
+    def __init__(self) -> None: # nocoverage
         super().__init__(role="sentry_tunnel", timeout=1)
 
 
@@ -116,7 +116,7 @@ def open_circuit_for(exc_value: Exception) -> bool:
     name="Sentry tunnel",
     exclude=(open_circuit_for,),
 )
-def sentry_request(url: str, data: bytes) -> None:
+def sentry_request(url: str, data: bytes) -> None: # nocoverage
     SentryTunnelSession().post(
         url=url,
         data=data,

--- a/zerver/worker/sentry_events.py
+++ b/zerver/worker/sentry_events.py
@@ -1,0 +1,68 @@
+# Documented in https://zulip.readthedocs.io/en/latest/subsystems/queuing.html
+import base64
+import logging
+from typing import Any
+
+from pybreaker import CircuitBreaker, CircuitBreakerError
+from requests.exceptions import HTTPError, ProxyError, RequestException, Timeout
+from sentry_sdk.integrations.logging import ignore_logger
+from typing_extensions import override
+
+from zerver.lib.outgoing_http import OutgoingSession
+from zerver.worker.base import QueueProcessingWorker, assign_queue
+
+logger = logging.getLogger(__name__)
+ignore_logger(logger.name)
+
+
+class SentryTunnelSession(OutgoingSession):
+    def __init__(self) -> None:  # nocoverage
+        super().__init__(role="sentry_tunnel", timeout=1)
+
+
+# Circuit-break and temporarily stop trying to report to
+# Sentry if it keeps timing out.  We include ProxyError in
+# here because we are likely making our requests through
+# Smokescreen as a CONNECT proxy, so failures from Smokescreen
+# failing to connect at the TCP level will report as
+# ProxyErrors.
+def open_circuit_for(exc_value: Exception) -> bool:
+    if isinstance(exc_value, ProxyError | Timeout):
+        return True
+    if isinstance(exc_value, HTTPError):
+        response = exc_value.response
+        if response.status_code == 429 or response.status_code >= 500:
+            return True
+    return False
+
+
+# Open the circuit after 2 failures, and leave it open for 30s.
+@CircuitBreaker(
+    fail_max=2,
+    reset_timeout=30,
+    name="Sentry tunnel",
+    exclude=(open_circuit_for,),
+)
+def sentry_request(url: str, data: bytes) -> None:  # nocoverage
+    SentryTunnelSession().post(
+        url=url,
+        data=data,
+        headers={"Content-Type": "application/x-sentry-envelope"},
+    ).raise_for_status()
+
+
+@assign_queue("sentry_events")
+class SentryEventsWorker(QueueProcessingWorker):
+    """Forwards browser-submitted Sentry error reports to Sentry's API."""
+
+    @override
+    def consume(self, event: dict[str, Any]) -> None:
+        try:
+            sentry_request(
+                event["url"],
+                base64.b64decode(event["body"]),
+            )
+        except CircuitBreakerError:
+            logger.warning("Dropped a client exception due to circuit-breaking")
+        except RequestException as e:
+            logger.exception(e)


### PR DESCRIPTION
The sentry_tunnel view forwarded browser error reports to Sentry
synchronously, so if Sentry was slow or unavailable, every request to
/error_tracing would tie up a uwsgi worker process. A circuit breaker
was added as a partial mitigation (see the commit message for that
change, which explicitly references this issue as the fuller fix), but
because the breaker state was per-uwsgi-process, it could require more
than 2 failures overall to trip, and might only trip for some workers
but not others.

To ensure that /error_tracing always returns immediately, this PR
moves the outbound Sentry request into a new queue processor
(sentry_events), implemented by the SentryEventsWorker class.

The view still handles envelope parsing and IP-address injection
synchronously, since REMOTE_ADDR is only available in the request
context. But the ready-to-forward URL and body are now published via
queue_event_on_commit, with the body base64-encoded to pass bytes
safely through the JSON queue. The circuit breaker configuration,
open_circuit_for exception classification, and outbound session
timeout are preserved verbatim from the original view.

Since enabling SENTRY_FRONTEND_DSN now requires a puppet run to
install the worker process, the logging documentation has been updated
accordingly. 

Two items from the original issue remain as potential follow-ups:

1. The memory footprint concern: deployments without Sentry configured
   will run a sentry_events worker that connects to RabbitMQ but never
   receives events. A general is_enabled() hook on QueueProcessingWorker
   could address this -- when is_enabled() returns False, the worker
   would replace itself with sleep infinity via os.execv, consuming
   essentially no memory while remaining visible to supervisord.
   SentryEventsWorker would override is_enabled() to return False when
   SENTRY_FRONTEND_DSN is unset. This was implemented during development
   but removed because the existing Nagios consumer monitoring
   infrastructure expects a RabbitMQ consumer for every registered
   queue, which conflicts with a worker that intentionally has none.

2. Dynamically respecting Sentry's Retry-After header on 429 responses,
   rather than using the fixed reset_timeout=30 on the circuit breaker.
   The 429 case is already handled (it trips the breaker), but the
   retry interval is not yet dynamically adjusted.

Fixes: #26229 

**How changes were tested:**
The new SentryEventsWorkerTest and SentryTunnelTest test
classes cover DSN/envelope validation, both envelope parsing branches
(including a multibyte UTF-8 case), IP-address injection, fallback
behavior when parsing fails, circuit-breaker and request-exception
handling, and the is_enabled() mechanism for both
QueueProcessingWorker and LoopQueueProcessingWorker.

Changes were manually verified by running process_queue in the dev
environment and enqueuing test events via the Django shell, confirming
the worker connected and consumed the event. Also verified end-to-end
with a real Sentry project: a browser error report submitted to
/error_tracing appeared in Sentry within seconds.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
