### PR TITLE
search: Add breathing room to wrapped search pills.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -71,7 +71,11 @@
     .search-input-and-pills {
         grid-area: search-pills;
         display: flex;
-        padding: 0;
+        /* Match the pills' single-line centering slack so wrapped rows
+           get the same breathing room without changing the single-line
+           box height. */
+        padding: calc((var(--search-box-height) - var(--height-input-pill)) / 2)
+            0;
         flex-wrap: wrap;
         gap: 0.3571em; /* 5px at 14px em, matches pill spacing in typeahead dropdown */
         align-self: center;


### PR DESCRIPTION
When search filter pills wrap onto a second line, they sit flush against the top and bottom edges of the search box, which looks cramped. A single line of pills already gets some vertical breathing room from being centered in the fixed-height box; this change gives the wrapped rows the same spacing.

Fixes #35426.
CZO: [#issues > 📂 search pill/text spacing](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20search.20pill.2Ftext.20spacing/with/2400125)
<hr>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Dark theme Before | Dark Theme After |
|--------|-------|
|<img width="1035" height="94" alt="image" src="https://github.com/user-attachments/assets/0902ad0e-3426-4f7c-93d4-4019b0b14a35" />|<img width="1035" height="94" alt="image" src="https://github.com/user-attachments/assets/2fbf0076-1a6d-4245-8086-0a2c125a74b7" />|

| Light theme Before | Light Theme After |
|--------|-------|
|<img width="1035" height="94" alt="image" src="https://github.com/user-attachments/assets/755a0ae6-037b-46bb-b532-85a38fa4b012" />|<img width="1035" height="94" alt="image" src="https://github.com/user-attachments/assets/5ba7c7e2-5ab4-4374-9597-9d3e2e04e672" />|

| Dark theme Before | Dark Theme After |
|--------|-------|
|<img width="1033" height="87" alt="image" src="https://github.com/user-attachments/assets/313f97bb-007b-4780-824a-4457e235b96c" />|<img width="1033" height="92" alt="image" src="https://github.com/user-attachments/assets/49ca41fe-4172-4681-80b0-47e2a92a85ec" />|

| Light theme Before | Light Theme After |
|--------|-------|
|<img width="1033" height="87" alt="image" src="https://github.com/user-attachments/assets/ceb1fc87-1364-4188-8cd4-328dfd0957d1" />|<img width="1033" height="92" alt="image" src="https://github.com/user-attachments/assets/1ec420e2-7a43-44c2-ba92-b914dc8d7ff9" />|

| 3 row search box | 3 row search box |
|--------|-------|
|<img width="1033" height="138" alt="image" src="https://github.com/user-attachments/assets/01c54683-8bad-4d62-8a72-2e92977969e9" />|<img width="1033" height="138" alt="image" src="https://github.com/user-attachments/assets/58fd9550-d1dc-4c72-90d3-fbe638224dcd" />|

| Before | After |
|--------|-------|
|<img width="1392" height="526" alt="image" src="https://github.com/user-attachments/assets/cf2ceed1-1c04-4e94-b2cf-c42153fdc7c7" />|<img width="1392" height="526" alt="image" src="https://github.com/user-attachments/assets/c3c134cc-013f-4c26-bdb3-c455461e215f" />|

| Before | After |
|--------|-------|
|<img width="1392" height="526" alt="image" src="https://github.com/user-attachments/assets/16e5640b-5a82-449a-b102-cebdc12c698f" />|<img width="1392" height="526" alt="image" src="https://github.com/user-attachments/assets/9750aba3-cbdd-495f-aa23-58af07fa3a8f" />|

| Before | After |
|--------|-------|
|<img width="1920" height="614" alt="image" src="https://github.com/user-attachments/assets/7c14f3be-b8d8-4734-bcd4-882d34fdcf78" />|<img width="1920" height="614" alt="image" src="https://github.com/user-attachments/assets/02fded26-f0ec-4d7c-9307-7183c411bf0c" />|

| Before | After |
|--------|-------|
|<img width="1920" height="130" alt="image" src="https://github.com/user-attachments/assets/62f0009b-a8ef-4951-9dac-3d2908ccd958" />|<img width="1920" height="130" alt="image" src="https://github.com/user-attachments/assets/3988c45c-57c0-44fe-a1be-4457e02367e1" />|




Proof that no change in the row search box.

| Before | After |
|--------|-------|
|<img width="1033" height="46" alt="image" src="https://github.com/user-attachments/assets/ec5d6be9-38b9-4e60-821e-70396060b88d" />|<img width="1033" height="46" alt="image" src="https://github.com/user-attachments/assets/af28518e-b3ee-4c19-a76c-61c03bab8f4b" />|





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
