### PR TITLE
mattermost: Handle users without team in combine_into_one_realm mode.

### DIFF
--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -1064,6 +1064,13 @@ def mattermost_data_file_to_dict(
                 )
                 mattermost_data["user"].append(bot_data)
             elif data_type == "user" and combine_into_one_realm:
+                if not row[data_type]["teams"]:
+                    # "teams" is null for users who are not a member of any
+                    # team. Keep it as is, so that such users are treated
+                    # just like in the non-combined code path: they only get
+                    # a mirror dummy account, backfilled from their posts.
+                    mattermost_data[data_type].append(row[data_type])
+                    continue
                 all_user_channels: list[dict[str, Any]] = []
                 all_user_team_roles: set[str] = set()
                 # Admin users in individual teams will have administrator role

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -1523,6 +1523,26 @@ class MattermostCombinedTeamsImportTest(MattermostImportTestBase):
         exported_bot_users = [user for user in mattermost_data["user"] if user.get("is_bot")]
         self.assert_length(exported_bot_users, len(self.BOT_EMAILS))
 
+    def test_combining_user_not_in_any_team(self) -> None:
+        # Mattermost exports "teams": null for users who are not a
+        # member of any team. Verify such users are passed through
+        # unchanged when combining teams, so that they are imported
+        # only as mirror dummies backfilled from their posts, just
+        # like in the non-combined code path.
+        user_object = {"type": "user", "user": {"username": "teamless.user", "teams": None}}
+        jsonl_line = json.dumps(user_object)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            import_jsonl_path = os.path.join(tmp_dir, "import.jsonl")
+            with open(import_jsonl_path, "w") as f:
+                f.write(jsonl_line + "\n")
+
+            mattermost_data = mattermost_data_file_to_dict(
+                import_jsonl_path, combine_into_one_realm=True
+            )
+        self.assert_length(mattermost_data["user"], 1)
+        self.assertEqual(mattermost_data["user"][0], {"username": "teamless.user", "teams": None})
+
     def test_e2e_export_data_v11_6_0(self) -> None:
         # The assert functions here iterate over the exported Mattermost objects and checks
         # whether a corresponding Zulip object exists in the imported realm. So, If


### PR DESCRIPTION
Fixes this error in
`convert_mattermost_data --combine-into-one-realm` when there are users with `"team": null`:
```
Traceback (most recent call last):
  File "./manage.py", line 154, in <module>
    execute_from_command_line(sys.argv)
  File "./manage.py", line 115, in execute_from_command_line
    utility.execute()
  File ".venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File ".venv/lib/python3.10/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "zerver/lib/management.py", line 133, in execute
    super().execute(*args, **options)
  File ".venv/lib/python3.10/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
  File "zerver/management/commands/convert_mattermost_data.py", line 78, in handle
    do_convert_data(
  File "zerver/data_import/mattermost.py", line 1130, in do_convert_data
    mattermost_data = mattermost_data_file_to_dict(import_jsonl_file, combine_into_one_realm)
  File "zerver/data_import/mattermost.py", line 1071, in mattermost_data_file_to_dict
    for team in row[data_type]["teams"]:
TypeError: 'NoneType' object is not iterable
```

