### PR TITLE
kandra: Add a bridge to relay relevant Bluesky posts to CZO.

### DIFF
--- a/puppet/kandra/files/bluesky_bridge
+++ b/puppet/kandra/files/bluesky_bridge
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Relay each new Bluesky post that contains the word "zulip",
+carries the #zulip hashtag, or @-mentions @zulip.bsky.social into
+a chat.zulip.org channel.
+
+Architecture: Every POLL_INTERVAL_SECONDS it searches Bluesky and posts
+matches to CZO. To manage state, we use a single cursor — the newest
+relayed post's `indexedAt` timestamp — in a one-line file, saved after
+each relayed post, so it only moves forward and a restart re-sends at
+most the one post in flight when the process died.
+
+Data needed:
+1. Get `bluesky_app_password` from https://bsky.app/settings/app-passwords
+2. Download a zulip bot's `zuliprc` file - https://zulip.com/api/api-keys#download-a-zuliprc-file
+
+To run in dev env:
+* Put `bluesky_identifier` and `bluesky_app_password` in [secrets] of
+  zproject/dev-secrets.conf and the `zuliprc` at /srv/zulip/var/bluesky_bridge.zuliprc.
+* Run `./puppet/kandra/files/bluesky_bridge --lookback-minutes 120` (Ctrl+C to stop).
+
+Production:
+* Put `bluesky_identifier` in the [bluesky_bridge] section of /etc/zulip/zulip.conf,
+  `bluesky_app_password` in [secrets] of /etc/zulip/zulip-secrets.conf, and
+  `zuliprc` at /etc/zulip/bluesky_bridge.zuliprc.
+* runs under `uv run` with no arguments (see the puppet manifest).
+"""
+
+import argparse
+import configparser
+import contextlib
+import json
+import logging
+import os
+import re
+import time
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import requests
+import zulip
+
+CHANNEL = "bluesky"
+TOPIC = 'new posts with "zulip"'
+POLL_INTERVAL_SECONDS = 5 * 60
+
+DEV_SECRETS_FILE = "/srv/zulip/zproject/dev-secrets.conf"
+_zulip_conf = configparser.RawConfigParser()
+_zulip_conf.read("/etc/zulip/zulip.conf")
+PRODUCTION = _zulip_conf.has_option("machine", "deploy_type")
+DEVELOPMENT = not PRODUCTION
+
+if PRODUCTION:
+    ZULIPRC = "/etc/zulip/bluesky_bridge.zuliprc"
+    CURSOR_FILE = "/var/lib/zulip/bluesky_bridge.cursor"
+else:
+    ZULIPRC = "/srv/zulip/var/bluesky_bridge.zuliprc"
+    CURSOR_FILE = "/srv/zulip/var/bluesky_bridge.cursor"
+
+TARGET_HANDLE = "zulip.bsky.social"
+BLUESKY_SERVICE = "https://bsky.social"
+USER_AGENT = "ZulipBlueskyBridge/1.0 (+https://chat.zulip.org)"
+TOKEN_ERRORS = frozenset({"ExpiredToken", "InvalidToken"})
+
+
+class BlueskyError(Exception):
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(f"HTTP {status}: {message}")
+        # status 0 marks a transport-level failure (no HTTP response).
+        self.status = status
+        self.error_name = ""
+        with contextlib.suppress(json.JSONDecodeError):
+            self.error_name = json.loads(message).get("error", "")
+
+    @property
+    def retryable(self) -> bool:
+        # Worth retrying: a transport failure (status 0),
+        # a rate limit (429), or a server error (5xx).
+        return self.status in (0, 429) or self.status >= 500
+
+
+@dataclass
+class BlueskyClient:
+    service: str
+    identifier: str
+    app_password: str
+    access_jwt: str = ""
+    refresh_jwt: str = ""
+
+    def _request(
+        self,
+        method: str,
+        nsid: str,
+        *,
+        params: dict[str, str | int] | None = None,
+        data: dict[str, str] | None = None,
+        token: str | None = None,
+    ) -> dict[str, Any]:
+        headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        try:
+            response = requests.request(
+                method,
+                f"{self.service}/xrpc/{nsid}",
+                params=params,
+                json=data,
+                headers=headers,
+                timeout=30,
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as error:
+            raise BlueskyError(0, str(error)) from error
+        if not response.ok:
+            raise BlueskyError(response.status_code, response.text)
+        return response.json()
+
+    def login(self) -> None:
+        result = self._request(
+            "POST",
+            "com.atproto.server.createSession",
+            data={"identifier": self.identifier, "password": self.app_password},
+        )
+        self.access_jwt = result["accessJwt"]
+        self.refresh_jwt = result["refreshJwt"]
+
+    def refresh(self) -> None:
+        result = self._request("POST", "com.atproto.server.refreshSession", token=self.refresh_jwt)
+        self.access_jwt = result["accessJwt"]
+        self.refresh_jwt = result["refreshJwt"]
+
+    def _reauth(self) -> None:
+        try:
+            self.refresh()
+        except BlueskyError:
+            self.login()
+
+    def resolve_handle(self, handle: str) -> str:
+        result = self._request(
+            "GET", "com.atproto.identity.resolveHandle", params={"handle": handle}
+        )
+        return result["did"]
+
+    def search_posts(self, **params: str | int) -> dict[str, Any]:
+        try:
+            return self._request(
+                "GET", "app.bsky.feed.searchPosts", params=params, token=self.access_jwt
+            )
+        except BlueskyError as error:
+            if error.status == 401 or error.error_name in TOKEN_ERRORS:
+                self._reauth()
+                return self._request(
+                    "GET", "app.bsky.feed.searchPosts", params=params, token=self.access_jwt
+                )
+            raise
+
+
+@dataclass
+class Config:
+    identifier: str
+    app_password: str
+    lookback_minutes: int
+    # Filled in at startup once the handle is resolved.
+    target_did: str = ""
+
+
+# Relayed text is untrusted and Zulip renders markdown, so we HTML-entity escape
+# (like zerver/lib/topic_link_util.py) the metacharacters that enable link/mention
+# injection or let fenced code swallow the trailing link. Cosmetic markup
+# (headings, lists, tables) is harmless here and left as-is.
+MARKDOWN_ESCAPES = {
+    "`": "&#96;",
+    ">": "&gt;",
+    "*": "&#42;",
+    "&": "&amp;",
+    "[": "&#91;",
+    "]": "&#93;",
+    "~": "&#126;",
+    "$$": "&#36;&#36;",
+}
+_MARKDOWN_METACHARACTERS = re.compile(r"[`>*&\[\]~]|\$\$")
+
+
+def escape_markdown(text: str) -> str:
+    return _MARKDOWN_METACHARACTERS.sub(lambda m: MARKDOWN_ESCAPES[m.group(0)], text)
+
+
+def profile_link(handle: str) -> str:
+    return "https://bsky.app/profile/" + urllib.parse.quote(handle, safe="")
+
+
+def format_message(post_view: dict[str, Any]) -> str:
+    author = post_view["author"]
+    handle = author["handle"]
+    display = author.get("displayName") or handle
+    record = post_view["record"]
+    text = escape_markdown((record.get("text") or "").strip())
+    rkey = post_view["uri"].rsplit("/", 1)[-1]
+    web_url = f"{profile_link(handle)}/post/{urllib.parse.quote(rkey, safe='')}"
+
+    parts = [
+        f"**{escape_markdown(display)}** ([@{escape_markdown(handle)}]({profile_link(handle)}))"
+    ]
+    if text:
+        parts += ["", text]
+    parts += ["", f"[View on Bluesky]({web_url})"]
+    return "\n".join(parts)
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def to_iso(when: datetime) -> str:
+    return when.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def load_cursor(path: str, lookback_minutes: int) -> datetime:
+    # The cursor is the indexedAt of the newest post we've relayed.
+    # --lookback-minutes overrides it to start N minutes back; else
+    # resume from the saved cursor, or from now on the first run.
+    if lookback_minutes:
+        return utcnow() - timedelta(minutes=lookback_minutes)
+    try:
+        with open(path) as f:
+            return parse_iso(f.read().strip())
+    except FileNotFoundError:
+        return utcnow()
+
+
+def save_cursor(path: str, when: datetime) -> None:
+    # Write atomically so a crash mid-write can't corrupt the cursor.
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        f.write(to_iso(when))
+    os.replace(tmp, path)
+
+
+def relay_to_zulip(zulip_client: zulip.Client, content: str) -> int | None:
+    # Any failure returns None so run_once retries next poll: transient errors
+    # self-heal, and permanent misconfig (unsubscribed channel, wrong zuliprc, etc.)
+    # is unlikely enough here that we don't bother classifying it.
+    # We let those repoll too and rely on the logged error.
+    try:
+        result = zulip_client.send_message(
+            {"type": "stream", "to": CHANNEL, "topic": TOPIC, "content": content}
+        )
+    except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as error:
+        logging.warning("relay to CZO failed (network): %s; will retry next poll", error)
+        return None
+    if result.get("result") == "success":
+        logging.info("relayed to CZO: msg_id=%s", result.get("id"))
+        return result.get("id")
+    logging.error("relay to CZO failed: code=%s msg=%s", result.get("code"), result.get("msg"))
+    return None
+
+
+# Note: 100 is the max allowed value by bluesky API.
+# In future, if the traffic reaches more than 100 posts per POLL_INTERVAL_SECONDS,
+# we should decrease POLL_INTERVAL_SECONDS first. At very high scale, we can refer
+# to pagination mechanism offered by the bluesky API.
+# ref: https://endpoints.bsky.app/#bluesky-app/tag/appbskyfeed/GET/xrpc/app.bsky.feed.searchPosts.query.limit
+MAX_POSTS_PER_REQUEST = 100
+
+
+def search_queries(cursor: datetime, target_did: str) -> list[dict[str, str | int]]:
+    base: dict[str, str | int] = {
+        "sort": "latest",
+        "limit": MAX_POSTS_PER_REQUEST,
+        "since": to_iso(cursor),
+    }
+    return [
+        {**base, "q": "zulip"},
+        {**base, "q": "*", "mentions": target_did},
+    ]
+
+
+def run_once(
+    bsky: BlueskyClient, zulip_client: zulip.Client, cursor: datetime, config: Config
+) -> datetime:
+    """Relay every matching post newer than the cursor (the indexedAt of the
+    newest post we've already relayed), then return the advanced cursor.
+    """
+    posts: dict[str, dict[str, Any]] = {}
+    for params in search_queries(cursor, config.target_did):
+        try:
+            response = bsky.search_posts(**params)
+        except BlueskyError as error:
+            if not error.retryable:
+                # Client error like a malformed query won't be
+                # fixed by repolling; let it propagate so main exits.
+                raise
+            # A transient failure: the cursor doesn't move, so nothing
+            # is lost or duplicated.
+            logging.warning("search failed for %s: %s; skipping this poll", params, error)
+            return cursor
+        post_views = response.get("posts", [])
+        if len(post_views) == MAX_POSTS_PER_REQUEST:
+            logging.warning(
+                "query %s hit the request limit of %d posts; older matches "
+                "may go unrelayed — consider lowering POLL_INTERVAL_SECONDS",
+                params,
+                MAX_POSTS_PER_REQUEST,
+            )
+        for post_view in post_views:
+            posts.setdefault(post_view["uri"], post_view)
+
+    relayed = 0
+    candidates = 0
+    new_cursor = cursor
+    for post_view in sorted(posts.values(), key=lambda p: parse_iso(p["indexedAt"])):
+        indexed_dt = parse_iso(post_view["indexedAt"])
+        # The inclusive `since` re-fetches the last relayed post each poll;
+        # skip it (and anything older) so it isn't relayed again.
+        if indexed_dt <= cursor:
+            continue
+        candidates += 1
+        content = format_message(post_view)
+        if relay_to_zulip(zulip_client, content) is None:
+            break
+        new_cursor = indexed_dt
+        # We save after each relay, not once per poll: a crash between sending and
+        # saving re-sends at most this one post on restart.
+        # TODO: Implementation of Idempotency-Key header will help to avoid this.
+        # ref: https://chat.zulip.org/#narrow/channel/378-api-design/topic/Idempotency-Key.20HTTP.20header/with/2205409
+        save_cursor(CURSOR_FILE, new_cursor)
+        relayed += 1
+
+    logging.info("poll complete: %d candidates, %d relayed", candidates, relayed)
+    return new_cursor
+
+
+def load_config(args: argparse.Namespace) -> Config:
+    secrets = configparser.RawConfigParser()
+    if DEVELOPMENT:
+        secrets.read(DEV_SECRETS_FILE)
+        identifier = secrets.get("secrets", "bluesky_identifier", fallback=None)
+        app_password = secrets.get("secrets", "bluesky_app_password", fallback=None)
+        source = f"[secrets] of {DEV_SECRETS_FILE}"
+    else:
+        conf = configparser.RawConfigParser()
+        conf.read("/etc/zulip/zulip.conf")
+        secrets.read("/etc/zulip/zulip-secrets.conf")
+        identifier = conf.get("bluesky_bridge", "bluesky_identifier", fallback=None)
+        app_password = secrets.get("secrets", "bluesky_app_password", fallback=None)
+        source = (
+            "[bluesky_bridge] of /etc/zulip/zulip.conf and [secrets] of "
+            "/etc/zulip/zulip-secrets.conf"
+        )
+    if not identifier or not app_password:
+        raise SystemExit(
+            f"Missing Bluesky credentials: set bluesky_identifier and "
+            f"bluesky_app_password in {source}."
+        )
+
+    return Config(
+        identifier=identifier,
+        app_password=app_password,
+        lookback_minutes=args.lookback_minutes,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Relay Bluesky posts mentioning Zulip to CZO.")
+    parser.add_argument(
+        "--lookback-minutes",
+        type=int,
+        default=0,
+        help="Start scanning Bluesky from this many minutes ago, "
+        "ignoring any saved cursor. Helpful in dev testing.",
+    )
+    return parser.parse_args()
+
+
+def run_bridge(config: Config) -> None:
+    bsky = BlueskyClient(BLUESKY_SERVICE, config.identifier, config.app_password)
+    bsky.login()
+    config.target_did = bsky.resolve_handle(TARGET_HANDLE)
+    cursor = load_cursor(CURSOR_FILE, config.lookback_minutes)
+    zulip_client = zulip.Client(config_file=ZULIPRC, client="ZulipBlueskyBridge")
+
+    logging.info("relaying Bluesky posts to CZO")
+    while True:
+        cursor = run_once(bsky, zulip_client, cursor, config)
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def main() -> None:
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s bluesky_bridge: %(message)s", level=logging.INFO
+    )
+    config = load_config(parse_args())
+
+    backoff = zulip.RandomExponentialBackoff(timeout_success_equivalent=POLL_INTERVAL_SECONDS * 2)
+    while backoff.keep_going():
+        try:
+            run_bridge(config)
+        except BlueskyError as error:
+            if not error.retryable:
+                logging.error("unrecoverable Bluesky error: %s; exiting", error)
+                raise SystemExit(1) from error
+            logging.warning("recoverable Bluesky error: %s; backing off before retry", error)
+            backoff.fail()
+        except zulip.UnrecoverableNetworkError as error:
+            # zulip.Client() connects to CZO at construction, so
+            # an unreachable server at startup surfaces here
+            logging.warning("could not reach CZO at startup: %s; backing off before retry", error)
+            backoff.fail()
+
+
+if __name__ == "__main__":
+    main()

--- a/puppet/kandra/files/hooks/post-deploy.d/restart_bluesky_bridge.hook
+++ b/puppet/kandra/files/hooks/post-deploy.d/restart_bluesky_bridge.hook
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+# This script uses `uv run`, and thus uses the production venv.  This
+# means that we need to make sure that we restart into the new venv,
+# so we don't start to error when the old venv gets garbage collected.
+supervisorctl restart bluesky_bridge:*

--- a/puppet/kandra/manifests/bluesky_bridge.pp
+++ b/puppet/kandra/manifests/bluesky_bridge.pp
@@ -1,0 +1,34 @@
+class kandra::bluesky_bridge {
+  include zulip::hooks::base
+  include zulip::supervisor
+
+  # We embed the hash of the contents into the name of the process, so
+  # that `supervisorctl reread` knows that it has updated.
+  $full_script_hash = sha256(file('kandra/bluesky_bridge'))
+  $script_hash = $full_script_hash[0,8]
+
+  $bin = '/usr/local/bin/bluesky_bridge'
+  file { $bin:
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/kandra/bluesky_bridge',
+  }
+
+  file { "${zulip::common::supervisor_conf_dir}/bluesky_bridge.conf":
+    ensure  => file,
+    require => [
+      User[zulip],
+      Package[supervisor],
+      File[$bin],
+    ],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('kandra/supervisor/conf.d/bluesky_bridge.conf.template.erb'),
+    notify  => Service[supervisor],
+  }
+
+  kandra::hooks::file { 'post-deploy.d/restart_bluesky_bridge.hook': }
+}

--- a/puppet/kandra/manifests/prod_app_frontend_once.pp
+++ b/puppet/kandra/manifests/prod_app_frontend_once.pp
@@ -4,6 +4,7 @@ class kandra::prod_app_frontend_once {
   include zulip::hooks::zulip_notify
   include kandra::hooks::zulip_notify_schema_diff
   include kandra::mirror_to_czo
+  include kandra::bluesky_bridge
 
   zulip::cron { 'update-first-visible-message-id':
     hour   => '7',

--- a/puppet/kandra/templates/supervisor/conf.d/bluesky_bridge.conf.template.erb
+++ b/puppet/kandra/templates/supervisor/conf.d/bluesky_bridge.conf.template.erb
@@ -1,0 +1,13 @@
+[program:bluesky_bridge]
+# We record the hash of the script so that we can update this file
+# with it, which will make `supervisorctl reread && supervisorctl
+# update` restart this job.
+command=uv run --no-sync /usr/local/bin/bluesky_bridge
+directory=/home/zulip/deployments/current/
+process_name=bluesky_bridge_<%= @script_hash %>
+priority=10
+autostart=true
+autorestart=true
+user=zulip
+redirect_stderr=true
+stdout_logfile=/var/log/zulip/bluesky_bridge.log


### PR DESCRIPTION
Relay each new Bluesky post that:
* contains the word "zulip"
* or carries the #zulip hashtag
* or @-mentions @zulip.bsky.social

into `#bluesky > new posts with "zulip"` on chat.zulip.org.

<!-- Describe your pull request here.-->

**How changes were tested:**

See [#test here > new posts with "zulip" @ 💬](https://chat.zulip.org/#narrow/channel/7-test-here/topic/new.20posts.20with.20.22zulip.22/near/2491933) for sample messages relayed while running on dev env.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
