### PR TITLE
message_viewport: Fix race between animated scroll and background rer…

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1546,12 +1546,30 @@ export class MessageListView {
 
     rerender_preserving_scrolltop(discard_rendering_state = false): void {
         // old_offset is the number of pixels between the top of the
-        // viewable window and the selected message
+        // viewable window and the selected message.
         let old_offset;
         const $selected_row = this.selected_row();
         const selected_in_view = $selected_row.length > 0;
         if (selected_in_view) {
-            old_offset = $selected_row.get_offset_to_window().top;
+            // Stop any in-progress system-initiated animated scroll and
+            // get its intended final scrollTop. If no animation is running,
+            // this just returns the current scrollTop.
+            //
+            // This fixes a race condition (issue #28768) where a background
+            // re-render triggered by narrow.activate receiving new messages
+            // fires mid-animation (e.g. the compose-box open scroll). Without
+            // this, rerender_with_target_scrolltop() would restore us to the
+            // mid-animation scroll position, which looks like the top of the
+            // feed. By using the intended final position, we restore the
+            // correct scroll position after the re-render.
+            const intended_scrolltop = message_viewport.stop_and_get_intended_scrolltop();
+            const current_scrolltop = message_viewport.scrollTop();
+            // The offset of the selected row from the viewport top reflects
+            // the current (potentially mid-animation) scrollTop. Adjust it
+            // to account for how much further the animation would have
+            // scrolled, so that after re-rendering we land at the right spot.
+            const scrolltop_delta = intended_scrolltop - current_scrolltop;
+            old_offset = $selected_row.get_offset_to_window().top - scrolltop_delta;
         }
         if (discard_rendering_state) {
             // If we know that the existing render is invalid way

--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -23,6 +23,11 @@ export function register_resize_handler(handler: () => void): void {
 }
 
 let in_stoppable_autoscroll = false;
+// Tracks the intended final scrollTop of a system-initiated animated scroll.
+// Set when an animation starts, cleared when it finishes or is stopped.
+// Used by rerender_preserving_scrolltop() to restore the correct position
+// even if a background re-render fires mid-animation (issue #28768).
+let autoscroll_target_scrolltop: number | null = null;
 
 const cached_width = new util.CachedValue({compute_value: () => $scroll_container.width() ?? 0});
 const cached_height = new util.CachedValue({compute_value: () => $scroll_container.height() ?? 0});
@@ -413,7 +418,22 @@ export function scrollTop(target_scrollTop?: number): JQuery | number {
 export function stop_auto_scrolling(): void {
     if (in_stoppable_autoscroll) {
         $scroll_container.stop();
+        autoscroll_target_scrolltop = null;
     }
+}
+
+// Stops any in-progress system-initiated animated scroll and returns the
+// scroll position that the animation was heading towards. If no animation
+// is in progress, returns the current scrollTop unchanged.
+// Used by rerender_preserving_scrolltop() to correctly restore scroll
+// position after a background re-render fires mid-animation (issue #28768).
+export function stop_and_get_intended_scrolltop(): number {
+    if (in_stoppable_autoscroll && autoscroll_target_scrolltop !== null) {
+        const intended = autoscroll_target_scrolltop;
+        stop_auto_scrolling();
+        return intended;
+    }
+    return scrollTop();
 }
 
 export function system_initiated_animate_scroll(
@@ -422,13 +442,19 @@ export function system_initiated_animate_scroll(
 ): void {
     message_scroll_state.set_update_selection_on_next_scroll(update_selection_on_scroll);
     const viewport_offset = scrollTop();
+    autoscroll_target_scrolltop = viewport_offset + scroll_amount;
     in_stoppable_autoscroll = true;
-    $scroll_container.animate({
-        scrollTop: viewport_offset + scroll_amount,
-        always() {
-            in_stoppable_autoscroll = false;
+    $scroll_container.animate(
+        {
+            scrollTop: autoscroll_target_scrolltop,
         },
-    });
+        {
+            always() {
+                in_stoppable_autoscroll = false;
+                autoscroll_target_scrolltop = null;
+            },
+        },
+    );
 }
 
 export function user_initiated_animate_scroll(scroll_amount: number): void {


### PR DESCRIPTION


When `narrow.activate` fetches additional message history from the server and calls `rerender_preserving_scrolltop()` while a system-initiated animated scroll (e.g., the compose-box open scroll) is still in progress, the re-render captures the transient mid-animation `scrollTop` as the restoration target. After clearing and re-rendering the DOM, it restores this mid-point value, which causes the feed to visually jump to near the top.

Fix this by:
- Tracking the intended final `scrollTop` of any system-initiated animated scroll in a new module-level variable `autoscroll_target_scrolltop` in `message_viewport.ts`.
- Exporting a new `stop_and_get_intended_scrolltop()` helper that stops the animation and returns the position it was heading towards.
- Updating `rerender_preserving_scrolltop()` in `message_list_view.ts` to call `stop_and_get_intended_scrolltop()` and adjust `old_offset` by the remaining animation delta, so that after re-rendering the scroll position is restored to where the animation intended to land.



Fixes: #28768

**How changes were tested:**

This bug involves a race condition that requires artificially slowing things down to reproduce reliably. To verify:
1. In `system_initiated_animate_scroll()`, temporarily increase the animation duration to ~10 seconds.
2. Open a topic/DM conversation (triggering `narrow.activate` and its background message fetch).
3. Press `c` to open the compose box while the fetch is still in-flight — this starts the animated scroll.
4. When the fetch completes and `rerender_preserving_scrolltop()` fires mid-animation:
   - **Before this fix**: the page jumps to the top of the feed.
   - **After this fix**: the page scrolls correctly to the intended position near the compose box.

No automated tests exist for this code path. The fix is a targeted, minimal change to the scroll position tracking logic.

**Screenshots and screen captures:**

_N/A — this is a race condition fix with no visual UI change under normal conditions._

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
