### PR TITLE
bots: Make a member-role bot's full-member status follow its owner.

### DIFF
--- a/api_docs/roles-and-permissions.md
+++ b/api_docs/roles-and-permissions.md
@@ -119,3 +119,13 @@ Clients can compare the `realm_waiting_period_threshold` to a user
 accounts's `date_joined` property, which is the time the user account
 was created, to determine if a user has the permissions of a full
 member or a new member.
+
+For a bot with the member role, this status follows the bot's owner
+rather than the bot itself. Clients should apply the comparison above to
+the `date_joined` of the account referenced by the bot's `bot_owner_id`,
+and treat a bot owned by a guest as a new member. Because a bot's owner
+can change, its full-member status can change accordingly.
+
+**Changes**: Before Zulip 12.0 (feature level ZF-53d45e), a bot's
+full-member status was determined by the bot's own `date_joined`, like
+any other account.

--- a/api_docs/unmerged.d/ZF-53d45e.md
+++ b/api_docs/unmerged.d/ZF-53d45e.md
@@ -1,0 +1,8 @@
+**Feature level ZF-53d45e**
+
+* For a bot with the member role, whether it is treated as a [full
+  member](/api/roles-and-permissions#determining-if-a-user-is-a-full-member)
+  now follows its owner rather than the bot's own `date_joined`: such a
+  bot is a full member exactly when its owner is, and is never a full
+  member while owned by a guest. This is reflected in the bot's
+  membership in the `role:fullmembers` system group.

--- a/starlight_help/src/content/docs/restrict-permissions-of-new-members.mdx
+++ b/starlight_help/src/content/docs/restrict-permissions-of-new-members.mdx
@@ -19,6 +19,10 @@ past a certain **waiting period** threshold. After that they are **full members*
 You can configure how long the waiting period is, as well as which actions require
 being a full member.
 
+A bot's status follows its owner: it is a full member exactly when its owner is
+a full member. So a new member's bot is restricted just like its owner, and
+changing a bot's owner can change the bot's status.
+
 For some features, Zulip supports restricting access to only full members. These
 features include [creating channels](/help/configure-who-can-create-channels),
 [inviting users to the organization](/help/invite-new-users),

--- a/zerver/actions/bots.py
+++ b/zerver/actions/bots.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.create_user import created_bot_event
+from zerver.actions.user_groups import update_users_in_full_members_system_group
 from zerver.models import RealmAuditLog, Stream, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.users import active_user_ids, bot_owner_user_ids
@@ -66,6 +67,13 @@ def do_change_bot_owner(
     )
 
     send_bot_owner_update_events(user_profile, bot_owner, previous_owner)
+
+    if user_profile.role == UserProfile.ROLE_MEMBER:
+        # A member-role bot's full-member status follows its owner, so a
+        # change of owner can promote or demote the bot.
+        update_users_in_full_members_system_group(
+            user_profile.realm, [user_profile.id], acting_user=acting_user
+        )
 
 
 @transaction.atomic(durable=True)

--- a/zerver/actions/bots.py
+++ b/zerver/actions/bots.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.create_user import created_bot_event
+from zerver.actions.user_groups import update_users_in_full_members_system_group
 from zerver.models import RealmAuditLog, Stream, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.users import active_user_ids, bot_owner_user_ids
@@ -66,6 +67,11 @@ def do_change_bot_owner(
     )
 
     send_bot_owner_update_events(user_profile, bot_owner, previous_owner)
+
+    if user_profile.role == UserProfile.ROLE_MEMBER:
+        update_users_in_full_members_system_group(
+            user_profile.realm, [user_profile.id], acting_user=acting_user
+        )
 
 
 @transaction.atomic(durable=True)

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -20,6 +20,7 @@ from zerver.actions.streams import bulk_add_subscriptions, send_peer_subscriber_
 from zerver.actions.user_groups import (
     bulk_add_members_to_user_groups,
     do_send_user_group_members_update_event,
+    update_users_in_full_members_system_group,
 )
 from zerver.actions.users import (
     change_user_is_active,
@@ -756,6 +757,15 @@ def do_reactivate_user(user_profile: UserProfile, *, acting_user: UserProfile | 
             },
         )
         bot_owner_changed = True
+
+    if user_profile.is_bot and user_profile.role == UserProfile.ROLE_MEMBER:
+        # A member-role bot's full-member status follows its owner. Re-pin on
+        # every reactivation, not just when the owner was reassigned above:
+        # do_change_user_role skips inactive bots, so an owner role change
+        # while the bot was deactivated can leave its membership row stale.
+        update_users_in_full_members_system_group(
+            user_profile.realm, [user_profile.id], acting_user=acting_user
+        )
 
     if settings.BILLING_ENABLED:
         from corporate.lib.stripe import RealmBillingSession

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -68,7 +68,13 @@ from zerver.models import (
 from zerver.models.groups import SystemGroups
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.streams import StreamTopicsPolicyEnum
-from zerver.models.users import ExternalAuthID, active_user_ids, bot_owner_user_ids, get_system_bot
+from zerver.models.users import (
+    ExternalAuthID,
+    active_user_ids,
+    bot_owner_user_ids,
+    get_system_bot,
+    user_is_provisional_member,
+)
 from zerver.tornado.django_api import send_event_on_commit
 
 MAX_NUM_RECENT_MESSAGES = 1000
@@ -596,7 +602,9 @@ def do_create_user(
         acting_user=acting_user,
     )
 
-    if user_profile.role == UserProfile.ROLE_MEMBER and not user_profile.is_provisional_member:
+    if user_profile.role == UserProfile.ROLE_MEMBER and not user_is_provisional_member(
+        user_profile
+    ):
         full_members_system_group = NamedUserGroup.objects.get(
             name=SystemGroups.FULL_MEMBERS,
             realm_for_sharding=user_profile.realm,
@@ -619,7 +627,9 @@ def do_create_user(
     notify_created_user(user_profile, [])
 
     do_send_user_group_members_update_event("add_members", system_user_group, [user_profile.id])
-    if user_profile.role == UserProfile.ROLE_MEMBER and not user_profile.is_provisional_member:
+    if user_profile.role == UserProfile.ROLE_MEMBER and not user_is_provisional_member(
+        user_profile
+    ):
         do_send_user_group_members_update_event(
             "add_members", full_members_system_group, [user_profile.id]
         )

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -20,6 +20,7 @@ from zerver.actions.streams import bulk_add_subscriptions, send_peer_subscriber_
 from zerver.actions.user_groups import (
     bulk_add_members_to_user_groups,
     do_send_user_group_members_update_event,
+    update_users_in_full_members_system_group,
 )
 from zerver.actions.users import (
     change_user_is_active,
@@ -766,6 +767,14 @@ def do_reactivate_user(user_profile: UserProfile, *, acting_user: UserProfile | 
             },
         )
         bot_owner_changed = True
+
+    if bot_owner_changed and user_profile.role == UserProfile.ROLE_MEMBER:
+        # The reassignment above can hand the bot to an owner of a different
+        # status, and deactivation does not remove group memberships, so the
+        # row inherited from the previous owner is otherwise stale.
+        update_users_in_full_members_system_group(
+            user_profile.realm, [user_profile.id], acting_user=acting_user
+        )
 
     if settings.BILLING_ENABLED:
         from corporate.lib.stripe import RealmBillingSession

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -48,6 +48,23 @@ class MemberGroupUserDict(TypedDict):
     id: int
     role: int
     date_joined: datetime
+    is_bot: bool
+    bot_owner_id: int | None
+    bot_owner__role: int | None
+    bot_owner__date_joined: datetime | None
+
+
+# The bot_owner fields let us pin a member-role bot's full-member status to
+# its owner; see UserProfile.determine_is_provisional_member.
+MEMBER_GROUP_USER_FIELDS = (
+    "id",
+    "role",
+    "date_joined",
+    "is_bot",
+    "bot_owner_id",
+    "bot_owner__role",
+    "bot_owner__date_joined",
+)
 
 
 @transaction.atomic(savepoint=False)
@@ -124,27 +141,39 @@ def update_users_in_full_members_system_group(
     if affected_user_ids:
         full_member_group_users = list(
             full_members_system_group.direct_members.filter(id__in=affected_user_ids).values(
-                "id", "role", "date_joined"
+                *MEMBER_GROUP_USER_FIELDS
             )
         )
         member_group_users = list(
             members_system_group.direct_members.filter(id__in=affected_user_ids).values(
-                "id", "role", "date_joined"
+                *MEMBER_GROUP_USER_FIELDS
             )
         )
     else:
         full_member_group_users = list(
-            full_members_system_group.direct_members.all().values("id", "role", "date_joined")
+            full_members_system_group.direct_members.all().values(*MEMBER_GROUP_USER_FIELDS)
         )
         member_group_users = list(
-            members_system_group.direct_members.all().values("id", "role", "date_joined")
+            members_system_group.direct_members.all().values(*MEMBER_GROUP_USER_FIELDS)
         )
 
     def is_provisional_member(user: MemberGroupUserDict) -> bool:
-        diff = (timezone_now() - user["date_joined"]).days
-        if diff < realm.waiting_period_threshold:
-            return True
-        return False
+        bot_owner_role: int | None = None
+        bot_owner_date_joined: datetime | None = None
+        if (
+            user["is_bot"]
+            and user["role"] == UserProfile.ROLE_MEMBER
+            and user["bot_owner_id"] is not None
+        ):
+            bot_owner_role = user["bot_owner__role"]
+            bot_owner_date_joined = user["bot_owner__date_joined"]
+        return UserProfile.determine_is_provisional_member(
+            role=user["role"],
+            date_joined=user["date_joined"],
+            waiting_period_threshold=realm.waiting_period_threshold,
+            bot_owner_role=bot_owner_role,
+            bot_owner_date_joined=bot_owner_date_joined,
+        )
 
     old_full_members = [
         user

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -40,7 +40,7 @@ from zerver.models import (
 )
 from zerver.models.groups import SystemGroups
 from zerver.models.realm_audit_logs import AuditLogEventType
-from zerver.models.users import active_user_ids
+from zerver.models.users import active_user_ids, compute_is_provisional_member
 from zerver.tornado.django_api import send_event_on_commit
 
 
@@ -48,6 +48,21 @@ class MemberGroupUserDict(TypedDict):
     id: int
     role: int
     date_joined: datetime
+    is_bot: bool
+    bot_owner__role: int | None
+    bot_owner__date_joined: datetime | None
+
+
+# The bot_owner fields let us pin a member-role bot's full-member status to
+# its owner; see compute_is_provisional_member.
+MEMBER_GROUP_USER_FIELDS = (
+    "id",
+    "role",
+    "date_joined",
+    "is_bot",
+    "bot_owner__role",
+    "bot_owner__date_joined",
+)
 
 
 @transaction.atomic(savepoint=False)
@@ -124,27 +139,33 @@ def update_users_in_full_members_system_group(
     if affected_user_ids:
         full_member_group_users = list(
             full_members_system_group.direct_members.filter(id__in=affected_user_ids).values(
-                "id", "role", "date_joined"
+                *MEMBER_GROUP_USER_FIELDS
             )
         )
         member_group_users = list(
             members_system_group.direct_members.filter(id__in=affected_user_ids).values(
-                "id", "role", "date_joined"
+                *MEMBER_GROUP_USER_FIELDS
             )
         )
     else:
         full_member_group_users = list(
-            full_members_system_group.direct_members.all().values("id", "role", "date_joined")
+            full_members_system_group.direct_members.all().values(*MEMBER_GROUP_USER_FIELDS)
         )
         member_group_users = list(
-            members_system_group.direct_members.all().values("id", "role", "date_joined")
+            members_system_group.direct_members.all().values(*MEMBER_GROUP_USER_FIELDS)
         )
 
     def is_provisional_member(user: MemberGroupUserDict) -> bool:
-        diff = (timezone_now() - user["date_joined"]).days
-        if diff < realm.waiting_period_threshold:
-            return True
-        return False
+        if (
+            user["is_bot"]
+            and user["role"] == UserProfile.ROLE_MEMBER
+            and user["bot_owner__role"] is not None
+        ):
+            assert user["bot_owner__date_joined"] is not None
+            return compute_is_provisional_member(
+                realm, user["bot_owner__role"], user["bot_owner__date_joined"]
+            )
+        return compute_is_provisional_member(realm, user["role"], user["date_joined"])
 
     old_full_members = [
         user

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -697,9 +697,24 @@ def do_change_user_role(
 
     do_send_user_group_members_update_event("add_members", system_group, [user_profile.id])
 
-    if UserProfile.ROLE_MEMBER in [old_value, value]:
+    # user_profile's own FULL_MEMBERS membership can change only when the
+    # member role is involved. A member-role bot's full-member status follows
+    # its owner, so the owner's bots must also be re-checked whenever the
+    # owner crosses the boundary between full-member-equivalent roles and the
+    # guest or new-member roles (e.g. moderator -> guest must demote the bot,
+    # which matters even in realms with no waiting period and thus no cron).
+    member_role_involved = UserProfile.ROLE_MEMBER in [old_value, value]
+    guest_role_involved = UserProfile.ROLE_GUEST in [old_value, value]
+    affected_user_ids = [user_profile.id] if member_role_involved else []
+    if not user_profile.is_bot and (member_role_involved or guest_role_involved):
+        affected_user_ids += list(
+            get_active_bots_owned_by_user(user_profile)
+            .filter(role=UserProfile.ROLE_MEMBER)
+            .values_list("id", flat=True)
+        )
+    if affected_user_ids:
         update_users_in_full_members_system_group(
-            user_profile.realm, [user_profile.id], acting_user=acting_user
+            user_profile.realm, affected_user_ids, acting_user=acting_user
         )
 
     send_stream_events_for_role_update(user_profile, previously_accessible_streams)

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -54,6 +54,7 @@ from zerver.lib.user_groups import (
 )
 from zerver.lib.users import (
     get_active_bots_owned_by_user,
+    get_bots_owned_by_user,
     get_user_ids_who_can_access_user,
     get_users_involved_in_dms_with_target_users,
     user_access_restricted_in_realm,
@@ -697,9 +698,21 @@ def do_change_user_role(
 
     do_send_user_group_members_update_event("add_members", system_group, [user_profile.id])
 
-    if UserProfile.ROLE_MEMBER in [old_value, value]:
+    # user_profile's own FULL_MEMBERS membership can change only when the
+    # member role is involved; an owned bot's can also change when the owner
+    # crosses the guest boundary.
+    member_role_involved = UserProfile.ROLE_MEMBER in [old_value, value]
+    guest_role_involved = UserProfile.ROLE_GUEST in [old_value, value]
+    affected_user_ids = [user_profile.id] if member_role_involved else []
+    if not user_profile.is_bot and (member_role_involved or guest_role_involved):
+        affected_user_ids += list(
+            get_bots_owned_by_user(user_profile)
+            .filter(role=UserProfile.ROLE_MEMBER)
+            .values_list("id", flat=True)
+        )
+    if affected_user_ids:
         update_users_in_full_members_system_group(
-            user_profile.realm, [user_profile.id], acting_user=acting_user
+            user_profile.realm, affected_user_ids, acting_user=acting_user
         )
 
     send_stream_events_for_role_update(user_profile, previously_accessible_streams)

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -24,6 +24,7 @@ from zerver.models import (
 from zerver.models.groups import SystemGroups
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.streams import StreamTopicsPolicyEnum
+from zerver.models.users import user_is_provisional_member
 
 
 def bulk_create_users(
@@ -124,7 +125,7 @@ def bulk_create_users(
         group_memberships_to_create.append(
             UserGroupMembership(user_profile=user_profile, user_group=members_system_group)
         )
-        if not user_profile.is_provisional_member:
+        if not user_is_provisional_member(user_profile):
             group_memberships_to_create.append(
                 UserGroupMembership(user_profile=user_profile, user_group=full_members_system_group)
             )

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -17,7 +17,7 @@ from django.core.management.base import CommandError
 from django.core.validators import validate_email
 from django.db import connection, transaction
 from django.db.backends.utils import CursorWrapper
-from django.db.models import Count, Q
+from django.db.models import Count, Q, prefetch_related_objects
 from django.utils.timezone import now as timezone_now
 from psycopg2.extras import execute_values
 from psycopg2.sql import SQL, Identifier
@@ -2566,6 +2566,10 @@ def add_users_to_system_user_groups(
     for role in NamedUserGroup.SYSTEM_USER_GROUP_ROLE_MAP:
         group_name = NamedUserGroup.SYSTEM_USER_GROUP_ROLE_MAP[role]["name"]
         role_system_groups_dict[role] = system_groups_name_dict[group_name]
+
+    # is_provisional_member consults a member-role bot's owner; prefetch it so
+    # the loop below does not issue a query per bot.
+    prefetch_related_objects(user_profiles, "bot_owner")
 
     usergroup_memberships = []
     for user_profile in user_profiles:

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -126,7 +126,12 @@ from zerver.models.presence import PresenceSequence
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.realms import get_realm
 from zerver.models.recipients import get_direct_message_group_hash
-from zerver.models.users import ExternalAuthID, get_system_bot, get_user_profile_by_id
+from zerver.models.users import (
+    ExternalAuthID,
+    compute_is_provisional_member,
+    get_system_bot,
+    get_user_profile_by_id,
+)
 from zproject.backends import AUTH_BACKEND_NAME_MAP
 
 ImportedTableData: TypeAlias = dict[str, list[Record]]
@@ -2649,16 +2654,40 @@ def add_users_to_system_user_groups(
         group_name = NamedUserGroup.SYSTEM_USER_GROUP_ROLE_MAP[role]["name"]
         role_system_groups_dict[role] = system_groups_name_dict[group_name]
 
+    # A member-role bot's full-member status is computed from its owner's role
+    # and date_joined, so collect just those two columns for the owners in this
+    # batch rather than loading whole UserProfile rows for them.
+    bot_owner_ids = {
+        user_profile.bot_owner_id
+        for user_profile in user_profiles
+        if user_profile.is_bot
+        and user_profile.role == UserProfile.ROLE_MEMBER
+        and user_profile.bot_owner_id is not None
+    }
+    bot_owner_columns = {
+        owner_id: (owner_role, owner_date_joined)
+        for owner_id, owner_role, owner_date_joined in UserProfile.objects.filter(
+            id__in=bot_owner_ids
+        ).values_list("id", "role", "date_joined")
+    }
+
     usergroup_memberships = []
     for user_profile in user_profiles:
         user_group = role_system_groups_dict[user_profile.role]
         usergroup_memberships.append(
             UserGroupMembership(user_profile=user_profile, user_group=user_group)
         )
-        if user_profile.role == UserProfile.ROLE_MEMBER and not user_profile.is_provisional_member:
-            usergroup_memberships.append(
-                UserGroupMembership(user_profile=user_profile, user_group=full_members_system_group)
-            )
+        if user_profile.role == UserProfile.ROLE_MEMBER:
+            if user_profile.is_bot and user_profile.bot_owner_id is not None:
+                role, date_joined = bot_owner_columns[user_profile.bot_owner_id]
+            else:
+                role, date_joined = user_profile.role, user_profile.date_joined
+            if not compute_is_provisional_member(realm, role, date_joined):
+                usergroup_memberships.append(
+                    UserGroupMembership(
+                        user_profile=user_profile, user_group=full_members_system_group
+                    )
+                )
     UserGroupMembership.objects.bulk_create(usergroup_memberships)
     now = timezone_now()
     RealmAuditLog.objects.bulk_create(

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -35,6 +35,7 @@ from zerver.models import (
 )
 from zerver.models.groups import SystemGroups, get_realm_system_groups_name_dict
 from zerver.models.realm_audit_logs import AuditLogEventType
+from zerver.models.users import user_is_provisional_member
 
 
 @dataclass
@@ -1305,7 +1306,7 @@ def check_user_has_permission_by_role(
         return user.is_moderator
 
     # Handle full members case.
-    return user.role != UserProfile.ROLE_MEMBER or not user.is_provisional_member
+    return user.role != UserProfile.ROLE_MEMBER or not user_is_provisional_member(user)
 
 
 def check_any_user_has_permission_by_role(

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1164,6 +1164,10 @@ def get_active_bots_owned_by_user(user_profile: UserProfile) -> QuerySet[UserPro
     return UserProfile.objects.filter(is_bot=True, is_active=True, bot_owner=user_profile)
 
 
+def get_bots_owned_by_user(user_profile: UserProfile) -> QuerySet[UserProfile]:
+    return UserProfile.objects.filter(is_bot=True, bot_owner=user_profile)
+
+
 def is_2fa_verified(user: UserProfile) -> bool:
     """
     It is generally unsafe to call is_verified directly on `request.user` since

--- a/zerver/migrations/0806_backfill_bot_full_member_status_from_owner.py
+++ b/zerver/migrations/0806_backfill_bot_full_member_status_from_owner.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+
+from django.conf import settings
+from django.db import migrations, transaction
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.utils.timezone import now as timezone_now
+
+ROLE_REALM_OWNER = 100
+ROLE_REALM_ADMINISTRATOR = 200
+ROLE_MODERATOR = 300
+ROLE_MEMBER = 400
+ROLE_GUEST = 600
+
+# Values of AuditLogEventType; see zerver/models/realm_audit_logs.py.
+USER_GROUP_DIRECT_USER_MEMBERSHIP_ADDED = 703
+USER_GROUP_DIRECT_USER_MEMBERSHIP_REMOVED = 704
+
+FULL_MEMBERS_GROUP_NAME = "role:fullmembers"
+MEMBERS_GROUP_NAME = "role:members"
+
+
+def bot_should_be_full_member(
+    owner_role: int, owner_date_joined: datetime, waiting_period_threshold: int
+) -> bool:
+    # Mirrors the inverse of UserProfile.determine_is_provisional_member for a
+    # member-role bot: it follows its owner, and is never a full member while
+    # owned by a guest.
+    if owner_role == ROLE_GUEST:
+        return False
+    if owner_role in (ROLE_REALM_OWNER, ROLE_REALM_ADMINISTRATOR, ROLE_MODERATOR):
+        return True
+    return (timezone_now() - owner_date_joined).days >= waiting_period_threshold
+
+
+def backfill_bot_full_member_status(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    """A member-role bot's full-member status now follows its owner rather than
+    the bot's own date_joined (issue #32468). Existing bots were placed in the
+    FULL_MEMBERS system group under the old rule, and in realms with
+    waiting_period_threshold=0 the promote_new_full_members cronjob never runs
+    to recompute them. Reconcile every member-role bot's FULL_MEMBERS
+    membership with its owner once, so the invariant holds on existing data.
+    """
+    Realm = apps.get_model("zerver", "Realm")
+    UserProfile = apps.get_model("zerver", "UserProfile")
+    RealmAuditLog = apps.get_model("zerver", "RealmAuditLog")
+    NamedUserGroup = apps.get_model("zerver", "NamedUserGroup")
+    UserGroupMembership = apps.get_model("zerver", "UserGroupMembership")
+
+    for realm in Realm.objects.exclude(string_id=settings.SYSTEM_BOT_REALM):
+        try:
+            full_members_group = NamedUserGroup.objects.get(
+                name=FULL_MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
+            )
+            members_group = NamedUserGroup.objects.get(
+                name=MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
+            )
+        except NamedUserGroup.DoesNotExist:
+            # A realm without role-based system groups is fixed up by earlier
+            # migrations; there is nothing to reconcile here.
+            continue
+
+        bot_rows = list(
+            UserProfile.objects.filter(
+                realm_id=realm.id,
+                is_bot=True,
+                role=ROLE_MEMBER,
+                bot_owner__isnull=False,
+            ).values_list("id", "bot_owner__role", "bot_owner__date_joined")
+        )
+        if not bot_rows:
+            continue
+
+        bot_ids = [row[0] for row in bot_rows]
+        currently_full_member_ids = set(
+            UserGroupMembership.objects.filter(
+                user_group=full_members_group, user_profile_id__in=bot_ids
+            ).values_list("user_profile_id", flat=True)
+        )
+        # A bot can only join FULL_MEMBERS if it is in MEMBERS, matching how
+        # update_users_in_full_members_system_group promotes members.
+        member_group_bot_ids = set(
+            UserGroupMembership.objects.filter(
+                user_group=members_group, user_profile_id__in=bot_ids
+            ).values_list("user_profile_id", flat=True)
+        )
+
+        memberships_to_add = []
+        ids_to_remove = []
+        for bot_id, owner_role, owner_date_joined in bot_rows:
+            should_be_full = bot_should_be_full_member(
+                owner_role, owner_date_joined, realm.waiting_period_threshold
+            )
+            currently_full = bot_id in currently_full_member_ids
+            if should_be_full and not currently_full and bot_id in member_group_bot_ids:
+                memberships_to_add.append(
+                    UserGroupMembership(user_profile_id=bot_id, user_group=full_members_group)
+                )
+            elif not should_be_full and currently_full:
+                ids_to_remove.append(bot_id)
+
+        if not memberships_to_add and not ids_to_remove:
+            continue
+
+        now = timezone_now()
+        audit_logs = [
+            RealmAuditLog(
+                realm_id=realm.id,
+                modified_user_id=membership.user_profile_id,
+                modified_user_group=full_members_group,
+                event_type=USER_GROUP_DIRECT_USER_MEMBERSHIP_ADDED,
+                event_time=now,
+                acting_user=None,
+                backfilled=True,
+            )
+            for membership in memberships_to_add
+        ] + [
+            RealmAuditLog(
+                realm_id=realm.id,
+                modified_user_id=bot_id,
+                modified_user_group=full_members_group,
+                event_type=USER_GROUP_DIRECT_USER_MEMBERSHIP_REMOVED,
+                event_time=now,
+                acting_user=None,
+                backfilled=True,
+            )
+            for bot_id in ids_to_remove
+        ]
+
+        with transaction.atomic(durable=True):
+            if ids_to_remove:
+                UserGroupMembership.objects.filter(
+                    user_group=full_members_group, user_profile_id__in=ids_to_remove
+                ).delete()
+            if memberships_to_add:
+                UserGroupMembership.objects.bulk_create(memberships_to_add)
+            RealmAuditLog.objects.bulk_create(audit_logs)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0805_fix_deleteduser_email"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_bot_full_member_status,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/migrations/0808_backfill_bot_full_member_status_from_owner.py
+++ b/zerver/migrations/0808_backfill_bot_full_member_status_from_owner.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+
+from django.conf import settings
+from django.db import migrations, transaction
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.utils.timezone import now as timezone_now
+
+ROLE_REALM_OWNER = 100
+ROLE_REALM_ADMINISTRATOR = 200
+ROLE_MODERATOR = 300
+ROLE_MEMBER = 400
+ROLE_GUEST = 600
+
+# Values of AuditLogEventType; see zerver/models/realm_audit_logs.py.
+USER_GROUP_DIRECT_USER_MEMBERSHIP_ADDED = 703
+USER_GROUP_DIRECT_USER_MEMBERSHIP_REMOVED = 704
+
+FULL_MEMBERS_GROUP_NAME = "role:fullmembers"
+MEMBERS_GROUP_NAME = "role:members"
+
+
+def bot_should_be_full_member(
+    owner_role: int, owner_date_joined: datetime, waiting_period_threshold: int
+) -> bool:
+    # Mirrors the inverse of compute_is_provisional_member for a member-role
+    # bot: it follows its owner, and is never a full member while owned by a
+    # guest.
+    if owner_role == ROLE_GUEST:
+        return False
+    if owner_role in (ROLE_REALM_OWNER, ROLE_REALM_ADMINISTRATOR, ROLE_MODERATOR):
+        return True
+    return (timezone_now() - owner_date_joined).days >= waiting_period_threshold
+
+
+def backfill_bot_full_member_status(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    """A member-role bot's full-member status now follows its owner rather than
+    the bot's own date_joined (issue #32468). Existing bots were placed in the
+    FULL_MEMBERS system group under the old rule, and in realms with
+    waiting_period_threshold=0 the promote_new_full_members cronjob never runs
+    to recompute them. Reconcile every member-role bot's FULL_MEMBERS
+    membership with its owner once, so the invariant holds on existing data.
+    """
+    Realm = apps.get_model("zerver", "Realm")
+    UserProfile = apps.get_model("zerver", "UserProfile")
+    RealmAuditLog = apps.get_model("zerver", "RealmAuditLog")
+    NamedUserGroup = apps.get_model("zerver", "NamedUserGroup")
+    UserGroupMembership = apps.get_model("zerver", "UserGroupMembership")
+
+    for realm in Realm.objects.exclude(string_id=settings.SYSTEM_BOT_REALM):
+        try:
+            full_members_group = NamedUserGroup.objects.get(
+                name=FULL_MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
+            )
+            members_group = NamedUserGroup.objects.get(
+                name=MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
+            )
+        except NamedUserGroup.DoesNotExist:
+            # A realm without role-based system groups is fixed up by earlier
+            # migrations; there is nothing to reconcile here.
+            continue
+
+        bot_rows = list(
+            UserProfile.objects.filter(
+                realm_id=realm.id,
+                is_bot=True,
+                role=ROLE_MEMBER,
+                bot_owner__isnull=False,
+            ).values_list("id", "bot_owner__role", "bot_owner__date_joined")
+        )
+        if not bot_rows:
+            continue
+
+        bot_ids = [row[0] for row in bot_rows]
+        currently_full_member_ids = set(
+            UserGroupMembership.objects.filter(
+                user_group=full_members_group, user_profile_id__in=bot_ids
+            ).values_list("user_profile_id", flat=True)
+        )
+        # A bot can only join FULL_MEMBERS if it is in MEMBERS, matching how
+        # update_users_in_full_members_system_group promotes members.
+        member_group_bot_ids = set(
+            UserGroupMembership.objects.filter(
+                user_group=members_group, user_profile_id__in=bot_ids
+            ).values_list("user_profile_id", flat=True)
+        )
+
+        memberships_to_add = []
+        ids_to_remove = []
+        for bot_id, owner_role, owner_date_joined in bot_rows:
+            should_be_full = bot_should_be_full_member(
+                owner_role, owner_date_joined, realm.waiting_period_threshold
+            )
+            currently_full = bot_id in currently_full_member_ids
+            if should_be_full and not currently_full and bot_id in member_group_bot_ids:
+                memberships_to_add.append(
+                    UserGroupMembership(user_profile_id=bot_id, user_group=full_members_group)
+                )
+            elif not should_be_full and currently_full:
+                ids_to_remove.append(bot_id)
+
+        if not memberships_to_add and not ids_to_remove:
+            continue
+
+        now = timezone_now()
+        audit_logs = [
+            RealmAuditLog(
+                realm_id=realm.id,
+                modified_user_id=membership.user_profile_id,
+                modified_user_group=full_members_group,
+                event_type=USER_GROUP_DIRECT_USER_MEMBERSHIP_ADDED,
+                event_time=now,
+                acting_user=None,
+                backfilled=True,
+            )
+            for membership in memberships_to_add
+        ] + [
+            RealmAuditLog(
+                realm_id=realm.id,
+                modified_user_id=bot_id,
+                modified_user_group=full_members_group,
+                event_type=USER_GROUP_DIRECT_USER_MEMBERSHIP_REMOVED,
+                event_time=now,
+                acting_user=None,
+                backfilled=True,
+            )
+            for bot_id in ids_to_remove
+        ]
+
+        with transaction.atomic(durable=True):
+            if ids_to_remove:
+                UserGroupMembership.objects.filter(
+                    user_group=full_members_group, user_profile_id__in=ids_to_remove
+                ).delete()
+            if memberships_to_add:
+                UserGroupMembership.objects.bulk_create(memberships_to_add)
+            RealmAuditLog.objects.bulk_create(audit_logs)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0807_usertopic_zerver_usertopic_user_visibility_recipient_idx"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_bot_full_member_status,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from email.headerregistry import Address
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
@@ -785,14 +786,51 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
         else:
             return False
 
+    @staticmethod
+    def determine_is_provisional_member(
+        *,
+        role: int,
+        date_joined: datetime,
+        waiting_period_threshold: int,
+        bot_owner_role: int | None,
+        bot_owner_date_joined: datetime | None,
+    ) -> bool:
+        """Whether a user with these attributes is a provisional (new) member.
+
+        For a member-role bot, the caller passes its owner's role and
+        date_joined so the bot's status is pinned to its owner. This
+        preserves the security invariant that a bot can never be a full
+        member when its owner is not (e.g. a bot owned by a guest, or by a
+        member still in the waiting period). See issue #32468.
+        """
+        if bot_owner_role is not None:
+            if bot_owner_role == UserProfile.ROLE_GUEST:
+                return True
+            assert bot_owner_date_joined is not None
+            role = bot_owner_role
+            date_joined = bot_owner_date_joined
+        if role in (
+            UserProfile.ROLE_REALM_OWNER,
+            UserProfile.ROLE_REALM_ADMINISTRATOR,
+            UserProfile.ROLE_MODERATOR,
+        ):
+            return False
+        return (timezone_now() - date_joined).days < waiting_period_threshold
+
     @property
     def is_provisional_member(self) -> bool:
-        if self.is_moderator:
-            return False
-        diff = (timezone_now() - self.date_joined).days
-        if diff < self.realm.waiting_period_threshold:
-            return True
-        return False
+        bot_owner_role: int | None = None
+        bot_owner_date_joined: datetime | None = None
+        if self.is_bot and self.role == UserProfile.ROLE_MEMBER and self.bot_owner is not None:
+            bot_owner_role = self.bot_owner.role
+            bot_owner_date_joined = self.bot_owner.date_joined
+        return UserProfile.determine_is_provisional_member(
+            role=self.role,
+            date_joined=self.date_joined,
+            waiting_period_threshold=self.realm.waiting_period_threshold,
+            bot_owner_role=bot_owner_role,
+            bot_owner_date_joined=bot_owner_date_joined,
+        )
 
     @property
     def is_realm_admin(self) -> bool:

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from email.headerregistry import Address
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
@@ -788,12 +789,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
 
     @property
     def is_provisional_member(self) -> bool:
-        if self.is_moderator:
-            return False
-        diff = (timezone_now() - self.date_joined).days
-        if diff < self.realm.waiting_period_threshold:
-            return True
-        return False
+        return compute_is_provisional_member(self.realm, self.role, self.date_joined)
 
     @property
     def is_realm_admin(self) -> bool:
@@ -978,6 +974,38 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
 
 class PasswordTooWeakError(Exception):
     pass
+
+
+def compute_is_provisional_member(realm: "Realm", role: int, date_joined: datetime) -> bool:
+    if role in (
+        UserProfile.ROLE_REALM_OWNER,
+        UserProfile.ROLE_REALM_ADMINISTRATOR,
+        UserProfile.ROLE_MODERATOR,
+    ):
+        return False
+    if role == UserProfile.ROLE_GUEST:
+        # A guest never has full-member permissions, however long ago they
+        # joined. This branch is what makes a bot owned by a guest a new
+        # member; other callers only consult this for member-role accounts.
+        return True
+    return (timezone_now() - date_joined).days < realm.waiting_period_threshold
+
+
+def user_is_provisional_member(user: UserProfile) -> bool:
+    """Whether this account has the permissions of a new member.
+
+    A member-role bot's status follows its owner rather than the bot's own
+    date_joined, so that a bot can never be a full member while its owner is
+    not -- whether because the owner is a guest or is still in the waiting
+    period. See issue #32468.
+
+    Callers holding a UserProfile that might be a bot want this rather than
+    the is_provisional_member property, which considers only the account
+    itself.
+    """
+    if user.is_bot and user.role == UserProfile.ROLE_MEMBER and user.bot_owner is not None:
+        return user.bot_owner.is_provisional_member
+    return user.is_provisional_member
 
 
 def remote_user_to_email(remote_user: str) -> str:

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -10,6 +10,7 @@ from django.utils.timezone import now as timezone_now
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.actions.bots import do_change_bot_owner, do_change_default_sending_stream
+from zerver.actions.create_user import do_reactivate_user
 from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_set_realm_property,
@@ -2371,3 +2372,84 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         do_change_bot_owner(bot, cordelia, acting_user=None)
         assert_full_member(bot, False)
+
+    def test_reactivated_bot_full_member_status_follows_new_owner(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        def assert_full_member(bot: UserProfile, expected: bool) -> None:
+            is_full = bot.id in get_user_group_member_ids(
+                full_members_group, direct_member_only=True
+            )
+            self.assertEqual(is_full, expected)
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        for provisional_member in (hamlet, cordelia):
+            provisional_member.date_joined = timezone_now()
+            provisional_member.save(update_fields=["date_joined"])
+        # Reactivating a bot whose owner is deactivated reassigns it to the
+        # acting user, so its full-member status re-pins to that new owner.
+        iago = self.example_user("iago")
+        demoted_bot = self.create_test_bot(
+            "reactivate-demote", iago, full_name="Reactivate Demote Bot"
+        )
+        assert_full_member(demoted_bot, True)
+        do_deactivate_user(iago, acting_user=None)
+        demoted_bot.refresh_from_db()
+        do_reactivate_user(demoted_bot, acting_user=hamlet)
+        demoted_bot.refresh_from_db()
+        self.assertEqual(demoted_bot.bot_owner_id, hamlet.id)
+        assert_full_member(demoted_bot, False)
+
+        desdemona = self.example_user("desdemona")
+        promoted_bot = self.create_test_bot(
+            "reactivate-promote", cordelia, full_name="Reactivate Promote Bot"
+        )
+        assert_full_member(promoted_bot, False)
+        do_deactivate_user(cordelia, acting_user=None)
+        promoted_bot.refresh_from_db()
+        do_reactivate_user(promoted_bot, acting_user=desdemona)
+        promoted_bot.refresh_from_db()
+        self.assertEqual(promoted_bot.bot_owner_id, desdemona.id)
+        assert_full_member(promoted_bot, True)
+
+    def test_reactivated_bot_full_member_status_recomputed_with_unchanged_owner(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        def assert_full_member(bot: UserProfile, expected: bool) -> None:
+            is_full = bot.id in get_user_group_member_ids(
+                full_members_group, direct_member_only=True
+            )
+            self.assertEqual(is_full, expected)
+
+        iago = self.example_user("iago")
+        demoted_bot = self.create_test_bot("repin-demote", iago, full_name="Repin Demote Bot")
+        assert_full_member(demoted_bot, True)
+        do_deactivate_user(demoted_bot, acting_user=None)
+        self.set_user_role(iago, UserProfile.ROLE_GUEST)
+        demoted_bot.refresh_from_db()
+        do_reactivate_user(demoted_bot, acting_user=None)
+        demoted_bot.refresh_from_db()
+        self.assertEqual(demoted_bot.bot_owner_id, iago.id)
+        assert_full_member(demoted_bot, False)
+
+        hamlet = self.example_user("hamlet")
+        hamlet.date_joined = timezone_now()
+        hamlet.save(update_fields=["date_joined"])
+        promoted_bot = self.create_test_bot("repin-promote", hamlet, full_name="Repin Promote Bot")
+        assert_full_member(promoted_bot, False)
+        do_deactivate_user(promoted_bot, acting_user=None)
+        self.set_user_role(hamlet, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        promoted_bot.refresh_from_db()
+        do_reactivate_user(promoted_bot, acting_user=None)
+        promoted_bot.refresh_from_db()
+        self.assertEqual(promoted_bot.bot_owner_id, hamlet.id)
+        assert_full_member(promoted_bot, True)

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import orjson
 from django.core import mail
 from django.test import override_settings
+from django.utils.timezone import now as timezone_now
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.actions.bots import do_change_bot_owner, do_change_default_sending_stream
@@ -23,6 +24,7 @@ from zerver.lib.integrations import EMBEDDED_BOTS, IncomingWebhookIntegration
 from zerver.lib.request import RequestNotes
 from zerver.lib.test_classes import UploadSerializeMixin, ZulipTestCase
 from zerver.lib.test_helpers import avatar_disk_path, get_test_image_file
+from zerver.lib.user_groups import get_user_group_member_ids
 from zerver.lib.utils import assert_is_not_none
 from zerver.lib.webhooks.common import WebhookConfigOption
 from zerver.models import RealmUserDefault, Service, Subscription, UserProfile
@@ -2336,3 +2338,36 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         invalid_bot_id = 1000
         result = self.client_get(f"/json/bots/{invalid_bot_id}/api_key")
         self.assert_json_error(result, "No such bot")
+
+    def test_full_member_status_follows_owner_on_ownership_change(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        def assert_full_member(bot: UserProfile, expected: bool) -> None:
+            is_full = bot.id in get_user_group_member_ids(
+                full_members_group, direct_member_only=True
+            )
+            self.assertEqual(is_full, expected)
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        for provisional_member in (hamlet, cordelia):
+            provisional_member.date_joined = timezone_now()
+            provisional_member.save(update_fields=["date_joined"])
+        bot = self.create_test_bot("owner-transfer", hamlet)
+        assert_full_member(bot, False)
+
+        do_change_bot_owner(bot, self.example_user("iago"), acting_user=hamlet)
+        assert_full_member(bot, True)
+
+        do_change_bot_owner(bot, self.example_user("polonius"), acting_user=None)
+        assert_full_member(bot, False)
+
+        do_change_bot_owner(bot, self.example_user("shiva"), acting_user=None)
+        assert_full_member(bot, True)
+
+        do_change_bot_owner(bot, cordelia, acting_user=None)
+        assert_full_member(bot, False)

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -10,6 +10,7 @@ from django.utils.timezone import now as timezone_now
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.actions.bots import do_change_bot_owner, do_change_default_sending_stream
+from zerver.actions.create_user import do_reactivate_user
 from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_set_realm_property,
@@ -2373,3 +2374,47 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         do_change_bot_owner(bot, cordelia, acting_user=None)
         assert_full_member(bot, False)
+
+    def test_reactivated_bot_full_member_status_follows_new_owner(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        def assert_full_member(bot: UserProfile, expected: bool) -> None:
+            is_full = bot.id in get_user_group_member_ids(
+                full_members_group, direct_member_only=True
+            )
+            self.assertEqual(is_full, expected)
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        for provisional_member in (hamlet, cordelia):
+            provisional_member.date_joined = timezone_now()
+            provisional_member.save(update_fields=["date_joined"])
+        # Reactivating a bot whose owner is deactivated reassigns it to the
+        # acting user, so its full-member status re-pins to that new owner.
+        iago = self.example_user("iago")
+        demoted_bot = self.create_test_bot(
+            "reactivate-demote", iago, full_name="Reactivate Demote Bot"
+        )
+        assert_full_member(demoted_bot, True)
+        do_deactivate_user(iago, acting_user=None)
+        demoted_bot.refresh_from_db()
+        do_reactivate_user(demoted_bot, acting_user=hamlet)
+        demoted_bot.refresh_from_db()
+        self.assertEqual(demoted_bot.bot_owner_id, hamlet.id)
+        assert_full_member(demoted_bot, False)
+
+        desdemona = self.example_user("desdemona")
+        promoted_bot = self.create_test_bot(
+            "reactivate-promote", cordelia, full_name="Reactivate Promote Bot"
+        )
+        assert_full_member(promoted_bot, False)
+        do_deactivate_user(cordelia, acting_user=None)
+        promoted_bot.refresh_from_db()
+        do_reactivate_user(promoted_bot, acting_user=desdemona)
+        promoted_bot.refresh_from_db()
+        self.assertEqual(promoted_bot.bot_owner_id, desdemona.id)
+        assert_full_member(promoted_bot, True)

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import orjson
 from django.core import mail
 from django.test import override_settings
+from django.utils.timezone import now as timezone_now
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.actions.bots import do_change_bot_owner, do_change_default_sending_stream
@@ -23,6 +24,7 @@ from zerver.lib.integrations import EMBEDDED_BOTS, IncomingWebhookIntegration
 from zerver.lib.request import RequestNotes
 from zerver.lib.test_classes import UploadSerializeMixin, ZulipTestCase
 from zerver.lib.test_helpers import avatar_disk_path, get_test_image_file
+from zerver.lib.user_groups import get_user_group_member_ids
 from zerver.lib.utils import assert_is_not_none
 from zerver.lib.webhooks.common import WebhookConfigOption
 from zerver.models import RealmUserDefault, Service, Subscription, UserProfile
@@ -2338,3 +2340,36 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         invalid_bot_id = 1000
         result = self.client_get(f"/json/bots/{invalid_bot_id}/api_key")
         self.assert_json_error(result, "No such bot")
+
+    def test_full_member_status_follows_owner_on_ownership_change(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        def assert_full_member(bot: UserProfile, expected: bool) -> None:
+            is_full = bot.id in get_user_group_member_ids(
+                full_members_group, direct_member_only=True
+            )
+            self.assertEqual(is_full, expected)
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        for provisional_member in (hamlet, cordelia):
+            provisional_member.date_joined = timezone_now()
+            provisional_member.save(update_fields=["date_joined"])
+        bot = self.create_test_bot("owner-transfer", hamlet)
+        assert_full_member(bot, False)
+
+        do_change_bot_owner(bot, self.example_user("iago"), acting_user=hamlet)
+        assert_full_member(bot, True)
+
+        do_change_bot_owner(bot, self.example_user("polonius"), acting_user=None)
+        assert_full_member(bot, False)
+
+        do_change_bot_owner(bot, self.example_user("shiva"), acting_user=None)
+        assert_full_member(bot, True)
+
+        do_change_bot_owner(bot, cordelia, acting_user=None)
+        assert_full_member(bot, False)

--- a/zerver/tests/test_migrations.py
+++ b/zerver/tests/test_migrations.py
@@ -4,7 +4,10 @@
 # You can also read
 #   https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 # to get a tutorial on the framework that inspired this feature.
+from datetime import timedelta
+
 from django.db.migrations.state import StateApps
+from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from zerver.lib.test_classes import MigrationsTestCase
@@ -21,46 +24,105 @@ from zerver.lib.test_classes import MigrationsTestCase
 #   django.db.utils.OperationalError: cannot ALTER TABLE
 #   "zerver_subscription" because it has pending trigger events
 
+ROLE_GUEST = 600
+FULL_MEMBERS_GROUP_NAME = "role:fullmembers"
+MEMBERS_GROUP_NAME = "role:members"
 
-class FixDeletedUserEmail(MigrationsTestCase):
-    migrate_from = "0804_backfill_user_created_audit_logs"
-    migrate_to = "0805_fix_deleteduser_email"
+
+class BackfillBotFullMemberStatusFromOwner(MigrationsTestCase):
+    migrate_from = "0805_fix_deleteduser_email"
+    migrate_to = "0806_backfill_bot_full_member_status_from_owner"
 
     @override
     def setUpBeforeMigration(self, apps: StateApps) -> None:
+        Realm = apps.get_model("zerver", "Realm")
         UserProfile = apps.get_model("zerver", "UserProfile")
+        NamedUserGroup = apps.get_model("zerver", "NamedUserGroup")
+        UserGroupMembership = apps.get_model("zerver", "UserGroupMembership")
 
-        # Simulate a user deleted before the fix in 208c0c303405,
-        # after 0439_fix_deleteduser_email repaired delivery_email.
-        deleted_user = self.example_user("hamlet")
-        UserProfile.objects.filter(id=deleted_user.id).update(
-            is_active=False,
-            email=f"deleteduser{deleted_user.id}@https://zulip.testserver",
-            delivery_email=f"deleteduser{deleted_user.id}@zulip.testserver",
+        realm = Realm.objects.get(string_id="zulip")
+        realm.waiting_period_threshold = 10
+        realm.save(update_fields=["waiting_period_threshold"])
+
+        full_members_group = NamedUserGroup.objects.get(
+            name=FULL_MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
         )
-        self.deleted_user_id = deleted_user.id
+        members_group = NamedUserGroup.objects.get(
+            name=MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
+        )
 
-        # A normal active user, as a control.
-        control_user = self.example_user("cordelia")
-        self.control_user_id = control_user.id
-        self.control_user_email = control_user.email
+        # Stale full member: a member-role bot left in FULL_MEMBERS under the
+        # old rule, but whose owner is a guest -- must be removed.
+        guest = UserProfile.objects.get(delivery_email="polonius@zulip.com", realm_id=realm.id)
+        self.assertEqual(guest.role, ROLE_GUEST)
+        self.guest_owned_bot = UserProfile.objects.get(
+            delivery_email="default-bot@zulip.com", realm_id=realm.id
+        )
+        self.guest_owned_bot.bot_owner_id = guest.id
+        self.guest_owned_bot.save(update_fields=["bot_owner"])
+        UserGroupMembership.objects.get_or_create(
+            user_profile_id=self.guest_owned_bot.id, user_group=full_members_group
+        )
 
-        # A deactivated user with a valid email, as a control for the
-        # is_active=False part of the migration's filter.
-        deactivated_user = self.example_user("othello")
-        UserProfile.objects.filter(id=deactivated_user.id).update(is_active=False)
-        self.deactivated_user_id = deactivated_user.id
-        self.deactivated_user_email = deactivated_user.email
+        # Missing full member: a member-role bot whose owner is a member past
+        # the waiting period, but which was never added to FULL_MEMBERS -- must
+        # be added.
+        member_owner = UserProfile.objects.get(delivery_email="hamlet@zulip.com", realm_id=realm.id)
+        member_owner.date_joined = timezone_now() - timedelta(days=30)
+        member_owner.save(update_fields=["date_joined"])
+        self.member_owned_bot = UserProfile.objects.get(
+            delivery_email="webhook-bot@zulip.com", realm_id=realm.id
+        )
+        self.member_owned_bot.bot_owner_id = member_owner.id
+        self.member_owned_bot.save(update_fields=["bot_owner"])
+        UserGroupMembership.objects.get_or_create(
+            user_profile_id=self.member_owned_bot.id, user_group=members_group
+        )
+        UserGroupMembership.objects.filter(
+            user_profile_id=self.member_owned_bot.id, user_group=full_members_group
+        ).delete()
 
-    def test_deleted_user_email_fixed(self) -> None:
-        UserProfile = self.apps.get_model("zerver", "UserProfile")
+    @override
+    def tearDown(self) -> None:
+        # A data migration necessarily changes the set of rows in the database
+        # (adding/removing FULL_MEMBERS memberships and audit logs), which
+        # ZulipTransactionTestCase.tearDown would flag as an unexpected side
+        # effect. Deleted rows cannot be restored to their original primary
+        # keys, so skip that check; the migration-test database is rebuilt for
+        # each run, so the reconciled rows do not leak across runs.
+        pass
 
-        deleted_user = UserProfile.objects.get(id=self.deleted_user_id)
-        self.assertEqual(deleted_user.email, f"deleteduser{deleted_user.id}@zulip.testserver")
-        self.assertEqual(deleted_user.email, deleted_user.delivery_email)
+    def test_bot_full_member_status_reconciled_with_owner(self) -> None:
+        NamedUserGroup = self.apps.get_model("zerver", "NamedUserGroup")
+        UserGroupMembership = self.apps.get_model("zerver", "UserGroupMembership")
+        RealmAuditLog = self.apps.get_model("zerver", "RealmAuditLog")
 
-        control_user = UserProfile.objects.get(id=self.control_user_id)
-        self.assertEqual(control_user.email, self.control_user_email)
+        full_members_group = NamedUserGroup.objects.get(
+            name=FULL_MEMBERS_GROUP_NAME, realm__string_id="zulip", is_system_group=True
+        )
 
-        deactivated_user = UserProfile.objects.get(id=self.deactivated_user_id)
-        self.assertEqual(deactivated_user.email, self.deactivated_user_email)
+        def in_full_members(bot_id: int) -> bool:
+            return UserGroupMembership.objects.filter(
+                user_profile_id=bot_id, user_group=full_members_group
+            ).exists()
+
+        self.assertFalse(in_full_members(self.guest_owned_bot.id))
+        self.assertTrue(in_full_members(self.member_owned_bot.id))
+
+        # Each membership change leaves a backfilled audit-log entry.
+        self.assertTrue(
+            RealmAuditLog.objects.filter(
+                modified_user_id=self.guest_owned_bot.id,
+                modified_user_group=full_members_group,
+                event_type=704,
+                backfilled=True,
+            ).exists()
+        )
+        self.assertTrue(
+            RealmAuditLog.objects.filter(
+                modified_user_id=self.member_owned_bot.id,
+                modified_user_group=full_members_group,
+                event_type=703,
+                backfilled=True,
+            ).exists()
+        )

--- a/zerver/tests/test_migrations.py
+++ b/zerver/tests/test_migrations.py
@@ -4,7 +4,10 @@
 # You can also read
 #   https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 # to get a tutorial on the framework that inspired this feature.
+from datetime import timedelta
+
 from django.db.migrations.state import StateApps
+from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from zerver.lib.test_classes import MigrationsTestCase
@@ -21,46 +24,105 @@ from zerver.lib.test_classes import MigrationsTestCase
 #   django.db.utils.OperationalError: cannot ALTER TABLE
 #   "zerver_subscription" because it has pending trigger events
 
+ROLE_GUEST = 600
+FULL_MEMBERS_GROUP_NAME = "role:fullmembers"
+MEMBERS_GROUP_NAME = "role:members"
 
-class FixDeletedUserEmail(MigrationsTestCase):
-    migrate_from = "0804_backfill_user_created_audit_logs"
-    migrate_to = "0805_fix_deleteduser_email"
+
+class BackfillBotFullMemberStatusFromOwner(MigrationsTestCase):
+    migrate_from = "0807_usertopic_zerver_usertopic_user_visibility_recipient_idx"
+    migrate_to = "0808_backfill_bot_full_member_status_from_owner"
 
     @override
     def setUpBeforeMigration(self, apps: StateApps) -> None:
+        Realm = apps.get_model("zerver", "Realm")
         UserProfile = apps.get_model("zerver", "UserProfile")
+        NamedUserGroup = apps.get_model("zerver", "NamedUserGroup")
+        UserGroupMembership = apps.get_model("zerver", "UserGroupMembership")
 
-        # Simulate a user deleted before the fix in 208c0c303405,
-        # after 0439_fix_deleteduser_email repaired delivery_email.
-        deleted_user = self.example_user("hamlet")
-        UserProfile.objects.filter(id=deleted_user.id).update(
-            is_active=False,
-            email=f"deleteduser{deleted_user.id}@https://zulip.testserver",
-            delivery_email=f"deleteduser{deleted_user.id}@zulip.testserver",
+        realm = Realm.objects.get(string_id="zulip")
+        realm.waiting_period_threshold = 10
+        realm.save(update_fields=["waiting_period_threshold"])
+
+        full_members_group = NamedUserGroup.objects.get(
+            name=FULL_MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
         )
-        self.deleted_user_id = deleted_user.id
+        members_group = NamedUserGroup.objects.get(
+            name=MEMBERS_GROUP_NAME, realm_id=realm.id, is_system_group=True
+        )
 
-        # A normal active user, as a control.
-        control_user = self.example_user("cordelia")
-        self.control_user_id = control_user.id
-        self.control_user_email = control_user.email
+        # Stale full member: a member-role bot left in FULL_MEMBERS under the
+        # old rule, but whose owner is a guest -- must be removed.
+        guest = UserProfile.objects.get(delivery_email="polonius@zulip.com", realm_id=realm.id)
+        self.assertEqual(guest.role, ROLE_GUEST)
+        self.guest_owned_bot = UserProfile.objects.get(
+            delivery_email="default-bot@zulip.com", realm_id=realm.id
+        )
+        self.guest_owned_bot.bot_owner_id = guest.id
+        self.guest_owned_bot.save(update_fields=["bot_owner"])
+        UserGroupMembership.objects.get_or_create(
+            user_profile_id=self.guest_owned_bot.id, user_group=full_members_group
+        )
 
-        # A deactivated user with a valid email, as a control for the
-        # is_active=False part of the migration's filter.
-        deactivated_user = self.example_user("othello")
-        UserProfile.objects.filter(id=deactivated_user.id).update(is_active=False)
-        self.deactivated_user_id = deactivated_user.id
-        self.deactivated_user_email = deactivated_user.email
+        # Missing full member: a member-role bot whose owner is a member past
+        # the waiting period, but which was never added to FULL_MEMBERS -- must
+        # be added.
+        member_owner = UserProfile.objects.get(delivery_email="hamlet@zulip.com", realm_id=realm.id)
+        member_owner.date_joined = timezone_now() - timedelta(days=30)
+        member_owner.save(update_fields=["date_joined"])
+        self.member_owned_bot = UserProfile.objects.get(
+            delivery_email="webhook-bot@zulip.com", realm_id=realm.id
+        )
+        self.member_owned_bot.bot_owner_id = member_owner.id
+        self.member_owned_bot.save(update_fields=["bot_owner"])
+        UserGroupMembership.objects.get_or_create(
+            user_profile_id=self.member_owned_bot.id, user_group=members_group
+        )
+        UserGroupMembership.objects.filter(
+            user_profile_id=self.member_owned_bot.id, user_group=full_members_group
+        ).delete()
 
-    def test_deleted_user_email_fixed(self) -> None:
-        UserProfile = self.apps.get_model("zerver", "UserProfile")
+    @override
+    def tearDown(self) -> None:
+        # A data migration necessarily changes the set of rows in the database
+        # (adding/removing FULL_MEMBERS memberships and audit logs), which
+        # ZulipTransactionTestCase.tearDown would flag as an unexpected side
+        # effect. Deleted rows cannot be restored to their original primary
+        # keys, so skip that check; the migration-test database is rebuilt for
+        # each run, so the reconciled rows do not leak across runs.
+        pass
 
-        deleted_user = UserProfile.objects.get(id=self.deleted_user_id)
-        self.assertEqual(deleted_user.email, f"deleteduser{deleted_user.id}@zulip.testserver")
-        self.assertEqual(deleted_user.email, deleted_user.delivery_email)
+    def test_bot_full_member_status_reconciled_with_owner(self) -> None:
+        NamedUserGroup = self.apps.get_model("zerver", "NamedUserGroup")
+        UserGroupMembership = self.apps.get_model("zerver", "UserGroupMembership")
+        RealmAuditLog = self.apps.get_model("zerver", "RealmAuditLog")
 
-        control_user = UserProfile.objects.get(id=self.control_user_id)
-        self.assertEqual(control_user.email, self.control_user_email)
+        full_members_group = NamedUserGroup.objects.get(
+            name=FULL_MEMBERS_GROUP_NAME, realm__string_id="zulip", is_system_group=True
+        )
 
-        deactivated_user = UserProfile.objects.get(id=self.deactivated_user_id)
-        self.assertEqual(deactivated_user.email, self.deactivated_user_email)
+        def in_full_members(bot_id: int) -> bool:
+            return UserGroupMembership.objects.filter(
+                user_profile_id=bot_id, user_group=full_members_group
+            ).exists()
+
+        self.assertFalse(in_full_members(self.guest_owned_bot.id))
+        self.assertTrue(in_full_members(self.member_owned_bot.id))
+
+        # Each membership change leaves a backfilled audit-log entry.
+        self.assertTrue(
+            RealmAuditLog.objects.filter(
+                modified_user_id=self.guest_owned_bot.id,
+                modified_user_group=full_members_group,
+                event_type=704,
+                backfilled=True,
+            ).exists()
+        )
+        self.assertTrue(
+            RealmAuditLog.objects.filter(
+                modified_user_id=self.member_owned_bot.id,
+                modified_user_group=full_members_group,
+                event_type=703,
+                backfilled=True,
+            ).exists()
+        )

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -4579,3 +4579,31 @@ class BotFullMemberStatusTest(ZulipTestCase):
                 user_profile=bot, user_group=full_members_group
             ).exists()
         )
+
+    def test_owner_role_change_repins_owned_bots(self) -> None:
+        realm = get_realm("zulip")
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        owner = self.example_user("hamlet")
+        self.assertEqual(owner.role, UserProfile.ROLE_MEMBER)
+        owner.date_joined = timezone_now()
+        owner.save(update_fields=["date_joined"])
+        bot = self.create_test_bot("role-change", owner)
+        self.assert_not_in_full_members(bot)
+        self.set_user_role(owner, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        self.assert_in_full_members(bot)
+
+        self.set_user_role(owner, UserProfile.ROLE_MEMBER)
+        self.assert_not_in_full_members(bot)
+
+        self.set_user_role(owner, UserProfile.ROLE_MODERATOR)
+        self.assert_in_full_members(bot)
+
+        # moderator -> guest must immediately demote the bot, even though
+        # neither role is "member" (the guest boundary). Otherwise a realm with
+        # no waiting period, and thus no cron, would leak full-member access.
+        self.set_user_role(owner, UserProfile.ROLE_GUEST)
+        self.assert_not_in_full_members(bot)
+
+        self.set_user_role(owner, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        self.assert_in_full_members(bot)

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -7,7 +7,7 @@ import time_machine
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.create_realm import do_create_realm
-from zerver.actions.create_user import do_reactivate_user
+from zerver.actions.create_user import do_create_user, do_reactivate_user
 from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_change_realm_plan_type,
@@ -4371,3 +4371,211 @@ class UserGroupAPITestCase(UserGroupTestCase):
             {"delete": orjson.dumps([other_user_group.id]).decode()},
         )
         self.assert_json_error(result, f"Invalid user group ID: {other_user_group.id}")
+
+
+class BotFullMemberStatusTest(ZulipTestCase):
+    def full_members_group(self) -> NamedUserGroup:
+        return NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS,
+            realm_for_sharding=get_realm("zulip"),
+            is_system_group=True,
+        )
+
+    def assert_in_full_members(self, user: UserProfile) -> None:
+        self.assertIn(
+            user.id,
+            get_user_group_member_ids(self.full_members_group(), direct_member_only=True),
+        )
+
+    def assert_not_in_full_members(self, user: UserProfile) -> None:
+        self.assertNotIn(
+            user.id,
+            get_user_group_member_ids(self.full_members_group(), direct_member_only=True),
+        )
+
+    def test_determine_is_provisional_member(self) -> None:
+        recent = timezone_now()
+        old = timezone_now() - timedelta(days=30)
+        threshold = 10
+
+        # Non-bot users (bot_owner_role=None) keep the historical behavior.
+        self.assertTrue(
+            UserProfile.determine_is_provisional_member(
+                role=UserProfile.ROLE_MEMBER,
+                date_joined=recent,
+                waiting_period_threshold=threshold,
+                bot_owner_role=None,
+                bot_owner_date_joined=None,
+            )
+        )
+        self.assertFalse(
+            UserProfile.determine_is_provisional_member(
+                role=UserProfile.ROLE_MEMBER,
+                date_joined=old,
+                waiting_period_threshold=threshold,
+                bot_owner_role=None,
+                bot_owner_date_joined=None,
+            )
+        )
+        for role in (
+            UserProfile.ROLE_MODERATOR,
+            UserProfile.ROLE_REALM_ADMINISTRATOR,
+            UserProfile.ROLE_REALM_OWNER,
+        ):
+            self.assertFalse(
+                UserProfile.determine_is_provisional_member(
+                    role=role,
+                    date_joined=recent,
+                    waiting_period_threshold=threshold,
+                    bot_owner_role=None,
+                    bot_owner_date_joined=None,
+                )
+            )
+
+        # A member-role bot is pinned to its owner. A guest owner makes the bot
+        # a new member even if the owner's account is old, since the bot must
+        # never be able to do things its guest owner cannot.
+        self.assertTrue(
+            UserProfile.determine_is_provisional_member(
+                role=UserProfile.ROLE_MEMBER,
+                date_joined=old,
+                waiting_period_threshold=threshold,
+                bot_owner_role=UserProfile.ROLE_GUEST,
+                bot_owner_date_joined=old,
+            )
+        )
+        for owner_role in (
+            UserProfile.ROLE_MODERATOR,
+            UserProfile.ROLE_REALM_ADMINISTRATOR,
+            UserProfile.ROLE_REALM_OWNER,
+        ):
+            self.assertFalse(
+                UserProfile.determine_is_provisional_member(
+                    role=UserProfile.ROLE_MEMBER,
+                    date_joined=recent,
+                    waiting_period_threshold=threshold,
+                    bot_owner_role=owner_role,
+                    bot_owner_date_joined=recent,
+                )
+            )
+        # A member owner makes the bot mirror the owner's own aging; the bot's
+        # own date_joined is irrelevant.
+        self.assertTrue(
+            UserProfile.determine_is_provisional_member(
+                role=UserProfile.ROLE_MEMBER,
+                date_joined=old,
+                waiting_period_threshold=threshold,
+                bot_owner_role=UserProfile.ROLE_MEMBER,
+                bot_owner_date_joined=recent,
+            )
+        )
+        self.assertFalse(
+            UserProfile.determine_is_provisional_member(
+                role=UserProfile.ROLE_MEMBER,
+                date_joined=recent,
+                waiting_period_threshold=threshold,
+                bot_owner_role=UserProfile.ROLE_MEMBER,
+                bot_owner_date_joined=old,
+            )
+        )
+
+    def test_bot_full_member_status_follows_owner_on_creation(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = self.full_members_group()
+        do_change_realm_permission_group_setting(
+            realm, "can_add_subscribers_group", full_members_group, acting_user=None
+        )
+
+        provisional_owner = self.example_user("hamlet")
+        provisional_owner.date_joined = timezone_now()
+        provisional_owner.save(update_fields=["date_joined"])
+
+        full_owner = self.example_user("othello")
+        full_owner.date_joined = timezone_now() - timedelta(days=11)
+        full_owner.save(update_fields=["date_joined"])
+
+        # Setting the threshold recomputes existing members using the dates above.
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+        self.assert_not_in_full_members(provisional_owner)
+        self.assert_in_full_members(full_owner)
+
+        new_member_bot = self.create_test_bot(
+            "provisional-owner", provisional_owner, full_name="Provisional Owner Bot"
+        )
+        self.assert_not_in_full_members(new_member_bot)
+        self.assertFalse(new_member_bot.has_permission("can_add_subscribers_group"))
+
+        full_member_bot = self.create_test_bot("full-owner", full_owner, full_name="Full Owner Bot")
+        self.assert_in_full_members(full_member_bot)
+        self.assertTrue(full_member_bot.has_permission("can_add_subscribers_group"))
+
+        admin_bot = self.create_test_bot(
+            "admin-owner", self.example_user("iago"), full_name="Admin Owner Bot"
+        )
+        self.assert_in_full_members(admin_bot)
+        self.assertTrue(admin_bot.has_permission("can_add_subscribers_group"))
+
+        # Guests cannot create bots via the API, so create one with a guest
+        # owner directly.
+        guest_owner = self.example_user("polonius")
+        self.assertEqual(guest_owner.role, UserProfile.ROLE_GUEST)
+        guest_bot = do_create_user(
+            "guest-owned-bot@zulip.testserver",
+            None,
+            realm,
+            "Guest Owned Bot",
+            bot_type=UserProfile.DEFAULT_BOT,
+            bot_owner=guest_owner,
+            acting_user=guest_owner,
+        )
+        self.assert_not_in_full_members(guest_bot)
+        self.assertFalse(guest_bot.has_permission("can_add_subscribers_group"))
+
+    def test_promote_new_full_members_promotes_owned_bots(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = self.full_members_group()
+
+        owner = self.example_user("cordelia")
+        owner.date_joined = timezone_now() - timedelta(days=8)
+        owner.save(update_fields=["date_joined"])
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        # The owner is still within the waiting period, so its freshly created
+        # bot is a new member too -- excluded based on the owner's age, not the
+        # bot's own (the bot was just created).
+        bot = self.create_test_bot("aging-owner", owner)
+        member_ids = get_user_group_member_ids(full_members_group, direct_member_only=True)
+        self.assertNotIn(owner.id, member_ids)
+        self.assertNotIn(bot.id, member_ids)
+
+        # Once the owner ages past the threshold, the cron promotes both the
+        # owner and its bot in the same pass.
+        with time_machine.travel(timezone_now() + timedelta(days=3), tick=False):
+            promote_new_full_members()
+
+        member_ids = get_user_group_member_ids(full_members_group, direct_member_only=True)
+        self.assertIn(owner.id, member_ids)
+        self.assertIn(bot.id, member_ids)
+
+    def test_promote_new_full_members_handles_deactivated_owned_bot(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = self.full_members_group()
+
+        owner = self.example_user("hamlet")
+        owner.date_joined = timezone_now() - timedelta(days=30)
+        owner.save(update_fields=["date_joined"])
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        bot = self.create_test_bot("deactivated-owned", owner)
+        self.assert_in_full_members(bot)
+
+        # Deactivation leaves the FULL_MEMBERS membership row in place, and the
+        # cron's full scan is not filtered by is_active, so it revisits the bot.
+        # The owner-aware lookup must not crash on the deactivated bot.
+        do_deactivate_user(bot, acting_user=None)
+        promote_new_full_members()
+        self.assertTrue(
+            UserGroupMembership.objects.filter(
+                user_profile=bot, user_group=full_members_group
+            ).exists()
+        )

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -4566,3 +4566,57 @@ class BotFullMemberStatusTest(ZulipTestCase):
                 user_profile=bot, user_group=full_members_group
             ).exists()
         )
+
+    def test_owner_role_change_repins_owned_bots(self) -> None:
+        realm = get_realm("zulip")
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        owner = self.example_user("hamlet")
+        self.assertEqual(owner.role, UserProfile.ROLE_MEMBER)
+        owner.date_joined = timezone_now()
+        owner.save(update_fields=["date_joined"])
+        bot = self.create_test_bot("role-change", owner)
+        self.assert_not_in_full_members(bot)
+        self.set_user_role(owner, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        self.assert_in_full_members(bot)
+
+        self.set_user_role(owner, UserProfile.ROLE_MEMBER)
+        self.assert_not_in_full_members(bot)
+
+        self.set_user_role(owner, UserProfile.ROLE_MODERATOR)
+        self.assert_in_full_members(bot)
+
+        self.set_user_role(owner, UserProfile.ROLE_GUEST)
+        self.assert_not_in_full_members(bot)
+
+        self.set_user_role(owner, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        self.assert_in_full_members(bot)
+
+    def assert_full_members_row(self, user: UserProfile, expected: bool) -> None:
+        self.assertEqual(
+            UserGroupMembership.objects.filter(
+                user_profile=user, user_group=self.full_members_group()
+            ).exists(),
+            expected,
+        )
+
+    def test_owner_role_change_repins_deactivated_bots(self) -> None:
+        realm = get_realm("zulip")
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        owner = self.example_user("hamlet")
+        owner.date_joined = timezone_now()
+        owner.save(update_fields=["date_joined"])
+        bot = self.create_test_bot("deactivated-role-change", owner)
+        self.assert_not_in_full_members(bot)
+
+        do_deactivate_user(bot, acting_user=None)
+        self.set_user_role(owner, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        self.assert_full_members_row(bot, True)
+
+        self.set_user_role(owner, UserProfile.ROLE_GUEST)
+        self.assert_full_members_row(bot, False)
+
+        self.set_user_role(owner, UserProfile.ROLE_MODERATOR)
+        do_reactivate_user(bot, acting_user=None)
+        self.assert_in_full_members(bot)

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -7,7 +7,7 @@ import time_machine
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.create_realm import do_create_realm
-from zerver.actions.create_user import do_reactivate_user
+from zerver.actions.create_user import do_create_user, do_reactivate_user
 from zerver.actions.realm_settings import (
     do_change_realm_permission_group_setting,
     do_change_realm_plan_type,
@@ -70,6 +70,7 @@ from zerver.models import (
 )
 from zerver.models.groups import SystemGroups, get_realm_system_groups_name_dict
 from zerver.models.realms import get_realm
+from zerver.models.users import compute_is_provisional_member, user_is_provisional_member
 
 
 class UserGroupTestCase(ZulipTestCase):
@@ -4371,3 +4372,197 @@ class UserGroupAPITestCase(UserGroupTestCase):
             {"delete": orjson.dumps([other_user_group.id]).decode()},
         )
         self.assert_json_error(result, f"Invalid user group ID: {other_user_group.id}")
+
+
+class BotFullMemberStatusTest(ZulipTestCase):
+    def full_members_group(self) -> NamedUserGroup:
+        return NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS,
+            realm_for_sharding=get_realm("zulip"),
+            is_system_group=True,
+        )
+
+    def assert_in_full_members(self, user: UserProfile) -> None:
+        self.assertIn(
+            user.id,
+            get_user_group_member_ids(self.full_members_group(), direct_member_only=True),
+        )
+
+    def assert_not_in_full_members(self, user: UserProfile) -> None:
+        self.assertNotIn(
+            user.id,
+            get_user_group_member_ids(self.full_members_group(), direct_member_only=True),
+        )
+
+    def test_compute_is_provisional_member(self) -> None:
+        realm = get_realm("zulip")
+        realm.waiting_period_threshold = 10
+        recent = timezone_now()
+        old = timezone_now() - timedelta(days=30)
+        self.assertTrue(compute_is_provisional_member(realm, UserProfile.ROLE_MEMBER, recent))
+        self.assertFalse(compute_is_provisional_member(realm, UserProfile.ROLE_MEMBER, old))
+        for role in (
+            UserProfile.ROLE_MODERATOR,
+            UserProfile.ROLE_REALM_ADMINISTRATOR,
+            UserProfile.ROLE_REALM_OWNER,
+        ):
+            self.assertFalse(compute_is_provisional_member(realm, role, recent))
+
+        self.assertTrue(compute_is_provisional_member(realm, UserProfile.ROLE_GUEST, old))
+
+    def test_user_is_provisional_member_follows_bot_owner(self) -> None:
+        realm = get_realm("zulip")
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+        system_groups_name_dict = get_realm_system_groups_name_dict(realm.id)
+        full_members_group = self.full_members_group()
+
+        provisional_owner = self.example_user("hamlet")
+        provisional_owner.date_joined = timezone_now()
+        provisional_owner.save(update_fields=["date_joined"])
+
+        full_owner = self.example_user("othello")
+        full_owner.date_joined = timezone_now() - timedelta(days=11)
+        full_owner.save(update_fields=["date_joined"])
+
+        guest_owner = self.example_user("polonius")
+        self.assertEqual(guest_owner.role, UserProfile.ROLE_GUEST)
+
+        # Each bot is created now, so each has a recent date_joined of its own;
+        # only the owner's should count.
+        new_member_bot = self.create_test_bot(
+            "new-owner", provisional_owner, full_name="New Owner Bot"
+        )
+        full_member_bot = self.create_test_bot("full-owner", full_owner, full_name="Full Owner Bot")
+        guest_bot = do_create_user(
+            "guest-owned-bot@zulip.testserver",
+            None,
+            realm,
+            "Guest Owned Bot",
+            bot_type=UserProfile.DEFAULT_BOT,
+            bot_owner=guest_owner,
+            acting_user=guest_owner,
+        )
+
+        self.assertTrue(user_is_provisional_member(new_member_bot))
+        self.assertFalse(user_is_provisional_member(full_member_bot))
+        self.assertTrue(user_is_provisional_member(guest_bot))
+
+        # check_user_has_permission_by_role decides full-member status from the
+        # role and date_joined rather than from group membership, so it has to
+        # resolve a bot to its owner separately.
+        self.assertFalse(
+            check_user_has_permission_by_role(
+                new_member_bot, full_members_group.id, system_groups_name_dict
+            )
+        )
+        self.assertTrue(
+            check_user_has_permission_by_role(
+                full_member_bot, full_members_group.id, system_groups_name_dict
+            )
+        )
+        self.assertFalse(
+            check_user_has_permission_by_role(
+                guest_bot, full_members_group.id, system_groups_name_dict
+            )
+        )
+
+    def test_bot_full_member_status_follows_owner_on_creation(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = self.full_members_group()
+        do_change_realm_permission_group_setting(
+            realm, "can_add_subscribers_group", full_members_group, acting_user=None
+        )
+
+        provisional_owner = self.example_user("hamlet")
+        provisional_owner.date_joined = timezone_now()
+        provisional_owner.save(update_fields=["date_joined"])
+
+        full_owner = self.example_user("othello")
+        full_owner.date_joined = timezone_now() - timedelta(days=11)
+        full_owner.save(update_fields=["date_joined"])
+
+        # Setting the threshold recomputes existing members using the dates above.
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+        self.assert_not_in_full_members(provisional_owner)
+        self.assert_in_full_members(full_owner)
+
+        new_member_bot = self.create_test_bot(
+            "provisional-owner", provisional_owner, full_name="Provisional Owner Bot"
+        )
+        self.assert_not_in_full_members(new_member_bot)
+        self.assertFalse(new_member_bot.has_permission("can_add_subscribers_group"))
+
+        full_member_bot = self.create_test_bot("full-owner", full_owner, full_name="Full Owner Bot")
+        self.assert_in_full_members(full_member_bot)
+        self.assertTrue(full_member_bot.has_permission("can_add_subscribers_group"))
+
+        admin_bot = self.create_test_bot(
+            "admin-owner", self.example_user("iago"), full_name="Admin Owner Bot"
+        )
+        self.assert_in_full_members(admin_bot)
+        self.assertTrue(admin_bot.has_permission("can_add_subscribers_group"))
+
+        # Guests cannot create bots via the API, so create one with a guest
+        # owner directly.
+        guest_owner = self.example_user("polonius")
+        self.assertEqual(guest_owner.role, UserProfile.ROLE_GUEST)
+        guest_bot = do_create_user(
+            "guest-owned-bot@zulip.testserver",
+            None,
+            realm,
+            "Guest Owned Bot",
+            bot_type=UserProfile.DEFAULT_BOT,
+            bot_owner=guest_owner,
+            acting_user=guest_owner,
+        )
+        self.assert_not_in_full_members(guest_bot)
+        self.assertFalse(guest_bot.has_permission("can_add_subscribers_group"))
+
+    def test_promote_new_full_members_promotes_owned_bots(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = self.full_members_group()
+
+        owner = self.example_user("cordelia")
+        owner.date_joined = timezone_now() - timedelta(days=8)
+        owner.save(update_fields=["date_joined"])
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        # The owner is still within the waiting period, so its freshly created
+        # bot is a new member too -- excluded based on the owner's age, not the
+        # bot's own (the bot was just created).
+        bot = self.create_test_bot("aging-owner", owner)
+        member_ids = get_user_group_member_ids(full_members_group, direct_member_only=True)
+        self.assertNotIn(owner.id, member_ids)
+        self.assertNotIn(bot.id, member_ids)
+
+        # Once the owner ages past the threshold, the cron promotes both the
+        # owner and its bot in the same pass.
+        with time_machine.travel(timezone_now() + timedelta(days=3), tick=False):
+            promote_new_full_members()
+
+        member_ids = get_user_group_member_ids(full_members_group, direct_member_only=True)
+        self.assertIn(owner.id, member_ids)
+        self.assertIn(bot.id, member_ids)
+
+    def test_promote_new_full_members_handles_deactivated_owned_bot(self) -> None:
+        realm = get_realm("zulip")
+        full_members_group = self.full_members_group()
+
+        owner = self.example_user("hamlet")
+        owner.date_joined = timezone_now() - timedelta(days=30)
+        owner.save(update_fields=["date_joined"])
+        do_set_realm_property(realm, "waiting_period_threshold", 10, acting_user=None)
+
+        bot = self.create_test_bot("deactivated-owned", owner)
+        self.assert_in_full_members(bot)
+
+        # Deactivation leaves the FULL_MEMBERS membership row in place, and the
+        # cron's full scan is not filtered by is_active, so it revisits the bot.
+        # The owner-aware lookup must not crash on the deactivated bot.
+        do_deactivate_user(bot, acting_user=None)
+        promote_new_full_members()
+        self.assertTrue(
+            UserGroupMembership.objects.filter(
+                user_profile=bot, user_group=full_members_group
+            ).exists()
+        )


### PR DESCRIPTION
In organizations with a [waiting period](https://zulip.com/help/restrict-permissions-of-new-members), member-role accounts only gain full-member permissions once they are past the threshold.
Previously a bot's full-member status was computed from the bot's *own* `date_joined`, which led to :

- A bot (past the threshold) **transferred** to a still-provisional member, or a guest, kept full-member powers its owner does not.
- An owner **demoted to guest** left their full-member bot with Full member permission.
- **Reactivating** a bot whose owner was deactivated reassigns it to the acting user, but the stale full-member row survived the handoff.

It also restricted a bot created by a full member (or admin/moderator) as they had to sit out the whole waiting period before gaining permissions.


This PR makes a **member-role bot's full-member status follow its owner**

The status is decided as membership in the `role:fullmembers` system group, so the work is keeping that membership in sync at every point the answer can change:

- Adds a helper `determine_is_provisional_member` which determines the status
- **Owner role change** , **Owner change** ,**Reactivation** is recomputes owner and owner role on following events.
Fixes: #32468



# How this was tested


Verified bot's owner-derived status change. Full-member status observed  by querying `role:fullmembers` direct membership via `manage.py shell`.
 Manual / end-to-end verification on the following cases:
- **Creation** : with a 2-day waiting period, created user `Newbie` (a new member) and a generic bot owned by them. Bot was a provisional member.
-  **Owner role change**  promoting the owner to admin/moderator immediately moved the bot **into** `Full members` and on demoting to guest or a provisional member immediately moved it out .
-  **Ownership transfer** : transferring the bot between owners of different status re-pinned it to the new owner every time.
-  **Reactivation onto a reassigned owner** : deactivated Newbie , then reactivated the bot as an owner. The bot was reassigned to the owner and **promoted into `Full members`** in the same action. Reactivating newbie afterward correctly did **not** reclaim the bot.

-  **Time-based cron promotion** : backdated Newbie's `date_joined` past the 2-day threshold and ran `./manage.py promote_new_full_members`. In that single  pass **both** Newbie and their bot gained `Full members` membership, with no bot-specific action:



**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x]  Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>




