### PR TITLE
fix: skip S3 objects without realm_id in export instead of AssertionError

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -2298,12 +2298,22 @@ def export_files_from_s3(
             s3_obj = bucket.Object(bkey.key)
 
             if "realm_id" not in s3_obj.metadata:
-                raise AssertionError(f"Missing realm_id in object metadata: {s3_obj.metadata}")
+                if bkey.key.endswith(".info"):
+                    continue
+                logging.warning(
+                    "Missing realm_id in object metadata, skipping: %s (%s)",
+                    bkey.key,
+                    s3_obj.metadata,
+                )
+                continue
 
             if "user_profile_id" not in s3_obj.metadata:
-                raise AssertionError(
-                    f"Missing user_profile_id in object metadata: {s3_obj.metadata}"
+                logging.warning(
+                    "Missing user_profile_id in object metadata, skipping: %s (%s)",
+                    bkey.key,
+                    s3_obj.metadata,
                 )
+                continue
 
             if int(s3_obj.metadata["user_profile_id"]) not in user_ids:
                 continue


### PR DESCRIPTION
Fixes #39771

- Skip .info sidecar files (tusd resumable upload)  
- Warn and skip objects missing realm_id/user_profile_id metadata instead of hard crash
- Include object key in warning message for easier diagnosis