### PR TITLE
thumbnail: Tolerate a missing content-type in missing_thumbnails. 

### DIFF
--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -295,9 +295,13 @@ def resize_emoji(
 
 
 def needs_transcoded_format(image_attachment: ImageAttachment) -> bool:
-    return not (
-        image_attachment.content_type is None
-        or bare_content_type(image_attachment.content_type) in INLINE_MIME_TYPES
+    # Images whose content-type browsers can't render inline need a
+    # transcoded, web-safe copy.  Some old uploads have a missing
+    # content-type -- null, or empty from a blank ?mimetype= -- which
+    # is falsy here and so judged inline, since we can't tell otherwise.
+    return bool(
+        image_attachment.content_type
+        and bare_content_type(image_attachment.content_type) not in INLINE_MIME_TYPES
     )
 
 

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -313,8 +313,7 @@ def missing_thumbnails(
         seen_thumbnails.add(StoredThumbnailFormat(**existing_thumbnail))
 
     potential_output_formats = list(THUMBNAIL_OUTPUT_FORMATS)
-    assert image_attachment.content_type
-    if bare_content_type(image_attachment.content_type) not in INLINE_MIME_TYPES:
+    if needs_transcoded_format(image_attachment):
         if image_attachment.original_width_px >= image_attachment.original_height_px:
             additional_format = ThumbnailFormat(
                 TRANSCODED_IMAGE_FORMAT.extension,

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -294,6 +294,13 @@ def resize_emoji(
         return (animated.write_to_buffer(write_file_ext), first_still)
 
 
+def needs_transcoded_format(image_attachment: ImageAttachment) -> bool:
+    return not (
+        image_attachment.content_type is None
+        or bare_content_type(image_attachment.content_type) in INLINE_MIME_TYPES
+    )
+
+
 def missing_thumbnails(
     image_attachment: ImageAttachment,
 ) -> list[ThumbnailFormat]:
@@ -524,10 +531,7 @@ def get_transcoded_format(
     # not in INLINE_MIME_TYPES get an extra large-resolution thumbnail
     # added to their list of formats, this is thus either None or a
     # high-resolution thumbnail.
-    if (
-        image_attachment.content_type is None
-        or bare_content_type(image_attachment.content_type) in INLINE_MIME_TYPES
-    ):
+    if not needs_transcoded_format(image_attachment):
         return None
 
     thumbs_by_size = sorted(

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -735,8 +735,33 @@ class TestStoreThumbnail(ZulipTestCase):
             )
             image_attachment.content_type = "image/png"
             self.assertEqual(get_transcoded_format(image_attachment), None)
+            # A null or empty content-type is judged inline.
             image_attachment.content_type = None
             self.assertEqual(get_transcoded_format(image_attachment), None)
+            image_attachment.content_type = ""
+            self.assertEqual(get_transcoded_format(image_attachment), None)
+
+    def test_missing_thumbnails_missing_content_type(self) -> None:
+        # A null or empty content-type (some old uploads) must not
+        # crash; it is judged inline, like get_transcoded_format.
+        image_attachment = ImageAttachment(
+            path_id="example",
+            original_width_px=150,
+            original_height_px=100,
+            frames=1,
+            thumbnail_metadata=[],
+            content_type="image/tiff",
+        )
+        still_webp = ThumbnailFormat("webp", 100, 75, animated=False, opts="Q=90")
+        transcoded = ThumbnailFormat("webp", 4032, 3024, animated=False)
+        with self.thumbnail_formats(still_webp):
+            # A known non-inline type gets the extra transcoded format.
+            self.assertEqual(missing_thumbnails(image_attachment), [still_webp, transcoded])
+
+            # A missing content-type does not, and does not crash.
+            for missing_content_type in (None, ""):
+                image_attachment.content_type = missing_content_type
+                self.assertEqual(missing_thumbnails(image_attachment), [still_webp])
 
     def test_maybe_thumbnail_from_stream(self) -> None:
         # If we put the file in place directly (e.g. simulating a


### PR DESCRIPTION
missing_thumbnails asserted that ImageAttachment.content_type is set.
That holds for anything maybe_thumbnail creates, but not for rows
migration 0660 backfilled from Attachment.content_type: uploads from
before we recorded a content-type left it null, and a blank ?mimetype=
parameter (before we guarded against it) left it empty.

The assertion fires on two paths for such an image: the thumbnail
queue worker (e.g. when `manage.py thumbnail` re-thumbnails old
images), and the thumbnail-status endpoint in zerver/views/thumbnail.py,
where an unhandled AssertionError becomes a user-facing 500.

Use needs_transcoded_format, which judges a null or empty content-type
as renderable inline (no transcoded format), exactly as
get_transcoded_format does when serving. Sharing the helper keeps the
generate and serve sides from disagreeing, which would otherwise
produce a transcoded format that is never served, or vice versa.

This stands on its own: it fixes the crash on every deployment,
_**including self-hosted installs using local uploads**_, where no S3-side
content-type backfill runs. Backfilling the underlying data is a
separate change.
