### PR TITLE
compose_banner: Keep upload banners when clearing compose errors.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -137,7 +137,16 @@ function hide_compose_spinner(): void {
 }
 
 export function clear_errors(): void {
-    $(`#compose_banners .${CSS.escape(ERROR)}`).remove();
+    clear_validation_errors();
+    clear_upload_errors();
+}
+
+export function clear_validation_errors(): void {
+    $(`#compose_banners .${CSS.escape(ERROR)}:not(.upload_banner)`).remove();
+}
+
+export function clear_upload_errors(): void {
+    $(`#compose_banners .upload_banner.${CSS.escape(ERROR)}`).remove();
 }
 
 export function clear_warnings(): void {

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -203,6 +203,9 @@ export function update_on_recipient_change(): void {
     update_narrow_to_recipient_visibility();
     compose_validate.warn_if_guest_in_dm_recipient();
     drafts.update_compose_draft_count();
+    // The validation run below only clears the error banners it owns,
+    // so clear stale upload error banners explicitly here.
+    compose_banner.clear_upload_errors();
     compose_validate.validate_and_update_send_button_status();
 
     // Clear the topic moved banner when the recipient

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -1188,7 +1188,7 @@ export let validate = (scheduling_message: boolean, show_banner = true): boolean
     disabled_send_tooltip_message_html = "";
     // Clear previous banners from the previous compose state; the
     // validation checks below will re-add any that are still relevant.
-    compose_banner.clear_errors();
+    compose_banner.clear_validation_errors();
     // Reset compose textarea state; validate_private_message may
     // disable it if the recipient is invalid.
     set_compose_textarea_disabled(false);

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -278,6 +278,11 @@ export let upload_files = (
     if (files.length === 0) {
         return;
     }
+
+    // A new upload attempt supersedes any error banner (e.g. "file too
+    // large") left over from a previous attempt, so we clear those here.
+    config.banner_container().find(".upload_banner.error").remove();
+
     if (realm.max_file_upload_size_mib === 0) {
         show_error_message(
             config,

--- a/web/tests/lib/compose_banner.cjs
+++ b/web/tests/lib/compose_banner.cjs
@@ -18,7 +18,9 @@ exports.mock_banners = () => {
     }
     $("#compose_banners .warning")[0].remove = noop;
     $("#compose_banners .error")[0].remove = noop;
+    $("#compose_banners .error:not(.upload_banner)")[0].remove = noop;
     $("#compose_banners .upload_banner")[0].remove = noop;
+    $("#compose_banners .upload_banner.error")[0].remove = noop;
 
     const $stub = $.set_results("stub_to_remove", []);
     const $cb = $("#compose_banners");

--- a/web/tests/lib/compose_banner.cjs
+++ b/web/tests/lib/compose_banner.cjs
@@ -26,6 +26,7 @@ exports.mock_banners = () => {
     const $cb = $("#compose_banners");
 
     $cb.set_closest_results(".edit_form_banners", $.create("edit-form-banners-stub"));
+    $cb.set_find_results(".upload_banner.error", $stub);
     $cb.set_find_results(".no_post_permissions", $stub);
     $cb.set_find_results(".message_too_long", $stub);
     $cb.set_find_results(".wildcards_not_allowed", $stub);


### PR DESCRIPTION
An upload error banner (such as "file too large") would flash and immediately disappear when the compose box was empty. Removing the failed upload's placeholder empties the textarea, which triggers compose validation; that calls clear_errors(), which removed every ".error" banner -- including the upload error banner, which has its own lifecycle and is cleared via clear_uploads().

Scope clear_errors() to skip ".upload_banner" so the error stays visible until the upload flow clears it. With text already in the textarea, validation did not re-run on placeholder removal, which is why the bug only appeared with an empty compose box.

https://chat.zulip.org/#narrow/channel/9-issues/topic/error.20message.20for.20.27attachment.20too.20large.27.20is.20inconsistent/with/2491153

<!-- Describe your pull request here.-->


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
Before:
<img width="930" height="626" alt="large file glitch" src="https://github.com/user-attachments/assets/636282e9-d0ff-4754-be4f-3df9f0118877" />

After:
<img width="930" height="626" alt="upload error glitch fixed" src="https://github.com/user-attachments/assets/ea3a71d0-5fde-4e0c-95e8-5116fb214a68" />

Error gets cleared on new upload:
<img width="930" height="626" alt="second upload" src="https://github.com/user-attachments/assets/6381f72b-8712-416b-babe-366b8f92cccf" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
