### PR TITLE
integrations: Support GitLab work item events

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/issue_hook__work_item_epic_opened.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_hook__work_item_epic_opened.json
@@ -1,0 +1,20 @@
+{
+    "object_kind": "work_item",
+    "user": {
+        "name": "Tomasz Kolek",
+        "username": "tomaszkolek0"
+    },
+    "project": {
+        "name": "my-awesome-project",
+        "web_url": "https://gitlab.com/tomaszkolek0/my-awesome-project",
+        "visibility_level": 20
+    },
+    "object_attributes": {
+        "iid": 8,
+        "title": "Plan next release",
+        "description": "Coordinate the next release.",
+        "url": "https://gitlab.com/tomaszkolek0/my-awesome-project/-/work_items/8",
+        "type": "Epic",
+        "action": "open"
+    }
+}

--- a/zerver/webhooks/gitlab/fixtures/issue_hook__work_item_task_closed.json
+++ b/zerver/webhooks/gitlab/fixtures/issue_hook__work_item_task_closed.json
@@ -1,0 +1,19 @@
+{
+    "object_kind": "work_item",
+    "user": {
+        "name": "Tomasz Kolek",
+        "username": "tomaszkolek0"
+    },
+    "project": {
+        "name": "my-awesome-project",
+        "web_url": "https://gitlab.com/tomaszkolek0/my-awesome-project",
+        "visibility_level": 20
+    },
+    "object_attributes": {
+        "iid": 9,
+        "title": "Update docs",
+        "url": "https://gitlab.com/tomaszkolek0/my-awesome-project/-/work_items/9",
+        "type": "Task",
+        "action": "close"
+    }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -178,6 +178,22 @@ class GitlabHookTests(WebhookTestCase):
             "issue_hook__issue_opened_with_null_description", expected_topic_name, expected_message
         )
 
+    def test_create_work_item_event_message(self) -> None:
+        expected_topic_name = "my-awesome-project / epic #8 Plan next release"
+        expected_message = "Tomasz Kolek created [epic #8](https://gitlab.com/tomaszkolek0/my-awesome-project/-/work_items/8):\n\n``` quote\nCoordinate the next release.\n```"
+
+        self.check_webhook(
+            "issue_hook__work_item_epic_opened", expected_topic_name, expected_message
+        )
+
+    def test_close_work_item_event_message(self) -> None:
+        expected_topic_name = "my-awesome-project / task #9 Update docs"
+        expected_message = "Tomasz Kolek closed [task #9](https://gitlab.com/tomaszkolek0/my-awesome-project/-/work_items/9)."
+
+        self.check_webhook(
+            "issue_hook__work_item_task_closed", expected_topic_name, expected_message
+        )
+
     def test_update_issue_event_message(self) -> None:
         expected_topic_name = "my-awesome-project / issue #1 Issue title_new"
         expected_message = "Tomasz Kolek updated [issue #1](https://gitlab.com/tomaszkolek0/my-awesome-project/issues/1)."

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -107,24 +107,25 @@ def get_tag_push_event_body(payload: WildValue, include_title: bool, realm: Real
     )
 
 
-def get_issue_created_event_body(payload: WildValue, include_title: bool, realm: Realm) -> str:
+def get_object_description(payload: WildValue) -> str | None:
     description = payload["object_attributes"].get("description")
-    # Filter out multiline hidden comments
     if description:
         stringified_description = description.tame(check_string)
         stringified_description = re.sub(
             r"<!--.*?-->", "", stringified_description, count=0, flags=re.DOTALL
         )
-        stringified_description = stringified_description.rstrip()
-    else:
-        stringified_description = None
+        return stringified_description.rstrip()
 
+    return None
+
+
+def get_issue_created_event_body(payload: WildValue, include_title: bool, realm: Realm) -> str:
     return get_issue_event_message(
         user_name=get_user_name(payload, realm),
         action="created",
         url=get_object_url(payload),
         number=payload["object_attributes"]["iid"].tame(check_int),
-        message=stringified_description,
+        message=get_object_description(payload),
         assignees=replace_assignees_username_with_name(get_assignees(payload)),
         title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
     )
@@ -136,6 +137,36 @@ def get_issue_event_body(action: str, payload: WildValue, include_title: bool, r
         action=action,
         url=get_object_url(payload),
         number=payload["object_attributes"]["iid"].tame(check_int),
+        title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
+    )
+
+
+def get_work_item_type(payload: WildValue) -> str:
+    return payload["object_attributes"]["type"].tame(check_string).lower()
+
+
+def get_work_item_created_event_body(payload: WildValue, include_title: bool, realm: Realm) -> str:
+    return get_pull_request_event_message(
+        user_name=get_user_name(payload, realm),
+        action="created",
+        url=get_object_url(payload),
+        number=payload["object_attributes"]["iid"].tame(check_int),
+        message=get_object_description(payload),
+        assignees=replace_assignees_username_with_name(get_assignees(payload)),
+        type=get_work_item_type(payload),
+        title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
+    )
+
+
+def get_work_item_event_body(
+    action: str, payload: WildValue, include_title: bool, realm: Realm
+) -> str:
+    return get_pull_request_event_message(
+        user_name=get_user_name(payload, realm),
+        action=action,
+        url=get_object_url(payload),
+        number=payload["object_attributes"]["iid"].tame(check_int),
+        type=get_work_item_type(payload),
         title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
     )
 
@@ -687,6 +718,10 @@ EVENT_FUNCTION_MAPPER: dict[str, EventFunction] = {
     "Confidential Issue Hook close": partial(get_issue_event_body, "closed"),
     "Confidential Issue Hook reopen": partial(get_issue_event_body, "reopened"),
     "Confidential Issue Hook update": partial(get_issue_event_body, "updated"),
+    "Work Item Hook open": get_work_item_created_event_body,
+    "Work Item Hook close": partial(get_work_item_event_body, "closed"),
+    "Work Item Hook reopen": partial(get_work_item_event_body, "reopened"),
+    "Work Item Hook update": partial(get_work_item_event_body, "updated"),
     "Note Hook Commit": get_commented_commit_event_body,
     "Note Hook MergeRequest": get_commented_merge_request_event_body,
     "Note Hook Issue": get_commented_issue_event_body,
@@ -790,10 +825,10 @@ def get_topic_based_on_event(event: str, payload: WildValue, use_merge_request_t
                 else ""
             ),
         )
-    elif event.startswith(("Issue Hook", "Confidential Issue Hook")):
+    elif event.startswith(("Issue Hook", "Confidential Issue Hook", "Work Item Hook")):
         return TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
             repo=get_repo_name(payload),
-            type="issue",
+            type=get_work_item_type(payload) if event.startswith("Work Item Hook") else "issue",
             id=payload["object_attributes"]["iid"].tame(check_int),
             title=payload["object_attributes"]["title"].tame(check_string),
         )
@@ -874,7 +909,15 @@ def get_event(request: HttpRequest, payload: WildValue, branches: str | None) ->
             event_name = payload["object_kind"].tame(check_string)
         event = event_name.split("__")[0].replace("_", " ").title()
         event = f"{event} Hook"
-    if event in ["Confidential Issue Hook", "Issue Hook", "Merge Request Hook", "Wiki Page Hook"]:
+    if event in [
+        "Confidential Issue Hook",
+        "Issue Hook",
+        "Merge Request Hook",
+        "Wiki Page Hook",
+        "Work Item Hook",
+    ]:
+        if event == "Issue Hook" and payload["object_kind"].tame(check_string) == "work_item":
+            event = "Work Item Hook"
         action = payload["object_attributes"].get("action", "open").tame(check_string)
         event = f"{event} {action}"
     elif event in ["Confidential Note Hook", "Note Hook"]:


### PR DESCRIPTION
## What changed

Added support for GitLab Work Item Hook events, mapping them through the existing GitLab webhook flow while rendering the concrete work item type, such as epic or task, in Zulip topics and messages.

Fixes #39170.

## Why

GitLab sends non-issue work items with object_kind: work_item; these were not covered by the integration's event mapper, so events like epics and tasks did not produce Zulip notifications.

## Testing

- python -m py_compile zerver\webhooks\gitlab\view.py zerver\webhooks\gitlab\tests.py
- python -m ruff format zerver\webhooks\gitlab\view.py zerver\webhooks\gitlab\tests.py
- python -m ruff check zerver\webhooks\gitlab\view.py zerver\webhooks\gitlab\tests.py

I could not run the targeted backend tests locally because this checkout does not have Zulip's .venv; python manage.py test zerver.webhooks.gitlab.tests.GitlabHookTests.test_create_work_item_event_message zerver.webhooks.gitlab.tests.GitlabHookTests.test_close_work_item_event_message fails before test collection with FileNotFoundError: .venv\bin\activate_this.py.