### PR TITLE
reactions: Truncate long user names in reaction pills.

### DIFF
--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -162,7 +162,7 @@ export type MessageCleanReaction = {
     local_id: string;
     reaction_type: "zulip_extra_emoji" | "realm_emoji" | "unicode_emoji";
     user_ids: number[];
-    vote_text: string;
+    vote_text: string[];
 };
 
 export type Message = (

--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -264,9 +264,14 @@ export function get_add_reaction_button(message_id: number): JQuery {
     return $add_button;
 }
 
-export let set_reaction_vote_text = ($reaction: JQuery, vote_text: string): void => {
+export let set_reaction_vote_text = ($reaction: JQuery, vote_text: string[]): void => {
     const $count_element = $reaction.find(".message_reaction_count");
-    $count_element.text(vote_text);
+    const $spans = vote_text.map((name, index) =>
+        $("<span>")
+            .addClass("message_reaction_name")
+            .text(index < vote_text.length - 1 ? `${name},` : name),
+    );
+    $count_element.empty().append($spans);
 };
 
 export function rewire_set_reaction_vote_text(value: typeof set_reaction_vote_text): void {
@@ -381,7 +386,7 @@ export let insert_new_reaction = (
         local_id: get_local_reaction_id(clean_reaction_object),
         emoji_alt_code: user_settings.emojiset === "text",
         is_realm_emoji,
-        vote_text: "", // Updated below
+        vote_text: [], // Updated below
         class: reaction_class,
     };
 
@@ -642,7 +647,7 @@ function build_reaction_data(
     count: number;
     label: string;
     class: string;
-    vote_text: string;
+    vote_text: string[];
 } {
     return {
         count: user_ids.length,
@@ -689,11 +694,11 @@ function get_reaction_counts_and_user_ids(message: Message): ReactionUserIdAndCo
         .toArray();
 }
 
-export function get_vote_text(user_ids: number[], should_display_reactors: boolean): string {
+export function get_vote_text(user_ids: number[], should_display_reactors: boolean): string[] {
     if (should_display_reactors) {
-        return comma_separated_usernames(user_ids);
+        return get_reaction_user_names(user_ids);
     }
-    return `${user_ids.length}`;
+    return [`${user_ids.length}`];
 }
 
 function check_should_display_reactors(
@@ -710,18 +715,15 @@ function check_should_display_reactors(
     return total_reactions <= 3;
 }
 
-function comma_separated_usernames(user_list: number[]): string {
+function get_reaction_user_names(user_list: number[]): string[] {
     const usernames = people.get_display_full_names(user_list);
     const current_user_has_reacted = user_list.includes(current_user.user_id);
 
     if (current_user_has_reacted) {
         const current_user_index = user_list.indexOf(current_user.user_id);
-        usernames[current_user_index] = $t({
-            defaultMessage: "You",
-        });
+        usernames[current_user_index] = $t({defaultMessage: "You"});
     }
-    const comma_separated_usernames = usernames.join(", ");
-    return comma_separated_usernames;
+    return usernames;
 }
 
 export let update_vote_text_on_message = (message: Message): void => {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -7,6 +7,8 @@
     }
 
     .message_reaction_container {
+        min-width: 0;
+
         &.disabled {
             cursor: not-allowed;
         }
@@ -89,6 +91,23 @@
            count/name.
            13px at 12.6/1em */
         line-height: 1.0317em;
+        display: flex;
+        flex: 1 1 auto;
+        min-width: 0;
+        flex-wrap: wrap;
+    }
+
+    .message_reaction_name {
+        flex: 0 1 auto;
+        max-width: 100%;
+        overflow: hidden;
+        padding-bottom: 0.1em;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .message_reaction_name:not(:last-child) {
+        margin-right: 0.25em;
     }
 
     .message_reaction:hover .message_reaction_count {

--- a/web/templates/message_reaction.hbs
+++ b/web/templates/message_reaction.hbs
@@ -7,6 +7,10 @@
         {{else}}
             <div class="emoji emoji-{{this.emoji_code}}"></div>
         {{/if}}
-        <div class="message_reaction_count">{{this.vote_text}}</div>
+        <div class="message_reaction_count">
+            {{#each this.vote_text}}
+                <span class="message_reaction_name">{{this}}{{#unless @last}},{{/unless}}</span>
+            {{/each}}
+        </div>
     </div>
 </div>

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1555,7 +1555,7 @@ test("predicate_basics", ({override}) => {
                     local_id: "unicode_emoji,1f3b1",
                     reaction_type: "unicode_emoji",
                     user_ids: [alice.user_id],
-                    vote_text: "translated: You, Bob van Roberts",
+                    vote_text: ["translated: You, Bob van Roberts"],
                 },
             }),
         ),

--- a/web/tests/reactions.test.cjs
+++ b/web/tests/reactions.test.cjs
@@ -150,7 +150,7 @@ test("basics", () => {
             emoji_code: "1f641",
             local_id: "unicode_emoji,1f641",
             count: 1,
-            vote_text: "1",
+            vote_text: ["1"],
             user_ids: [7],
             label: "translated: Cali reacted with :frown:",
             emoji_alt_code: false,
@@ -163,7 +163,7 @@ test("basics", () => {
             emoji_code: "992",
             local_id: "realm_emoji,992",
             count: 1,
-            vote_text: "1",
+            vote_text: ["1"],
             user_ids: [5],
             label: "translated: You (click to remove) reacted with :inactive_realm_emoji:",
             emoji_alt_code: false,
@@ -178,7 +178,7 @@ test("basics", () => {
             emoji_code: "1f604",
             local_id: "unicode_emoji,1f604",
             count: 2,
-            vote_text: "2",
+            vote_text: ["2"],
             user_ids: [5, 6],
             label: "translated: You (click to remove) and Bob van Roberts reacted with :smile:",
             emoji_alt_code: false,
@@ -191,7 +191,7 @@ test("basics", () => {
             emoji_code: "1f389",
             local_id: "unicode_emoji,1f389",
             count: 2,
-            vote_text: "2",
+            vote_text: ["2"],
             user_ids: [7, 8],
             label: "translated: Cali and Alexus reacted with :tada:",
             emoji_alt_code: false,
@@ -204,7 +204,7 @@ test("basics", () => {
             emoji_code: "1f680",
             local_id: "unicode_emoji,1f680",
             count: 3,
-            vote_text: "3",
+            vote_text: ["3"],
             user_ids: [5, 6, 7],
             label: "translated: You (click to remove), Bob van Roberts and Cali reacted with :rocket:",
             emoji_alt_code: false,
@@ -217,7 +217,7 @@ test("basics", () => {
             emoji_code: "1f44b",
             local_id: "unicode_emoji,1f44b",
             count: 3,
-            vote_text: "3",
+            vote_text: ["3"],
             user_ids: [6, 7, 8],
             label: "translated: Bob van Roberts, Cali and Alexus reacted with :wave:",
             emoji_alt_code: false,
@@ -254,7 +254,7 @@ test("reactions from unknown users", () => {
             emoji_code: "1f641",
             local_id: "unicode_emoji,1f641",
             count: 1,
-            vote_text: "1",
+            vote_text: ["1"],
             user_ids: [9],
             label: "translated: translated: Unknown user reacted with :frown:",
             emoji_alt_code: false,
@@ -267,7 +267,7 @@ test("reactions from unknown users", () => {
             emoji_code: "1f604",
             local_id: "unicode_emoji,1f604",
             count: 2,
-            vote_text: "2",
+            vote_text: ["2"],
             user_ids: [5, 9],
             label: "translated: You (click to remove) and translated: Unknown user reacted with :smile:",
             emoji_alt_code: false,
@@ -280,7 +280,7 @@ test("reactions from unknown users", () => {
             emoji_code: "1f389",
             local_id: "unicode_emoji,1f389",
             count: 2,
-            vote_text: "2",
+            vote_text: ["2"],
             user_ids: [6, 10],
             label: "translated: Bob van Roberts and translated: Unknown user reacted with :tada:",
             emoji_alt_code: false,
@@ -454,27 +454,24 @@ function stub_reaction(message_id, local_id) {
 
 test("get_vote_text (more than 3 reactions)", ({override}) => {
     const user_ids = [5, 6, 7];
-    const message = {...sample_message};
 
     override(user_settings, "display_emoji_reaction_users", true);
-    assert.equal(
-        "translated: You, Bob van Roberts, Cali",
-        reactions.get_vote_text(user_ids, message),
-    );
+    assert.deepEqual(reactions.get_vote_text(user_ids, true), [
+        "translated: You",
+        "Bob van Roberts",
+        "Cali",
+    ]);
 });
 
 test("get_vote_text (3 reactions)", ({override}) => {
     const user_ids = [5, 6, 7];
-    const message = {...sample_message};
-
-    // slicing the reactions array to only include first 3 reactions
-    message.reactions = message.reactions.slice(0, 3);
 
     override(user_settings, "display_emoji_reaction_users", true);
-    assert.equal(
-        "translated: You, Bob van Roberts, Cali",
-        reactions.get_vote_text(user_ids, message),
-    );
+    assert.deepEqual(reactions.get_vote_text(user_ids, true), [
+        "translated: You",
+        "Bob van Roberts",
+        "Cali",
+    ]);
 });
 
 test("update_vote_text_on_message", ({override, override_rewire}) => {
@@ -489,14 +486,14 @@ test("update_vote_text_on_message", ({override, override_rewire}) => {
                 user_id: 5,
                 reaction_type: "unicode_emoji",
                 emoji_code: "1f44b",
-                vote_text: "2",
+                vote_text: ["2"],
             },
             {
                 emoji_name: "wave",
                 user_id: 6,
                 reaction_type: "unicode_emoji",
                 emoji_code: "1f44b",
-                vote_text: "2",
+                vote_text: ["2"],
             },
 
             {
@@ -504,7 +501,7 @@ test("update_vote_text_on_message", ({override, override_rewire}) => {
                 user_id: 5,
                 reaction_type: "realm_emoji",
                 emoji_code: "992",
-                vote_text: "1",
+                vote_text: ["1"],
             },
         ],
     };
@@ -533,7 +530,7 @@ test("update_vote_text_on_message", ({override, override_rewire}) => {
                     still_url: "/still/url/for/992",
                     url: "/url/for/992",
                     user_ids: [5],
-                    vote_text: "translated: You",
+                    vote_text: ["translated: You"],
                 },
                 "unicode_emoji,1f44b": {
                     class: "message_reaction reacted",
@@ -546,7 +543,7 @@ test("update_vote_text_on_message", ({override, override_rewire}) => {
                     local_id: "unicode_emoji,1f44b",
                     reaction_type: "unicode_emoji",
                     user_ids: [5, 6],
-                    vote_text: "translated: You, Bob van Roberts",
+                    vote_text: ["translated: You", "Bob van Roberts"],
                 },
             }),
         ),
@@ -695,7 +692,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
         local_id: "unicode_emoji,1f3b1",
         reaction_type: alice_8ball_event.reaction_type,
         user_ids: [alice.user_id],
-        vote_text: "translated: You",
+        vote_text: ["translated: You"],
     };
     test_function_calls({
         run_code() {
@@ -739,7 +736,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
         local_id: "unicode_emoji,1f3b1",
         reaction_type: bob_8ball_event.reaction_type,
         user_ids: [alice.user_id, bob.user_id],
-        vote_text: "translated: You, Bob van Roberts",
+        vote_text: ["translated: You", "Bob van Roberts"],
     };
     test_function_calls({
         run_code() {
@@ -774,7 +771,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
         local_id: "unicode_emoji,2708",
         reaction_type: cali_airplane_event.reaction_type,
         user_ids: [cali.user_id],
-        vote_text: "Cali",
+        vote_text: ["Cali"],
     };
     test_function_calls({
         run_code() {
@@ -840,7 +837,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
                     local_id: "unicode_emoji,1f3b1",
                     reaction_type: alice_8ball_event.reaction_type,
                     user_ids: [],
-                    vote_text: "",
+                    vote_text: [],
                 },
                 message: {
                     clean_reactions: new Map(
@@ -896,7 +893,7 @@ test("insert_new_reaction (first reaction)", ({mock_template, override_rewire}) 
                         label: "translated: You (click to remove) reacted with :8ball:",
                         reaction_type: clean_reaction_object.reaction_type,
                         is_realm_emoji: false,
-                        vote_text: "",
+                        vote_text: [],
                     },
                 ],
             },
@@ -976,7 +973,7 @@ test("insert_new_reaction (me w/unicode emoji)", ({mock_template}) => {
             label: "translated: You (click to remove) reacted with :8ball:",
             reaction_type: clean_reaction_object.reaction_type,
             is_realm_emoji: false,
-            vote_text: "",
+            vote_text: [],
         });
         return "<new-reaction-stub>";
     });
@@ -1054,7 +1051,7 @@ test("insert_new_reaction (them w/zulip emoji)", ({mock_template}) => {
             label: "translated: Bob van Roberts reacted with :zulip:",
             still_url: null,
             reaction_type: clean_reaction_object.reaction_type,
-            vote_text: "",
+            vote_text: [],
         });
         return "<new-reaction-stub>";
     });


### PR DESCRIPTION
## Problem

A reaction pill currently stores the list of reactors as a single comma-separated string. When one display name is very long, it can overflow and disrupt the layout on the right side of the pill.

CSS `text-overflow: ellipsis` only truncates an entire text node, not individual names within it. To truncate each name independently, each display name needs to be rendered as its own element.

A straightforward approach of splitting the existing comma-separated string is not reliable, since display names may themselves contain commas (for example, `"Cordelia, Lear's daughter"`), causing a single name to be interpreted as multiple names.

## Solution

Keep the list of reactor names as an array throughout the rendering pipeline instead of joining it into a comma-separated string and splitting it apart later.

Render each reactor name as a separate element, inserting comma separators between elements. This allows CSS ellipsis to be applied independently to each name while correctly handling display names that contain commas.


Fixes: #38594.




| Before | After |
| :---: | :---: |
|<img width="278" height="99" alt="chrome_8JoNZHgRXl" src="https://github.com/user-attachments/assets/40ebdd94-ffec-4a90-bc29-ca2ddddee636" />  | <img width="278" height="99" alt="GKT8LpUYCr" src="https://github.com/user-attachments/assets/e9dfcd9b-b04d-4b50-a94f-7977ae46141f" /> |
| <img width="278" height="104" alt="yqtDSp7oJZ" src="https://github.com/user-attachments/assets/2de157e5-9e71-4edd-9616-4b69aca6c88e" />  | <img width="278" height="104" alt="hTKJx6ytEG" src="https://github.com/user-attachments/assets/55039221-cc41-40e0-83a2-2b74334451c0" />|
| <img width="278" height="104" alt="6J7X2PAyea" src="https://github.com/user-attachments/assets/c2584302-793a-4cb3-9b85-4064727eb87a" /> | <img width="278" height="104" alt="9AuFcFfXsv" src="https://github.com/user-attachments/assets/e5b90af2-2f67-4e07-b3fa-f224ec92e0ca" /> |
| <img width="278" height="104" alt="lMRjzE1gQe" src="https://github.com/user-attachments/assets/ed66a6ea-77f3-45f7-9704-665f182f3db6" /> | <img width="278" height="104" alt="lEJOx7ZcBe" src="https://github.com/user-attachments/assets/d8563f70-5096-4e0e-bdf8-25d3b7334f68" />|
| <img width="278" height="104" alt="mGC1eltcU7" src="https://github.com/user-attachments/assets/0764f197-f34c-4759-9a00-e0734b708eb9" /> | <img width="278" height="104" alt="7pC1ei7RY5" src="https://github.com/user-attachments/assets/088c779e-26b2-44b9-9e03-c168dcb78701" /> |

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
