### PR TITLE
messages: Add icons to show more/show less buttons.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -330,6 +330,13 @@
         font-family: inherit;
         font-size: inherit;
 
+        .zulip-icon {
+            vertical-align: middle;
+            margin-right: 4px;
+            position: relative;
+            top: 1px;
+        }
+
         &:hover {
             background-color: var(
                 --color-show-more-less-button-background-hover

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -5,6 +5,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{else if (eq toggle_type "condenser")}}
@@ -14,6 +15,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{/if}}


### PR DESCRIPTION
Adds zulip-icon-expand and zulip-icon-collapse icons before the label text on the message expander and condenser buttons, following the existing icon usage pattern elsewhere in the codebase (e.g. show_inactive_or_muted_channels.hbs).

Fixes: #38844

How changes were tested: Ran the change locally in the dev environment, sent long test messages to trigger the show more/show less buttons, and confirmed both icons render correctly and toggle appropriately between expand/collapse states, in both light and dark themes.

Screenshots and screen captures:

Before: <img width="1802" height="364" alt="before-fix" src="https://github.com/user-attachments/assets/04d6aa31-f832-4351-a842-41c6509fe838" />
<img width="1806" height="388" alt="before-fix2" src="https://github.com/user-attachments/assets/c8dcf979-c8ca-45a8-bde0-98914ddf47b0" />
<img width="1814" height="354" alt="before-fix3" src="https://github.com/user-attachments/assets/52f2ce4a-be79-4538-9de7-570b4e7a80c7" />
<img width="1810" height="418" alt="before-fix4" src="https://github.com/user-attachments/assets/a2eb0efc-a3da-46ec-9852-40abe0b0fe0b" />


After: <img width="1808" height="354" alt="after-fix" src="https://github.com/user-attachments/assets/67c3afc9-a496-4091-a204-3d0b3dc2bffd" />
<img width="1808" height="480" alt="after-fix2" src="https://github.com/user-attachments/assets/85db13ed-7981-4204-893d-dcbec8b19404" />
<img width="1802" height="368" alt="after-fix3" src="https://github.com/user-attachments/assets/472d768f-e22f-4aa0-856b-02c718712b2f" />
<img width="1810" height="356" alt="after-fix4" src="https://github.com/user-attachments/assets/e8e82970-5ff8-4749-b185-34dfca084cf0" />


Self-review checklist
    [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
    [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.
    [x] Explains differences from previous plans (e.g., issue description).
    [ ] Highlights technical choices and bugs encountered.
    [ ] Calls out remaining decisions and concerns.
    [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review.
    [x] Each commit is a coherent idea.
    [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
    [x] Visual appearance of the changes.
    [ ] Responsiveness and internationalization.
    [ ] Strings and tooltips.
    [x] End-to-end functionality of buttons, interactions and flows.
    [ ] Corner cases, error conditions, and easily imagined bugs.

