### PR TITLE
[ai] help: Document the date: search operator.

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -152,6 +152,18 @@ that also accept a `narrow` parameter; see
 [GET /messages][anchor-get-messages] and
 [POST /messages/flags/narrow][anchor-post-flags].
 
+The [help center](/help/search-for-messages#search-by-date) similarly
+documents the `date` operator for searching for messages around a
+calendar date. Like `near`, this operator has no effect on filtering
+messages when sent to the server, and it is not a valid server-side
+narrow term. When the `date` operator is used to search for messages,
+or is part of a URL fragment such as `/#narrow/date/2026-01-01`,
+clients should omit it from the `narrow` parameter and instead pass
+`anchor` as `date` and `anchor_date` as the operand; see
+[GET /messages][anchor-get-messages]. The operand is an ISO 8601
+date. Clients should convert that calendar date to
+the user's local midnight when sending `anchor_date`.
+
 **Changes**: Prior to Zulip 8.0 (feature level 194), the message ID
 operand for the `id` operator needed to be encoded as a string.
 

--- a/starlight_help/src/content/docs/scroll-to-date.mdx
+++ b/starlight_help/src/content/docs/scroll-to-date.mdx
@@ -13,6 +13,8 @@ viewing [a conversation](/help/reading-conversations), [a channel
 feed](/help/channel-feed), [search results](/help/search-for-messages), or
 anything else. Suggested dates help you quickly find key moments.
 
+You can also [search by date](/help/search-for-messages#search-by-date).
+
 <Tabs>
   <TabItem label="Desktop/Web">
     1. Click on a date on the right side of a message recipient bar or a date

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -161,6 +161,17 @@ filters, to search additional messages.
   both muted and unmuted messages are included in keyword search results.
 * `has:reaction`: Search messages with [emoji reactions](/help/emoji-reactions).
 
+### Search by date
+
+Sometimes you know approximately when the message you are looking for was sent.
+
+* `date:2023-05-17`: Show messages around May 17, 2023.
+* `channel:design date:2023-05-17`: Show messages around May 17, 2023 in
+  **#design**.
+
+You can also pick a date from the search suggestions, such as today, yesterday,
+a week ago, or a month ago.
+
 ### Search by message ID
 
 Each message in Zulip has a unique ID, which is used for [linking to a specific
@@ -200,6 +211,7 @@ A summary of the search filters above is available in the Zulip app.
 
 ## Related articles
 
+* [Scroll to date](/help/scroll-to-date)
 * [Configure multi-language search](/help/configure-multi-language-search)
 * [Filter users](/help/user-list#filter-users)
 * [Link to a message or


### PR DESCRIPTION
Follow-up to [this comment](https://github.com/zulip/zulip/pull/38486#issuecomment-4916166832) on help center documentation for the `date:` operator.

Also documents the `date:` search operator next to `near` in [construct a narrow](https://zulip.com/api/construct-narrow#message-ids), for this [ merge follow-up](https://github.com/zulip/zulip/pull/38486#issuecomment-4968309402).

**Screenshots and screen captures:**

| | Before | After |
| --- | --- | --- |
| Search by date | ![before](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/before-search-by-date.png) | ![after](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/after-search-by-date.png) |
| Related articles | ![before](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/before-search-related-articles.png) | ![after](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/after-search-related-articles.png) |
| Scroll to date | ![before](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/before-scroll-to-date.png) | ![after](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/after-scroll-to-date.png) |
| Construct a narrow | ![before](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/before-construct-narrow.png) | ![after](https://raw.githubusercontent.com/apoorvapendse/zulip/help-date-pr-screenshots/screenshots/after-construct-narrow.png) |