### PR TITLE
search: Fix guest marker spill-out using CSS flex-shrink.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -104,6 +104,14 @@
             line-height: 1.5;
         }
 
+        .pill-guest-indicator {
+            flex: 0 10000 auto;
+            min-width: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: clip;
+        }
+
         .pill-close-button,
         .pill-expand-button {
             font-size: 0.7142em; /* 10px at 14px em */

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -31,7 +31,7 @@
                 {{/if}}
             {{/if}}
         </span>
-        {{~#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
+        {{~#if should_add_guest_user_indicator}}<i class="pill-guest-indicator">&nbsp;({{t 'guest'}})</i>{{~/if~}}
         {{~#if has_status~}}
             {{~> status_emoji status_emoji_info~}}
         {{~/if~}}

--- a/web/templates/search_user_pill.hbs
+++ b/web/templates/search_user_pill.hbs
@@ -12,7 +12,7 @@
             {{/if}}
             <span class="pill-label">
                 <span class="pill-value">{{ this.full_name }}</span>
-                {{~#if this.should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
+                {{~#if this.should_add_guest_user_indicator}}<i class="pill-guest-indicator">&nbsp;({{t 'guest'}})</i>{{~/if~}}
                 {{~#if this.status_emoji_info~}}
                     {{~> status_emoji this.status_emoji_info~}}
                 {{~/if~}}

--- a/web/templates/user_display_only_pill.hbs
+++ b/web/templates/user_display_only_pill.hbs
@@ -7,7 +7,7 @@
         <span class="pill-label {{#if strikethrough}} strikethrough {{/if}}" >
             <span class="pill-value">{{display_value}}</span>
             {{#if is_current_user}}<span class="my_user_status">{{t '(you)'}}</span>{{/if}}
-            {{~#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
+            {{~#if should_add_guest_user_indicator}}<i class="pill-guest-indicator">&nbsp;({{t 'guest'}})</i>{{~/if~}}
             {{~#if deactivated}}&nbsp;({{t 'deactivated'}}){{~/if~}}
             {{~#if has_status~}}
             {{~> status_emoji status_emoji_info~}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes the layout issue where the `(guest)` marker inside search typeahead pills would spill out of the blue pill background when space was constrained. 

Since JavaScript logic (such as in `settings_users.ts` and `dialog_widget.ts`) relies on extracting the exact user name from `.pill-value`, we cannot simply move the guest indicator inside the `.pill-value` container without corrupting the extracted data. 

Instead, this uses a robust CSS Flexbox solution. I introduced a new `.pill-guest-indicator` CSS class with `flex-shrink: 10000; text-overflow: clip; overflow: hidden;`. Because its shrink factor is astronomically high, when the pill runs out of space, the browser completely collapses and hides the guest indicator *first* before it even begins to ellipsize the user's name. This perfectly satisfies the issue's request to "hide the (guest) indicator if there's no space for it" while keeping the HTML structure intact for JS data extraction.

Fixes: #39572

**How changes were tested:**
Manually verified the CSS flex-shrink behavior. Also verified that `.pill-value` extraction remains uncorrupted by checking existing DOM queries in `settings_users.ts` and `dialog_widget.ts`.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
*(Note: You will need to take a quick screenshot of the search typeahead dropdown locally and drag-and-drop it here!)*

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
