### PR TITLE
event_queue: Fix event collapsing reordering flag updates.

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1535,6 +1535,125 @@ class EventQueueTest(ZulipTestCase):
         )
         self.verify_to_dict_end_to_end(client)
 
+    def test_collapsing_does_not_reorder_conflicting_flag_updates(self) -> None:
+        """
+        Regression test for a bug where compressing repeated
+        update_message_flags events into a single "virtual event"
+        could reorder events relative to each other.
+
+        Concretely: if message 101 is marked read, then marked
+        unread, and then a *different* message 202 is marked read,
+        the "mark 202 as read" event would get merged with the
+        earlier "mark 101 as read" event (since both are
+        flags/add/read events). That merged event's position is
+        the position of its most recent contributor (202's), which
+        is *after* the real, non-collapsible "mark 101 as unread"
+        event. This incorrectly told clients that 101 was marked
+        read *after* it was marked unread, when the reverse was
+        true, causing 101 to be shown as read when it should be
+        unread.
+
+        The fix: whenever an update_message_flags event arrives,
+        we first strip its message ids out of any pending virtual
+        event for the *opposite* operation on the same flag, since
+        that pending event is now stale for those specific messages.
+        """
+        client = self.get_client_descriptor()
+        queue = client.event_queue
+
+        def umfe(operation: str, messages: list[int]) -> dict[str, Any]:
+            return dict(
+                type="update_message_flags",
+                operation=operation,
+                flag="read",
+                all=False,
+                timestamp="1",
+                messages=messages,
+            )
+
+        # 101 marked read, then unread, then a different message
+        # (202) marked read.
+        queue.push(umfe(operation="add", messages=[101]))
+        self.verify_to_dict_end_to_end(client)
+        queue.push(umfe(operation="remove", messages=[101]))
+        self.verify_to_dict_end_to_end(client)
+        queue.push(umfe(operation="add", messages=[202]))
+        self.verify_to_dict_end_to_end(client)
+
+        self.assertEqual(
+            queue.contents(),
+            [
+                dict(
+                    id=1,
+                    type="update_message_flags",
+                    operation="remove",
+                    flag="read",
+                    all=False,
+                    timestamp="1",
+                    messages=[101],
+                ),
+                dict(
+                    id=2,
+                    type="update_message_flags",
+                    operation="add",
+                    flag="read",
+                    all=False,
+                    timestamp="1",
+                    messages=[202],
+                ),
+            ],
+        )
+
+    def test_collapsing_handles_repeated_flag_flips(self) -> None:
+        """
+        Extension of the above: a message that flips back and forth
+        (read, unread, read, unread) should never have a stale
+        "read" virtual event survive to delivery -- each new event
+        should prune the previous pending event for the opposite
+        operation.
+        """
+        client = self.get_client_descriptor()
+        queue = client.event_queue
+
+        def umfe(operation: str) -> dict[str, Any]:
+            return dict(
+                type="update_message_flags",
+                operation=operation,
+                flag="read",
+                all=False,
+                timestamp="1",
+                messages=[601],
+            )
+
+        queue.push(umfe(operation="add"))
+        queue.push(umfe(operation="remove"))
+        queue.push(umfe(operation="add"))
+        queue.push(umfe(operation="remove"))
+
+        self.assertEqual(
+            queue.contents(),
+            [
+                dict(
+                    id=1,
+                    type="update_message_flags",
+                    operation="remove",
+                    flag="read",
+                    all=False,
+                    timestamp="1",
+                    messages=[601],
+                ),
+                dict(
+                    id=3,
+                    type="update_message_flags",
+                    operation="remove",
+                    flag="read",
+                    all=False,
+                    timestamp="1",
+                    messages=[601],
+                ),
+            ],
+        )
+
     def test_collapse_event(self) -> None:
         """
         This mostly focuses on the internals of

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -400,6 +400,30 @@ class EventQueue:
         event["id"] = self.next_event_id
         self.next_event_id += 1
         full_event_type = compute_full_event_type(event)
+        if (
+            event["type"] == "update_message_flags"
+            and not event["all"]
+            and event["operation"] in ("add", "remove")
+        ):
+            # Before doing anything else with this event, check whether
+            # there's a pending (not yet delivered) virtual event for the
+            # *opposite* operation on this same flag that already contains
+            # some of these message ids. If so, those messages' presence
+            # in that opposite virtual event is now stale -- this new
+            # event supersedes it for those specific messages -- so we
+            # must remove them before they can be delivered at the wrong,
+            # stale position.
+            opposite_operation = "remove" if event["operation"] == "add" else "add"
+            opposite_full_event_type = f"flags/{opposite_operation}/{event['flag']}"
+            opposite_virtual_event = self.virtual_events.get(opposite_full_event_type)
+            if opposite_virtual_event is not None:
+                incoming_ids = set(event["messages"])
+                opposite_virtual_event["messages"] = [
+                    m for m in opposite_virtual_event["messages"] if m not in incoming_ids
+                ]
+                if len(opposite_virtual_event["messages"]) == 0:
+                    del self.virtual_events[opposite_full_event_type]
+
         if full_event_type.startswith("flags/") and not full_event_type.startswith(
             "flags/remove/read"
         ):
@@ -413,10 +437,10 @@ class EventQueue:
             # We need to exclude flags/remove/read, because it has an
             # extra message_details field that cannot be compressed.
             #
-            # BUG: This compression algorithm is incorrect in the
-            # presence of mark-as-unread, since it does not respect
-            # the ordering of "mark as read" and "mark as unread"
-            # updates for a given message.
+            # Note: we handle the ordering interaction between this
+            # compression and mark-as-unread/mark-as-unstarred/etc.
+            # events above, by pruning stale entries from the opposite
+            # operation's virtual event before reaching this point.
             if full_event_type not in self.virtual_events:
                 self.virtual_events[full_event_type] = copy.deepcopy(event)
                 return


### PR DESCRIPTION
Previously, when EventQueue.push() compressed repeated update_message_flags events into a single virtual event (an optimization to avoid many small events while a user scrolls and marks messages read), the virtual event's position was always overwritten to match its most recently merged contributor.

This meant that if a message was marked read, then marked unread, and then a different message was marked read afterward, the first message's "read" event would be silently repositioned to appear after the "unread" event, even though it actually happened before. A client receiving this event stream could end up believing a message was read when the last real operation on it was actually marking it unread, until the next full state resync.

This isn't specific to read/unread: the same virtual-event key is shared by add and remove operations for other user-settable flags (starred, collapsed), which can suffer the identical reordering.

Fix this by, whenever a flag event arrives, first pruning that event's message ids out of any pending virtual event for the opposite operation on the same flag. A message's presence in a stale, already-superseded virtual event is removed before it can be delivered at an incorrect position, while the compression optimization is preserved for the common case where no such conflict exists.

Verified against a live server via the /api/v1/register and /api/v1/messages/flags endpoints, confirming the incorrect ordering before this change and the corrected ordering after.

<!-- Describe your pull request here.-->

Fixes: N/A, Raised as a discussion thread at https://chat.zulip.org/#narrow/channel/3-backend/topic/compression.20bug.20in.20event.20queue/with/2497444


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
