### PR TITLE
message_fetch: Do not show loading indicator when not needed.

### DIFF
--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -8,7 +8,6 @@ import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 
 function show_history_limit_notice(): void {
-    $(".top-messages-logo").hide();
     $(".history-limited-box").show();
     // The history-limit notice and the empty-narrow banner are mutually
     // exclusive top-of-feed states; clear the latter when showing this.
@@ -18,7 +17,6 @@ function show_history_limit_notice(): void {
 }
 
 function hide_history_limit_notice(): void {
-    $(".top-messages-logo").show();
     $(".history-limited-box").hide();
 }
 
@@ -28,13 +26,10 @@ function hide_end_of_results_notice(): void {
 }
 
 function show_end_of_results_notice(): void {
-    // Both end-of-results notices are hidden for spectators, so leave the
-    // top-of-feed logo in place for them rather than hiding it and showing
-    // nothing.
+    // Both end-of-results notices are hidden for spectators.
     if (page_params.is_spectator) {
         return;
     }
-    $(".top-messages-logo").hide();
 
     const narrow_filter = narrow_state.filter();
     assert(narrow_filter !== undefined);
@@ -51,12 +46,22 @@ function show_end_of_results_notice(): void {
     $(".all-messages-search-caution .search-shared-history").attr("data-url", update_hash);
 }
 
+export function update_top_of_feed_logo(): void {
+    if (message_lists.current?.data.fetch_status.has_found_oldest()) {
+        $(".top-messages-logo").hide();
+    } else {
+        $(".top-messages-logo").show();
+    }
+}
+
 export function update_top_of_narrow_notices(msg_list: MessageList): void {
     // Assumes that the current state is all notices hidden (i.e. this
     // will not hide a notice that should not be there)
     if (message_lists.current === undefined || msg_list !== message_lists.current) {
         return;
     }
+
+    update_top_of_feed_logo();
 
     if (msg_list.data.fetch_status.has_found_oldest()) {
         const filter = narrow_state.filter();
@@ -77,6 +82,11 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
 }
 
 export function hide_top_of_narrow_notices(): void {
+    // Restore the top-of-feed logo; this runs when resetting for a new
+    // narrow, whose fetch status we don't know yet. It is hidden again
+    // once we learn we have the narrow's oldest message (see
+    // update_top_of_feed_logo).
+    $(".top-messages-logo").show();
     hide_end_of_results_notice();
     hide_history_limit_notice();
 }

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -644,8 +644,12 @@ export function show_empty_narrow_message(current_filter: Filter, invalid_narrow
 
     // Removing messages from the current narrow can leave a stale
     // top-of-feed notice visible, so hide all of them before showing
-    // the empty-narrow banner.
+    // the empty-narrow banner. Hiding the notices restores the
+    // top-of-feed logo, so re-evaluate whether it should be visible;
+    // an empty narrow whose history is fully fetched should not
+    // suggest that more messages may load above.
     message_feed_top_notices.hide_top_of_narrow_notices();
+    message_feed_top_notices.update_top_of_feed_logo();
 
     if (current_filter.may_have_incomplete_message_history()) {
         $(".empty_feed_notice .empty-feed-notice-action").show();


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Earlier, the Zulip logo at the top of the message feed was always visible, even when the client knew it already had the oldest message in the narrow, so no older-history loading could happen above it.

Hide the logo once the current message list's fetch status reports found_oldest, and restore it when switching to a narrow whose fetch status is not yet known. Since showing the empty-narrow banner resets the top-of-feed notices (which restores the logo), re-evaluate the logo's visibility there too, so that a fully fetched empty narrow doesn't suggest more messages may load above. All logic for the logo's visibility now lives in the new update_top_of_feed_logo function, so the notice show/hide helpers no longer toggle it as a side effect.

This changes behavior for spectators: previously the logo was deliberately left in place for them when the end-of-results notices (hidden for spectators) would otherwise replace it; now a fully fetched narrow shows no logo for spectators either.

Addresses parts of [#design > loading indicator at the top of message feed](https://chat.zulip.org/#narrow/channel/101-design/topic/loading.20indicator.20at.20the.20top.20of.20message.20feed/with/2493209)

**How changes were tested:**
I populated a realm with 30k messages and throttled the network speed to 3G to replicate this.


https://github.com/user-attachments/assets/f4e289c0-5f8d-48b9-90eb-54344befdc84






<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
