### PR TITLE
nginx: Allow configuring an explicit server_name.

### DIFF
--- a/docs/production/install-existing-server.md
+++ b/docs/production/install-existing-server.md
@@ -52,9 +52,11 @@ Zulip's Puppet configuration will change the ownership of
 `/var/log/nginx` so that the `zulip` user can access it. Depending on
 your configuration, this may or may not cause problems.
 
-Depending on how you have configured `nginx` for your other services,
-you may need to add a `server_name` for the Zulip `server` block in
-the `nginx` configuration.
+Depending on how you have configured `nginx` for your other
+services, you may need to set
+[`nginx_server_name`](system-configuration.md#nginx_server_name) in
+`/etc/zulip/zulip.conf`, so that Zulip's `nginx` `server` blocks
+only claim requests for their intended hostnames.
 
 ### Puppet
 

--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -113,6 +113,28 @@ SSL/TLS termination.
 Set to the port number if you [prefer to listen on a port other than
 443](deployment.md#using-an-alternate-port).
 
+#### `nginx_server_name`
+
+Sets the [`server_name`][nginx_server_name] directive on Zulip's
+nginx `server` blocks; by default it is unset, so they match any
+hostname. Set it if you run other software alongside Zulip whose
+nginx configuration would otherwise claim requests meant for Zulip.
+List every hostname Zulip is served on, separated by spaces,
+including those on its TLS certificate; otherwise automatic
+certificate renewal will fail.
+
+If Zulip is served on more than one hostname, or on a hostname plus
+several subdomains, list them all; nginx's `server_name` supports a
+trailing wildcard for matching subdomains. For example, to serve
+Zulip on both `example.com` and any subdomain of it:
+
+```ini
+[application_server]
+nginx_server_name = example.com *.example.com
+```
+
+[nginx_server_name]: https://nginx.org/en/docs/http/server_names.html
+
 #### `nginx_worker_processes`
 
 Adjusts the [`worker_processes`][nginx_worker_processes] setting in

--- a/puppet/zulip/manifests/profile/app_frontend.pp
+++ b/puppet/zulip/manifests/profile/app_frontend.pp
@@ -10,6 +10,7 @@ class zulip::profile::app_frontend {
   } else {
     $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 443)
   }
+  $nginx_server_name = zulipconf('application_server', 'nginx_server_name', '')
   $ssl_dir = $facts['os']['family'] ? {
     'Debian' => '/etc/ssl',
     'RedHat' => '/etc/pki/tls',

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -15,6 +15,9 @@ server {
 server {
     listen 80;
     listen [::]:80;
+<% if @nginx_server_name != '' -%>
+    server_name <%= @nginx_server_name %>;
+<% end -%>
 
     location / {
         return 301 https://$host$request_uri;
@@ -41,6 +44,9 @@ server {
 
     ssl_certificate <%= @ssl_dir %>/certs/zulip.combined-chain.crt;
     ssl_certificate_key <%= @ssl_dir %>/private/zulip.key;
+<% end -%>
+<% if @nginx_server_name != '' -%>
+    server_name <%= @nginx_server_name %>;
 <% end -%>
 
     include /etc/nginx/zulip-include/certbot;


### PR DESCRIPTION
Fixes: #5134

Some server admins run other software alongside Zulip on the same
host, and need nginx to route requests by a specific hostname instead
of matching all hostnames (Zulip's current default). Previously the
only way to do this was to manually edit the puppet-managed nginx
config after every `zulip-puppet-apply` run, and have that edit get
silently reverted on the next run.

This adds a `server_name` option under `[application_server]` in
`zulip.conf`, which is rendered into both nginx server blocks
(the HTTP-to-HTTPS redirect and the main block) when set, following
the same pattern as the existing `http_only` / `nginx_listen_port`
options in this file.

**How changes were tested:**

- [x] Manually reviewed the rendered `zulip-enterprise.template.erb`
      output for both the default (unset) case and with `server_name`
      set, confirming the directive only appears when configured and
      is placed correctly within each `server {}` block.
- [x] Confirmed no `server_name` directive exists anywhere in the
      current template/config, so this doesn't collide with anything.
- [x] `git diff --check` to confirm no whitespace issues.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>