### PR TITLE
composebox: Match topics diacritics-agnostically

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -246,17 +246,11 @@ export function get_slash_matcher(query: string): (item: SlashCommand) => boolea
 }
 
 function get_topic_matcher(query: string): (topic: string) => boolean {
-    query = typeahead.clean_query_lowercase(query, false);
-    const should_remove_diacritics = !typeahead.contains_diacritics(query);
+    query = typeahead.remove_diacritics(typeahead.clean_query_lowercase(query, false));
 
     return function (topic: string): boolean {
         const topic_display_name = util.get_final_topic_display_name(topic);
-        return typeahead.query_matches_string_in_order(
-            query,
-            topic_display_name,
-            " ",
-            should_remove_diacritics,
-        );
+        return typeahead.query_matches_string_in_order(query, topic_display_name, " ", true);
     };
 }
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -937,6 +937,20 @@ test("topic typeahead source suppresses an exact-match topic", ({override}) => {
     assert.deepEqual(topic_edit_config.source("new"), ["design", "design docs"]);
 });
 
+test("topic typeahead matches diacritics agnostically", ({override}) => {
+    let topic_edit_config;
+    override(bootstrap_typeahead, "Typeahead", (_input_element, config) => {
+        topic_edit_config = config;
+    });
+
+    ct.initialize_topic_edit_typeahead($.create("fake-diacritic-input"), "The Netherlands", false);
+
+    assert.ok(topic_edit_config.matcher("gael")("Gaël"));
+    assert.ok(topic_edit_config.matcher("gaël")("gael"));
+    assert.deepEqual(topic_edit_config.sorter(["gael", "Gaël"], "gael"), ["gael", "Gaël"]);
+    assert.deepEqual(topic_edit_config.sorter(["gaël", "Gael"], "gaël"), ["gaël", "Gael"]);
+});
+
 test("content_typeahead_selected", ({override}) => {
     const input_element = {
         $element: {},


### PR DESCRIPTION
This change makes topic typeahead ignore diacritics on both the query and the candidate topic, while still letting the existing sorter keep exact raw-prefix matches ahead of diacritic-only matches.

I also added a regression test covering both matching and ordering.

Validation:
- 
ode web/tests/lib/index.cjs D:\zulip\zulip\web\tests\typeahead.test.cjs
- A focused local harness for the new topic matcher/sorter behavior

Fixes #39704.