### PR TITLE
Parallel forkserver

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
     # We can only import this when type checking.
     from zerver.lib.test_runner import Runner
 
-multiprocessing.set_start_method("fork")
-
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(os.path.dirname(TOOLS_DIR))
 sys.path.insert(0, os.path.dirname(TOOLS_DIR))
@@ -554,4 +552,11 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # We use the "fork" method, rather than Python 3.14's default of
+    # "forkserver", for the pools that run the test shards.  This is
+    # done only when run as a script, since multiprocessing workers
+    # re-import their parent's __main__ module -- including the
+    # forkserver-based workers that zerver.tests.test_parallel makes
+    # this process the parent of.
+    multiprocessing.set_start_method("fork")
     main()

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -2398,17 +2398,28 @@ def import_message_data(
         message_files,
         num_processes,
         initializer=_initialize_message_worker,
-        initargs=(ID_MAP, realm.id, sender_map, import_dir),
+        initargs=(
+            ID_MAP,
+            path_maps,
+            message_id_to_attachments,
+            realm.id,
+            sender_map,
+            import_dir,
+        ),
     )
 
 
 def _initialize_message_worker(
     id_map: dict[str, dict[int, int]],
+    path_maps_value: dict[str, dict[str, str]],
+    message_id_to_attachments_value: dict[str, dict[int, list[str]]],
     realm_id: int,
     sender_map: dict[int, Record],
     import_dir: Path,
 ) -> None:
     ID_MAP.update(id_map)
+    path_maps.update(path_maps_value)
+    message_id_to_attachments.update(message_id_to_attachments_value)
     ctx = MessageImportContext(
         realm=Realm.objects.get(id=realm_id),
         sender_map=sender_map,

--- a/zerver/lib/parallel.py
+++ b/zerver/lib/parallel.py
@@ -1,11 +1,13 @@
 import logging
+import os
 from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import BrokenExecutor, Future, ProcessPoolExecutor
 from contextlib import contextmanager
-from multiprocessing import current_process
+from multiprocessing import current_process, forkserver, get_context
 from typing import Any, TypeVar
 
 import bmemcached
+from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
@@ -17,9 +19,9 @@ ParallelRecordType = TypeVar("ParallelRecordType")
 
 
 def _disconnect() -> None:
-    # Close our database, cache, and RabbitMQ connections, so our
-    # forked children do not share them.  Django will transparently
-    # re-open them as needed.
+    # Close the database, cache, and RabbitMQ connections, so that
+    # processes forked from this one do not share them.  Django will
+    # transparently re-open them as needed.
     connection.close()
     _cache = cache._cache  # type: ignore[attr-defined] # not in stubs
     if isinstance(_cache, bmemcached.Client):  # nocoverage
@@ -30,6 +32,10 @@ def _disconnect() -> None:
         rabbitmq_client = get_queue_client()
         if rabbitmq_client.connection and rabbitmq_client.connection.is_open:
             rabbitmq_client.close()
+
+
+def _worker_has_django_loaded() -> bool:  # nocoverage
+    return apps.ready
 
 
 def func_with_catch(func: Callable[[ParallelRecordType], None], item: ParallelRecordType) -> None:
@@ -96,13 +102,51 @@ def run_parallel_queue(
         return
 
     else:  # nocoverage
-        _disconnect()
+        # Workers are forked from the multiprocessing "forkserver,"
+        # not from this process, so they do not inherit -- and thus
+        # share -- this process's database, cache, and RabbitMQ
+        # connections; concurrent use of a shared connection corrupts
+        # its wire protocol.  The preload module sets up Django in
+        # the forkserver, and then drops any connections that doing
+        # so opened.
+        forkserver.set_forkserver_preload(["zerver.lib.parallel_preload"])
+
+        # Python 3.10's forkserver does not inherit sys.path from
+        # this process, so it would (silently!) fail to import the
+        # preload module when run from outside the deployment root;
+        # see https://github.com/python/cpython/issues/90876, fixed
+        # in Python 3.11.  Provide the path via PYTHONPATH while
+        # starting the forkserver.
+        old_pythonpath = os.environ.get("PYTHONPATH")
+        os.environ["PYTHONPATH"] = os.pathsep.join(
+            [settings.DEPLOY_ROOT] + ([old_pythonpath] if old_pythonpath is not None else [])
+        )
+        try:
+            forkserver.ensure_running()
+        finally:
+            if old_pythonpath is None:
+                del os.environ["PYTHONPATH"]
+            else:
+                os.environ["PYTHONPATH"] = old_pythonpath
 
         exceptions = []
         try:
             with ProcessPoolExecutor(
-                max_workers=processes, initializer=initializer, initargs=initargs
+                max_workers=processes,
+                mp_context=get_context("forkserver"),
+                initializer=initializer,
+                initargs=initargs,
             ) as executor:
+                # The forkserver ignores failures to import the
+                # preload module, so verify, before starting on any
+                # real work, that Django is set up in the workers --
+                # most work items cannot even be unpickled without
+                # their Django models.
+                if not executor.submit(_worker_has_django_loaded).result():
+                    raise Exception(
+                        "forkserver failed to preload zerver.lib.parallel_preload, "
+                        "so workers cannot load Django"
+                    )
 
                 def report_callback(future: Future[None]) -> None:
                     if exc := future.exception():

--- a/zerver/lib/parallel_preload.py
+++ b/zerver/lib/parallel_preload.py
@@ -1,0 +1,14 @@
+"""This module is preloaded into the multiprocessing forkserver by
+zerver.lib.parallel.run_parallel_queue, so that worker processes are
+forked with Django already set up, and do not each pay to re-import
+it.  Setting up Django can itself open connections (e.g. to
+memcached); close them, so that the workers do not share them.
+"""
+
+import django
+
+django.setup()
+
+from zerver.lib.parallel import _disconnect
+
+_disconnect()

--- a/zerver/tests/test_parallel.py
+++ b/zerver/tests/test_parallel.py
@@ -181,6 +181,18 @@ def db_query(output_dir: str, barrier: Barrier, item: int) -> None:  # nocoverag
         barrier.wait(60)
 
 
+def set_file_logger(output_dir: str) -> None:  # nocoverage
+    # In each worker process, we set up the logger to write to a
+    # (pid).error file.  This must be a module-level function, since
+    # worker initializers are pickled into the workers.
+    logging.basicConfig(
+        filename=f"{output_dir}/{os.getpid()}.error",
+        level=logging.INFO,
+        filemode="w",
+        force=True,
+    )
+
+
 class RunParallelTest(ZulipTestCase):
     def skip_in_parallel_harness(self) -> None:
         if current_process().daemon:
@@ -250,17 +262,6 @@ class RunParallelTest(ZulipTestCase):
         self.skip_in_parallel_harness()
         output_dir = tempfile.mkdtemp()
         report_lines = []
-
-        def set_file_logger(output_dir: str) -> None:
-            # In each worker process, we set up the logger to write to
-            # a (pid).error file.
-            logging.basicConfig(
-                filename=f"{output_dir}/{os.getpid()}.error",
-                level=logging.INFO,
-                filemode="w",
-                force=True,
-            )
-
         try:
             barrier = Manager().Barrier(2)
             run_parallel(

--- a/zerver/tests/test_parallel.py
+++ b/zerver/tests/test_parallel.py
@@ -193,6 +193,23 @@ def set_file_logger(output_dir: str) -> None:  # nocoverage
     )
 
 
+def get_backend_pid() -> int:  # nocoverage
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_backend_pid()")
+        row = cursor.fetchone()
+        assert row is not None
+        return row[0]
+
+
+def write_backend_pid(output_dir: str, barrier: Barrier, item: int) -> None:  # nocoverage
+    output_file = f"{output_dir}/{os.getpid()}.output"
+    first_time = not os.path.exists(output_file)
+    with open(output_file, "a") as fh:
+        fh.write(f"{get_backend_pid()}\n")
+    if first_time:
+        barrier.wait(60)
+
+
 class RunParallelTest(ZulipTestCase):
     def skip_in_parallel_harness(self) -> None:
         if current_process().daemon:
@@ -290,6 +307,36 @@ class RunParallelTest(ZulipTestCase):
                 with open(error_path) as error_file:
                     error_lines.extend(error_file.readlines())
             self.assertEqual(error_lines[0], "ERROR:root:Error processing item: 103\n")
+        finally:
+            shutil.rmtree(output_dir)
+
+    def test_parallel_queue_connection_isolation(self) -> None:  # nocoverage
+        self.skip_in_parallel_harness()
+        output_dir = tempfile.mkdtemp()
+        try:
+            barrier = Manager().Barrier(2)
+            with run_parallel_queue(
+                partial(write_backend_pid, output_dir, barrier),
+                processes=2,
+            ) as submit:
+                # Perform a database query inside the block, before
+                # any workers have been forked; the workers must not
+                # end up sharing the connection this opens.
+                parent_backend_pid = get_backend_pid()
+                for item in range(100, 104):
+                    submit(item)
+
+            output_files = glob.glob(f"{output_dir}/*.output")
+            self.assert_length(output_files, 2)
+            worker_backend_pids: set[int] = set()
+            for output_path in output_files:
+                with open(output_path) as output_file:
+                    worker_backend_pids.update(int(line) for line in output_file)
+            self.assert_length(worker_backend_pids, 2)
+            self.assertNotIn(parent_backend_pid, worker_backend_pids)
+
+            # And this process's connection is still usable.
+            self.assertTrue(connection.is_usable())
         finally:
             shutil.rmtree(output_dir)
 


### PR DESCRIPTION
Workers in `zerver/lib/parallel.py` are forked lazily by
`ProcessPoolExecutor`, at first `submit()` — after the parent's
`_disconnect()` has run. Any query inside the `with
run_parallel_queue(...)` block (including iterating a `QuerySet`
passed to `run_parallel`, as `zerver/lib/transfer.py` does)
transparently reopens a connection that the workers then inherit and
share, corrupting its wire protocol. Noticed in review of #39125.

This series forks workers from a multiprocessing forkserver instead:
a separate process that never runs application code, so there is
nothing to inherit no matter what the parent does. A preload module
sets up Django once in the forkserver (~1.5s, one-time) and sheds the
memcached connection that `django.setup()` opens; workers then fork
from it with Django loaded and no connections.

Hardenings, discovered by testing:
- CPython 3.10's forkserver ignores `sys_path`
  (python/cpython#90876, fixed in 3.11), so it is started with an
  explicit `PYTHONPATH`; a probe task fails fast with a clear error
  if the preload silently failed to import.
- Forkserver children re-import the parent's `__main__`, so
  `tools/test-backend`'s top-level `set_start_method("fork")` moved
  under its `__main__` guard.
- Initializers/initargs are now pickled into workers (fork never
  pickled them), and workers no longer inherit parent-mutated module
  globals; the two prep commits adjust the message-import worker and
  a test that relied on those properties.