### PR TITLE
api docs: Document three /remotes/server push bouncer endpoints.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -161,6 +161,7 @@
 * [Get data export consent state](/api/get-realm-export-consents)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate a registered server](/api/deactivate-remote-server)
+* [Check analytics upload status](/api/remote-server-check-analytics)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -160,6 +160,7 @@
 * [Create a data export](/api/export-realm)
 * [Get data export consent state](/api/get-realm-export-consents)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
+* [Deactivate a registered server](/api/deactivate-remote-server)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -162,6 +162,7 @@
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate a registered server](/api/deactivate-remote-server)
 * [Check analytics upload status](/api/remote-server-check-analytics)
+* [Begin transferring a server registration](/api/transfer-remote-server-registration)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -162,6 +162,7 @@
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate an organization](/api/deactivate-realm)
 * [Deactivate a registered server](/api/deactivate-remote-server)
+* [Check analytics upload status](/api/remote-server-check-analytics)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -163,6 +163,7 @@
 * [Deactivate an organization](/api/deactivate-realm)
 * [Deactivate a registered server](/api/deactivate-remote-server)
 * [Check analytics upload status](/api/remote-server-check-analytics)
+* [Begin transferring a server registration](/api/transfer-remote-server-registration)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -161,6 +161,7 @@
 * [Get data export consent state](/api/get-realm-export-consents)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate an organization](/api/deactivate-realm)
+* [Deactivate a registered server](/api/deactivate-remote-server)
 
 ## Real-time events
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -270,6 +270,7 @@ INSECURE_OPERATIONS = [
     "/fetch_api_key:post",
     "/jwt/fetch_api_key:post",
     "/dev_list_users:get",
+    "/remotes/server/register/transfer:post",
 ]
 
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -328,6 +328,8 @@ def generate_curl_example(
             raise AssertionError(
                 "Unknown operation without a securityScheme. Please update insecure_operations."
             )
+    elif operation_security == [{"remoteServerAuth": []}]:
+        authentication_required = True
     else:
         raise AssertionError(
             "Unhandled securityScheme. Please update the code to handle this scheme."

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -271,6 +271,7 @@ INSECURE_OPERATIONS = [
     "/fetch_api_key:post",
     "/jwt/fetch_api_key:post",
     "/dev_list_users:get",
+    "/remotes/server/register/transfer:post",
 ]
 
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -329,6 +329,8 @@ def generate_curl_example(
             raise AssertionError(
                 "Unknown operation without a securityScheme. Please update insecure_operations."
             )
+    elif operation_security == [{"remoteServerAuth": []}]:
+        authentication_required = True
     else:
         raise AssertionError(
             "Unhandled securityScheme. Please update the code to handle this scheme."

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -28,10 +28,11 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     # Requires organization-specific JWT_AUTH_KEYS configuration.
     "jwt-fetch-api-key",
     # Would need push notification bouncer set up to test the
-    # generated curl example for the following three endpoints.
+    # generated curl example for the following endpoints.
     "e2ee-test-notify",
     "test-notify",
     "register-remote-push-device",
+    "deactivate-remote-server",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -33,6 +33,7 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "test-notify",
     "register-remote-push-device",
     "deactivate-remote-server",
+    "remote-server-check-analytics",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -34,6 +34,7 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "register-remote-push-device",
     "deactivate-remote-server",
     "remote-server-check-analytics",
+    "transfer-remote-server-registration",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14106,6 +14106,59 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /remotes/server/analytics/status:
+    get:
+      operationId: remote-server-check-analytics
+      summary: Check analytics upload status
+      tags: ["server_and_organizations"]
+      description: |
+        Fetch the IDs of the most recent analytics rows the [Mobile Push
+        Notification Service][mobile-push] has received from a self-hosted
+        Zulip server.
+
+        A self-hosted server uses this endpoint to determine which
+        analytics rows it still needs to upload via
+        `POST /remotes/server/analytics`. It is not meant to be used by
+        mobile clients directly.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      last_realm_count_id:
+                        type: integer
+                        description: |
+                          The ID of the last `RealmCount` analytics row the
+                          service has received from this server.
+                      last_installation_count_id:
+                        type: integer
+                        description: |
+                          The ID of the last `InstallationCount` analytics row
+                          the service has received from this server.
+                      last_realmauditlog_id:
+                        type: integer
+                        description: |
+                          The ID of the last `RealmAuditLog` row the service has
+                          received from this server.
+                    example:
+                      {
+                        "last_installation_count_id": 0,
+                        "last_realm_count_id": 0,
+                        "last_realmauditlog_id": 0,
+                        "msg": "",
+                        "result": "success",
+                      }
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14087,6 +14087,25 @@ paths:
                     description: |
                       An example JSON response for when no realm is registered for
                       the authenticated server on the bouncer for the given `realm_uuid`:
+  /remotes/server/deactivate:
+    post:
+      operationId: deactivate-remote-server
+      summary: Deactivate a registered server
+      tags: ["server_and_organizations"]
+      description: |
+        Deactivate a self-hosted Zulip server's registration with the
+        [Mobile Push Notification Service][mobile-push].
+
+        A self-hosted server uses this endpoint to deactivate its own
+        registration with the service. It is not meant to be used by
+        mobile clients directly.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13989,6 +13989,8 @@ paths:
         It is not meant to be used by mobile clients directly.
 
         **Changes**: New in Zulip 11.0 (feature level 406).
+      security:
+        - remoteServerAuth: []
       requestBody:
         required: true
         content:
@@ -27328,6 +27330,18 @@ components:
         Basic authentication, with the user's email as the username, and the API
         key as the password. The API key can be fetched using the
         `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
+    remoteServerAuth:
+      type: http
+      scheme: basic
+      description: |
+        Basic authentication used by self-hosted Zulip servers to
+        communicate with the [Mobile Push Notification Service][mobile-push].
+        Unlike the user-facing API, the username is the server's
+        `zulip_org_id` (a UUID) and the password is its `zulip_org_key`,
+        both obtained when the server registers with the service using
+        `manage.py register_server`.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
 
   schemas:
     IgnoredParametersUnsupported:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14159,6 +14159,62 @@ paths:
                         "msg": "",
                         "result": "success",
                       }
+  /remotes/server/register/transfer:
+    post:
+      operationId: transfer-remote-server-registration
+      summary: Begin transferring a server registration
+      tags: ["server_and_organizations"]
+      description: |
+        Begin transferring an existing server's registration with the
+        [Mobile Push Notification Service][mobile-push] to a server that
+        no longer has the original registration credentials.
+
+        The service returns a short-lived `verification_secret` that the
+        requesting server proves it controls by serving it from the
+        registered hostname; the service then reissues the credentials.
+        This endpoint is unauthenticated, since a server performing a
+        transfer does not have valid credentials to authenticate with.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                hostname:
+                  description: |
+                    The hostname of the registration to transfer. It must
+                    already be registered with the service.
+                  type: string
+                  example: "zulip.example.com"
+              required:
+                - hostname
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      verification_secret:
+                        type: string
+                        description: |
+                          The secret the requesting server should serve from
+                          its hostname to prove control of it.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "verification_secret": "3430...",
+                      }
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14212,6 +14212,62 @@ paths:
                         "msg": "",
                         "result": "success",
                       }
+  /remotes/server/register/transfer:
+    post:
+      operationId: transfer-remote-server-registration
+      summary: Begin transferring a server registration
+      tags: ["server_and_organizations"]
+      description: |
+        Begin transferring an existing server's registration with the
+        [Mobile Push Notification Service][mobile-push] to a server that
+        no longer has the original registration credentials.
+
+        The service returns a short-lived `verification_secret` that the
+        requesting server proves it controls by serving it from the
+        registered hostname; the service then reissues the credentials.
+        This endpoint is unauthenticated, since a server performing a
+        transfer does not have valid credentials to authenticate with.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                hostname:
+                  description: |
+                    The hostname of the registration to transfer. It must
+                    already be registered with the service.
+                  type: string
+                  example: "zulip.example.com"
+              required:
+                - hostname
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      verification_secret:
+                        type: string
+                        description: |
+                          The secret the requesting server should serve from
+                          its hostname to prove control of it.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "verification_secret": "3430...",
+                      }
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14160,6 +14160,58 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /remotes/server/analytics/status:
+    get:
+      operationId: remote-server-check-analytics
+      summary: Check analytics upload status
+      tags: ["server_and_organizations"]
+      description: |
+        Fetch the IDs of the most recent analytics rows the [Mobile Push
+        Notification Service][mobile-push] has received from a self-hosted
+        Zulip server.
+
+        A self-hosted server uses this endpoint to determine which
+        analytics rows it still needs to upload via
+        `POST /remotes/server/analytics`.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      last_realm_count_id:
+                        type: integer
+                        description: |
+                          The ID of the last per-realm analytics count the
+                          service has received from this server.
+                      last_installation_count_id:
+                        type: integer
+                        description: |
+                          The ID of the last server-wide analytics count the
+                          service has received from this server.
+                      last_realmauditlog_id:
+                        type: integer
+                        description: |
+                          The ID of the last audit log entry the service has
+                          received from this server.
+                    example:
+                      {
+                        "last_installation_count_id": 0,
+                        "last_realm_count_id": 0,
+                        "last_realmauditlog_id": 0,
+                        "msg": "",
+                        "result": "success",
+                      }
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14145,6 +14145,21 @@ paths:
                     description: |
                       An example JSON response for when no realm is registered for
                       the authenticated server on the bouncer for the given `realm_uuid`:
+  /remotes/server/deactivate:
+    post:
+      operationId: deactivate-remote-server
+      summary: Deactivate a registered server
+      tags: ["server_and_organizations"]
+      description: |
+        Deactivate a self-hosted Zulip server's registration with the
+        [Mobile Push Notification Service][mobile-push].
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14047,6 +14047,8 @@ paths:
         It is not meant to be used by mobile clients directly.
 
         **Changes**: New in Zulip 11.0 (feature level 406).
+      security:
+        - remoteServerAuth: []
       requestBody:
         required: true
         content:
@@ -27516,6 +27518,17 @@ components:
         Basic authentication, with the user's email as the username, and the API
         key as the password. The API key can be fetched using the
         `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
+    remoteServerAuth:
+      type: http
+      scheme: basic
+      description: |
+        Basic authentication used by self-hosted Zulip servers to
+        communicate with the [Mobile Push Notification Service][mobile-push].
+        Unlike the user-facing API, the username is the server's
+        `zulip_org_id` (a UUID) and the password is its `zulip_org_key`,
+        both generated locally with `scripts/setup/generate_secrets.py`.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
 
   schemas:
     IgnoredParametersUnsupported:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -253,7 +253,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
         "/remotes/server/analytics",
-        "/remotes/server/analytics/status",
         "/remotes/server/billing",
     }
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -252,7 +252,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/server/register",
         "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
-        "/remotes/server/deactivate",
         "/remotes/server/analytics",
         "/remotes/server/analytics/status",
         "/remotes/server/billing",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -250,7 +250,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/push/e2ee/notify",
         # Lower priority to document
         "/remotes/server/register",
-        "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
         "/remotes/server/analytics",
         "/remotes/server/billing",
@@ -262,6 +261,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "fetch_api_key",
         "dev_fetch_api_key",
         "jwt/fetch_api_key",
+        "remotes/server/register/transfer",
     }
 
     # Endpoints where the documentation is currently failing our

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -251,7 +251,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/server/register",
         "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
-        "/remotes/server/deactivate",
         "/remotes/server/analytics",
         "/remotes/server/analytics/status",
         "/remotes/server/billing",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -249,7 +249,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/push/e2ee/notify",
         # Lower priority to document
         "/remotes/server/register",
-        "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
         "/remotes/server/analytics",
         "/remotes/server/billing",
@@ -261,6 +260,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "fetch_api_key",
         "dev_fetch_api_key",
         "jwt/fetch_api_key",
+        "remotes/server/register/transfer",
     }
 
     # Endpoints where the documentation is currently failing our

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -252,7 +252,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
         "/remotes/server/analytics",
-        "/remotes/server/analytics/status",
         "/remotes/server/billing",
     }
 


### PR DESCRIPTION
Documents three of the seven undocumented `/remotes/server/*` push notification bouncer endpoints, the server↔bouncer API a self-hosted Zulip server uses to talk to the Mobile Push Notification Service:

- `POST /remotes/server/deactivate`
- `GET /remotes/server/analytics/status`
- `POST /remotes/server/register/transfer`

Bouncer endpoints authenticate as a server, not a user: the HTTP Basicusername is the server's `zulip_org_id` (a UUID) and the password is its `zulip_org_key`, and `validate_remote_server` even rejects a username containing `@`. The global `basicAuth` scheme documents the username as the user's email, so any bouncer endpoint inheriting it is documented
with the wrong credentials. The first commit adds a dedicated `remoteServerAuth` security scheme and migrates the one already-documented bouncer endpoint, `register-remote-push-device`, onto it, fixing the same inaccuracy. Teaching `generate_curl_example` about the new scheme is required because every doc page is rendered by `test_docs.test_api_doc_endpoints`.

Note to maintainers:
The shared curl auth-credentials note still points to the user/bot credentials doc, which is slightly off for these server-authenticated endpoints (pre-existing; already shown for `register-remote-push-device`).
Left out here since it touches a shared include; can become a follow up if worthwhile.

<details>
<summary>Screenshots and screen captures:</summary>

The sidebar:

<img width="352" height="117" alt="image" src="https://github.com/user-attachments/assets/ac12dfdb-c427-41f6-bf1b-d2069104f690" />

Rendered documentation page: `POST /remotes/server/deactivate`
<img width="1280" height="1024" alt="deactivate-remote-server" src="https://github.com/user-attachments/assets/5fd82d16-63e5-414a-ae9d-1b39fdb4fd2a" />

Rendered documentation page: `GET /remotes/server/analytics/status`
<img width="1280" height="1315" alt="remote-server-check-analytics" src="https://github.com/user-attachments/assets/0977d119-7b58-4946-aca6-4b67d83be5c0" />

Rendered documentation page: `POST /remotes/server/register/transfer`
<img width="1280" height="1233" alt="transfer-remote-server-registration" src="https://github.com/user-attachments/assets/92611cd3-82e2-43b6-8709-1877b7e00a07" />

</details>
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
