### PR TITLE
webhooks: Add GitLab Work Item Hook support.

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/work_item_hook__epic_updated.json
+++ b/zerver/webhooks/gitlab/fixtures/work_item_hook__epic_updated.json
@@ -1,0 +1,54 @@
+{
+   "object_kind":"work_item",
+   "user":{
+      "name":"Tomasz Kolek",
+      "username":"tomaszkolek0",
+      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
+   },
+   "project":{
+      "name":"my-awesome-project",
+      "description":"",
+      "web_url":"https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "avatar_url":null,
+      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
+      "namespace":"tomaszkolek0",
+      "visibility_level":0,
+      "path_with_namespace":"tomaszkolek0/my-awesome-project",
+      "default_branch":"master",
+      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git"
+   },
+   "object_attributes":{
+      "id":2788274,
+      "title":"Epic title",
+      "assignee_id":670043,
+      "author_id":670043,
+      "project_id":1534233,
+      "created_at":"2016-08-18 17:47:36 UTC",
+      "updated_at":"2016-08-18 17:47:36 UTC",
+      "position":0,
+      "branch_name":null,
+      "description":"Epic description",
+      "milestone_id":null,
+      "state":"opened",
+      "iid":1,
+      "updated_by_id":null,
+      "weight":3,
+      "confidential":false,
+      "moved_to_id":null,
+      "deleted_at":null,
+      "due_date":"2016-08-01",
+      "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1",
+      "action":"update",
+      "type":"Epic"
+   },
+   "repository":{
+      "name":"my-awesome-project",
+      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "description":"",
+      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project"
+   }
+}

--- a/zerver/webhooks/gitlab/fixtures/work_item_hook__task_created.json
+++ b/zerver/webhooks/gitlab/fixtures/work_item_hook__task_created.json
@@ -1,0 +1,54 @@
+{
+   "object_kind":"work_item",
+   "user":{
+      "name":"Tomasz Kolek",
+      "username":"tomaszkolek0",
+      "avatar_url":"https://secure.gravatar.com/avatar/116a6fdbcfd00466297a39174da11fbb?s=80\u0026d=identicon"
+   },
+   "project":{
+      "name":"my-awesome-project",
+      "description":"",
+      "web_url":"https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "avatar_url":null,
+      "git_ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "git_http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git",
+      "namespace":"tomaszkolek0",
+      "visibility_level":0,
+      "path_with_namespace":"tomaszkolek0/my-awesome-project",
+      "default_branch":"master",
+      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project",
+      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "ssh_url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "http_url":"https://gitlab.com/tomaszkolek0/my-awesome-project.git"
+   },
+   "object_attributes":{
+      "id":2788274,
+      "title":"Task title",
+      "assignee_id":670043,
+      "author_id":670043,
+      "project_id":1534233,
+      "created_at":"2016-08-18 17:47:36 UTC",
+      "updated_at":"2016-08-18 17:47:36 UTC",
+      "position":0,
+      "branch_name":null,
+      "description":"Task description",
+      "milestone_id":null,
+      "state":"opened",
+      "iid":1,
+      "updated_by_id":null,
+      "weight":3,
+      "confidential":false,
+      "moved_to_id":null,
+      "deleted_at":null,
+      "due_date":"2016-08-01",
+      "url":"https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1",
+      "action":"open",
+      "type":"Task"
+   },
+   "repository":{
+      "name":"my-awesome-project",
+      "url":"git@gitlab.com:tomaszkolek0/my-awesome-project.git",
+      "description":"",
+      "homepage":"https://gitlab.com/tomaszkolek0/my-awesome-project"
+   }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -90,6 +90,34 @@ class GitlabHookTests(WebhookTestCase):
 
         self.check_webhook("tag_push_hook__remove_tag", expected_topic_name, expected_message)
 
+    def test_create_task_work_item_event_message(self) -> None:
+        expected_topic_name = "my-awesome-project / task #1 Task title"
+        expected_message = (
+            "Tomasz Kolek created [task #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1):\n\n"
+            "``` quote\nTask description\n```"
+        )
+
+        self.check_webhook(
+            "work_item_hook__task_created",
+            expected_topic_name,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Work Item Hook",
+        )
+
+    def test_update_epic_work_item_event_message(self) -> None:
+        expected_topic_name = "my-awesome-project / epic #1 Epic title"
+        expected_message = (
+            "Tomasz Kolek updated [epic #1]"
+            "(https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)."
+        )
+
+        self.check_webhook(
+            "work_item_hook__epic_updated",
+            expected_topic_name,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Work Item Hook",
+        )
+
     def test_create_issue_without_assignee_event_message(self) -> None:
         expected_topic_name = "my-awesome-project / issue #1 Issue title"
         expected_message = "Tomasz Kolek created [issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1):\n\n``` quote\nIssue description\n```"

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -140,6 +140,42 @@ def get_issue_event_body(action: str, payload: WildValue, include_title: bool, r
     )
 
 
+def get_work_item_created_event_body(payload: WildValue, include_title: bool, realm: Realm) -> str:
+    description = payload["object_attributes"].get("description")
+    if description:
+        stringified_description = description.tame(check_string)
+        stringified_description = re.sub(
+            r"<!--.*?-->", "", stringified_description, count=0, flags=re.DOTALL
+        )
+        stringified_description = stringified_description.rstrip()
+    else:
+        stringified_description = None
+
+    return get_pull_request_event_message(
+        user_name=get_user_name(payload, realm),
+        action="created",
+        url=get_object_url(payload),
+        number=payload["object_attributes"]["iid"].tame(check_int),
+        message=stringified_description,
+        assignees=replace_assignees_username_with_name(get_assignees(payload)),
+        title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
+        type=payload["object_attributes"]["type"].tame(check_string).lower(),
+    )
+
+
+def get_work_item_event_body(
+    action: str, payload: WildValue, include_title: bool, realm: Realm
+) -> str:
+    return get_pull_request_event_message(
+        user_name=get_user_name(payload, realm),
+        action=action,
+        url=get_object_url(payload),
+        number=payload["object_attributes"]["iid"].tame(check_int),
+        title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
+        type=payload["object_attributes"]["type"].tame(check_string).lower(),
+    )
+
+
 def get_merge_request_updated_event_body(
     payload: WildValue, include_title: bool, realm: Realm
 ) -> str:
@@ -683,6 +719,8 @@ EVENT_FUNCTION_MAPPER: dict[str, EventFunction] = {
     "Issue Hook close": partial(get_issue_event_body, "closed"),
     "Issue Hook reopen": partial(get_issue_event_body, "reopened"),
     "Issue Hook update": partial(get_issue_event_body, "updated"),
+    "Work Item Hook open": get_work_item_created_event_body,
+    "Work Item Hook update": partial(get_work_item_event_body, "updated"),
     "Confidential Issue Hook open": get_issue_created_event_body,
     "Confidential Issue Hook close": partial(get_issue_event_body, "closed"),
     "Confidential Issue Hook reopen": partial(get_issue_event_body, "reopened"),
@@ -797,6 +835,13 @@ def get_topic_based_on_event(event: str, payload: WildValue, use_merge_request_t
             id=payload["object_attributes"]["iid"].tame(check_int),
             title=payload["object_attributes"]["title"].tame(check_string),
         )
+    elif event.startswith("Work Item Hook"):
+        return TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
+            repo=get_repo_name(payload),
+            type=payload["object_attributes"]["type"].tame(check_string).lower(),
+            id=payload["object_attributes"]["iid"].tame(check_int),
+            title=payload["object_attributes"]["title"].tame(check_string),
+        )
     elif event in ("Note Hook Issue", "Confidential Note Hook Issue"):
         return TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
             repo=get_repo_name(payload),
@@ -874,7 +919,13 @@ def get_event(request: HttpRequest, payload: WildValue, branches: str | None) ->
             event_name = payload["object_kind"].tame(check_string)
         event = event_name.split("__")[0].replace("_", " ").title()
         event = f"{event} Hook"
-    if event in ["Confidential Issue Hook", "Issue Hook", "Merge Request Hook", "Wiki Page Hook"]:
+    if event in [
+        "Confidential Issue Hook",
+        "Issue Hook",
+        "Merge Request Hook",
+        "Wiki Page Hook",
+        "Work Item Hook",
+    ]:
         action = payload["object_attributes"].get("action", "open").tame(check_string)
         event = f"{event} {action}"
     elif event in ["Confidential Note Hook", "Note Hook"]:


### PR DESCRIPTION
Fixes #39170.
<!-- Describe your pull request here.-->
GitLab has expanded their system to include "Work Items" like Epics and Tasks, but currently, Zulip's GitLab webhook integration ignores them because they are sent with `object_kind: "work_item"` and the `X-Gitlab-Event: Work Item Hook` header, which are missing from the `EVENT_FUNCTION_MAPPER`.

This PR updates the GitLab webhook integration to recognize and properly parse Work Item events. It adds `"Work Item Hook"` to the mapping dictionary and dynamically extracts the work item `type` (e.g., "Task", "Epic") from the payload so the message accurately reads `[User] created task #1` instead of defaulting to `issue`.



**How changes were tested:**
Added two new JSON fixtures for work items:
- `work_item_hook__task_created.json`
- `work_item_hook__epic_updated.json`

Added `test_create_task_work_item_event_message` and `test_update_epic_work_item_event_message` to `zerver/webhooks/gitlab/tests.py` to verify the routing logic and ensure the generated markdown strings are perfectly formatted for different work item types.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
N/A (Backend webhook logic only).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
