### PR TITLE
stream_settings: Avoid unnecessary channel DOM reordering

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -728,8 +728,6 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()): 
         return Number.parseInt($(row).attr("data-stream-id")!, 10);
     }
 
-    const widgets = new Map<number, JQuery>();
-
     const stream_ids = [];
 
     for (const row of $("#channels_overlay_container .stream-row")) {
@@ -741,35 +739,37 @@ export function redraw_left_panel(left_panel_params = get_left_panel_params()): 
 
     // If we just re-built the DOM from scratch we wouldn't need
     // all this hidden/notdisplayed logic.
-    const hidden_ids = new Set();
-
-    for (const stream_id of buckets.other) {
-        hidden_ids.add(stream_id);
-    }
+    const hidden_ids = new Set(buckets.other);
 
     for (const row of $("#channels_overlay_container .stream-row")) {
         const stream_id = stream_id_for_row(row);
 
-        // Below code goes away if we don't do sort-DOM-in-place.
         if (hidden_ids.has(stream_id)) {
             $(row).addClass("notdisplayed");
         } else {
             $(row).removeClass("notdisplayed");
         }
-
-        widgets.set(stream_id, $(row).detach());
     }
 
     scroll_util.reset_scrollbar($("#subscription_overlay .streams-list"));
 
     const all_stream_ids = [...buckets.name, ...buckets.desc, ...buckets.other];
 
-    for (const stream_id of all_stream_ids) {
-        const $widget = widgets.get(stream_id);
-        assert($widget !== undefined);
-        scroll_util
-            .get_content_element($("#channels_overlay_container .streams-list"))
-            .append($widget);
+    if (!stream_ids.every((stream_id, index) => stream_id === all_stream_ids[index])) {
+        const widgets = new Map<number, JQuery>();
+
+        for (const row of $("#channels_overlay_container .stream-row")) {
+            const stream_id = stream_id_for_row(row);
+            widgets.set(stream_id, $(row).detach());
+        }
+
+        for (const stream_id of all_stream_ids) {
+            const $widget = widgets.get(stream_id);
+            assert($widget !== undefined);
+            scroll_util
+                .get_content_element($("#channels_overlay_container .streams-list"))
+                .append($widget);
+        }
     }
     update_empty_left_panel_message();
 

--- a/web/tests/stream_settings_ui.test.cjs
+++ b/web/tests/stream_settings_ui.test.cjs
@@ -277,6 +277,35 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
         );
     }
 
+    // Avoid reordering the DOM when the channels are already in the requested order.
+    const streams_by_name = [abcd, cpp, denmark, jerry, poland, pomona, utopia, zzyzx];
+    const rows_by_name = streams_by_name.map((stream) => `.stream-row-${CSS.escape(stream.elem)}`);
+
+    $.reset_selector("#channels_overlay_container .stream-row");
+    $.set_results("#channels_overlay_container .stream-row", rows_by_name);
+
+    for (const row of rows_by_name) {
+        $(row)[0].remove = assert.fail;
+    }
+
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_available: false,
+            sort_order: "by-stream-name",
+        },
+        streams_by_name,
+    );
+
+    // Restore the original mocked row order and remove behavior for the remaining tests.
+    for (const row of rows_by_name) {
+        $(row)[0].remove = () => {};
+    }
+
+    $.reset_selector("#channels_overlay_container .stream-row");
+    $.set_results("#channels_overlay_container .stream-row", sub_stubs);
+
     // Search with single keyword
     test_filter({input: "Po", show_subscribed: false, show_available: false}, [poland, pomona]);
     assert.ok(ui_called);


### PR DESCRIPTION
Optimize the channel settings UI to avoid unnecessary DOM reordering when filtering channels.

Previously, `redraw_left_panel` detached and re-appended all channel rows on every redraw, even when the desired channel order was unchanged. With hundreds of channels, this caused noticeable input lag while filtering, especially when holding Backspace to clear the search query.

This change compares the current channel order with the desired order and only detaches and re-appends rows when the order actually needs to change. Visibility updates still happen normally without unnecessary DOM reordering.

A regression test verifies that rows are not detached when they are already in the requested order.

Fixes: #39755

**How changes were tested:**

- Ran `./tools/test-js-with-node web/tests/stream_settings_ui.test.cjs`.
- Ran `./tools/lint web/src/stream_settings_ui.ts web/tests/stream_settings_ui.test.cjs`.
- Ran `git diff --check`.
- Manually tested the channel settings UI with 331 active channels, including 314 performance-test private channels.
- Verified that typing in the channel search field and holding Backspace to clear the query remain responsive.
- Verified that sorting by channel name, number of subscribers, and recent traffic continues to work correctly.
- Chrome DevTools performance testing showed the previously laggy interaction improving from approximately 1349 ms INP to approximately 168 ms in the tested development environment.

**Screenshots and screen captures:**

No visual appearance changes. This PR is a performance optimization to the existing channel filtering and sorting behavior.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked. -->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>