### PR TITLE
typeahead: Add a bottom fade to scrollable suggestion lists.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -225,6 +225,11 @@ export class Typeahead<ItemType extends string | object> {
     $container: JQuery;
     $menu: JQuery;
     $footer: JQuery;
+    scroll_fade_observer: IntersectionObserver | undefined;
+    scroll_fade_frame: number | undefined;
+    // Resolved once, so the scroll handler, the observer and the fade all
+    // read the same element.
+    scroll_fade_element: HTMLElement | undefined;
     source: (
         query: string,
         input_element: TypeaheadInputElement,
@@ -470,6 +475,10 @@ export class Typeahead<ItemType extends string | object> {
                         // This detects any overflows by default and adjusts
                         // the placement of typeahead.
                         void instance.popperInstance?.update();
+                        // The typeahead is on screen and sized now, so we can
+                        // tell whether it scrolls. It is just opening, so the
+                        // fade should not animate in.
+                        this.update_scroll_fade(false);
                     });
 
                     // While the above requestAnimationFrame call works well in
@@ -518,6 +527,9 @@ export class Typeahead<ItemType extends string | object> {
             // Call this after $container is in DOM which is true here since
             // that happens in the constructor for non-tippy typeaheads.
             this.$container.show();
+            // The container is visible now, so we can tell whether it
+            // scrolls. It is just opening, so the fade should not animate in.
+            this.update_scroll_fade(false);
         }
 
         return this;
@@ -528,6 +540,7 @@ export class Typeahead<ItemType extends string | object> {
             return this;
         }
         this.shown = false;
+        this.teardown_scroll_fade();
         if (this.non_tippy_parent_element) {
             this.$container.hide();
         } else {
@@ -635,7 +648,100 @@ export class Typeahead<ItemType extends string | object> {
         // before we render it.
         scroll_util.get_scroll_element(this.$menu);
         scroll_util.get_content_element(this.$menu).empty().append($items);
+        this.update_scroll_fade();
         return this;
+    }
+
+    // Resolves the scroll element, doing the one-time setup on the first call.
+    setup_scroll_fade(): HTMLElement | undefined {
+        if (this.scroll_fade_element !== undefined) {
+            return this.scroll_fade_element;
+        }
+        const scroll_element = scroll_util.get_scroll_element(this.$menu)[0];
+        // The Node tests have no real DOM, and the fade is only visual.
+        if (typeof HTMLElement === "undefined" || !(scroll_element instanceof HTMLElement)) {
+            return undefined;
+        }
+        this.scroll_fade_element = scroll_element;
+        $(scroll_element).on("scroll.typeahead_scroll_fade", () => {
+            this.schedule_scroll_fade();
+        });
+        if (typeof IntersectionObserver !== "undefined") {
+            // Catches a scroll position set a frame after opening, with no
+            // scroll event: for example, reopening the search typeahead that
+            // was left scrolled to the bottom.
+            this.scroll_fade_observer = new IntersectionObserver(
+                () => {
+                    this.schedule_scroll_fade();
+                },
+                {root: scroll_element},
+            );
+        }
+        return scroll_element;
+    }
+
+    update_scroll_fade(animate = true): void {
+        if (this.setup_scroll_fade() === undefined) {
+            return;
+        }
+        // We just re-rendered, so point the observer at the new last result.
+        this.scroll_fade_observer?.disconnect();
+        const last_item = this.$menu.find("li").last()[0];
+        if (last_item !== undefined) {
+            this.scroll_fade_observer?.observe(last_item);
+        }
+        this.refresh_scroll_fade(animate);
+    }
+
+    schedule_scroll_fade(): void {
+        // Batch updates into one animation frame, so a scroll doesn't measure
+        // the layout on every event.
+        if (this.scroll_fade_frame !== undefined) {
+            return;
+        }
+        this.scroll_fade_frame = requestAnimationFrame(() => {
+            this.scroll_fade_frame = undefined;
+            this.refresh_scroll_fade();
+        });
+    }
+
+    refresh_scroll_fade(animate = true): void {
+        const scroll_element = this.scroll_fade_element;
+        if (scroll_element === undefined) {
+            return;
+        }
+        // Show the fade only when there are more results below the visible
+        // area. The 1px allowance covers rounding from SimpleBar.
+        const has_more_below =
+            scroll_element.scrollHeight - scroll_element.scrollTop - scroll_element.clientHeight >
+            1;
+        if (animate) {
+            this.$menu.toggleClass("has-scroll-fade", has_more_below);
+            return;
+        }
+        // The typeahead is opening, so the fade should already be there rather
+        // than fading in. Reading the layout forces the browser to apply the
+        // change while the transition is off, so only later changes animate.
+        this.$menu.addClass("no-scroll-fade-transition");
+        this.$menu.toggleClass("has-scroll-fade", has_more_below);
+        the(this.$menu).getBoundingClientRect();
+        this.$menu.removeClass("no-scroll-fade-transition");
+    }
+
+    teardown_scroll_fade(): void {
+        this.scroll_fade_observer?.disconnect();
+        if (this.scroll_fade_frame !== undefined) {
+            cancelAnimationFrame(this.scroll_fade_frame);
+            this.scroll_fade_frame = undefined;
+        }
+        if (this.scroll_fade_element !== undefined) {
+            $(this.scroll_fade_element).off("scroll.typeahead_scroll_fade");
+        }
+        this.$menu.removeClass("has-scroll-fade");
+        // The observer is rooted at the scroll element, so we clear both and
+        // set them up again the next time the typeahead is shown.
+        this.scroll_fade_element = undefined;
+        this.scroll_fade_observer = undefined;
     }
 
     next(): void {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -171,6 +171,8 @@
         width: 100%;
         background: var(--color-background-search);
         color: var(--color-text-search);
+        /* The bottom scroll fade blends into the search background. */
+        --typeahead-fade-color: var(--color-background-search);
 
         border-width: 0;
         border-top-width: 1px;

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -140,11 +140,46 @@
 }
 
 .typeahead.dropdown-menu {
+    /* The color the bottom scroll fade blends into. The search typeahead
+       has its own background and overrides this (see search.css). */
+    --typeahead-fade-color: var(--color-background-dropdown-widget);
+
     .typeahead-menu {
+        position: relative;
         list-style: none;
         margin: 4px 0;
         max-height: min(248px, 95vh);
         overflow-y: auto;
+
+        &::after {
+            /* Bottom fade hinting that the list can be scrolled.
+               bootstrap_typeahead.ts adds `has-scroll-fade` only while there
+               is more to scroll, so it stays hidden on short lists and at the
+               end of the list. */
+            content: "";
+            position: absolute;
+            inset-inline: 0;
+            bottom: 0;
+            height: 1.5em;
+            pointer-events: none;
+            background: linear-gradient(
+                to bottom,
+                transparent,
+                var(--typeahead-fade-color)
+            );
+            opacity: 0;
+            transition: opacity 180ms ease-out;
+        }
+
+        /* The fade is already in place when the typeahead opens; only later
+           changes, like scrolling to the end of the list, animate. */
+        &.no-scroll-fade-transition::after {
+            transition: none;
+        }
+
+        &.has-scroll-fade::after {
+            opacity: 1;
+        }
     }
 
     .typeahead-footer {


### PR DESCRIPTION
When a typeahead's list of suggestions was long enough to scroll, nothing indicated that more results were available below the visible area. This adds a gradient that fades the last visible results into the dropdown background, hinting that the list can be scrolled.

The fade is shown only while there are more results below the current scroll position: it appears as soon as a scrollable list opens, fades out smoothly once the list is scrolled to its end, and never shows on a short list that fits without scrolling. It is driven from `bootstrap_typeahead.ts`, which toggles a class based on the scroll position, and works for both the Tippy typeaheads and the search box.

**_Note: added a smooth fade-out animation (on fade end); if it looks good, we can proceed, and if not, I'll revert it._**

> fades out smoothly once the list is scrolled to its end

Fixes #34478.
CZO: [#design > Add shadow at the bottom of scrollable typeaheads  #34478.](https://chat.zulip.org/#narrow/channel/101-design/topic/Add.20shadow.20at.20the.20bottom.20of.20scrollable.20typeaheads.20.20.2334478.2E/with/2493834)

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Dark theme Before | Dark Theme After |
|--------|-------|
|<img width="1031" height="427" alt="image" src="https://github.com/user-attachments/assets/c12e94b2-eb12-4fcb-8c45-75897199eecc" />|<img width="1031" height="427" alt="image" src="https://github.com/user-attachments/assets/d6235287-a7ec-44e4-b518-ef94c6693746" />|

| Light Theme Before | Light Theme After |
|--------|-------|
|<img width="1031" height="427" alt="image" src="https://github.com/user-attachments/assets/d75b0202-7fd5-4ad9-8c82-a901bfba2072" />|<img width="1031" height="427" alt="image" src="https://github.com/user-attachments/assets/f2afe738-4193-45ac-ae46-0fe88cc8aa1a" />|

| Dark Theme When no item to scroll | Dark Theme When no item to scroll |
|--------|-------|
|<img width="1029" height="63" alt="image" src="https://github.com/user-attachments/assets/3ec982cc-7678-4440-968f-a8e17b4e1626" />|<img width="1029" height="63" alt="image" src="https://github.com/user-attachments/assets/a721600d-1f87-4868-a48c-5000afc321b0" />|

| Dark Theme On Hover | Light Theme On Hover |
|--------|-------|
|<img width="1031" height="427" alt="image" src="https://github.com/user-attachments/assets/58ae7672-4657-472e-ab45-9d326ddb417c" />|<img width="1031" height="427" alt="image" src="https://github.com/user-attachments/assets/0ca200d0-5848-4c96-856f-6ea087bf27b6" />|


| Dark Theme On Hover | Light Theme On Hover |
|--------|-------|
|<img width="1029" height="63" alt="image" src="https://github.com/user-attachments/assets/a470a5c3-65ea-4593-9519-842157e22c9f" />|<img width="1029" height="63" alt="image" src="https://github.com/user-attachments/assets/d1dd2a81-ebb7-4f4b-97ce-842a81c108ee" />|

| Dark Theme Before | Dark theme After |
|--------|-------|
|<img width="540" height="388" alt="image" src="https://github.com/user-attachments/assets/decc38cb-b1a0-4c87-b0ea-065115977854" />|<img width="540" height="388" alt="image" src="https://github.com/user-attachments/assets/fb83a40d-0070-40d9-b604-d980b6d4e027" />|

| Light Theme Before | Light theme After |
|--------|-------|
|<img width="540" height="388" alt="image" src="https://github.com/user-attachments/assets/6d573a9e-670a-4662-9c75-36089e27217c" />|<img width="540" height="388" alt="image" src="https://github.com/user-attachments/assets/82bffc9e-0e37-4f8a-b250-66cebb1f1245" />|

| Dark Theme On Hover | Light theme On Hover |
|--------|-------|
|<img width="540" height="388" alt="image" src="https://github.com/user-attachments/assets/f4cf13c0-3aa8-4237-9a4a-eaf0afefe651" />|<img width="540" height="388" alt="image" src="https://github.com/user-attachments/assets/3e3557d2-7769-4b4a-8e39-903c1d3f66ef" />|

| Dark theme Before | Dark Theme After |
|--------|-------|
|<img width="376" height="388" alt="image" src="https://github.com/user-attachments/assets/b23b0abc-0ed2-4c5b-8e21-19a3838ab8de" />|<img width="376" height="388" alt="image" src="https://github.com/user-attachments/assets/51a15dd3-8802-4f9f-9b07-b83e26c41aec" />|

| Light Theme Before | Light theme After |
|--------|-------|
|<img width="376" height="388" alt="image" src="https://github.com/user-attachments/assets/e0d3b992-72ac-42e9-8d90-f6dc73eaf14d" />|<img width="376" height="388" alt="image" src="https://github.com/user-attachments/assets/648f107b-fa3f-4c0e-af3e-3094cf1e0970" />|

| Dark Theme On Hover | Light theme On Hover |
|--------|-------|
|<img width="376" height="388" alt="image" src="https://github.com/user-attachments/assets/72c92c1c-95ae-469a-a859-8dc3e9100342" />|<img width="376" height="388" alt="image" src="https://github.com/user-attachments/assets/ebc315e9-3ecb-4299-b9e7-9a23a4655ba8" />|

| Dark Theme Before | Dark theme After |
|--------|-------|
|<img width="522" height="388" alt="image" src="https://github.com/user-attachments/assets/bddebf2a-a904-477b-a8cd-274c1a24a5ec" />|<img width="522" height="388" alt="image" src="https://github.com/user-attachments/assets/c5b90de8-7e0b-4c15-8fd6-85bd192b5d60" />|

| Light Theme Before | Light theme After |
|--------|-------|
|<img width="522" height="388" alt="image" src="https://github.com/user-attachments/assets/c12067a6-a025-4ded-add7-55363adcb34a" />|<img width="522" height="388" alt="image" src="https://github.com/user-attachments/assets/93d452cf-bc6b-4fcc-9f52-2aa01b16c026" />|


| Dark Theme Video | Light Theme Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/5bdd5163-d3df-4ab0-8d24-f5cd5155afc6" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/6523ad46-0ad9-4a22-8bc6-cee54b16aeec" width="400" controls></video> |


| Dark Theme Video | Light Theme Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/9cbc2359-9c4b-43c9-94db-8b4a5ad35696" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/5d3d5b76-e9a2-4aff-8264-03df132bcdb3" width="400" controls></video> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
