### PR TITLE
desktop_notifications: Send test notification upon enabling permission.

### DIFF
--- a/web/src/desktop_notifications.ts
+++ b/web/src/desktop_notifications.ts
@@ -74,8 +74,19 @@ export function get_notifications(): NoticeMemory {
     return notice_memory;
 }
 
+let ignore_next_focus_close = false;
+
+export function suppress_next_focus_close(): void {
+    ignore_next_focus_close = true;
+}
+
 export function initialize(): void {
     $(window).on("focus", () => {
+        if (ignore_next_focus_close) {
+            ignore_next_focus_close = false;
+            return;
+        }
+
         for (const notice_mem_entry of notice_memory.values()) {
             notice_mem_entry.obj.close();
         }

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -582,6 +582,20 @@ export function initialize(): void {
                 if (permission === "granted" || permission === "denied") {
                     close_navbar_banner_and_resize($banner);
                 }
+                if (
+                    permission === "granted" &&
+                    desktop_notifications.NotificationAPI !== undefined
+                ) {
+                    new desktop_notifications.NotificationAPI(
+                        $t({defaultMessage: "Notification Bot"}),
+                        {
+                            icon: people.gravatar_url_for_email("notification-bot@zulip.com"),
+                            body: $t({defaultMessage: "Zulip desktop notifications are enabled"}),
+                            tag: Math.random().toString(),
+                        },
+                    );
+                    void ui_util.play_audio(util.the($("#user-notification-sound-audio")));
+                }
             })();
         },
     );

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -577,6 +577,7 @@ export function initialize(): void {
         function (this: HTMLElement): void {
             void (async () => {
                 const $banner = $(this).closest(".banner");
+                desktop_notifications.suppress_next_focus_close();
                 const permission =
                     await desktop_notifications.request_desktop_notifications_permission();
                 if (permission === "granted" || permission === "denied") {

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -11,6 +11,7 @@ import * as banners from "./banners.ts";
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
+import * as desktop_notifications from "./desktop_notifications.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as message_notifications from "./message_notifications.ts";
@@ -402,6 +403,7 @@ export function set_up(settings_panel: SettingsPanel): void {
         // do not need to do a mobile check here--as that banner is
         // not shown in a mobile context anyway.
         void (async () => {
+            desktop_notifications.suppress_next_focus_close();
             const permission = await Notification.requestPermission();
             if (permission === "granted") {
                 update_desktop_notification_banner();

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -405,6 +405,9 @@ export function set_up(settings_panel: SettingsPanel): void {
             const permission = await Notification.requestPermission();
             if (permission === "granted") {
                 update_desktop_notification_banner();
+                message_notifications.send_test_notification(
+                    $t({defaultMessage: "Zulip desktop notifications enabled"}),
+                );
             } else if (permission === "denied") {
                 window.open(
                     "/help/desktop-notifications#check-platform-settings",


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR adds code to send a notification from Notification Bot to a user when desktop notifications are granted with the message "Zulip desktop notifications are enabled." Before, there would be no indication that anything had changed when the user would grant notification permissions. With our changes, the user can now be alerted and confirm their permission with this notification.

To implement this change, we did the following:
- Identify the two entry points for the notification permissions banner, one in the navbar and another in settings
- For the banner in the desktop settings file, we followed the structure of the "Send a test notification" button and added a function that will send a test notification with the message after permissions are granted
- For the banner in the navbar file, after trying the above solution and running into a dependency error, we instead added a new Notification object after permissions are granted that follows a simpler flow of how notifications are implemented in `message_notifications.ts`

We also ran into some issues when testing on Windows of the notification not appearing due to conflicting pop-ups sent by the Windows system itself. This was resolved by adding a function targeted to Windows OS that ignores additional system pop-ups. 


Fixes #14433 

**How changes were tested:**

For testing, we first checked that our computer's notification settings allows notification messages. Then, we did the following:
- Checked that clicking allow notifications on the banner (both in home and settings) triggered the notification
- Repeatedly clearing our notification settings and re-triggering the banner to make sure it was consistent
- Tested this on both MacOS and Windows, as well as different browsers such as Firefox, Safari, and Microsoft Edge to ensure consistency

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Before - notification entry points:
<img width="1713" height="281" alt="Screenshot 2026-07-15 at 10 50 22 AM" src="https://github.com/user-attachments/assets/54c18006-00b3-4ddb-9b24-b8d778c1a013" />
<img width="867" height="149" alt="Screenshot 2026-07-15 at 10 50 38 AM" src="https://github.com/user-attachments/assets/9bcfccc7-57de-4d39-8c36-5186f093f2ef" />

After - notification when allow is clicked:
<img width="378" height="104" alt="Screenshot 2026-07-15 at 10 51 19 AM" src="https://github.com/user-attachments/assets/ba67117a-9df7-478f-9479-66f753c572f1" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>

