### PR TITLE
webhooks/docs: Update Incoming webhook docs.

### DIFF
--- a/docs/webhooks/incoming-webhooks-overview.md
+++ b/docs/webhooks/incoming-webhooks-overview.md
@@ -74,7 +74,8 @@ examples below are for an incoming webhook named `MyWebHook`.
   necessary helper functions.
 - `zerver/webhooks/mywebhook/fixtures/message_type.json`: A sample
   of payload data, from the third-party service, used by tests. Add
-  one fixture file per event type supported by your integration.
+  fixtures covering the event types and conditions your integration
+  supports.
 - `zerver/webhooks/mywebhook/tests.py`: Tests for your webhook.
 - `zerver/webhooks/mywebhook/doc.md`: End-user documentation explaining
   how to set up the integration.

--- a/docs/webhooks/incoming-webhooks-reference.md
+++ b/docs/webhooks/incoming-webhooks-reference.md
@@ -59,7 +59,7 @@ allow using single underscores within each segment.
 
 To get the HTTP header value from the fixture's filename in your `tests.py`,
 you can use the `default_fixture_to_headers` function in
-`zerver/webhooks/common.py`, like so:
+`zerver/lib/webhooks/common.py`, like so:
 
 ```python
 fixture_to_headers = default_fixture_to_headers("HTTP_X_GITHUB_EVENT")

--- a/docs/webhooks/incoming-webhooks-reference.md
+++ b/docs/webhooks/incoming-webhooks-reference.md
@@ -57,8 +57,9 @@ allow using single underscores within each segment.
 
 ### Extracting event-type HTTP headers from fixtures
 
-To get the HTTP header value from the fixture's filename in your `tests.py`,
-you can use the `default_fixture_to_headers` function in
+To get the HTTP header value from the fixture's filename in your
+tests, you can define a `fixture_to_headers` function in your
+`view.py`, using the `default_fixture_to_headers` function in
 `zerver/lib/webhooks/common.py`, like so:
 
 ```python
@@ -70,9 +71,8 @@ fixture_to_headers = default_fixture_to_headers("HTTP_X_GITHUB_EVENT")
 The default implementation `default_fixture_to_headers` uses the first part
 of the fixture's filename as the header value, separated by a double
 underscore (`__`). If you need to use a different method for encoding the
-header value(s), you can directly pass your function with the custom parsing
-logic to the `fixture_to_headers` function defined in
-`zerver/tests/test_webhooks_common.py`, instead of using
+header value(s), you can define your own `fixture_to_headers` function with
+the custom parsing logic in your `view.py`, instead of using
 `default_fixture_to_headers`.
 
 ## Custom URL query parameters

--- a/docs/webhooks/incoming-webhooks-reference.md
+++ b/docs/webhooks/incoming-webhooks-reference.md
@@ -225,7 +225,6 @@ attribute `TOPIC` as a keyword argument to `build_webhook_url`, like so:
 class QuerytestHookTests(WebhookTestCase):
 
     TOPIC = "Default topic"
-    FIXTURE_DIR_NAME = 'querytest'
 
     def test_querytest_test_one(self) -> None:
         # construct the URL used for this test

--- a/docs/webhooks/incoming-webhooks-reference.md
+++ b/docs/webhooks/incoming-webhooks-reference.md
@@ -194,11 +194,16 @@ For example, here is the definition of a webhook function that gets both
 `stream` and `topic` from the query parameters:
 
 ```python
+@webhook_view("Querytest")
 @typed_endpoint
-def api_querytest_webhook(request: HttpRequest, user_profile: UserProfile,
-                          payload: Annotated[str, ApiParamConfig(argument_type_is_body=True)],
-                          stream: str = "test",
-                          topic: str= "Default Alert":
+def api_querytest_webhook(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    payload: Annotated[str, ApiParamConfig(argument_type_is_body=True)],
+    stream: str = "test",
+    topic: str = "Default Alert",
+) -> HttpResponse:
 ```
 
 In actual use, you might configure the third-party service to call your

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -285,7 +285,7 @@ development environment.
 1. Click **Send**. The webhook notification message will be sent to the
    default Zulip organization in your development environment.
 
-By having Zulip open in one browsre tab and this tool in another, you can
+By having Zulip open in one browser tab and this tool in another, you can
 quickly tweak your webhook code and send sample messages for different
 test fixtures.
 

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -311,7 +311,7 @@ class HelloWorldHookTests(WebhookTestCase):
         expected_topic_name = "Hello World"
         expected_message = "Hello! I am happy to be here! :smile:\nThe Wikipedia featured article for today is **[Marilyn Monroe](https://en.wikipedia.org/wiki/Marilyn_Monroe)**"
 
-        # use fixture named helloworld_hello
+        # use fixture named hello.json
         self.check_webhook(
             "hello",
             expected_topic_name,
@@ -345,7 +345,7 @@ Hello World webhook, then we would add another test function to
         expected_topic_name = "Hello World"
         expected_message = "Hello! I am happy to be here! :smile:\nThe Wikipedia featured article for today is **[Goodbye](https://en.wikipedia.org/wiki/Goodbye)**"
 
-        # use fixture named helloworld_goodbye
+        # use fixture named goodbye.json
         self.check_webhook(
             "goodbye",
             expected_topic_name,

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -44,7 +44,7 @@ it requires only one fixture,
 ```json
 {
   "featured_title":"Marilyn Monroe",
-  "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe",
+  "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe"
 }
 ```
 
@@ -360,7 +360,7 @@ As well as a new fixture `goodbye.json` in
 ```json
 {
   "featured_title":"Goodbye",
-  "featured_url":"https://en.wikipedia.org/wiki/Goodbye",
+  "featured_url":"https://en.wikipedia.org/wiki/Goodbye"
 }
 ```
 

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -48,11 +48,52 @@ it requires only one fixture,
 }
 ```
 
-For integrations that send the event type or other important information as
-part of the HTTP header, you will need to record the header value for each
-fixture. Refer to
+### Fixture guidelines
+
+Fixtures for a real third-party service must always be actual
+captured payloads, or payloads from the service's official API
+documentation, never hand-written, invented, or AI-generated. A
+fabricated payload does not accurately reflect what the service
+really sends, so an integration developed against one may not work
+with real events.
+
+When setting up the integration, make sure not to use any personal
+details that you would not want to be part of the fixtures. Use
+fixtures exactly as you captured them; do not edit their contents. An
+edited fixture no longer records what the service really sends, and
+subtle mistakes are easy to introduce. If you need a variation,
+capture a new fixture instead.
+
+If you absolutely must remove personal details from a captured
+payload, commit the captured fixture locally first, then replace the
+personal details with equally realistic strings and amend the commit.
+This makes the scrub a reviewable diff, and the original data never
+reaches the public history.
+
+Fixture data appears in the messages and topics that your integration
+produces, and in the auto-generated example screenshots in the
+integration's documentation, so when setting up the third-party
+service, use realistic names for projects, tasks, and other entities.
+Where you can, use the same names and email addresses as the shared
+example content in `zerver/webhooks/fixtureless_integrations.py`, so
+that the example screenshots are consistent across integrations.
+
+Fixture files are named descriptively, in snake_case, after the event
+(and variant) they capture. The Hello World integration's fixture is
+`hello.json`; for a richer service, a fixture might be named
+something like `issue_created_with_assignee.json`.
+
+For integrations that send the event type or other important
+information as part of the HTTP header, the value of the header is
+encoded in the first part of the fixture's filename, separated from
+the rest by a double underscore. Refer to
 [the section on custom HTTP headers](incoming-webhooks-reference.md#custom-http-headers)
 in the reference guide for more details.
+
+Once captured, fixtures rarely need to be updated: as long as the
+fields your integration reads are still what the service sends, there
+is no need to update fixtures just because the service has added new
+fields over the years.
 
 ## Step 1: Initialize the python package
 

--- a/docs/webhooks/incoming-webhooks-walkthrough.md
+++ b/docs/webhooks/incoming-webhooks-walkthrough.md
@@ -24,16 +24,16 @@ payload(s) from the service. Examining this data allows you to:
 
 - Determine how you will structure your webhook integration code,
   including what event types your integration should support and how.
-- Create fixtures. A test fixture is a small file containing test data,
-  generally one for each event type. Fixtures enable the testing of
+- Create fixtures. A test fixture is a small file containing test data
+  for one kind of event or scenario. Fixtures enable the testing of
   webhook integration code without the need to actually contact the
   service being integrated.
 
 You'll want to write a test for each distinct event type your incoming
-webhook integration supports, and you'll need a corresponding fixture
-for each of these tests. Depending on the type of data the third-party
-service sends, your fixtures may contain JSON, URL encoded text, or
-some other kind of data. [Step 5: Create automated tests](#step-5-create-automated-tests)
+webhook integration supports, and you'll need fixtures for these
+tests. Depending on the type of data the third-party service sends,
+your fixtures may contain JSON, URL encoded text, or some other kind
+of data. [Step 5: Create automated tests](#step-5-create-automated-tests)
 and [our testing documentation](../testing/testing.md) have further
 details about writing tests and using test fixtures.
 
@@ -56,6 +56,11 @@ documentation, never hand-written, invented, or AI-generated. A
 fabricated payload does not accurately reflect what the service
 really sends, so an integration developed against one may not work
 with real events.
+
+Collect only the fixtures your integration's tests need. If you want
+to test how the integration handles different values of a URL query
+parameter, prefer writing tests that reuse one fixture, instead of
+capturing several fixtures that are almost identical.
 
 When setting up the integration, make sure not to use any personal
 details that you would not want to be part of the fixtures. Use
@@ -373,9 +378,8 @@ class HelloWorldHookTests(WebhookTestCase):
         )
 ```
 
-When writing tests, you'll want to include one test function (and a
-corresponding test fixture) for each distinct event type and condition
-that the integration supports.
+When writing tests, you'll want to include one test function for each
+distinct event type and condition that the integration supports.
 
 If, for example, we added support for sending a goodbye message to the
 Hello World webhook, then we would add another test function to

--- a/zerver/webhooks/airbyte/tests.py
+++ b/zerver/webhooks/airbyte/tests.py
@@ -2,8 +2,6 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class AirbyteHookTests(WebhookTestCase):
-    STREAM_NAME = "airbyte"
-
     def test_airbyte_job_success(self) -> None:
         expected_topic = "Zulip Airbyte Integration - Google Sheets → Postgres"
 

--- a/zerver/webhooks/airbyte/tests.py
+++ b/zerver/webhooks/airbyte/tests.py
@@ -3,7 +3,6 @@ from zerver.lib.test_classes import WebhookTestCase
 
 class AirbyteHookTests(WebhookTestCase):
     STREAM_NAME = "airbyte"
-    FIXTURE_DIR_NAME = "airbyte"
 
     def test_airbyte_job_success(self) -> None:
         expected_topic = "Zulip Airbyte Integration - Google Sheets → Postgres"

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -13,7 +13,7 @@ class HelloWorldHookTests(WebhookTestCase):
         expected_topic_name = "Hello World"
         expected_message = "Hello! I am happy to be here! :smile:\nThe Wikipedia featured article for today is **[Marilyn Monroe](https://en.wikipedia.org/wiki/Marilyn_Monroe)**"
 
-        # use fixture named helloworld_hello
+        # use fixture named hello.json
         self.check_webhook(
             "hello",
             expected_topic_name,
@@ -25,7 +25,7 @@ class HelloWorldHookTests(WebhookTestCase):
         expected_topic_name = "Hello World"
         expected_message = "Hello! I am happy to be here! :smile:\nThe Wikipedia featured article for today is **[Goodbye](https://en.wikipedia.org/wiki/Goodbye)**"
 
-        # use fixture named helloworld_goodbye
+        # use fixture named goodbye.json
         self.check_webhook(
             "goodbye",
             expected_topic_name,

--- a/zerver/webhooks/wekan/tests.py
+++ b/zerver/webhooks/wekan/tests.py
@@ -4,8 +4,6 @@ from zerver.lib.test_classes import WebhookTestCase
 
 
 class WekanHookTests(WebhookTestCase):
-    FIXTURE_DIR_NAME = "wekan"
-
     def test_add_attachment_message(self) -> None:
         expected_message = 'JohnFish added attachment "hGfm5ksud8k" to card "Markdown and emoji\'s" at list "Design" at swimlane "Default" at board "Bucket List".\n\n[See in Wekan](http://127.0.0.1/b/Jinj4Xj7qnHLRmrTY/bucket-list/pMtu7kPZvMuhhC4hL)'
         self.check_webhook(


### PR DESCRIPTION
This PR primarly aims in adding new guidelines - regarding fixtures. Thanks to @Niloth-p as Most the guidelines here were provided by them(in our dm's).

The new guidlines are just present in the pre-final and the commit before that, the rest of the 7 commits are minor nits/fixes which I found while I was skimming through the docs finiding relevant positions to add the new guidlines.

Follow ups:
* Document the call back helper when we support the `config_data` entirely.
* Document the directory to store api responses (if standardized).
**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Screenshots and screen captures:</summary>
<img width="881" height="1174" alt="image" src="https://github.com/user-attachments/assets/0c67304c-7df9-40f0-8310-37bd182fe1ef" />



| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/8cff81bc-7564-41f7-ae49-f633f11431ee) | ![after](https://github.com/user-attachments/assets/feae84e5-efe7-4645-b618-b58a5a54a524) |
| ![before](https://github.com/user-attachments/assets/c26ca603-5c7b-44df-bf78-9ae4688167b8) | ![after](https://github.com/user-attachments/assets/d19cba4d-6d2f-48f6-91ba-3e0d4386ad5a) |
| ![before](https://github.com/user-attachments/assets/faaa81f6-7bbe-4c17-bbb5-be31791a60ff) | ![after](https://github.com/user-attachments/assets/711256c3-b8cd-4ed2-ac70-cc1eaaed37d6) |
| ![before](https://github.com/user-attachments/assets/4fee477d-3dbc-4e24-bf7d-a2d973a2e21b) | ![after](https://github.com/user-attachments/assets/7d580d90-dfcb-41a4-9d50-7940360f375c) |
| ![before](https://github.com/user-attachments/assets/9f85e860-55c8-4cd9-8ee0-6fe87903fa12) | ![after](https://github.com/user-attachments/assets/75a0f377-be0c-44da-92ae-84cea532aae8) |
| ![before](https://github.com/user-attachments/assets/737d7fa8-d768-41a2-9b75-eed0cbc590d9) | ![after](https://github.com/user-attachments/assets/8e4f720d-de3c-404e-87bf-6d8ea7aecc2a) |



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
