### PR TITLE
[ai] narrow: Restore backward compatibility for email-based narrow URLs.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1590,7 +1590,9 @@ export class Filter {
             const names = user_ids.map((user_id) => {
                 const person = people.maybe_get_user_by_id(user_id, ignore_missing);
                 if (!person) {
-                    return $t({defaultMessage: "Unknown user ({user_id})"}, {user_id});
+                    return user_id < 0
+                        ? $t({defaultMessage: "Unknown user"})
+                        : $t({defaultMessage: "Unknown user ({user_id})"}, {user_id});
                 }
                 if (muted_users.is_user_muted(person.user_id)) {
                     if (people.should_add_guest_user_indicator(person.user_id)) {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -62,11 +62,13 @@ export function encode_stream_id(stream_id: number): string {
     return internal_url.encode_slug(stream_id, slug);
 }
 
-function decode_user_ids_from_slug(operand: string): number[] | undefined {
+function decode_user_ids_from_slug(operand: string): number[] {
     // The slug for user-based operators (dm, dm-including, sender,
     // mentions) is normally a user-ID prefix. We also decode legacy
     // links whose slug is one or more email addresses instead; those
     // must be URI-decoded first, since emails are escaped in the hash.
+    // Unknown emails resolve to the -1 sentinel, so we always get a
+    // user-ID list rather than falling through to an invalid operand.
     return (
         people.slug_to_user_ids(operand) ??
         people.email_slug_to_user_ids(internal_url.decodeHashComponent(operand))
@@ -87,15 +89,12 @@ export function decode_operand(
     }
 
     if (operator === "dm-including" || operator === "dm") {
-        const user_ids = decode_user_ids_from_slug(operand);
-        if (user_ids) {
-            return user_ids;
-        }
+        return decode_user_ids_from_slug(operand);
     }
 
     if (operator === "sender" || operator === "mentions") {
         const user_ids = decode_user_ids_from_slug(operand);
-        if (user_ids?.length !== 1) {
+        if (user_ids.length !== 1) {
             // User mistyped the URL since we don't support
             // group operand for `sender` or `mentions` narrow.
             // Returning -1 will lead to us showing a proper

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -62,6 +62,17 @@ export function encode_stream_id(stream_id: number): string {
     return internal_url.encode_slug(stream_id, slug);
 }
 
+function decode_user_ids_from_slug(operand: string): number[] | undefined {
+    // The slug for user-based operators (dm, dm-including, sender,
+    // mentions) is normally a user-ID prefix. We also decode legacy
+    // links whose slug is one or more email addresses instead; those
+    // must be URI-decoded first, since emails are escaped in the hash.
+    return (
+        people.slug_to_user_ids(operand) ??
+        people.email_slug_to_user_ids(internal_url.decodeHashComponent(operand))
+    );
+}
+
 export function decode_operand(
     operator: NarrowCanonicalOperator,
     operand: string,
@@ -76,14 +87,14 @@ export function decode_operand(
     }
 
     if (operator === "dm-including" || operator === "dm") {
-        const user_ids = people.slug_to_user_ids(operand);
+        const user_ids = decode_user_ids_from_slug(operand);
         if (user_ids) {
             return user_ids;
         }
     }
 
     if (operator === "sender" || operator === "mentions") {
-        const user_ids = people.slug_to_user_ids(operand);
+        const user_ids = decode_user_ids_from_slug(operand);
         if (user_ids?.length !== 1) {
             // User mistyped the URL since we don't support
             // group operand for `sender` or `mentions` narrow.

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -664,18 +664,16 @@ export function slug_to_user_ids(slug: string): number[] | undefined {
     return undefined;
 }
 
-export function email_slug_to_user_ids(slug: string): number[] | undefined {
+export function email_slug_to_user_ids(slug: string): number[] {
     // Support legacy direct message and sender narrow links whose
     // slug is one or more comma-separated email addresses rather than
     // the user IDs used in current slugs, so that old links keep
-    // working after the switch to user-ID-based slugs. Returns
-    // undefined if any email doesn't resolve to a known user.
-    const user_ids = util.try_parse_as_truthy(
-        slug.split(",").map((email) => get_by_email(email.trim())?.user_id),
-    );
-    if (user_ids === undefined) {
-        return undefined;
-    }
+    // working after the switch to user-ID-based slugs. An email that
+    // doesn't resolve to a known user becomes -1, the same sentinel
+    // used for unknown sender/mentions operands, so the header and
+    // narrow banner can flag the unknown user rather than rejecting
+    // the whole link.
+    const user_ids = slug.split(",").map((email) => get_by_email(email.trim())?.user_id ?? -1);
     return exclude_me_from_user_ids(user_ids);
 }
 

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -661,8 +661,22 @@ export function slug_to_user_ids(slug: string): number[] | undefined {
         const user_ids_string = m[1]!;
         return exclude_me_from_user_ids(split_to_ints(user_ids_string));
     }
-    /* istanbul ignore next */
     return undefined;
+}
+
+export function email_slug_to_user_ids(slug: string): number[] | undefined {
+    // Support legacy direct message and sender narrow links whose
+    // slug is one or more comma-separated email addresses rather than
+    // the user IDs used in current slugs, so that old links keep
+    // working after the switch to user-ID-based slugs. Returns
+    // undefined if any email doesn't resolve to a known user.
+    const user_ids = util.try_parse_as_truthy(
+        slug.split(",").map((email) => get_by_email(email.trim())?.user_id),
+    );
+    if (user_ids === undefined) {
+        return undefined;
+    }
+    return exclude_me_from_user_ids(user_ids);
 }
 
 export function exclude_me_from_user_ids(user_ids: number[]): number[] {

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -214,6 +214,34 @@ run_test("test_parse_narrow", () => {
     ]);
 });
 
+run_test("parse_narrow_legacy_email_slugs", () => {
+    // Before we switched to user-ID-based slugs, DM and sender narrow
+    // links used the (escaped) email address as the slug. Those old
+    // links must still resolve to user IDs; "hamlet@example.com"
+    // encodes as "hamlet.40example.2Ecom".
+    const hamlet_email_slug = "hamlet.40example.2Ecom";
+
+    assert.deepEqual(hash_util.decode_operand("dm", hamlet_email_slug), [hamlet.user_id]);
+    assert.deepEqual(hash_util.decode_operand("dm-including", hamlet_email_slug), [hamlet.user_id]);
+    assert.equal(hash_util.decode_operand("sender", hamlet_email_slug), hamlet.user_id);
+
+    // The full parse must satisfy the narrow term schema, which
+    // requires numeric operands for these operators; a stringy email
+    // operand would previously throw and show an "Invalid URL" banner.
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "dm", hamlet_email_slug]), [
+        {negated: false, operator: "dm", operand: [hamlet.user_id]},
+    ]);
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "sender", hamlet_email_slug]), [
+        {negated: false, operator: "sender", operand: hamlet.user_id},
+    ]);
+
+    // An unknown email in a sender slug degrades to the -1 sentinel
+    // rather than throwing.
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "sender", "nobody.40example.2Ecom"]), [
+        {negated: false, operator: "sender", operand: -1},
+    ]);
+});
+
 run_test("test_channels_settings_edit_url", () => {
     const sub = {
         name: "research & development",

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -235,11 +235,19 @@ run_test("parse_narrow_legacy_email_slugs", () => {
         {negated: false, operator: "sender", operand: hamlet.user_id},
     ]);
 
-    // An unknown email in a sender slug degrades to the -1 sentinel
-    // rather than throwing.
+    // An unknown email degrades to the -1 sentinel rather than
+    // throwing, so the header and narrow banner can flag the unknown
+    // user. In a group slug, the recipients that do resolve are kept.
     assert.deepEqual(hash_util.parse_narrow(["narrow", "sender", "nobody.40example.2Ecom"]), [
         {negated: false, operator: "sender", operand: -1},
     ]);
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "dm", "nobody.40example.2Ecom"]), [
+        {negated: false, operator: "dm", operand: [-1]},
+    ]);
+    assert.deepEqual(
+        hash_util.decode_operand("dm", "hamlet.40example.2Ecom,nobody.40example.2Ecom"),
+        [hamlet.user_id, -1],
+    );
 });
 
 run_test("test_channels_settings_edit_url", () => {

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -991,9 +991,13 @@ run_test("multi_user_methods", () => {
         people.email_slug_to_user_ids("emp401@example.com,EMP402@example.com"),
         [401, 402],
     );
-    // An unknown email makes the whole slug unresolvable.
-    assert.equal(people.email_slug_to_user_ids("nobody@example.com"), undefined);
-    assert.equal(people.email_slug_to_user_ids("emp401@example.com,nobody@example.com"), undefined);
+    // An unknown email resolves to the -1 sentinel; other recipients
+    // in the slug still resolve normally.
+    assert.deepEqual(people.email_slug_to_user_ids("nobody@example.com"), [-1]);
+    assert.deepEqual(
+        people.email_slug_to_user_ids("emp401@example.com,nobody@example.com"),
+        [401, -1],
+    );
 });
 
 run_test("user_ids_to_full_names_string", () => {

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -983,6 +983,17 @@ run_test("multi_user_methods", () => {
     assert.equal(people.user_ids_to_slug([401, 402]), "401,402-group");
     assert.equal(people.user_ids_to_slug([402]), "402-whatever-402");
     assert.equal(people.user_ids_to_slug([]), undefined);
+
+    // Legacy email-based slugs, used before we switched to
+    // user-ID-based slugs, still resolve to user IDs.
+    assert.deepEqual(people.email_slug_to_user_ids("emp401@example.com"), [401]);
+    assert.deepEqual(
+        people.email_slug_to_user_ids("emp401@example.com,EMP402@example.com"),
+        [401, 402],
+    );
+    // An unknown email makes the whole slug unresolvable.
+    assert.equal(people.email_slug_to_user_ids("nobody@example.com"), undefined);
+    assert.equal(people.email_slug_to_user_ids("emp401@example.com,nobody@example.com"), undefined);
 });
 
 run_test("user_ids_to_full_names_string", () => {


### PR DESCRIPTION
Before we switched direct message and sender narrows to user-ID-based
slugs, these narrow links embedded the (escaped) email address in the
slug, e.g. `#narrow/dm/hamlet.40zulip.2Ecom`. Commit 0570e016c0
("filter: Use user_id instead email for user type operators.") changed
`dm`/`dm-including`/`sender`/`mentions` to user-ID operands and
tightened the narrow term schema to require numeric operands.

As a side effect, decoding a legacy email-based link no longer matched
the numeric-prefix slug, fell through to returning a *string* operand,
and failed schema validation in `parse_narrow` — so instead of opening
the conversation, the app showed an **"Invalid URL"** banner. Old links
(shared in chat, bookmarked, or pasted from other tools) silently broke.

This PR restores support for those links, and makes links whose email
no longer resolves(email hidden from other users or invalid emails)
degrade gracefully instead of throwing an error.

#### Effect

- **Valid email link** → opens the DM/sender narrow as before (header
  shows the user's name).
- **Unresolvable email** → header shows the unknown user (alongside any
  resolved recipients in a group), and the view shows the "This user
  does not exist!" narrow banner — no "Invalid URL" banner, no crash.

Fixes: zulip#39664.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Screenshots and screen captures:</summary>

|Before|After|
|-|-|
|Correct email based url||
|<img width="1564" height="545" alt="image" src="https://github.com/user-attachments/assets/d40a68a4-010a-4b08-b5c2-f85f845e46a6" />|<img width="1564" height="545" alt="Screenshot from 2026-07-09 18-03-46" src="https://github.com/user-attachments/assets/db408e6b-5623-4c6a-a819-e995c2cab558" />|
|Email is hidden/invalid||
|<img width="1564" height="545" alt="image" src="https://github.com/user-attachments/assets/05ab3151-5900-4f9a-b87b-0cf6c912232d" />|<img width="1564" height="545" alt="Screenshot from 2026-07-09 18-03-58" src="https://github.com/user-attachments/assets/967b8c21-20b4-434e-b811-a2c98d5cb9f4" />|
|One of the email is invalid/hidden in group dm url||
|<img width="1564" height="545" alt="image" src="https://github.com/user-attachments/assets/2c77901a-b8db-4d00-a0e1-de9666ae6d30" />|<img width="1564" height="545" alt="Screenshot from 2026-07-09 18-03-30" src="https://github.com/user-attachments/assets/56b2b9c4-49ed-47bc-a879-918587e293d8" />|
||<img width="1564" height="545" alt="image" src="https://github.com/user-attachments/assets/389f9b6d-1d13-4b7b-a13e-a9a444444048" />|
|Sender email based url||
|<img width="1564" height="545" alt="image" src="https://github.com/user-attachments/assets/f8d4569c-7a70-4d54-8bd7-12c5579e9289" />|<img width="1564" height="545" alt="image" src="https://github.com/user-attachments/assets/69bb33f7-4650-4c9d-b294-6cba6b266a53" />|

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
