### PR TITLE
compose_reply: Update stale mentions when quoting.

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -357,6 +357,42 @@ function generate_sender_mention(sent_message: Message): string {
     return `@_**${sent_message.sender_full_name}|${sent_message.sender_id}**`;
 }
 
+// When quoting a message that contains `@**Old Name|ID**` or `@_**Old Name|ID**`
+// syntax, the name part may be outdated (if the user changed their display name).
+// The backend Markdown parser enforces that the name must exactly match the current
+// full_name for the given ID, so stale names cause the mention to render as broken
+// raw text. This function rewrites any such mentions in the raw markdown to use
+// the current full name for the given ID, so they parse correctly when sent.
+//
+// See: https://github.com/zulip/zulip/issues/26281
+export function update_mentions_in_quote(content: string): string {
+    // Matches both `@**name|id**` and `@_**name|id**` forms.
+    // The name group is optional to also handle `@**|id**` (ID-only) forms,
+    // which are already valid and do not need updating.
+    return content.replaceAll(
+        /@(?<silent>_)?\*\*(?<name>[^*|]+)?\|(?<user_id>\d+)\*\*/g,
+        (match, silent, name, user_id_str) => {
+            if (name === undefined) {
+                // `@**|id**` or `@_**|id**` form — already valid, leave as-is.
+                return match;
+            }
+            const user_id = Number.parseInt(String(user_id_str), 10);
+            const person = people.maybe_get_user_by_id(user_id, true);
+            if (person === undefined) {
+                // Unknown user — leave as-is.
+                return match;
+            }
+            if (person.full_name === name) {
+                // Name is current — no change needed.
+                return match;
+            }
+            // Update the name to the current full_name.
+            const silent_prefix = silent === "_" ? "_" : "";
+            return `@${silent_prefix}**${person.full_name}|${user_id_str}**`;
+        },
+    );
+}
+
 function generate_sender_only_quote_context(message: Message): string {
     const sender_mention = generate_sender_mention(message);
     // Final message looks like:
@@ -501,8 +537,9 @@ function generate_replace_content(info: ReplaceContentOpts): string {
             break;
     }
 
-    const fence = fenced_code.get_unused_fence(raw_markdown);
-    content += `${fence}quote\n${raw_markdown}\n${fence}`;
+    const updated_markdown = update_mentions_in_quote(raw_markdown);
+    const fence = fenced_code.get_unused_fence(updated_markdown);
+    content += `${fence}quote\n${updated_markdown}\n${fence}`;
     return content;
 }
 

--- a/web/tests/compose_reply.test.cjs
+++ b/web/tests/compose_reply.test.cjs
@@ -7,6 +7,7 @@ const {run_test} = require("./lib/test.cjs");
 
 const compose_reply = zrequire("compose_reply");
 const message_store = zrequire("message_store");
+const people = zrequire("people");
 const message_fetch_raw_content = mock_esm("../src/message_fetch_raw_content");
 const compose_paste = mock_esm("../src/compose_paste");
 const message_lists = mock_esm("../src/message_lists");
@@ -388,5 +389,63 @@ run_test("build_and_process_quote_assets_for_messages", ({override}) => {
         result_assets[1],
         {message: msg_unhydrated, quote_content: "converted_by_turndown: <p>unhydrated</p>"},
         "Fallback to using paste_handler_converter",
+    );
+});
+
+run_test("update_mentions_in_quote", () => {
+    // Set up a user with the current full name "New Name" and ID 42.
+    const user = {
+        user_id: 42,
+        full_name: "New Name",
+        email: "newname@example.com",
+    };
+    people.add_active_user(user);
+
+    // Case 1: Name is already current — no change expected.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("Hello @**New Name|42**!"),
+        "Hello @**New Name|42**!",
+    );
+
+    // Case 2: Stale name (user changed name) — should be updated to the current name.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("Hello @**Old Name|42**!"),
+        "Hello @**New Name|42**!",
+    );
+
+    // Case 3: Silent mention (@_**...**) with stale name — should also be updated.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("@_**Old Name|42** said something."),
+        "@_**New Name|42** said something.",
+    );
+
+    // Case 4: Silent mention (@_**...**) with current name — no change.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("@_**New Name|42** said something."),
+        "@_**New Name|42** said something.",
+    );
+
+    // Case 5: ID-only form (@**|id**) — no name to update, leave as-is.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("Mention @**|42** via ID only."),
+        "Mention @**|42** via ID only.",
+    );
+
+    // Case 6: Silent ID-only form (@_**|id**) — leave as-is.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("Mention @_**|42** via ID only."),
+        "Mention @_**|42** via ID only.",
+    );
+
+    // Case 7: Unknown user ID — leave as-is.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("Unknown @**Ghost User|9999**."),
+        "Unknown @**Ghost User|9999**.",
+    );
+
+    // Case 8: Multiple mentions in one string — all stale names updated.
+    assert.equal(
+        compose_reply.update_mentions_in_quote("@_**Old Name|42** said: @**Old Name|42** replied."),
+        "@_**New Name|42** said: @**New Name|42** replied.",
     );
 });


### PR DESCRIPTION
Fixes #26281.

<!-- Describe your pull request here.-->
When a user changes their display name, old messages retain their previous name in the `@**Old Name|ID**` syntax. When another user uses "Quote and reply" on such a message, the raw markdown is copied exactly. Because the Zulip backend parser deliberately enforces that the name must match the user's current `full_name`, the mention fails to parse and renders as broken raw text.

This PR fixes the issue by updating `web/src/compose_reply.ts`. When generating a quote, the raw markdown is scanned using a new helper `update_mentions_in_quote`, which rewrites any outdated names in `@**Name|ID**` or `@_**Name|ID**` mentions with the user's *current* name before inserting it into the compose box.



**How changes were tested:**
Added a new test block to `web/tests/compose_reply.test.cjs` covering 8 edge cases for `update_mentions_in_quote`:
- Current names (unchanged)
- Stale names (updated)
- Silent mentions with stale names (updated)
- ID-only forms like `@**|123**` (unchanged)
- Unknown users (unchanged)

Successfully ran the full JS test suite via `node web/tests/lib/index.cjs web/tests/compose_reply.test.cjs`.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
N/A (No visual UI changes, just backend compose box text generation behavior).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
