### PR TITLE
search: Increase gap between pills and text in search box.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -73,7 +73,7 @@
         display: flex;
         padding: 0;
         flex-wrap: wrap;
-        gap: 0.3571em; /* 5px at 14px em, matches pill spacing in typeahead dropdown */
+        gap: 0.5714em; /* 8px at 14px em, provides more breathing space */
         align-self: center;
     }
 


### PR DESCRIPTION




<!-- Describe your pull request here.-->
Increased the CSS `gap` property for the `.search-input-and-pills` flex container from `0.3571em` (5px) to `0.5714em` (8px). 

Because the pills in the search box include a close (`x`) button on their right edge, the previous 5px gap made the plain text visually too close to the pill. This small adjustment provides the additional breathing room requested in the issue, making the spacing look much cleaner and more comparable to the visual spacing in the typeahead dropdown (which hides its close buttons).

Fixes: #38921

**How changes were tested:**
Ran the frontend linter via `tools/lint` to ensure no styling rules were violated. 
*(Note: Please review the visual changes on your local server to verify the spacing feels right across different window sizes.)*


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>