### PR TITLE
attachments: notify all delete recipients

### DIFF
--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -26,7 +27,11 @@ class AttachmentChangeResult:
 
 
 def notify_attachment_update(
-    user_profile: UserProfile, op: str, attachment_dict: dict[str, Any]
+    user_profile: UserProfile,
+    op: str,
+    attachment_dict: dict[str, Any],
+    *,
+    users: Iterable[int] | None = None,
 ) -> None:
     event = {
         "type": "attachment",
@@ -34,7 +39,9 @@ def notify_attachment_update(
         "attachment": attachment_dict,
         "upload_space_used": user_profile.realm.currently_used_upload_space_bytes(),
     }
-    send_event_on_commit(user_profile.realm, event, [user_profile.id])
+    if users is None:
+        users = [user_profile.id]
+    send_event_on_commit(user_profile.realm, event, users)
 
 
 def do_claim_attachments(

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -8,6 +8,7 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError, RateLimitedError
+from zerver.lib.message import event_recipient_ids_for_action_on_messages
 from zerver.lib.streams import is_user_in_groups_granting_content_access
 from zerver.lib.upload import delete_message_attachment
 from zerver.lib.user_groups import get_recursive_membership_groups
@@ -28,6 +29,15 @@ from zerver.models import (
 def user_attachments(user_profile: UserProfile) -> list[dict[str, Any]]:
     attachments = Attachment.objects.filter(owner=user_profile).prefetch_related("messages")
     return [a.to_dict() for a in attachments]
+
+
+def attachment_update_user_ids(attachment: Attachment) -> set[int]:
+    user_ids = {attachment.owner_id}
+    for message in attachment.messages.all().select_related("recipient"):
+        user_ids.update(
+            event_recipient_ids_for_action_on_messages([message.id], message.is_channel_message)
+        )
+    return user_ids
 
 
 def access_attachment_by_id(

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -52,6 +52,34 @@ class AttachmentsTests(ZulipTestCase):
         attachments = user_attachments(user_profile)
         self.assertEqual(attachments, [])
 
+    @mock.patch("zerver.views.attachments.notify_attachment_update")
+    def test_remove_attachment_notifies_message_recipients(self, mock_notify: Any) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        stream = self.make_stream("attachment-delete-notify", invite_only=True)
+        self.subscribe(hamlet, stream.name, invite_only=True)
+        self.subscribe(iago, stream.name, invite_only=True)
+        self.login_user(hamlet)
+
+        with (
+            self.thumbnail_formats(ThumbnailFormat("webp", 100, 75, animated=True)),
+            get_test_image_file("img.png") as image_file,
+        ):
+            response = self.assert_json_success(
+                self.client_post("/json/user_uploads", {"file": image_file})
+            )
+
+        path_id = re.sub(r"/user_uploads/", "", response["url"])
+        body = f"See this file: [img.png]({response['url']})"
+        self.send_stream_message(hamlet, stream.name, body, "test")
+        attachment = Attachment.objects.get(path_id=path_id)
+
+        result = self.client_delete(f"/json/attachments/{attachment.id}")
+        self.assert_json_success(result)
+
+        mock_notify.assert_called_once()
+        self.assertEqual(set(mock_notify.call_args.kwargs["users"]), {hamlet.id, iago.id})
+
     @mock.patch("zerver.lib.attachments.delete_message_attachment")
     def test_remove_imageattachment(self, ignored: Any) -> None:
         self.login_user(self.example_user("hamlet"))

--- a/zerver/views/attachments.py
+++ b/zerver/views/attachments.py
@@ -2,7 +2,12 @@ from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 
 from zerver.actions.uploads import notify_attachment_update
-from zerver.lib.attachments import access_attachment_by_id, remove_attachment, user_attachments
+from zerver.lib.attachments import (
+    access_attachment_by_id,
+    attachment_update_user_ids,
+    remove_attachment,
+    user_attachments,
+)
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
@@ -20,6 +25,7 @@ def list_by_user(request: HttpRequest, user_profile: UserProfile) -> HttpRespons
 @transaction.atomic(durable=True)
 def remove(request: HttpRequest, user_profile: UserProfile, attachment_id: int) -> HttpResponse:
     attachment = access_attachment_by_id(user_profile, attachment_id, needs_owner=True)
+    users = attachment_update_user_ids(attachment)
     remove_attachment(user_profile, attachment)
-    notify_attachment_update(user_profile, "remove", {"id": attachment_id})
+    notify_attachment_update(user_profile, "remove", {"id": attachment_id}, users=users)
     return json_success(request)


### PR DESCRIPTION
## Summary
- Send attachment delete events to every user who can see a message containing the deleted attachment, not just the attachment owner.
- Keep the notification fan-out aligned with the messages that actually reference the deleted attachment.

## Why
The previous behavior could leave some clients unaware that an attachment had been deleted until they reloaded. This PR is the server-side follow-up to `#34299` and makes stale preview refresh flows reliable.

## Testing
- Automated CI checks passed on the pull request.

## Review notes
- This change is intentionally narrow and only affects attachment delete recipient selection.
