### PR TITLE
Fix realmemoji migration 0770

### DIFF
--- a/zerver/migrations/0770_recreate_missing_realmemoji.py
+++ b/zerver/migrations/0770_recreate_missing_realmemoji.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import orjson
 from django.db import connection, migrations, transaction
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
@@ -50,7 +51,7 @@ def recreate_missing_realmemoji(apps: StateApps, schema_editor: BaseDatabaseSche
                     WHERE zerver_realmauditlog.realm_id = %s
                     AND zerver_realmauditlog.event_type = %s
                 )
-                SELECT * FROM distinct_emoji
+                SELECT distinct_emoji.e FROM distinct_emoji
                 LEFT JOIN zerver_realmemoji
                     ON zerver_realmemoji.id = (e->>'id')::integer
                     OR (zerver_realmemoji.name = e->>'name'
@@ -59,7 +60,8 @@ def recreate_missing_realmemoji(apps: StateApps, schema_editor: BaseDatabaseSche
             """
             with connection.cursor() as cursor:
                 cursor.execute(sql, [realm.id, REALM_EMOJI_ADDED, realm.id])
-                for (orphaned_emoji,) in cursor.fetchall():
+                for (raw_emoji,) in cursor.fetchall():
+                    orphaned_emoji = orjson.loads(raw_emoji)
                     print(
                         f"Creating missing emoji {orphaned_emoji['id']} = {realm.string_id} / {orphaned_emoji['name']}"
                     )


### PR DESCRIPTION
This PR is supposed to fix  two bugs present during migration 0770, if an orphaned emoji is detected.

Fixes: There are two bugs currently present in the migration
1. The Query return not only the expected JSON object of the emoji, but also all other rows of zerver_realmemoji, which would all be Null values anyway. Since only the JSON object is needed, the fix is only selecting the object instead of *.
2. Afterwards the for loop tries to consume the object but fails, because the JSON object is not yet parsed correctly. By loading the object, the present code is able to correctly use the object to recreate the emoji.

**How changes were tested:**

I noticed the issue on a Zulip installation I administrate.
For testing I installed a fresh installation of Zulip version 11.6 on Debian Trixie, created a new custom emoji, deleted the DB entry and then tried the update to 12.1. Without my PR, the migration fails. Afterwards, I edited the current release to include my changes and ran the update again, which passed without issue, and the emoji was recreated. 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [?] Explains differences from previous plans (e.g., issue description). (There was no issue yet, at least i didn´t find any)
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [?] Automated tests verify logic where appropriate. (I did not write any additional tests, since it was not supposed to be a new feature but merely a bug fix)

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [NONE] Visual appearance of the changes.
- [NONE] Responsiveness and internationalization.
- [NONE] Strings and tooltips.
- [NONE] End-to-end functionality of buttons, interactions and flows.
- [?] Corner cases, error conditions, and easily imagined bugs. (I only tested according to the bug i encountered and recreated it in a controlled environment, afterwards fixing it, according to the original code's intent)
</details>

Edit:
I just created a discussion in the backend channel: [#backend > migration 0770 bug when orphaned emoji present](https://chat.zulip.org/#narrow/channel/3-backend/topic/migration.200770.20bug.20when.20orphaned.20emoji.20present/with/2496998)

Please bear with me, this is my first PR, if there is anything I missed, or anything I can improve, I would be glad for feedback.