### PR TITLE
notification_data: Avoid redundant queries in get_mentioned_user_group.

### DIFF
--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -386,11 +386,18 @@ def get_mentioned_user_group(
 
     # We now want to calculate the name of the smallest user group mentioned among
     # all these messages.
-    smallest_user_group_size = math.inf
-    for user_group_id in mentioned_user_group_ids:
-        current_user_group = NamedUserGroup.objects.get(
-            id=user_group_id, realm_for_sharding=user_profile.realm
+    # Deduplicate IDs while preserving message order.
+    unique_user_group_ids = list(dict.fromkeys(mentioned_user_group_ids))
+    user_groups_by_id = {
+        user_group.id: user_group
+        for user_group in NamedUserGroup.objects.filter(
+            id__in=unique_user_group_ids, realm_for_sharding=user_profile.realm
         )
+    }
+
+    smallest_user_group_size = math.inf
+    for user_group_id in unique_user_group_ids:
+        current_user_group = user_groups_by_id[user_group_id]
         current_mentioned_user_group = MentionedUserGroup(
             id=current_user_group.id,
             name=current_user_group.name,


### PR DESCRIPTION
Previously, get_mentioned_user_group looped over every message's mentioned_user_group_id without deduplicating, so a group mentioned across N messages in the same batch triggered N redundant NamedUserGroup lookups and N redundant recursive membership queries for an answer that cannot change within a single call.

Deduplicate the mentioned group IDs and fetch them in a single NamedUserGroup.objects.filter(id__in=...) query instead of querying once per message. Verified via CaptureQueriesContext that a batch of 5 messages mentioning the same group dropped from 10 queries to 2 with identical output.

<!-- Describe your pull request here.-->

Fixes: N/A - Raised as a performance improvement in https://chat.zulip.org/#narrow/channel/3-backend/topic/possible.20overhead.20in.20notification_data.20for.20batched.20emails/with/2493345

### **How changes were tested:**

- Verified locally via manage.py shell + CaptureQueriesContext that a batch of 5 messages mentioning the same group dropped from 10 queries to 2.

**Ran**

1. ./tools/test-backend on test_notification_data.py (6/6 pass) and
2. test_message_notification_emails.py (59/59 pass). 
3. ./tools/run-mypy and ./tools/lint both clean.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

</details>
