### PR TITLE
portico: List Foundation board members and advisory members.

### DIFF
--- a/templates/corporate/team.html
+++ b/templates/corporate/team.html
@@ -110,10 +110,10 @@ contributors, and 97+ people with 100+ commits." %}
 
                 <h1 id="the-core-team">The core team</h1>
                 <p>
-                    The Kandra Labs team includes 12 amazing people who have an
-                    average of over 4 years of professional experience working
-                    on Zulip, and almost 25,000 Zulip commits between them. They
-                    have shipped major improvements end-to-end across every
+                    The Kandra Labs team is a group of amazing people who have
+                    numerous years of professional experience working on Zulip,
+                    and tens of thousands of Zulip commits between them. They
+                    frequently ship major improvements end-to-end across every
                     facet of the product.
                 </p>
                 <p>

--- a/templates/corporate/team.html
+++ b/templates/corporate/team.html
@@ -29,8 +29,7 @@ contributors, and 97+ people with 100+ commits." %}
                     below!
                 </p>
 
-                <h1 id="the-core-team">The core team</h1>
-
+                <h1 id="the-zulip-foundation">The Zulip Foundation</h1>
                 <p>
                     Zulip is stewarded by the <a
                     href="https://blog.zulip.com/2026/05/15/announcing-zulip-foundation/">Zulip
@@ -42,6 +41,74 @@ contributors, and 97+ people with 100+ commits." %}
                     <a href="/plans/#self-hosted">supporting</a>, and improving
                     Zulip for use across all industries.
                 </p>
+
+                <h2>Board of Directors</h2>
+                <ul>
+                    <li>
+                        Tim Abbott, Zulip’s founder, and project leader from 2015
+                        to May 2026.
+                    </li>
+                    <li>
+                        Greg Price, Zulip's long-time mobile team lead, who had
+                        a cofounder-like role from 2017 to May 2026.
+                    </li>
+                    <li>
+                        Alya Abbott, Zulip’s long-time product lead, who had a
+                        cofounder-like role from 2021 to May 2026.
+                    </li>
+                    <li>
+                        Josh Triplett, a leader in the Rust programming
+                        language, experienced in open source, and a
+                        <a href="https://zulip.com/case-studies/rust/">major advocate</a>
+                        for Zulip.
+                    </li>
+                </ul>
+
+                <h2>Advisory Board</h2>
+                <ul>
+                    <li>
+                        Jeremy Avigad, a Professor of Philosophy and Mathematical
+                        Sciences at Carnegie Mellon University and Director of the
+                        NSF Institute for Computer-Aided Reasoning in Mathematics.
+                        He is a founding member of the
+                        <a href="https://leanprover.zulipchat.com/">Lean Community organization</a>,
+                        for which Zulip has hosted more than two million messages
+                        to date.
+                    </li>
+                    <li>
+                        Nick Bergson-Shilcock, the CEO and cofounder of the
+                        <a href="https://www.recurse.com/">Recurse Center</a>,
+                        a programming retreat based in New York whose community of
+                        3,000+ alums has run on Zulip since 2013.
+                    </li>
+                    <li>
+                        Puneeth Chaganti, an OCaml developer working on core
+                        ecosystem tooling, and a mentor for
+                        <a href="https://zulip.readthedocs.io/en/latest/outreach/overview.html">
+                            Zulip's Google Summer of Code program
+                        </a>
+                        since 2018.
+                    </li>
+                    <li>
+                        Andrew Sutherland, mathematician and senior researcher at
+                        the Massachusetts Institute of Technology, and President
+                        of the Number Theory Foundation. He is a leading advocate
+                        of Zulip for research collaborations, including the
+                        <a href="https://www.lmfdb.org/">L-functions and Modular Forms Database</a>.
+                    </li>
+                    <li>
+                        Alex Vandiver, who led Zulip's infrastructure team from
+                        2020 to May 2026.
+                    </li>
+                    <li>
+                        Hazel Weakly, a former Director of the
+                        <a href="https://haskell.foundation/">Haskell Foundation</a>
+                        Board, open source and community advocate, and a Fellow of
+                        the <a href="https://nivenly.org/">Nivenly Foundation</a>.
+                    </li>
+                </ul>
+
+                <h1 id="the-core-team">The core team</h1>
                 <p>
                     The Kandra Labs team includes 12 amazing people who have an
                     average of over 4 years of professional experience working


### PR DESCRIPTION
- Content from https://blog.zulip.com/2026/05/15/announcing-zulip-foundation/ cleaned up for this context. Adds Alex, who became and advisory member after the publication of the post.
- Foundation section is above the Core team section, as the intro paragraphs worked better this way. Could be rewritten to rearrange.

Questions:
1. Are we happy with the amount of vertical space this takes up? It's quite a bit more than Tim's bio took up previously.


<details><summary>Screenshot</summary>
<p>

<img width="755" height="934" alt="Screenshot 2026-07-12 at 16 31 08" src="https://github.com/user-attachments/assets/94535be5-09be-4ce3-87a1-f36a95c93448" />


</p>
</details> 