### PR TITLE
upload: Don't hold a read open on S3 objects during self-copy.

### DIFF
--- a/zerver/tests/test_tusd.py
+++ b/zerver/tests/test_tusd.py
@@ -730,6 +730,68 @@ class TusdPreFinishTest(ZulipTestCase):
         self.assertEqual(attachment.content_type, "text/plain")
         self.assertEqual(bucket.Object(path_id).get()["ContentType"], "text/plain")
 
+    @use_s3_backend
+    def test_s3_upload_reopens_source_after_self_copy(self) -> None:
+        # Regression test for the pre-finish hook holding its
+        # charset-sniffing read of the object open while issuing a
+        # self-CopyObject to update the object's Content-Type.  Some
+        # S3-compatible backends (e.g. MinIO) hold a read lock for
+        # the duration of an open GetObject, which made that copy
+        # block until the reader was torn down.  We now close the
+        # sniffing read before copying, and open a fresh one
+        # afterwards for create_attachment/maybe_thumbnail.
+        assert settings.LOCAL_FILES_DIR is None
+        self.login("hamlet")
+        hamlet = self.example_user("hamlet")
+        bucket = create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)[0]
+        upload_backend = S3UploadBackend()
+
+        filename = "zulip.txt"
+        path_id = upload_backend.generate_message_upload_path(
+            str(hamlet.realm.id), sanitize_name(filename, strict=True)
+        )
+        info = TusUpload(
+            id=path_id,
+            size=len("zulip!"),
+            offset=0,
+            size_is_deferred=False,
+            meta_data={
+                "filename": filename,
+                "filetype": "text/plain",
+                "name": filename,
+                "type": "text/plain",
+            },
+            is_final=False,
+            is_partial=False,
+            partial_uploads=None,
+            storage=None,
+        )
+        bucket.Object(path_id).put(
+            Body=b"zulip!",
+            ContentType="application/octet-stream",
+            Metadata={k: v.encode("ascii", "replace").decode() for k, v in info.meta_data.items()},
+        )
+        bucket.Object(f"{path_id}.info").put(
+            Body=info.model_dump_json().encode(),
+        )
+
+        with mock.patch("zerver.views.tusd.attachment_source") as mock_attachment_source:
+            mock_attachment_source.return_value.size = len("zulip!")
+            reader = mock_attachment_source.return_value.reader.return_value
+            reader.read.return_value = b""
+            result = self.client_post(
+                "/api/internal/tusd",
+                self.request(info).model_dump(),
+                content_type="application/json",
+            )
+        self.assertEqual(result.status_code, 200)
+
+        # Opened once to sniff the charset, and a second, fresh time
+        # to hand to create_attachment/maybe_thumbnail -- never
+        # holding a single read open across the self-copy.
+        self.assertEqual(mock_attachment_source.call_count, 2)
+        self.assertTrue(reader.close.called)
+
 
 class TusdPreTerminateTest(ZulipTestCase):
     def request(self, info: TusUpload) -> TusHook:

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -156,8 +156,18 @@ def handle_upload_pre_finish_hook(
         content_type = guess_type(filename)[0]
         if content_type is None:
             content_type = "application/octet-stream"
-    file_data = attachment_source(path_id)
-    content_type = maybe_add_charset(content_type, file_data)
+
+    # maybe_add_charset only inspects the file contents for
+    # text/plain, the one text type we serve inline; for anything
+    # else, opening the object is pointless.  We close this source
+    # immediately after, rather than holding it open through the
+    # self-copy below, because with the S3 backend a read held open
+    # on an object blocks a concurrent copy of that same object until
+    # the reader is torn down.
+    if bare_content_type(content_type) == "text/plain":
+        file_data = attachment_source(path_id)
+        content_type = maybe_add_charset(content_type, file_data)
+        file_data.reader().close()
 
     if settings.LOCAL_UPLOADS_DIR is None:
         # We "copy" the file to itself to update the Content-Type,
@@ -199,6 +209,10 @@ def handle_upload_pre_finish_hook(
                 MetadataDirective="COPY",
                 StorageClass=settings.S3_UPLOADS_STORAGE_CLASS,
             )
+
+    # Open a fresh source for create_attachment/maybe_thumbnail to
+    # read from, now that the self-copy above (if any) has finished.
+    file_data = attachment_source(path_id)
 
     with transaction.atomic(durable=True):
         create_attachment(


### PR DESCRIPTION
Fixes: #39752

Zulip's S3 upload backend opens a `GetObject` on an object while the
tusd pre-finish hook simultaneously issues a self-`CopyObject` on
that same object, to update its Content-Type and Content-Disposition
after upload. AWS S3 doesn't mind this, but S3-compatible backends
that use per-object locking for consistency (MinIO, as reported in
the issue) hold a read lock for the duration of the open
`GetObject`. The concurrent `CopyObject` then blocks until MinIO's
write-deadline timeout tears down the idle reader, which is a
constant ~30 second stall on every upload above roughly 100 KB.

The object was only ever opened to sniff its charset, and that
sniffing only applies to `text/plain` content. So the fix opens the
object at all only when that's actually needed, explicitly closes
that read before the self-copy runs, and opens a fresh, unrelated
read afterwards for attachment creation/thumbnailing. This keeps no
read open across the self-copy, regardless of backend.

**How changes were tested:**

- Added a regression test that asserts the pre-finish hook opens the
  object twice (once to sniff, once fresh afterwards) and explicitly
  closes the sniffing read, rather than holding a single read open
  across the self-copy.
- Traced the change against the existing tests covering the
  pre-finish hook, for both the local backend and the S3 backend, to
  confirm the reordering doesn't change any externally observable
  behavior (content type, size, storage class, or file contents).
- Full CI (backend tests on Debian 12/13 and Ubuntu 22.04/24.04/26.04,
  mypy, CodeQL) is passing on this PR.

**Screenshots and screen captures:**

N/A -- this is a backend-only change with no UI surface.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
