### PR TITLE
Message reactions causing shifts fix and created inset shadow for highlighting users reactions

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -35,7 +35,8 @@
             background-color: var(--color-message-reaction-background-reacted);
             border-color: var(--color-message-reaction-border-reacted);
             font-weight: var(--font-weight-message-reaction);
-            box-shadow: none;
+            box-shadow: inset 0 0 0.2px 0.1px
+                var(--color-message-reaction-border-reacted);
         }
 
         &.disabled {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -34,13 +34,6 @@
             color: var(--color-message-reaction-text-reacted);
             background-color: var(--color-message-reaction-background-reacted);
             border-color: var(--color-message-reaction-border-reacted);
-            /* Make this border thicker by half a pixel,
-               to make own reactions more prominent. */
-            border-width: 1.5px;
-            /* Reduce the padding top and bottom by half
-               a pixel accordingly, to maintain the same
-               pill height. */
-            padding: 1px 4px 1px 3px;
             font-weight: var(--font-weight-message-reaction);
             box-shadow: none;
         }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Normalized the sizes of the pills between reacted and unreacted to prevent layout shifts. The reacted emphasis was lowered with the normalization, so I added a slight inside shadow to offset this.
Fixes:  #38923 

**How changes were tested:**
Changes were tested by analyzing the pixels of messages before and after the user reacted.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<details>
<summary>Screenshots</summary>
<details>
<summary>light-mode</summary>
<table>
<tr>
<th align="center">Before</th>
<th align="center">After</th>
</tr>

<tr>
<td align="center">
<img width="65" height="28" alt="firefox_3SDsd3SN6R" src="https://github.com/user-attachments/assets/d6a53397-9398-4441-805f-f2a340bdb26e" />
</td>
<td align="center">
<img width="65" height="28" alt="firefox_I9Q6jrWDxh" src="https://github.com/user-attachments/assets/c45d175d-1a13-4bd2-bc58-b1700d57275d" />
</td>
</tr>

  <tr>
    <td align="center">
<img width="94" height="28" alt="firefox_RxaStV8SEe" src="https://github.com/user-attachments/assets/b468d305-2d0f-4312-8257-fb5708e57978" />
    </td>
    <td align="center">
<img width="94" height="28" alt="firefox_0oweuSw3u5" src="https://github.com/user-attachments/assets/ad15d45c-58ac-4185-a257-abd0c235ea29" />
    </td>
  </tr>
  <tr>
    <td align="center">
<img width="161" height="28" alt="firefox_vwMuRcfzLv" src="https://github.com/user-attachments/assets/24415752-db24-4bbe-a11b-2828e58c3c5a" />
    </td>
    <td align="center">
<img width="161" height="28" alt="firefox_GT52g4G8l0" src="https://github.com/user-attachments/assets/787790db-b7da-4362-a6bc-058dad038f2c" />
    </td>
  </tr>
</table>

<table>
<tr><th align="center">Before</th>
<th align="center">After</th></tr>
<tr>
<td align="center">
<img width="909" height="157" alt="firefox_G0jvShtNKF" src="https://github.com/user-attachments/assets/e5c9236f-f234-467d-94d1-e4363ece2ac9" />
</td>
<td align="center">
<img width="909" height="157" alt="firefox_6N2R0dwZA5" src="https://github.com/user-attachments/assets/a2cca6f6-e800-4780-9558-4f55df3bb65c" />
</td>
</tr>
</table>
Before: <br>
<img width="1920" height="1080" alt="firefox_BtqrOc77M7" src="https://github.com/user-attachments/assets/f85c9a05-cdce-43f9-9e42-8b06d4414061" />
<br>After<br>
<img width="1920" height="1080" alt="firefox_9fnUvch8ic" src="https://github.com/user-attachments/assets/f70e3359-ae08-43a2-a046-39f966ab0db6" />
</details>

<details>
<summary>dark-mode</summary>
<table>
<tr>
<th align="center">Before</th>
<th align="center">After</th>
</tr>

<tr>
<td align="center">
<img width="65" height="28" alt="firefox_06h4qKcVlh" src="https://github.com/user-attachments/assets/a2d4876c-e055-4ef6-98e7-5b99260f08f2" />
</td>
<td align="center">
<img width="65" height="28" alt="firefox_h3bGW7HZm5" src="https://github.com/user-attachments/assets/270edc0b-cbab-4df5-86db-9719e442508d" />
</td>
</tr>

  <tr>
    <td align="center">
<img width="94" height="28" alt="firefox_6NCSLil6Ig" src="https://github.com/user-attachments/assets/06d6cb06-f07b-4c5f-89dc-66999432a146" />
    </td>
    <td align="center">
<img width="94" height="28" alt="firefox_jkTwJD2qr2" src="https://github.com/user-attachments/assets/b67852ab-04b6-4fa7-80e0-752947f3208d" />
    </td>
  </tr>
  <tr>
    <td align="center">
<img width="161" height="28" alt="firefox_cqZefM8QyW" src="https://github.com/user-attachments/assets/2e4c9bcd-9fc0-4e58-bd5a-ef2be603d160" />
    </td>
    <td align="center">
<img width="161" height="28" alt="firefox_l4udifOLMu" src="https://github.com/user-attachments/assets/3454a877-74ea-4252-ae1d-6d7768bcccc7" />
    </td>
  </tr>
</table>

<table>
<tr><th align="center">Before</th>
<th align="center">After</th></tr>
<tr>
<td align="center">
<img width="909" height="157" alt="firefox_bMyfwMKDNz" src="https://github.com/user-attachments/assets/d103fc2c-527e-4eac-941c-7ddad0f99539" />
</td>
<td align="center">
<img width="909" height="157" alt="firefox_htdsA91ZyV" src="https://github.com/user-attachments/assets/57913277-a092-45dc-99cc-e6a9b9404aed" />
</td>
</tr>
</table>
Before: <br>
<img width="1920" height="1080" alt="firefox_SMlWprGfGo" src="https://github.com/user-attachments/assets/a4cf5e83-9cfc-4d46-ae1c-b8f47d6392bf" />
<br>After<br>
<img width="1920" height="1080" alt="firefox_BY1ZOLrgow" src="https://github.com/user-attachments/assets/043cad1b-9c26-43dc-a5de-1bbb8edfd320" />
</details>
</details>
<details>
<summary>Proof of fix</summary>
Web Before:<br>
<img width="1920" height="1080" alt="webbefore" src="https://github.com/user-attachments/assets/a5f56bdb-0aa5-46da-bf71-ddeb49f9cd9d" />
<br> Web After:<br>
<img width="1920" height="1080" alt="webafter" src="https://github.com/user-attachments/assets/00730e34-3256-4b98-86fe-6fff74bb7c7f" />
<br><br>Mobile Before:<br>
<img width="414" height="846" alt="before" src="https://github.com/user-attachments/assets/386b92f3-d204-4c45-933b-4805ccf17703" />
<br>Mobile After:<br>
<img width="414" height="846" alt="after" src="https://github.com/user-attachments/assets/82c4d1dc-4092-45f2-a16d-8f8b64b77a5f" />
</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
