### PR TITLE
compose: Show banner close focus outline only for keyboard focus.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1047,6 +1047,19 @@
     }
 }
 
+/* Show the focus outline on banner close buttons only for
+   keyboard navigation, not for mouse clicks.
+   TODO: These banners still use the legacy .main-view-banner
+   markup. We should migrate the compose and edit-form banners
+   to the modern banner and button components, which handle
+   keyboard vs. mouse focus correctly; this rule is an interim fix. */
+#compose_banners,
+.edit_form_banners {
+    .main-view-banner-close-button:focus:not(:focus-visible) {
+        outline: 0;
+    }
+}
+
 .upload_banner {
     overflow: hidden;
 


### PR DESCRIPTION
Clicking a compose banner's close (×) button with the mouse click a square focus outline around it. The close button is an
`<a role="button" tabindex="0">` element, so a mouse click gives it real focus, and the global focus rules in `web/styles/zulip.css` use plain `:focus`, which matches mouse-initiated focus.

This PR suppresses the outline with `:focus:not(:focus-visible)`, scoped to compose box banners and the message edit form banners that render the same templates. Keyboard (Tab) focus still shows the outline via `:focus-visible`, so keyboard accessibility is unchanged.

Fixes: [#issues > keyboard focus shown on mouse click in compose box banners.](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20focus.20shown.20on.20mouse.20click.20in.20compose.20box.20banners.2E/with/2494927)

<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/d7011097-d7fd-45bc-9cc0-de6aa99597ce" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/9994f40f-7efe-4368-8d73-d3c468fbb1e8" width="400" controls></video> |

| Before Video | After Video |
|--------------|-------------|
| <video src="https://github.com/user-attachments/assets/e80b1a3c-d7bf-4c00-8ac2-ef1159e00e33" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/23d33d50-abdd-4e44-b2ad-271655dce739" width="400" controls></video> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
