### PR TITLE
[ai] dropdown_widget: Fix "None" row height in channel-folder selector.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2243,28 +2243,6 @@ body:not(.spectator-view) {
         }
     }
 
-    &.folder_id-dropdown-list-container {
-        width: calc(var(--modal-input-width) * 0.75);
-
-        /* Alignment adjustments on channel-folder selector. */
-        .dropdown-list-item-name:has(.dropdown-list-buttons) {
-            /* We hold the first row height to 28px at 16px/1em
-               for the sake of the buttons plus their padding. */
-            grid-template-rows: 1.75em minmax(0, auto);
-            /* We also align everything to start, so that we can
-               offset the text from the top to align it with the
-               buttons. */
-            align-items: start;
-
-            .dropdown-list-text-neutral {
-                /* 0.2em is an eyeballed value that keeps the buttons
-                   well aligned with the first/only line of text. */
-                padding-top: 0.2em;
-                align-self: start;
-            }
-        }
-    }
-
     .no-dropdown-items {
         color: hsl(0deg 0% 60%);
         display: none;
@@ -2415,6 +2393,31 @@ body:not(.spectator-view) {
             .dropdown-list-text-selected,
             .setting-disabled-option-text {
                 color: var(--color-current-setting-dropdown-item);
+            }
+        }
+    }
+
+    &.folder_id-dropdown-list-container {
+        width: calc(var(--modal-input-width) * 0.75);
+
+        /* Alignment adjustments on the channel-folder selector. */
+        .dropdown-list .dropdown-list-item-name {
+            /* We hold the first row height to 28px at 16px/1em
+               for the sake of the buttons plus their padding.
+               Unlike the base rules above, we apply this to rows
+               without buttons, too, so that the "None" row is the
+               same height as the folder rows. */
+            grid-template-rows: 1.75em minmax(0, auto);
+            /* We also align everything to start, so that we can
+               offset the text from the top to align it with the
+               buttons. */
+            align-items: start;
+
+            .dropdown-list-text-neutral {
+                /* 0.2em is an eyeballed value that keeps the buttons
+                   well aligned with the first/only line of text. */
+                padding-top: 0.2em;
+                align-self: start;
             }
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2397,7 +2397,8 @@ body:not(.spectator-view) {
         }
     }
 
-    &.folder_id-dropdown-list-container {
+    &.folder_id-dropdown-list-container,
+    &.new_channel_folder_id-dropdown-list-container {
         width: calc(var(--modal-input-width) * 0.75);
 
         /* Alignment adjustments on the channel-folder selector. */


### PR DESCRIPTION
This addresses the second checklist item of #37647: the "None" row in the channel-folder selector rendered ~8px shorter than the single-line folder rows (29.4px vs 38px), with its text sitting on a different baseline.

Fixes part of #37647.

**Technical notes:**

- The folder-specific alignment block in `zulip.css` turned out to be dead code: the generic `.dropdown-list-item-name` rules appear later in the file at equal specificity, so the button-row styling actually came from the generic `:has(.dropdown-list-buttons)` block that applies to every dropdown widget. The first commit moves the folder-specific block after the generic rules so it takes effect, and drops its `:has(.dropdown-list-buttons)` qualifier so that every row of this selector — including "None" — shares the same 28px first grid row and 0.2em text offset. Per the issue's guidance, this matches row heights without setting a fixed `height`.
- The create-channel form contains a separate instance of this widget (`new_channel_folder_id`), which received none of the folder-selector adjustments — neither the width nor the alignment rules. The second commit extends the block to cover it, so both instances render identically. (`web/src/tippyjs.ts` already targets both container classes together for the folder-button tooltips, so styling them together follows the existing intent.)

**Status of the issue's checklist:**

1. Left/right spacing: already balanced on current main (6px text inset on both sides, measured) — no change needed.
2. "None" row height: fixed by this PR.
3. Width cinching to content: not addressed here; that one also involves the saved-snippets selector and seems worth a design discussion first. Happy to pick it up as a follow-up.

**Affected UI surfaces:**

The widget is instantiated in exactly two places, both captured below:

```console
$ git grep -l 'channel_folder_widget_name=' web/templates/
web/templates/stream_settings/stream_creation_form.hbs
web/templates/stream_settings/stream_settings.hbs
```

**How changes were tested:**

Ran a Puppeteer script against the dev server (branch rebased onto latest `main`; Before = `main`, After = this branch) that opens both instances of the selector and measures row geometry via `getBoundingClientRect`:

- "None" row height: 29.42px → **38px**, exactly matching folder rows, in both instances.
- Folder rows: unchanged at 38px; text inset unchanged at 6px.
- Create-form dropdown width: 229px → 278.56px, now matching the channel-settings instance (folder names no longer wrap unnecessarily).

Also ran `./tools/lint`.

**Screenshots and screen captures:**

All screenshots are 560×620 viewport clips anchored on the selector, captured with identical UI state.

| | Before | After |
|---|---|---|
| Channel settings | ![before](https://raw.githubusercontent.com/gt12889/zulip/assets-37647/precise-before-settings.png) | ![after](https://raw.githubusercontent.com/gt12889/zulip/assets-37647/precise-after-settings.png) |
| Folder row hovered | ![before](https://raw.githubusercontent.com/gt12889/zulip/assets-37647/precise-before-settings-hover.png) | ![after](https://raw.githubusercontent.com/gt12889/zulip/assets-37647/precise-after-settings-hover.png) |
| Create-channel form | ![before](https://raw.githubusercontent.com/gt12889/zulip/assets-37647/precise-before-create-form.png) | ![after](https://raw.githubusercontent.com/gt12889/zulip/assets-37647/precise-after-create-form.png) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>