### PR TITLE
migrations: Fix invalid deleted user "email" field values.

### DIFF
--- a/zerver/migrations/0805_fix_deleteduser_email.py
+++ b/zerver/migrations/0805_fix_deleteduser_email.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import F, Q
+
+
+def fix_invalid_emails(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    """Users deleted prior to the fix in 208c0c303405 have invalid
+    addresses of the form deleteduser123@https://zulip.example.com.
+    0439_fix_deleteduser_email repaired the delivery_email field, but
+    not the email field; on realms whose (then realm-level)
+    email_address_visibility setting was "everyone", the email field
+    held the same invalid address and should equal delivery_email.
+    (On other realms, the dummy's email field got a valid
+    user{id}@<fake domain> address, which this filter won't match.)
+    """
+
+    UserProfile = apps.get_model("zerver", "UserProfile")
+    UserProfile.objects.filter(is_active=False).filter(
+        Q(email__icontains="@https://") | Q(email__icontains="@http://")
+    ).update(email=F("delivery_email"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0804_backfill_user_created_audit_logs"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            fix_invalid_emails, reverse_code=migrations.RunPython.noop, elidable=True
+        ),
+    ]

--- a/zerver/tests/test_migrations.py
+++ b/zerver/tests/test_migrations.py
@@ -4,9 +4,6 @@
 # You can also read
 #   https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 # to get a tutorial on the framework that inspired this feature.
-from unittest import skip
-from unittest.mock import patch
-
 from django.db.migrations.state import StateApps
 from typing_extensions import override
 
@@ -25,33 +22,45 @@ from zerver.lib.test_classes import MigrationsTestCase
 #   "zerver_subscription" because it has pending trigger events
 
 
-@skip("Fails because newer migrations have since been merged.")  # nocoverage
-class RenameUserHotspot(MigrationsTestCase):
-    migrate_from = "0492_realm_push_notifications_enabled_and_more"
-    migrate_to = "0493_rename_userhotspot_to_onboardingstep"
-
-    @override
-    def setUp(self) -> None:
-        with patch("builtins.print") as _:
-            super().setUp()
+class FixDeletedUserEmail(MigrationsTestCase):
+    migrate_from = "0804_backfill_user_created_audit_logs"
+    migrate_to = "0805_fix_deleteduser_email"
 
     @override
     def setUpBeforeMigration(self, apps: StateApps) -> None:
-        self.assertRaises(LookupError, lambda: apps.get_model("zerver", "onboardingstep"))
+        UserProfile = apps.get_model("zerver", "UserProfile")
 
-        UserHotspot = apps.get_model("zerver", "userhotspot")
+        # Simulate a user deleted before the fix in 208c0c303405,
+        # after 0439_fix_deleteduser_email repaired delivery_email.
+        deleted_user = self.example_user("hamlet")
+        UserProfile.objects.filter(id=deleted_user.id).update(
+            is_active=False,
+            email=f"deleteduser{deleted_user.id}@https://zulip.testserver",
+            delivery_email=f"deleteduser{deleted_user.id}@zulip.testserver",
+        )
+        self.deleted_user_id = deleted_user.id
 
-        expected_field_names = {"id", "hotspot", "timestamp", "user"}
-        fields_name = {field.name for field in UserHotspot._meta.get_fields()}
+        # A normal active user, as a control.
+        control_user = self.example_user("cordelia")
+        self.control_user_id = control_user.id
+        self.control_user_email = control_user.email
 
-        self.assertEqual(fields_name, expected_field_names)
+        # A deactivated user with a valid email, as a control for the
+        # is_active=False part of the migration's filter.
+        deactivated_user = self.example_user("othello")
+        UserProfile.objects.filter(id=deactivated_user.id).update(is_active=False)
+        self.deactivated_user_id = deactivated_user.id
+        self.deactivated_user_email = deactivated_user.email
 
-    def test_renamed_model_and_field(self) -> None:
-        self.assertRaises(LookupError, lambda: self.apps.get_model("zerver", "userhotspot"))
+    def test_deleted_user_email_fixed(self) -> None:
+        UserProfile = self.apps.get_model("zerver", "UserProfile")
 
-        OnboardingStep = self.apps.get_model("zerver", "onboardingstep")
+        deleted_user = UserProfile.objects.get(id=self.deleted_user_id)
+        self.assertEqual(deleted_user.email, f"deleteduser{deleted_user.id}@zulip.testserver")
+        self.assertEqual(deleted_user.email, deleted_user.delivery_email)
 
-        expected_field_names = {"id", "onboarding_step", "timestamp", "user"}
-        fields_name = {field.name for field in OnboardingStep._meta.get_fields()}
+        control_user = UserProfile.objects.get(id=self.control_user_id)
+        self.assertEqual(control_user.email, self.control_user_email)
 
-        self.assertEqual(fields_name, expected_field_names)
+        deactivated_user = UserProfile.objects.get(id=self.deactivated_user_id)
+        self.assertEqual(deactivated_user.email, self.deactivated_user_email)


### PR DESCRIPTION
208c0c3 fixed `do_delete_user` to stop generating dummy users with invalid addresses of the form deleteduser@http://zulip.example.com, and `0439_fix_deleteduser_email` (ed4de6da4a20e7a153d165e5f74ee1779289a303) repaired the `delivery_email` field of users deleted before that fix. However, on realms whose `email_address_visibility` setting was "everyone", the `email` field held a copy of the same invalid address,  such values still break realm import.

Since `delivery_email` is guaranteed to have already been repaired on every affected row, and the `email` field of the affected rows is by definition a copy of `delivery_email`, we restore the invariant by copying the repaired value.

#28622 called for using `get_fake_email_domain`. While this will produce a currently correct result for the `email` field, if `FAKE_EMAIL_DOMAIN` has changed since an instance upgraded past ed4de6da4a20e7a153d165e5f74ee1779289a303, it would cause the `email` and `delivery_email` fields to mismatch.

Fixes: #28622

**How changes were tested:**

Tested with a migration test, as well as running the migration locally.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
