### PR TITLE
feat: implement event queue size limiting and overflow handling for T…

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1598,22 +1598,18 @@ class EventQueueTest(ZulipTestCase):
         # Push one more event to trigger overflow
         queue.push({"type": "overflow_trigger", "value": "overflow"})
         self.assertTrue(queue.overflowed)
-        self.assert_length(queue.queue, queue.MAX_QUEUE_SIZE)
+        # Queue should be cleared to release memory immediately
+        self.assert_length(queue.queue, 0)
 
-        # The oldest event (value: 0) should have been popped
-        self.assertEqual(queue.queue[0]["value"], 1)
-        self.assertEqual(queue.queue[-1]["value"], "overflow")
+        from zerver.lib.exceptions import ErrorCode
+        from zerver.tornado.exceptions import BadEventQueueIdError
 
-        from zerver.lib.exceptions import JsonableError
-
-        with self.assertRaises(JsonableError) as cm:
+        with self.assertRaises(BadEventQueueIdError) as cm:
             queue.contents(include_internal_data=False)
-        self.assertEqual(str(cm.exception), "Event queue overflowed. Client must reload state.")
+        self.assertEqual(cm.exception.code, ErrorCode.BAD_EVENT_QUEUE_ID)
 
         events = queue.contents(include_internal_data=True)
-        self.assert_length(events, queue.MAX_QUEUE_SIZE)
-        self.assertEqual(events[0]["value"], 1)
-        self.assertEqual(events[-1]["value"], "overflow")
+        self.assert_length(events, 0)
 
     def test_queue_overflow_serialization(self) -> None:
         client = self.get_client_descriptor()
@@ -1629,58 +1625,6 @@ class EventQueueTest(ZulipTestCase):
 
         # After overflow
         self.verify_to_dict_end_to_end(client)
-
-    def test_finish_handler_error_response(self) -> None:
-        from django.http import HttpRequest
-
-        from zerver.lib.exceptions import JsonableError
-        from zerver.tornado.handlers import finish_handler, handlers
-
-        class MockHandler:
-            def __init__(self) -> None:
-                self.handler_id = 9999
-                self.status_code: int | None = None
-                self._request = HttpRequest()
-                self.finished_dict: dict[str, Any] | None = None
-
-            def set_status(self, status: int) -> None:
-                self.status_code = status
-
-            def zulip_finish(self, result_dict: dict[str, Any], request: HttpRequest) -> None:
-                self.finished_dict = result_dict
-
-        mock_handler = MockHandler()
-        handlers[mock_handler.handler_id] = mock_handler  # type: ignore[assignment]
-
-        try:
-            # We also need RequestNotes on the mock request
-            from zerver.lib.request import RequestNotes
-
-            request_notes = RequestNotes()
-            request_notes.log_data = {}
-            RequestNotes.set_notes(mock_handler._request, request_notes)
-
-            # Call finish_handler with a JsonableError
-            error = JsonableError("Some error message")
-            with mock.patch("tornado.ioloop.IOLoop.current") as mock_current:
-                mock_loop = mock_current.return_value
-
-                def mock_add_callback(callback: Any, *args: Any, **kwargs: Any) -> None:
-                    callback(*args, **kwargs)
-
-                mock_loop.add_callback.side_effect = mock_add_callback
-
-                finish_handler(mock_handler.handler_id, "test_queue_id", error)
-
-            # Verify handler state
-            self.assertEqual(mock_handler.status_code, 400)
-            self.assertIsNotNone(mock_handler.finished_dict)
-            assert mock_handler.finished_dict is not None
-            self.assertEqual(mock_handler.finished_dict["result"], "error")
-            self.assertEqual(mock_handler.finished_dict["msg"], "Some error message")
-            self.assertEqual(mock_handler.finished_dict["code"], "BAD_REQUEST")
-        finally:
-            handlers.pop(mock_handler.handler_id, None)
 
 
 class OfflineEventQueueTest(ZulipTestCase):

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1584,6 +1584,104 @@ class EventQueueTest(ZulipTestCase):
         queue.prune(1)
         self.verify_to_dict_end_to_end(client)
 
+    def test_queue_overflow_behavior(self) -> None:
+        client = self.get_client_descriptor()
+        queue = client.event_queue
+        self.assertFalse(queue.overflowed)
+
+        for i in range(queue.MAX_QUEUE_SIZE):
+            queue.push({"type": "arbitrary", "value": i})
+
+        self.assertFalse(queue.overflowed)
+        self.assert_length(queue.queue, queue.MAX_QUEUE_SIZE)
+
+        # Push one more event to trigger overflow
+        queue.push({"type": "overflow_trigger", "value": "overflow"})
+        self.assertTrue(queue.overflowed)
+        self.assert_length(queue.queue, queue.MAX_QUEUE_SIZE)
+
+        # The oldest event (value: 0) should have been popped
+        self.assertEqual(queue.queue[0]["value"], 1)
+        self.assertEqual(queue.queue[-1]["value"], "overflow")
+
+        from zerver.lib.exceptions import JsonableError
+
+        with self.assertRaises(JsonableError) as cm:
+            queue.contents(include_internal_data=False)
+        self.assertEqual(str(cm.exception), "Event queue overflowed. Client must reload state.")
+
+        events = queue.contents(include_internal_data=True)
+        self.assert_length(events, queue.MAX_QUEUE_SIZE)
+        self.assertEqual(events[0]["value"], 1)
+        self.assertEqual(events[-1]["value"], "overflow")
+
+    def test_queue_overflow_serialization(self) -> None:
+        client = self.get_client_descriptor()
+        queue = client.event_queue
+
+        # Before overflow
+        self.verify_to_dict_end_to_end(client)
+
+        # Trigger overflow
+        for i in range(queue.MAX_QUEUE_SIZE + 1):
+            queue.push({"type": "arbitrary", "value": i})
+        self.assertTrue(queue.overflowed)
+
+        # After overflow
+        self.verify_to_dict_end_to_end(client)
+
+    def test_finish_handler_error_response(self) -> None:
+        from django.http import HttpRequest
+
+        from zerver.lib.exceptions import JsonableError
+        from zerver.tornado.handlers import finish_handler, handlers
+
+        class MockHandler:
+            def __init__(self) -> None:
+                self.handler_id = 9999
+                self.status_code: int | None = None
+                self._request = HttpRequest()
+                self.finished_dict: dict[str, Any] | None = None
+
+            def set_status(self, status: int) -> None:
+                self.status_code = status
+
+            def zulip_finish(self, result_dict: dict[str, Any], request: HttpRequest) -> None:
+                self.finished_dict = result_dict
+
+        mock_handler = MockHandler()
+        handlers[mock_handler.handler_id] = mock_handler  # type: ignore[assignment]
+
+        try:
+            # We also need RequestNotes on the mock request
+            from zerver.lib.request import RequestNotes
+
+            request_notes = RequestNotes()
+            request_notes.log_data = {}
+            RequestNotes.set_notes(mock_handler._request, request_notes)
+
+            # Call finish_handler with a JsonableError
+            error = JsonableError("Some error message")
+            with mock.patch("tornado.ioloop.IOLoop.current") as mock_current:
+                mock_loop = mock_current.return_value
+
+                def mock_add_callback(callback: Any, *args: Any, **kwargs: Any) -> None:
+                    callback(*args, **kwargs)
+
+                mock_loop.add_callback.side_effect = mock_add_callback
+
+                finish_handler(mock_handler.handler_id, "test_queue_id", error)
+
+            # Verify handler state
+            self.assertEqual(mock_handler.status_code, 400)
+            self.assertIsNotNone(mock_handler.finished_dict)
+            assert mock_handler.finished_dict is not None
+            self.assertEqual(mock_handler.finished_dict["result"], "error")
+            self.assertEqual(mock_handler.finished_dict["msg"], "Some error message")
+            self.assertEqual(mock_handler.finished_dict["code"], "BAD_REQUEST")
+        finally:
+            handlers.pop(mock_handler.handler_id, None)
+
 
 class OfflineEventQueueTest(ZulipTestCase):
     """Tests for the offline marking mechanism for long-lived event queues."""

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -234,6 +234,12 @@ class ClientDescriptor:
                 self.event_queue.id,
                 self.event_queue.contents(),
             )
+        except JsonableError as e:
+            finish_handler(
+                self.current_handler_id,
+                self.event_queue.id,
+                e,
+            )
         except Exception:
             logging.exception(
                 "Got error finishing handler for queue %s", self.event_queue.id, stack_info=True
@@ -355,6 +361,8 @@ def compute_full_event_type(event: Mapping[str, Any]) -> str:
 
 
 class EventQueue:
+    MAX_QUEUE_SIZE = 2500
+
     def __init__(self, id: str) -> None:
         # When extending this list of properties, one must be sure to
         # update to_dict and from_dict.
@@ -365,6 +373,7 @@ class EventQueue:
         self.newest_pruned_id: int | None = -1
         self.id: str = id
         self.virtual_events: dict[str, dict[str, Any]] = {}
+        self.overflowed: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         # If you add a new key to this dict, make sure you add appropriate
@@ -375,6 +384,7 @@ class EventQueue:
             next_event_id=self.next_event_id,
             queue=list(self.queue),
             virtual_events=self.virtual_events,
+            overflowed=self.overflowed,
         )
         if self.newest_pruned_id is not None:
             d["newest_pruned_id"] = self.newest_pruned_id
@@ -387,6 +397,7 @@ class EventQueue:
         ret.newest_pruned_id = d.get("newest_pruned_id")
         ret.queue = deque(d["queue"])
         ret.virtual_events = d.get("virtual_events", {})
+        ret.overflowed = d.get("overflowed", False)
         return ret
 
     def push(self, orig_event: Mapping[str, Any]) -> None:
@@ -429,6 +440,9 @@ class EventQueue:
                 virtual_event["timestamp"] = event["timestamp"]
 
         else:
+            if len(self.queue) >= self.MAX_QUEUE_SIZE:
+                self.queue.popleft()
+                self.overflowed = True
             self.queue.append(event)
 
     # Note that pop ignores virtual events.  This is fine in our
@@ -447,6 +461,9 @@ class EventQueue:
             self.pop()
 
     def contents(self, include_internal_data: bool = False) -> list[dict[str, Any]]:
+        if self.overflowed and not include_internal_data:
+            raise JsonableError(_("Event queue overflowed. Client must reload state."))
+
         contents: list[dict[str, Any]] = []
         virtual_id_map: dict[str, dict[str, Any]] = {}
         for event_type in self.virtual_events:

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -234,12 +234,6 @@ class ClientDescriptor:
                 self.event_queue.id,
                 self.event_queue.contents(),
             )
-        except JsonableError as e:
-            finish_handler(
-                self.current_handler_id,
-                self.event_queue.id,
-                e,
-            )
         except Exception:
             logging.exception(
                 "Got error finishing handler for queue %s", self.event_queue.id, stack_info=True
@@ -440,10 +434,12 @@ class EventQueue:
                 virtual_event["timestamp"] = event["timestamp"]
 
         else:
-            if len(self.queue) >= self.MAX_QUEUE_SIZE:
-                self.queue.popleft()
+            if self.overflowed or len(self.queue) >= self.MAX_QUEUE_SIZE:
                 self.overflowed = True
-            self.queue.append(event)
+                self.queue.clear()
+                self.virtual_events.clear()
+            else:
+                self.queue.append(event)
 
     # Note that pop ignores virtual events.  This is fine in our
     # current usage since virtual events should always be resolved to
@@ -462,7 +458,7 @@ class EventQueue:
 
     def contents(self, include_internal_data: bool = False) -> list[dict[str, Any]]:
         if self.overflowed and not include_internal_data:
-            raise JsonableError(_("Event queue overflowed. Client must reload state."))
+            raise BadEventQueueIdError(self.id)
 
         contents: list[dict[str, Any]] = []
         virtual_id_map: dict[str, dict[str, Any]] = {}

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -17,7 +17,6 @@ from tornado.iostream import StreamClosedError
 from tornado.wsgi import WSGIContainer
 from typing_extensions import override
 
-from zerver.lib.exceptions import JsonableError
 from zerver.lib.response import AsynchronousResponse, json_response
 from zerver.tornado.descriptors import get_descriptor_by_handler_id
 
@@ -46,9 +45,7 @@ def handler_stats_string() -> str:
     return f"{len(handlers)} handlers, latest ID {current_handler_id}"
 
 
-def finish_handler(
-    handler_id: int, event_queue_id: str, contents: list[dict[str, Any]] | JsonableError
-) -> None:
+def finish_handler(handler_id: int, event_queue_id: str, contents: list[dict[str, Any]]) -> None:
     try:
         # We do the import during runtime to avoid cyclic dependency
         # with zerver.lib.request
@@ -71,29 +68,14 @@ def finish_handler(
         log_data = RequestNotes.get_notes(request).log_data
         assert log_data is not None
 
-        if isinstance(contents, JsonableError):
-            log_data["extra"] = f"[{event_queue_id}/error]"
-            handler.set_status(contents.http_status_code)
-            result_dict = dict(
-                result="error",
-                msg=contents.msg,
-                **contents.data,
-            )
+        if len(contents) != 1:
+            log_data["extra"] = f"[{event_queue_id}/1]"
         else:
-            if len(contents) != 1:
-                log_data["extra"] = f"[{event_queue_id}/1]"
-            else:
-                log_data["extra"] = "[{}/1/{}]".format(event_queue_id, contents[0]["type"])
-            result_dict = dict(
-                result="success",
-                msg="",
-                events=contents,
-                queue_id=event_queue_id,
-            )
+            log_data["extra"] = "[{}/1/{}]".format(event_queue_id, contents[0]["type"])
 
         tornado.ioloop.IOLoop.current().add_callback(
             handler.zulip_finish,
-            result_dict,
+            dict(result="success", msg="", events=contents, queue_id=event_queue_id),
             request,
         )
     except Exception as e:

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -17,6 +17,7 @@ from tornado.iostream import StreamClosedError
 from tornado.wsgi import WSGIContainer
 from typing_extensions import override
 
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.response import AsynchronousResponse, json_response
 from zerver.tornado.descriptors import get_descriptor_by_handler_id
 
@@ -45,7 +46,9 @@ def handler_stats_string() -> str:
     return f"{len(handlers)} handlers, latest ID {current_handler_id}"
 
 
-def finish_handler(handler_id: int, event_queue_id: str, contents: list[dict[str, Any]]) -> None:
+def finish_handler(
+    handler_id: int, event_queue_id: str, contents: list[dict[str, Any]] | JsonableError
+) -> None:
     try:
         # We do the import during runtime to avoid cyclic dependency
         # with zerver.lib.request
@@ -67,14 +70,30 @@ def finish_handler(handler_id: int, event_queue_id: str, contents: list[dict[str
         async_request_timer_restart(request)
         log_data = RequestNotes.get_notes(request).log_data
         assert log_data is not None
-        if len(contents) != 1:
-            log_data["extra"] = f"[{event_queue_id}/1]"
+
+        if isinstance(contents, JsonableError):
+            log_data["extra"] = f"[{event_queue_id}/error]"
+            handler.set_status(contents.http_status_code)
+            result_dict = dict(
+                result="error",
+                msg=contents.msg,
+                **contents.data,
+            )
         else:
-            log_data["extra"] = "[{}/1/{}]".format(event_queue_id, contents[0]["type"])
+            if len(contents) != 1:
+                log_data["extra"] = f"[{event_queue_id}/1]"
+            else:
+                log_data["extra"] = "[{}/1/{}]".format(event_queue_id, contents[0]["type"])
+            result_dict = dict(
+                result="success",
+                msg="",
+                events=contents,
+                queue_id=event_queue_id,
+            )
 
         tornado.ioloop.IOLoop.current().add_callback(
             handler.zulip_finish,
-            dict(result="success", msg="", events=contents, queue_id=event_queue_id),
+            result_dict,
             request,
         )
     except Exception as e:


### PR DESCRIPTION


<!-- Describe your pull request here.-->

When events occur (e.g. new messages on streams), they are pushed to the client event queue via EventQueue.push(orig_event). The queue stores events in a deque. However, **there is no limit on the number of events buffered in the deque**.

If a user is subscribed to high-traffic streams and goes offline or closes their browser tab, thousands of messages continue to accumulate in memory. 

The Remediation Code:
**Enforce a capacity limit on the event queue.** If the queue overflows, evict old events, mark the queue as overflowed, and raise an exception when the client attempts to retrieve events, forcing a clean reload of state.


Fixes: <!-- Issue link, or clear description.-->
Under heavy load or during large-realm spikes, this leads to:

**Tornado Memory Exhaustion**: Memory usage of the Tornado process balloons, causing resource starvation.
**Process Crash (OOM)**: The system kernel terminates Tornado via the OOM Killer, disconnecting all active websocket connections.



**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
