### PR TITLE
api docs: Support JSON request bodies in OpenAPI tooling.

### DIFF
--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -245,6 +245,13 @@ cURL example."""
         # We currently don't have any non-JSON encoded arrays.
         assert parameter.json_encoded
         if curl_argument:
+            if parameter.kind == "body":
+                # A whole-body JSON payload is the entire request body, not a
+                # named field, so it's sent with --json rather than a key=value.
+                # Pretty-print it, preserving the documented key order, since a
+                # dense single line is hard to read.
+                pretty_json = json.dumps(parameter.example, indent=4)
+                return "    --json " + shlex.quote(pretty_json)
             return "    --data-urlencode " + shlex.quote(f"{parameter.name}={ordered_ex_val_str}")
         return ordered_ex_val_str  # nocoverage
     else:

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -334,7 +334,7 @@ NO_EXAMPLE = object()
 
 
 class Parameter(BaseModel):
-    kind: Literal["query", "path", "formData"]
+    kind: Literal["query", "path", "formData", "body"]
     name: str
     description: str
     json_encoded: bool
@@ -408,6 +408,26 @@ def get_openapi_parameters(
                     deprecated=schema.get("deprecated", False),
                 )
             )
+
+    if "requestBody" in operation and "application/json" in (
+        content := operation["requestBody"]["content"]
+    ):
+        # typed_endpoint registers a whole-body JsonBodyPayload argument under
+        # the fixed name "request"; match that so the consistency check passes.
+        media_type = content["application/json"]
+        schema = media_type["schema"]
+        parameters.append(
+            Parameter(
+                kind="body",
+                name="request",
+                description=schema["description"],
+                json_encoded=True,
+                value_schema=schema,
+                example=media_type.get("example", NO_EXAMPLE),
+                required=operation["requestBody"].get("required", False),
+                deprecated=False,
+            )
+        )
 
     return parameters
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -745,6 +745,37 @@ class TestCurlExampleGeneration(ZulipTestCase):
         },
     }
 
+    spec_mock_using_json_body = {
+        "security": [{"basicAuth": []}],
+        "paths": {
+            "/endpoint": {
+                "post": {
+                    "description": "Send a JSON request body.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "The JSON request body.",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "age": {"type": "integer"},
+                                    },
+                                    "required": ["name", "age"],
+                                },
+                                "example": {
+                                    "name": "Zulip",
+                                    "age": 10,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
     def curl_example(self, endpoint: str, method: str, *args: Any, **kwargs: Any) -> list[str]:
         return generate_curl_example(endpoint, method, "http://localhost:9991/api", *args, **kwargs)
 
@@ -830,6 +861,19 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             '    --data-urlencode \'param1={"key": "value"}\'',
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+    @patch("zerver.openapi.openapi.OpenAPISpec.openapi")
+    def test_generate_and_render_curl_with_json_body(self, spec_mock: MagicMock) -> None:
+        spec_mock.return_value = self.spec_mock_using_json_body
+        generated_curl_example = self.curl_example("/endpoint", "POST")
+        expected_curl_example = [
+            "```curl",
+            "curl -sSX POST http://localhost:9991/api/v1/endpoint \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            '    --json \'{\n    "name": "Zulip",\n    "age": 10\n}\'',
             "```",
         ]
         self.assertEqual(generated_curl_example, expected_curl_example)


### PR DESCRIPTION
Our OpenAPI tooling had no way to document an endpoint whose entire request body is a single JSON object (a JsonBodyPayload), since every documented endpoint so far sends its body as x-www-form-urlencoded or multipart/form-data form fields. Documenting one meant declaring the body as a fake form field, which produced a misleading curl example. Add that support, needed to document `POST /remotes/push/e2ee/notify` in a follow-up:

* get_openapi_parameters now reads an application/json request body, emitting a single parameter under the fixed name "request" that typed_endpoint gives a JsonBodyPayload argument, so the existing consistency check matches it with no changes.
* generate_curl_example renders that whole-body parameter with --json rather than a --data-urlencode key=value pair.

No currently-documented endpoint is affected.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:** N/A

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
