### PR TITLE
narrow: Bound message-fetch range on the driving usermessage index.

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1229,10 +1229,14 @@ def limit_query_to_range(
     anchored_to_left: bool,
     anchored_to_right: bool,
     first_visible_message_id: int,
+    id_field: str,
 ) -> QuerySet[Message]:
     """
     This code is actually generic enough that we could move it to a
     library, but our only caller for now is message search.
+
+    id_field is the message-id column to order and bound the range by;
+    see fetch_messages for why the table it comes from matters.
     """
     need_before_query = (not anchored_to_left) and (num_before > 0)
     need_after_query = (not anchored_to_right) and (num_after > 0)
@@ -1272,17 +1276,17 @@ def limit_query_to_range(
         before_query = query
 
         if not anchored_to_right:
-            before_query = before_query.filter(id__lte=before_anchor)
+            before_query = before_query.filter(**{f"{id_field}__lte": before_anchor})
 
-        before_query = before_query.order_by("-id")[:before_limit]
+        before_query = before_query.order_by(f"-{id_field}")[:before_limit]
 
     if need_after_query:
         after_query = query
 
         if not anchored_to_left:
-            after_query = after_query.filter(id__gte=after_anchor)
+            after_query = after_query.filter(**{f"{id_field}__gte": after_anchor})
 
-        after_query = after_query.order_by("id")[:after_limit]
+        after_query = after_query.order_by(id_field)[:after_limit]
 
     if before_query is not None and after_query is not None:
         return before_query.union(after_query, all=True)
@@ -1299,7 +1303,7 @@ def limit_query_to_range(
         # for something like `message_id = 42` is exactly what we want.  In other
         # cases, which could possibly be buggy API clients, at least we will
         # return at most one row here.
-        return query.filter(id=anchor)
+        return query.filter(**{id_field: anchor})
 
 
 MessageRowT = TypeVar("MessageRowT", bound=Sequence[Any])
@@ -1512,6 +1516,17 @@ def fetch_messages(
         if anchored_to_right:
             num_after = 0
 
+        if need_user_message:
+            # Order/bound pagination on the driving zerver_usermessage
+            # (user_profile_id, message_id) index. PostgreSQL won't push a
+            # zerver_message.id bound across the outer join, so using it would
+            # scan the user's whole history to reach an old anchor. The alias
+            # reuses the existing join rather than adding a second one.
+            query = query.alias(_range_message_id=F("usermessage__message_id"))
+            id_field = "_range_message_id"
+        else:
+            id_field = "id"
+
         query = limit_query_to_range(
             query=query,
             num_before=num_before,
@@ -1521,6 +1536,7 @@ def fetch_messages(
             anchored_to_left=anchored_to_left,
             anchored_to_right=anchored_to_right,
             first_visible_message_id=first_visible_message_id,
+            id_field=id_field,
         )
 
     values_query = query.values_list(

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -4816,11 +4816,15 @@ class GetOldMessagesTest(ZulipTestCase):
         capture.assert_called_once()
         sql = get_django_sql(capture.call_args.args[0])
         self.assertNotIn(f"message_id = {LARGER_THAN_MAX_MESSAGE_ID}", sql)
-        self.assertIn("ORDER BY 1 ASC", sql)
+        # Pagination must be ordered/bounded on zerver_usermessage.message_id,
+        # not zerver_message.id, to avoid a full-history scan; see fetch_messages.
+        self.assertIn('ORDER BY "zerver_usermessage"."message_id" ASC', sql)
 
         self.assertIn(f' WHERE ("zerver_usermessage"."user_profile_id" = {user_profile.id} ', sql)
-        self.assertIn(f' AND "zerver_message"."id" >= {first_unread_message_id})', sql)
-        self.assertIn(f' AND "zerver_message"."id" <= {first_unread_message_id - 1})', sql)
+        self.assertIn(f' AND "zerver_usermessage"."message_id" >= {first_unread_message_id})', sql)
+        self.assertIn(
+            f' AND "zerver_usermessage"."message_id" <= {first_unread_message_id - 1})', sql
+        )
         self.assertIn("UNION", sql)
 
     def test_visible_messages_use_first_unread_anchor_with_some_unread_messages(self) -> None:
@@ -4865,10 +4869,12 @@ class GetOldMessagesTest(ZulipTestCase):
         capture.assert_called_once()
         sql = get_django_sql(capture.call_args.args[0])
         self.assertNotIn(f"message_id = {LARGER_THAN_MAX_MESSAGE_ID}", sql)
-        self.assertIn("ORDER BY 1 ASC", sql)
+        self.assertIn('ORDER BY "zerver_usermessage"."message_id" ASC', sql)
         self.assertIn(f' WHERE ("zerver_usermessage"."user_profile_id" = {user_profile.id} ', sql)
-        self.assertIn(f' AND "zerver_message"."id" <= {first_unread_message_id - 1})', sql)
-        self.assertIn(f' AND "zerver_message"."id" >= {first_visible_message_id})', sql)
+        self.assertIn(
+            f' AND "zerver_usermessage"."message_id" <= {first_unread_message_id - 1})', sql
+        )
+        self.assertIn(f' AND "zerver_usermessage"."message_id" >= {first_visible_message_id})', sql)
 
     def test_use_first_unread_anchor_with_no_unread_messages(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -5189,7 +5195,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."id" = 0)\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_usermessage"."message_id" = 0)\
 """
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({"anchor": 0, "num_before": 0, "num_after": 0}, sql)
@@ -5201,7 +5207,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."id" = 0)\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_usermessage"."message_id" = 0)\
 """
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({"anchor": 0, "num_before": 1, "num_after": 0}, sql)
@@ -5213,7 +5219,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1))) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1))) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 2\
 """
         sql = sql_template.format(**query_ids)
@@ -5226,7 +5232,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1))) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1))) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 11\
 """
         sql = sql_template.format(**query_ids)
@@ -5239,7 +5245,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."id" <= 100) ORDER BY 1 DESC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_usermessage"."message_id" <= 100) ORDER BY "zerver_usermessage"."message_id" DESC\
  LIMIT 11\
 """
         sql = sql_template.format(**query_ids)
@@ -5252,14 +5258,14 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."id" <= 99) ORDER BY 1 DESC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_usermessage"."message_id" <= 99) ORDER BY "zerver_usermessage"."message_id" DESC\
  LIMIT 10) UNION ALL (SELECT "zerver_message"."id" AS "id", "zerver_usermessage"."flags" AS "user_flags" \
 FROM "zerver_message" LEFT OUTER JOIN "zerver_usermessage" ON ("zerver_message"."id" = "zerver_usermessage"."message_id") INNER JOIN "zerver_recipient" ON ("zerver_message"."recipient_id" = "zerver_recipient"."id") \
 WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_recipient"."type" = 2) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."id" >= 100) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_usermessage"."message_id" >= 100) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 11)\
 """
         sql = sql_template.format(**query_ids)
@@ -5280,7 +5286,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_and_othello_recipient} AND "zerver_message"."id" = 0)\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_and_othello_recipient} AND "zerver_usermessage"."message_id" = 0)\
 """
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query(
@@ -5300,7 +5306,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_and_othello_recipient} AND "zerver_message"."id" = 0)\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_and_othello_recipient} AND "zerver_usermessage"."message_id" = 0)\
 """
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query(
@@ -5320,7 +5326,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_and_othello_recipient}) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_and_othello_recipient}) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5341,7 +5347,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_usermessage"."flags" & 2 != 0) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_usermessage"."flags" & 2 != 0) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5356,7 +5362,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."sender_id" = {othello_id}) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."sender_id" = {othello_id}) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5401,7 +5407,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND NOT ("zerver_message"."recipient_id" IN ({public_channels_recipients}))) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND NOT ("zerver_message"."recipient_id" IN ({public_channels_recipients}))) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5422,7 +5428,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."is_channel_message" AND UPPER("zerver_message"."subject"::text) = UPPER('blah')) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."is_channel_message" AND UPPER("zerver_message"."subject"::text) = UPPER('blah')) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5455,7 +5461,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_recipient}) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {hamlet_recipient}) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5476,7 +5482,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {scotland_recipient} AND "zerver_usermessage"."flags" & 2 != 0) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND "zerver_message"."recipient_id" = {scotland_recipient} AND "zerver_usermessage"."flags" & 2 != 0) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5505,7 +5511,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND ("zerver_message"."search_tsvector" @@ plainto_tsquery('zulip.english_us_search', 'jumping')) = true) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND ("zerver_message"."search_tsvector" @@ plainto_tsquery('zulip.english_us_search', 'jumping')) = true) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)
@@ -5545,7 +5551,7 @@ WHERE ("zerver_usermessage"."user_profile_id" = {hamlet_id} AND (NOT ("zerver_re
 FROM "zerver_stream" U0 \
 WHERE (U0."recipient_id" = ("zerver_message"."recipient_id") AND (NOT U0."invite_only" OR U0."can_subscribe_group_id" IN {hamlet_groups} OR U0."can_add_subscribers_group_id" IN {hamlet_groups})) LIMIT 1) OR EXISTS(SELECT 1 AS "a" \
 FROM "zerver_subscription" U0 \
-WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND (UPPER("zerver_message"."content"::text) LIKE UPPER('%jumping%') OR ("zerver_message"."is_channel_message" AND UPPER("zerver_message"."subject"::text) LIKE UPPER('%jumping%'))) AND ("zerver_message"."search_tsvector" @@ plainto_tsquery('zulip.english_us_search', '"jumping" quickly')) = true) ORDER BY 1 ASC\
+WHERE (U0."active" AND U0."recipient_id" = ("zerver_message"."recipient_id") AND U0."user_profile_id" = {hamlet_id}) LIMIT 1)) AND (UPPER("zerver_message"."content"::text) LIKE UPPER('%jumping%') OR ("zerver_message"."is_channel_message" AND UPPER("zerver_message"."subject"::text) LIKE UPPER('%jumping%'))) AND ("zerver_message"."search_tsvector" @@ plainto_tsquery('zulip.english_us_search', '"jumping" quickly')) = true) ORDER BY "zerver_usermessage"."message_id" ASC\
  LIMIT 10\
 """
         sql = sql_template.format(**query_ids)


### PR DESCRIPTION
discussion: [#backend > Remove SQLAlchemy](https://chat.zulip.org/#narrow/channel/3-backend/topic/Remove.20SQLAlchemy/with/2448492)

The Django ORM rewrite of message fetch (commit c286f39d46) changed limit_query_to_range to bound and order the before/after pagination queries on zerver_message.id. But the scan that actually walks and orders those rows is the zerver_usermessage (user_profile_id, message_id) index, and PostgreSQL does not propagate an inequality on zerver_message.id across the outer join onto that index. So the driving scan lost its bound: fetching num_before/num_after messages around an anchor far from the user's newest messages walked the user's entire UserMessage history to fill a ~30-row limit.

The most common trigger is opening the combined feed at the "first_unread" anchor for a user with a long, old unread backlog. On chat.zulip.org this took ~98s (client timeout) for a user with ~880k messages whose first unread was years old; the before-query walked all ~880k rows newest-first, discarding each as newer than the anchor, before reaching the 30 older ones it needed.

Restore the pre-rewrite behavior by bounding and ordering the range on zerver_usermessage.message_id, which equals zerver_message.id but lives on the driving index. A non-selected alias carries it and reuses the existing join, so no second join is added and the index seeks straight to the anchor, reading ~30 rows instead of the whole history.

Recent anchors were unaffected, since the unbounded scan already started at the correct (newest) end and stopped after 30 rows; that is why this escaped tests and everyday use. The golden-SQL tests are updated to assert the bound and ordering are on the usermessage column.

---


With help of Claude I did EXPLAIN ANALYZE on GET /messages queries for @neiljp to arrive at this bug fix.