### PR TITLE
html2text to Markdownify migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ prod = [
 
   # Needed for the email mirror
   "html2text",
+  "markdownify",
   "talon-core",
 
   # Needed for inlining the CSS in emails

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ prod = [
   "firebase-admin",
 
   # Needed for the email mirror
-  "html2text",
   "markdownify",
   "talon-core",
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-09T13:27:49.746035219Z"
 exclude-newer-span = "PT24H"
 
 [[package]]
@@ -6366,7 +6366,6 @@ dev = [
     { name = "gitlint-core" },
     { name = "google-re2" },
     { name = "google-re2-stubs" },
-    { name = "html2text" },
     { name = "idna" },
     { name = "ipython" },
     { name = "jinja2" },
@@ -6504,7 +6503,6 @@ prod = [
     { name = "dnspython" },
     { name = "firebase-admin" },
     { name = "google-re2" },
-    { name = "html2text" },
     { name = "idna" },
     { name = "ipython" },
     { name = "jinja2" },
@@ -6607,7 +6605,6 @@ dev = [
     { name = "gitlint-core" },
     { name = "google-re2" },
     { name = "google-re2-stubs" },
-    { name = "html2text" },
     { name = "idna" },
     { name = "ipython", specifier = "<9" },
     { name = "jinja2" },
@@ -6746,7 +6743,6 @@ prod = [
     { name = "dnspython" },
     { name = "firebase-admin" },
     { name = "google-re2" },
-    { name = "html2text" },
     { name = "idna" },
     { name = "ipython", specifier = "<9" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2587,6 +2587,19 @@ wheels = [
 ]
 
 [[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -6364,6 +6377,7 @@ dev = [
     { name = "lxml-stubs" },
     { name = "markdown" },
     { name = "markdown-it-py" },
+    { name = "markdownify" },
     { name = "moto", extra = ["s3"] },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "mypy-boto3-s3" },
@@ -6498,6 +6512,7 @@ prod = [
     { name = "jsx-lexer" },
     { name = "lxml" },
     { name = "markdown" },
+    { name = "markdownify" },
     { name = "mypy-boto3-s3" },
     { name = "mypy-boto3-ses" },
     { name = "mypy-boto3-sns" },
@@ -6603,6 +6618,7 @@ dev = [
     { name = "lxml-stubs" },
     { name = "markdown" },
     { name = "markdown-it-py", specifier = "<4" },
+    { name = "markdownify" },
     { name = "moto", extras = ["s3"] },
     { name = "mypy", extras = ["faster-cache"] },
     { name = "mypy-boto3-s3" },
@@ -6738,6 +6754,7 @@ prod = [
     { name = "jsx-lexer" },
     { name = "lxml" },
     { name = "markdown" },
+    { name = "markdownify" },
     { name = "mypy-boto3-s3" },
     { name = "mypy-boto3-ses" },
     { name = "mypy-boto3-sns" },

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 509
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (386, 0)  # bumped 2026-07-28 to upgrade JavaScript dependencies
+PROVISION_VERSION = (386, 1)  # bumped 2026-08-13 to add markdownify dependency

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 509
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (386, 1)  # bumped 2026-08-13 to add markdownify dependency
+PROVISION_VERSION = (387, 0)  # bumped 2026-08-13 to remove html2text dependency

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 507
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (386, 1)  # bumped 2026-08-02 to add markdownify dependency
+PROVISION_VERSION = (387, 0)  # bumped 2026-07-28 to remove html2text dependency

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 507
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (386, 0)  # bumped 2026-07-28 to upgrade JavaScript dependencies
+PROVISION_VERSION = (386, 1)  # bumped 2026-08-02 to add markdownify dependency

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -3,7 +3,6 @@ import os
 import random
 import secrets
 import shutil
-import subprocess
 from collections import defaultdict
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
 from collections.abc import Set as AbstractSet
@@ -929,11 +928,6 @@ def validate_user_emails_for_import(user_emails: list[str]) -> None:
             f"Invalid email format, please fix the following email(s) and try again: {details}"
         )
         raise ValidationError(error_log)
-
-
-def convert_html_to_text(content: str) -> str:
-    # html2text is GPL licensed, so run it as a subprocess.
-    return subprocess.check_output(["html2text", "--unicode-snob"], input=content, text=True)
 
 
 def get_data_file(path: str) -> Any:

--- a/zerver/data_import/microsoft_teams.py
+++ b/zerver/data_import/microsoft_teams.py
@@ -29,7 +29,6 @@ from zerver.data_import.import_util import (
     build_user_profile,
     build_usermessages,
     build_zerver_realm,
-    convert_html_to_text,
     create_converted_data_files,
     get_attachment_path_and_content,
     get_data_file,
@@ -38,6 +37,10 @@ from zerver.data_import.import_util import (
     scrub_missing_upload_records_after_download,
     validate_user_emails_for_import,
     write_response_file_stream_to_path,
+)
+from zerver.data_import.microsoft_teams_message_conversion import (
+    HOSTED_CONTENT_MARKDOWN_IMAGE_SYNTAX_REGEX,
+    convert_microsoft_teams_html_to_markdown,
 )
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE, do_common_export_processes
@@ -210,16 +213,6 @@ class ODataQueryParameter:
 
 
 MICROSOFT_GRAPH_API_URL = "https://graph.microsoft.com/v1.0{endpoint}"
-
-# https://learn.microsoft.com/en-us/graph/api/chatmessagehostedcontent-get
-HOSTED_CONTENT_GRAPH_API_URL_REGEX = r"https://graph\.microsoft\.com/v1\.0/teams/[^/]+/channels/[^/]+/messages/[^/]+/hostedContents/[^/]+/\$value"
-HOSTED_CONTENT_MARKDOWN_IMAGE_SYNTAX_REGEX = rf"""
-            !\[
-               (?P<file_name>[^\]]+)
-            \]\(
-               (?P<api_url>{HOSTED_CONTENT_GRAPH_API_URL_REGEX})
-            \)
-            """
 
 
 def get_microsoft_graph_api_data(
@@ -507,8 +500,8 @@ def process_hosted_content_attachments(
      * code snippets
 
     Since custom emoji and code snippet are formatted as custom HTML blocks,
-    convert_html_to_text will turn them into empty strings, so this currently
-    only supports processing image hosted contents.
+    convert_microsoft_teams_html_to_markdown will turn them into empty strings,
+    so this currently only supports processing image hosted contents.
 
     It's worth checking the API documentation for the hosted content once in a
     while to verify what file types "hosted content" includes, since the code path
@@ -592,7 +585,7 @@ def process_messages(
         message_content_type = message["Body"]["ContentType"]
         if message_content_type == "html":
             try:
-                content = convert_html_to_text(message["Body"]["Content"])
+                content = convert_microsoft_teams_html_to_markdown(message["Body"]["Content"])
             except Exception:  # nocoverage
                 logging.warning(
                     "Error converting HTML to text for message: '%s'; continuing", content

--- a/zerver/data_import/microsoft_teams_message_conversion.py
+++ b/zerver/data_import/microsoft_teams_message_conversion.py
@@ -1,0 +1,41 @@
+import re
+
+from bs4 import Tag
+from typing_extensions import override
+
+from zerver.lib.markdown import get_markdown_image_for_url
+from zerver.lib.markdown.from_html import ZulipMarkdownConverter, convert_html_to_markdown
+
+# https://learn.microsoft.com/en-us/graph/api/chatmessagehostedcontent-get
+HOSTED_CONTENT_GRAPH_API_URL_REGEX = r"https://graph\.microsoft\.com/v1\.0/teams/[^/]+/channels/[^/]+/messages/[^/]+/hostedContents/[^/]+/\$value"
+HOSTED_CONTENT_MARKDOWN_IMAGE_SYNTAX_REGEX = rf"""
+            !\[
+               (?P<file_name>[^\]]+)
+            \]\(
+               (?P<api_url>{HOSTED_CONTENT_GRAPH_API_URL_REGEX})
+            \)
+            """
+
+
+class MicrosoftTeamsToZulipMarkdownConverter(ZulipMarkdownConverter):
+    """HTML-to-Markdown converter for Microsoft Teams exports.
+
+    Hosted-content images are kept in inline `![alt](src)` form, which
+    process_hosted_content_attachments matches to download each image
+    and rewrite it into a Zulip upload link.  Other images get the base
+    class's external-link treatment.
+    """
+
+    @override
+    def convert_img(self, el: Tag, text: str, parent_tags: set[str]) -> str:
+        src = el.get("src", "")
+        alt = el.get("alt", "")
+        assert isinstance(src, str)
+        assert isinstance(alt, str)
+        if re.fullmatch(HOSTED_CONTENT_GRAPH_API_URL_REGEX, src):
+            return get_markdown_image_for_url(alt, src)
+        return super().convert_img(el, text, parent_tags)
+
+
+def convert_microsoft_teams_html_to_markdown(html: str) -> str:
+    return convert_html_to_markdown(html, converter_class=MicrosoftTeamsToZulipMarkdownConverter)

--- a/zerver/lib/markdown/from_html.py
+++ b/zerver/lib/markdown/from_html.py
@@ -1,18 +1,53 @@
-import os
-import re
-import subprocess
-import sys
+import posixpath
+import warnings
+from urllib.parse import urlsplit
+
+import markdownify
+from bs4 import MarkupResemblesLocatorWarning, Tag
+
+from zerver.lib.markdown import get_markdown_link_for_url, sanitize_url
+
+
+class ZulipMarkdownConverter(markdownify.MarkdownConverter):
+    """HTML-to-Markdown converter that linkifies images.
+
+    Zulip doesn't inline-render external images, so images become
+    `[label](src)` links instead of broken `![alt](src)`.
+    """
+
+    def convert_img(self, el: Tag, text: str, parent_tags: set[str]) -> str:
+        src = el.get("src", "")
+        alt = el.get("alt", "")
+        # BeautifulSoup returns a list only for multi-valued attributes
+        # (e.g. class), never for src or alt.
+        assert isinstance(src, str)
+        assert isinstance(alt, str)
+        if not src:
+            return alt
+        url = sanitize_url(src)
+        if not url:
+            # Unlinkable src (e.g. data: URIs, unsafe schemes): emit just the
+            # alt text rather than a bogus link.
+            return alt
+        label = alt or posixpath.basename(urlsplit(url).path)
+        # No brackets inside an <a> or without a label return a bare URL
+        if "a" in parent_tags or not label:
+            return label or url
+        return get_markdown_link_for_url(label, url)
 
 
 def convert_html_to_markdown(html: str) -> str:
-    # html2text is GPL licensed, so run it as a subprocess.
-    markdown = subprocess.check_output(
-        [os.path.join(sys.prefix, "bin", "html2text"), "--unicode-snob"], input=html, text=True
-    ).strip()
-
-    # We want images to get linked and inline previewed, but html2text will turn
-    # them into links of the form `![](http://foo.com/image.png)`, which is
-    # ugly. Run a regex over the resulting description, turning links of the
-    # form `![](http://foo.com/image.png?12345)` into
-    # `[image.png](http://foo.com/image.png)`.
-    return re.sub(r"!\[\]\((\S*)/(\S*)\?(\S*)\)", "[\\2](\\1/\\2)", markdown)
+    # BeautifulSoup warns when content is a bare URL ("looks like a URL, not
+    # markup"); harmless here, but fatal under CI's PYTHONWARNINGS=error.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
+        # ATX headings ("# Title"): Zulip doesn't render Setext underlines.
+        # Asterisk/underscore escaping is disabled: Zulip's Markdown has no
+        # backslash escaping, so "\*" renders as a literal backslash.
+        converter = ZulipMarkdownConverter(
+            heading_style="ATX",
+            escape_asterisks=False,
+            escape_underscores=False,
+        )
+        markdown: str = converter.convert(html).strip()
+    return markdown

--- a/zerver/lib/markdown/from_html.py
+++ b/zerver/lib/markdown/from_html.py
@@ -36,7 +36,9 @@ class ZulipMarkdownConverter(markdownify.MarkdownConverter):
         return get_markdown_link_for_url(label, url)
 
 
-def convert_html_to_markdown(html: str) -> str:
+def convert_html_to_markdown(
+    html: str, *, converter_class: type[ZulipMarkdownConverter] = ZulipMarkdownConverter
+) -> str:
     # BeautifulSoup warns when content is a bare URL ("looks like a URL, not
     # markup"); harmless here, but fatal under CI's PYTHONWARNINGS=error.
     with warnings.catch_warnings():
@@ -44,7 +46,7 @@ def convert_html_to_markdown(html: str) -> str:
         # ATX headings ("# Title"): Zulip doesn't render Setext underlines.
         # Asterisk/underscore escaping is disabled: Zulip's Markdown has no
         # backslash escaping, so "\*" renders as a literal backslash.
-        converter = ZulipMarkdownConverter(
+        converter = converter_class(
             heading_style="ATX",
             escape_asterisks=False,
             escape_underscores=False,

--- a/zerver/lib/markdown/from_html.py
+++ b/zerver/lib/markdown/from_html.py
@@ -46,13 +46,15 @@ class ZulipMarkdownConverter(markdownify.MarkdownConverter):
         return ""
 
 
-def convert_html_to_markdown(html: str) -> str:
+def convert_html_to_markdown(
+    html: str, *, converter_class: type[ZulipMarkdownConverter] = ZulipMarkdownConverter
+) -> str:
     # A bare URL is expected input here (the text/html part of an incoming
     # email), but BeautifulSoup warns about it ("looks like a URL, not markup").
     # Suppress the warning so that expected input doesn't spam our logs.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", MarkupResemblesLocatorWarning)
-        converter = ZulipMarkdownConverter(
+        converter = converter_class(
             # Zulip's Markdown supports only ATX headings, not Setext headings.
             heading_style="ATX",
             # Zulip's Markdown has no backslash escaping; it renders "\" as a

--- a/zerver/lib/markdown/from_html.py
+++ b/zerver/lib/markdown/from_html.py
@@ -1,18 +1,72 @@
-import os
+import posixpath
 import re
-import subprocess
 import sys
+import warnings
+from urllib.parse import urlsplit
+
+import markdownify
+from bs4 import MarkupResemblesLocatorWarning, Tag
+
+from zerver.lib.markdown import get_markdown_link_for_url, sanitize_url
+
+
+class ZulipMarkdownConverter(markdownify.MarkdownConverter):
+    """HTML-to-Markdown converter adapted to Zulip's Markdown.
+
+    Zulip doesn't inline-render external images, so images become
+    `[label](src)` links instead of broken `![alt](src)`.
+    """
+
+    def convert_img(self, el: Tag, text: str, parent_tags: set[str]) -> str:
+        src = el.get("src", "")
+        alt = el.get("alt", "")
+        # BeautifulSoup returns a list only for multi-valued attributes
+        # (e.g. class), never for src or alt.
+        assert isinstance(src, str)
+        assert isinstance(alt, str)
+        if not src:
+            return alt
+        url = sanitize_url(src)
+        if not url:
+            # Unlinkable src (e.g. data: URIs, unsafe schemes): emit just the
+            # alt text rather than a bogus link.
+            return alt
+        label = alt or posixpath.basename(urlsplit(url).path)
+        if not label:
+            # No alt text, and no filename in the path to fall back on, as in
+            # `<img src="https://example.com/?token=abc">`.
+            return url
+        if "a" in parent_tags:
+            # Markdown has no nested links, so hand the label up for the
+            # enclosing <a> to use as its text, with brackets stripped.
+            return re.sub(r"\[|\]", "", label)
+        return get_markdown_link_for_url(label, url)
+
+    def convert_title(self, el: Tag, text: str, parent_tags: set[str]) -> str:
+        return ""
 
 
 def convert_html_to_markdown(html: str) -> str:
-    # html2text is GPL licensed, so run it as a subprocess.
-    markdown = subprocess.check_output(
-        [os.path.join(sys.prefix, "bin", "html2text"), "--unicode-snob"], input=html, text=True
-    ).strip()
-
-    # We want images to get linked and inline previewed, but html2text will turn
-    # them into links of the form `![](http://foo.com/image.png)`, which is
-    # ugly. Run a regex over the resulting description, turning links of the
-    # form `![](http://foo.com/image.png?12345)` into
-    # `[image.png](http://foo.com/image.png)`.
-    return re.sub(r"!\[\]\((\S*)/(\S*)\?(\S*)\)", "[\\2](\\1/\\2)", markdown)
+    # A bare URL is expected input here (the text/html part of an incoming
+    # email), but BeautifulSoup warns about it ("looks like a URL, not markup").
+    # Suppress the warning so that expected input doesn't spam our logs.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", MarkupResemblesLocatorWarning)
+        converter = ZulipMarkdownConverter(
+            # Zulip's Markdown supports only ATX headings, not Setext headings.
+            heading_style="ATX",
+            # Zulip's Markdown has no backslash escaping; it renders "\" as a
+            # literal character.
+            escape_asterisks=False,
+            escape_underscores=False,
+            # HTML treats a newline as insignificant whitespace, but Zulip
+            # renders it as a line break. Collapse source newlines to spaces.
+            # <br>, <pre>, and block-level elements still produce line breaks.
+            wrap=True,
+            # An effectively infinite width disables column wrapping. Don't
+            # use None, which also disables wrapping but skips the pass that
+            # strips indentation from lines following a <br>.
+            wrap_width=sys.maxsize,
+        )
+        markdown: str = converter.convert(html).strip()
+    return markdown

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1,5 +1,6 @@
 import os
 import re
+import warnings
 from dataclasses import dataclass
 from html import escape
 from textwrap import dedent
@@ -9,7 +10,7 @@ from unittest import mock
 import orjson
 import requests
 import responses
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, MarkupResemblesLocatorWarning
 from django.conf import settings
 from django.test import override_settings
 from markdown import Markdown
@@ -3958,42 +3959,69 @@ class TestHtmlToMarkdown(ZulipTestCase):
 
     def test_unordered_lists(self) -> None:
         html = "<ul><li>foo</li><li>bar</li></ul>"
-        self.assertEqual(convert_html_to_markdown(html), "* foo\n  * bar")
+        self.assertEqual(convert_html_to_markdown(html), "* foo\n* bar")
+
+    def test_title_is_stripped(self) -> None:
+        html = "<html><head><title>Some title</title></head><body><p>Hello</p></body></html>"
+        self.assertEqual(convert_html_to_markdown(html), "Hello")
 
     def test_atx_style_headings(self) -> None:
         self.assertEqual(convert_html_to_markdown("<h1>Title</h1>"), "# Title")
         self.assertEqual(convert_html_to_markdown("<h2>Sub</h2>"), "## Sub")
 
     def test_external_img_with_alt(self) -> None:
+        # Zulip doesn't inline-render external images, so an external <img>
+        # must become a [label](url) link to render at all.
         html = '<img src="http://example.com/img.png" alt="photo">'
-        self.assertEqual(convert_html_to_markdown(html), "![photo](http://example.com/img.png)")
+        self.assertEqual(convert_html_to_markdown(html), "[photo](http://example.com/img.png)")
 
     def test_external_img_with_query_string(self) -> None:
+        # The query string is stripped from the filename label but kept in
+        # the URL, where it can be important (e.g. signed URLs).
         html = '<img src="http://foo.com/image.png?12345">'
-        self.assertEqual(convert_html_to_markdown(html), "[image.png](http://foo.com/image.png)")
+        self.assertEqual(
+            convert_html_to_markdown(html), "[image.png](http://foo.com/image.png?12345)"
+        )
 
     def test_external_img_without_alt_or_filename(self) -> None:
         html = '<img src="https://example.com/?token=abc">'
-        self.assertEqual(convert_html_to_markdown(html), "[](https://example.com/)")
+        self.assertEqual(convert_html_to_markdown(html), "https://example.com/?token=abc")
 
     def test_external_img_alt_with_brackets(self) -> None:
+        # Brackets in link text break Zulip's escaping-free Markdown.
         html = '<img src="http://x.com/a.png" alt="see [details]">'
-        self.assertEqual(
-            convert_html_to_markdown(html), "![see \\[details\\]](http://x.com/a.png)"
-        )
+        self.assertEqual(convert_html_to_markdown(html), "[see details](http://x.com/a.png)")
+
+    def test_img_without_src(self) -> None:
+        self.assertEqual(convert_html_to_markdown('<img alt="logo">'), "logo")
 
     def test_data_uri_img(self) -> None:
+        # Inline base64 data: images (e.g. email/canvas placeholders) aren't
+        # linkable and Zulip can't render them; emit the alt text, or nothing,
+        # rather than a bogus link or a dumped base64 blob.
         data_uri = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
-        self.assertEqual(
-            convert_html_to_markdown(f'<img src="{data_uri}" alt="logo">'), f"![logo]({data_uri})"
-        )
-        self.assertEqual(convert_html_to_markdown(f'<img src="{data_uri}">'), f"![]({data_uri})")
+        self.assertEqual(convert_html_to_markdown(f'<img src="{data_uri}" alt="logo">'), "logo")
+        self.assertEqual(convert_html_to_markdown(f'<img src="{data_uri}">'), "")
 
     def test_linked_external_img(self) -> None:
+        # Inside an <a>, only the image's label is emitted, so that the
+        # anchor doesn't end up with a nested link inside it.
         html = '<a href="https://example.com"><img src="https://foo.com/a.png" alt="logo"></a>'
+        self.assertEqual(convert_html_to_markdown(html), "[logo](https://example.com)")
+
+    def test_linked_external_img_without_alt_or_filename(self) -> None:
+        # With no alt text or filename to fall back on, the image's bare
+        # src URL is emitted as the anchor's label.
+        html = '<a href="https://example.com"><img src="https://foo.com/?token=abc"></a>'
         self.assertEqual(
-            convert_html_to_markdown(html), "[![logo](https://foo.com/a.png)](https://example.com)"
+            convert_html_to_markdown(html), "[https://foo.com/?token=abc](https://example.com)"
         )
+
+    def test_linked_external_img_alt_with_brackets(self) -> None:
+        html = (
+            '<a href="https://example.com"><img src="http://x.com/a.png" alt="see [details]"></a>'
+        )
+        self.assertEqual(convert_html_to_markdown(html), "[see details](https://example.com)")
 
     def test_anchor_tag(self) -> None:
         html = '<a href="http://example.com">click here</a>'
@@ -4001,7 +4029,7 @@ class TestHtmlToMarkdown(ZulipTestCase):
 
     def test_bold_and_italic(self) -> None:
         self.assertEqual(convert_html_to_markdown("<strong>bold</strong>"), "**bold**")
-        self.assertEqual(convert_html_to_markdown("<em>italic</em>"), "_italic_")
+        self.assertEqual(convert_html_to_markdown("<em>italic</em>"), "*italic*")
 
     def test_special_characters_are_not_escaped(self) -> None:
         html = "<p>snake_case_var and 2*3 stars</p>"
@@ -4009,17 +4037,39 @@ class TestHtmlToMarkdown(ZulipTestCase):
 
     def test_bare_url_content(self) -> None:
         # Message content (e.g. from the email mirror) is often a bare URL.
+        # convert_html_to_markdown suppresses BeautifulSoup's warning about
+        # such input; promote that warning to an error here so this test fails
+        # if the suppression is ever removed. The warning would also be fatal
+        # under the PYTHONWARNINGS=error policy CI runs with.
         url = "https://www.youtube.com/watch?v=MRmGDhlMhNA"
-        self.assertEqual(convert_html_to_markdown(url), url)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", MarkupResemblesLocatorWarning)
+            self.assertEqual(convert_html_to_markdown(url), url)
 
-    def test_paragraph_wrapping(self) -> None:
+    def test_no_unnecessary_paragraph_wrapping(self) -> None:
         sentence = (
             "The quick brown fox jumps over the lazy dog"
             " again and again until the sentence is long. "
         )
         self.assertEqual(
-            convert_html_to_markdown("<p>" + sentence * 2 + "</p>"),
-            "The quick brown fox jumps over the lazy dog again and again until the sentence\n"
-            "is long. The quick brown fox jumps over the lazy dog again and again until the\n"
-            "sentence is long.",
+            convert_html_to_markdown("<p>" + sentence * 2 + "</p>"), (sentence * 2).strip()
+        )
+
+    def test_new_line_in_source_html(self) -> None:
+        html = (
+            "<p>Thanks for signing up for Acme. To get started, click the button\n"
+            "below and confirm your email address.</p>"
+        )
+        self.assertEqual(
+            convert_html_to_markdown(html),
+            "Thanks for signing up for Acme. To get started, click the button below and"
+            " confirm your email address.",
+        )
+
+    def test_explicit_line_break_is_preserved(self) -> None:
+        self.assertEqual(
+            convert_html_to_markdown("<p>line one<br>line two</p>"), "line one  \nline two"
+        )
+        self.assertEqual(
+            convert_html_to_markdown("<p>line one<br>\nline two</p>"), "line one  \nline two"
         )

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3948,7 +3948,78 @@ class MarkdownErrorTests(ZulipTestCase):
 
 
 class TestHtmlToMarkdown(ZulipTestCase):
-    def test_unicode(self) -> None:
+    def test_real_html(self) -> None:
+        self.assertEqual(convert_html_to_markdown("<p>Hello <b>world</b></p>"), "Hello **world**")
+
+    def test_html_entity_decoding(self) -> None:
         self.assertEqual(
             convert_html_to_markdown("a rose is not a ros&eacute;"), "a rose is not a rosé"
+        )
+
+    def test_unordered_lists(self) -> None:
+        html = "<ul><li>foo</li><li>bar</li></ul>"
+        self.assertEqual(convert_html_to_markdown(html), "* foo\n  * bar")
+
+    def test_atx_style_headings(self) -> None:
+        self.assertEqual(convert_html_to_markdown("<h1>Title</h1>"), "# Title")
+        self.assertEqual(convert_html_to_markdown("<h2>Sub</h2>"), "## Sub")
+
+    def test_external_img_with_alt(self) -> None:
+        html = '<img src="http://example.com/img.png" alt="photo">'
+        self.assertEqual(convert_html_to_markdown(html), "![photo](http://example.com/img.png)")
+
+    def test_external_img_with_query_string(self) -> None:
+        html = '<img src="http://foo.com/image.png?12345">'
+        self.assertEqual(convert_html_to_markdown(html), "[image.png](http://foo.com/image.png)")
+
+    def test_external_img_without_alt_or_filename(self) -> None:
+        html = '<img src="https://example.com/?token=abc">'
+        self.assertEqual(convert_html_to_markdown(html), "[](https://example.com/)")
+
+    def test_external_img_alt_with_brackets(self) -> None:
+        html = '<img src="http://x.com/a.png" alt="see [details]">'
+        self.assertEqual(
+            convert_html_to_markdown(html), "![see \\[details\\]](http://x.com/a.png)"
+        )
+
+    def test_data_uri_img(self) -> None:
+        data_uri = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+        self.assertEqual(
+            convert_html_to_markdown(f'<img src="{data_uri}" alt="logo">'), f"![logo]({data_uri})"
+        )
+        self.assertEqual(convert_html_to_markdown(f'<img src="{data_uri}">'), f"![]({data_uri})")
+
+    def test_linked_external_img(self) -> None:
+        html = '<a href="https://example.com"><img src="https://foo.com/a.png" alt="logo"></a>'
+        self.assertEqual(
+            convert_html_to_markdown(html), "[![logo](https://foo.com/a.png)](https://example.com)"
+        )
+
+    def test_anchor_tag(self) -> None:
+        html = '<a href="http://example.com">click here</a>'
+        self.assertEqual(convert_html_to_markdown(html), "[click here](http://example.com)")
+
+    def test_bold_and_italic(self) -> None:
+        self.assertEqual(convert_html_to_markdown("<strong>bold</strong>"), "**bold**")
+        self.assertEqual(convert_html_to_markdown("<em>italic</em>"), "_italic_")
+
+    def test_special_characters_are_not_escaped(self) -> None:
+        html = "<p>snake_case_var and 2*3 stars</p>"
+        self.assertEqual(convert_html_to_markdown(html), "snake_case_var and 2*3 stars")
+
+    def test_bare_url_content(self) -> None:
+        # Message content (e.g. from the email mirror) is often a bare URL.
+        url = "https://www.youtube.com/watch?v=MRmGDhlMhNA"
+        self.assertEqual(convert_html_to_markdown(url), url)
+
+    def test_paragraph_wrapping(self) -> None:
+        sentence = (
+            "The quick brown fox jumps over the lazy dog"
+            " again and again until the sentence is long. "
+        )
+        self.assertEqual(
+            convert_html_to_markdown("<p>" + sentence * 2 + "</p>"),
+            "The quick brown fox jumps over the lazy dog again and again until the sentence\n"
+            "is long. The quick brown fox jumps over the lazy dog again and again until the\n"
+            "sentence is long.",
         )

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1,5 +1,6 @@
 import os
 import re
+import warnings
 from dataclasses import dataclass
 from html import escape
 from textwrap import dedent
@@ -3957,42 +3958,61 @@ class TestHtmlToMarkdown(ZulipTestCase):
         )
 
     def test_unordered_lists(self) -> None:
+        # html2text indented continuation bullets, which Zulip renders as a
+        # spurious nested list.
         html = "<ul><li>foo</li><li>bar</li></ul>"
-        self.assertEqual(convert_html_to_markdown(html), "* foo\n  * bar")
+        self.assertEqual(convert_html_to_markdown(html), "* foo\n* bar")
 
     def test_atx_style_headings(self) -> None:
         self.assertEqual(convert_html_to_markdown("<h1>Title</h1>"), "# Title")
         self.assertEqual(convert_html_to_markdown("<h2>Sub</h2>"), "## Sub")
 
     def test_external_img_with_alt(self) -> None:
+        # Zulip doesn't inline-render external images, so an external <img>
+        # must become a [label](url) link to render at all.
         html = '<img src="http://example.com/img.png" alt="photo">'
-        self.assertEqual(convert_html_to_markdown(html), "![photo](http://example.com/img.png)")
+        self.assertEqual(convert_html_to_markdown(html), "[photo](http://example.com/img.png)")
 
     def test_external_img_with_query_string(self) -> None:
+        # The query string is stripped from the filename label but kept in
+        # the URL, where it can be load-bearing (e.g. signed URLs).
         html = '<img src="http://foo.com/image.png?12345">'
-        self.assertEqual(convert_html_to_markdown(html), "[image.png](http://foo.com/image.png)")
+        self.assertEqual(
+            convert_html_to_markdown(html), "[image.png](http://foo.com/image.png?12345)"
+        )
 
     def test_external_img_without_alt_or_filename(self) -> None:
         html = '<img src="https://example.com/?token=abc">'
-        self.assertEqual(convert_html_to_markdown(html), "[](https://example.com/)")
+        self.assertEqual(convert_html_to_markdown(html), "https://example.com/?token=abc")
 
     def test_external_img_alt_with_brackets(self) -> None:
+        # Brackets in link text break Zulip's escaping-free Markdown.
         html = '<img src="http://x.com/a.png" alt="see [details]">'
-        self.assertEqual(
-            convert_html_to_markdown(html), "![see \\[details\\]](http://x.com/a.png)"
-        )
+        self.assertEqual(convert_html_to_markdown(html), "[see details](http://x.com/a.png)")
+
+    def test_img_without_src(self) -> None:
+        self.assertEqual(convert_html_to_markdown('<img alt="logo">'), "logo")
 
     def test_data_uri_img(self) -> None:
+        # Inline base64 data: images (e.g. email/canvas placeholders) aren't
+        # linkable and Zulip can't render them; emit the alt text, or nothing,
+        # rather than a bogus link or a dumped base64 blob.
         data_uri = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
-        self.assertEqual(
-            convert_html_to_markdown(f'<img src="{data_uri}" alt="logo">'), f"![logo]({data_uri})"
-        )
-        self.assertEqual(convert_html_to_markdown(f'<img src="{data_uri}">'), f"![]({data_uri})")
+        self.assertEqual(convert_html_to_markdown(f'<img src="{data_uri}" alt="logo">'), "logo")
+        self.assertEqual(convert_html_to_markdown(f'<img src="{data_uri}">'), "")
 
     def test_linked_external_img(self) -> None:
+        # Inside an <a>, only the image's label is emitted, so that the
+        # anchor doesn't end up with a nested link inside it.
         html = '<a href="https://example.com"><img src="https://foo.com/a.png" alt="logo"></a>'
+        self.assertEqual(convert_html_to_markdown(html), "[logo](https://example.com)")
+
+    def test_linked_external_img_without_alt_or_filename(self) -> None:
+        # With no alt text or filename to fall back on, the image's bare
+        # src URL is emitted as the anchor's label.
+        html = '<a href="https://example.com"><img src="https://foo.com/?token=abc"></a>'
         self.assertEqual(
-            convert_html_to_markdown(html), "[![logo](https://foo.com/a.png)](https://example.com)"
+            convert_html_to_markdown(html), "[https://foo.com/?token=abc](https://example.com)"
         )
 
     def test_anchor_tag(self) -> None:
@@ -4001,7 +4021,7 @@ class TestHtmlToMarkdown(ZulipTestCase):
 
     def test_bold_and_italic(self) -> None:
         self.assertEqual(convert_html_to_markdown("<strong>bold</strong>"), "**bold**")
-        self.assertEqual(convert_html_to_markdown("<em>italic</em>"), "_italic_")
+        self.assertEqual(convert_html_to_markdown("<em>italic</em>"), "*italic*")
 
     def test_special_characters_are_not_escaped(self) -> None:
         html = "<p>snake_case_var and 2*3 stars</p>"
@@ -4009,17 +4029,23 @@ class TestHtmlToMarkdown(ZulipTestCase):
 
     def test_bare_url_content(self) -> None:
         # Message content (e.g. from the email mirror) is often a bare URL.
+        # BeautifulSoup emits MarkupResemblesLocatorWarning for such input,
+        # which becomes fatal under the PYTHONWARNINGS=error policy used in
+        # CI, so convert_html_to_markdown suppresses it. Promote warnings to
+        # errors here so this test fails deterministically (not only in CI)
+        # if that suppression is removed.
         url = "https://www.youtube.com/watch?v=MRmGDhlMhNA"
-        self.assertEqual(convert_html_to_markdown(url), url)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.assertEqual(convert_html_to_markdown(url), url)
 
     def test_paragraph_wrapping(self) -> None:
+        # Zulip renders every newline as a line break, so html2text's hard
+        # wrapping at 78 columns produced spurious mid-paragraph breaks.
         sentence = (
             "The quick brown fox jumps over the lazy dog"
             " again and again until the sentence is long. "
         )
         self.assertEqual(
-            convert_html_to_markdown("<p>" + sentence * 2 + "</p>"),
-            "The quick brown fox jumps over the lazy dog again and again until the sentence\n"
-            "is long. The quick brown fox jumps over the lazy dog again and again until the\n"
-            "sentence is long.",
+            convert_html_to_markdown("<p>" + sentence * 2 + "</p>"), (sentence * 2).strip()
         )

--- a/zerver/tests/test_microsoft_teams_importer.py
+++ b/zerver/tests/test_microsoft_teams_importer.py
@@ -17,9 +17,8 @@ from django.utils.timezone import now as timezone_now
 from requests import PreparedRequest
 from typing_extensions import ParamSpec
 
-from zerver.data_import.import_util import AttachmentRecordData, convert_html_to_text, get_data_file
+from zerver.data_import.import_util import AttachmentRecordData, get_data_file
 from zerver.data_import.microsoft_teams import (
-    HOSTED_CONTENT_GRAPH_API_URL_REGEX,
     MICROSOFT_GRAPH_API_URL,
     ChannelMetadata,
     MicrosoftTeamsFieldsT,
@@ -36,6 +35,10 @@ from zerver.data_import.microsoft_teams import (
     get_user_roles,
     is_microsoft_teams_event_message,
     process_hosted_content_attachments,
+)
+from zerver.data_import.microsoft_teams_message_conversion import (
+    HOSTED_CONTENT_GRAPH_API_URL_REGEX,
+    convert_microsoft_teams_html_to_markdown,
 )
 from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE
 from zerver.lib.import_realm import do_import_realm
@@ -620,6 +623,36 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
             str(e.exception),
         )
 
+    def test_convert_microsoft_teams_html_to_markdown_list_conversion(self) -> None:
+        """
+        convert_html_to_text used to mangle plain-text bulleted lists by
+        escaping the leading dashes and collapsing the line breaks;
+        convert_microsoft_teams_html_to_markdown leaves them intact.
+        See #39351.
+        """
+        raw_text = "- bullet 1\n- bullet 2\n- bullet 3\n- bullet 4"
+        content = convert_microsoft_teams_html_to_markdown(raw_text)
+
+        self.assertEqual(raw_text, content)
+
+    def test_convert_microsoft_teams_html_to_markdown_image_conversion(self) -> None:
+        hosted_content_url = "https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/aWQ9eF8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZA==/$value"
+        self.assertEqual(
+            convert_microsoft_teams_html_to_markdown(
+                f'<img src="{hosted_content_url}" alt="image">'
+            ),
+            f"![image]({hosted_content_url})",
+        )
+
+        external_url = (
+            "https://raw.githubusercontent.com/zulip/zulip/main/static/images/logo/"
+            "zulip-icon-128x128.png"
+        )
+        self.assertEqual(
+            convert_microsoft_teams_html_to_markdown(f'<img src="{external_url}" alt="logo">'),
+            f"[logo]({external_url})",
+        )
+
     @responses.activate
     def test_failed_get_microsoft_graph_api_data(self) -> None:
         responses.add(
@@ -759,7 +792,7 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
             # This is actual decoded content from a message in messages_1d513e46-d8cd-41db-b84f-381fe5730794.json
             # The original message was just some text followed by an image.
             MessageFixture(
-                content=convert_html_to_text(
+                content=convert_microsoft_teams_html_to_markdown(
                     """
                     <ul>
                         <li>dashes are ok</li>
@@ -776,7 +809,7 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                          alt="image"
                          itemid="0-wus-d6-3d6dbcb8048aa88f1c1cd57faab3c4ad">
                     </p>
-                    """
+                    """,
                 ),
                 hosted_content_count=1,
                 is_direct_message_type=False,
@@ -800,11 +833,12 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                 test_name="multiple images",
             ),
             # This is actual decoded content from a message in messages_002145f2-eaba-4962-997d-6d841a9f50af.json
-            # The original message was just two custom emojis, nothing else. convert_html_to_text doesn't know
-            # how to process MS Teams-specific tags such as <customemoji>, so this will be converted to empty
-            # string.
+            # The original message was just two custom emojis, nothing else.
+            # convert_microsoft_teams_html_to_markdown doesn't know how to process MS
+            # Teams-specific tags such as <customemoji>, so this will be converted to
+            # empty string.
             MessageFixture(
-                content=convert_html_to_text(
+                content=convert_microsoft_teams_html_to_markdown(
                     """
                     <p>
                         <span>
@@ -822,7 +856,7 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                             </customemoji>
                         </span>
                     </p>
-                    """
+                    """,
                 ),
                 hosted_content_count=0,
                 is_direct_message_type=False,

--- a/zerver/tests/test_microsoft_teams_importer.py
+++ b/zerver/tests/test_microsoft_teams_importer.py
@@ -17,9 +17,8 @@ from django.utils.timezone import now as timezone_now
 from requests import PreparedRequest
 from typing_extensions import ParamSpec
 
-from zerver.data_import.import_util import AttachmentRecordData, convert_html_to_text, get_data_file
+from zerver.data_import.import_util import AttachmentRecordData, get_data_file
 from zerver.data_import.microsoft_teams import (
-    HOSTED_CONTENT_GRAPH_API_URL_REGEX,
     MICROSOFT_GRAPH_API_URL,
     ChannelMetadata,
     MicrosoftTeamsFieldsT,
@@ -36,6 +35,10 @@ from zerver.data_import.microsoft_teams import (
     get_user_roles,
     is_microsoft_teams_event_message,
     process_hosted_content_attachments,
+)
+from zerver.data_import.microsoft_teams_message_conversion import (
+    HOSTED_CONTENT_GRAPH_API_URL_REGEX,
+    convert_microsoft_teams_html_to_markdown,
 )
 from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE
 from zerver.lib.import_realm import do_import_realm
@@ -620,6 +623,36 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
             str(e.exception),
         )
 
+    def test_convert_microsoft_teams_html_to_markdown_list_conversion(self) -> None:
+        """
+        convert_html_to_text used to mangle plain-text bulleted lists by
+        escaping the leading dashes and collapsing the line breaks;
+        convert_microsoft_teams_html_to_markdown leaves them intact.
+        See #39351.
+        """
+        html = "<p>- bullet 1<br>- bullet 2<br>- bullet 3<br>- bullet 4</p>"
+        content = convert_microsoft_teams_html_to_markdown(html)
+
+        self.assertEqual(content, "- bullet 1  \n- bullet 2  \n- bullet 3  \n- bullet 4")
+
+    def test_convert_microsoft_teams_html_to_markdown_image_conversion(self) -> None:
+        hosted_content_url = "https://graph.microsoft.com/v1.0/teams/1d513e46-d8cd-41db-b84f-381fe5730794/channels/19:f0088fc2bb264dfe9a7a7924a23c7252@thread.tacv2/messages/1755002994809/hostedContents/aWQ9eF8wLXd1cy1kNi0zZDZkYmNiODA0OGFhODhmMWMxY2Q1N2ZhYWIzYzRhZA==/$value"
+        self.assertEqual(
+            convert_microsoft_teams_html_to_markdown(
+                f'<img src="{hosted_content_url}" alt="image">'
+            ),
+            f"![image]({hosted_content_url})",
+        )
+
+        external_url = (
+            "https://raw.githubusercontent.com/zulip/zulip/main/static/images/logo/"
+            "zulip-icon-128x128.png"
+        )
+        self.assertEqual(
+            convert_microsoft_teams_html_to_markdown(f'<img src="{external_url}" alt="logo">'),
+            f"[logo]({external_url})",
+        )
+
     @responses.activate
     def test_failed_get_microsoft_graph_api_data(self) -> None:
         responses.add(
@@ -759,7 +792,7 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
             # This is actual decoded content from a message in messages_1d513e46-d8cd-41db-b84f-381fe5730794.json
             # The original message was just some text followed by an image.
             MessageFixture(
-                content=convert_html_to_text(
+                content=convert_microsoft_teams_html_to_markdown(
                     """
                     <ul>
                         <li>dashes are ok</li>
@@ -776,7 +809,7 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                          alt="image"
                          itemid="0-wus-d6-3d6dbcb8048aa88f1c1cd57faab3c4ad">
                     </p>
-                    """
+                    """,
                 ),
                 hosted_content_count=1,
                 is_direct_message_type=False,
@@ -800,11 +833,12 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                 test_name="multiple images",
             ),
             # This is actual decoded content from a message in messages_002145f2-eaba-4962-997d-6d841a9f50af.json
-            # The original message was just two custom emojis, nothing else. convert_html_to_text doesn't know
-            # how to process MS Teams-specific tags such as <customemoji>, so this will be converted to empty
-            # string.
+            # The original message was just two custom emojis, nothing else.
+            # convert_microsoft_teams_html_to_markdown doesn't know how to process MS
+            # Teams-specific tags such as <customemoji>, so this will be converted to
+            # empty string.
             MessageFixture(
-                content=convert_html_to_text(
+                content=convert_microsoft_teams_html_to_markdown(
                     """
                     <p>
                         <span>
@@ -822,7 +856,7 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                             </customemoji>
                         </span>
                     </p>
-                    """
+                    """,
                 ),
                 hosted_content_count=0,
                 is_direct_message_type=False,

--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -117,7 +117,7 @@ Requester Bob <requester-bob@example.com> added a {} note to \
         """
         expected_topic_name = "#12: Not enough ☃ guinea pigs"
         expected_message = """
-Requester \u2603 Bob <requester-bob@example.com> created [ticket #12](http://test1234zzz.freshdesk.com/helpdesk/tickets/12):\n\n``` quote\nThere are too many cat pictures on the internet \u2603. We need more guinea pigs.\nExhibit 1:\n\n  \n\n[guinea_pig.png](http://cdn.freshdesk.com/data/helpdesk/attachments/production/12744808/original/guinea_pig.png)\n```\n\n* **Type**: Problem\n* **Priority**: Urgent\n* **Status**: Open
+Requester \u2603 Bob <requester-bob@example.com> created [ticket #12](http://test1234zzz.freshdesk.com/helpdesk/tickets/12):\n\n``` quote\nThere are too many cat pictures on the internet \u2603. We need more guinea pigs. Exhibit 1:\n\n[guinea_pig.png](http://cdn.freshdesk.com/data/helpdesk/attachments/production/12744808/original/guinea_pig.png?1383958880)\n```\n\n* **Type**: Problem\n* **Priority**: Urgent\n* **Status**: Open
 """.strip()
         self.api_channel_message(
             self.test_user,


### PR DESCRIPTION
Preparatory changes split out of #38650.

Four commits:
- **markdown: Expand convert_html_to_markdown test coverage.** Documents the current html2text-based behavior (verified against actual html2text output), so the next commit's diff shows each behavior change as a test-expectation change.
- **lib: Switch convert_html_to_markdown to use markdownify.** markdownify is MIT-licensed and imported directly, unlike the GPL html2text subprocess. External images become `[label](url)` links, also handling alt-text labels, `data:` URIs and other unsafe schemes, and images nested inside links. Importers that re-host images themselves can pass `use_inline_image_format=True` to keep the inline `![alt](url)` syntax.
- **microsoft_teams: Convert message HTML with convert_html_to_markdown.** Drops the now-unused convert_html_to_text the equivalent Mattermost fix (#39351) was merged separately in #39602.
- **dependencies: Remove html2text dependency.** html2text remains in `uv.lock` only as a transitive dependency of zulip-bots removing it fully needs a follow-up in zulip/python-zulip-api.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
