### PR TITLE
search: Restore focused outer spacing for wrapped pills

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -271,6 +271,11 @@
             gap: 0;
             /* Override padding. */
             padding: 0;
+
+            /* Restore top/bottom outer spacing when pills wrap in focused state. */
+            &.focused {
+                padding: var(--outer-spacing-input-pill-container) 0;
+            }
         }
 
         .pill {


### PR DESCRIPTION
Fixes #35426.

### Summary
When the search box is focused and pills wrap to multiple lines, the search-specific `pill-container` overrides remove all container padding, so wrapped pills lose top/bottom outer spacing.

This change restores vertical outer spacing in focused state only by applying:
- `padding: var(--outer-spacing-input-pill-container) 0`

That keeps wrapped pills visually consistent while avoiding regressions to collapsed/unfocused search states.

### Testing
- `npx --no-install stylelint web/styles/search.css`