### PR TITLE
realm: Handle plan_type set to a paid plan without Customer.

### DIFF
--- a/zerver/lib/workplace_users.py
+++ b/zerver/lib/workplace_users.py
@@ -71,7 +71,13 @@ def realm_eligible_for_non_workplace_pricing(realm: Realm) -> bool:
     from corporate.models.plans import get_current_plan_by_realm
 
     customer_plan = get_current_plan_by_realm(realm)
-    assert customer_plan is not None
+
+    if customer_plan is None:
+        # Support staff have manually set a paid plan type for
+        # this realm, and we want them to be able to correctly
+        # configure their billing.
+        return True
+
     if customer_plan.fixed_price is not None:
         # Discounted pricing for non-workplace users is
         # currently incompatible with a fixed-price plan.
@@ -90,10 +96,13 @@ def realm_on_discounted_cloud_plan(realm: Realm) -> bool:
 
     from corporate.models.customers import get_customer_by_realm
 
-    # We can assume that an active plan will be present
-    # if realm is not on free or fully sponsored plan.
     customer = get_customer_by_realm(realm)
-    assert customer is not None
+
+    if customer is None:
+        # Support staff have manually set a paid plan type for
+        # this realm.
+        return False
+
     return customer.monthly_discounted_price > 0 or customer.annual_discounted_price > 0
 
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -3326,9 +3326,21 @@ class RealmAPITest(ZulipTestCase):
             "workplace_users_group": orjson.dumps({"new": members_group.id}).decode(),
         }
 
+        # Organizations where support staff have manually set plan_type to
+        # PLAN_TYPE_STANDARD can enable discounted billing for non-workplace
+        # users.
+        do_change_realm_plan_type(realm, Realm.PLAN_TYPE_STANDARD, acting_user=None)
+        result = self.client_patch("/json/realm", params)
+        self.assert_json_success(result)
+        realm.refresh_from_db()
+        self.assertEqual(realm.workplace_users_group_id, members_group.id)
+
+        params = {
+            "workplace_users_group": orjson.dumps({"new": moderators_group.id}).decode(),
+        }
+
         # Organizations with a fixed-price plan cannot enable discounted
         # billing for non-workplace users.
-        do_change_realm_plan_type(realm, Realm.PLAN_TYPE_STANDARD, acting_user=None)
         customer = Customer.objects.create(realm=realm, stripe_customer_id="cus_id")
         plan = CustomerPlan.objects.create(
             customer=customer,
@@ -3372,7 +3384,7 @@ class RealmAPITest(ZulipTestCase):
         result = self.client_patch("/json/realm", params)
         self.assert_json_success(result)
         realm.refresh_from_db()
-        self.assertEqual(realm.workplace_users_group_id, members_group.id)
+        self.assertEqual(realm.workplace_users_group_id, moderators_group.id)
 
     def test_changing_can_manage_all_groups(self) -> None:
         realm = get_realm("zulip")


### PR DESCRIPTION
There can be cases where `realm.plan_type` is set to one of the paid plans but there are no
`CustomerPlan` or `Customer` objects for that realm.

This happens when support staff have manually set `plan_type`. We want to allow such realms
to be able to configure two tier billing before they start paying, so this commit updates `realm_eligible_for_non_workplace_pricing` and `realm_on_discounted_cloud_plan` such that
UI is enabled for the setting.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
