### PR TITLE
[ai] markdown: Fetch Dropbox folder/file previews asynchronously.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -7,15 +7,13 @@ from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from email.message import EmailMessage
 from functools import lru_cache
 from re import Match, Pattern
-from typing import Any, Generic, Optional, TypeAlias, TypedDict, TypeVar, cast
+from typing import Generic, Literal, Optional, TypeAlias, TypedDict, TypeVar, cast
 from urllib.parse import parse_qs, parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 from xml.etree.ElementTree import Element, SubElement
 
 import ahocorasick
-import lxml.etree
 import markdown
 import markdown.blockprocessors
 import markdown.inlinepatterns
@@ -25,14 +23,12 @@ import markdown.treeprocessors
 import markdown.util
 import re2
 import regex
-import requests
 import uri_template
-import urllib3.exceptions
 from django.conf import settings
 from markdown.blockparser import BlockParser
 from markdown.extensions import codehilite, nl2br, sane_lists, tables
 from tlds import tld_set
-from typing_extensions import NotRequired, Self, override
+from typing_extensions import Self, override
 
 from zerver.lib import mention
 from zerver.lib.camo import get_camo_url
@@ -50,7 +46,6 @@ from zerver.lib.mention import (
     get_user_group_mention_display_name,
 )
 from zerver.lib.mime_types import AUDIO_INLINE_MIME_TYPES, guess_type
-from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.per_request_cache import cache_for_current_request
 from zerver.lib.subdomains import is_static_or_current_realm_url
 from zerver.lib.tex import render_tex
@@ -470,56 +465,6 @@ def has_blockquote_ancestor(element_pair: ElementPair | None) -> bool:
         return has_blockquote_ancestor(element_pair.parent)
 
 
-class OpenGraphSession(OutgoingSession):
-    def __init__(self) -> None:
-        super().__init__(role="markdown", timeout=1)
-
-
-def fetch_open_graph_image(url: str) -> dict[str, Any] | None:
-    og: dict[str, str | None] = {"image": None, "title": None, "desc": None}
-
-    try:
-        with OpenGraphSession().get(
-            url, headers={"Accept": "text/html,application/xhtml+xml"}, stream=True
-        ) as res:
-            if res.status_code != requests.codes.ok:
-                return None
-
-            m = EmailMessage()
-            m["Content-Type"] = res.headers.get("Content-Type")
-            mimetype = m.get_content_type()
-            if mimetype not in ("text/html", "application/xhtml+xml"):
-                return None
-            html = mimetype == "text/html"
-
-            res.raw.decode_content = True
-            for event, element in lxml.etree.iterparse(
-                res.raw, events=("start",), no_network=True, remove_comments=True, html=html
-            ):
-                parent = element.getparent()
-                if parent is not None:
-                    # Reduce memory usage.
-                    parent.text = None
-                    parent.remove(element)
-
-                if element.tag in ("body", "{http://www.w3.org/1999/xhtml}body"):
-                    break
-                elif element.tag in ("meta", "{http://www.w3.org/1999/xhtml}meta"):
-                    if element.get("property") == "og:image":
-                        content = element.get("content")
-                        if content is not None:
-                            og["image"] = urljoin(res.url, content)
-                    elif element.get("property") == "og:title":
-                        og["title"] = element.get("content")
-                    elif element.get("property") == "og:description":
-                        og["desc"] = element.get("content")
-
-    except (requests.RequestException, urllib3.exceptions.HTTPError):
-        return None
-
-    return None if og["image"] is None else og
-
-
 class InlineImageProcessor(markdown.treeprocessors.Treeprocessor):
     """
     Rewrite inline img tags to serve external content via Camo.
@@ -607,12 +552,20 @@ class BacktickInlineProcessor(markdown.inlinepatterns.BacktickInlineProcessor):
 IMAGE_EXTENSIONS = [".bmp", ".gif", ".jpe", ".jpeg", ".jpg", ".png", ".webp"]
 
 
-class DropboxMediaInfo(TypedDict):
-    is_image: bool
-    is_video: bool
+@dataclass
+class DropboxInlineMediaInfo:
+    # An file that we inline directly, using the link rewritten to point
+    # at the raw file.
+    type: Literal["image", "video"]
     media_url: str
-    title: NotRequired[str]
-    desc: NotRequired[str]
+
+
+@dataclass
+class DropboxDeferredPreviewInfo:
+    # We preview these via their OpenGraph image. That image is fetched
+    # asynchronously by the embed_links worker rather than during
+    # rendering, so no media_url is available here.
+    type: Literal["folder", "file"]
 
 
 class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
@@ -795,7 +748,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             return "https://linx.li/s" + parsed_url.path
         return None
 
-    def dropbox_media(self, url: str) -> DropboxMediaInfo | None:
+    def dropbox_media(self, url: str) -> DropboxInlineMediaInfo | DropboxDeferredPreviewInfo | None:
         if not self.zmd.image_preview_enabled:
             return None
         parsed_url = urlsplit(url)
@@ -817,29 +770,12 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             # in the url before passing it to `is_video`.
             is_video = self.is_video(urlsplit(url).path)
 
-            # If it is from an album or not an actual image file,
-            # just use open graph image.
+            # Albums, and files that aren't an image or video, are
+            # previewed via their OpenGraph image, which the caller
+            # fetches asynchronously through the embed_links worker
+            # rather than blocking rendering on a network request.
             if is_album or not (is_image or is_video):
-                open_graph_image_info = fetch_open_graph_image(url)
-                # Failed to follow link to find an image preview so
-                # use placeholder image and guess filename
-                if open_graph_image_info is None:
-                    return None
-
-                if is_album:
-                    title = "Dropbox folder"
-                    desc = "Click to open folder."
-                else:
-                    title = "Dropbox file"
-                    desc = "Click to open file."
-
-                return DropboxMediaInfo(
-                    title=title,
-                    desc=desc,
-                    is_image=is_image,
-                    is_video=is_video,
-                    media_url=open_graph_image_info["image"],
-                )
+                return DropboxDeferredPreviewInfo(type="folder" if is_album else "file")
 
             # Adding raw=1 as query param will give us the URL of the
             # actual image instead of the dropbox image preview page.
@@ -847,9 +783,8 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             query_params["raw"] = "1"
             query = urlencode(query_params)
 
-            return DropboxMediaInfo(
-                is_image=is_image,
-                is_video=is_video,
+            return DropboxInlineMediaInfo(
+                type="image" if is_image else "video",
                 media_url=parsed_url._replace(query=query).geturl(),
             )
         return None
@@ -1124,32 +1059,49 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 continue
 
             dropbox_media = self.dropbox_media(url)
-            if dropbox_media is not None:
-                is_image = dropbox_media["is_image"]
-                if is_image:
-                    found_url = ResultWithFamily(
-                        family=found_url.family,
-                        result=(dropbox_media["media_url"], dropbox_media["media_url"]),
-                    )
-                    self.handle_image_inlining(root, found_url)
+            if isinstance(dropbox_media, DropboxDeferredPreviewInfo):
+                # Media previewed via its OpenGraph image. Register the URL
+                # until the embed_links worker supplies that image, then build
+                # the embed from it.
+                if self.zmd.url_embed_data is None or url not in self.zmd.url_embed_data:
+                    self.zmd.zulip_rendering_result.links_for_preview.add(url)
                     continue
 
-                is_video = dropbox_media["is_video"]
-                if is_video:
-                    found_url = ResultWithFamily(
-                        family=found_url.family,
-                        result=(dropbox_media["media_url"], dropbox_media["media_url"]),
-                    )
-                    self.handle_video_inlining(root, found_url)
+                # If there is data, but it's None, we did process the URL,
+                # but it was not valid to preview. If no image was found,
+                # `add_embed` below will skip building the embed.
+                extracted_data = self.zmd.url_embed_data[url]
+                if extracted_data is None:
                     continue
 
-                dropbox_embed_data = UrlEmbedData(
-                    type="image",
-                    title=dropbox_media["title"],
-                    description=dropbox_media["desc"],
-                    image=dropbox_media["media_url"],
+                if dropbox_media.type == "folder":
+                    embed_title = "Dropbox folder"
+                    embed_description = "Click to open folder."
+                else:
+                    embed_title = "Dropbox file"
+                    embed_description = "Click to open file."
+
+                self.add_embed(
+                    root,
+                    url,
+                    UrlEmbedData(
+                        type="image",
+                        title=embed_title,
+                        description=embed_description,
+                        image=extracted_data.image,
+                    ),
                 )
-                self.add_embed(root, url, dropbox_embed_data)
+                continue
+
+            if isinstance(dropbox_media, DropboxInlineMediaInfo):
+                found_url = ResultWithFamily(
+                    family=found_url.family,
+                    result=(dropbox_media.media_url, dropbox_media.media_url),
+                )
+                if dropbox_media.type == "image":
+                    self.handle_image_inlining(root, found_url)
+                else:
+                    self.handle_video_inlining(root, found_url)
                 continue
 
             # This needs to run after all the dropbox code has been run.

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -69,6 +69,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.tex import render_tex
 from zerver.lib.types import UserGroupMembersData
 from zerver.lib.upload import get_emoji_url, upload_message_attachment
+from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_groups import UserGroupMembershipDetails
 from zerver.models import Message, NamedUserGroup, RealmEmoji, RealmFilter, UserMessage, UserProfile
 from zerver.models.clients import get_client
@@ -1169,38 +1170,50 @@ class MarkdownEmbedsTest(ZulipTestCase):
             self.assertFalse(url_embed_preview_enabled(message, no_previews=True))
 
     def test_inline_dropbox(self) -> None:
+        # Image files are inlined directly, with no network request, so
+        # they render on the initial pass. The inlined image points at
+        # the raw file (raw=1 appended), while the link keeps the
+        # original URL.
         msg = "Look at how hilarious our old office was: https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0"
-        image_info = {
-            "image": "https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0&raw=1",
-        }
-        with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=image_info):
-            converted = markdown_convert_wrapper(msg)
-
+        converted = markdown_convert_wrapper(msg)
         self.assertEqual(
             converted,
             f"""<p>Look at how hilarious our old office was: <a href="https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0">https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0</a></p>\n<div class="message_inline_image"><a href="https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0&amp;raw=1"><img src="{get_camo_url("https://www.dropbox.com/scl/fi/cbabl5ryv1veky9ehs603/IMG_0923.JPG?rlkey=24sfgf0k0dneebzf5tfccldg0&raw=1")}"></a></div>""",
         )
 
-        msg = "Look at my hilarious drawing folder: https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&st=dz5p1ytw"  # codespell:ignore fo
-        image_info = {
-            "image": "https://www.dropbox.com/static/metaserver/static/images/opengraph/opengraph-content-icon-folder-dropbox-landscape.png",
-        }
-        with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=image_info):
-            converted = markdown_convert_wrapper(msg)
-
+        # Folders are previewed via their OpenGraph image. That image is
+        # fetched asynchronously by the embed_links worker, so the initial
+        # render only registers the URL for preview, without a network
+        # request or an embed.
+        folder_url = "https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&st=dz5p1ytw"  # codespell:ignore fo
+        escaped_url = folder_url.replace("&", "&amp;")
+        rendered = markdown_convert(folder_url, message_realm=get_realm("zulip"))
         self.assertEqual(
-            converted,
-            """<p>Look at my hilarious drawing folder: <a href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw">https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw</a></p>\n<div class="message_embed"><a class="message_embed_image" href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw" style="background-image: url(&quot;https://external-content.zulipcdn.net/external_content/a301902b9942efb85cfe2a6f4bb07d76ba7b86de/68747470733a2f2f7777772e64726f70626f782e636f6d2f7374617469632f6d6574617365727665722f7374617469632f696d616765732f6f70656e67726170682f6f70656e67726170682d636f6e74656e742d69636f6e2d666f6c6465722d64726f70626f782d6c616e6473636170652e706e67&quot;)"></a><div class="data-container"><div class="message_embed_title"><a href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw" title="Dropbox folder">Dropbox folder</a></div><div class="message_embed_description">Click to open folder.</div></div></div>""",  # codespell:ignore fo
+            rendered.rendered_content,
+            f'<p><a href="{escaped_url}">{escaped_url}</a></p>',
+        )
+        self.assertEqual(rendered.links_for_preview, {folder_url})
+
+        # With the OpenGraph image supplied directly — as the embed_links
+        # worker would after fetching it — rendering produces the folder
+        # embed.
+        image = "https://www.dropbox.com/static/metaserver/static/images/opengraph/opengraph-content-icon-folder-dropbox-landscape.png"
+        rendered = markdown_convert(
+            folder_url,
+            message_realm=get_realm("zulip"),
+            url_embed_data={folder_url: UrlEmbedData(image=image)},
+        )
+        self.assertEqual(
+            rendered.rendered_content,
+            """<p><a href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw">https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw</a></p>\n<div class="message_embed"><a class="message_embed_image" href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw" style="background-image: url(&quot;https://external-content.zulipcdn.net/external_content/a301902b9942efb85cfe2a6f4bb07d76ba7b86de/68747470733a2f2f7777772e64726f70626f782e636f6d2f7374617469632f6d6574617365727665722f7374617469632f696d616765732f6f70656e67726170682f6f70656e67726170682d636f6e74656e742d69636f6e2d666f6c6465722d64726f70626f782d6c616e6473636170652e706e67&quot;)"></a><div class="data-container"><div class="message_embed_title"><a href="https://www.dropbox.com/scl/fo/ty22bx4thyhl9r89p839g/AAzfPX5IbiOb8wmxHvns2pM?rlkey=5pinfuoghias9cueq0zyhj2rp&amp;st=dz5p1ytw" title="Dropbox folder">Dropbox folder</a></div><div class="message_embed_description">Click to open folder.</div></div></div>""",  # codespell:ignore fo
         )
 
     def test_inline_dropbox_video(self) -> None:
+        # Video files are inlined directly, with no network request. As
+        # with images, the inlined video points at the raw file (raw=1
+        # appended), while the link keeps the original URL.
         msg = "Look at this video: https://www.dropbox.com/scl/fi/x8z01rodq1n6pgyznt1kh/SampleVideo_1280x720_1mb.mp4?rlkey=fiibsgnu06tms041vfzfopmos&st=kjtkea8h&dl=0"
-        image_info = {
-            "image": "https://www.dropbox.com/scl/fi/x8z01rodq1n6pgyznt1kh/SampleVideo_1280x720_1mb.mp4?rlkey=fiibsgnu06tms041vfzfopmos&st=kjtkea8h&dl=0&raw=1",
-        }
-        with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=image_info):
-            converted = markdown_convert_wrapper(msg)
-
+        converted = markdown_convert_wrapper(msg)
         self.assertEqual(
             converted,
             """<p>Look at this video: <a href="https://www.dropbox.com/scl/fi/x8z01rodq1n6pgyznt1kh/SampleVideo_1280x720_1mb.mp4?rlkey=fiibsgnu06tms041vfzfopmos&amp;st=kjtkea8h&amp;dl=0">https://www.dropbox.com/scl/fi/x8z01rodq1n6pgyznt1kh/SampleVideo_1280x720_1mb.mp4?rlkey=fiibsgnu06tms041vfzfopmos&amp;st=kjtkea8h&amp;dl=0</a></p>
@@ -1221,16 +1234,25 @@ class MarkdownEmbedsTest(ZulipTestCase):
         )
 
     def test_inline_dropbox_preview(self) -> None:
-        # Test photo album previews
-        msg = "https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5"
-        image_info = {
-            "image": "https://photos-6.dropbox.com/t/2/AAAlawaeD61TyNewO5vVi-DGf2ZeuayfyHFdNTNzpGq-QA/12/271544745/jpeg/1024x1024/2/_/0/5/baby-piglet.jpg/CKnjvYEBIAIgBygCKAc/tditp9nitko60n5/AADX03VAIrQlTl28CtujDcMla/0",
-        }
-        with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=image_info):
-            converted = markdown_convert_wrapper(msg)
-
+        # Photo album (/sc/) links are previewed as folders via their
+        # OpenGraph image, fetched asynchronously by the embed_links
+        # worker. The initial render only registers the URL for preview.
+        url = "https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5"
+        rendered = markdown_convert(url, message_realm=get_realm("zulip"))
         self.assertEqual(
-            converted,
+            rendered.rendered_content,
+            f'<p><a href="{url}">{url}</a></p>',
+        )
+        self.assertEqual(rendered.links_for_preview, {url})
+
+        image = "https://photos-6.dropbox.com/t/2/AAAlawaeD61TyNewO5vVi-DGf2ZeuayfyHFdNTNzpGq-QA/12/271544745/jpeg/1024x1024/2/_/0/5/baby-piglet.jpg/CKnjvYEBIAIgBygCKAc/tditp9nitko60n5/AADX03VAIrQlTl28CtujDcMla/0"
+        rendered = markdown_convert(
+            url,
+            message_realm=get_realm("zulip"),
+            url_embed_data={url: UrlEmbedData(image=image)},
+        )
+        self.assertEqual(
+            rendered.rendered_content,
             """<p><a href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5">https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5</a></p>
 <div class="message_embed"><a class="message_embed_image" href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5" style="background-image: url(&quot;https://external-content.zulipcdn.net/external_content/e7584a56d9ba7f2a2aee96ee1427a6b746eab5ff/68747470733a2f2f70686f746f732d362e64726f70626f782e636f6d2f742f322f4141416c6177616544363154794e65774f357656692d444766325a6575617966794846644e544e7a7047712d51412f31322f3237313534343734352f6a7065672f3130323478313032342f322f5f2f302f352f626162792d7069676c65742e6a70672f434b6e6a7659454249414967427967434b41632f7464697470396e69746b6f36306e352f41414458303356414972516c546c32384374756a44634d6c612f30&quot;)"></a><div class="data-container"><div class="message_embed_title"><a href="https://www.dropbox.com/sc/tditp9nitko60n5/03rEiZldy5" title="Dropbox folder">Dropbox folder</a></div><div class="message_embed_description">Click to open folder.</div></div></div>""",
         )
@@ -1239,8 +1261,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
         # Make sure we're not overzealous in our conversion:
         url = "https://www.dropbox.com/static/images/home_logo.png"
         msg = f"Look at the new dropbox logo: {url}"
-        with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=None):
-            converted = markdown_convert_wrapper(msg)
+        converted = markdown_convert_wrapper(msg)
 
         camo_url = get_camo_url(url)
         self.assertEqual(
@@ -1255,29 +1276,60 @@ class MarkdownEmbedsTest(ZulipTestCase):
     def test_inline_dropbox_bad(self) -> None:
         # Don't fail on bad dropbox links
         msg = "https://zulip-test.dropbox.com/photos/cl/ROmr9K1XYtmpneM"
-        with mock.patch("zerver.lib.markdown.fetch_open_graph_image", return_value=None):
-            converted = markdown_convert_wrapper(msg)
+        converted = markdown_convert_wrapper(msg)
         self.assertEqual(
             converted,
             '<p><a href="https://zulip-test.dropbox.com/photos/cl/ROmr9K1XYtmpneM">https://zulip-test.dropbox.com/photos/cl/ROmr9K1XYtmpneM</a></p>',
         )
 
+    def test_inline_dropbox_file_deferred_preview(self) -> None:
+        # A non-image/non-video Dropbox file is previewed via its
+        # OpenGraph image. Rendering must not perform the fetch itself
+        # (which would risk do_convert's 5-second timeout); it registers
+        # the URL so the embed_links worker can fetch it asynchronously.
+        url = "https://www.dropbox.com/scl/fi/8xq0p2m4n6k8j1h3g5f7d/quarterly-report.pdf?dl=0"
+        rendered = markdown_convert(url, message_realm=get_realm("zulip"))
+        self.assertEqual(
+            rendered.rendered_content,
+            f'<p><a href="{url}">{url}</a></p>',
+        )
+        self.assertEqual(rendered.links_for_preview, {url})
+
+        image = "https://www.dropbox.com/static/metaserver/static/images/opengraph/opengraph-content-icon-file-dropbox-landscape.png"
+        rendered = markdown_convert(
+            url,
+            message_realm=get_realm("zulip"),
+            url_embed_data={url: UrlEmbedData(image=image)},
+        )
+        self.assertIn('title="Dropbox file"', rendered.rendered_content)
+        self.assertIn("Click to open file.", rendered.rendered_content)
+
+        # If the worker could not find an OpenGraph image (the fetch
+        # failed, or the page has no og:image), no embed is produced and
+        # the message renders as a plain link.
+        for missing_image in (None, UrlEmbedData(image=None)):
+            rendered = markdown_convert(
+                url,
+                message_realm=get_realm("zulip"),
+                url_embed_data={url: missing_image},
+            )
+            self.assertEqual(
+                rendered.rendered_content,
+                f'<p><a href="{url}">{url}</a></p>',
+            )
+
     def test_inline_dropbox_no_previews(self) -> None:
         # When previews are disabled (e.g., for channel descriptions),
-        # dropbox_media should not invoke fetch_open_graph_image, since
-        # network calls in that context can time out and abort rendering.
-        # Use a non-image/non-video file link so that, without the fix,
-        # dropbox_media would reach the fetch_open_graph_image call.
+        # Dropbox links must not be registered for preview, since the
+        # asynchronous fetch that follows would surface a preview in a
+        # context where previews are meant to be suppressed. Use a
+        # non-image/non-video file link, which is the case that would
+        # otherwise request a preview.
         url = "https://www.dropbox.com/scl/fi/8xq0p2m4n6k8j1h3g5f7d/quarterly-report.pdf?dl=0"
-        with mock.patch(
-            "zerver.lib.markdown.fetch_open_graph_image"
-        ) as mock_fetch_open_graph_image:
-            converted = markdown_convert(
-                url, message_realm=get_realm("zulip"), no_previews=True
-            ).rendered_content
-        mock_fetch_open_graph_image.assert_not_called()
+        rendered = markdown_convert(url, message_realm=get_realm("zulip"), no_previews=True)
+        self.assertEqual(rendered.links_for_preview, set())
         self.assertEqual(
-            converted,
+            rendered.rendered_content,
             f'<p><a href="{url}">{url}</a></p>',
         )
 


### PR DESCRIPTION
`dropbox_media()` fetched a link's OpenGraph image synchronously while rendering, for folder, album, and non-image/non-video file links. Because rendering is bounded by `do_convert`'s 5-second timeout, a message with several such links could spend longer than that on the serial fetches and abort with `MarkdownRenderingError`, surfacing to the sender as a message that repeatedly fails to send.

Move that fetch off the render path onto the `embed_links` worker, the same way every other URL preview is handled: rendering now records the link in `links_for_preview`, and the worker fetches the image via `get_link_embed_data` and re-renders the message. This removes all network access from Dropbox rendering, so the render budget no longer depends on how many links a message has. The folder/file previews now appear shortly after the message is sent, consistent with other URL previews.

An earlier change (b84e2239b2) made `dropbox_media` respect `image_preview_enabled`, which avoided this for contexts that disable previews (channel descriptions and similar); ordinary messages, where previews are enabled, were still affected.

---

Sentry issue: https://zulip.sentry.io/issues/7101441584/?query=TimeoutExpiredError&referrer=issue-stream

CZO discussion: [#issues > DM w/ four Paper links failing to send](https://chat.zulip.org/#narrow/channel/9-issues/topic/DM.20w.2F.20four.20Paper.20links.20failing.20to.20send/with/2493925)