### PR TITLE
message feed: Animate only content-edited messages.

### DIFF
--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -439,6 +439,7 @@ function get_post_edit_topic(
 
 export function update_messages(events: UpdateMessageEvent[]): void {
     const messages_to_rerender: Message[] = [];
+    const content_edited_message_ids = new Set<number>();
     let changed_narrow = false;
     let refreshed_current_narrow = false;
     let changed_compose = false;
@@ -504,6 +505,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                     ];
                 }
                 any_message_content_edited = true;
+                content_edited_message_ids.add(event.message_id);
 
                 // Update raw_content, so that editing a few times in a row is fast.
                 message_store.maybe_update_raw_content(anchor_message.id, event.content);
@@ -981,15 +983,8 @@ export function update_messages(events: UpdateMessageEvent[]): void {
     }
 
     if (messages_to_rerender.length > 0) {
-        // If the content of the message was edited, we do a special animation.
-        //
-        // BUG: This triggers the "message edited" animation for every
-        // message that was edited if any one of them had its content
-        // edited. We should replace any_message_content_edited with
-        // passing two sets to rerender_messages; the set of all that
-        // are changed, and the set with content changes.
         for (const list of message_lists.all_rendered_message_lists()) {
-            list.view.rerender_messages(messages_to_rerender, any_message_content_edited);
+            list.view.rerender_messages(messages_to_rerender, content_edited_message_ids);
         }
     }
 

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1922,7 +1922,10 @@ export class MessageListView {
         });
     }
 
-    rerender_messages(messages: Message[], message_content_edited = false): void {
+    rerender_messages(
+        messages: Message[],
+        content_edited_message_ids: ReadonlySet<number> = new Set(),
+    ): void {
         // this.render is never called in this code path, we use
         // `_rerender_message` instead which is optimized for this use
         // case.
@@ -1949,7 +1952,7 @@ export class MessageListView {
         const rerendered_group_ids = new Set<string>();
         for (const message_container of message_containers) {
             const $rendered = this._rerender_message(message_container, {
-                message_content_edited,
+                message_content_edited: content_edited_message_ids.has(message_container.msg.id),
                 is_revealed: false,
             });
             rerendered_elements.push(...$rendered);

--- a/web/tests/message_events.test.cjs
+++ b/web/tests/message_events.test.cjs
@@ -114,9 +114,12 @@ run_test("update_messages", ({override, override_rewire}) => {
 
     let rendered_msgs;
 
-    message_lists.current.view.rerender_messages = (msgs_to_rerender, message_content_edited) => {
+    message_lists.current.view.rerender_messages = (
+        msgs_to_rerender,
+        content_edited_message_ids,
+    ) => {
         rendered_msgs = msgs_to_rerender;
-        assert.equal(message_content_edited, true);
+        assert.deepEqual(content_edited_message_ids, new Set([original_message.id]));
     };
 
     const side_effects = [

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -351,6 +351,36 @@ test("rerender_messages rebuilds every distinct recipient bar", () => {
     assert.deepEqual(rerendered_group_ids, ["group-A", "group-B"]);
 });
 
+test("rerender_messages marks only messages with content edits", () => {
+    const view = new MessageListView({id: 1}, true, true);
+    const dm1 = {msg: {id: 1, type: "private", to_user_ids: "5"}};
+    const dm2 = {msg: {id: 2, type: "private", to_user_ids: "5"}};
+    view.message_containers = new Map([
+        [1, dm1],
+        [2, dm2],
+    ]);
+
+    view.get_row = (id) => ({
+        length: 1,
+        parent: () => ({expectOne: () => ({attr: () => `group-${id}`})}),
+    });
+    view._message_groups = [{message_group_id: "group-1"}, {message_group_id: "group-2"}];
+    view._rerender_header = () => {};
+
+    const content_edit_statuses = [];
+    view._rerender_message = (message_container, opts) => {
+        content_edit_statuses.push([message_container.msg.id, opts.message_content_edited]);
+        return [];
+    };
+
+    view.rerender_messages([dm1.msg, dm2.msg], new Set([dm2.msg.id]));
+
+    assert.deepEqual(content_edit_statuses, [
+        [dm1.msg.id, false],
+        [dm2.msg.id, true],
+    ]);
+});
+
 test("muted_message_vars", () => {
     // This verifies that the variables for muted/hidden messages are set
     // correctly.


### PR DESCRIPTION
Part of #22879.

When multiple `update_message` events are processed in one batch, a content edit in any one event currently causes every message rerendered by that batch to use the edited-content animation. This is most noticeable after reconnecting and receiving several pending edits at once.

This change keeps track of which message IDs actually had content edits, so unrelated messages in the same batch rerender without the fade animation. The separate `update_muting_and_rerender` optimization mentioned in #22879 remains out of scope.

**How changes were tested:**

- `./tools/test-js-with-node message_events message_list_view`
- `./tools/test-js-with-node`
- `./tools/lint web/src/message_events.ts web/src/message_list_view.ts web/tests/message_events.test.cjs web/tests/message_list_view.test.cjs`
- Browser smoke test on the development server: logged in through `/devlogin/`, opened Recent conversations, and opened a topic containing two rendered message rows. No browser console errors occurred.

**Screenshots and screen captures:**

Not included because there is no static visual change. This limits an existing transient animation to the correct message row; the batched-event behavior is covered by the regression test.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
