### PR TITLE
compose_call: Base meeting name on compose state.

### DIFF
--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -149,7 +149,8 @@ export function generate_and_insert_audio_or_video_call_link(
     } else {
         switch (realm.realm_video_chat_provider) {
             case available_providers.big_blue_button?.id: {
-                const meeting_name = `${get_recipient_label()?.label_text ?? ""} meeting`;
+                const meeting_name =
+                    `${get_recipient_label()?.label_text ?? ""} meeting`.trimStart();
                 const request = {
                     meeting_name,
                     voice_only: is_audio_call,
@@ -208,7 +209,8 @@ export function generate_and_insert_audio_or_video_call_link(
                 break;
             }
             case available_providers.nextcloud_talk?.id: {
-                const room_name = `${get_recipient_label()?.label_text ?? ""} conversation`;
+                const room_name =
+                    `${get_recipient_label()?.label_text ?? ""} conversation`.trimStart();
                 const request = {room_name};
 
                 const handle_success = (response: unknown): void => {

--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -5,9 +5,16 @@ import * as channel from "./channel.ts";
 import * as compose_banner from "./compose_banner.ts";
 import * as compose_call from "./compose_call.ts";
 import {compose_call_session_manager} from "./compose_call_session.ts";
-import {get_recipient_label} from "./compose_closed_ui.ts";
+import {
+    type RecipientLabel,
+    get_direct_message_recipient_label,
+    get_stream_recipient_label,
+} from "./compose_closed_ui.ts";
+import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
 import {$t, $t_html} from "./i18n.ts";
+import * as message_store from "./message_store.ts";
+import * as people from "./people.ts";
 import * as rows from "./rows.ts";
 import {current_user, realm} from "./state_data.ts";
 import * as ui_report from "./ui_report.ts";
@@ -18,6 +25,48 @@ const call_response_schema = z.object({
     result: z.string(),
     url: z.string(),
 });
+
+// Builds the meeting/room name label for some video providers from
+// the current compose target or, when editing, from the message
+// being edited.
+export let get_recipient_label_for_call = (
+    edit_message_id: string | undefined,
+): RecipientLabel | undefined => {
+    if (edit_message_id !== undefined) {
+        const message = message_store.get(Number(edit_message_id));
+        if (message === undefined) {
+            return undefined;
+        }
+        if (message.is_stream) {
+            return get_stream_recipient_label(message.stream_id, message.topic);
+        }
+        return get_direct_message_recipient_label(
+            people.user_ids_string_to_ids_array(message.to_user_ids),
+        );
+    }
+    const message_type = compose_state.get_message_type();
+    if (message_type === "stream") {
+        const stream_id = compose_state.stream_id();
+        if (stream_id === undefined) {
+            return undefined;
+        }
+        return get_stream_recipient_label(stream_id, compose_state.topic());
+    }
+    if (message_type === "private") {
+        const recipient_ids = compose_state.private_message_recipient_ids();
+        if (recipient_ids.length === 0) {
+            return undefined;
+        }
+        return get_direct_message_recipient_label(recipient_ids);
+    }
+    return undefined;
+};
+
+export function rewire_get_recipient_label_for_call(
+    value: typeof get_recipient_label_for_call,
+): void {
+    get_recipient_label_for_call = value;
+}
 
 export function update_audio_and_video_chat_button_display(): void {
     update_audio_chat_button_display();
@@ -150,7 +199,7 @@ export function generate_and_insert_audio_or_video_call_link(
         switch (realm.realm_video_chat_provider) {
             case available_providers.big_blue_button?.id: {
                 const meeting_name =
-                    `${get_recipient_label()?.label_text ?? ""} meeting`.trimStart();
+                    `${get_recipient_label_for_call(edit_message_id)?.label_text ?? ""} meeting`.trimStart();
                 const request = {
                     meeting_name,
                     voice_only: is_audio_call,
@@ -210,7 +259,7 @@ export function generate_and_insert_audio_or_video_call_link(
             }
             case available_providers.nextcloud_talk?.id: {
                 const room_name =
-                    `${get_recipient_label()?.label_text ?? ""} conversation`.trimStart();
+                    `${get_recipient_label_for_call(edit_message_id)?.label_text ?? ""} conversation`.trimStart();
                 const request = {room_name};
 
                 const handle_success = (response: unknown): void => {

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -21,7 +21,7 @@ import * as util from "./util.ts";
 // paths in compose_call_ui.ts to build a meeting/room name.
 // The reply-button template uses the structured `stream` / `topic_display_name`
 // fields instead, so it can render the decorated channel icon.
-type RecipientLabel = {
+export type RecipientLabel = {
     label_text: string;
     has_empty_string_topic?: boolean;
     stream?: StreamSubscription;
@@ -30,7 +30,10 @@ type RecipientLabel = {
     user_ids?: number[];
 };
 
-function get_stream_recipient_label(stream_id: number, topic: string): RecipientLabel | undefined {
+export function get_stream_recipient_label(
+    stream_id: number,
+    topic: string,
+): RecipientLabel | undefined {
     const stream = stream_data.get_sub_by_id(stream_id);
     const topic_display_name = util.get_final_topic_display_name(topic);
     if (stream) {
@@ -45,7 +48,7 @@ function get_stream_recipient_label(stream_id: number, topic: string): Recipient
     return undefined;
 }
 
-function get_direct_message_recipient_label(user_ids: number[]): RecipientLabel {
+export function get_direct_message_recipient_label(user_ids: number[]): RecipientLabel {
     let label_text = "";
     let is_dm_with_self = false;
     if (people.is_direct_message_conversation_with_self(user_ids)) {

--- a/web/tests/compose_call.test.cjs
+++ b/web/tests/compose_call.test.cjs
@@ -356,6 +356,26 @@ test("videos", ({override}) => {
         assert.match(syntax_to_insert, audio_link_regex);
     })();
 
+    (function test_bbb_meeting_name_empty_label() {
+        const $textarea = $.create("bbb-empty-label-stub");
+        $textarea.set_parents_result(".message_edit_form", []);
+
+        override(compose_closed_ui, "get_recipient_label", () => ({label_text: ""}));
+
+        let checked = false;
+        channel.get = (options) => {
+            assert.equal(options.data.meeting_name, "meeting");
+            checked = true;
+            return {abort() {}};
+        };
+
+        $("textarea#compose-textarea").val("");
+        $("body")
+            .get_on_handler("click", ".video_link")
+            .call($textarea, {preventDefault() {}, stopPropagation() {}});
+        assert.ok(checked);
+    })();
+
     (function test_constructor_groups_video_link_compose_clicked() {
         let syntax_to_insert;
         let called = false;
@@ -460,6 +480,26 @@ test("videos", ({override}) => {
             /\[translated: Join video call\.]\(https:\/\/nextcloud\.example\.com\/index\.php\/call\/abc123token\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
+    })();
+
+    (function test_nextcloud_talk_room_name_empty_label() {
+        const $textarea = $.create("nextcloud-empty-label-stub");
+        $textarea.set_parents_result(".message_edit_form", []);
+
+        override(compose_closed_ui, "get_recipient_label", () => ({label_text: ""}));
+
+        let checked = false;
+        channel.post = (options) => {
+            assert.equal(options.data.room_name, "conversation");
+            checked = true;
+            return {abort() {}};
+        };
+
+        $("textarea#compose-textarea").val("");
+        $("body")
+            .get_on_handler("click", ".video_link")
+            .call($textarea, {preventDefault() {}, stopPropagation() {}});
+        assert.ok(checked);
     })();
 });
 

--- a/web/tests/compose_call.test.cjs
+++ b/web/tests/compose_call.test.cjs
@@ -4,14 +4,17 @@ const assert = require("node:assert/strict");
 
 const events = require("./lib/events.cjs");
 const {make_realm} = require("./lib/example_realm.cjs");
+const {make_stream} = require("./lib/example_stream.cjs");
+const {make_user} = require("./lib/example_user.cjs");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const {$} = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
 const channel = mock_esm("../src/channel");
-const compose_closed_ui = mock_esm("../src/compose_closed_ui");
+const compose_state = mock_esm("../src/compose_state");
 const compose_ui = mock_esm("../src/compose_ui");
+const message_store = mock_esm("../src/message_store");
 mock_esm("../src/resize", {
     watch_manual_resize() {},
 });
@@ -27,13 +30,29 @@ set_global(
 );
 
 const server_events_dispatch = zrequire("server_events_dispatch");
+const compose_call_ui = zrequire("compose_call_ui");
 const compose_setup = zrequire("compose_setup");
+const people = zrequire("people");
+const stream_data = zrequire("stream_data");
 const {set_current_user, set_realm} = zrequire("state_data");
 
 const realm = make_realm();
 set_realm(realm);
-const current_user = {};
+const current_user = make_user({
+    email: "alice@zulip.com",
+    user_id: 1,
+    full_name: "Alice",
+});
 set_current_user(current_user);
+people.add_active_user(current_user);
+people.add_active_user(
+    make_user({
+        email: "bob@zulip.com",
+        user_id: 2,
+        full_name: "Bob",
+    }),
+);
+people.initialize_current_user(current_user.user_id);
 
 const realm_available_video_chat_providers = {
     disabled: {
@@ -77,7 +96,7 @@ function test(label, f) {
     });
 }
 
-test("videos", ({override}) => {
+test("videos", ({override, override_rewire}) => {
     override(realm, "realm_video_chat_provider", realm_available_video_chat_providers.disabled.id);
     override(window, "to_$", () => $("window-stub"));
 
@@ -312,7 +331,9 @@ test("videos", ({override}) => {
             realm_available_video_chat_providers.big_blue_button.id,
         );
 
-        override(compose_closed_ui, "get_recipient_label", () => ({label_text: "a"}));
+        override_rewire(compose_call_ui, "get_recipient_label_for_call", () => ({
+            label_text: "a",
+        }));
 
         let success_callback;
         const xhr_object = {abort() {}};
@@ -360,7 +381,7 @@ test("videos", ({override}) => {
         const $textarea = $.create("bbb-empty-label-stub");
         $textarea.set_parents_result(".message_edit_form", []);
 
-        override(compose_closed_ui, "get_recipient_label", () => ({label_text: ""}));
+        override_rewire(compose_call_ui, "get_recipient_label_for_call", () => undefined);
 
         let checked = false;
         channel.get = (options) => {
@@ -452,7 +473,9 @@ test("videos", ({override}) => {
             realm_available_video_chat_providers.nextcloud_talk.id,
         );
 
-        override(compose_closed_ui, "get_recipient_label", () => ({label_text: "general"}));
+        override_rewire(compose_call_ui, "get_recipient_label_for_call", () => ({
+            label_text: "general",
+        }));
         let success_callback;
         function call_success_callback() {
             assert.ok(success_callback !== undefined);
@@ -486,7 +509,7 @@ test("videos", ({override}) => {
         const $textarea = $.create("nextcloud-empty-label-stub");
         $textarea.set_parents_result(".message_edit_form", []);
 
-        override(compose_closed_ui, "get_recipient_label", () => ({label_text: ""}));
+        override_rewire(compose_call_ui, "get_recipient_label_for_call", () => undefined);
 
         let checked = false;
         channel.post = (options) => {
@@ -501,6 +524,76 @@ test("videos", ({override}) => {
             .call($textarea, {preventDefault() {}, stopPropagation() {}});
         assert.ok(checked);
     })();
+});
+
+run_test("get_recipient_label_for_call", ({override}) => {
+    const stream = make_stream({
+        subscribed: true,
+        name: "design",
+        stream_id: 200,
+    });
+    stream_data.add_sub_for_tests(stream);
+
+    // --- Compose-box branch (edit_message_id === undefined) ---
+
+    // Stream + non-empty topic.
+    override(compose_state, "get_message_type", () => "stream");
+    override(compose_state, "stream_id", () => stream.stream_id);
+    override(compose_state, "topic", () => "typography");
+    assert.equal(
+        compose_call_ui.get_recipient_label_for_call(undefined).label_text,
+        "#design > typography",
+    );
+
+    // Stream with no stream_id → undefined.
+    override(compose_state, "stream_id", () => undefined);
+    assert.equal(compose_call_ui.get_recipient_label_for_call(undefined), undefined);
+
+    // DM with distinct recipients uses the recipient full names. User 2 is
+    // "Bob", set up at the top of this file.
+    override(compose_state, "get_message_type", () => "private");
+    override(compose_state, "private_message_recipient_ids", () => [2]);
+    override(message_store, "get_pm_full_names", () => "Bob");
+    assert.equal(compose_call_ui.get_recipient_label_for_call(undefined).label_text, "Bob");
+
+    // DM compose with no pills selected yet → undefined, so the meeting-name
+    // fallback produces "meeting" instead of leaking the caller's own name via
+    // sorted_other_user_ids's self-DM fallback.
+    override(compose_state, "private_message_recipient_ids", () => []);
+    assert.equal(compose_call_ui.get_recipient_label_for_call(undefined), undefined);
+
+    // Unknown message type → undefined.
+    override(compose_state, "get_message_type", () => undefined);
+    assert.equal(compose_call_ui.get_recipient_label_for_call(undefined), undefined);
+
+    // --- Edit-form branch (edit_message_id !== undefined) ---
+    // The edit-form path reads from message_store, not compose_state, so we
+    // deliberately don't override compose_state here.
+
+    // Stream edit target uses the message's own stream/topic.
+    override(message_store, "get", () => ({
+        is_stream: true,
+        is_private: false,
+        stream_id: stream.stream_id,
+        topic: "reviews",
+    }));
+    assert.equal(
+        compose_call_ui.get_recipient_label_for_call("42").label_text,
+        "#design > reviews",
+    );
+
+    // DM edit target uses the message's own recipients.
+    override(message_store, "get", () => ({
+        is_stream: false,
+        is_private: true,
+        to_user_ids: "2",
+    }));
+    override(message_store, "get_pm_full_names", () => "Bob");
+    assert.equal(compose_call_ui.get_recipient_label_for_call("43").label_text, "Bob");
+
+    // Unknown/evicted message id → undefined.
+    override(message_store, "get", () => undefined);
+    assert.equal(compose_call_ui.get_recipient_label_for_call("999"), undefined);
 });
 
 test("test_video_chat_button_toggle disabled", ({override}) => {


### PR DESCRIPTION
The BigBlueButton and Nextcloud Talk call-creation paths built the meeting/room name from `get_recipient_label()`, which derives its result from `message_lists.current.selected_message()` when called without arguments. That's the reply target of the visible narrow, not the recipient the composed message will be sent to. Changing the topic (or recipient) in the compose box therefore had no effect on the meeting name, the call link kept naming the previous target.

This PR adds `get_recipient_label_for_call` that reads directly from `compose_state`, and use it in both call-creation paths. 

Rather than widen get_recipient_label — whose recipient_information branch asserts it's only reached from Inbox or Recent Conversations — we introduce a dedicated helper. Keeping the two callers separate preserves that invariant and avoids overloading one function with two different recipient sources (message list vs. compose state) and two different objectives. CZO where this is discussed: [#issues > Stream/topic calls get empty meeting/room name (nextcloud) @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/Stream.2Ftopic.20calls.20get.20empty.20meeting.2Froom.20name.20.28nextcloud.29/near/2491396)

Depends on #39565 (first commit 3a60fbbecbac1e2947a2beb0f351e222eef04cac is part of this first PR). This PR (second commit) builds on top of it.

**Before:**
[Screencast_20260707_115618.webm](https://github.com/user-attachments/assets/bd1671fc-aeab-4e8e-a7ac-1744593a7fb1)


**After:**
[Screencast_20260707_115334.webm](https://github.com/user-attachments/assets/b908765d-69a1-409e-ac30-a9db21279e2c)


**Screenshots and screen captures:**
Tested for Nextcloud and BigBlueButton:

<img width="933" height="400" alt="image" src="https://github.com/user-attachments/assets/79c8e12b-1813-43a0-aff2-3d4470a94b09" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
