### PR TITLE
settings: Fix height of creating indicator overlay.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1262,7 +1262,7 @@ h4.stream_setting_subsection_title {
                 &:not(:empty) {
                     position: absolute;
                     width: 100% !important;
-                    height: calc(100% - 105px) !important;
+                    height: 100% !important;
                     display: flex !important;
                     justify-content: center;
                     align-items: center;


### PR DESCRIPTION
The "Creating channel..." and "Creating group..." overlay shown when creating channels and user groups respectively did not cover the available full height and thus did not look good. This commit fixes the CSS so that they cover the full height.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| | Before | After |
| ------ | ------ | ------ |
| Light theme | <img width="2178" height="1784" alt="Screenshot from 2026-07-06 12-37-37" src="https://github.com/user-attachments/assets/b1383754-e1d9-43a5-9dbb-12025c22072c" /> | <img width="2178" height="1784" alt="Screenshot from 2026-07-06 12-35-30" src="https://github.com/user-attachments/assets/daf0792b-06e2-4efd-b58a-4aebd22370b1" /> |
| Dark theme | <img width="2178" height="1784" alt="Screenshot from 2026-07-06 12-37-08" src="https://github.com/user-attachments/assets/b0498802-700e-4393-9916-1a31d9b33eb1" /> | <img width="2178" height="1784" alt="Screenshot from 2026-07-06 12-35-53" src="https://github.com/user-attachments/assets/b472c8df-321b-480b-bec8-7805bef92e7a" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
