### PR TITLE
compose: Use a global regex to normalize tab-indented lists on paste.

### DIFF
--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -772,6 +772,10 @@ function do_paste_text(
     compose_ui.insert_and_scroll_into_view(text_to_insert, $textarea);
 }
 
+export function normalize_tabs_to_spaces(text: string): string {
+    return text.replaceAll(/^(\t+)(?=[*+-]|\d+\.)/gm, (match) => "  ".repeat(match.length));
+}
+
 export function paste_handler(
     this: HTMLTextAreaElement,
     event: JQuery.TriggeredEvent,
@@ -792,8 +796,16 @@ export function paste_handler(
     if (clipboardData.getData) {
         const $textarea = $(this);
         const existing_text = $textarea.val() ?? "";
-        const paste_text = clipboardData.getData("text");
+        let paste_text = clipboardData.getData("text");
         let paste_html = clipboardData.getData("text/html");
+        // check if the pasted text has nested lists indented with tabs
+        const has_tab_indented_list =
+            !compose_ui.cursor_inside_code_block($textarea) &&
+            /^\t+([*+-]|\d+\.)\s/m.test(paste_text);
+
+        if (has_tab_indented_list) {
+            paste_text = normalize_tabs_to_spaces(paste_text);
+        }
         const reverse_linkified_text = compose_ui.reverse_linkify_text(paste_text);
         // Trim the paste_text to accommodate sloppy copying
         const trimmed_paste_text = paste_text.trim();
@@ -881,7 +893,7 @@ export function paste_handler(
         // if not, we proceed with the default formatted paste.
         if (
             !compose_ui.cursor_inside_code_block($textarea) &&
-            (paste_html || reverse_linkified_text !== null) &&
+            (paste_html || reverse_linkified_text !== null || has_tab_indented_list) &&
             !compose_ui.shift_pressed
         ) {
             if (is_single_image(paste_html)) {

--- a/web/tests/compose_paste.test.cjs
+++ b/web/tests/compose_paste.test.cjs
@@ -663,3 +663,15 @@ run_test("paste_handler_converter", () => {
         );
     }
 });
+
+run_test("normalize_tabs_to_spaces", () => {
+    // testcase1
+    let input = "\t* Level 1\n\t\t* Level 2\n\t\t\t1. Numbered Level 3";
+    let expected = "  * Level 1\n    * Level 2\n      1. Numbered Level 3";
+    assert.equal(compose_paste.normalize_tabs_to_spaces(input), expected);
+
+    // testcase2
+    input = "\tconst x = 1;\n\t\tif (x === 1) {\n\t\t\treturn true;\n\t\t}";
+    expected = "\tconst x = 1;\n\t\tif (x === 1) {\n\t\t\treturn true;\n\t\t}";
+    assert.equal(compose_paste.normalize_tabs_to_spaces(input), expected);
+});


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR updates the paste handler to correctly format nested lists that use tabs for indentation. 

Instead of checking the pasted text line-by-line, it uses a single global regex to find tabs at the start of list items and converts each tab into 2 spaces. This simplifies the code, improves performance, and prevents Python-Markdown from breaking Zulip's standard list layout when users paste text.

Fixes: #38436 

**How changes were tested:**
* Added a new unit test for `normalize_tabs_to_spaces`.
* Ran `./tools/test-js-with-node web/tests/compose_paste.test.cjs` to verify all tests pass.
* Manually pasted a tab-indented bulleted list into the compose box to ensure it formats correctly.

**Screenshots and screen captures:**
<img width="1920" height="956" alt="localhost_zulip1" src="https://github.com/user-attachments/assets/106ae938-65f1-4cb3-9255-2e56af4b2c38" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>