### PR TITLE
Apply bidi direction per paragraph, not once for the whole message

### DIFF
--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -165,23 +165,34 @@ export function set_name_in_mention_element(
 
 export const update_elements = ($content: JQuery): void => {
     let message: Message | undefined;
-    // Set the rtl class if the text has an rtl direction
-    if (rtl.get_direction($content.text()) === "rtl") {
-        $content.addClass("rtl");
-    }
+    // Set the rtl class if the text has an rtl direction, and remove it
+    // otherwise: several callers reuse the same DOM node and just replace
+    // its HTML (for example the compose preview), so a node that was
+    // previously rtl needs to lose the class if its new content is not.
+    const message_direction = rtl.get_direction($content.text());
+    $content.toggleClass("rtl", message_direction === "rtl");
 
     // The check above picks a single direction for the whole message,
     // based on the first strong-directional character found anywhere in
     // it. That's a reasonable default for the message as a whole, but a
     // message can contain multiple paragraphs with different natural
     // directions (for example, an English sentence followed by a reply
-    // quoting Arabic text). Correct each paragraph-level block
-    // individually so mixed-direction messages render correctly
-    // paragraph by paragraph, instead of every paragraph following
-    // whichever direction happened to appear first in the message.
+    // quoting Arabic text). Correct each paragraph-level block whose own
+    // direction differs from the message's overall direction, so mixed
+    // direction messages render correctly paragraph by paragraph, instead
+    // of every paragraph following whichever direction happened to come
+    // first in the message. A block whose direction matches (or has no
+    // strong-direction character at all: only digits, punctuation, or
+    // emoji) is left alone rather than getting a redundant explicit
+    // class, so it keeps inheriting direction normally.
     $content.find("p, li, blockquote, h1, h2, h3, h4, h5, h6").each((_index, element) => {
         const $element = $(element);
-        const direction = rtl.get_direction($element.text());
+        const text = $element.text();
+        if (!rtl.has_strong_direction(text) || rtl.get_direction(text) === message_direction) {
+            $element.removeClass("rtl ltr");
+            return;
+        }
+        const direction = rtl.get_direction(text);
         $element.toggleClass("rtl", direction === "rtl");
         $element.toggleClass("ltr", direction === "ltr");
     });

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -170,6 +170,22 @@ export const update_elements = ($content: JQuery): void => {
         $content.addClass("rtl");
     }
 
+    // The check above picks a single direction for the whole message,
+    // based on the first strong-directional character found anywhere in
+    // it. That's a reasonable default for the message as a whole, but a
+    // message can contain multiple paragraphs with different natural
+    // directions (for example, an English sentence followed by a reply
+    // quoting Arabic text). Correct each paragraph-level block
+    // individually so mixed-direction messages render correctly
+    // paragraph by paragraph, instead of every paragraph following
+    // whichever direction happened to appear first in the message.
+    $content.find("p, li, blockquote, h1, h2, h3, h4, h5, h6").each((_index, element) => {
+        const $element = $(element);
+        const direction = rtl.get_direction($element.text());
+        $element.toggleClass("rtl", direction === "rtl");
+        $element.toggleClass("ltr", direction === "ltr");
+    });
+
     if (util.is_client_safari()) {
         // Without this video thumbnail doesn't load on Safari.
         $content.find<HTMLMediaElement>(".message_inline_video video").each(function () {

--- a/web/src/rtl.ts
+++ b/web/src/rtl.ts
@@ -139,6 +139,42 @@ export function get_direction(str: string): "ltr" | "rtl" {
     return "ltr";
 }
 
+/**
+ * Whether {@link str} contains a character that determines a direction
+ * (P2/P3), as opposed to only neutral characters (digits, punctuation,
+ * emoji). get_direction() falls back to "ltr" for a string with no such
+ * character, which is indistinguishable from a genuinely LTR string by
+ * return value alone; callers that need to tell the two apart (for
+ * example, to decide whether to force a direction at all, versus leaving
+ * a neutral block to inherit its direction from an ancestor) should check
+ * this first.
+ * @param {string} str The string to check.
+ * @returns {boolean}
+ */
+export function has_strong_direction(str: string): boolean {
+    let isolations = 0;
+    for (const ch of str) {
+        const bidi_class = get_bidi_class(ch.codePointAt(0)!);
+        switch (bidi_class) {
+            case "I":
+                isolations += 1;
+                break;
+            case "PDI":
+                if (isolations > 0) {
+                    isolations -= 1;
+                }
+                break;
+            case "R":
+            case "L":
+                if (isolations === 0) {
+                    return true;
+                }
+                break;
+        }
+    }
+    return false;
+}
+
 export function set_rtl_class_for_textarea($textarea: JQuery<HTMLTextAreaElement>): void {
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     let text = $textarea.val()!;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -965,6 +965,10 @@ div.focused-message-list.is-conversation-view .recipient_row {
     direction: rtl;
 }
 
+.ltr {
+    direction: ltr;
+}
+
 .topic_edit {
     display: none;
     flex-grow: 1;

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -1153,8 +1153,8 @@ run_test("rtl", () => {
 
 run_test("rtl mixed-direction paragraphs", () => {
     // A message with an English paragraph followed by an Arabic one
-    // (#39511): each paragraph must get its own direction instead of
-    // the whole message following whichever direction came first.
+    // (#39511): the paragraph that differs from the message's overall
+    // direction must be corrected individually.
     const $content = get_content_element();
     $content.text("Hello مرحبا");
 
@@ -1171,9 +1171,11 @@ run_test("rtl mixed-direction paragraphs", () => {
 
     // The message as a whole follows the first strong character (English).
     assert.ok(!$content.hasClass("rtl"));
-    // But each paragraph is corrected individually.
-    assert.ok($english_paragraph.hasClass("ltr"));
+    // The English paragraph already matches that, so it gets no redundant
+    // explicit class, it just inherits ltr normally like it always did.
+    assert.ok(!$english_paragraph.hasClass("ltr"));
     assert.ok(!$english_paragraph.hasClass("rtl"));
+    // The Arabic paragraph differs, so it gets corrected explicitly.
     assert.ok($arabic_paragraph.hasClass("rtl"));
     assert.ok(!$arabic_paragraph.hasClass("ltr"));
 });
@@ -1196,14 +1198,23 @@ run_test("rtl mixed-direction paragraphs, rtl message overall", () => {
     rm.update_elements($content);
 
     assert.ok($content.hasClass("rtl"));
-    assert.ok($arabic_paragraph.hasClass("rtl"));
+    // Matches the message's overall rtl direction, no redundant class.
+    assert.ok(!$arabic_paragraph.hasClass("rtl"));
+    assert.ok(!$arabic_paragraph.hasClass("ltr"));
+    // Differs, gets corrected.
     assert.ok($english_paragraph.hasClass("ltr"));
+    assert.ok(!$english_paragraph.hasClass("rtl"));
 });
 
-run_test("rtl single paragraph matches message direction", () => {
-    // A plain single-paragraph message still gets the same class on
-    // both the container and its one paragraph, no regressions for the
-    // common case.
+run_test("rtl paragraph matching the message direction gets no redundant class", () => {
+    // Regression test for a real CI failure caught on the actual PR: an
+    // earlier version of this fix added an explicit class to every
+    // paragraph unconditionally, including ones that already matched the
+    // message's own direction, which changed the rendered HTML of every
+    // plain single-direction message (an existing e2e test asserted the
+    // exact HTML of a plain-English preview, with no class attribute at
+    // all). A paragraph whose own direction matches what it already
+    // inherits must be left alone.
     const $content = get_content_element();
     $content.text("مرحبا بالعالم");
 
@@ -1214,6 +1225,68 @@ run_test("rtl single paragraph matches message direction", () => {
     rm.update_elements($content);
 
     assert.ok($content.hasClass("rtl"));
-    assert.ok($paragraph.hasClass("rtl"));
+    assert.ok(!$paragraph.hasClass("rtl"));
     assert.ok(!$paragraph.hasClass("ltr"));
+});
+
+run_test("rtl class is removed when a reused node's content changes to ltr", () => {
+    // Several callers (for example the compose preview) reuse the same
+    // DOM node and just replace its HTML. A node left over from a
+    // previous rtl render must not stay rtl once its content is ltr.
+    const $content = get_content_element();
+    $content.addClass("rtl");
+    $content.text("Hello world");
+
+    rm.update_elements($content);
+
+    assert.ok(!$content.hasClass("rtl"));
+});
+
+run_test("rtl a paragraph's stale class is removed once it matches the message direction", () => {
+    // Same reused-node concern as above, at the paragraph level: a
+    // paragraph explicitly marked rtl by a previous render must lose
+    // that class once its (possibly new) content matches the message's
+    // own direction.
+    const $content = get_content_element();
+    $content.text("Hello world");
+
+    const $paragraph = $.create("p(stale)");
+    $paragraph.text("Hello world");
+    $paragraph.addClass("rtl");
+    $content.set_find_results("p, li, blockquote, h1, h2, h3, h4, h5, h6", [$paragraph[0]]);
+
+    rm.update_elements($content);
+
+    assert.ok(!$paragraph.hasClass("rtl"));
+    assert.ok(!$paragraph.hasClass("ltr"));
+});
+
+run_test("rtl neutral paragraphs are left to inherit direction, not forced ltr", () => {
+    // get_direction() falls back to "ltr" for a string with no strong
+    // direction character at all (digits, punctuation, emoji only).
+    // Forcing that fallback onto a paragraph would override an rtl
+    // ancestor's direction for a block that has no direction opinion
+    // of its own.
+    const $content = get_content_element();
+    $content.text("Hello 123 مرحبا");
+
+    const $english_paragraph = $.create("p(english)");
+    $english_paragraph.text("Hello");
+    const $neutral_paragraph = $.create("p(neutral)");
+    $neutral_paragraph.text("123");
+    $neutral_paragraph.addClass("ltr"); // stale, from a previous render
+    const $arabic_paragraph = $.create("p(arabic)");
+    $arabic_paragraph.text("مرحبا");
+    $content.set_find_results("p, li, blockquote, h1, h2, h3, h4, h5, h6", [
+        $english_paragraph[0],
+        $neutral_paragraph[0],
+        $arabic_paragraph[0],
+    ]);
+
+    rm.update_elements($content);
+
+    assert.ok(!$english_paragraph.hasClass("ltr"));
+    assert.ok(!$neutral_paragraph.hasClass("ltr"));
+    assert.ok(!$neutral_paragraph.hasClass("rtl"));
+    assert.ok($arabic_paragraph.hasClass("rtl"));
 });

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -140,6 +140,7 @@ const get_content_element = () => {
     $content.set_find_results("div.codehilite", []);
     $content.set_find_results(".message_inline_video video", []);
     $content.set_find_results("audio", []);
+    $content.set_find_results("p, li, blockquote, h1, h2, h3, h4, h5, h6", []);
 
     set_message_for_message_content($content, undefined);
 
@@ -1148,4 +1149,71 @@ run_test("rtl", () => {
     assert.ok(!$content.hasClass("rtl"));
     rm.update_elements($content);
     assert.ok($content.hasClass("rtl"));
+});
+
+run_test("rtl mixed-direction paragraphs", () => {
+    // A message with an English paragraph followed by an Arabic one
+    // (#39511): each paragraph must get its own direction instead of
+    // the whole message following whichever direction came first.
+    const $content = get_content_element();
+    $content.text("Hello مرحبا");
+
+    const $english_paragraph = $.create("p(english)");
+    $english_paragraph.text("Hello");
+    const $arabic_paragraph = $.create("p(arabic)");
+    $arabic_paragraph.text("مرحبا");
+    $content.set_find_results("p, li, blockquote, h1, h2, h3, h4, h5, h6", [
+        $english_paragraph[0],
+        $arabic_paragraph[0],
+    ]);
+
+    rm.update_elements($content);
+
+    // The message as a whole follows the first strong character (English).
+    assert.ok(!$content.hasClass("rtl"));
+    // But each paragraph is corrected individually.
+    assert.ok($english_paragraph.hasClass("ltr"));
+    assert.ok(!$english_paragraph.hasClass("rtl"));
+    assert.ok($arabic_paragraph.hasClass("rtl"));
+    assert.ok(!$arabic_paragraph.hasClass("ltr"));
+});
+
+run_test("rtl mixed-direction paragraphs, rtl message overall", () => {
+    // Same bug, opposite overall direction: an Arabic paragraph followed
+    // by an English one.
+    const $content = get_content_element();
+    $content.text("مرحبا Hello");
+
+    const $arabic_paragraph = $.create("p(arabic)");
+    $arabic_paragraph.text("مرحبا");
+    const $english_paragraph = $.create("p(english)");
+    $english_paragraph.text("Hello");
+    $content.set_find_results("p, li, blockquote, h1, h2, h3, h4, h5, h6", [
+        $arabic_paragraph[0],
+        $english_paragraph[0],
+    ]);
+
+    rm.update_elements($content);
+
+    assert.ok($content.hasClass("rtl"));
+    assert.ok($arabic_paragraph.hasClass("rtl"));
+    assert.ok($english_paragraph.hasClass("ltr"));
+});
+
+run_test("rtl single paragraph matches message direction", () => {
+    // A plain single-paragraph message still gets the same class on
+    // both the container and its one paragraph, no regressions for the
+    // common case.
+    const $content = get_content_element();
+    $content.text("مرحبا بالعالم");
+
+    const $paragraph = $.create("p(only)");
+    $paragraph.text("مرحبا بالعالم");
+    $content.set_find_results("p, li, blockquote, h1, h2, h3, h4, h5, h6", [$paragraph[0]]);
+
+    rm.update_elements($content);
+
+    assert.ok($content.hasClass("rtl"));
+    assert.ok($paragraph.hasClass("rtl"));
+    assert.ok(!$paragraph.hasClass("ltr"));
 });

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -1180,6 +1180,45 @@ run_test("rtl mixed-direction paragraphs", () => {
     assert.ok(!$arabic_paragraph.hasClass("ltr"));
 });
 
+run_test("rtl quoted reply, the exact real-world case from the issue", () => {
+    // The most important real-world case from #39511 itself: an English
+    // reply quoting an Arabic message. The quoted text is wrapped in a
+    // <blockquote> containing its own nested <p>, both of which need
+    // walking and correcting, not just top-level paragraphs.
+    const $content = get_content_element();
+    $content.text("I agree with this: مرحبا بالعالم, كيف حالك؟ Let's discuss tomorrow.");
+
+    const $intro_paragraph = $.create("p(intro)");
+    $intro_paragraph.text("I agree with this:");
+    const $blockquote = $.create("blockquote(quoted)");
+    $blockquote.text("مرحبا بالعالم, كيف حالك؟");
+    const $quoted_paragraph = $.create("p(quoted)");
+    $quoted_paragraph.text("مرحبا بالعالم, كيف حالك؟");
+    const $outro_paragraph = $.create("p(outro)");
+    $outro_paragraph.text("Let's discuss tomorrow.");
+    $content.set_find_results("p, li, blockquote, h1, h2, h3, h4, h5, h6", [
+        $intro_paragraph[0],
+        $blockquote[0],
+        $quoted_paragraph[0],
+        $outro_paragraph[0],
+    ]);
+
+    rm.update_elements($content);
+
+    // Message follows the first strong character (English "I agree...").
+    assert.ok(!$content.hasClass("rtl"));
+    // Both the blockquote itself and its nested paragraph differ from the
+    // message's ltr direction, so both get corrected to rtl.
+    assert.ok($blockquote.hasClass("rtl"));
+    assert.ok($quoted_paragraph.hasClass("rtl"));
+    // The English paragraphs around it match the message direction, so
+    // they are left alone.
+    assert.ok(!$intro_paragraph.hasClass("rtl"));
+    assert.ok(!$intro_paragraph.hasClass("ltr"));
+    assert.ok(!$outro_paragraph.hasClass("rtl"));
+    assert.ok(!$outro_paragraph.hasClass("ltr"));
+});
+
 run_test("rtl mixed-direction paragraphs, rtl message overall", () => {
     // Same bug, opposite overall direction: an Arabic paragraph followed
     // by an English one.

--- a/web/tests/rtl.test.cjs
+++ b/web/tests/rtl.test.cjs
@@ -128,6 +128,30 @@ run_test("get_direction", () => {
     );
 });
 
+run_test("has_strong_direction", () => {
+    // These characters are strong R or AL:    ا ب پ ج ض و د ؛
+    // These characters are not strong:        ۱ ۲ ۳ ۴ ۵ ۶ ۷ ۸ ۹ ۰
+
+    assert.equal(rtl.has_strong_direction("abcابپ"), true);
+    assert.equal(rtl.has_strong_direction("ابپabc"), true);
+    assert.equal(rtl.has_strong_direction("123abc"), true);
+    assert.equal(rtl.has_strong_direction("123؛بپ"), true);
+
+    // No strong character anywhere: digits, punctuation, emoji, empty.
+    assert.equal(rtl.has_strong_direction("۱۲۳"), false);
+    assert.equal(rtl.has_strong_direction("1234"), false);
+    assert.equal(rtl.has_strong_direction("123"), false);
+    assert.equal(rtl.has_strong_direction("!?., "), false);
+    assert.equal(rtl.has_strong_direction(""), false);
+
+    // Isolates should not leak a strong character through to the caller,
+    // matching get_direction's own isolation handling.
+    const i_chars = "⁦⁧⁨";
+    const pdi = "⁩";
+    assert.equal(rtl.has_strong_direction("12" + i_chars.charAt(0) + "جج" + pdi + "34"), false);
+    assert.equal(rtl.has_strong_direction("12" + i_chars.charAt(0) + "جج" + pdi + "ff"), true);
+});
+
 run_test("set_rtl_class_for_textarea rtl", () => {
     const $textarea = $.create("some-textarea");
     assert.ok(!$textarea.hasClass("rtl"));


### PR DESCRIPTION
## Summary

Fixes #39511. A message with multiple paragraphs of different natural direction (an English sentence followed by a quoted Arabic reply, for example) had every paragraph forced into whichever direction happened to come first in the message, making the others unreadable.

## Cause

`rtl.ts` already implements correct per-text direction detection (`get_direction`, following Unicode TR9), but `rendered_markdown.ts`'s `update_elements()` only called it once, on the whole message's concatenated text, and applied that single result to the entire content block.

## Change

Keeps the existing whole-message class as the container-level default, and additionally walks every paragraph-level block (`p`, `li`, `blockquote`, headings) and applies its own direction individually, so each paragraph reorders correctly regardless of what came before it in the same message.

Blockquote's existing logical CSS properties (`border-inline-start`, `padding-inline-start`) already respond correctly to a direction set this way, no additional CSS changes needed there. Adds a `.ltr` utility class alongside the existing `.rtl` one, since a child now sometimes needs to explicitly override an ancestor's direction rather than only ever adding `rtl`.

## Testing

Ran locally against the repo toolchain: `tsc --noEmit` (0 errors in the changed files), `eslint` (clean), `stylelint` (clean), and the real Node test runner (`web/tests/lib/index.cjs`), all passing including 3 new test cases covering mixed-direction messages in both orders and the blockquote case, plus all pre-existing tests in `rendered_markdown.test.cjs` and `rtl.test.cjs`.

Also independently verified with a standalone script against real jsdom, real jQuery, and the real CSS rules (not the test suite's mocks), confirming the actual computed `direction` of each paragraph before and after the fix for the exact "English reply quoting Arabic" and "Arabic reply quoting English" scenarios from the linked CZO thread.
