### PR TITLE
Fix duplicate rows in recent view due to corner case events.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -313,6 +313,39 @@ export function create<Key, Item = Key>(
         meta.sort_by_filter_value = opts.sort_by_filter_value;
     }
 
+    function compute_filtered_list(): void {
+        meta.filtered_list = get_filtered_items(meta.filter_value, meta.list, opts);
+
+        if (meta.sort_by_filter_value) {
+            assert(meta.sorting_function === null);
+            meta.filtered_list = meta.sort_by_filter_value(meta.filtered_list, meta.filter_value);
+            return;
+        }
+
+        if (meta.sorting_function) {
+            // If the sorting function is already applied, remove it to avoid duplicate sorting.
+            const existing_sorting_function_index = meta.applied_sorting_functions.findIndex(
+                ([sorting_function, _]) => sorting_function === meta.sorting_function,
+            );
+            if (existing_sorting_function_index !== -1) {
+                meta.applied_sorting_functions.splice(existing_sorting_function_index, 1);
+            }
+
+            meta.applied_sorting_functions.push([meta.sorting_function, meta.reverse_mode]);
+            meta.filtered_list.sort((a, b) => {
+                for (let i = meta.applied_sorting_functions.length - 1; i >= 0; i -= 1) {
+                    const sorting_function = meta.applied_sorting_functions[i]![0];
+                    const is_reverse = meta.applied_sorting_functions[i]![1];
+                    const result = sorting_function(a, b);
+                    if (result !== 0) {
+                        return is_reverse ? -result : result;
+                    }
+                }
+                return 0;
+            });
+        }
+    }
+
     const widget: ListWidget<Key, Item> = {
         get_current_list() {
             return meta.filtered_list;
@@ -323,39 +356,7 @@ export function create<Key, Item = Key>(
         },
 
         filter_and_sort() {
-            meta.filtered_list = get_filtered_items(meta.filter_value, meta.list, opts);
-
-            if (meta.sort_by_filter_value) {
-                assert(meta.sorting_function === null);
-                meta.filtered_list = meta.sort_by_filter_value(
-                    meta.filtered_list,
-                    meta.filter_value,
-                );
-                return;
-            }
-
-            if (meta.sorting_function) {
-                // If the sorting function is already applied, remove it to avoid duplicate sorting.
-                const existing_sorting_function_index = meta.applied_sorting_functions.findIndex(
-                    ([sorting_function, _]) => sorting_function === meta.sorting_function,
-                );
-                if (existing_sorting_function_index !== -1) {
-                    meta.applied_sorting_functions.splice(existing_sorting_function_index, 1);
-                }
-
-                meta.applied_sorting_functions.push([meta.sorting_function, meta.reverse_mode]);
-                meta.filtered_list.sort((a, b) => {
-                    for (let i = meta.applied_sorting_functions.length - 1; i >= 0; i -= 1) {
-                        const sorting_function = meta.applied_sorting_functions[i]![0];
-                        const is_reverse = meta.applied_sorting_functions[i]![1];
-                        const result = sorting_function(a, b);
-                        if (result !== 0) {
-                            return is_reverse ? -result : result;
-                        }
-                    }
-                    return 0;
-                });
-            }
+            compute_filtered_list();
         },
 
         // Used in case of Multiselect DropdownListWidget to retain
@@ -571,7 +572,7 @@ export function create<Key, Item = Key>(
         },
 
         clean_redraw() {
-            widget.filter_and_sort();
+            compute_filtered_list();
             widget.clear();
             widget.render(DEFAULTS.INITIAL_RENDER_COUNT);
         },

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -72,7 +72,7 @@ type BaseListWidget = {
 export type ListWidget<Key, Item = Key> = BaseListWidget & {
     get_current_list: () => Item[];
     get_rendered_list: () => Item[];
-    filter_and_sort: () => void;
+    filter_and_sort: () => Item[];
     retain_selected_items: () => void;
     all_rendered: () => boolean;
     render: (how_many?: number) => void;
@@ -355,8 +355,40 @@ export function create<Key, Item = Key>(
             return meta.filtered_list.slice(0, meta.offset);
         },
 
+        // Recomputes the filtered list and removes the rendered rows of
+        // items it no longer includes, returning those items. Callers
+        // update the rows of the items they know changed with
+        // render_item/insert_rendered_row; this covers items hidden by
+        // changes they were not told about. A row left behind for such
+        // an item would no longer be counted by meta.offset, so a later
+        // render() would append rows that are already on screen.
         filter_and_sort() {
+            const previously_rendered_items = widget.get_rendered_list();
             compute_filtered_list();
+            if (!opts.html_selector || previously_rendered_items.length === 0) {
+                return [];
+            }
+
+            const listed_items = new Set(meta.filtered_list);
+            const removed_items: Item[] = [];
+            for (const item of previously_rendered_items) {
+                if (listed_items.has(item)) {
+                    continue;
+                }
+                const $row = opts.html_selector(item);
+                if ($row.length === 0) {
+                    continue;
+                }
+                $row.remove();
+                widget.reduce_rendered_offset();
+                removed_items.push(item);
+            }
+            if (removed_items.length > 0 && widget.all_rendered()) {
+                // As in remove_rendered_row: if the container is now
+                // empty, render() will display the empty-list message.
+                widget.render();
+            }
+            return removed_items;
         },
 
         // Used in case of Multiselect DropdownListWidget to retain

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -82,9 +82,6 @@ export type ListWidget<Key, Item = Key> = BaseListWidget & {
     set_reverse_mode: (reverse_mode: boolean) => void;
     set_sorting_function: (sorting_function: string | string[] | SortingFunction<Item>) => void;
     set_up_event_handlers: () => void;
-    increase_rendered_offset: () => void;
-    reduce_rendered_offset: () => void;
-    remove_rendered_row: (row: JQuery) => void;
     clean_redraw: () => void;
     hard_redraw: () => void;
     insert_rendered_row: (
@@ -346,6 +343,19 @@ export function create<Key, Item = Key>(
         }
     }
 
+    function increase_rendered_offset(): void {
+        meta.offset = Math.min(meta.offset + 1, meta.filtered_list.length);
+    }
+
+    function reduce_rendered_offset(): void {
+        meta.offset = Math.max(meta.offset - 1, 0);
+    }
+
+    function remove_row($row: JQuery): void {
+        $row.remove();
+        reduce_rendered_offset();
+    }
+
     const widget: ListWidget<Key, Item> = {
         get_current_list() {
             return meta.filtered_list;
@@ -379,13 +389,11 @@ export function create<Key, Item = Key>(
                 if ($row.length === 0) {
                     continue;
                 }
-                $row.remove();
-                widget.reduce_rendered_offset();
+                remove_row($row);
                 removed_items.push(item);
             }
             if (removed_items.length > 0 && widget.all_rendered()) {
-                // As in remove_rendered_row: if the container is now
-                // empty, render() will display the empty-list message.
+                // render() shows the empty-list message once the last row is gone.
                 widget.render();
             }
             return removed_items;
@@ -584,25 +592,6 @@ export function create<Key, Item = Key>(
             opts.filter?.$element?.off("input.list_widget_filter");
         },
 
-        increase_rendered_offset() {
-            meta.offset = Math.min(meta.offset + 1, meta.filtered_list.length);
-        },
-
-        reduce_rendered_offset() {
-            meta.offset = Math.max(meta.offset - 1, 0);
-        },
-
-        remove_rendered_row(rendered_row) {
-            rendered_row.remove();
-            // We removed a rendered row, so we need to reduce one offset.
-            widget.reduce_rendered_offset();
-            // If the container is now empty, render() will display
-            // the empty-list message.
-            if (this.all_rendered()) {
-                this.render();
-            }
-        },
-
         clean_redraw() {
             compute_filtered_list();
             widget.clear();
@@ -669,7 +658,7 @@ export function create<Key, Item = Key>(
                         widget.clean_redraw();
                     }
                 }
-                widget.increase_rendered_offset();
+                increase_rendered_offset();
             }
         },
 

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -431,7 +431,7 @@ export function create<Key, Item = Key>(
             }
 
             $container.append($(html));
-            meta.offset += load_count;
+            meta.offset += slice.length;
 
             if (opts.multiselect) {
                 widget.retain_selected_items();

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -375,6 +375,14 @@ export function create<Key, Item = Key>(
         return false;
     }
 
+    function is_row_at_index($row: JQuery, index: number): boolean {
+        assert(opts.html_selector !== undefined);
+        if (index === 0) {
+            return $row.prev().length === 0;
+        }
+        return $row.prev().is(opts.html_selector(meta.filtered_list[index - 1]!));
+    }
+
     const widget: ListWidget<Key, Item> = {
         get_current_list() {
             return meta.filtered_list;
@@ -528,10 +536,16 @@ export function create<Key, Item = Key>(
                 blueslip.error("List item is not a string", {item: html});
                 return;
             }
+            const $row = $(html);
 
-            // At this point, we have asserted we have all the information to replace
-            // the html now.
-            $html_item.replaceWith($(html));
+            if (index !== -1 && !is_row_at_index($html_item, index)) {
+                $html_item.remove();
+                if (!insert_row_at_index($row, index)) {
+                    widget.clean_redraw();
+                }
+                return;
+            }
+            $html_item.replaceWith($row);
         },
 
         clear() {

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -648,6 +648,10 @@ export function create<Key, Item = Key>(
                 const rendered_row = opts.modifier_html(item, meta.filter_value);
                 if (insert_index === meta.filtered_list.length - 1) {
                     const $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]!);
+                    if ($target_row.length === 0) {
+                        widget.clean_redraw();
+                        return;
+                    }
                     $target_row.after($(rendered_row));
                 } else {
                     let $target_row = opts.html_selector!(meta.filtered_list[insert_index + 1]!);
@@ -666,6 +670,7 @@ export function create<Key, Item = Key>(
                     // not being rendered yet, just do a clean redraw.
                     if ($target_row.length === 0) {
                         widget.clean_redraw();
+                        return;
                     }
                 }
                 increase_rendered_offset();

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -494,6 +494,16 @@ export function create<Key, Item = Key>(
                 return;
             }
 
+            // An item moved past the rendered range no longer belongs on screen:
+            // its row would not be counted by meta.offset, and a later render()
+            // would append the item again. Widgets whose get_item returns fresh
+            // objects cannot be matched by identity and keep the in-place update.
+            const index = meta.filtered_list.indexOf(item);
+            if (index !== -1 && index >= meta.offset) {
+                remove_row($html_item);
+                return;
+            }
+
             const html = opts.modifier_html(item, meta.filter_value);
             if (typeof html !== "string") {
                 blueslip.error("List item is not a string", {item: html});

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -76,6 +76,7 @@ export type ListWidget<Key, Item = Key> = BaseListWidget & {
     retain_selected_items: () => void;
     all_rendered: () => boolean;
     render: (how_many?: number) => void;
+    maybe_render_more: () => boolean;
     render_item: (item: Item) => void;
     clear: () => void;
     set_filter_value: (value: string) => void;
@@ -509,6 +510,22 @@ export function create<Key, Item = Key>(
             }
         },
 
+        maybe_render_more() {
+            let should_render;
+            if (opts.is_scroll_position_for_render === undefined) {
+                const scroll_element = meta.$scroll_container[0];
+                assert(scroll_element !== undefined);
+                should_render = is_scroll_position_for_render(scroll_element);
+            } else {
+                should_render = opts.is_scroll_position_for_render();
+            }
+            if (!should_render) {
+                return false;
+            }
+            widget.render();
+            return true;
+        },
+
         render_item(item) {
             if (!opts.html_selector) {
                 // We don't have any way to find the existing item.
@@ -581,22 +598,11 @@ export function create<Key, Item = Key>(
         set_up_event_handlers() {
             // on scroll of the nearest scrolling container, if it hits the bottom
             // of the container then fetch a new block of items and render them.
-            meta.$scroll_listening_element.on("scroll.list_widget_container", function () {
+            meta.$scroll_listening_element.on("scroll.list_widget_container", () => {
                 if (opts.post_scroll__pre_render_callback) {
                     opts.post_scroll__pre_render_callback();
                 }
-
-                let should_render;
-                if (opts.is_scroll_position_for_render === undefined) {
-                    assert(!(this instanceof Window));
-                    should_render = is_scroll_position_for_render(this);
-                } else {
-                    should_render = opts.is_scroll_position_for_render();
-                }
-
-                if (should_render) {
-                    widget.render();
-                }
+                widget.maybe_render_more();
             });
 
             if (opts.$parent_container) {

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -356,6 +356,25 @@ export function create<Key, Item = Key>(
         reduce_rendered_offset();
     }
 
+    function insert_row_at_index($row: JQuery, index: number): boolean {
+        assert(opts.html_selector !== undefined);
+        if (index + 1 < meta.filtered_list.length) {
+            const $next_row = opts.html_selector(meta.filtered_list[index + 1]!);
+            if ($next_row.length > 0) {
+                $next_row.before($row);
+                return true;
+            }
+        }
+        if (index > 0) {
+            const $previous_row = opts.html_selector(meta.filtered_list[index - 1]!);
+            if ($previous_row.length > 0) {
+                $previous_row.after($row);
+                return true;
+            }
+        }
+        return false;
+    }
+
     const widget: ListWidget<Key, Item> = {
         get_current_list() {
             return meta.filtered_list;
@@ -644,34 +663,12 @@ export function create<Key, Item = Key>(
                     blueslip.error(
                         "Please specify modifier and html_selector when creating the widget.",
                     );
+                    return;
                 }
-                const rendered_row = opts.modifier_html(item, meta.filter_value);
-                if (insert_index === meta.filtered_list.length - 1) {
-                    const $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]!);
-                    if ($target_row.length === 0) {
-                        widget.clean_redraw();
-                        return;
-                    }
-                    $target_row.after($(rendered_row));
-                } else {
-                    let $target_row = opts.html_selector!(meta.filtered_list[insert_index + 1]!);
-                    if ($target_row.length > 0) {
-                        $target_row.before($(rendered_row));
-                    } else if (insert_index > 0) {
-                        // We don't have a row rendered after row we are trying to insert at.
-                        // So, try looking for the row before current row.
-                        $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]!);
-                        if ($target_row.length > 0) {
-                            $target_row.after($(rendered_row));
-                        }
-                    }
-
-                    // If we failed at inserting the row due rows around the row
-                    // not being rendered yet, just do a clean redraw.
-                    if ($target_row.length === 0) {
-                        widget.clean_redraw();
-                        return;
-                    }
+                const $row = $(opts.modifier_html(item, meta.filter_value));
+                if (!insert_row_at_index($row, insert_index)) {
+                    widget.clean_redraw();
+                    return;
                 }
                 increase_rendered_offset();
             }

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -324,7 +324,7 @@ export function insert_new_messages(opts: InsertNewMessagesOpts): Message[] {
         messages = local_messages;
     }
 
-    const any_untracked_unread_messages = unread.process_loaded_messages(messages, false);
+    const untracked_unread_messages = unread.process_loaded_messages(messages, false);
     direct_message_group_data.process_loaded_messages(messages);
 
     let need_user_to_scroll = false;
@@ -386,7 +386,7 @@ export function insert_new_messages(opts: InsertNewMessagesOpts): Message[] {
         });
     }
 
-    if (any_untracked_unread_messages) {
+    if (untracked_unread_messages.length > 0) {
         unread_ui.update_unread_counts();
     }
 

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -16,8 +16,8 @@ import type {MessageList} from "./message_list.ts";
 import type {MessageListData} from "./message_list_data.ts";
 import * as message_list_data_cache from "./message_list_data_cache.ts";
 import * as message_lists from "./message_lists.ts";
+import type {Message} from "./message_store.ts";
 import {raw_message_schema} from "./message_store.ts";
-import * as message_util from "./message_util.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as narrow_banner from "./narrow_banner.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
@@ -30,7 +30,9 @@ import {narrow_operator_schema} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_list from "./stream_list.ts";
+import * as unread from "./unread.ts";
 import * as unread_ops from "./unread_ops.ts";
+import * as unread_ui from "./unread_ui.ts";
 
 export const message_ids_response_schema = z.object({
     found_newest: z.boolean(),
@@ -154,6 +156,16 @@ export function fetch_more_if_required_for_current_msg_list(
     }
 }
 
+export function do_unread_count_updates(messages: Message[], expect_no_new_unreads = false): void {
+    const any_new_unreads = unread.process_loaded_messages(messages, expect_no_new_unreads);
+
+    if (any_new_unreads) {
+        // The following operations are expensive, and thus should
+        // only happen if we found any unread messages justifying it.
+        unread_ui.update_unread_counts();
+    }
+}
+
 function process_result(data: MessageFetchResponse, opts: MessageFetchOptions): void {
     const raw_messages = data.messages;
 
@@ -165,7 +177,7 @@ function process_result(data: MessageFetchResponse, opts: MessageFetchOptions): 
 
     // In some rare situations, we expect to discover new unread
     // messages not tracked in unread.ts during this fetching process.
-    message_util.do_unread_count_updates(messages, true);
+    do_unread_count_updates(messages, true);
 
     const is_contiguous_history = true;
     if (messages.length > 0) {

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -25,6 +25,7 @@ import {page_params} from "./page_params.ts";
 import * as popup_banners from "./popup_banners.ts";
 import {recent_view_messages_data} from "./recent_view_messages_data.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
+import * as recent_view_util from "./recent_view_util.ts";
 import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import {narrow_operator_schema} from "./state_data.ts";
 import type {NarrowTerm} from "./state_data.ts";
@@ -157,12 +158,24 @@ export function fetch_more_if_required_for_current_msg_list(
 }
 
 export function do_unread_count_updates(messages: Message[], expect_no_new_unreads = false): void {
-    const any_new_unreads = unread.process_loaded_messages(messages, expect_no_new_unreads);
+    const untracked_unread_messages = unread.process_loaded_messages(
+        messages,
+        expect_no_new_unreads,
+    );
 
-    if (any_new_unreads) {
+    if (untracked_unread_messages.length > 0) {
         // The following operations are expensive, and thus should
         // only happen if we found any unread messages justifying it.
         unread_ui.update_unread_counts();
+        // Recent view learns of unread counts only through explicit updates,
+        // so a conversation with a row would otherwise keep a stale count,
+        // and stay hidden under the "unread" filter, until a full redraw.
+        const conversation_keys = new Set(
+            untracked_unread_messages.map((message) =>
+                recent_view_util.get_key_from_message(message),
+            ),
+        );
+        recent_view_ui.update_conversations_unread_count(conversation_keys);
     }
 }
 

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -9,8 +9,6 @@ import * as people from "./people.ts";
 import * as pm_conversations from "./pm_conversations.ts";
 import {recent_view_messages_data} from "./recent_view_messages_data.ts";
 import {realm} from "./state_data.ts";
-import * as unread from "./unread.ts";
-import * as unread_ui from "./unread_ui.ts";
 import * as user_groups from "./user_groups.ts";
 
 type DirectMessagePermissionHints = {
@@ -60,16 +58,6 @@ export function get_last_message_id_in_narrow(
             // we just ignore the error.
         },
     });
-}
-
-export function do_unread_count_updates(messages: Message[], expect_no_new_unreads = false): void {
-    const any_new_unreads = unread.process_loaded_messages(messages, expect_no_new_unreads);
-
-    if (any_new_unreads) {
-        // The following operations are expensive, and thus should
-        // only happen if we found any unread messages justifying it.
-        unread_ui.update_unread_counts();
-    }
 }
 
 export function get_count_of_messages_in_topic_sent_after_current_message(

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1145,6 +1145,56 @@ export function filters_should_hide_row(topic_data: ConversationData): boolean {
     return false;
 }
 
+// Remove the DOM rows for conversations that filter_and_sort() just hid.
+//
+// Ideally every event that hides a rendered conversation would rerender
+// that row, and the remove path in inplace_rerender would keep the DOM
+// and meta.offset consistent. But some events change the filter
+// predicate's inputs without any per-row notification reaching us:
+//
+// - Reads of messages this client never fetched: a conversation's row
+//   exists because its latest message was fetched, but its unread count
+//   also covers older messages beyond our fetch horizon. When another
+//   client reads those, the flags event carries only message ids --
+//   unread counts update, but ids absent from message_store cannot be
+//   mapped back to a row, and recent view is not registered in
+//   unread_ui's coarse update hooks. Under the "unread" filter, the
+//   row silently hides.
+// - Renames while a search keyword is active: the search matches topic
+//   rows against the live channel name and DM rows against participant
+//   names, so renaming a channel or a user can flip rows' visibility.
+//   The rename handlers cannot know which rows flipped -- finding them
+//   would mean re-evaluating every rendered row against the filters,
+//   which is exactly the reconciliation done here.
+//
+// When filter_and_sort() drops such a conversation, its row is stranded:
+// the DOM holds more rows than meta.offset accounts for, and a later
+// render() re-appends rows already on screen, showing duplicates. A
+// stranded key is gone from the filtered list, so later calls cannot
+// find it via get_rendered_list() -- this reconciliation must run at
+// every filter_and_sort() call, on the rows rendered just before it.
+function remove_now_hidden_rendered_rows(previously_rendered_rows: ConversationData[]): void {
+    assert(topics_widget !== undefined);
+    for (const topic_data of previously_rendered_rows) {
+        if (!filters_should_hide_row(topic_data)) {
+            continue;
+        }
+        const $topic_row = get_topic_row(topic_data);
+        if ($topic_row.length === 0) {
+            continue;
+        }
+        // If the row being removed is the focused last row, adjust row_focus
+        // so it doesn't reset to the first or a middle row. We read the
+        // focused row from the DOM since the filtered list no longer contains
+        // this conversation.
+        const row_is_focused = get_focused_row_message()?.id === topic_data.last_msg_id;
+        if (row_is_focused && row_focus >= topics_widget.get_current_list().length) {
+            row_focus = topics_widget.get_current_list().length - 1;
+        }
+        topics_widget.remove_rendered_row($topic_row);
+    }
+}
+
 export function bulk_inplace_rerender(row_keys: string[]): void {
     if (!topics_widget || !recent_view_util.is_visible()) {
         return;
@@ -1157,8 +1207,14 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     // Save whether all rows were rendered before updating the data,
     // so we know if it's safe to use render() for new items below.
     const was_all_rendered = topics_widget.all_rendered();
+    const previously_rendered_rows = topics_widget.get_rendered_list();
     topics_widget.replace_list_data(get_list_data_for_widget(), false);
     topics_widget.filter_and_sort();
+    // Drop the rows that filter_and_sort() just hid but left in the DOM;
+    // the loop below only reconciles row_keys, so without this a
+    // conversation hidden outside of row_keys would linger and desync
+    // meta.offset. See remove_now_hidden_rendered_rows() for details.
+    remove_now_hidden_rendered_rows(previously_rendered_rows);
     // Iterate in the order in which the rows should be present so that
     // we are not inserting rows without any rows being present around them.
     let processed_count = 0;
@@ -1199,11 +1255,6 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
 
     const topic_data = recent_view_data.conversations.get(topic_key);
     assert(topic_data !== undefined);
-    const $topic_row = get_topic_row(topic_data);
-    // We cannot rely on `topic_widget.meta.filtered_list` to know
-    // if a topic is rendered since the `filtered_list` might have
-    // already been updated via other calls.
-    const is_topic_rendered = $topic_row.length;
     assert(topics_widget !== undefined);
     if (!is_bulk_rerender) {
         // Resorting the topics_widget is important for the case where we
@@ -1212,39 +1263,32 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         //
         // NOTE: This doesn't add any new entry to the original list but updates the filtered list
         // based on the current filters and updated row data.
+        const previously_rendered_rows = topics_widget.get_rendered_list();
         topics_widget.filter_and_sort();
+        remove_now_hidden_rendered_rows(previously_rendered_rows);
     }
 
+    // We cannot rely on `topic_widget.meta.filtered_list` to know if a topic
+    // is rendered since the `filtered_list` might have already been updated
+    // via other calls; read its presence from the DOM instead.
+    const $topic_row = get_topic_row(topic_data);
+    const is_topic_rendered = $topic_row.length;
     const current_topics_list = topics_widget.get_current_list();
-    if (is_topic_rendered && filters_should_hide_row(topic_data)) {
-        // Since the row needs to be removed from DOM, we need to adjust `row_focus`
-        // if the row being removed is focused and is the last row in the list.
-        // This prevents the row_focus either being reset to the first row or
-        // middle of the visible table rows.
-        // We need to get the current focused row details from DOM since we cannot
-        // rely on `current_topics_list` since it has already been updated and row
-        // doesn't exist inside it.
-        const row_is_focused = get_focused_row_message()?.id === topic_data.last_msg_id;
-        if (row_is_focused && row_focus >= current_topics_list.length) {
-            row_focus = current_topics_list.length - 1;
-        }
-        topics_widget.remove_rendered_row($topic_row);
-    } else if (!is_topic_rendered && filters_should_hide_row(topic_data)) {
-        // In case `topic_row` is not present, our job is already done here
-        // since it has not been rendered yet and we already removed it from
-        // the filtered list in `topic_widget`. So, it won't be displayed in
-        // the future too.
-    } else if (is_topic_rendered && !filters_should_hide_row(topic_data)) {
+    if (is_topic_rendered && !filters_should_hide_row(topic_data)) {
         // Only a re-render is required in this case.
         topics_widget.render_item(topic_data);
-    } else {
-        // Final case: !is_topic_rendered && !filters_should_hide_row(topic_data).
+    } else if (!is_topic_rendered && !filters_should_hide_row(topic_data)) {
+        // Newly visible: insert it at its sorted position.
         topics_widget.insert_rendered_row(topic_data, () =>
             current_topics_list.findIndex(
                 (list_item) => list_item.last_msg_id === topic_data.last_msg_id,
             ),
         );
     }
+    // A row the filters now hide needs no work here: if it was rendered,
+    // remove_now_hidden_rendered_rows() above removed it (or, for a bulk
+    // rerender, bulk_inplace_rerender() did); if it was never rendered, it
+    // simply stays absent.
     if (!is_bulk_rerender) {
         update_unread_sort_header_state();
         setTimeout(revive_current_focus, 0);

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1160,6 +1160,11 @@ function filter_and_sort_topics_widget(): void {
     }
 }
 
+function finish_rerender(): void {
+    update_unread_sort_header_state();
+    setTimeout(revive_current_focus, 0);
+}
+
 export function bulk_inplace_rerender(row_keys: string[]): void {
     if (!topics_widget || !recent_view_util.is_visible()) {
         return;
@@ -1181,8 +1186,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
             inplace_rerender(topic_key, true);
         }
     }
-    update_unread_sort_header_state();
-    setTimeout(revive_current_focus, 0);
+    finish_rerender();
 }
 
 export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): boolean => {
@@ -1225,8 +1229,7 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         );
     }
     if (!is_bulk_rerender) {
-        update_unread_sort_header_state();
-        setTimeout(revive_current_focus, 0);
+        finish_rerender();
     }
     return true;
 };

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1196,11 +1196,6 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
 
     const topic_data = recent_view_data.conversations.get(topic_key);
     assert(topic_data !== undefined);
-    const $topic_row = get_topic_row(topic_data);
-    // We cannot rely on `topic_widget.meta.filtered_list` to know
-    // if a topic is rendered since the `filtered_list` might have
-    // already been updated via other calls.
-    const is_topic_rendered = $topic_row.length;
     assert(topics_widget !== undefined);
     if (!is_bulk_rerender) {
         // Resorting the topics_widget is important for the case where we
@@ -1212,6 +1207,11 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         topics_widget.filter_and_sort();
     }
 
+    // We cannot rely on `topic_widget.meta.filtered_list` to know
+    // if a topic is rendered since the `filtered_list` might have
+    // already been updated via other calls.
+    const $topic_row = get_topic_row(topic_data);
+    const is_topic_rendered = $topic_row.length;
     const current_topics_list = topics_widget.get_current_list();
     if (is_topic_rendered && filters_should_hide_row(topic_data)) {
         // Since the row needs to be removed from DOM, we need to adjust `row_focus`

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -953,11 +953,14 @@ function format_conversation(conversation_data: ConversationData): ConversationC
     };
 }
 
-function get_topic_row(topic_data: ConversationData): JQuery {
-    const msg = message_store.get(topic_data.last_msg_id);
+function get_conversation_key(conversation: ConversationData): string {
+    const msg = message_store.get(conversation.last_msg_id);
     assert(msg !== undefined);
-    const topic_key = recent_view_util.get_key_from_message(msg);
-    return $(`#${CSS.escape(recent_conversation_key_prefix + topic_key)}`);
+    return recent_view_util.get_key_from_message(msg);
+}
+
+function get_topic_row(topic_data: ConversationData): JQuery {
+    return $(`#${CSS.escape(recent_conversation_key_prefix + get_conversation_key(topic_data))}`);
 }
 
 export function process_topic_edit(
@@ -1162,9 +1165,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
         if (processed_count >= row_keys.length) {
             break;
         }
-        const msg = message_store.get(topic_data.last_msg_id);
-        assert(msg !== undefined);
-        const topic_key = recent_view_util.get_key_from_message(msg);
+        const topic_key = get_conversation_key(topic_data);
         if (row_keys.includes(topic_key)) {
             inplace_rerender(topic_key, true);
             processed_count += 1;

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1165,38 +1165,21 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
         return;
     }
 
-    // When doing bulk rerender, we assume that order of rows are not going
-    // to change by default. Row insertion can still change the order but
-    // we ensure the list remains sorted after insertion.
-    //
-    // Save whether all rows were rendered before updating the data,
-    // so we know if it's safe to use render() for new items below.
-    const was_all_rendered = topics_widget.all_rendered();
     topics_widget.replace_list_data(get_list_data_for_widget(), false);
     filter_and_sort_topics_widget();
-    // Iterate in the order in which the rows should be present so that
-    // we are not inserting rows without any rows being present around them.
-    let processed_count = 0;
-    for (const topic_data of topics_widget.get_rendered_list()) {
-        if (processed_count >= row_keys.length) {
+
+    const remaining_keys = new Set(row_keys);
+    const current_list = topics_widget.get_current_list();
+    // Update the rows in list order, so that a row inserted next to another
+    // one finds it already in place.
+    for (const topic_data of current_list) {
+        if (remaining_keys.size === 0) {
             break;
         }
         const topic_key = get_conversation_key(topic_data);
-        if (row_keys.includes(topic_key)) {
+        if (remaining_keys.delete(topic_key)) {
             inplace_rerender(topic_key, true);
-            processed_count += 1;
         }
-    }
-    // New conversations from backfilled old messages sort at the end
-    // of the list, beyond the current render offset. Use render() to
-    // efficiently batch-append them in a single DOM operation, rather
-    // than inserting one at a time via insert_rendered_row.
-    //
-    // We can only use render() when the DOM already had all rows up
-    // to the render offset (was_all_rendered), ensuring new items
-    // start right at the offset boundary with no gap.
-    if (processed_count < row_keys.length && was_all_rendered) {
-        topics_widget.render(row_keys.length - processed_count);
     }
     update_unread_sort_header_state();
     setTimeout(revive_current_focus, 0);

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -110,6 +110,7 @@ const ls = localstorage();
 
 let filters = new Set<string>();
 let dropdown_filters = new Set<string>();
+const pending_topic_visibility_updates = new Set<string>();
 let folder_filter_value: number = folder_dropdown_widget.FOLDER_FILTERS.ANY_FOLDER_DROPDOWN_OPTION;
 let folder_filter_dropdown_widget: dropdown_widget.DropdownWidget | undefined;
 
@@ -216,6 +217,7 @@ export function clear_for_tests(): void {
     dropdown_filters.clear();
     folder_filter_value = folder_dropdown_widget.FOLDER_FILTERS.ANY_FOLDER_DROPDOWN_OPTION;
     recent_view_data.conversations.clear();
+    pending_topic_visibility_updates.clear();
     topics_widget = undefined;
 }
 
@@ -1144,9 +1146,10 @@ export function filters_should_hide_row(topic_data: ConversationData): boolean {
     return false;
 }
 
-// Recomputes the widget's filtered list, keeping keyboard focus
-// sensible when the resort removed the focused row.
-function filter_and_sort_topics_widget(): void {
+// Recomputes the widget's filtered list for a rerender of the given
+// conversations, reporting rows removed for conversations it was not
+// asked about.
+function filter_and_sort_topics_widget(rerendering_keys: string[]): void {
     assert(topics_widget !== undefined);
     // Look up the focused row while row_focus still indexes the rows the
     // resort may remove.
@@ -1157,6 +1160,26 @@ function filter_and_sort_topics_widget(): void {
     );
     if (focused_row_removed && row_focus >= topics_widget.get_current_list().length) {
         row_focus = Math.max(topics_widget.get_current_list().length - 1, 0);
+    }
+
+    const stranded_conversations = removed_conversations.filter((conversation) => {
+        const key = get_conversation_key(conversation);
+        return !rerendering_keys.includes(key) && !pending_topic_visibility_updates.has(key);
+    });
+    if (stranded_conversations.length > 0) {
+        // Every event that can hide a rendered conversation should rerender it
+        // or redraw the view; a row removed here was left on screen by one
+        // that does neither, so report it to be handled directly.
+        blueslip.error("Recent view rows hidden without a rerender", {
+            count: stranded_conversations.length,
+            types: [...new Set(stranded_conversations.map((conversation) => conversation.type))],
+            filters: [...filters].toSorted(),
+            dropdown_filters: [...dropdown_filters],
+            has_search_keyword: $<HTMLInputElement>("#recent_view_search").val() !== "",
+            has_folder_filter:
+                folder_filter_value !==
+                folder_dropdown_widget.FOLDER_FILTERS.ANY_FOLDER_DROPDOWN_OPTION,
+        });
     }
 }
 
@@ -1178,7 +1201,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     }
 
     topics_widget.replace_list_data(get_list_data_for_widget(), false);
-    filter_and_sort_topics_widget();
+    filter_and_sort_topics_widget(row_keys);
 
     const remaining_keys = new Set(row_keys);
     const current_list = topics_widget.get_current_list();
@@ -1214,7 +1237,7 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         //
         // NOTE: This doesn't add any new entry to the original list but updates the filtered list
         // based on the current filters and updated row data.
-        filter_and_sort_topics_widget();
+        filter_and_sort_topics_widget([topic_key]);
     }
 
     // We cannot rely on `topic_widget.meta.filtered_list` to know
@@ -1246,7 +1269,8 @@ export function rewire_inplace_rerender(value: typeof inplace_rerender): void {
 }
 
 // Applies a topic's visibility policy change after delay_ms, which lets
-// a popover anchored on the row finish closing first.
+// a popover anchored on the row finish closing first. Until then the
+// row is stale by design, so a resort removing it is not reported.
 export function update_topic_visibility_policy(
     stream_id: number,
     topic: string,
@@ -1259,7 +1283,9 @@ export function update_topic_visibility_policy(
         return false;
     }
 
+    pending_topic_visibility_updates.add(key);
     setTimeout(() => {
+        pending_topic_visibility_updates.delete(key);
         inplace_rerender(key);
     }, delay_ms);
     return true;

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1257,9 +1257,8 @@ export function update_topic_visibility_policy(stream_id: number, topic: string)
     return true;
 }
 
-export function update_topic_unread_count(message: Message): void {
-    const topic_key = recent_view_util.get_key_from_message(message);
-    inplace_rerender(topic_key);
+export function update_conversations_unread_count(conversation_keys: Set<string>): void {
+    bulk_inplace_rerender([...conversation_keys]);
 }
 
 export function set_filter(filter: string): void {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1157,16 +1157,16 @@ export function filters_should_hide_row(topic_data: ConversationData): boolean {
 }
 
 // Recomputes the widget's filtered list for a rerender of the given
-// conversations, reporting rows removed for conversations it was not
-// asked about.
-function filter_and_sort_topics_widget(rerendering_keys: string[]): void {
+// conversations, and returns the conversation the keyboard focus
+// should follow once the rows have settled; see finish_rerender.
+function filter_and_sort_topics_widget(rerendering_keys: string[]): string | undefined {
     assert(topics_widget !== undefined);
     // Look up the focused row while row_focus still indexes the rows the
     // resort may remove.
-    const focused_message_id = get_focused_row_message()?.id;
+    const focused_conversation_key = get_focused_conversation_key();
     const removed_conversations = topics_widget.filter_and_sort();
     const focused_row_removed = removed_conversations.some(
-        (conversation) => conversation.last_msg_id === focused_message_id,
+        (conversation) => get_conversation_key(conversation) === focused_conversation_key,
     );
     if (focused_row_removed && row_focus >= topics_widget.get_current_list().length) {
         row_focus = Math.max(topics_widget.get_current_list().length - 1, 0);
@@ -1191,10 +1191,28 @@ function filter_and_sort_topics_widget(rerendering_keys: string[]): void {
                 folder_dropdown_widget.FOLDER_FILTERS.ANY_FOLDER_DROPDOWN_OPTION,
         });
     }
+
+    // The focus follows its conversation's row, unless that conversation is
+    // being rerendered: its row may then move to its sorted place, and the
+    // focus stays where it is, as it does when the row is removed.
+    if (
+        focused_conversation_key === undefined ||
+        rerendering_keys.includes(focused_conversation_key)
+    ) {
+        return undefined;
+    }
+    return focused_conversation_key;
 }
 
-function finish_rerender(): void {
+function finish_rerender(conversation_key_to_focus: string | undefined): void {
     assert(topics_widget !== undefined);
+    // Rows can move during a rerender, and row_focus is a DOM index.
+    if (conversation_key_to_focus !== undefined) {
+        const $row = get_conversation_row(conversation_key_to_focus);
+        if ($row.length > 0) {
+            row_focus = $row.index();
+        }
+    }
     // Removals can leave the table short of the scroll end with no scroll
     // event to come. Rendering runs callback_after_render, which does the
     // rest of the work below.
@@ -1211,7 +1229,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     }
 
     topics_widget.replace_list_data(get_list_data_for_widget(), false);
-    filter_and_sort_topics_widget(row_keys);
+    const conversation_key_to_focus = filter_and_sort_topics_widget(row_keys);
 
     const remaining_keys = new Set(row_keys);
     const current_list = topics_widget.get_current_list();
@@ -1226,7 +1244,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
             inplace_rerender(topic_key, true);
         }
     }
-    finish_rerender();
+    finish_rerender(conversation_key_to_focus);
 }
 
 export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): boolean => {
@@ -1240,6 +1258,7 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
     const topic_data = recent_view_data.conversations.get(topic_key);
     assert(topic_data !== undefined);
     assert(topics_widget !== undefined);
+    let conversation_key_to_focus: string | undefined;
     if (!is_bulk_rerender) {
         // Resorting the topics_widget is important for the case where we
         // are rerendering because of message editing or new messages
@@ -1247,7 +1266,7 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         //
         // NOTE: This doesn't add any new entry to the original list but updates the filtered list
         // based on the current filters and updated row data.
-        filter_and_sort_topics_widget([topic_key]);
+        conversation_key_to_focus = filter_and_sort_topics_widget([topic_key]);
     }
 
     // We cannot rely on `topic_widget.meta.filtered_list` to know
@@ -1269,7 +1288,7 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         );
     }
     if (!is_bulk_rerender) {
-        finish_rerender();
+        finish_rerender(conversation_key_to_focus);
     }
     return true;
 };

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1245,7 +1245,13 @@ export function rewire_inplace_rerender(value: typeof inplace_rerender): void {
     inplace_rerender = value;
 }
 
-export function update_topic_visibility_policy(stream_id: number, topic: string): boolean {
+// Applies a topic's visibility policy change after delay_ms, which lets
+// a popover anchored on the row finish closing first.
+export function update_topic_visibility_policy(
+    stream_id: number,
+    topic: string,
+    delay_ms = 0,
+): boolean {
     const key = recent_view_util.get_topic_key(stream_id, topic);
     if (!recent_view_data.conversations.has(key)) {
         // we receive mute request for a topic we are
@@ -1253,7 +1259,9 @@ export function update_topic_visibility_policy(stream_id: number, topic: string)
         return false;
     }
 
-    inplace_rerender(key);
+    setTimeout(() => {
+        inplace_rerender(key);
+    }, delay_ms);
     return true;
 }
 

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1161,6 +1161,13 @@ function filter_and_sort_topics_widget(): void {
 }
 
 function finish_rerender(): void {
+    assert(topics_widget !== undefined);
+    // Removals can leave the table short of the scroll end with no scroll
+    // event to come. Rendering runs callback_after_render, which does the
+    // rest of the work below.
+    if (topics_widget.maybe_render_more()) {
+        return;
+    }
     update_unread_sort_header_state();
     setTimeout(revive_current_focus, 0);
 }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1144,6 +1144,22 @@ export function filters_should_hide_row(topic_data: ConversationData): boolean {
     return false;
 }
 
+// Recomputes the widget's filtered list, keeping keyboard focus
+// sensible when the resort removed the focused row.
+function filter_and_sort_topics_widget(): void {
+    assert(topics_widget !== undefined);
+    // Look up the focused row while row_focus still indexes the rows the
+    // resort may remove.
+    const focused_message_id = get_focused_row_message()?.id;
+    const removed_conversations = topics_widget.filter_and_sort();
+    const focused_row_removed = removed_conversations.some(
+        (conversation) => conversation.last_msg_id === focused_message_id,
+    );
+    if (focused_row_removed && row_focus >= topics_widget.get_current_list().length) {
+        row_focus = Math.max(topics_widget.get_current_list().length - 1, 0);
+    }
+}
+
 export function bulk_inplace_rerender(row_keys: string[]): void {
     if (!topics_widget || !recent_view_util.is_visible()) {
         return;
@@ -1157,7 +1173,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     // so we know if it's safe to use render() for new items below.
     const was_all_rendered = topics_widget.all_rendered();
     topics_widget.replace_list_data(get_list_data_for_widget(), false);
-    topics_widget.filter_and_sort();
+    filter_and_sort_topics_widget();
     // Iterate in the order in which the rows should be present so that
     // we are not inserting rows without any rows being present around them.
     let processed_count = 0;
@@ -1204,38 +1220,21 @@ export let inplace_rerender = (topic_key: string, is_bulk_rerender?: boolean): b
         //
         // NOTE: This doesn't add any new entry to the original list but updates the filtered list
         // based on the current filters and updated row data.
-        topics_widget.filter_and_sort();
+        filter_and_sort_topics_widget();
     }
 
     // We cannot rely on `topic_widget.meta.filtered_list` to know
     // if a topic is rendered since the `filtered_list` might have
     // already been updated via other calls.
-    const $topic_row = get_topic_row(topic_data);
-    const is_topic_rendered = $topic_row.length;
+    const is_topic_rendered = get_topic_row(topic_data).length > 0;
     const current_topics_list = topics_widget.get_current_list();
-    if (is_topic_rendered && filters_should_hide_row(topic_data)) {
-        // Since the row needs to be removed from DOM, we need to adjust `row_focus`
-        // if the row being removed is focused and is the last row in the list.
-        // This prevents the row_focus either being reset to the first row or
-        // middle of the visible table rows.
-        // We need to get the current focused row details from DOM since we cannot
-        // rely on `current_topics_list` since it has already been updated and row
-        // doesn't exist inside it.
-        const row_is_focused = get_focused_row_message()?.id === topic_data.last_msg_id;
-        if (row_is_focused && row_focus >= current_topics_list.length) {
-            row_focus = current_topics_list.length - 1;
-        }
-        topics_widget.remove_rendered_row($topic_row);
-    } else if (!is_topic_rendered && filters_should_hide_row(topic_data)) {
-        // In case `topic_row` is not present, our job is already done here
-        // since it has not been rendered yet and we already removed it from
-        // the filtered list in `topic_widget`. So, it won't be displayed in
-        // the future too.
-    } else if (is_topic_rendered && !filters_should_hide_row(topic_data)) {
+    if (filters_should_hide_row(topic_data)) {
+        // Nothing to do: the widget removed the row when the filtered list was
+        // recomputed, and a row never rendered stays out of the list.
+    } else if (is_topic_rendered) {
         // Only a re-render is required in this case.
         topics_widget.render_item(topic_data);
     } else {
-        // Final case: !is_topic_rendered && !filters_should_hide_row(topic_data).
         topics_widget.insert_rendered_row(topic_data, () =>
             current_topics_list.findIndex(
                 (list_item) => list_item.last_msg_id === topic_data.last_msg_id,

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -509,30 +509,36 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
     return true;
 }
 
-export function get_focused_row_message(): Message | undefined {
-    if (is_table_focused()) {
-        assert(topics_widget !== undefined);
-        if (topics_widget.get_current_list().length === 0) {
-            return undefined;
-        }
-
-        const $topic_rows = $("#recent-view-content-tbody tr");
-        const $topic_row = $topic_rows.eq(row_focus);
-        if ($topic_row.length === 0) {
-            // There are less items in the table than `row_focus`.
-            // We don't reset `row_focus` here since that is not the
-            // purpose of this function.
-            return undefined;
-        }
-        const topic_id = $topic_row.attr("id");
-        assert(topic_id !== undefined);
-        const conversation_id = topic_id.slice(recent_conversation_key_prefix.length);
-        const last_conversation = recent_view_data.conversations.get(conversation_id);
-        assert(last_conversation !== undefined);
-        const topic_last_msg_id = last_conversation.last_msg_id;
-        return message_store.get(topic_last_msg_id);
+function get_focused_conversation_key(): string | undefined {
+    if (!is_table_focused()) {
+        return undefined;
     }
-    return undefined;
+    assert(topics_widget !== undefined);
+    if (topics_widget.get_current_list().length === 0) {
+        return undefined;
+    }
+
+    const $topic_rows = $("#recent-view-content-tbody tr");
+    const $topic_row = $topic_rows.eq(row_focus);
+    if ($topic_row.length === 0) {
+        // There are less items in the table than `row_focus`.
+        // We don't reset `row_focus` here since that is not the
+        // purpose of this function.
+        return undefined;
+    }
+    const topic_id = $topic_row.attr("id");
+    assert(topic_id !== undefined);
+    return topic_id.slice(recent_conversation_key_prefix.length);
+}
+
+export function get_focused_row_message(): Message | undefined {
+    const conversation_key = get_focused_conversation_key();
+    if (conversation_key === undefined) {
+        return undefined;
+    }
+    const conversation = recent_view_data.conversations.get(conversation_key);
+    assert(conversation !== undefined);
+    return message_store.get(conversation.last_msg_id);
 }
 
 export function revive_current_focus(): boolean {
@@ -961,8 +967,12 @@ function get_conversation_key(conversation: ConversationData): string {
     return recent_view_util.get_key_from_message(msg);
 }
 
+function get_conversation_row(conversation_key: string): JQuery {
+    return $(`#${CSS.escape(recent_conversation_key_prefix + conversation_key)}`);
+}
+
 function get_topic_row(topic_data: ConversationData): JQuery {
-    return $(`#${CSS.escape(recent_conversation_key_prefix + get_conversation_key(topic_data))}`);
+    return get_conversation_row(get_conversation_key(topic_data));
 }
 
 export function process_topic_edit(

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -806,6 +806,9 @@ export function dispatch_normal_event(event) {
                             );
                         }
                         const message_ids = message_store.get_message_ids_in_stream(stream_id);
+                        // Redraw before processing the reads, which rerenders recent view too
+                        // and would otherwise report the channel's stale rows.
+                        recent_view_ui.complete_rerender();
                         unread_ops.process_read_messages_event(message_ids);
                         message_events.remove_messages(message_ids);
                         stream_topic_history.remove_history_for_stream(stream_id);

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -721,6 +721,18 @@ export function get_unread_messages(messages: Message[]): Message[] {
     return messages.filter((message) => unread_messages.has(message.id));
 }
 
+// The key recent_view_util.get_key_from_message would give for this
+// message, from the data recorded when it became unread: unlike
+// message_store, this covers messages the client never fetched, but
+// only until the message is read.
+export function get_conversation_key(message_id: number): string | undefined {
+    const stream_topic = unread_topic_counter.reverse_lookup.get(message_id);
+    if (stream_topic !== undefined) {
+        return recent_view_util.get_topic_key(stream_topic.stream_id, stream_topic.topic);
+    }
+    return unread_direct_message_counter.reverse_lookup.get(message_id);
+}
+
 export function get_unread_message_count(): number {
     return unread_messages.size;
 }

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -772,17 +772,17 @@ export function update_unread_topic_name_case(
 export function process_loaded_messages(
     messages: Message[],
     expect_no_new_unreads = false,
-): boolean {
+): Message[] {
     // Process a set of messages that we have full copies of from the
     // server for whether any are unread but not tracked as such by
     // our data structures. This can occur due to old_unreads_missing,
     // changes in muting configuration, innocent races, or potentially bugs.
     //
-    // Returns whether there were any new unread messages; in that
-    // case, the caller will need to trigger a rerender of UI
+    // Returns the messages newly discovered to be unread; if there
+    // are any, the caller will need to trigger a rerender of UI
     // displaying unread counts.
 
-    let any_untracked_unread_messages = false;
+    const untracked_unread_messages: Message[] = [];
     for (const message of messages) {
         if (message.unread) {
             if (unread_messages.has(message.id)) {
@@ -818,11 +818,11 @@ export function process_loaded_messages(
                     unread: true,
                 });
             }
-            any_untracked_unread_messages = true;
+            untracked_unread_messages.push(message);
         }
     }
 
-    return any_untracked_unread_messages;
+    return untracked_unread_messages;
 }
 
 type UnreadMessageData = {

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -24,6 +24,7 @@ import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
 import * as popup_banners from "./popup_banners.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
+import * as recent_view_util from "./recent_view_util.ts";
 import {get_retry_backoff_seconds} from "./retry_backoff.ts";
 import type {MessageDetails} from "./server_event_types.ts";
 import type {NarrowTerm} from "./state_data.ts";
@@ -402,7 +403,6 @@ function process_newly_read_message(
         msg_list.view.show_message_as_read(message, options);
     }
     desktop_notifications.close_notification(message);
-    recent_view_ui.update_topic_unread_count(message);
 }
 
 export function mark_as_unread_from_here(message_id: number): void {
@@ -678,18 +678,22 @@ export function process_read_messages_event(message_ids: number[]): void {
         return;
     }
 
+    const conversation_keys = new Set<string>();
     for (const message_id of message_ids) {
+        // The unread data knows the conversation of every message it
+        // tracks, fetched or not, but only until we mark it as read.
+        const conversation_key = unread.get_conversation_key(message_id);
+        if (conversation_key !== undefined) {
+            conversation_keys.add(conversation_key);
+        }
         unread.mark_as_read(message_id);
 
         const message = message_store.get(message_id);
-
-        // TODO: This ends up doing one in-place rerender operation on
-        // recent conversations per message, not a single global
-        // rerender or one per conversation.
         if (message) {
             process_newly_read_message(message, options);
         }
     }
+    recent_view_ui.update_conversations_unread_count(conversation_keys);
 
     if (message_lists.current !== undefined && !message_lists.current.has_unread_messages()) {
         unread_ui.hide_unread_banner();
@@ -797,10 +801,13 @@ export function notify_server_messages_read(
 
     message_flags.send_read(messages);
 
+    const conversation_keys = new Set<string>();
     for (const message of messages) {
         unread.mark_as_read(message.id);
         process_newly_read_message(message, options);
+        conversation_keys.add(recent_view_util.get_key_from_message(message));
     }
+    recent_view_ui.update_conversations_unread_count(conversation_keys);
 
     unread_ui.update_unread_counts();
 }

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -18,6 +18,7 @@ import * as navbar_alerts from "./navbar_alerts.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
 import * as reactions from "./reactions.ts";
+import * as recent_view_ui from "./recent_view_ui.ts";
 import * as settings from "./settings.ts";
 import * as settings_account from "./settings_account.ts";
 import * as settings_bots from "./settings_bots.ts";
@@ -119,6 +120,12 @@ export const update_person = function update(event: UserUpdate): void {
         if (user.is_bot && bot_data.get(event.user_id) !== undefined) {
             bot_data.update(event.user_id, {user_id: event.user_id, full_name: event.full_name});
         }
+    }
+
+    if ("full_name" in event || "new_email" in event || "delivery_email" in event) {
+        // Recent view rows show user names, and its search matches
+        // participants by name and email.
+        recent_view_ui.complete_rerender();
     }
 
     if ("role" in event) {

--- a/web/src/user_topics_ui.ts
+++ b/web/src/user_topics_ui.ts
@@ -46,37 +46,40 @@ export function handle_topic_updates(
     // Update the UI after changes in topic visibility policies.
     user_topics.set_user_topic(user_topic_event);
 
-    setTimeout(
-        () => {
-            stream_list.update_streams_sidebar();
-            unread_ui.update_unread_counts();
-            recent_view_ui.update_topic_visibility_policy(
-                user_topic_event.stream_id,
-                user_topic_event.topic_name,
-            );
-
-            if (!refreshed_current_narrow) {
-                if (message_lists.current?.data.filter.is_in_home()) {
-                    const is_topic_visible_in_home = user_topics.is_topic_visible_in_home(
-                        user_topic_event.stream_id,
-                        user_topic_event.topic_name,
-                    );
-                    if (
-                        rerender_combined_feed_callback &&
-                        !was_topic_visible_in_home &&
-                        is_topic_visible_in_home
-                    ) {
-                        rerender_combined_feed_callback(message_lists.current);
-                    } else {
-                        message_lists.current.update_muting_and_rerender();
-                    }
-                } else {
-                    message_lists.current?.update_muting_and_rerender();
-                }
-            }
-        },
-        should_add_topic_update_delay(user_topic_event.visibility_policy) ? 500 : 0,
+    const update_delay_ms = should_add_topic_update_delay(user_topic_event.visibility_policy)
+        ? 500
+        : 0;
+    // Recent view schedules its own update, so that it knows which row is
+    // waiting for one.
+    recent_view_ui.update_topic_visibility_policy(
+        user_topic_event.stream_id,
+        user_topic_event.topic_name,
+        update_delay_ms,
     );
+    setTimeout(() => {
+        stream_list.update_streams_sidebar();
+        unread_ui.update_unread_counts();
+
+        if (!refreshed_current_narrow) {
+            if (message_lists.current?.data.filter.is_in_home()) {
+                const is_topic_visible_in_home = user_topics.is_topic_visible_in_home(
+                    user_topic_event.stream_id,
+                    user_topic_event.topic_name,
+                );
+                if (
+                    rerender_combined_feed_callback &&
+                    !was_topic_visible_in_home &&
+                    is_topic_visible_in_home
+                ) {
+                    rerender_combined_feed_callback(message_lists.current);
+                } else {
+                    message_lists.current.update_muting_and_rerender();
+                }
+            } else {
+                message_lists.current?.update_muting_and_rerender();
+            }
+        }
+    }, update_delay_ms);
 
     if (overlays.settings_open() && settings_user_topics.loaded) {
         const stream_id = user_topic_event.stream_id;

--- a/web/tests/dispatch_subs.test.cjs
+++ b/web/tests/dispatch_subs.test.cjs
@@ -20,7 +20,7 @@ mock_esm("../src/inbox_ui", {
 });
 const message_events = mock_esm("../src/message_events");
 const overlays = mock_esm("../src/overlays");
-mock_esm("../src/recent_view_ui", {
+const recent_view_ui = mock_esm("../src/recent_view_ui", {
     complete_rerender: noop,
 });
 const settings_org = mock_esm("../src/settings_org");
@@ -252,12 +252,27 @@ test("stream delete (normal)", ({override, override_rewire}) => {
 
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
 
-    override(unread_ops, "process_read_messages_event", noop);
+    // Recent view is redrawn before each channel's reads are processed,
+    // which would otherwise find the channel's rows still on screen.
+    const recent_view_calls = [];
+    override(recent_view_ui, "complete_rerender", () => {
+        recent_view_calls.push("complete_rerender");
+    });
+    override(unread_ops, "process_read_messages_event", () => {
+        recent_view_calls.push("process_read_messages_event");
+    });
     override(message_events, "remove_messages", noop);
     override(user_group_edit, "update_group_permissions_panel_on_losing_stream_access", noop);
     dispatch(event);
 
     assert.deepEqual(removed_stream_ids, [event.stream_ids[0], event.stream_ids[1]]);
+    assert.deepEqual(recent_view_calls, [
+        "complete_rerender",
+        "process_read_messages_event",
+        "complete_rerender",
+        "process_read_messages_event",
+        "complete_rerender",
+    ]);
 });
 
 test("stream delete (special streams)", ({override, override_rewire}) => {

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -1066,6 +1066,37 @@ run_test("render_item drops the row of an item moved past the rendered range", (
     assert.equal(rows.at(-1), moved);
 });
 
+run_test("insert_rendered_row falls back to a redraw without counting a row", () => {
+    const list = make_items(100);
+    const {widget, rows, row, stats} = make_tracked_widget(list, {
+        filter: {predicate: () => true},
+        init_sort: (a, b) => a.key - b.key,
+    });
+    const insert = (item) => {
+        list.push(item);
+        widget.replace_list_data(list, false);
+        widget.filter_and_sort();
+        widget.insert_rendered_row(item, (items) => items.indexOf(item));
+    };
+
+    // Neither neighbor of the new item has a row: the one before went
+    // missing, the one after is past the rendered range. The widget redraws
+    // and must not count the row it did not insert.
+    row(rows.at(-1)).remove();
+    insert({value: 101, key: 80.5});
+    assert.equal(stats.redraws, 1);
+    assert.deepEqual(widget.get_rendered_list(), rows);
+    assert.ok(!rows.includes(list.at(-1)));
+
+    // The same for a new last item whose predecessor's row went missing.
+    widget.render(list.length);
+    row(rows.at(-1)).remove();
+    insert({value: 102, key: 200});
+    assert.equal(stats.redraws, 2);
+    assert.deepEqual(widget.get_rendered_list(), rows);
+    assert.ok(!rows.includes(list.at(-1)));
+});
+
 run_test("Multiselect dropdown retain_selected_items", () => {
     const $container = make_container();
     const $scroll_container = make_scroll_container();

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -185,18 +185,28 @@ function make_items(count) {
 }
 
 // A widget over `list` with a stand-in for its DOM: `rows` holds the items
-// that have a row, in order, and refuses to render an item twice; `stats`
-// counts the redraws that threw rendered rows away.
+// that have a row, in DOM order, and refuses to render an item twice; the
+// row stubs remove, replace and position rows the way jQuery does. `stats`
+// counts the redraws that threw rendered rows away and lists the items
+// whose row was replaced in place.
 function make_tracked_widget(list, opts = {}) {
     const rows = [];
-    const stats = {redraws: 0};
+    const stats = {redraws: 0, replaced: []};
     const items_in = (html) =>
         html
             .matchAll(/data-item=(\d+)/g)
             .map((match) => list[Number(match[1]) - 1])
             .toArray();
+    function insert_items(index, $data) {
+        assert.ok(index >= 0, "anchor row is not in the DOM");
+        for (const [i, item] of items_in($data.html()).entries()) {
+            assert.ok(!rows.includes(item), `item ${item.value} was rendered twice`);
+            rows.splice(index + i, 0, item);
+        }
+    }
     function row(item) {
         return {
+            item,
             get length() {
                 return rows.includes(item) ? 1 : 0;
             },
@@ -204,14 +214,28 @@ function make_tracked_widget(list, opts = {}) {
                 assert.ok(rows.includes(item), "row is not in the DOM");
                 rows.splice(rows.indexOf(item), 1);
             },
+            before($data) {
+                insert_items(rows.indexOf(item), $data);
+            },
+            after($data) {
+                insert_items(rows.indexOf(item) + 1, $data);
+            },
+            replaceWith($data) {
+                assert.deepEqual(items_in($data.html()), [item]);
+                stats.replaced.push(item);
+            },
+            prev() {
+                // For the first row, row(undefined) stands in for no row.
+                return row(rows[rows.indexOf(item) - 1]);
+            },
+            is($other) {
+                return $other.item === item;
+            },
         };
     }
     const $container = make_container();
     $container.append = ($data) => {
-        for (const item of items_in($data.html())) {
-            assert.ok(!rows.includes(item), `item ${item.value} was rendered twice`);
-            rows.push(item);
-        }
+        insert_items(rows.length, $data);
     };
     $container.empty = () => {
         if (rows.length > 0) {
@@ -1064,6 +1088,30 @@ run_test("render_item drops the row of an item moved past the rendered range", (
     widget.render(list.length);
     assert.ok(widget.all_rendered());
     assert.equal(rows.at(-1), moved);
+});
+
+run_test("render_item moves a row to its item's new position", () => {
+    const list = make_items(50);
+    const {widget, rows, stats} = make_tracked_widget(list, {init_sort: (a, b) => a.key - b.key});
+    assert.ok(widget.all_rendered());
+
+    // Item 6 now sorts between items 25 and 26, item 40 first and item 8
+    // last; item 7 stays where it is.
+    list[5].key = 25.5;
+    list[39].key = 0.5;
+    list[7].key = 100;
+    widget.filter_and_sort();
+    widget.render_item(list[5]);
+    widget.render_item(list[39]);
+    widget.render_item(list[7]);
+    widget.render_item(list[6]);
+    assert.equal(rows[rows.indexOf(list[24]) + 1], list[5]);
+    assert.equal(rows[0], list[39]);
+    assert.equal(rows.at(-1), list[7]);
+    assert.deepEqual(widget.get_rendered_list(), rows);
+    // Only item 7's row was replaced in place; the other three moved, and
+    // nothing fell back to a redraw.
+    assert.deepEqual(stats, {redraws: 0, replaced: [list[6]]});
 });
 
 run_test("insert_rendered_row falls back to a redraw without counting a row", () => {

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -180,6 +180,59 @@ function div(item) {
     return "<div>" + item + "</div>";
 }
 
+function make_items(count) {
+    return Array.from({length: count}, (_, i) => ({value: i + 1, key: i + 1}));
+}
+
+// A widget over `list` with a stand-in for its DOM: `rows` holds the items
+// that have a row, in order, and refuses to render an item twice; `stats`
+// counts the redraws that threw rendered rows away.
+function make_tracked_widget(list, opts = {}) {
+    const rows = [];
+    const stats = {redraws: 0};
+    const items_in = (html) =>
+        html
+            .matchAll(/data-item=(\d+)/g)
+            .map((match) => list[Number(match[1]) - 1])
+            .toArray();
+    function row(item) {
+        return {
+            get length() {
+                return rows.includes(item) ? 1 : 0;
+            },
+            remove() {
+                assert.ok(rows.includes(item), "row is not in the DOM");
+                rows.splice(rows.indexOf(item), 1);
+            },
+        };
+    }
+    const $container = make_container();
+    $container.append = ($data) => {
+        for (const item of items_in($data.html())) {
+            assert.ok(!rows.includes(item), `item ${item.value} was rendered twice`);
+            rows.push(item);
+        }
+    };
+    $container.empty = () => {
+        if (rows.length > 0) {
+            stats.redraws += 1;
+        }
+        rows.length = 0;
+    };
+    const $scroll_container = make_scroll_container();
+    $scroll_container.find = ($row) => $row;
+    const widget = ListWidget.create($container, list, {
+        name: "tracked",
+        modifier_html: (item) => `<tr data-item=${item.value}></tr>\n`,
+        get_item: (item) => item,
+        html_selector: row,
+        $simplebar_container: $scroll_container,
+        ...opts,
+    });
+    stats.redraws = 0;
+    return {widget, rows, row, stats};
+}
+
 run_test("scrolling", () => {
     const $container = make_container();
     const $scroll_container = make_scroll_container();
@@ -960,6 +1013,37 @@ run_test("render advances the offset by the rows appended", () => {
     widget.render();
     assert.equal($container.$appended_data.html(), "<div>4</div>");
     assert.ok(widget.all_rendered());
+});
+
+run_test("filter_and_sort removes rows of items no longer listed", () => {
+    const list = make_items(100);
+    let hidden_items = new Set();
+    let render_count = 0;
+    const {widget, rows} = make_tracked_widget(list, {
+        filter: {predicate: (item) => !hidden_items.has(item)},
+        callback_after_render() {
+            render_count += 1;
+        },
+    });
+    assert.ok(!widget.all_rendered());
+
+    // Two rendered items and one not rendered yet get hidden without their
+    // rows being updated.
+    const hidden_rows = [rows[4], rows.at(-1)];
+    hidden_items = new Set([...hidden_rows, list.at(-1)]);
+    assert.deepEqual(widget.filter_and_sort(), hidden_rows);
+    // The rendered list still matches the rows in the DOM, so rendering
+    // more continues right after them, duplicating nothing.
+    assert.deepEqual(widget.get_rendered_list(), rows);
+    widget.render();
+    assert.deepEqual(widget.get_rendered_list(), rows);
+    assert.ok(widget.all_rendered());
+
+    // With everything rendered, removing rows calls render() once, so that
+    // an emptied list shows its empty-list message.
+    hidden_items.add(list[0]);
+    assert.deepEqual(widget.filter_and_sort(), [list[0]]);
+    assert.equal(render_count, 3);
 });
 
 run_test("Multiselect dropdown retain_selected_items", () => {

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -279,10 +279,13 @@ run_test("scrolling", () => {
         $simplebar_container: $scroll_container,
     };
 
-    ListWidget.create($container, items, opts);
+    const widget = ListWidget.create($container, items, opts);
 
     assert.deepEqual($container.$appended_data.html(), items.slice(0, 80).join(""));
     assert.equal(get_scroll_element_called, true);
+
+    // Nothing to render while the container is not scrolled to its end.
+    assert.equal(widget.maybe_render_more(), false);
 
     // Set up our fake geometry so it forces a scroll action.
     $scroll_container[0].scrollTop = 180;
@@ -293,6 +296,9 @@ run_test("scrolling", () => {
     // our widget.
     $scroll_container.call_scroll();
     assert.deepEqual($container.$appended_data.html(), items.slice(80, 100).join(""));
+
+    assert.equal(widget.maybe_render_more(), true);
+    assert.deepEqual($container.$appended_data.html(), items.slice(100, 120).join(""));
 });
 
 run_test("not_scrolling", () => {

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -939,6 +939,29 @@ run_test("render item", () => {
     blueslip.reset();
 });
 
+run_test("render advances the offset by the rows appended", () => {
+    const $container = make_container();
+    const $scroll_container = make_scroll_container();
+    const widget = ListWidget.create($container, [1, 2, 3], {
+        name: "render-offset",
+        modifier_html: div,
+        get_item: (item) => item,
+        $simplebar_container: $scroll_container,
+    });
+    assert.equal($container.$appended_data.html(), "<div>1</div><div>2</div><div>3</div>");
+    assert.ok(widget.all_rendered());
+
+    // The initial render asked for more rows than the list had; the offset
+    // must not end up past its end, or items added later would count as
+    // rendered and never be appended.
+    widget.replace_list_data([1, 2, 3, 4], false);
+    widget.filter_and_sort();
+    assert.ok(!widget.all_rendered());
+    widget.render();
+    assert.equal($container.$appended_data.html(), "<div>4</div>");
+    assert.ok(widget.all_rendered());
+});
+
 run_test("Multiselect dropdown retain_selected_items", () => {
     const $container = make_container();
     const $scroll_container = make_scroll_container();

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -1046,6 +1046,26 @@ run_test("filter_and_sort removes rows of items no longer listed", () => {
     assert.equal(render_count, 3);
 });
 
+run_test("render_item drops the row of an item moved past the rendered range", () => {
+    const list = make_items(100);
+    const {widget, rows, stats} = make_tracked_widget(list, {init_sort: (a, b) => a.key - b.key});
+    const moved = rows[4];
+
+    // The item now sorts last, past the rendered range: its row goes, with
+    // no redraw, and the rendered list still matches the rows in the DOM.
+    moved.key = 200;
+    widget.filter_and_sort();
+    widget.render_item(moved);
+    assert.ok(!rows.includes(moved));
+    assert.equal(stats.redraws, 0);
+    assert.deepEqual(widget.get_rendered_list(), rows);
+
+    // Rendering the rest reaches it last, and once.
+    widget.render(list.length);
+    assert.ok(widget.all_rendered());
+    assert.equal(rows.at(-1), moved);
+});
+
 run_test("Multiselect dropdown retain_selected_items", () => {
     const $container = make_container();
     const $scroll_container = make_scroll_container();

--- a/web/tests/message_fetch.test.cjs
+++ b/web/tests/message_fetch.test.cjs
@@ -2,13 +2,17 @@
 
 const assert = require("node:assert/strict");
 
-const {zrequire} = require("./lib/namespace.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
+
+const recent_view_ui = mock_esm("../src/recent_view_ui");
+const unread_ui = mock_esm("../src/unread_ui");
 
 const {Filter} = zrequire("filter");
 const {MessageListData} = zrequire("message_list_data");
 const message_fetch = zrequire("message_fetch");
+const unread = zrequire("unread");
 
 run_test("get_parameters_for_message_fetch_api date anchor", () => {
     const msg_list_data = new MessageListData({
@@ -37,4 +41,35 @@ run_test("get_parameters_for_message_fetch_api date anchor", () => {
         msg_list_data,
     });
     assert.equal(missing_date.anchor_date, undefined);
+});
+
+run_test("do_unread_count_updates", ({override}) => {
+    unread.declare_bankruptcy();
+    const messages = [
+        {id: 1, type: "stream", stream_id: 5, topic: "Lunch", unread: true},
+        {id: 2, type: "stream", stream_id: 5, topic: "lunch", unread: true},
+        {id: 3, type: "stream", stream_id: 5, topic: "read", unread: false},
+    ];
+
+    let unread_counts_updated = false;
+    override(unread_ui, "update_unread_counts", () => {
+        unread_counts_updated = true;
+    });
+    let updated_conversation_keys;
+    override(recent_view_ui, "update_conversations_unread_count", (conversation_keys) => {
+        updated_conversation_keys = conversation_keys;
+    });
+
+    // Newly discovered unreads update the unread UI and the rows of
+    // their conversations in recent view.
+    message_fetch.do_unread_count_updates(messages);
+    assert.ok(unread_counts_updated);
+    assert.deepEqual(updated_conversation_keys, new Set(["5:lunch"]));
+
+    // Fetching the same messages again discovers nothing new.
+    unread_counts_updated = false;
+    updated_conversation_keys = undefined;
+    message_fetch.do_unread_count_updates(messages);
+    assert.ok(!unread_counts_updated);
+    assert.equal(updated_conversation_keys, undefined);
 });

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -886,18 +886,14 @@ test("test_update_unread_count", () => {
     rt.update_topic_unread_count(messages[9]);
 });
 
-test("rerender leaves behind rows the filters now hide", ({override}) => {
-    // When a conversation becomes hidden without its own rerender -- here, a
-    // muted topic under the default "unmuted topics" filter -- a rerender
-    // triggered by a different topic calls filter_and_sort(), which drops the
-    // hidden conversation from the widget's filtered list but leaves its row
-    // in the DOM. The DOM then keeps more rows than the filtered list,
-    // meta.offset drifts below the rendered-row count, and a subsequent
-    // render() from scrolling or focus handling re-appends rows that are
-    // already on screen, showing duplicates.
-    //
-    // This test pins the current buggy behavior: the stale row is not
-    // removed. The next commit fixes it and updates this test.
+test("rerender removes rows the filters now hide", ({override}) => {
+    // Regression test for duplicate rows in Recent Conversations. When a
+    // conversation becomes hidden without its own rerender -- here, a muted
+    // topic under the default "unmuted topics" filter -- a later rerender
+    // triggered by a different topic must still remove its stale DOM row.
+    // Otherwise the DOM keeps more rows than the filtered list, meta.offset
+    // drifts below the rendered-row count, and a subsequent render() from
+    // scrolling or focus handling re-appends rows that are already on screen.
     recent_view_util.set_visible(true);
     rt.clear_for_tests();
     rt.set_filters_for_tests();
@@ -914,25 +910,18 @@ test("rerender leaves behind rows the filters now hide", ({override}) => {
 
     // The muted conversation's row is still in the DOM even though a
     // different, visible topic is what triggered this rerender.
-    override(ListWidget, "get_rendered_list", () => [muted_conversation, visible_conversation], {
-        unused: false,
-    });
+    override(ListWidget, "get_rendered_list", () => [muted_conversation, visible_conversation]);
     override(ListWidget, "get_current_list", () => [visible_conversation]);
     override(ListWidget, "render_item", noop);
     const removed_row_selectors = [];
-    override(
-        ListWidget,
-        "remove_rendered_row",
-        ($row) => {
-            removed_row_selectors.push($row.selector);
-        },
-        {unused: false},
-    );
+    override(ListWidget, "remove_rendered_row", ($row) => {
+        removed_row_selectors.push($row.selector);
+    });
 
     rt.inplace_rerender(visible_key);
 
-    // The now-hidden muted conversation's row is left in the DOM.
-    assert.deepEqual(removed_row_selectors, []);
+    // Only the now-hidden muted conversation's row should be removed.
+    assert.deepEqual(removed_row_selectors, [`#${CSS.escape(`recent_conversation:${muted_key}`)}`]);
 });
 
 test("basic assertions", ({mock_template, override_rewire}) => {

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -179,6 +179,7 @@ mock_esm("../src/unread", {
         }
         return 1;
     },
+    get_unread_message_count: () => 0,
     num_unread_for_user_ids_string() {
         return 0;
     },
@@ -883,6 +884,55 @@ test("test_update_unread_count", () => {
     // update a message
     generate_topic_data([[1, "topic-7", 1, all_visibility_policies.INHERIT]]);
     rt.update_topic_unread_count(messages[9]);
+});
+
+test("rerender leaves behind rows the filters now hide", ({override}) => {
+    // When a conversation becomes hidden without its own rerender -- here, a
+    // muted topic under the default "unmuted topics" filter -- a rerender
+    // triggered by a different topic calls filter_and_sort(), which drops the
+    // hidden conversation from the widget's filtered list but leaves its row
+    // in the DOM. The DOM then keeps more rows than the filtered list,
+    // meta.offset drifts below the rendered-row count, and a subsequent
+    // render() from scrolling or focus handling re-appends rows that are
+    // already on screen, showing duplicates.
+    //
+    // This test pins the current buggy behavior: the stale row is not
+    // removed. The next commit fixes it and updates this test.
+    recent_view_util.set_visible(true);
+    rt.clear_for_tests();
+    rt.set_filters_for_tests();
+    stub_out_filter_buttons();
+    rt.process_messages(messages);
+
+    const muted_key = recent_view_util.get_topic_key(stream1, topic7);
+    const muted_conversation = rt_data.conversations.get(muted_key);
+    assert.ok(rt.filters_should_hide_row(muted_conversation));
+
+    const visible_key = recent_view_util.get_topic_key(stream1, topic1);
+    const visible_conversation = rt_data.conversations.get(visible_key);
+    assert.ok(!rt.filters_should_hide_row(visible_conversation));
+
+    // The muted conversation's row is still in the DOM even though a
+    // different, visible topic is what triggered this rerender.
+    override(ListWidget, "get_rendered_list", () => [muted_conversation, visible_conversation], {
+        unused: false,
+    });
+    override(ListWidget, "get_current_list", () => [visible_conversation]);
+    override(ListWidget, "render_item", noop);
+    const removed_row_selectors = [];
+    override(
+        ListWidget,
+        "remove_rendered_row",
+        ($row) => {
+            removed_row_selectors.push($row.selector);
+        },
+        {unused: false},
+    );
+
+    rt.inplace_rerender(visible_key);
+
+    // The now-hidden muted conversation's row is left in the DOM.
+    assert.deepEqual(removed_row_selectors, []);
 });
 
 test("basic assertions", ({mock_template, override_rewire}) => {

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -83,6 +83,7 @@ const ListWidget = mock_esm("../src/list_widget", {
 
     hard_redraw: noop,
     filter_and_sort: () => [],
+    maybe_render_more: noop,
     replace_list_data(data) {
         assert.notEqual(
             expected_data_to_replace_in_list_widget,
@@ -920,6 +921,11 @@ test("bulk_inplace_rerender updates the requested rows in list order", ({overrid
         updates.push(["insert", conversation]);
     });
     override(ListWidget, "get_current_list", () => [third, first, second]);
+    let render_more_calls = 0;
+    override(ListWidget, "maybe_render_more", () => {
+        render_more_calls += 1;
+        return false;
+    });
 
     // A conversation with a row is rerendered and one without gets a row,
     // in list order, so that a row inserted next to another one finds it
@@ -929,6 +935,8 @@ test("bulk_inplace_rerender updates the requested rows in list order", ({overrid
         ["insert", third],
         ["rerender", first],
     ]);
+    // The rerender ends by rendering more rows if the table has room.
+    assert.equal(render_more_calls, 1);
 });
 
 test("basic assertions", ({mock_template, override_rewire}) => {

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -897,17 +897,6 @@ test("test_filter_participated", ({mock_template}) => {
     rt.process_messages([messages[4]]);
 });
 
-test("test_update_unread_count", () => {
-    recent_view_util.set_visible(false);
-    rt.clear_for_tests();
-    stub_out_filter_buttons();
-    rt.process_messages(messages);
-
-    // update a message
-    generate_topic_data([[1, "topic-7", 1, all_visibility_policies.INHERIT]]);
-    rt.update_topic_unread_count(messages[9]);
-});
-
 test("bulk_inplace_rerender updates the requested rows in list order", ({override}) => {
     show_recent_view_with_messages();
     const [first, second, third] = [topic1, topic2, topic3].map((topic) => conversation_for(topic));

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const {make_realm} = require("./lib/example_realm.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
+const blueslip = require("./lib/zblueslip.cjs");
 const {$} = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
@@ -926,6 +927,37 @@ test("bulk_inplace_rerender updates the requested rows in list order", ({overrid
     ]);
     // The rerender ends by rendering more rows if the table has room.
     assert.equal(render_more_calls, 1);
+});
+
+test("resort reports rows hidden without a rerender", ({override}) => {
+    show_recent_view_with_messages();
+    const muted_key = get_topic_key(stream1, topic7);
+    const visible_key = get_topic_key(stream1, topic1);
+    override(ListWidget, "render_item", noop);
+    override(ListWidget, "get_current_list", () => [conversation_for(topic1)]);
+    // Recomputing the filtered list removes the muted conversation's row.
+    override(ListWidget, "filter_and_sort", () => [conversation_for(topic7)]);
+
+    // Removing the row of the conversation being rerendered is expected;
+    // removing it while rerendering another one means the event that hid
+    // it left its row behind.
+    rt.inplace_rerender(muted_key);
+    blueslip.expect("error", "Recent view rows hidden without a rerender");
+    rt.inplace_rerender(visible_key);
+    blueslip.reset();
+
+    // A topic visibility change is applied after a delay; a resort in the
+    // meantime removes the row without a report, until the update runs.
+    const delayed_callbacks = [];
+    override(global, "setTimeout", (callback, delay) => {
+        delayed_callbacks.push({callback, delay});
+    });
+    rt.update_topic_visibility_policy(stream1, topic7, 500);
+    rt.inplace_rerender(visible_key);
+    delayed_callbacks.find(({delay}) => delay === 500).callback();
+    blueslip.expect("error", "Recent view rows hidden without a rerender");
+    rt.inplace_rerender(visible_key);
+    blueslip.reset();
 });
 
 test("basic assertions", ({mock_template, override, override_rewire}) => {

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -82,7 +82,7 @@ const ListWidget = mock_esm("../src/list_widget", {
     },
 
     hard_redraw: noop,
-    filter_and_sort: noop,
+    filter_and_sort: () => [],
     replace_list_data(data) {
         assert.notEqual(
             expected_data_to_replace_in_list_widget,
@@ -181,6 +181,7 @@ mock_esm("../src/unread", {
         }
         return 1;
     },
+    get_unread_message_count: () => 0,
     num_unread_for_user_ids_string() {
         return 0;
     },

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -480,6 +480,25 @@ function stub_out_filter_buttons() {
     }
 }
 
+function show_recent_view_with_messages() {
+    $.clear_all_elements();
+    recent_view_util.set_visible(true);
+    rt.clear_for_tests();
+    rt.set_filters_for_tests();
+    rt.set_default_focus();
+    stub_out_filter_buttons();
+    rt.process_messages(messages);
+}
+
+function conversation_for(topic) {
+    return rt_data.conversations.get(get_topic_key(stream1, topic));
+}
+
+function bulk_rerender(keys) {
+    expected_data_to_replace_in_list_widget = rt_data.get_conversations().values().toArray();
+    rt.bulk_inplace_rerender(keys);
+}
+
 function test(label, f) {
     run_test(label, (helpers) => {
         page_params.development_environment = true;
@@ -886,6 +905,30 @@ test("test_update_unread_count", () => {
     // update a message
     generate_topic_data([[1, "topic-7", 1, all_visibility_policies.INHERIT]]);
     rt.update_topic_unread_count(messages[9]);
+});
+
+test("bulk_inplace_rerender updates the requested rows in list order", ({override}) => {
+    show_recent_view_with_messages();
+    const [first, second, third] = [topic1, topic2, topic3].map((topic) => conversation_for(topic));
+    // The third conversation has no row yet; the others do.
+    $.set_results(`#${CSS.escape(`recent_conversation:${get_topic_key(stream1, topic3)}`)}`, []);
+    const updates = [];
+    override(ListWidget, "render_item", (conversation) => {
+        updates.push(["rerender", conversation]);
+    });
+    override(ListWidget, "insert_rendered_row", (conversation) => {
+        updates.push(["insert", conversation]);
+    });
+    override(ListWidget, "get_current_list", () => [third, first, second]);
+
+    // A conversation with a row is rerendered and one without gets a row,
+    // in list order, so that a row inserted next to another one finds it
+    // already in place.
+    bulk_rerender([get_topic_key(stream1, topic1), get_topic_key(stream1, topic3)]);
+    assert.deepEqual(updates, [
+        ["insert", third],
+        ["rerender", first],
+    ]);
 });
 
 test("basic assertions", ({mock_template, override_rewire}) => {

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -928,7 +928,7 @@ test("bulk_inplace_rerender updates the requested rows in list order", ({overrid
     assert.equal(render_more_calls, 1);
 });
 
-test("basic assertions", ({mock_template, override_rewire}) => {
+test("basic assertions", ({mock_template, override, override_rewire}) => {
     override_rewire(rt, "inplace_rerender", noop);
     rt.clear_for_tests();
     rt.set_filters_for_tests();
@@ -1094,6 +1094,10 @@ test("basic assertions", ({mock_template, override_rewire}) => {
     // so we don't need to check anythere here.
     generate_topic_data([[1, topic1, 0, all_visibility_policies.INHERIT]]);
     $("#search_query").trigger("focus");
+    // The update is applied after a delay; run it right away here.
+    override(global, "setTimeout", (callback) => {
+        callback();
+    });
     assert.equal(rt.update_topic_visibility_policy(stream1, topic1), true);
     // a topic gets muted which we are not tracking
     assert.equal(rt.update_topic_visibility_policy(stream1, "topic-10"), false);

--- a/web/tests/unread.test.cjs
+++ b/web/tests/unread.test.cjs
@@ -492,6 +492,33 @@ test("private_messages", () => {
     test_notifiable_count(counts.home_unread_messages, 0);
 });
 
+test("get_conversation_key", () => {
+    const stream_message = {
+        id: 21,
+        type: "stream",
+        stream_id: social.stream_id,
+        topic: "Lunch",
+        unread: true,
+    };
+    const dm_message = {
+        id: 22,
+        type: "private",
+        display_recipient: [{id: anybody.user_id}, {id: me.user_id}],
+        unread: true,
+    };
+    unread.process_loaded_messages([stream_message, dm_message]);
+
+    // The keys match recent view's conversation keys, and come from the
+    // unread data rather than message_store, so they are available for
+    // messages this client never fetched.
+    assert.equal(unread.get_conversation_key(stream_message.id), `${social.stream_id}:lunch`);
+    assert.equal(unread.get_conversation_key(dm_message.id), anybody.user_id.toString());
+    assert.equal(unread.get_conversation_key(23), undefined);
+
+    unread.mark_as_read(stream_message.id);
+    assert.equal(unread.get_conversation_key(stream_message.id), undefined);
+});
+
 test("private_messages", () => {
     const alice = make_user({
         email: "alice@example.com",

--- a/web/tests/unread.test.cjs
+++ b/web/tests/unread.test.cjs
@@ -519,6 +519,30 @@ test("get_conversation_key", () => {
     assert.equal(unread.get_conversation_key(stream_message.id), undefined);
 });
 
+test("process_loaded_messages returns newly tracked unreads", () => {
+    const unread_message = {
+        id: 31,
+        type: "stream",
+        stream_id: social.stream_id,
+        topic: "lunch",
+        unread: true,
+    };
+    const read_message = {
+        id: 32,
+        type: "stream",
+        stream_id: social.stream_id,
+        topic: "lunch",
+        unread: false,
+    };
+    assert.deepEqual(unread.process_loaded_messages([unread_message, read_message]), [
+        unread_message,
+    ]);
+    assert.equal(unread.num_unread_for_topic(social.stream_id, "lunch"), 1);
+
+    // Messages already tracked as unread are not reported again.
+    assert.deepEqual(unread.process_loaded_messages([unread_message, read_message]), []);
+});
+
 test("private_messages", () => {
     const alice = make_user({
         email: "alice@example.com",

--- a/web/tests/unread_ops.test.cjs
+++ b/web/tests/unread_ops.test.cjs
@@ -2,10 +2,19 @@
 
 const assert = require("node:assert/strict");
 
-const {set_global, zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
 
 set_global("document", {hasFocus: () => true});
+mock_esm("../src/desktop_notifications", {close_notification: noop});
+mock_esm("../src/message_flags", {send_read: noop});
+mock_esm("../src/unread_ui", {
+    hide_unread_banner: noop,
+    update_unread_counts: noop,
+});
+const recent_view_ui = mock_esm("../src/recent_view_ui");
+
+const message_store = zrequire("message_store");
 const unread = zrequire("unread");
 const unread_ops = zrequire("unread_ops");
 
@@ -29,4 +38,82 @@ run_test("get_message_count_text", () => {
         unread_ops.get_message_count_text(1),
         "translated: 1 message will be marked as read.",
     );
+});
+
+function track_unread_stream_message(id, topic) {
+    unread.process_unread_message({
+        id,
+        type: "stream",
+        stream_id: 7,
+        topic,
+        unread: true,
+        mentioned: false,
+        mentioned_me_directly: false,
+    });
+}
+
+run_test("process_read_messages_event", ({override}) => {
+    unread.declare_bankruptcy();
+    // Only the first message was fetched; the others are known to the
+    // unread data alone, as with reads on another client of messages
+    // older than what this client has loaded.
+    const fetched_message = {id: 101, type: "stream", stream_id: 7, topic: "Lunch", unread: true};
+    message_store.set_messages_for_tests([{message: fetched_message}]);
+    track_unread_stream_message(101, "Lunch");
+    track_unread_stream_message(102, "lunch");
+    track_unread_stream_message(103, "dinner");
+    unread.process_unread_message({
+        id: 104,
+        type: "private",
+        user_ids_string: "5",
+        unread: true,
+        mentioned: false,
+        mentioned_me_directly: false,
+    });
+
+    let updated_conversation_keys;
+    override(recent_view_ui, "update_conversations_unread_count", (conversation_keys) => {
+        updated_conversation_keys = conversation_keys;
+    });
+
+    // Recent view hears about each affected conversation once, whether
+    // or not its messages were fetched. Message 105 is not unread.
+    unread_ops.process_read_messages_event([101, 102, 103, 104, 105]);
+    assert.deepEqual(updated_conversation_keys, new Set(["7:lunch", "7:dinner", "5"]));
+    assert.equal(fetched_message.unread, false);
+    assert.equal(unread.get_unread_message_count(), 0);
+
+    // Nothing happens for messages that are already read.
+    updated_conversation_keys = undefined;
+    unread_ops.process_read_messages_event([101, 102]);
+    assert.equal(updated_conversation_keys, undefined);
+});
+
+run_test("notify_server_messages_read", ({override}) => {
+    unread.declare_bankruptcy();
+    const messages = [
+        {id: 201, type: "stream", stream_id: 7, topic: "Lunch", unread: true},
+        {id: 202, type: "stream", stream_id: 7, topic: "lunch", unread: true},
+        {id: 203, type: "private", to_user_ids: "5", unread: true},
+        {id: 204, type: "stream", stream_id: 7, topic: "already read", unread: false},
+    ];
+    track_unread_stream_message(201, "Lunch");
+    track_unread_stream_message(202, "lunch");
+    unread.process_unread_message({
+        id: 203,
+        type: "private",
+        user_ids_string: "5",
+        unread: true,
+        mentioned: false,
+        mentioned_me_directly: false,
+    });
+
+    let updated_conversation_keys;
+    override(recent_view_ui, "update_conversations_unread_count", (conversation_keys) => {
+        updated_conversation_keys = conversation_keys;
+    });
+
+    unread_ops.notify_server_messages_read(messages);
+    assert.deepEqual(updated_conversation_keys, new Set(["7:lunch", "5"]));
+    assert.equal(unread.get_unread_message_count(), 0);
 });

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -59,6 +59,9 @@ mock_esm("../src/compose_recipient", {
 const pm_list = mock_esm("../src/pm_list", {
     update_private_messages() {},
 });
+const recent_view_ui = mock_esm("../src/recent_view_ui", {
+    complete_rerender() {},
+});
 
 const buddy_data = new buddy_list.BuddyList();
 buddy_list.buddy_list = buddy_data;
@@ -126,6 +129,10 @@ run_test("updates", ({override}) => {
     people.add_active_user(isaac);
 
     override(navbar_alerts, "maybe_toggle_empty_required_profile_fields_banner", noop);
+    let recent_view_rerender_count = 0;
+    override(recent_view_ui, "complete_rerender", () => {
+        recent_view_rerender_count += 1;
+    });
     user_events.update_person({
         user_id: isaac.user_id,
         role: settings_config.user_role_values.guest.code,
@@ -178,6 +185,9 @@ run_test("updates", ({override}) => {
     assert.equal(person.user_id, isaac.user_id);
     assert.equal(person.role, settings_config.user_role_values.owner.code);
 
+    // Role changes do not affect recent view.
+    assert.equal(recent_view_rerender_count, 0);
+
     let user_id;
     let full_name;
     message_live_update.update_user_full_name = (user_id_arg, full_name_arg) => {
@@ -200,6 +210,8 @@ run_test("updates", ({override}) => {
     assert.equal(user_id, isaac.user_id);
     assert.equal(full_name, "Sir Isaac");
     assert.equal($navbar_title.text(), "Sir Isaac");
+    // Recent view rows show user names, so a rename redraws them.
+    assert.equal(recent_view_rerender_count, 1);
 
     // Renaming someone the title does not mention leaves it untouched.
     user_events.update_person({user_id: me.user_id, full_name: "Me Interim"});
@@ -231,10 +243,13 @@ run_test("updates", ({override}) => {
     assert.equal(full_name, "Me V2");
     assert.equal(user_list_style_preview_name, "Me V2");
 
+    recent_view_rerender_count = 0;
     user_events.update_person({user_id: isaac.user_id, new_email: "newton@example.com"});
     person = people.get_by_user_id(isaac.user_id);
     assert.equal(person.email, "newton@example.com");
     assert.equal(person.full_name, "Sir Isaac");
+    // Recent view's search matches participants by email too.
+    assert.equal(recent_view_rerender_count, 1);
 
     user_events.update_person({user_id: me.user_id, new_email: "meforu@example.com"});
     person = people.get_by_user_id(me.user_id);
@@ -267,12 +282,14 @@ run_test("updates", ({override}) => {
 
     person = people.get_by_email(isaac.email);
     assert.equal(person.delivery_email, null);
+    recent_view_rerender_count = 0;
     user_events.update_person({
         user_id: isaac.user_id,
         delivery_email: "isaac-delivery@example.com",
     });
     person = people.get_by_email(isaac.email);
     assert.equal(person.delivery_email, "isaac-delivery@example.com");
+    assert.equal(recent_view_rerender_count, 1);
 
     user_events.update_person({user_id: isaac.user_id, delivery_email: null});
     person = people.get_by_email(isaac.email);

--- a/web/tests/user_topics_ui.test.cjs
+++ b/web/tests/user_topics_ui.test.cjs
@@ -3,9 +3,16 @@
 const assert = require("node:assert/strict");
 
 const {make_stream} = require("./lib/example_stream.cjs");
-const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
 
+const popover_menus = mock_esm("../src/popover_menus", {
+    is_topic_menu_popover_displayed: () => false,
+    is_visibility_policy_popover_displayed: () => false,
+});
+const recent_view_ui = mock_esm("../src/recent_view_ui", {
+    update_topic_visibility_policy: noop,
+});
 const user_topics = zrequire("user_topics");
 const user_topics_ui = zrequire("user_topics_ui");
 const stream_data = zrequire("stream_data");
@@ -102,4 +109,36 @@ test("toggle_topic_visibility_policy", ({override_rewire}) => {
         user_topics.get_topic_visibility_policy(design.stream_id, "java") ===
             user_topics.all_visibility_policies.INHERIT,
     );
+});
+
+test("handle_topic_updates delays hiding the topic for popovers", ({override}) => {
+    const scheduled_delays = [];
+    override(global, "setTimeout", (_callback, delay) => {
+        scheduled_delays.push(delay);
+    });
+    const recent_view_updates = [];
+    override(recent_view_ui, "update_topic_visibility_policy", (stream_id, topic, delay_ms) => {
+        recent_view_updates.push([stream_id, topic, delay_ms]);
+    });
+    const mute_event = {
+        stream_id: design.stream_id,
+        topic_name: "java",
+        visibility_policy: user_topics.all_visibility_policies.MUTED,
+        last_updated: 1,
+    };
+
+    // Recent view is told right away, with the delay it should apply,
+    // and the other UI updates wait for the same delay.
+    user_topics_ui.handle_topic_updates(mute_event);
+    assert.ok(user_topics.is_topic_muted(design.stream_id, "java"));
+    assert.deepEqual(recent_view_updates, [[design.stream_id, "java", 0]]);
+    assert.ok(scheduled_delays.includes(0));
+    assert.ok(!scheduled_delays.includes(500));
+
+    // With a topic popover open, the muted topic's row waits for the
+    // popover to finish closing.
+    override(popover_menus, "is_topic_menu_popover_displayed", () => true);
+    user_topics_ui.handle_topic_updates(mute_event);
+    assert.deepEqual(recent_view_updates.at(-1), [design.stream_id, "java", 500]);
+    assert.ok(scheduled_delays.includes(500));
 });


### PR DESCRIPTION
Some events hide a rendered conversation without any per-row
notification reaching recent view; see the comment on the new
remove_now_hidden_rendered_rows() for the catalog (another client
reading messages this client never fetched; channel/user renames
while a search keyword is active). The in-place rerender paths call
list_widget's filter_and_sort(), which recomputes the filtered list
against the live filters and drops such a conversation -- but they
only reconcile the specific rows they were asked about, so the
hidden conversation keeps its row in the DOM. The DOM then holds
more rows than the filtered list, and increase_rendered_offset()'s
cap at filtered_list.length pulls meta.offset below the true
rendered-row count. A later render() from scrolling or keyboard-focus
handling slices from that stale offset and appends a copy of a row
that is already on screen. A clean redraw empties the container
first, which is why a filter toggle or revisiting the view cleared
the duplicates.


---


This is hard to reproduce locally and is a rare occurance.

Possible fix for [#issues > duplicate conversation row in recent conversations](https://chat.zulip.org/#narrow/channel/9-issues/topic/duplicate.20conversation.20row.20in.20recent.20conversations/with/2488536)