### PR TITLE
[ai] email_mirror: Ignore deactivated users in group DM email replies.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -509,7 +509,25 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         recipient_str = stream.name
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         display_recipient = get_display_recipient(recipient)
-        emails = [user_dict["email"] for user_dict in display_recipient]
+        # Drop members who have been deactivated, matching the check in
+        # validate_recipient_user_profiles. The web app blocks composing
+        # to such a group entirely, but the email gateway can receive
+        # replies to notification emails that predate the deactivation.
+        user_ids = [user_dict["id"] for user_dict in display_recipient]
+        emails = list(
+            UserProfile.objects.filter(id__in=user_ids)
+            .exclude(is_active=False, is_mirror_dummy=False)
+            .values_list("email", flat=True)
+        )
+        if len(emails) <= 1:
+            # Everyone but the sender (whom we verified active above)
+            # has been deactivated; there is nobody left to receive
+            # the reply.
+            logger.info(
+                "Dropping message notification email reply from user %s to a group direct message with no active recipients",
+                user_profile.id,
+            )
+            return
         recipient_str = ", ".join(emails)
         internal_send_group_direct_message(user_profile.realm, user_profile, body, emails=emails)
     else:

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -9,6 +9,7 @@ from email.utils import parseaddr
 from re import Match
 
 from django.conf import settings
+from django.db.models import Q
 from django.utils.translation import gettext as _
 from typing_extensions import override
 
@@ -509,7 +510,25 @@ def process_missed_message(to: str, message: EmailMessage) -> None:
         recipient_str = stream.name
     elif recipient.type == Recipient.DIRECT_MESSAGE_GROUP:
         display_recipient = get_display_recipient(recipient)
-        emails = [user_dict["email"] for user_dict in display_recipient]
+        # Drop members who have been deactivated, matching the check in
+        # validate_recipient_user_profiles. The web app blocks composing
+        # to such a group entirely, but the email gateway can receive
+        # replies to notification emails that predate the deactivation.
+        user_ids = [user_dict["id"] for user_dict in display_recipient]
+        emails = list(
+            UserProfile.objects.filter(id__in=user_ids)
+            .filter(Q(is_active=True) | Q(is_mirror_dummy=True))
+            .values_list("email", flat=True)
+        )
+        if len(emails) <= 1:
+            # Everyone but the sender (whom we verified active above)
+            # has been deactivated; there is nobody left to receive
+            # the reply.
+            logger.info(
+                "Dropping message notification email reply from user %s to a group direct message with no active recipients",
+                user_profile.id,
+            )
+            return
         recipient_str = ", ".join(emails)
         internal_send_group_direct_message(user_profile.realm, user_profile, body, emails=emails)
     else:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -22,7 +22,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.realm_settings import do_deactivate_realm
 from zerver.actions.streams import do_change_stream_group_based_setting, do_deactivate_stream
-from zerver.actions.users import do_deactivate_user
+from zerver.actions.users import change_user_is_active, do_deactivate_user
 from zerver.lib.email_mirror import (
     RateLimitedRealmMirror,
     create_missed_message_address,
@@ -1332,7 +1332,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             othello, mm_address, "TestMissedMessageEmailMessages body"
         )
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(23):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message
@@ -1360,7 +1360,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             cordelia, mm_address, "TestMissedGroupDirectMessageEmailMessages body"
         )
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(23):
             process_message(incoming_valid_message)
 
         # Confirm Iago and Othello received the message.
@@ -1369,6 +1369,99 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
             self.assertEqual(message.sender, cordelia)
             self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
+    def test_receive_missed_group_direct_message_email_with_deactivated_user(self) -> None:
+        # A reply to a message notification email for a group direct
+        # message is delivered to the remaining active members when a
+        # member of the group has since been deactivated, and the
+        # conversation remains a group direct message.
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        mm_address = self.send_dm_and_get_reply_address(
+            othello, [cordelia, iago, hamlet], reply_sender=cordelia
+        )
+
+        iago_message_before = most_recent_message(iago)
+        do_deactivate_user(iago, acting_user=None)
+
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "Reply with deactivated group member body"
+        )
+        process_message(incoming_valid_message)
+
+        # The remaining active members received the message, in the
+        # direct message group of just the active members.
+        direct_message_group = get_or_create_direct_message_group(
+            id_list=[othello.id, cordelia.id, hamlet.id]
+        )
+        for user_profile in [othello, hamlet]:
+            message = most_recent_message(user_profile)
+            self.assertEqual(message.content, "Reply with deactivated group member body")
+            self.assertEqual(message.sender, cordelia)
+            self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+            self.assertEqual(message.recipient.type_id, direct_message_group.id)
+
+        # The deactivated user did not receive the message.
+        self.assertEqual(most_recent_message(iago).id, iago_message_before.id)
+
+    def test_receive_missed_group_direct_message_email_keeps_mirror_dummy_user(self) -> None:
+        # A mirror-dummy user is inactive but a valid recipient; unlike a
+        # deactivated user, it must be kept in the group when delivering
+        # the reply.
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        mm_address = self.send_dm_and_get_reply_address(
+            othello, [cordelia, iago], reply_sender=cordelia
+        )
+
+        iago.is_mirror_dummy = True
+        iago.save(update_fields=["is_mirror_dummy"])
+        change_user_is_active(iago, False)
+
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "Reply with mirror-dummy group member body"
+        )
+        process_message(incoming_valid_message)
+
+        # The reply reaches the full three-person group (the mirror-dummy
+        # user was kept), not a reduced group.
+        direct_message_group = get_or_create_direct_message_group(
+            id_list=[othello.id, cordelia.id, iago.id]
+        )
+        message = most_recent_message(othello)
+        self.assertEqual(message.content, "Reply with mirror-dummy group member body")
+        self.assertEqual(message.sender, cordelia)
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(message.recipient.type_id, direct_message_group.id)
+
+    def test_receive_missed_group_direct_message_email_all_recipients_deactivated(self) -> None:
+        # If every member other than the sender has been deactivated,
+        # the reply is dropped with a log message rather than an
+        # exception.
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        mm_address = self.send_dm_and_get_reply_address(
+            othello, [cordelia, iago], reply_sender=cordelia
+        )
+
+        do_deactivate_user(othello, acting_user=None)
+        do_deactivate_user(iago, acting_user=None)
+
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "Reply with no active recipients body"
+        )
+        initial_last_message = self.get_last_message()
+        with self.assertLogs("zerver.lib.email_mirror", level="INFO") as info_logs:
+            process_message(incoming_valid_message)
+        self.assertIn(
+            f"INFO:zerver.lib.email_mirror:Dropping message notification email reply from user {cordelia.id} to a group direct message with no active recipients",
+            info_logs.output,
+        )
+        self.assertEqual(initial_last_message, self.get_last_message())
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1330,7 +1330,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             othello, mm_address, "TestMissedMessageEmailMessages body"
         )
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(23):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message
@@ -1358,7 +1358,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             cordelia, mm_address, "TestMissedGroupDirectMessageEmailMessages body"
         )
 
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(23):
             process_message(incoming_valid_message)
 
         # Confirm Iago and Othello received the message.
@@ -1367,6 +1367,95 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
             self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
             self.assertEqual(message.sender, cordelia)
             self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+
+    def test_receive_missed_group_direct_message_email_with_deactivated_user(self) -> None:
+        # A reply to a message notification email for a group direct
+        # message is delivered to the remaining active members when a
+        # member of the group has since been deactivated, and the
+        # conversation remains a group direct message.
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        hamlet = self.example_user("hamlet")
+        mm_address = self.send_dm_and_get_reply_address(
+            othello, [cordelia, iago, hamlet], reply_sender=cordelia
+        )
+
+        iago_message_before = most_recent_message(iago)
+        do_deactivate_user(iago, acting_user=None)
+
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "Reply with deactivated group member body"
+        )
+        process_message(incoming_valid_message)
+
+        # The remaining active members received the message, in the
+        # direct message group of just the active members.
+        direct_message_group = get_or_create_direct_message_group(
+            id_list=[othello.id, cordelia.id, hamlet.id]
+        )
+        for user_profile in [othello, hamlet]:
+            message = most_recent_message(user_profile)
+            self.assertEqual(message.content, "Reply with deactivated group member body")
+            self.assertEqual(message.sender, cordelia)
+            self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+            self.assertEqual(message.recipient.type_id, direct_message_group.id)
+
+        # The deactivated user did not receive the message.
+        self.assertEqual(most_recent_message(iago).id, iago_message_before.id)
+
+    def test_receive_missed_group_direct_message_email_keeps_mirror_dummy_user(self) -> None:
+        # A mirror-dummy user is inactive but a valid recipient; unlike a
+        # deactivated user, it must be kept in the group when delivering
+        # the reply.
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        iago = self.example_user("iago")
+        mm_address = self.send_dm_and_get_reply_address(
+            othello, [cordelia, iago], reply_sender=cordelia
+        )
+
+        iago.is_mirror_dummy = True
+        iago.save(update_fields=["is_mirror_dummy"])
+        change_user_is_active(iago, False)
+
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "Reply with mirror-dummy group member body"
+        )
+        process_message(incoming_valid_message)
+
+        # The reply reaches the full three-person group (the mirror-dummy
+        # user was kept), not a reduced group.
+        direct_message_group = get_or_create_direct_message_group(
+            id_list=[othello.id, cordelia.id, iago.id]
+        )
+        message = most_recent_message(othello)
+        self.assertEqual(message.content, "Reply with mirror-dummy group member body")
+        self.assertEqual(message.sender, cordelia)
+        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        self.assertEqual(message.recipient.type_id, direct_message_group.id)
+
+    def test_receive_missed_group_direct_message_email_all_recipients_deactivated(self) -> None:
+        # If every member other than the sender has been deactivated,
+        # the reply is dropped with a log message rather than an
+        # exception.
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        mm_address = self.send_dm_and_get_reply_address(othello, [cordelia], reply_sender=cordelia)
+
+        do_deactivate_user(othello, acting_user=None)
+
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "Reply with no active recipients body"
+        )
+        initial_last_message = self.get_last_message()
+        with self.assertLogs("zerver.lib.email_mirror", level="INFO") as info_logs:
+            process_message(incoming_valid_message)
+        self.assertIn(
+            f"INFO:zerver.lib.email_mirror:Dropping message notification email reply from user {cordelia.id} to a group direct message with no active recipients",
+            info_logs.output,
+        )
+        self.assertEqual(initial_last_message, self.get_last_message())
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1282,37 +1282,55 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
 
 class TestMissedMessageEmailMessages(ZulipTestCase):
-    def test_receive_missed_personal_message_email_messages(self) -> None:
-        # Build dummy messages for message notification email reply.
-        # Have Hamlet send Othello a direct message. Othello will
-        # reply via email Hamlet will receive the message.
-        self.login("hamlet")
-        othello = self.example_user("othello")
+    def send_dm_and_get_reply_address(
+        self,
+        sender: UserProfile,
+        recipients: list[UserProfile],
+        *,
+        reply_sender: UserProfile,
+        content: str = "original direct message",
+    ) -> str:
+        # Send a direct message from `sender` to `recipients` (a group
+        # DM, or a 1:1 when there is a single recipient), and return a
+        # missed-message reply address for `reply_sender`.
+        self.login_user(sender)
         result = self.client_post(
             "/json/messages",
             {
                 "type": "private",
-                "content": "test_receive_missed_message_email_messages",
-                "to": orjson.dumps([othello.id]).decode(),
+                "content": content,
+                "to": orjson.dumps([user.id for user in recipients]).decode(),
             },
         )
         self.assert_json_success(result)
 
+        usermessage = most_recent_usermessage(reply_sender)
+        # We don't want to send actual emails, but we do need to
+        # create and store the token for looking up who did reply.
+        return create_missed_message_address(reply_sender, usermessage.message)
+
+    def build_missed_message_reply_email(
+        self, sender: UserProfile, mm_address: str, body: str
+    ) -> EmailMessage:
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content(body)
+        incoming_valid_message["Subject"] = "reply subject"
+        incoming_valid_message["From"] = sender.delivery_email
+        incoming_valid_message["To"] = mm_address
+        incoming_valid_message["Reply-to"] = sender.delivery_email
+        return incoming_valid_message
+
+    def test_receive_missed_personal_message_email_messages(self) -> None:
+        # Build dummy messages for message notification email reply.
+        # Have Hamlet send Othello a direct message. Othello will
+        # reply via email Hamlet will receive the message.
         othello = self.example_user("othello")
         hamlet = self.example_user("hamlet")
-        usermessage = most_recent_usermessage(othello)
+        mm_address = self.send_dm_and_get_reply_address(hamlet, [othello], reply_sender=othello)
 
-        # we don't want to send actual emails but we do need to create and store the
-        # token for looking up who did reply.
-        mm_address = create_missed_message_address(othello, usermessage.message)
-
-        incoming_valid_message = EmailMessage()
-        incoming_valid_message.set_content("TestMissedMessageEmailMessages body")
-
-        incoming_valid_message["Subject"] = "TestMissedMessageEmailMessages subject"
-        incoming_valid_message["From"] = self.example_email("othello")
-        incoming_valid_message["To"] = mm_address
-        incoming_valid_message["Reply-to"] = self.example_email("othello")
+        incoming_valid_message = self.build_missed_message_reply_email(
+            othello, mm_address, "TestMissedMessageEmailMessages body"
+        )
 
         with self.assert_database_query_count(22):
             process_message(incoming_valid_message)
@@ -1322,7 +1340,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         direct_group_message = get_or_create_direct_message_group(id_list=[hamlet.id, othello.id])
         self.assertEqual(message.content, "TestMissedMessageEmailMessages body")
-        self.assertEqual(message.sender, self.example_user("othello"))
+        self.assertEqual(message.sender, othello)
         self.assertEqual(message.recipient.type_id, direct_group_message.id)
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
@@ -1331,52 +1349,26 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         # Have Othello send Iago and Cordelia a group direct message.
         # Cordelia will reply via email Iago and Othello will receive
         # the message.
-        self.login("othello")
+        othello = self.example_user("othello")
         cordelia = self.example_user("cordelia")
         iago = self.example_user("iago")
-        result = self.client_post(
-            "/json/messages",
-            {
-                "type": "private",
-                "content": "test_receive_missed_message_email_messages",
-                "to": orjson.dumps([cordelia.id, iago.id]).decode(),
-            },
+        mm_address = self.send_dm_and_get_reply_address(
+            othello, [cordelia, iago], reply_sender=cordelia
         )
-        self.assert_json_success(result)
 
-        user_profile = self.example_user("cordelia")
-        usermessage = most_recent_usermessage(user_profile)
-
-        # we don't want to send actual emails but we do need to create and store the
-        # token for looking up who did reply.
-        mm_address = create_missed_message_address(user_profile, usermessage.message)
-
-        incoming_valid_message = EmailMessage()
-        incoming_valid_message.set_content("TestMissedGroupDirectMessageEmailMessages body")
-
-        incoming_valid_message["Subject"] = "TestMissedGroupDirectMessageEmailMessages subject"
-        incoming_valid_message["From"] = self.example_email("cordelia")
-        incoming_valid_message["To"] = mm_address
-        incoming_valid_message["Reply-to"] = self.example_email("cordelia")
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "TestMissedGroupDirectMessageEmailMessages body"
+        )
 
         with self.assert_database_query_count(22):
             process_message(incoming_valid_message)
 
-        # Confirm Iago received the message.
-        user_profile = self.example_user("iago")
-        message = most_recent_message(user_profile)
-
-        self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
-        self.assertEqual(message.sender, self.example_user("cordelia"))
-        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
-
-        # Confirm Othello received the message.
-        user_profile = self.example_user("othello")
-        message = most_recent_message(user_profile)
-
-        self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
-        self.assertEqual(message.sender, self.example_user("cordelia"))
-        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        # Confirm Iago and Othello received the message.
+        for user_profile in [iago, othello]:
+            message = most_recent_message(user_profile)
+            self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
+            self.assertEqual(message.sender, cordelia)
+            self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -22,7 +22,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.realm_settings import do_deactivate_realm
 from zerver.actions.streams import do_change_stream_group_based_setting, do_deactivate_stream
-from zerver.actions.users import do_deactivate_user
+from zerver.actions.users import change_user_is_active, do_deactivate_user
 from zerver.lib.email_mirror import (
     RateLimitedRealmMirror,
     create_missed_message_address,
@@ -1280,37 +1280,55 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
 
 class TestMissedMessageEmailMessages(ZulipTestCase):
-    def test_receive_missed_personal_message_email_messages(self) -> None:
-        # Build dummy messages for message notification email reply.
-        # Have Hamlet send Othello a direct message. Othello will
-        # reply via email Hamlet will receive the message.
-        self.login("hamlet")
-        othello = self.example_user("othello")
+    def send_dm_and_get_reply_address(
+        self,
+        sender: UserProfile,
+        recipients: list[UserProfile],
+        *,
+        reply_sender: UserProfile,
+        content: str = "original direct message",
+    ) -> str:
+        # Send a direct message from `sender` to `recipients` (a group
+        # DM, or a 1:1 when there is a single recipient), and return a
+        # missed-message reply address for `reply_sender`.
+        self.login_user(sender)
         result = self.client_post(
             "/json/messages",
             {
                 "type": "private",
-                "content": "test_receive_missed_message_email_messages",
-                "to": orjson.dumps([othello.id]).decode(),
+                "content": content,
+                "to": orjson.dumps([user.id for user in recipients]).decode(),
             },
         )
         self.assert_json_success(result)
 
+        usermessage = most_recent_usermessage(reply_sender)
+        # We don't want to send actual emails, but we do need to
+        # create and store the token for looking up who did reply.
+        return create_missed_message_address(reply_sender, usermessage.message)
+
+    def build_missed_message_reply_email(
+        self, sender: UserProfile, mm_address: str, body: str
+    ) -> EmailMessage:
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content(body)
+        incoming_valid_message["Subject"] = "reply subject"
+        incoming_valid_message["From"] = sender.delivery_email
+        incoming_valid_message["To"] = mm_address
+        incoming_valid_message["Reply-to"] = sender.delivery_email
+        return incoming_valid_message
+
+    def test_receive_missed_personal_message_email_messages(self) -> None:
+        # Build dummy messages for message notification email reply.
+        # Have Hamlet send Othello a direct message. Othello will
+        # reply via email Hamlet will receive the message.
         othello = self.example_user("othello")
         hamlet = self.example_user("hamlet")
-        usermessage = most_recent_usermessage(othello)
+        mm_address = self.send_dm_and_get_reply_address(hamlet, [othello], reply_sender=othello)
 
-        # we don't want to send actual emails but we do need to create and store the
-        # token for looking up who did reply.
-        mm_address = create_missed_message_address(othello, usermessage.message)
-
-        incoming_valid_message = EmailMessage()
-        incoming_valid_message.set_content("TestMissedMessageEmailMessages body")
-
-        incoming_valid_message["Subject"] = "TestMissedMessageEmailMessages subject"
-        incoming_valid_message["From"] = self.example_email("othello")
-        incoming_valid_message["To"] = mm_address
-        incoming_valid_message["Reply-to"] = self.example_email("othello")
+        incoming_valid_message = self.build_missed_message_reply_email(
+            othello, mm_address, "TestMissedMessageEmailMessages body"
+        )
 
         with self.assert_database_query_count(22):
             process_message(incoming_valid_message)
@@ -1320,7 +1338,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         direct_group_message = get_or_create_direct_message_group(id_list=[hamlet.id, othello.id])
         self.assertEqual(message.content, "TestMissedMessageEmailMessages body")
-        self.assertEqual(message.sender, self.example_user("othello"))
+        self.assertEqual(message.sender, othello)
         self.assertEqual(message.recipient.type_id, direct_group_message.id)
         self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
@@ -1329,52 +1347,26 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         # Have Othello send Iago and Cordelia a group direct message.
         # Cordelia will reply via email Iago and Othello will receive
         # the message.
-        self.login("othello")
+        othello = self.example_user("othello")
         cordelia = self.example_user("cordelia")
         iago = self.example_user("iago")
-        result = self.client_post(
-            "/json/messages",
-            {
-                "type": "private",
-                "content": "test_receive_missed_message_email_messages",
-                "to": orjson.dumps([cordelia.id, iago.id]).decode(),
-            },
+        mm_address = self.send_dm_and_get_reply_address(
+            othello, [cordelia, iago], reply_sender=cordelia
         )
-        self.assert_json_success(result)
 
-        user_profile = self.example_user("cordelia")
-        usermessage = most_recent_usermessage(user_profile)
-
-        # we don't want to send actual emails but we do need to create and store the
-        # token for looking up who did reply.
-        mm_address = create_missed_message_address(user_profile, usermessage.message)
-
-        incoming_valid_message = EmailMessage()
-        incoming_valid_message.set_content("TestMissedGroupDirectMessageEmailMessages body")
-
-        incoming_valid_message["Subject"] = "TestMissedGroupDirectMessageEmailMessages subject"
-        incoming_valid_message["From"] = self.example_email("cordelia")
-        incoming_valid_message["To"] = mm_address
-        incoming_valid_message["Reply-to"] = self.example_email("cordelia")
+        incoming_valid_message = self.build_missed_message_reply_email(
+            cordelia, mm_address, "TestMissedGroupDirectMessageEmailMessages body"
+        )
 
         with self.assert_database_query_count(22):
             process_message(incoming_valid_message)
 
-        # Confirm Iago received the message.
-        user_profile = self.example_user("iago")
-        message = most_recent_message(user_profile)
-
-        self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
-        self.assertEqual(message.sender, self.example_user("cordelia"))
-        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
-
-        # Confirm Othello received the message.
-        user_profile = self.example_user("othello")
-        message = most_recent_message(user_profile)
-
-        self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
-        self.assertEqual(message.sender, self.example_user("cordelia"))
-        self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
+        # Confirm Iago and Othello received the message.
+        for user_profile in [iago, othello]:
+            message = most_recent_message(user_profile)
+            self.assertEqual(message.content, "TestMissedGroupDirectMessageEmailMessages body")
+            self.assertEqual(message.sender, cordelia)
+            self.assertEqual(message.recipient.type, Recipient.DIRECT_MESSAGE_GROUP)
 
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for message notification email reply


### PR DESCRIPTION
Fixes: #35273

Replying by email to a message notification email for a group direct message raised an unhandled `JsonableError` when any member of the group had since been deactivated, and the reply was silently lost (while the mirror still logged "Successfully processed email").

This filters the group's members to active users when constructing the recipient list, so the reply is delivered to the remaining active participants — consistent with the web app, which does not offer composing to such a group at all. If nobody but the sender remains active, the reply is dropped with an INFO log rather than an exception.

Two notes for review:

- Since personal `Recipient` rows no longer exist (1:1 direct messages are direct message groups), the same branch covers the 1:1 case raised in the review of #37449; a separate commit for it is no longer meaningful.
- The filtering query adds one database query to the reply path, so the query-count assertions in the two existing tests are updated from 22 to 23.

A possible follow-up (not included, to keep this scoped like the previously reviewed approach): notifying the sender via the notification bot when the reply is dropped, as `send_mm_reply_to_stream` does for channel replies.

Prior work on this issue: #36882, #37449 (whose review feedback is addressed here: `values_list`-based filtering, a test where the conversation remains a group DM, and the repeated test setup extracted into helpers), #38117, #38933.

**How changes were tested:**

- [x] `./tools/test-backend zerver.tests.test_email_mirror.TestMissedMessageEmailMessages` — 12/12 pass (re-run after rebasing on current main); the three new tests fail without the lib change (silent message loss, no drop log).
- [x] `./tools/lint zerver/lib/email_mirror.py zerver/tests/test_email_mirror.py`
- [x] Coverage: `zerver/lib/email_mirror.py` shows no uncovered lines under this test class.
- [x] Reproduced end-to-end in the dev environment (group DM → deactivate a member → email reply): before the fix the reply is lost; after, it is delivered to the remaining active members.

**Screenshots and screen captures:**

N/A (backend-only change).

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of the changes.
- [ ] Accessibility.
- [ ] Theming.

</details>