### PR TITLE
fix for issue 17419: preventing tabspace getting converted to normal space in fenced code in markdown

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2221,6 +2221,18 @@ def get_sub_registry(r: markdown.util.Registry[T], keys: list[str]) -> markdown.
 DEFAULT_MARKDOWN_KEY = -1
 
 
+class ZulipNormalizeWhitespace(markdown.preprocessors.Preprocessor):
+    """Variant of NormalizeWhitespace that preserves tabs and trailing whitespace."""
+
+    @override
+    def run(self, lines: list[str]) -> list[str]:
+        source = "\n".join(lines)
+        source = source.replace(markdown.util.STX, "").replace(markdown.util.ETX, "")
+        source = source.replace("\r\n", "\n").replace("\r", "\n") + "\n\n"
+        source = re.sub(r"(?<=\n) +\n", "\n", source)
+        return source.split("\n")
+
+
 class ZulipMarkdown(markdown.Markdown):
     zulip_message: Message | None
     zulip_realm: Realm | None
@@ -2275,9 +2287,7 @@ class ZulipMarkdown(markdown.Markdown):
         # reference - references don't make sense in a chat context.
         preprocessors = markdown.util.Registry[markdown.preprocessors.Preprocessor]()
         preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 35)
-        preprocessors.register(
-            markdown.preprocessors.NormalizeWhitespace(self), "normalize_whitespace", 30
-        )
+        preprocessors.register(ZulipNormalizeWhitespace(self), "normalize_whitespace", 30)
         preprocessors.register(fenced_code.FencedBlockPreprocessor(self), "fenced_code_block", 25)
         preprocessors.register(
             AlertWordNotificationProcessor(self), "custom_text_notifications", 20

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -55,6 +55,12 @@
       "text_content": "Hamlet once said\ndef func():\n    x = 1\n\n    y = 2\n\n    z = 3\n\nAnd all was good."
     },
     {
+      "name": "codeblock_tabs_preserved",
+      "input": "```\nreal\t0m0.322s\nuser\t0m0.344s\nsys\t0m0.036s\n```",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>real\t0m0.322s\nuser\t0m0.344s\nsys\t0m0.036s\n</code></pre></div>",
+      "text_content": "real\t0m0.322s\nuser\t0m0.344s\nsys\t0m0.036s\n"
+    },
+    {
       "name": "inline_code_spaces",
       "input": "` outer ` ```    space    ```",
       "expected_output": "<p><code> outer </code> <code>    space    </code></p>",


### PR DESCRIPTION
Fixes: #17419

This PR preserves tab characters in fenced code blocks during
server-side Markdown rendering.

The reported issue occurs because Python-Markdown's
`markdown.preprocessors.NormalizeWhitespace` calls `expandtabs()` before fenced code blocks are processed, replacing literal tab
characters with spaces. As a result, the rendered code block no longer matches the original input, and copying the rendered code block also returns spaces instead of tabs.

To address this, this PR introduces a Zulip-specific class which inherits from `markdown.preprocessors.Preprocessor` to override a methon
`ZulipNormalizeWhitespace` preprocessor that preserves tab characters by removing the upstream `expandtabs()` behavior. The custom preprocessor is registered in place of the upstream implementation, allowing fenced code blocks to preserve the original text without affecting Zulip's Markdown pipeline.

**How changes were tested:**

- Reproduced the issue by generating terminal output containing literal tab characters and pasting it into a fenced code block.
- Verified that before this change, the rendered message replaced tabs with spaces.
- Verified that after this change, tab characters are preserved in the rendered code block.
- Verified that using the "Copy code" button preserves the original tab characters.

I also had one question regarding testing. I noticed that PR #38363 adds a regression test for a similar Markdown change. Is adding a similar regression test the preferred approach for this fix, or would a different test location be more appropriate?

**Self Review Checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.