### PR TITLE
api docs: Document GET /realm/subdomain/{subdomain}.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -152,6 +152,7 @@
 * [Reorder custom profile fields](/api/reorder-custom-profile-fields)
 * [Create a custom profile field](/api/create-custom-profile-field)
 * [Update realm-level defaults of user settings](/api/update-realm-user-settings-defaults)
+* [Check subdomain availability](/api/check-subdomain-availability)
 * [Get allowed domains](/api/get-realm-domains)
 * [Add an allowed domain](/api/add-realm-domain)
 * [Update an allowed domain](/api/patch-realm-domain)

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -270,6 +270,7 @@ INSECURE_OPERATIONS = [
     "/fetch_api_key:post",
     "/jwt/fetch_api_key:post",
     "/dev_list_users:get",
+    "/realm/subdomain/{subdomain}:get",
 ]
 
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -271,6 +271,7 @@ INSECURE_OPERATIONS = [
     "/fetch_api_key:post",
     "/jwt/fetch_api_key:post",
     "/dev_list_users:get",
+    "/realm/subdomain/{subdomain}:get",
 ]
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14859,6 +14859,62 @@ paths:
                         "result": "success",
                         "server_timestamp": 1656958539.6287155,
                       }
+  /realm/subdomain/{subdomain}:
+    get:
+      operationId: check-subdomain-availability
+      summary: Check subdomain availability
+      tags: ["server_and_organizations"]
+      description: |
+        Check whether an organization subdomain is available for a new
+        organization to use: the `{subdomain}` in
+        `https://{subdomain}.zulipchat.com` on Zulip Cloud, or the same
+        on a self-hosted server [configured to host multiple
+        organizations][prod-multiple-orgs].
+
+        This is used by the [organization creation](/help/create-an-organization)
+        form to validate the subdomain as the user types it.
+
+        This endpoint does not require authentication, since a user filling
+        out that form does not yet have a Zulip account. It always returns
+        a successful response; the result of the check is reported via
+        the `msg` field in the example response below, not via the HTTP
+        status code or `result`.
+
+        [prod-multiple-orgs]: https://zulip.readthedocs.io/en/latest/production/multiple-organizations.html
+      security: []
+      parameters:
+        - name: subdomain
+          in: path
+          description: |
+            The subdomain to check.
+          schema:
+            type: string
+            example: "hufflepuff"
+          required: true
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg:
+                        description: |
+                          `available` if the subdomain can be used for a new
+                          organization. Otherwise, an explanation of why not,
+                          suitable for displaying directly to the user.
+                        enum:
+                          - available
+                          - Subdomain needs to have length 3 or greater.
+                          - Subdomain cannot start or end with a '-'.
+                          - Subdomain can only have lowercase letters, numbers, and '-'s.
+                          - Subdomain is already in use. Please choose a different one.
+                          - Subdomain reserved. Please choose a different one.
+                    example: {"msg": "available", "result": "success"}
   /realm/domains:
     get:
       operationId: get-realm-domains

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14882,6 +14882,62 @@ paths:
                         "result": "success",
                         "server_timestamp": 1656958539.6287155,
                       }
+  /realm/subdomain/{subdomain}:
+    get:
+      operationId: check-subdomain-availability
+      summary: Check subdomain availability
+      tags: ["server_and_organizations"]
+      description: |
+        Check whether an organization subdomain is available for a new
+        organization to use: the `{subdomain}` in
+        `https://{subdomain}.zulipchat.com` on Zulip Cloud, or the same
+        on a self-hosted server [configured to host multiple
+        organizations][prod-multiple-orgs].
+
+        This is used by the [organization creation](/help/create-an-organization)
+        form to validate the subdomain as the user types it.
+
+        This endpoint does not require authentication, since a user filling
+        out that form does not yet have a Zulip account. It always returns
+        a successful response; the result of the check is reported via
+        the `msg` field in the example response below, not via the HTTP
+        status code or `result`.
+
+        [prod-multiple-orgs]: https://zulip.readthedocs.io/en/latest/production/multiple-organizations.html
+      security: []
+      parameters:
+        - name: subdomain
+          in: path
+          description: |
+            The subdomain to check.
+          schema:
+            type: string
+            example: "hufflepuff"
+          required: true
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg:
+                        description: |
+                          `available` if the subdomain can be used for a new
+                          organization. Otherwise, an explanation of why not,
+                          suitable for displaying directly to the user.
+                        enum:
+                          - available
+                          - Subdomain needs to have length 3 or greater.
+                          - Subdomain cannot start or end with a '-'.
+                          - Subdomain can only have lowercase letters, numbers, and '-'s.
+                          - Subdomain is already in use. Please choose a different one.
+                          - Subdomain reserved. Please choose a different one.
+                    example: {"msg": "available", "result": "success"}
   /realm/domains:
     get:
       operationId: get-realm-domains

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -234,7 +234,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/realm/icon",
         "/realm/logo",
         "/realm/deactivate",
-        "/realm/subdomain/{subdomain}",
         # API for Zoom video calls.  Unclear if this can support other apps.
         "/calls/zoom/create",
         #### The following are fake endpoints that live in our zulip.yaml

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -233,7 +233,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/realm/profile_fields/{field_id}",
         "/realm/icon",
         "/realm/logo",
-        "/realm/subdomain/{subdomain}",
         # API for Zoom video calls.  Unclear if this can support other apps.
         "/calls/zoom/create",
         #### The following are fake endpoints that live in our zulip.yaml


### PR DESCRIPTION
Documents `GET /realm/subdomain/{subdomain}`, the subdomain-availability check used by the organization-creation form to validate the URL as the user types it.
**Note to maintainers:**

This endpoint has two quirks the docs describe as-is:

- It's **unauthenticated** (bare `path()`, `@require_safe` only), since a user on the signup form has no account yet. Marked `security: []` and added to `INSECURE_OPERATIONS`, which the curl-example generator requires before it will emit an authless example.
- It **always returns `result: success`**; whether the subdomain is available, taken, malformed, or reserved is reported in `msg`.

I documented `msg` as an `enum` of the exact strings `check_subdomain_available` returns, so `test_subdomain_check_api`'s
per-request OpenAPI validation fails if that wording drifts. Two things worth your call:

- The return-values table generator lists `msg` in its `IGNORE` set, so the enum/description doesn't render on the page; the contract is conveyed by the description prose and the example response instead. I left `msg` as an enum for its test value rather than reshaping it, but we can switch to `type: string`.
- Those enum strings are English while the endpoint returns them translated. This is safe only because the validator runs under the English locale in tests.

**How changes were tested:**

- [x] `./tools/test-backend zerver.tests.test_openapi`
- [x] `./tools/test-backend zerver.tests.test_realm_creation.RealmCreationTest.test_subdomain_check_api`
- [x] `tools/check-openapi.ts zerver/openapi/zulip.yaml` and `./tools/lint`.
- [x] Rendered the page locally; confirmed the curl example is authless and fills in the path parameter (screenshot below).

<details>
<summary>Screenshots and screen captures:</summary>

The sidebar:

<img width="360" height="158" alt="image" src="https://github.com/user-attachments/assets/02cb1ac6-cb61-4091-a5f4-89de78ebb08c" />

The rendered documentation page:

<img width="755" height="1039" alt="image" src="https://github.com/user-attachments/assets/50e3b2c6-fab9-4910-8cec-0d8b706fc938" />

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
