### PR TITLE
i18n: Add date localization and match user clock preference in analytics page

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -86,6 +86,7 @@ def render_stats(
         upload_space_used=space_used,
         guest_users=guest_users,
         translation_data=get_language_translation_data(request_language),
+        twenty_four_hour_time=request.user.twenty_four_hour_time,
     )
 
     return render(

--- a/web/src/base_page_params.ts
+++ b/web/src/base_page_params.ts
@@ -71,6 +71,7 @@ const stats_params_schema = z.object({
     upload_space_used: z.nullable(z.number()),
     guest_users: z.nullable(z.number()),
     translation_data: z.record(z.string(), z.string()),
+    twenty_four_hour_time: z.boolean(),
 });
 
 // Sync this with corporate.views.portico.team_view.

--- a/web/src/stats/stats.ts
+++ b/web/src/stats/stats.ts
@@ -179,31 +179,20 @@ function floor_to_local_week(date: Date): Date {
 }
 
 function format_date(date: Date, include_hour: boolean): string {
-    const months = [
-        $t({defaultMessage: "January"}),
-        $t({defaultMessage: "February"}),
-        $t({defaultMessage: "March"}),
-        $t({defaultMessage: "April"}),
-        $t({defaultMessage: "May"}),
-        $t({defaultMessage: "June"}),
-        $t({defaultMessage: "July"}),
-        $t({defaultMessage: "August"}),
-        $t({defaultMessage: "September"}),
-        $t({defaultMessage: "October"}),
-        $t({defaultMessage: "November"}),
-        $t({defaultMessage: "December"}),
-    ];
-    const month_str = months[date.getMonth()];
-    const year = date.getFullYear();
-    const day = date.getDate();
+    const date_options: Intl.DateTimeFormatOptions = {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+    };
     if (include_hour) {
-        const hour = date.getHours();
-
-        const str = hour >= 12 ? "PM" : "AM";
-
-        return `${month_str} ${day}, ${hour % 12}:00${str}`;
+        return new Intl.DateTimeFormat(page_params.request_language, {
+            ...date_options,
+            hour: "numeric",
+            minute: "2-digit",
+            hourCycle: page_params.twenty_four_hour_time ? "h23" : "h12",
+        }).format(date);
     }
-    return `${month_str} ${day}, ${year}`;
+    return new Intl.DateTimeFormat(page_params.request_language, date_options).format(date);
 }
 
 function update_last_full_update(end_times: number[]): void {

--- a/web/src/stats/stats.ts
+++ b/web/src/stats/stats.ts
@@ -202,17 +202,18 @@ function update_last_full_update(end_times: number[]): void {
 
     last_full_update = Math.min(last_full_update, end_times.at(-1)!);
     const update_time = new Date(last_full_update * 1000);
-    const locale_date = update_time.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-    });
-    const locale_time = update_time.toLocaleTimeString(undefined, {
-        hour: "numeric",
-        minute: "numeric",
-    });
+    const locale_date = format_date(update_time, false);
+    const time_options: Intl.DateTimeFormatOptions = page_params.twenty_four_hour_time
+        ? {hourCycle: "h23", hour: "2-digit", minute: "2-digit"}
+        : {hourCycle: "h12", hour: "numeric", minute: "2-digit"};
 
-    $("#id_last_full_update").text(locale_time + " on " + locale_date);
+    const locale_time = new Intl.DateTimeFormat(page_params.request_language, time_options).format(
+        update_time,
+    );
+
+    $("#id_last_full_update").text(
+        $t({defaultMessage: "{time} on {date}"}, {time: locale_time, date: locale_date}),
+    );
     $("#id_last_full_update").closest(".last-update").show();
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Localized date labels on the last-updated footer and when hovering over charts in the analytics page. Updated time displays in the analytics page to match the user's clock preference. 

Fixes part of: #16094 

Based on the feedback I received from @shubham-padia and @laurynmm on the [Zulip dev community chat](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Fix.20i18n.20on.20.2Fstats.20.20.2316094/with/2496883), this PR does not address the remaining issue of the Plotly charts' x-axis labels not being translated. This is due to an ongoing transition from Plotly to Chart.js.

**How changes were tested:**
- Run Zulip development environment on local machine
- Run automated tests for the main stats view `./tools/test-backend analytics.tests.test_stats_views` 
- Run Prettier formatting command `tools/lint --only=prettier --fix`
- Verify in `http://localhost:9991/stats/realm/analytics/` that dates were being localized on the last-updated footer and when hovering over charts in multiple languages (set in URL or user preferences)
- Verify in `http://localhost:9991/stats/realm/analytics/` that time displays respected user's clock preference 

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<details>
<summary><strong>Chart hover and date labels (format_date)</strong></summary>

<p><strong>Before this PR:</strong> chart hover text only supported the 12-hour clock preference and did not localize dates according to the user's locale.</p>
<p align="center">
<img width="800" height="92" alt="image" src="https://github.com/user-attachments/assets/ca9344de-5ac0-43b7-871d-71003b2ddc8f" />
<p align="center">
  <img width="800" height="92" alt="Old German chart hover (not localized, 12-hour only)" src="https://github.com/user-attachments/assets/19fc32b2-7ea1-4372-9526-4b860d42d3a7" />

</p>

<hr>

<table>
<tr><td align="center">Before</td><td align="center">After</td></tr>
<tr><td colspan="2" align="center"><strong>Active users bar chart hover — English (en)</strong></td></tr>
<tr>
  <td align="center">
    <img width="250" height="46" alt="Active users bar hover before (English)" src="https://github.com/user-attachments/assets/e76442f8-1c18-419f-b096-7953e6b52abe" />
  </td>
  <td align="center">
    <img width="250" height="46" alt="Active users bar hover after (English)" src="https://github.com/user-attachments/assets/b5ce2bae-4776-44dd-9666-10c8061ddcb7" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Active users bar chart hover — German (de)</strong></td></tr>
<tr>
  <td align="center">
    <img width="1182" height="103" alt="Active users bar hover before (German)" src="https://github.com/user-attachments/assets/2c51eec6-8abf-4934-90a9-b67996ddca64" />
  </td>
  <td align="center">
    <img width="1182" height="103" alt="Active users bar hover after (German)" src="https://github.com/user-attachments/assets/44a5ba23-fef7-45f1-827e-7f9f0d16e489" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Weekly bar chart labels (“Week of …”)</strong></td></tr>
<tr>
  <td align="center">
    <img width="390" height="92" alt="Week of label before" src="https://github.com/user-attachments/assets/ac83dfb9-0347-4916-89c0-cd0c585f9b53" />
  </td>
  <td align="center">
    <img width="390" height="92" alt="Week of label after" src="https://github.com/user-attachments/assets/0c1bd181-2d8a-4519-a740-b9f11adb698d" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Cumulative line chart hover — English (en), 12-hour clock</strong></td></tr>
<tr>
  <td align="center">
<img width="800" height="92" alt="image" src="https://github.com/user-attachments/assets/fa938ca9-5f16-4612-9e08-e941cf0bd2ab" />
  </td>
  <td align="center">
    <img width="800" height="92" alt="English 12-hour chart hover after" src="https://github.com/user-attachments/assets/0ea92aec-7cfb-43a3-b2ec-55d91475eebb" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Cumulative line chart hover — English (en), 24-hour clock</strong></td></tr>
<tr>
  <td align="center">
<img width="800" height="92" alt="image" src="https://github.com/user-attachments/assets/a9ca8366-e322-4715-b465-692d13790d9d" />
  </td>
  <td align="center">
    <img width="800" height="92" alt="English 24-hour chart hover after" src="https://github.com/user-attachments/assets/eb823deb-487a-4c91-8ceb-dc2000dbb8c0" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Cumulative line chart hover — German (de), 12-hour clock</strong></td></tr>
<tr>
  <td align="center">
    <img width="800" height="92" alt="German 12-hour chart hover before" src="https://github.com/user-attachments/assets/5cffc5c8-2f69-4b5b-92be-f81e78cb1134" />
  </td>
  <td align="center">
    <img width="800" height="92" alt="German 12-hour chart hover after" src="https://github.com/user-attachments/assets/9190c840-c1db-4596-8be9-7c23ea44184b" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Cumulative line chart hover — German (de), 24-hour clock</strong></td></tr>
<tr>
  <td align="center">
    <img width="800" height="92" alt="German 24-hour chart hover before" src="https://github.com/user-attachments/assets/5cffc5c8-2f69-4b5b-92be-f81e78cb1134" />
  </td>
  <td align="center">
    <img width="800" height="92" alt="German 24-hour chart hover after" src="https://github.com/user-attachments/assets/84e10caf-6832-4c86-9eb3-47789d4af76a" />
  </td>
</tr>
</table>

</details>

<details>
<summary><strong>Last full update footer (update_last_full_update)</strong></summary>

<p><strong>Before this PR:</strong> Footer used <code>en-US</code> formatting, a hardcoded English <code>" on "</code> joiner, and did not respect the 24-hour clock preference. The German UI translated “Last update”, but date/time stayed <code>en-US</code> and 12-hour only. Note: According to Zulip's translation guide, my understanding was that the "on" joiner would be properly translated after a Weblate commit is merged by a maintainer.</p>
<p align="center">
  <img width="1000" height="92" alt="Original English footer" src="https://github.com/user-attachments/assets/89063e6b-7459-4383-b726-05b933cb7431" />
</p>
<p align="center">
  <img width="1000" height="92" alt="Old German footer (not localized, 12-hour only)" src="https://github.com/user-attachments/assets/ea6c9f5d-642d-4348-8ab9-3d4b64beed60" />
</p>

<table>
<tr><td align="center">Before</td><td align="center">After</td></tr>
<tr><td colspan="2" align="center"><strong>Footer — English (en), 24-hour clock</strong></td></tr>
<tr>
  <td align="center">
    <img width="1000" height="92" alt="English 24-hour footer before" src="https://github.com/user-attachments/assets/89063e6b-7459-4383-b726-05b933cb7431" />
  </td>
  <td align="center">
    <img width="1000" height="92" alt="English 24-hour footer after" src="https://github.com/user-attachments/assets/d31269e0-58f5-4a7e-a960-e25fa674a00c" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Footer — German (de), 12-hour clock</strong></td></tr>
<tr>
  <td align="center">
    <img width="1000" height="92" alt="German 12-hour footer before" src="https://github.com/user-attachments/assets/ea6c9f5d-642d-4348-8ab9-3d4b64beed60" />
  </td>
  <td align="center">
    <img width="1000" height="92" alt="German 12-hour footer after" src="https://github.com/user-attachments/assets/a36e4153-3e30-4e2c-8359-82aa08aecd87" />
  </td>
</tr>
<tr><td colspan="2" align="center"><strong>Footer — German (de), 24-hour clock</strong></td></tr>
<tr>
  <td align="center">
    <img width="1000" height="92" alt="German 24-hour footer before" src="https://github.com/user-attachments/assets/ea6c9f5d-642d-4348-8ab9-3d4b64beed60" />
  </td>
  <td align="center">
    <img width="1000" height="92" alt="German 24-hour footer after" src="https://github.com/user-attachments/assets/518687ae-c40d-41fd-89de-a6dda81720b8" />
  </td>
</tr>
</table>

</details>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

<details>
  <summary>Self Review Checklist</summary>
  
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>