### PR TITLE
[ai]Use avatars in DMs navbar

### DIFF
--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -3,19 +3,41 @@ import assert from "minimalistic-assert";
 
 import render_message_view_header from "../templates/message_view_header.hbs";
 
+import * as buddy_data from "./buddy_data.ts";
 import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
 import * as inbox_util from "./inbox_util.ts";
+import * as muted_users from "./muted_users.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as peer_data from "./peer_data.ts";
+import * as people from "./people.ts";
 import * as recent_view_util from "./recent_view_util.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
 import * as search from "./search.ts";
 import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
+import * as util from "./util.ts";
+
+// Cap on the number of names listed in the "+N" overflow tooltip,
+// matching recent_view_ui's participant overflow tooltip.
+const MAX_DM_OVERFLOW_TOOLTIP_NAMES = 10;
+
+type DmAvatar = {
+    user_id: number;
+    avatar_url: string;
+    name: string;
+    is_muted: boolean;
+    user_circle_class: string;
+};
+
+type DmAvatarsContext = {
+    is_dm_narrow: true;
+    is_one_on_one_dm: boolean;
+    dm_users: DmAvatar[];
+};
 
 type MessageViewHeaderContext = {
     title?: string | undefined;
@@ -29,6 +51,9 @@ type MessageViewHeaderContext = {
     is_admin?: boolean;
     stream?: StreamSubscription;
     stream_settings_link?: string;
+    is_dm_narrow?: boolean;
+    is_one_on_one_dm?: boolean;
+    dm_users?: DmAvatar[];
 } & (
     | {
           zulip_icon: string;
@@ -37,6 +62,38 @@ type MessageViewHeaderContext = {
           icon: string | undefined;
       }
 );
+
+export function get_dm_avatars_context(user_ids: number[]): DmAvatarsContext {
+    // Order avatars by display name so they match the participant order
+    // shown in the message recipient header bar (see
+    // message_store.get_pm_full_names, which sorts the same way). We
+    // render an avatar for every participant; how many actually fit is
+    // decided responsively at layout time (see relayout_dm_avatars).
+    const strcmp = util.make_strcmp();
+    const sorted_user_ids = user_ids.toSorted((a, b) =>
+        strcmp(people.get_display_full_name(a), people.get_display_full_name(b)),
+    );
+
+    const dm_users = sorted_user_ids.map((user_id) => {
+        const person = people.get_by_user_id(user_id);
+        return {
+            user_id,
+            avatar_url: people.small_avatar_url_for_person(person),
+            name: people.get_display_full_name(user_id),
+            is_muted: muted_users.is_user_muted(user_id),
+            user_circle_class: buddy_data.get_user_circle_class(
+                user_id,
+                !people.is_active_user_or_system_bot(user_id),
+            ),
+        };
+    });
+
+    return {
+        is_dm_narrow: true,
+        is_one_on_one_dm: user_ids.length === 1,
+        dm_users,
+    };
+}
 
 function get_message_view_header_context(filter: Filter | undefined): MessageViewHeaderContext {
     if (recent_view_util.is_visible()) {
@@ -129,6 +186,16 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
         };
     }
 
+    if (filter.has_operator("dm")) {
+        const user_ids = filter.terms_with_operator("dm")[0]!.operand;
+        if (user_ids.length > 0) {
+            return {
+                ...context,
+                ...get_dm_avatars_context(user_ids),
+            };
+        }
+    }
+
     return context;
 }
 
@@ -138,6 +205,114 @@ export function colorize_message_view_header(): void {
         return;
     }
     $("#message_view_header .navbar-icon").css("color", current_sub.color);
+}
+
+let dm_avatars_resize_observer: ResizeObserver | undefined;
+
+function disconnect_dm_avatars_resize_observer(): void {
+    if (dm_avatars_resize_observer !== undefined) {
+        dm_avatars_resize_observer.disconnect();
+        dm_avatars_resize_observer = undefined;
+    }
+}
+
+// Show as many DM participant avatars as fit the navbar, collapsing the
+// rest into a "+N" indicator whose tooltip lists the hidden users. This
+// runs on every navbar resize; see setup_dm_avatars_overflow.
+function relayout_dm_avatars(): void {
+    const header = $("#message_view_header")[0];
+    const container = $("#message_view_header .navbar-dm-avatars")[0];
+    if (!(header instanceof HTMLElement) || !(container instanceof HTMLElement)) {
+        return;
+    }
+    const avatars = [...container.querySelectorAll<HTMLElement>(".navbar-dm-avatar")];
+    const overflow = container.querySelector<HTMLElement>(".navbar-dm-avatar-overflow");
+    const names_template = container.querySelector<HTMLTemplateElement>(
+        "template.navbar-dm-avatar-overflow-names",
+    );
+    if (avatars.length === 0 || overflow === null || names_template === null) {
+        return;
+    }
+
+    // Start from the natural layout so we measure true widths: every
+    // avatar visible, the "+N" indicator hidden.
+    for (const avatar of avatars) {
+        avatar.classList.remove("hidden");
+    }
+    overflow.classList.add("hidden");
+
+    const gap = Number.parseFloat(window.getComputedStyle(container).columnGap) || 0;
+    const available = header.getBoundingClientRect().right - container.getBoundingClientRect().left;
+
+    let total_width = 0;
+    for (const [i, avatar] of avatars.entries()) {
+        total_width += avatar.offsetWidth + (i > 0 ? gap : 0);
+    }
+    if (total_width <= available) {
+        // Every avatar fits.
+        return;
+    }
+
+    // Reserve room for the "+N" indicator, using the widest count so the
+    // reservation can't be undersized, then fit as many avatars as we can.
+    overflow.classList.remove("hidden");
+    overflow.textContent = `+${avatars.length}`;
+    const reserved = overflow.offsetWidth + gap;
+
+    let used = 0;
+    let shown = 0;
+    for (const [i, avatar] of avatars.entries()) {
+        const width = avatar.offsetWidth + (i > 0 ? gap : 0);
+        if (used + width + reserved <= available) {
+            used += width;
+            shown += 1;
+        } else {
+            break;
+        }
+    }
+
+    shown = Math.max(shown, 1);
+
+    for (const [i, avatar] of avatars.entries()) {
+        avatar.classList.toggle("hidden", i >= shown);
+    }
+
+    const hidden_avatars = avatars.slice(shown);
+    overflow.textContent = `+${hidden_avatars.length}`;
+
+    const listed = hidden_avatars.slice(0, MAX_DM_OVERFLOW_TOOLTIP_NAMES);
+    const remaining = hidden_avatars.length - listed.length;
+    names_template.content.replaceChildren();
+    for (const avatar of listed) {
+        const chip = document.createElement("span");
+        chip.className = "navbar-dm-avatar-overflow-name";
+        chip.textContent = avatar.dataset["fullName"] ?? "";
+        names_template.content.append(chip);
+    }
+    if (remaining > 0) {
+        const more = document.createElement("span");
+        more.className = "navbar-dm-avatar-overflow-more";
+        more.textContent = $t(
+            {defaultMessage: "and {remaining, plural, one {1 other} other {# others}}"},
+            {remaining},
+        );
+        names_template.content.append(more);
+    }
+}
+
+function setup_dm_avatars_overflow(context: MessageViewHeaderContext): void {
+    disconnect_dm_avatars_resize_observer();
+    if (!context.is_dm_narrow) {
+        return;
+    }
+    const header = $("#message_view_header")[0];
+    if (!(header instanceof HTMLElement)) {
+        return;
+    }
+    dm_avatars_resize_observer = new ResizeObserver(() => {
+        relayout_dm_avatars();
+    });
+    dm_avatars_resize_observer.observe(header);
 }
 
 function append_and_display_title_area(context: MessageViewHeaderContext): void {
@@ -152,12 +327,16 @@ function append_and_display_title_area(context: MessageViewHeaderContext): void 
         // Update syntax like stream names, emojis, mentions, timestamps.
         rendered_markdown.update_elements($content);
     }
+    setup_dm_avatars_overflow(context);
 }
 
 function build_message_view_header(filter: Filter | undefined): void {
     // This makes sure we don't waste time appending
     // message_view_header on a template where it's never used
     if (filter && !filter.is_common_narrow()) {
+        // Leaving a DM narrow for a search view; stop watching for
+        // avatar overflow.
+        disconnect_dm_avatars_resize_observer();
         search.open_search_bar_and_close_narrow_description();
     } else {
         const context = get_message_view_header_context(filter);
@@ -257,7 +436,9 @@ export function maybe_update_navbar_title_for_user(modified_user_id: number): vo
         // header with render_title_area(), which would close or reset a
         // search bar the user has open to refine the narrow. For these
         // narrows the title is plain text and the icon doesn't depend on
-        // the renamed user.
+        // the renamed user. For a 1:1 DM this refreshes the name shown
+        // next to the avatar; group DMs render no name here, so it's a
+        // no-op for them.
         const title = filter.get_title();
         assert(title !== undefined);
         $("#message_view_header .message-header-navbar-title").text(title);

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -167,6 +167,25 @@ export function initialize(): void {
         target: ".tippy-zulip-tooltip",
     });
 
+    tippy.delegate("body", {
+        target: "#message_view_header .navbar-dm-avatar-image, #message_view_header .navbar-dm-avatar-overflow",
+        appendTo: () => document.body,
+        placement: "bottom",
+        onShow(instance) {
+            const {reference} = instance;
+            const content =
+                reference instanceof HTMLElement ? reference.dataset["tippyContent"] : undefined;
+            if (content !== undefined && content !== "") {
+                instance.setContent(content);
+            } else {
+                instance.setContent(get_tooltip_content(reference));
+            }
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
     // variant of tippy-zulip-tooltip above having delay=LONG_HOVER_DELAY,
     // default placement="top" with fallback placement="bottom",
     // and appended to body

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -907,6 +907,26 @@ function register_click_handlers(): void {
         },
     );
 
+    function open_dm_avatar_user_card(element: HTMLElement): void {
+        const user_id = Number.parseInt($(element).attr("data-user-id")!, 10);
+        const user = people.get_by_user_id(user_id);
+        toggle_user_card_popover(element, user);
+    }
+
+    $("#message_view_header").on("click", ".navbar-dm-avatar", function (this: HTMLElement, e) {
+        e.stopPropagation();
+        e.preventDefault();
+        open_dm_avatar_user_card(this);
+    });
+
+    $("#message_view_header").on("keydown", ".navbar-dm-avatar", function (this: HTMLElement, e) {
+        if (e.key === "Enter" || e.key === " ") {
+            e.stopPropagation();
+            e.preventDefault();
+            open_dm_avatar_user_card(this);
+        }
+    });
+
     /* These click handlers are implemented as just deep links to the
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -133,6 +133,145 @@
             animation: contract-extended-description 100ms ease-in both !important;
         }
     }
+
+    /* Participant avatars shown in place of the DM icon for DM
+       conversation views. */
+    .navbar-dm-avatars {
+        display: flex;
+        align-self: center;
+        align-items: center;
+        /* Breathing room between avatars; we don't expect horizontal
+           space to be a problem in the navbar. */
+        gap: 5px;
+        /* Vertical padding gives the presence dot, which sits ~0.5px
+           outside the avatar box, room so overflow: hidden doesn't clip
+           it. Horizontal overflow is hidden so avatars that don't fit
+           are clipped (then collapsed to "+N" by relayout_dm_avatars)
+           rather than spilling toward the search box. */
+        padding: 2px 4px;
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .navbar-dm-avatar {
+        /* Anchor the em context to 16px (as in the right sidebar) so
+           the avatar and presence dot render at the same sizes there. */
+        font-size: 1.1429em; /* 16px at 14px/1em */
+        position: relative;
+        display: inline-flex;
+        flex: none;
+        line-height: 1;
+
+        /* Avatars that don't fit are hidden by relayout_dm_avatars. The
+           compound selector is needed to win over `display: inline-flex`
+           above (the header's generic .hidden rule has equal
+           specificity but loses on source order). */
+        &.hidden {
+            display: none;
+        }
+
+        .navbar-dm-avatar-image {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            /* 28px at 16px/1em */
+            width: 1.75em;
+            height: 1.75em;
+            /* 6px at 16px/1em */
+            border-radius: 0.375em;
+            overflow: hidden;
+
+            & img {
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
+                display: block;
+            }
+
+            /* Placeholder shown for muted participants in place of the
+               avatar, matching how recent conversations hides muted
+               senders' avatars. */
+            & .fa-user {
+                font-size: 1em;
+                color: var(--color-text-message-view-header);
+                opacity: 0.6;
+            }
+        }
+
+        .navbar-dm-avatar-image:has(.fa-user) {
+            background-color: hsl(0deg 0% 50% / 20%);
+        }
+
+        /* Availability dot, sized to match the right sidebar in avatar
+           mode (right_sidebar.css .user_sidebar_entry.with_avatar
+           .user-circle). line-height: 1 keeps the header's tall
+           line-height from stretching the circle into an oval. */
+        .user-circle {
+            position: absolute;
+            /* 10px at 16px/1em */
+            font-size: 0.625em;
+            line-height: 1;
+            bottom: -0.5px;
+            right: -0.5px;
+            background-color: var(--color-background-navbar);
+            border: 1.5px solid var(--color-background-navbar);
+            border-radius: 50%;
+
+            &.user-circle-offline {
+                display: none;
+            }
+        }
+
+        /* Round the avatar's bottom-right corner behind a visible
+           presence dot, avoiding stray pixels bleeding past it. Only
+           applies when a non-offline dot is actually shown (muted
+           participants have no dot at all). */
+        &:has(.user-circle:not(.user-circle-offline)) .navbar-dm-avatar-image {
+            border-bottom-right-radius: 0.3875em; /* 6.2px at 16px/1em */
+        }
+    }
+
+    .navbar-dm-avatar-overflow {
+        align-self: center;
+        line-height: 1;
+        /* 16px at 14px/1em */
+        font-size: 1.1429em;
+        font-weight: 600;
+        /* Plain "+N" with no background and reduced opacity, matching
+           the recent conversations participant overflow. */
+        opacity: 0.7;
+        cursor: default;
+        white-space: nowrap;
+
+        &.hidden {
+            display: none;
+        }
+    }
+}
+
+/* Rounded name chips listed in the DM navbar avatar overflow ("+N")
+   tooltip. These live inside a Tippy popover rendered outside
+   #message_view_header, so the rules are not scoped to the header. */
+.navbar-dm-avatar-overflow-name,
+.navbar-dm-avatar-overflow-more {
+    display: block;
+}
+
+.navbar-dm-avatar-overflow-name {
+    border-radius: 4px;
+    padding: 1px 6px;
+    background-color: hsl(0deg 0% 100% / 12%);
+    white-space: nowrap;
+}
+
+.navbar-dm-avatar-overflow-name + .navbar-dm-avatar-overflow-name,
+.navbar-dm-avatar-overflow-more {
+    margin-top: 3px;
+}
+
+.navbar-dm-avatar-overflow-more {
+    opacity: 0.85;
+    font-size: 0.9em;
 }
 
 /* Media Queries */

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -161,6 +161,8 @@
         display: inline-flex;
         flex: none;
         line-height: 1;
+        cursor: pointer;
+        border-radius: 5px;
 
         /* Avatars that don't fit are hidden by relayout_dm_avatars. The
            compound selector is needed to win over `display: inline-flex`
@@ -168,6 +170,15 @@
            specificity but loses on source order). */
         &.hidden {
             display: none;
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--color-outline-focus);
+            outline-offset: 1px;
+        }
+
+        &:hover .navbar-dm-avatar-image {
+            opacity: 0.9;
         }
 
         .navbar-dm-avatar-image {

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -1,7 +1,7 @@
 {{#if is_dm_narrow}}
 <span class="navbar-dm-avatars">
     {{#each dm_users}}
-        <span class="navbar-dm-avatar" data-user-id="{{this.user_id}}" data-full-name="{{this.name}}">
+        <span class="navbar-dm-avatar" data-user-id="{{this.user_id}}" data-full-name="{{this.name}}" role="button" tabindex="0" aria-label="{{this.name}}">
             {{#if this.is_muted}}
             <span class="navbar-dm-avatar-image" data-tippy-content="{{this.name}}">
                 <i class="fa fa-user" aria-hidden="true"></i>

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -1,3 +1,27 @@
+{{#if is_dm_narrow}}
+<span class="navbar-dm-avatars">
+    {{#each dm_users}}
+        <span class="navbar-dm-avatar" data-user-id="{{this.user_id}}" data-full-name="{{this.name}}">
+            {{#if this.is_muted}}
+            <span class="navbar-dm-avatar-image" data-tippy-content="{{this.name}}">
+                <i class="fa fa-user" aria-hidden="true"></i>
+            </span>
+            {{else}}
+            <span class="navbar-dm-avatar-image avatar-preload-background" data-tippy-content="{{this.name}}">
+                <img loading="lazy" src="{{this.avatar_url}}" alt="" />
+            </span>
+            <span class="zulip-icon zulip-icon-{{this.user_circle_class}} {{this.user_circle_class}} user-circle" data-presence-indicator-user-id="{{this.user_id}}" aria-hidden="true"></span>
+            {{/if}}
+        </span>
+    {{/each}}
+    {{! The "+N" indicator and its participant list are populated by relayout_dm_avatars once we know how many avatars fit. }}
+    <span class="navbar-dm-avatar-overflow hidden" data-tooltip-template-id="navbar-dm-avatar-overflow-names" aria-hidden="true"></span>
+    <template id="navbar-dm-avatar-overflow-names" class="navbar-dm-avatar-overflow-names"></template>
+</span>
+{{#if is_one_on_one_dm}}
+<span class="message-header-navbar-title">{{title}}</span>
+{{/if}}
+{{else}}
 {{#if zulip_icon}}
 <i class="navbar-icon zulip-icon zulip-icon-{{zulip_icon}}" aria-hidden="true"></i>
 {{else if icon}}
@@ -15,4 +39,5 @@
         <i class="archived-indicator">({{t 'archived' }})</i>
     </span>
     {{/if}}
+{{/if}}
 {{/if}}

--- a/web/tests/message_view_header.test.cjs
+++ b/web/tests/message_view_header.test.cjs
@@ -1,0 +1,122 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_user} = require("./lib/example_user.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+const {page_params} = require("./lib/zpage_params.cjs");
+
+// message_view_header pulls in a number of peripheral modules that are
+// irrelevant to the DM avatar context logic we exercise here.
+mock_esm("../src/hash_util");
+mock_esm("../src/inbox_util");
+mock_esm("../src/narrow_state");
+mock_esm("../src/peer_data");
+mock_esm("../src/recent_view_util");
+mock_esm("../src/rendered_markdown", {update_elements: noop});
+mock_esm("../src/search", {
+    open_search_bar_and_close_narrow_description: noop,
+    close_search: noop,
+});
+mock_esm("../src/stream_data");
+
+const muted_users = zrequire("muted_users");
+const people = zrequire("people");
+const presence = zrequire("presence");
+const {set_current_user, set_realm} = zrequire("state_data");
+const {initialize_user_settings} = zrequire("user_settings");
+const message_view_header = zrequire("message_view_header");
+
+const user_settings = {presence_enabled: true};
+initialize_user_settings({user_settings});
+set_realm({});
+set_current_user({});
+
+const me = make_user({user_id: 1, full_name: "Myself", email: "me@example.com"});
+const alice = make_user({user_id: 2, full_name: "Alice", email: "alice@example.com"});
+const bob = make_user({user_id: 3, full_name: "Bob", email: "bob@example.com"});
+const cordelia = make_user({user_id: 4, full_name: "Cordelia", email: "cordelia@example.com"});
+const desdemona = make_user({user_id: 5, full_name: "Desdemona", email: "desdemona@example.com"});
+
+function test(label, f) {
+    run_test(label, (helpers) => {
+        page_params.is_spectator = false;
+        people.init();
+        presence.presence_info.clear();
+        for (const user of [me, alice, bob, cordelia, desdemona]) {
+            people.add_active_user(user);
+        }
+        people.initialize_current_user(me.user_id);
+        muted_users.set_muted_users([]);
+        f(helpers);
+    });
+}
+
+test("one_on_one_dm shows a single avatar and flags 1:1", () => {
+    const context = message_view_header.get_dm_avatars_context([alice.user_id]);
+    assert.equal(context.is_dm_narrow, true);
+    assert.equal(context.is_one_on_one_dm, true);
+    assert.deepEqual(
+        context.dm_users.map((u) => u.user_id),
+        [alice.user_id],
+    );
+    assert.equal(context.dm_users[0].name, "Alice");
+    assert.equal(context.dm_users[0].is_muted, false);
+    assert.equal(context.dm_users[0].avatar_url, `/avatar/${alice.user_id}`);
+});
+
+test("self dm is treated as a 1:1 conversation", () => {
+    const context = message_view_header.get_dm_avatars_context([me.user_id]);
+    assert.equal(context.is_one_on_one_dm, true);
+    assert.deepEqual(
+        context.dm_users.map((u) => u.user_id),
+        [me.user_id],
+    );
+});
+
+test("group dm returns every participant, ordered by display name", () => {
+    // Pass user ids out of name order to confirm they get sorted. Every
+    // participant is returned; how many render is decided responsively at
+    // layout time, not here.
+    const context = message_view_header.get_dm_avatars_context([
+        desdemona.user_id,
+        cordelia.user_id,
+        alice.user_id,
+        bob.user_id,
+    ]);
+    assert.equal(context.is_one_on_one_dm, false);
+    assert.deepEqual(
+        context.dm_users.map((u) => u.name),
+        ["Alice", "Bob", "Cordelia", "Desdemona"],
+    );
+});
+
+test("muted users are flagged and sorted as 'Muted user'", () => {
+    muted_users.set_muted_users([{id: alice.user_id, timestamp: 0}]);
+    const context = message_view_header.get_dm_avatars_context([alice.user_id, bob.user_id]);
+    // "Bob" sorts before "Muted user", so the muted Alice comes second.
+    // ("translated:" is the prefix added by the test i18n stub.)
+    assert.deepEqual(
+        context.dm_users.map((u) => ({name: u.name, is_muted: u.is_muted})),
+        [
+            {name: "Bob", is_muted: false},
+            {name: "translated: Muted user", is_muted: true},
+        ],
+    );
+});
+
+test("presence determines the user circle class", () => {
+    presence.presence_info.set(alice.user_id, {status: "active"});
+    presence.presence_info.set(bob.user_id, {status: "idle"});
+    // cordelia has no presence info, so she is offline.
+    const context = message_view_header.get_dm_avatars_context([
+        alice.user_id,
+        bob.user_id,
+        cordelia.user_id,
+    ]);
+    const class_by_name = new Map(context.dm_users.map((u) => [u.name, u.user_circle_class]));
+    assert.equal(class_by_name.get("Alice"), "user-circle-active");
+    assert.equal(class_by_name.get("Bob"), "user-circle-idle");
+    assert.equal(class_by_name.get("Cordelia"), "user-circle-offline");
+});


### PR DESCRIPTION
When we're viewing a direct message conversation, the top bar used to show a plain "direct message" icon next to the participants' names. This PR updates it to show the people themselves -- their avatars, each with a
little availability dot.

**What changed:**

- Shows the other person's avatar with their availability, alongside their name in 1:1 DMs.
- Shows the participants' avatars, and if there are more people than fit, the extras collapse into a small "+N" badge in group DMs. Hovering it reveals the full list of the remaining people. The number of avatars shown adapts automatically as the window resizes.
- Presence dots appear on avatars just like in the right sidebar, and are hidden when someone is offline.
- Avatars are listed in the same order as the names shown just below in the conversation, and hovering an avatar shows that person's name.
- The old direct message icon is dropped, since the avatars now serve as the visual cue for a DM view.

Discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/availability.20and.20status.20emoji.20in.20DM.20views/with/2326526

Fixes: https://github.com/zulip/zulip/issues/37078

<details>

<summary>Screenshorts</summary>

**Before:**

<img width="946" height="813" alt="image" src="https://github.com/user-attachments/assets/545729d0-66e2-4187-a943-569f7c57ddd2" />

<img width="946" height="813" alt="image" src="https://github.com/user-attachments/assets/8548ad83-22ac-47e1-9a05-87287c5822c1" />

<img width="946" height="813" alt="image" src="https://github.com/user-attachments/assets/88b8353d-430c-4960-871f-57177ad43ab2" />

<img width="424" height="789" alt="image" src="https://github.com/user-attachments/assets/faebb0ac-2b40-4e60-b9ba-811d2c354a6d" />

**After:**

<img width="952" height="758" alt="image" src="https://github.com/user-attachments/assets/197a289b-c6a9-4c93-89f7-ce13efe4a833" />

<img width="952" height="758" alt="image" src="https://github.com/user-attachments/assets/2e4ce179-641d-42d6-b15d-c99587ecf6f5" />

<img width="875" height="397" alt="image" src="https://github.com/user-attachments/assets/735f5372-9f35-4da9-bbdf-361dd4cbb8a7" />

<img width="330" height="225" alt="image" src="https://github.com/user-attachments/assets/ec810b35-1df8-4c89-8785-648e72d17158" /> 
<img width="448" height="455" alt="image" src="https://github.com/user-attachments/assets/4c867f0d-13c8-4589-b26b-3921356be8bd" />  
<img width="414" height="494" alt="image" src="https://github.com/user-attachments/assets/c0d607a2-45d2-492c-a957-2567ceb33ece" /> 
<img width="414" height="494" alt="image" src="https://github.com/user-attachments/assets/aedaf60e-cb25-4b37-bdf2-981538307dc8" />

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
