### PR TITLE
users: Grant access to deactivated DM-group partners consistently.

### DIFF
--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -768,11 +768,14 @@ def check_can_access_user(
         recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
     ).values_list("recipient_id", flat=True)
 
+    # A user retains access to a deactivated user they
+    # share a direct message group with.
     return Subscription.objects.filter(
+        Q(recipient__type=Recipient.STREAM, is_user_active=True)
+        | Q(recipient__type=Recipient.DIRECT_MESSAGE_GROUP),
         recipient_id__in=subscribed_recipient_ids,
         user_profile=target_user,
         active=True,
-        is_user_active=True,
     ).exists()
 
 
@@ -798,12 +801,15 @@ def get_inaccessible_user_ids(
         recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
     ).values_list("recipient_id", flat=True)
 
+    # Deactivated users remain accessible through a shared
+    # direct message group.
     common_subscription_user_ids = (
         Subscription.objects.filter(
+            Q(recipient__type=Recipient.STREAM, is_user_active=True)
+            | Q(recipient__type=Recipient.DIRECT_MESSAGE_GROUP),
             recipient_id__in=subscribed_recipient_ids,
             user_profile_id__in=target_human_user_ids,
             active=True,
-            is_user_active=True,
         )
         .distinct("user_profile_id")
         .values_list("user_profile_id", flat=True)

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -769,11 +769,14 @@ def check_can_access_user(
         recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
     ).values_list("recipient_id", flat=True)
 
+    # A user retains access to a deactivated user they
+    # share a direct message group with.
     return Subscription.objects.filter(
+        Q(recipient__type=Recipient.STREAM, is_user_active=True)
+        | Q(recipient__type=Recipient.DIRECT_MESSAGE_GROUP),
         recipient_id__in=subscribed_recipient_ids,
         user_profile=target_user,
         active=True,
-        is_user_active=True,
     ).exists()
 
 
@@ -790,11 +793,14 @@ def get_inaccessible_users_queryset(
         recipient__type__in=[Recipient.STREAM, Recipient.DIRECT_MESSAGE_GROUP],
     ).values("recipient_id")
 
+    # Deactivated users remain accessible through a shared
+    # direct message group.
     common_subscriptions = Subscription.objects.filter(
+        Q(recipient__type=Recipient.STREAM, is_user_active=True)
+        | Q(recipient__type=Recipient.DIRECT_MESSAGE_GROUP),
         recipient_id__in=acting_user_recipient_ids,
         user_profile_id=OuterRef("pk"),
         active=True,
-        is_user_active=True,
     )
     # All users can access all the bots, so we exclude them.
     target_human_users = UserProfile.objects.filter(id__in=target_user_ids, is_bot=False)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -3730,6 +3730,7 @@ class GetProfileTest(ZulipTestCase):
         shiva = self.example_user("shiva")
         hamlet = self.example_user("hamlet")
         prospero = self.example_user("prospero")
+        aaron = self.example_user("aaron")
 
         inaccessible_user_ids = get_inaccessible_user_ids(
             [bot.id, hamlet.id, othello.id, shiva.id, prospero.id], polonius
@@ -3753,6 +3754,18 @@ class GetProfileTest(ZulipTestCase):
         )
         self.assertEqual(inaccessible_user_ids, {othello.id})
 
+        # A deactivated user remains accessible through a shared direct
+        # message group (prospero, a 1:1 DM partner and aaron, a group DM
+        # partner), but a deactivated user only sharing a stream (hamlet)
+        # becomes inaccessible.
+        do_deactivate_user(prospero, acting_user=None)
+        do_deactivate_user(hamlet, acting_user=None)
+        do_deactivate_user(aaron, acting_user=None)
+        inaccessible_user_ids = get_inaccessible_user_ids(
+            [hamlet.id, prospero.id, aaron.id], polonius
+        )
+        self.assertEqual(inaccessible_user_ids, {hamlet.id})
+
     def test_get_inaccessible_user_ids_with_null_recipient(self) -> None:
         polonius = self.example_user("polonius")
 
@@ -3775,12 +3788,27 @@ class GetProfileTest(ZulipTestCase):
         polonius = self.example_user("polonius")
         prospero = self.example_user("prospero")
         desdemona = self.example_user("desdemona")
+        aaron = self.example_user("aaron")
+        hamlet = self.example_user("hamlet")
 
         # prospero and polonius had personal messages history
         self.assertTrue(check_can_access_user(prospero, polonius))
 
+        # polonius and aaron shared a group direct message
+        self.assertTrue(check_can_access_user(aaron, polonius))
+
         # no personal messages history between desdemona and polonius
         self.assertFalse(check_can_access_user(desdemona, polonius))
+
+        # A guest keeps access to a deactivated user they share a direct
+        # message group with (prospero and aaron), but loses access to a
+        # deactivated user they only shared a stream with (hamlet).
+        do_deactivate_user(prospero, acting_user=None)
+        do_deactivate_user(hamlet, acting_user=None)
+        do_deactivate_user(aaron, acting_user=None)
+        self.assertTrue(check_can_access_user(prospero, polonius))
+        self.assertTrue(check_can_access_user(aaron, polonius))
+        self.assertFalse(check_can_access_user(hamlet, polonius))
 
     def test_get_users_involved_in_dms_excludes_deactivated_users(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -3771,6 +3771,7 @@ class GetProfileTest(ZulipTestCase):
         shiva = self.example_user("shiva")
         hamlet = self.example_user("hamlet")
         prospero = self.example_user("prospero")
+        aaron = self.example_user("aaron")
 
         inaccessible_user_ids = get_inaccessible_user_ids(
             [bot.id, hamlet.id, othello.id, shiva.id, prospero.id], polonius
@@ -3794,6 +3795,18 @@ class GetProfileTest(ZulipTestCase):
         )
         self.assertEqual(inaccessible_user_ids, {othello.id})
 
+        # A deactivated user remains accessible through a shared direct
+        # message group (prospero, a 1:1 DM partner and aaron, a group DM
+        # partner), but a deactivated user only sharing a stream (hamlet)
+        # becomes inaccessible.
+        do_deactivate_user(prospero, acting_user=None)
+        do_deactivate_user(hamlet, acting_user=None)
+        do_deactivate_user(aaron, acting_user=None)
+        inaccessible_user_ids = get_inaccessible_user_ids(
+            [hamlet.id, prospero.id, aaron.id], polonius
+        )
+        self.assertEqual(inaccessible_user_ids, {hamlet.id})
+
     def test_get_inaccessible_user_ids_with_null_recipient(self) -> None:
         polonius = self.example_user("polonius")
 
@@ -3816,12 +3829,27 @@ class GetProfileTest(ZulipTestCase):
         polonius = self.example_user("polonius")
         prospero = self.example_user("prospero")
         desdemona = self.example_user("desdemona")
+        aaron = self.example_user("aaron")
+        hamlet = self.example_user("hamlet")
 
         # prospero and polonius had personal messages history
         self.assertTrue(check_can_access_user(prospero, polonius))
 
+        # polonius and aaron shared a group direct message
+        self.assertTrue(check_can_access_user(aaron, polonius))
+
         # no personal messages history between desdemona and polonius
         self.assertFalse(check_can_access_user(desdemona, polonius))
+
+        # A guest keeps access to a deactivated user they share a direct
+        # message group with (prospero and aaron), but loses access to a
+        # deactivated user they only shared a stream with (hamlet).
+        do_deactivate_user(prospero, acting_user=None)
+        do_deactivate_user(hamlet, acting_user=None)
+        do_deactivate_user(aaron, acting_user=None)
+        self.assertTrue(check_can_access_user(prospero, polonius))
+        self.assertTrue(check_can_access_user(aaron, polonius))
+        self.assertFalse(check_can_access_user(hamlet, polonius))
 
     def test_check_can_access_user_for_a_guest_with_themself(self) -> None:
         """


### PR DESCRIPTION
`check_can_access_user()` and `get_inaccessible_user_ids()` required `is_user_active=True` on the shared subscription, so a guest was denied access to a deactivated user they share a direct message group (or 1:1 DM) with -- even though `get_accessible_user_ids()` already treats such users as accessible and delivers their real data in the initial data set. The visible symptom was the user card showing the inaccessible-user avatar (served via `/avatar/{id}/medium`, which routes through `check_can_access_user`) while the message feed, which uses the real person object, showed the correct avatar.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
