### PR TITLE
notifications: Pass notification sounds to the desktop app through electron bridge.

### DIFF
--- a/web/src/audible_notifications.ts
+++ b/web/src/audible_notifications.ts
@@ -9,6 +9,10 @@ export function initialize(): void {
     update_notification_sound_source("user-notification-sound-audio", user_settings);
 }
 
+export function notification_sound_path(notification_sound: string, format: "ogg" | "mp3"): string {
+    return `/static/audio/notification_sounds/${notification_sound}.${format}`;
+}
+
 export function update_notification_sound_source(
     audio_element_id: string,
     settings_object: {notification_sound: string},
@@ -21,11 +25,10 @@ export function update_notification_sound_source(
         return;
     }
 
-    const audio_file_without_extension = "/static/audio/notification_sounds/" + notification_sound;
     const rendered_audio = render_notification_sound_sources({
         audio_element_id,
-        audio_file_ogg: `${audio_file_without_extension}.ogg`,
-        audio_file_mp3: `${audio_file_without_extension}.mp3`,
+        audio_file_ogg: notification_sound_path(notification_sound, "ogg"),
+        audio_file_mp3: notification_sound_path(notification_sound, "mp3"),
     });
     $container_elem.replaceWith($(rendered_audio));
 

--- a/web/src/desktop_integration.ts
+++ b/web/src/desktop_integration.ts
@@ -28,6 +28,11 @@ export function initialize(): void {
         browser_history.go_to_location("settings/notifications");
     });
 
+    // Tell the desktop app that the web app now plays notification
+    // sounds via play_notification_sound, so it no longer needs to
+    // filter out that sound and mute itself.
+    electron_bridge.set_play_notification_sound_supported?.(true);
+
     // The code below is for sending a message received from notification reply which
     // is often referred to as inline reply feature. This is done so desktop app doesn't
     // have to depend on channel.post for setting crsf_token and message_view.narrow_by_topic

--- a/web/src/electron_bridge.ts
+++ b/web/src/electron_bridge.ts
@@ -34,6 +34,8 @@ export type ElectronBridge = {
     get_last_active_on_system?: () => number;
     get_send_notification_reply_message_supported?: () => boolean;
     set_send_notification_reply_message_supported?: (value: boolean) => void;
+    play_notification_sound?: (sound_path: string) => void;
+    set_play_notification_sound_supported?: (supported: boolean) => void;
     decrypt_clipboard?: (version: number) => ClipboardDecrypter;
 };
 

--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -1,9 +1,11 @@
 import $ from "jquery";
 
 import * as alert_words from "./alert_words.ts";
+import * as audible_notifications from "./audible_notifications.ts";
 import * as blueslip from "./blueslip.ts";
 import * as desktop_notifications from "./desktop_notifications.ts";
 import type {ElectronBridgeNotification} from "./desktop_notifications.ts";
+import {electron_bridge} from "./electron_bridge.ts";
 import {$t} from "./i18n.ts";
 import * as message_parser from "./message_parser.ts";
 import type {Message} from "./message_store.ts";
@@ -450,7 +452,20 @@ export function received_messages(messages: (Message | TestNotificationMessage)[
             });
         }
         if (should_send_audible_notification(message)) {
-            void ui_util.play_audio(util.the($("#user-notification-sound-audio")));
+            // On the desktop app, hand the sound to the shell so it can
+            // honor Do Not Disturb / silent mode without muting other page
+            // media. Older desktop apps without this method fall back to
+            // in-page playback.
+            if (electron_bridge?.play_notification_sound !== undefined) {
+                electron_bridge.play_notification_sound(
+                    audible_notifications.notification_sound_path(
+                        user_settings.notification_sound,
+                        "ogg",
+                    ),
+                );
+            } else {
+                void ui_util.play_audio(util.the($("#user-notification-sound-audio")));
+            }
         }
     }
 }

--- a/web/tests/notifications.test.cjs
+++ b/web/tests/notifications.test.cjs
@@ -9,7 +9,7 @@ const {run_test} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
-mock_esm("../src/electron_bridge");
+const electron_bridge = mock_esm("../src/electron_bridge");
 mock_esm("../src/spoilers", {hide_spoilers_in_notification() {}});
 
 const user_topics = zrequire("user_topics");
@@ -560,4 +560,50 @@ test("basic_notifications", () => {
     assert.equal(n.has("test:Notification Bot"), true);
     assert.equal(n.size, 1);
     desktop_notifications.close_notification(test_notification_message);
+});
+
+// A direct message that is notifiable and audible, but with desktop
+// notifications disabled so that received_messages exercises only the
+// audible-notification path.
+const audible_direct_message = {
+    id: 4000,
+    type: "private",
+    sent_by_me: false,
+    notification_sent: false,
+    unread: true,
+};
+
+test("audible notification delegates to desktop bridge", ({override}) => {
+    override(user_settings, "enable_desktop_notifications", false);
+
+    let played_sound_path;
+    override(electron_bridge, "electron_bridge", {
+        play_notification_sound(sound_path) {
+            played_sound_path = sound_path;
+        },
+    });
+
+    message_notifications.received_messages([{...audible_direct_message}]);
+    assert.equal(played_sound_path, "/static/audio/notification_sounds/ding.ogg");
+});
+
+test("audible notification falls back to in-page playback", ({override}) => {
+    override(user_settings, "enable_desktop_notifications", false);
+    // A desktop app that predates play_notification_sound.
+    override(electron_bridge, "electron_bridge", {});
+
+    let played_element_id;
+    $.create("#user-notification-sound-audio", {
+        elements: [
+            {
+                id: "user-notification-sound-audio",
+                play() {
+                    played_element_id = this.id;
+                },
+            },
+        ],
+    });
+
+    message_notifications.received_messages([{...audible_direct_message}]);
+    assert.equal(played_element_id, "user-notification-sound-audio");
 });


### PR DESCRIPTION
Earlier all the notification sounds were played via an audio tag. But electron only supports muting all sounds in the application all at once. This caused the muting of YouTube videos whenever `Do Not Disturb` was on. For older server versions we have made a change in the desktop app so that `Do not disturb` only blocks notifications based on their path. But that is not a reliable mechanism because that path can change anytime. To overcome that, we explicitly pass the notification to be played to the desktop app through the electron bridge.

`set_play_notification_sound_supported` notifies the desktop app that it can stop using the preload script that takes care of backward compatibility for older server versions. `play_notification_sound` delivers the actual notification. We pass the relative path to the audio file to the desktop app.


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
