### PR TITLE
fix: markdown: Restrict "file" scheme links based on ENABLE_FILE_LINK…

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1429,6 +1429,13 @@ def sanitize_url(url: str) -> str | None:
     # on the safe side, we allow a fixed set of schemes.
     if scheme not in allowed_schemes:
         return None
+    
+    # The "file" scheme is only allowed when ENABLE_FILE_LINKS is set;
+    # otherwise, explicit Markdown links like [text](file:///etc/passwd)
+    # would bypass the restriction that already applies to bare
+    # file:// URLs via the autolinker (see file_links above).
+    if scheme == "file" and not settings.ENABLE_FILE_LINKS:
+        return None
 
     # Upstream code scans path, parameters, and query for colon characters
     # because

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1429,7 +1429,7 @@ def sanitize_url(url: str) -> str | None:
     # on the safe side, we allow a fixed set of schemes.
     if scheme not in allowed_schemes:
         return None
-    
+
     # The "file" scheme is only allowed when ENABLE_FILE_LINKS is set;
     # otherwise, explicit Markdown links like [text](file:///etc/passwd)
     # would bypass the restriction that already applies to bare

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1430,6 +1430,13 @@ def sanitize_url(url: str) -> str | None:
     if scheme not in allowed_schemes:
         return None
 
+    # The "file" scheme is only allowed when ENABLE_FILE_LINKS is set;
+    # otherwise, explicit Markdown links like [text](file:///etc/passwd)
+    # would bypass the restriction that already applies to bare
+    # file:// URLs via the autolinker (see file_links above).
+    if scheme == "file" and not settings.ENABLE_FILE_LINKS:
+        return None
+
     # Upstream code scans path, parameters, and query for colon characters
     # because
     #

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -758,6 +758,31 @@ class MarkdownLinkTest(ZulipTestCase):
         finally:
             clear_web_link_regex_for_testing()
 
+    def test_explicit_link_file(self) -> None:
+        # Regression test: explicit Markdown links like
+        # [text](file:///...) must respect ENABLE_FILE_LINKS just
+        # like bare file:// URLs do (see test_inline_file above).
+        # Previously this bypassed the setting because sanitize_url()
+        # unconditionally allowed the "file" scheme.
+        msg = "[click me](file:///etc/passwd)"
+
+        realm = do_create_realm(string_id="file_links_disabled_2", name="File links disabled")
+        self.assertEqual(
+            markdown_convert(msg, message_realm=realm).rendered_content,
+            "<p>[click me](file:///etc/passwd)</p>",
+        )
+        clear_web_link_regex_for_testing()
+
+        try:
+            with self.settings(ENABLE_FILE_LINKS=True):
+                realm = do_create_realm(string_id="file_links_enabled_2", name="File links enabled")
+                self.assertEqual(
+                    markdown_convert(msg, message_realm=realm).rendered_content,
+                    '<p><a href="file:///etc/passwd">click me</a></p>',
+                )
+        finally:
+            clear_web_link_regex_for_testing()
+
     def test_inline_bitcoin(self) -> None:
         msg = "To bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa or not to bitcoin"
         converted = markdown_convert_wrapper(msg)


### PR DESCRIPTION
…S setting. Fixed the bypass which was causing the issue.

Fixes: #39628 
https://github.com/zulip/zulip/issues/39628

<!-- Describe your pull request here.-->
Currently, `sanitize_url()` in `zerver/lib/markdown/__init__.py` unconditionally allows the `file` URL scheme, regardless of the `ENABLE_FILE_LINKS` setting.

This means that while bare `file://` URLs typed directly into a message are correctly left unlinked when `ENABLE_FILE_LINKS` is off, the same restriction does not apply to explicit Markdown links, e.g. `[click me](file:///etc/passwd)`.
Since the autolinker regex is the only place currently gated on `ENABLE_FILE_LINKS`, an explicit link bypasses it entirely and gets rendered as a clickable `file://` link.

This PR adds a check inside `sanitize_url()` itself so that the `file` scheme is only permitted when `ENABLE_FILE_LINKS` is `True`, closing this gap consistently for both bare URLs and explicit Markdown links.

How changes were tested:
<!-- If the PR makes UI changes, you must include screenshots. Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html -->
- Added `test_explicit_link_file` in `zerver/tests/test_markdown.py`, covering both `ENABLE_FILE_LINKS=False` (link should render as plain text) and  `ENABLE_FILE_LINKS=True` (link should render normally).
- Ran `./tools/test-backend zerver.tests.test_markdown.MarkdownLinkTest.test_explicit_link_file`  — passes after the fix.
- Verified the test fails without the fix by temporarily reverting the change in `sanitize_url()` and re-running the same test, confirming it catches the  original bug.
- Manually reproduced the issue in the Django shell before and after the fix using `markdown_convert()` with a `[text](file:///...)` message, confirming the rendered output changes from a clickable link to plain text.
- Ran the full `test_markdown.py` suite locally to check for regressions in related link-handling tests.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines). Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>