### PR TITLE
tornado: fix notification sending with multiple queue types.

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -29,6 +29,7 @@ from zerver.tornado.event_queue import (
     add_client_gc_hook,
     allocate_client_descriptor,
     clients,
+    do_gc_event_queues,
     gc_event_queues,
     mark_clients_offline,
     maybe_enqueue_notifications,
@@ -1595,13 +1596,14 @@ class OfflineEventQueueTest(ZulipTestCase):
         self,
         user: UserProfile,
         queue_timeout: int | str | None,
+        event_types: list[str] | None = None,
     ) -> ClientDescriptor:
         queue_data: dict[str, Any] = dict(
             all_public_streams=False,
             apply_markdown=True,
             client_gravatar=True,
             client_type_name="ZulipFlutter",
-            event_types=["message"],
+            event_types=["message"] if event_types is None else event_types,
             last_connection_time=time.time(),
             queue_timeout=queue_timeout,
             realm_id=user.realm.id,
@@ -1739,6 +1741,105 @@ class OfflineEventQueueTest(ZulipTestCase):
             # For the expired queue, the long-lived queue is still active so
             # last_client_for_user is False and it short-circuits.
             mock_enqueue.assert_called_once()
+
+    @time_machine.travel(NOW, tick=False)
+    def test_gc_message_queue_before_non_message_queue(self) -> None:
+        hamlet = self.example_user("hamlet")
+        add_client_gc_hook(missedmessage_hook)
+
+        message_client = self.allocate_queue(
+            hamlet,
+            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
+            event_types=["message"],
+        )
+        non_message_client = self.allocate_queue(
+            hamlet,
+            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
+            event_types=["presence"],
+        )
+
+        iago = self.example_user("iago")
+        self.send_personal_message(iago, hamlet)
+
+        # First, expire only the queue containing the message event. The
+        # presence-only queue should not prevent this from being treated as
+        # the user's last message-receiving client.
+        message_client.last_connection_time = time.time() - DEFAULT_EVENT_QUEUE_TIMEOUT_SECS - 1
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            gc_event_queues(port=9993)
+
+            self.assertNotIn(message_client.event_queue.id, clients)
+            self.assertIn(non_message_client.event_queue.id, clients)
+
+            # Later, garbage collecting the presence-only queue cannot send
+            # the missed-message notification, since it has no message event.
+            non_message_client.last_connection_time = (
+                time.time() - DEFAULT_EVENT_QUEUE_TIMEOUT_SECS - 1
+            )
+            gc_event_queues(port=9993)
+
+            mock_enqueue.assert_called_once()
+
+    @time_machine.travel(NOW, tick=False)
+    def test_gc_multiple_message_queues_in_same_sweep(self) -> None:
+        hamlet = self.example_user("hamlet")
+        add_client_gc_hook(missedmessage_hook)
+
+        message_clients = [
+            self.allocate_queue(
+                hamlet,
+                queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
+                event_types=["message"],
+            )
+            for _ in range(2)
+        ]
+
+        iago = self.example_user("iago")
+        self.send_personal_message(iago, hamlet)
+
+        # Both queues contain the same message event and expire in the same
+        # sweep. Only one queue should be treated as the user's last
+        # message-receiving client, to avoid duplicate notifications.
+        for client in message_clients:
+            client.last_connection_time = time.time() - DEFAULT_EVENT_QUEUE_TIMEOUT_SECS - 1
+
+        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
+            gc_event_queues(port=9993)
+
+            for client in message_clients:
+                self.assertNotIn(client.event_queue.id, clients)
+            mock_enqueue.assert_called_once()
+
+    def test_gc_message_and_non_message_queues_in_same_sweep(self) -> None:
+        hamlet = self.example_user("hamlet")
+        message_client = self.allocate_queue(
+            hamlet,
+            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
+            event_types=["message"],
+        )
+        non_message_client = self.allocate_queue(
+            hamlet,
+            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
+            event_types=["presence"],
+        )
+
+        gc_hook = mock.Mock()
+        add_client_gc_hook(gc_hook)
+
+        # A dict keys view is an ordered AbstractSet, making the non-message
+        # queue the last queue considered for notification responsibility.
+        to_remove = dict.fromkeys(
+            [message_client.event_queue.id, non_message_client.event_queue.id]
+        ).keys()
+        do_gc_event_queues(to_remove, {hamlet.id}, {hamlet.realm_id})
+
+        self.assertEqual(
+            gc_hook.call_args_list,
+            [
+                mock.call(hamlet.id, message_client, True),
+                mock.call(hamlet.id, non_message_client, False),
+            ],
+        )
 
     def test_idle_queue_timeout_resolution(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -128,11 +128,7 @@ class StreamWatchersTest(ZulipTestCase):
         # This next line of code should silently succeed and basically do
         # nothing under the covers.  This test is here to prevent a bug
         # from re-appearing.
-        missedmessage_hook(
-            user_profile_id=hamlet.id,
-            client=client,
-            last_client_for_user=True,
-        )
+        missedmessage_hook(hamlet.id, client.event_queue.contents(include_internal_data=True))
 
 
 class MissedMessageHookTest(ZulipTestCase):
@@ -222,15 +218,11 @@ class MissedMessageHookTest(ZulipTestCase):
             # To test the missed_message hook, we first need to send a message
             msg_id = self.send_stream_message(self.iago, "Denmark")
 
-            # Verify that nothing happens if you call it as not the
-            # "last client descriptor", in which case the function
-            # short-circuits, since the `missedmessage_hook` handler
-            # for garbage-collection is only for the user's last queue.
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, False)
-            mock_enqueue.assert_not_called()
-
-            # Now verify that we called the appropriate enqueue function
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            # Verify that the hook calls the appropriate enqueue function.
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -245,7 +237,10 @@ class MissedMessageHookTest(ZulipTestCase):
         # By default, email and push notifications should be sent for direct messages
         msg_id = self.send_personal_message(self.iago, self.user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -266,7 +261,10 @@ class MissedMessageHookTest(ZulipTestCase):
         )
         msg_id = self.send_personal_message(self.iago, self.user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -285,7 +283,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.example_user("iago"), "Denmark", content="@**King Hamlet** what's up?"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -305,7 +306,10 @@ class MissedMessageHookTest(ZulipTestCase):
         )
         msg_id = self.send_personal_message(self.iago, self.user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -327,7 +331,10 @@ class MissedMessageHookTest(ZulipTestCase):
         Device.objects.filter(push_token_id__isnull=False).delete()
         msg_id = self.send_personal_message(self.iago, self.user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -345,7 +352,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.send_stream_message(self.user_profile, "Denmark")
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**topic** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called()
             args_dict = mock_enqueue.call_args_list[1][1]
 
@@ -364,7 +374,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.send_stream_message(self.user_profile, "Denmark")
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**topic** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called()
             args_dict = mock_enqueue.call_args_list[1][1]
 
@@ -390,7 +403,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", topic_name="mutingtest", content="@**topic** what's up?"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called()
             args_dict = mock_enqueue.call_args_list[1][1]
 
@@ -407,7 +423,10 @@ class MissedMessageHookTest(ZulipTestCase):
         # By default, stream wildcard mentions should send notifications, just like regular mentions
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -425,7 +444,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.change_subscription_properties({"is_muted": True})
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -444,7 +466,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.change_subscription_properties({"is_muted": True, "wildcard_mentions_notify": True})
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -469,7 +494,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", topic_name="mutingtest", content="@**all** what's up?"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -496,7 +524,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", topic_name="mutingtest", content="@**all** what's up?"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -516,7 +547,10 @@ class MissedMessageHookTest(ZulipTestCase):
         )
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -540,7 +574,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.change_subscription_properties({"wildcard_mentions_notify": True})
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -564,7 +601,10 @@ class MissedMessageHookTest(ZulipTestCase):
         )
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -589,7 +629,10 @@ class MissedMessageHookTest(ZulipTestCase):
         )
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -613,7 +656,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", content="@*hamlet_and_cordelia* what's up?"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -633,7 +679,10 @@ class MissedMessageHookTest(ZulipTestCase):
         )
         msg_id = self.send_stream_message(self.iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -652,7 +701,10 @@ class MissedMessageHookTest(ZulipTestCase):
         )
         msg_id = self.send_stream_message(self.iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -673,7 +725,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.change_subscription_properties({"is_muted": True})
         msg_id = self.send_stream_message(self.iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -699,7 +754,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", topic_name="mutingtest", content="what's up everyone?"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -714,7 +772,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.change_subscription_properties({"push_notifications": True})
         msg_id = self.send_stream_message(self.iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -731,7 +792,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.change_subscription_properties({"email_notifications": True})
         msg_id = self.send_stream_message(self.iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -760,7 +824,10 @@ class MissedMessageHookTest(ZulipTestCase):
             topic_name="mutingtest",
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -776,7 +843,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.change_subscription_properties({"email_notifications": True, "is_muted": True})
         msg_id = self.send_stream_message(self.iago, "Denmark", content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -805,7 +875,10 @@ class MissedMessageHookTest(ZulipTestCase):
             topic_name="unmutingtest",
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -840,7 +913,10 @@ class MissedMessageHookTest(ZulipTestCase):
             topic_name="unmutingtest",
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -873,7 +949,10 @@ class MissedMessageHookTest(ZulipTestCase):
             topic_name="unmutingtest",
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -903,7 +982,10 @@ class MissedMessageHookTest(ZulipTestCase):
             topic_name="unmutingtest",
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -932,7 +1014,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", content="what's up everyone?", topic_name="followed_topic_test"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -959,7 +1044,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", content="what's up everyone?", topic_name="followed_topic_test"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -986,7 +1074,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", content="what's up everyone?", topic_name="followed_topic_test"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -1022,7 +1113,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", content="@**topic** what's up?", topic_name="followed_topic_test"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called()
             args_dict = mock_enqueue.call_args_list[1][1]
 
@@ -1057,7 +1151,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", content="@**all** what's up?", topic_name="followed_topic_test"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -1093,7 +1190,10 @@ class MissedMessageHookTest(ZulipTestCase):
 
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**topic** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called()
             args_dict = mock_enqueue.call_args_list[1][1]
 
@@ -1129,7 +1229,10 @@ class MissedMessageHookTest(ZulipTestCase):
 
         msg_id = self.send_stream_message(self.iago, "Denmark", content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called()
             args_dict = mock_enqueue.call_args_list[1][1]
 
@@ -1170,7 +1273,10 @@ class MissedMessageHookTest(ZulipTestCase):
             self.iago, "Denmark", content="@**all** what's up?", topic_name="followed_topic_test"
         )
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -1185,7 +1291,10 @@ class MissedMessageHookTest(ZulipTestCase):
         do_mute_user(self.user_profile, self.iago)
         msg_id = self.send_personal_message(self.iago, self.user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -1219,7 +1328,10 @@ class MissedMessageHookTest(ZulipTestCase):
         self.client_descriptor = self.allocate_event_queue(hambot)
         msg_id = self.send_personal_message(self.iago, hambot)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(hambot.id, self.client_descriptor, True)
+            missedmessage_hook(
+                hambot.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -1242,7 +1354,10 @@ class MissedMessageHookTest(ZulipTestCase):
             )
         assert msg_id is not None
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
+            missedmessage_hook(
+                self.user_profile.id,
+                self.client_descriptor.event_queue.contents(include_internal_data=True),
+            )
             mock_enqueue.assert_called_once()
             args_dict = mock_enqueue.call_args_list[0][1]
 
@@ -1649,7 +1764,7 @@ class OfflineEventQueueTest(ZulipTestCase):
 
         self.assertTrue(client.offline)
 
-    def test_missedmessage_hook_skips_offline_queue(self) -> None:
+    def test_mark_clients_offline_skips_offline_queue(self) -> None:
         hamlet = self.example_user("hamlet")
         client = self.allocate_queue(hamlet, queue_timeout=self.LONG_LIVED_EVENT_QUEUE_TIMEOUT_SECS)
         client.offline = True
@@ -1658,7 +1773,7 @@ class OfflineEventQueueTest(ZulipTestCase):
         self.send_personal_message(iago, hamlet)
 
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            missedmessage_hook(hamlet.id, client, True)
+            mark_clients_offline({client.event_queue.id}, {hamlet.id})
             mock_enqueue.assert_not_called()
 
     def test_last_client_for_user_with_multiple_queues(self) -> None:
@@ -1743,103 +1858,130 @@ class OfflineEventQueueTest(ZulipTestCase):
             mock_enqueue.assert_called_once()
 
     @time_machine.travel(NOW, tick=False)
-    def test_gc_message_queue_before_non_message_queue(self) -> None:
+    def test_gc_multiple_queue_configurations(self) -> None:
         hamlet = self.example_user("hamlet")
-        add_client_gc_hook(missedmessage_hook)
-
-        message_client = self.allocate_queue(
-            hamlet,
-            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
-            event_types=["message"],
-        )
-        non_message_client = self.allocate_queue(
-            hamlet,
-            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
-            event_types=["presence"],
-        )
-
         iago = self.example_user("iago")
-        self.send_personal_message(iago, hamlet)
+        gc_hook = mock.Mock(wraps=missedmessage_hook)
+        add_client_gc_hook(gc_hook)
 
-        # First, expire only the queue containing the message event. The
-        # presence-only queue should not prevent this from being treated as
-        # the user's last message-receiving client.
-        message_client.last_connection_time = time.time() - DEFAULT_EVENT_QUEUE_TIMEOUT_SECS - 1
-        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            gc_event_queues(port=9993)
-
-            self.assertNotIn(message_client.event_queue.id, clients)
-            self.assertIn(non_message_client.event_queue.id, clients)
-
-            # Later, garbage collecting the presence-only queue cannot send
-            # the missed-message notification, since it has no message event.
-            non_message_client.last_connection_time = (
-                time.time() - DEFAULT_EVENT_QUEUE_TIMEOUT_SECS - 1
-            )
-            gc_event_queues(port=9993)
-
-            mock_enqueue.assert_called_once()
-
-    @time_machine.travel(NOW, tick=False)
-    def test_gc_multiple_message_queues_in_same_sweep(self) -> None:
-        hamlet = self.example_user("hamlet")
-        add_client_gc_hook(missedmessage_hook)
-
-        message_clients = [
-            self.allocate_queue(
-                hamlet,
-                queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
-                event_types=["message"],
-            )
-            for _ in range(2)
+        configurations = [
+            (
+                "message queue expires before non-message queue",
+                [["message"], ["presence"]],
+                [[0], [1]],
+            ),
+            (
+                "multiple message queues expire in the same sweep",
+                [["message"], ["message"]],
+                [[0, 1]],
+            ),
+            (
+                "message and non-message queues expire in the same sweep",
+                [["message"], ["presence"]],
+                [[0, 1]],
+            ),
         ]
 
-        iago = self.example_user("iago")
-        self.send_personal_message(iago, hamlet)
+        for name, event_types_by_queue, expiration_batches in configurations:
+            gc_hook.reset_mock()
+            with self.subTest(name):
+                queue_clients = [
+                    self.allocate_queue(
+                        hamlet,
+                        queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
+                        event_types=event_types,
+                    )
+                    for event_types in event_types_by_queue
+                ]
+                message_id = self.send_personal_message(iago, hamlet)
 
-        # Both queues contain the same message event and expire in the same
-        # sweep. Only one queue should be treated as the user's last
-        # message-receiving client, to avoid duplicate notifications.
-        for client in message_clients:
-            client.last_connection_time = time.time() - DEFAULT_EVENT_QUEUE_TIMEOUT_SECS - 1
+                with mock.patch(
+                    "zerver.tornado.event_queue.maybe_enqueue_notifications"
+                ) as mock_enqueue:
+                    for expiration_batch in expiration_batches:
+                        for client_index in expiration_batch:
+                            queue_clients[client_index].last_connection_time = (
+                                time.time() - DEFAULT_EVENT_QUEUE_TIMEOUT_SECS - 1
+                            )
+                        gc_event_queues(port=9993)
 
-        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
-            gc_event_queues(port=9993)
+                for client in queue_clients:
+                    self.assertNotIn(client.event_queue.id, clients)
+                gc_hook.assert_called_once()
+                user_id, messages = gc_hook.call_args.args
+                self.assertEqual(user_id, hamlet.id)
+                self.assertEqual([event["message"]["id"] for event in messages], [message_id])
+                mock_enqueue.assert_called_once()
 
-            for client in message_clients:
-                self.assertNotIn(client.event_queue.id, clients)
-            mock_enqueue.assert_called_once()
-
-    def test_gc_message_and_non_message_queues_in_same_sweep(self) -> None:
+    def test_aggregates_messages_from_multiple_queues(self) -> None:
         hamlet = self.example_user("hamlet")
-        message_client = self.allocate_queue(
-            hamlet,
-            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
-            event_types=["message"],
-        )
-        non_message_client = self.allocate_queue(
-            hamlet,
-            queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
-            event_types=["presence"],
-        )
-
         gc_hook = mock.Mock()
         add_client_gc_hook(gc_hook)
 
-        # A dict keys view is an ordered AbstractSet, making the non-message
-        # queue the last queue considered for notification responsibility.
-        to_remove = dict.fromkeys(
-            [message_client.event_queue.id, non_message_client.event_queue.id]
-        ).keys()
-        do_gc_event_queues(to_remove, {hamlet.id}, {hamlet.realm_id})
+        message_configurations = [
+            ("only one queue has messages", [[1], []], [1]),
+            ("queues have unique messages", [[1], [2]], [1, 2]),
+            ("queues have overlapping messages", [[1, 2], [2, 3]], [1, 2, 3]),
+        ]
 
-        self.assertEqual(
-            gc_hook.call_args_list,
-            [
-                mock.call(hamlet.id, message_client, True),
-                mock.call(hamlet.id, non_message_client, False),
-            ],
-        )
+        with mock.patch("zerver.tornado.event_queue.missedmessage_hook") as missedmessage_hook:
+            operations: list[tuple[str, Callable[[set[str]], None], mock.Mock, bool]] = [
+                (
+                    "garbage collection",
+                    lambda queue_ids: do_gc_event_queues(queue_ids, {hamlet.id}, {hamlet.realm.id}),
+                    gc_hook,
+                    False,
+                ),
+                (
+                    "mark offline",
+                    lambda queue_ids: mark_clients_offline(queue_ids, {hamlet.id}),
+                    missedmessage_hook,
+                    True,
+                ),
+            ]
+
+            for operation_name, operation, hook, queues_remain in operations:
+                for (
+                    configuration_name,
+                    message_ids_by_queue,
+                    expected_message_ids,
+                ) in message_configurations:
+                    gc_hook.reset_mock()
+                    missedmessage_hook.reset_mock()
+                    with self.subTest(operation=operation_name, configuration=configuration_name):
+                        message_clients = [
+                            self.allocate_queue(
+                                hamlet,
+                                queue_timeout=DEFAULT_EVENT_QUEUE_TIMEOUT_SECS,
+                                event_types=["message"],
+                            )
+                            for _ in message_ids_by_queue
+                        ]
+                        for client, message_ids in zip(
+                            message_clients, message_ids_by_queue, strict=True
+                        ):
+                            for message_id in message_ids:
+                                client.event_queue.push(
+                                    {"type": "message", "message": {"id": message_id}}
+                                )
+
+                        queue_ids = {client.event_queue.id for client in message_clients}
+                        operation(queue_ids)
+
+                        hook.assert_called_once()
+                        user_id, messages = hook.call_args.args
+                        self.assertEqual(user_id, hamlet.id)
+                        self.assertCountEqual(
+                            [event["message"]["id"] for event in messages],
+                            expected_message_ids,
+                        )
+
+                        for client in message_clients:
+                            self.assertEqual(client.event_queue.id in clients, queues_remain)
+                        if queues_remain:
+                            for client in message_clients:
+                                self.assertTrue(client.offline)
+                            do_gc_event_queues(queue_ids, {hamlet.id}, {hamlet.realm.id})
 
     def test_idle_queue_timeout_resolution(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -7,7 +7,7 @@ import random
 import time
 import traceback
 import uuid
-from collections import deque
+from collections import defaultdict, deque
 from collections.abc import Callable, Collection, Iterable, Mapping, MutableMapping, Sequence
 from collections.abc import Set as AbstractSet
 from contextlib import suppress
@@ -504,12 +504,9 @@ user_clients: dict[int, list[ClientDescriptor]] = {}
 # maps realm id to list of client descriptors with all_public_streams=True
 realm_clients_all_streams: dict[int, list[ClientDescriptor]] = {}
 
-# list of registered gc hooks.
-# each one will be called with a user profile id, queue, and bool
-# last_client_for_user that is true if this is the last queue pertaining
-# to this user_profile_id
-# that is about to be deleted
-gc_hooks: list[Callable[[int, ClientDescriptor, bool], None]] = []
+# Each registered GC hook is called once per user with the unique message
+# events from that user's queues that are being garbage-collected together.
+gc_hooks: list[Callable[[int, list[dict[str, Any]]], None]] = []
 
 
 def clear_client_event_queues_for_testing() -> None:
@@ -521,7 +518,7 @@ def clear_client_event_queues_for_testing() -> None:
     gc_hooks.clear()
 
 
-def add_client_gc_hook(hook: Callable[[int, ClientDescriptor, bool], None]) -> None:
+def add_client_gc_hook(hook: Callable[[int, list[dict[str, Any]]], None]) -> None:
     gc_hooks.append(hook)
 
 
@@ -563,15 +560,51 @@ def allocate_client_descriptor(new_queue_data: MutableMapping[str, Any]) -> Clie
     return client
 
 
-def user_has_active_message_queue(user_id: int, to_remove: AbstractSet[str]) -> bool:
+def user_client_map(client_ids: AbstractSet[str]) -> dict[int, set[str]]:
+    users_with_active_queues: set[int] = set()
+    for cid in client_ids:
+        uid = clients[cid].user_profile_id
+        if user_has_active_message_queue(uid, client_ids):
+            users_with_active_queues.add(uid)
+
+    user_clients: defaultdict[int, set[str]] = defaultdict(set)
+    for cid in client_ids:
+        client = clients[cid]
+        uid = client.user_profile_id
+        if uid in users_with_active_queues or not is_active_message_queue(client):
+            continue
+
+        user_clients[uid].add(cid)
+    return user_clients
+
+
+def user_has_active_message_queue(user_id: int, excluded_queue_ids: AbstractSet[str]) -> bool:
     for client in get_client_descriptors_for_user(user_id):
-        if (
-            client.accepts_messages()
-            and not client.offline
-            and client.event_queue.id not in to_remove
-        ):
+        if is_active_message_queue(client) and client.event_queue.id not in excluded_queue_ids:
             return True
     return False
+
+
+def is_active_message_queue(client: ClientDescriptor) -> bool:
+    return client.accepts_messages() and not client.offline
+
+
+# build a set of message events given a list of client ids
+def unique_message_events(client_ids: AbstractSet[str]) -> list[Any]:
+    msgs: dict[str, Any] = {}
+
+    # messages are unhashable so we use a dict
+    for cid in client_ids:
+        client = clients[cid]
+        for event in client.event_queue.contents(include_internal_data=True):
+            if event["type"] != "message":
+                continue
+            id = event.get("message", {}).get("id")
+            if id is None:
+                logging.warning("message in message queue is None")
+                continue
+            msgs[id] = event
+    return sorted(msgs.values(), key=lambda x: x["message"]["id"])
 
 
 def do_gc_event_queues(
@@ -595,33 +628,17 @@ def do_gc_event_queues(
     for realm_id in affected_realms:
         filter_client_dict(realm_clients_all_streams, realm_id)
 
-    # pick an arbitrary message queue when user has multiple message queues to clean up
-    # this prevents duplicate notifications
-    notification_queue_by_user: dict[int, str] = {}
-    for queue_id in to_remove:
-        user_id = clients[queue_id].user_profile_id
+    for uid, client_ids in user_client_map(to_remove).items():
+        messages = unique_message_events(client_ids)
+        # TODO: call missedmessage_hook directly, gc_hooks are only used for that
+        # so the indirection is unnecessary
+        for hook in gc_hooks:
+            hook(uid, messages)
 
-        if not clients[queue_id].accepts_messages():
-            continue
-
-        if user_has_active_message_queue(user_id, to_remove):
-            continue
-
-        notification_queue_by_user[user_id] = queue_id
-
-    for id in to_remove:
-        web_reload_clients.pop(id, None)
-
-        client = clients[id]
-
-        # Note: the only hook ever added is `missedmessage_hook`
-        for cb in gc_hooks:
-            cb(
-                client.user_profile_id,
-                client,
-                notification_queue_by_user.get(client.user_profile_id) == id,
-            )
-        del clients[id]
+    # GC all clients in to_remove
+    for cid in to_remove:
+        web_reload_clients.pop(cid, None)
+        del clients[cid]
 
 
 def mark_clients_offline(
@@ -632,22 +649,12 @@ def mark_clients_offline(
     EVENT_QUEUE_OFFLINE_TIMEOUT_SECS rather than waiting for the
     full queue_timeout.
     """
-    # Pre-compute which users still have active queues after
-    # offline marking, following the same pattern as
-    # do_gc_event_queues for last_client_for_user.
-    users_with_active_queues: set[int] = set()
-    for user_id in affected_users:
-        if user_has_active_message_queue(user_id, to_mark_offline):
-            users_with_active_queues.add(user_id)
+    for uid, client_ids in user_client_map(to_mark_offline).items():
+        messages = unique_message_events(client_ids)
+        missedmessage_hook(uid, messages)
 
-    for id in to_mark_offline:
-        client = clients[id]
-        missedmessage_hook(
-            client.user_profile_id,
-            client,
-            client.user_profile_id not in users_with_active_queues,
-        )
-        client.offline = True
+    for cid in to_mark_offline:
+        clients[cid].offline = True
 
 
 def gc_event_queues(port: int) -> None:
@@ -900,9 +907,7 @@ def build_offline_notification(user_profile_id: int, message_id: int) -> dict[st
     }
 
 
-def missedmessage_hook(
-    user_profile_id: int, client: ClientDescriptor, last_client_for_user: bool
-) -> None:
+def missedmessage_hook(user_profile_id: int, messages: list[Any]) -> None:
     """The receiver_is_off_zulip logic used to determine whether a user
     has no active client suffers from a somewhat fundamental race
     condition. If the client is no longer on the Internet,
@@ -924,16 +929,7 @@ def missedmessage_hook(
     When the queue later expires and is garbage-collected, we skip
     this hook since notifications were already handled.
     """
-    if not last_client_for_user:
-        return
-
-    # For long-lived queues, notifications are sent when the queue
-    # is first marked offline. When the queue later expires, we
-    # skip it here to avoid duplicate notifications.
-    if client.offline:
-        return
-
-    for event in client.event_queue.contents(include_internal_data=True):
+    for event in messages:
         if event["type"] != "message":
             continue
         internal_data = event.get("internal_data", {})

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -563,6 +563,17 @@ def allocate_client_descriptor(new_queue_data: MutableMapping[str, Any]) -> Clie
     return client
 
 
+def user_has_active_message_queue(user_id: int, to_remove: AbstractSet[str]) -> bool:
+    for client in get_client_descriptors_for_user(user_id):
+        if (
+            client.accepts_messages()
+            and not client.offline
+            and client.event_queue.id not in to_remove
+        ):
+            return True
+    return False
+
+
 def do_gc_event_queues(
     to_remove: AbstractSet[str], affected_users: AbstractSet[int], affected_realms: AbstractSet[int]
 ) -> None:
@@ -584,21 +595,31 @@ def do_gc_event_queues(
     for realm_id in affected_realms:
         filter_client_dict(realm_clients_all_streams, realm_id)
 
-    # TODO: If a user has multiple queues and all of them are being
-    # removed in the same sweep, `last_client_for_user` will be
-    # True for all of them, causing `missedmessage_hook` to enqueue
-    # duplicate notifications. Push notifications are deduplicated
-    # by the `active_mobile_push_notification` flag on UserMessage,
-    # but email notifications are not — duplicate
-    # ScheduledMessageNotificationEmail rows will be created.
-    # The same issue exists in mark_clients_offline below.
+    # pick an arbitrary message queue when user has multiple message queues to clean up
+    # this prevents duplicate notifications
+    notification_queue_by_user: dict[int, str] = {}
+    for queue_id in to_remove:
+        user_id = clients[queue_id].user_profile_id
+
+        if not clients[queue_id].accepts_messages():
+            continue
+
+        if user_has_active_message_queue(user_id, to_remove):
+            continue
+
+        notification_queue_by_user[user_id] = queue_id
+
     for id in to_remove:
         web_reload_clients.pop(id, None)
+
+        client = clients[id]
+
+        # Note: the only hook ever added is `missedmessage_hook`
         for cb in gc_hooks:
             cb(
-                clients[id].user_profile_id,
-                clients[id],
-                clients[id].user_profile_id not in user_clients,
+                client.user_profile_id,
+                client,
+                notification_queue_by_user.get(client.user_profile_id) == id,
             )
         del clients[id]
 
@@ -616,10 +637,8 @@ def mark_clients_offline(
     # do_gc_event_queues for last_client_for_user.
     users_with_active_queues: set[int] = set()
     for user_id in affected_users:
-        for c in get_client_descriptors_for_user(user_id):
-            if c.accepts_messages() and not c.offline and c.event_queue.id not in to_mark_offline:
-                users_with_active_queues.add(user_id)
-                break
+        if user_has_active_message_queue(user_id, to_mark_offline):
+            users_with_active_queues.add(user_id)
 
     for id in to_mark_offline:
         client = clients[id]


### PR DESCRIPTION
Always send a notification if the last active message queue is expiring. Only send a single notification if multiple message queues are expiring at the same time.

<!-- Describe your pull request here.-->

Added a new helper function (user_has_active_message_queue) because the logic is used in do_gc_event_queues and mark_clients_offline. In my comment on the bug I though it was going to be 2 commits, but I realized it was easier as a single commit.

Fixes:  #38859

**How changes were tested:**

Added new unit tests, tested with ./tools/test-backed

```
Ran 4291 tests in 482.660s

OK (skipped=1)
```


<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

<details>
<summary>Self-review checklist</summary>

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.


</details>
