### PR TITLE
reaction_pills: Shift from border to outline.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -14,15 +14,17 @@
 
     .message_reaction {
         display: flex;
-        /* Set a pixel and half padding to maintain
-           pill height adjacent own reactions. */
-        padding: 1.5px 4px 1.5px 3px;
+        padding: 2.5px 5px 2.5px 4px;
         box-sizing: border-box;
         min-width: 44px;
         cursor: pointer;
         color: var(--color-message-reaction-text);
         background-color: var(--color-message-reaction-background);
-        border: 1px solid var(--color-message-reaction-border);
+        /* Use an outline around the reaction pill so that
+           it does not change the dimensions of the reaction-pill
+           box when going in and out of the .reacted state. */
+        outline: 1px solid var(--color-message-reaction-border);
+        outline-offset: -1px;
         border-radius: 21px;
         align-items: center;
         box-shadow: inset 0 0 5px 0 var(--color-message-reaction-shadow-inner);
@@ -33,14 +35,11 @@
         &.reacted {
             color: var(--color-message-reaction-text-reacted);
             background-color: var(--color-message-reaction-background-reacted);
-            border-color: var(--color-message-reaction-border-reacted);
-            /* Make this border thicker by half a pixel,
+            outline-color: var(--color-message-reaction-border-reacted);
+            /* Make this outline thicker by half a pixel,
                to make own reactions more prominent. */
-            border-width: 1.5px;
-            /* Reduce the padding top and bottom by half
-               a pixel accordingly, to maintain the same
-               pill height. */
-            padding: 1px 4px 1px 3px;
+            outline-width: 1.5px;
+            outline-offset: -1.5px;
             font-weight: var(--font-weight-message-reaction);
             box-shadow: none;
         }


### PR DESCRIPTION
This PR changes the borders on reaction pills to outlines. As outlines, there should no longer be any interactions between the line width and shifting elements.

Fixes: #38923

**Screenshots**

_Note that there is a very slight subpixel shift in the After shot, likely owing to a subpixel render of the borders in the Before shot._

| Before | After |
| --- | --- |
| <img width="1520" height="1600" alt="showing-reactions-before" src="https://github.com/user-attachments/assets/d025af46-78f3-42de-9ef9-f1974fa28e24" /> | <img width="1520" height="1600" alt="showing-reactions-after" src="https://github.com/user-attachments/assets/87d545df-06d9-4108-bdba-483613af061e" /> |

_Showing the interaction (subtle shift in Before; none in After):_

| Before | After |
| --- | --- |
| <img alt="reaction-interaction-before" src="https://github.com/user-attachments/assets/5be7b2fa-6c56-4e37-b0b6-fdb6da65549d" /> | <img alt="reaction-interaction-after" src="https://github.com/user-attachments/assets/1508cb48-a4fa-45d6-a6dd-f6aa75a3aa6b" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>