### PR TITLE
import: Sort UserMessage bulk inserts by message ID

### DIFF
--- a/zerver/lib/user_message.py
+++ b/zerver/lib/user_message.py
@@ -59,7 +59,12 @@ def bulk_insert_ums(ums: list[UserMessageLite]) -> None:
     if not ums:
         return
 
-    vals = [(um.user_profile_id, um.message_id, um.flags) for um in ums]
+    # Keep the insert order consistent with the rows locked by
+    # process_fts_updates, which helps avoid deadlocks during realm imports.
+    vals = sorted(
+        ((um.user_profile_id, um.message_id, um.flags) for um in ums),
+        key=lambda row: (row[1], row[0]),
+    )
     query = SQL(
         """
         INSERT into

--- a/zerver/tests/test_user_message.py
+++ b/zerver/tests/test_user_message.py
@@ -1,0 +1,32 @@
+from unittest import TestCase, mock
+
+from zerver.lib.user_message import UserMessageLite, bulk_insert_ums
+
+
+class BulkInsertUserMessageTests(TestCase):
+    def test_bulk_insert_ums_sorts_by_message_id(self) -> None:
+        ums = [
+            UserMessageLite(user_profile_id=1, message_id=5, flags=1),
+            UserMessageLite(user_profile_id=2, message_id=3, flags=2),
+            UserMessageLite(user_profile_id=3, message_id=4, flags=3),
+            UserMessageLite(user_profile_id=4, message_id=3, flags=4),
+        ]
+
+        with (
+            mock.patch("zerver.lib.user_message.execute_values") as mock_execute_values,
+            mock.patch("zerver.lib.user_message.connection.cursor") as mock_cursor,
+        ):
+            mock_cursor.return_value.__enter__.return_value.cursor = mock.MagicMock()
+
+            bulk_insert_ums(ums)
+
+        mock_execute_values.assert_called_once()
+        self.assertEqual(
+            mock_execute_values.call_args.args[2],
+            [
+                (2, 3, 2),
+                (4, 3, 4),
+                (3, 4, 3),
+                (1, 5, 1),
+            ],
+        )


### PR DESCRIPTION
## Summary
- Sort `bulk_insert_ums` by `message_id` before the batch insert.
- Add a regression test that verifies the emitted insert order.

## Why
Realm imports can deadlock against `process_fts_updates` when `UserMessage` rows are inserted in a different order than the lock acquisition order used by the FTS updater. Sorting the batch by message ID makes the lock order deterministic.

## Testing
- `python -m py_compile zerver/lib/user_message.py zerver/tests/test_user_message.py`
- Full backend tests could not be run in this Windows container because Zulip's backend runner expects the Linux `fork` multiprocessing context and the local Python environment does not have the full Django test dependencies installed.
