### PR TITLE
[ai] css: Remove unreachable alert selectors and merge duplicate rules.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -156,15 +156,13 @@
         border-color: hsl(205deg 58% 69% / 40%);
     }
 
-    .alert.alert-error,
-    .alert.alert-danger {
+    .alert.alert-error {
         background-color: hsl(318deg 12% 21%);
         color: inherit;
         border: 1px solid hsl(0deg 75% 65%);
     }
 
     .alert-box .alert,
-    .alert-box .stacktrace,
     .alert.alert-error {
         background-color: hsl(318deg 12% 21%);
         color: inherit;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -156,12 +156,6 @@
         border-color: hsl(205deg 58% 69% / 40%);
     }
 
-    .alert.alert-error {
-        background-color: hsl(318deg 12% 21%);
-        color: inherit;
-        border: 1px solid hsl(0deg 75% 65%);
-    }
-
     .alert-box .alert,
     .alert.alert-error {
         background-color: hsl(318deg 12% 21%);


### PR DESCRIPTION
Fixes part of #39354.

Two commits, after @laurynmm pointed out that some of these selectors may not be reachable at all (they were right, two of the four were dead):

1. **Remove unreachable alert selectors.** `dark_theme.css` is only imported from `web/src/bundles/app.ts`, so it applies to the web app and nothing else.
   * `.alert-box .stacktrace`: blueslip appends stacktraces to `.blueslip-error-container`, which is a sibling of the alert box in `templates/zerver/app/index.html`, never a descendant. The unscoped `.stacktrace` rule below is what styles them.
   * `.alert.alert-danger`: `alert-danger` only appears in the corporate billing and support templates, which are portico pages and load `bootstrap.portico.css` instead of the app bundle.

2. **Merge the two remaining rules**, which declare the same three properties, with `.alert.alert-error` listed in both.

`.alert-box .alert` is kept on purpose: the banner from `ui_report.generic_embed_error` is `.alert.home-error-bar` with no `alert-error` class, and it picks up these colors through that selector, so dropping it would be a visual change rather than a cleanup.

**How changes were tested:**

- `./tools/lint web/styles/dark_theme.css`
- Measured the computed styles of the real elements these rules style, in the running app, on `main` and on this branch, in both themes. Values are identical:
  * `#home-error` (the `.alert.alert-error` inside `.alert-box` in index.html)
  * the `.alert.home-error-bar` banner that `generic_embed_error` appends into `.alert-box`

```
                                             light theme                          dark theme
#home-error            background   rgb(242, 222, 222)                  rgb(60, 47, 56)
                       color        rgb(184, 20, 20)                    rgb(222, 222, 222)
                       border       1px solid rgb(184, 20, 20)          1px solid rgb(233, 99, 99)

generic_embed_error    background   rgb(255, 255, 255)                  rgb(60, 47, 56)
                       color        rgb(184, 83, 46)                    rgb(222, 222, 222)
                       border       1px solid rgb(184, 83, 46)          1px solid rgb(233, 99, 99)
```

- The same script asserts `document.querySelector(".alert-box .blueslip-error-container")` is `null` in the app, which is the reachability check for the removed `.alert-box .stacktrace` selector.

**Screenshots and screen captures:**

No visual change, and the two removed selectors have no rendering surface in the web app, so there is nothing new to show. Happy to add screenshots if you would like them anyway.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.

</details>
