### PR TITLE
compose: Allow arrow navigation from restored drafts.

### DIFF
--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -182,6 +182,11 @@ function cursor_at_start_of_whitespace_in_compose(): boolean {
     return message_content() === "" && cursor_position === 0;
 }
 
+function cursor_at_end_of_content_in_compose(): boolean {
+    const cursor_position = $("textarea#compose-textarea").caret();
+    return cursor_position === untrimmed_message_content().length;
+}
+
 export function focus_in_formatting_buttons(): boolean {
     const is_focused_formatting_button =
         document.activeElement?.classList.contains("compose_control_button");
@@ -234,6 +239,23 @@ export function focus_in_empty_compose(
     }
 
     return false;
+}
+
+export function focus_at_end_of_unedited_restored_draft(): boolean {
+    // A user pressing the Down Arrow at the end of an unedited restored
+    // draft is most likely trying to navigate messages. This helper
+    // function detects that case.
+    if (!composing()) {
+        return false;
+    }
+
+    // Only apply this check when focus is in the message textarea. Down
+    // Arrow has different semantics in other compose inputs.
+    return (
+        document.activeElement?.id === "compose-textarea" &&
+        is_content_unedited_restored_draft &&
+        cursor_at_end_of_content_in_compose()
+    );
 }
 
 export function private_message_recipient_emails(): string {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -177,9 +177,18 @@ export const message_content = get_or_set("textarea#compose-textarea", true);
 
 const untrimmed_message_content = get_or_set("textarea#compose-textarea", true, true);
 
+function cursor_at_start_of_content_in_compose(): boolean {
+    return $("textarea#compose-textarea").caret() === 0;
+}
+
 function cursor_at_start_of_whitespace_in_compose(): boolean {
     const cursor_position = $("textarea#compose-textarea").caret();
     return message_content() === "" && cursor_position === 0;
+}
+
+function cursor_at_end_of_content_in_compose(): boolean {
+    const cursor_position = $("textarea#compose-textarea").caret();
+    return cursor_position === untrimmed_message_content().length;
 }
 
 export function focus_in_formatting_buttons(): boolean {
@@ -234,6 +243,40 @@ export function focus_in_empty_compose(
     }
 
     return false;
+}
+
+export function focus_at_start_of_unedited_restored_draft(): boolean {
+    // A user pressing the Up Arrow at the start of an unedited restored
+    // draft is most likely trying to navigate messages. This helper
+    // function detects that case.
+    if (!composing()) {
+        return false;
+    }
+
+    // Only apply this check when focus is in the message textarea. Up
+    // Arrow has different semantics in other compose inputs.
+    return (
+        document.activeElement?.id === "compose-textarea" &&
+        is_content_unedited_restored_draft &&
+        cursor_at_start_of_content_in_compose()
+    );
+}
+
+export function focus_at_end_of_unedited_restored_draft(): boolean {
+    // A user pressing the Down Arrow at the end of an unedited restored
+    // draft is most likely trying to navigate messages. This helper
+    // function detects that case.
+    if (!composing()) {
+        return false;
+    }
+
+    // Only apply this check when focus is in the message textarea. Down
+    // Arrow has different semantics in other compose inputs.
+    return (
+        document.activeElement?.id === "compose-textarea" &&
+        is_content_unedited_restored_draft &&
+        cursor_at_end_of_content_in_compose()
+    );
 }
 
 export function private_message_recipient_emails(): string {

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1077,7 +1077,10 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         }
 
         if (
-            ((event_name === "down_arrow" || event_name === "page_down" || event_name === "end") &&
+            (event_name === "down_arrow" &&
+                (compose_state.focus_in_empty_compose() ||
+                    compose_state.focus_at_end_of_unedited_restored_draft())) ||
+            ((event_name === "page_down" || event_name === "end") &&
                 compose_state.focus_in_empty_compose()) ||
             ((event_name === "up_arrow" || event_name === "page_up" || event_name === "home") &&
                 compose_state.focus_in_empty_compose(true))

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1080,7 +1080,10 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
             ((event_name === "down_arrow" || event_name === "page_down" || event_name === "end") &&
                 compose_state.focus_in_empty_compose()) ||
             ((event_name === "up_arrow" || event_name === "page_up" || event_name === "home") &&
-                compose_state.focus_in_empty_compose(true))
+                compose_state.focus_in_empty_compose(true)) ||
+            (event_name === "down_arrow" &&
+                compose_state.focus_at_end_of_unedited_restored_draft()) ||
+            (event_name === "up_arrow" && compose_state.focus_at_start_of_unedited_restored_draft())
         ) {
             compose_actions.cancel();
             // don't return, as we still want it to be picked up by the code below

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -995,6 +995,35 @@ test("focus_in_empty_compose", () => {
     assert.ok(!compose_state.focus_in_empty_compose());
 });
 
+test("focus_at_end_of_unedited_restored_draft", () => {
+    document.activeElement = {id: "compose-textarea"};
+    compose_state.set_message_type("stream");
+    compose_state.set_is_content_unedited_restored_draft(true);
+    const $textarea = $("textarea#compose-textarea");
+    $textarea.val("hello");
+    $textarea.caret(5);
+    assert.ok(compose_state.focus_at_end_of_unedited_restored_draft());
+
+    compose_state.set_message_type(undefined);
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    compose_state.set_message_type("stream");
+    compose_state.set_is_content_unedited_restored_draft(false);
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    compose_state.set_is_content_unedited_restored_draft(true);
+    document.activeElement = {id: "stream_message_recipient_topic"};
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    document.activeElement = {id: "compose-textarea"};
+    $textarea.caret(3);
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    document.activeElement = undefined;
+    compose_state.set_is_content_unedited_restored_draft(false);
+    compose_state.set_message_type(undefined);
+});
+
 test("on_narrow", ({override, override_rewire}) => {
     let narrowed_by_topic_reply;
     override(narrow_state, "narrowed_by_topic_reply", () => narrowed_by_topic_reply);

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -995,6 +995,64 @@ test("focus_in_empty_compose", () => {
     assert.ok(!compose_state.focus_in_empty_compose());
 });
 
+test("focus_at_start_of_unedited_restored_draft", () => {
+    document.activeElement = {id: "compose-textarea"};
+    compose_state.set_message_type("stream");
+    compose_state.set_is_content_unedited_restored_draft(true);
+    const $textarea = $("textarea#compose-textarea");
+    $textarea.val("hello");
+    $textarea.caret(0);
+    assert.ok(compose_state.focus_at_start_of_unedited_restored_draft());
+
+    compose_state.set_message_type(undefined);
+    assert.ok(!compose_state.focus_at_start_of_unedited_restored_draft());
+
+    compose_state.set_message_type("stream");
+    compose_state.set_is_content_unedited_restored_draft(false);
+    assert.ok(!compose_state.focus_at_start_of_unedited_restored_draft());
+
+    compose_state.set_is_content_unedited_restored_draft(true);
+    document.activeElement = {id: "stream_message_recipient_topic"};
+    assert.ok(!compose_state.focus_at_start_of_unedited_restored_draft());
+
+    document.activeElement = {id: "compose-textarea"};
+    $textarea.caret(3);
+    assert.ok(!compose_state.focus_at_start_of_unedited_restored_draft());
+
+    document.activeElement = undefined;
+    compose_state.set_is_content_unedited_restored_draft(false);
+    compose_state.set_message_type(undefined);
+});
+
+test("focus_at_end_of_unedited_restored_draft", () => {
+    document.activeElement = {id: "compose-textarea"};
+    compose_state.set_message_type("stream");
+    compose_state.set_is_content_unedited_restored_draft(true);
+    const $textarea = $("textarea#compose-textarea");
+    $textarea.val("hello");
+    $textarea.caret(5);
+    assert.ok(compose_state.focus_at_end_of_unedited_restored_draft());
+
+    compose_state.set_message_type(undefined);
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    compose_state.set_message_type("stream");
+    compose_state.set_is_content_unedited_restored_draft(false);
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    compose_state.set_is_content_unedited_restored_draft(true);
+    document.activeElement = {id: "stream_message_recipient_topic"};
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    document.activeElement = {id: "compose-textarea"};
+    $textarea.caret(3);
+    assert.ok(!compose_state.focus_at_end_of_unedited_restored_draft());
+
+    document.activeElement = undefined;
+    compose_state.set_is_content_unedited_restored_draft(false);
+    compose_state.set_message_type(undefined);
+});
+
 test("on_narrow", ({override, override_rewire}) => {
     let narrowed_by_topic_reply;
     override(narrow_state, "narrowed_by_topic_reply", () => narrowed_by_topic_reply);


### PR DESCRIPTION
[#feedback > Drafts getting in the way](https://chat.zulip.org/#narrow/channel/137-feedback/topic/Drafts.20getting.20in.20the.20way/with/2420268)

## Problem

When the compose box contains an unedited restored draft, pressing Up Arrow when the cursor is at the start or Down Arrow when it is at the end of the message does not leave the compose box and resume keyboard navigation in the message list.

This differs from the behavior of an empty compose box, where the Up and Down Arrow keys are treated as an intent to navigate messages.

## Solution

Add a helper functions to detect when the compose box contains an unedited
restored draft with the cursor at the start/end of the message, and use it in
the Up and Down Arrow keyboard navigation logic.


With this change, pressing Up Arrow when cursor is at start of the unedited draft and pressing
Down Arrow when cursor is at the end of unedited draft will  collapse and  leave the
compose box resuming keyboard navigation in the message list, while
the behavior of all other navigation keys remains unchanged.

Fixes: #38846.


**Screenshots and screen captures:**
<h1> Before : </h1>
<img width="1884" height="836" alt="zulip issue 1 3" src="https://github.com/user-attachments/assets/a2a1d73c-ac43-41e0-a4f3-d47c16507179" />


<h1>After : </h1>
<h3> case 1 : when we have restored unedited draft message in compose box.</h3>
<img width="1885" height="836" alt="zulip issue 1" src="https://github.com/user-attachments/assets/3b37ad7f-8795-4801-9342-76d61a994c99" />





<h3> case 2 : when we edited the restored draft message in compose box.</h3>
<img width="1884" height="836" alt="zulip issue 1 2" src="https://github.com/user-attachments/assets/c8c6c18b-2393-4efb-b6cd-99ab3ce219b0" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

-  [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

