### PR TITLE
Allow send unsubscribed channels

### DIFF
--- a/api_docs/unmerged.d/ZF-916282.md
+++ b/api_docs/unmerged.d/ZF-916282.md
@@ -1,0 +1,6 @@
+* [`message`](/api/get-events#message) and
+  [`update_message`](/api/get-events#update_message): The sender of a message
+  to a channel they are not subscribed to now receives these events for their
+  own message and their own edits to it, with the `read` and `historical`
+  flags that fetching the message would report. Previously, such a user
+  received no event, because they have no `UserMessage` row for the message.

--- a/starlight_help/src/content/docs/configure-who-can-subscribe.mdx
+++ b/starlight_help/src/content/docs/configure-who-can-subscribe.mdx
@@ -29,7 +29,8 @@ subscribing.
   follow a [link to a
   conversation](/help/link-to-a-message-or-conversation#link-to-a-topic-within-zulip)
   in the private engineering channel, and read it without subscribing. They could
-  subscribe if they need to send a message there, without asking for help.
+  subscribe to get notified about replies to the conversation, without asking for
+  help.
 </ZulipTip>
 
 If you have permission to administer a public channel, you can configure who can

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -55,7 +55,6 @@ EXEMPT_FILES = make_set(
         "web/src/alert_words_ui.ts",
         "web/src/animate.ts",
         "web/src/assets.d.ts",
-        "web/src/attachments.ts",
         "web/src/attachments_ui.ts",
         "web/src/audible_notifications.ts",
         "web/src/avatar.ts",

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -314,17 +314,7 @@ export function initialize(): void {
     $("body").on("click", ".not-subscribed-banner .load-newer-messages-button", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const filter = narrow_state.filter();
-        if (filter === undefined) {
-            return;
-        }
-
-        message_view.show(filter.terms(), {
-            then_select_id: message_lists.current?.selected_id(),
-            then_select_offset: browser_history.current_scroll_offset(),
-            force_rerender: true,
-            trigger: "bookend load updates",
-        });
+        message_view.reload_current_narrow();
     });
 
     $("body").on("click", "#scroll-to-bottom-button-clickable-area", (e) => {

--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -19,6 +19,7 @@ import * as echo from "./echo.ts";
 import type {PostMessageAPIData} from "./echo.ts";
 import * as message_events from "./message_events.ts";
 import type {LocalMessage} from "./message_helper.ts";
+import * as message_view from "./message_view.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as onboarding_steps from "./onboarding_steps.ts";
 import * as reload from "./reload.ts";
@@ -26,6 +27,7 @@ import * as scheduled_messages from "./scheduled_messages.ts";
 import * as sent_messages from "./sent_messages.ts";
 import * as server_events_state from "./server_events_state.ts";
 import {current_user} from "./state_data.ts";
+import * as stream_data from "./stream_data.ts";
 import * as transmit from "./transmit.ts";
 import * as typing from "./typing.ts";
 import {user_settings} from "./user_settings.ts";
@@ -140,6 +142,16 @@ export function send_message_success(
     drafts.draft_model.deleteDrafts([sent_message.draft_id]);
 
     if (sent_message.type === "stream") {
+        if (!stream_data.is_subscribed(sent_message.stream_id)) {
+            // Channels you aren't subscribed to don't deliver live updates, so
+            // refresh the view to show the message in its current context, then
+            // warn that replies won't reach the user as notifications. The
+            // refresh clears message-sent banners, so it must run first.
+            message_view.maybe_reload_unsubscribed_channel_narrow(sent_message.stream_id);
+            compose_notifications.notify_sent_to_unsubscribed_channel(sent_message.stream_id);
+            return;
+        }
+
         if (data.automatic_new_visibility_policy) {
             if (!onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY.has("visibility_policy_banner")) {
                 return;

--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -26,6 +26,7 @@ import * as scheduled_messages from "./scheduled_messages.ts";
 import * as sent_messages from "./sent_messages.ts";
 import * as server_events_state from "./server_events_state.ts";
 import {current_user} from "./state_data.ts";
+import * as stream_data from "./stream_data.ts";
 import * as transmit from "./transmit.ts";
 import * as typing from "./typing.ts";
 import {user_settings} from "./user_settings.ts";
@@ -140,6 +141,8 @@ export function send_message_success(
     drafts.draft_model.deleteDrafts([sent_message.draft_id]);
 
     if (sent_message.type === "stream") {
+        const sent_to_unsubscribed_channel = !stream_data.is_subscribed(sent_message.stream_id);
+
         if (data.automatic_new_visibility_policy) {
             if (!onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY.has("visibility_policy_banner")) {
                 return;
@@ -150,6 +153,11 @@ export function send_message_success(
                 ...data,
                 automatic_new_visibility_policy: data.automatic_new_visibility_policy,
             });
+            return;
+        }
+
+        if (sent_to_unsubscribed_channel) {
+            compose_notifications.notify_sent_to_unsubscribed_channel(sent_message.stream_id);
             return;
         }
 

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -7,10 +7,7 @@ import render_stream_does_not_exist_error from "../templates/compose_banner/stre
 import render_topics_required_error_banner from "../templates/compose_banner/topics_required_error_banner.hbs";
 import render_unknown_zoom_user_error from "../templates/compose_banner/unknown_zoom_user_error.hbs";
 
-import {$t} from "./i18n.ts";
 import * as scroll_util from "./scroll_util.ts";
-import * as stream_data from "./stream_data.ts";
-import type {StreamSubscription} from "./sub_store.ts";
 
 export let scroll_to_message_banner_message_id: number | null = null;
 export function set_scroll_to_message_banner_message_id(val: number | null): void {
@@ -65,7 +62,6 @@ export const CLASSNAMES = {
     deactivated_user: "deactivated_user",
     topic_missing: "topic_missing",
     generic_compose_error: "generic_compose_error",
-    user_not_subscribed: "user_not_subscribed",
     unknown_zoom_user: "unknown_zoom_user",
 };
 
@@ -244,24 +240,6 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
 
     // Open stream select dropdown.
     $("#compose_select_recipient_widget").trigger("click");
-}
-
-export function show_stream_not_subscribed_error(
-    sub: StreamSubscription,
-    banner_text: string,
-): void {
-    const new_row_html = render_compose_banner({
-        banner_type: ERROR,
-        banner_text,
-        button_text: stream_data.can_toggle_subscription(sub)
-            ? $t({defaultMessage: "Subscribe"})
-            : null,
-        classname: CLASSNAMES.user_not_subscribed,
-        // The message cannot be sent until the user subscribes to the stream, so
-        // closing the banner would be more confusing than helpful.
-        hide_close_button: true,
-    });
-    append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
 }
 
 export function show_unknown_zoom_user_error(email: string): void {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -26,6 +26,7 @@ const MESSAGE_SENT_CLASSNAMES = {
     automatic_new_visibility_policy: "automatic_new_visibility_policy",
     jump_to_sent_message_conversation: "jump_to_sent_message_conversation",
     narrow_to_recipient: "narrow_to_recipient",
+    sent_to_unsubscribed_channel: "sent_to_unsubscribed_channel",
 };
 // Technically, unmute_topic_notification is a message sent banner, but
 // it has distinct behavior / look - it has an associated action button,

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -7,10 +7,7 @@ import render_stream_does_not_exist_error from "../templates/compose_banner/stre
 import render_topics_required_error_banner from "../templates/compose_banner/topics_required_error_banner.hbs";
 import render_unknown_zoom_user_error from "../templates/compose_banner/unknown_zoom_user_error.hbs";
 
-import {$t} from "./i18n.ts";
 import * as scroll_util from "./scroll_util.ts";
-import * as stream_data from "./stream_data.ts";
-import type {StreamSubscription} from "./sub_store.ts";
 
 export let scroll_to_message_banner_message_id: number | null = null;
 export function set_scroll_to_message_banner_message_id(val: number | null): void {
@@ -29,6 +26,7 @@ const MESSAGE_SENT_CLASSNAMES = {
     automatic_new_visibility_policy: "automatic_new_visibility_policy",
     jump_to_sent_message_conversation: "jump_to_sent_message_conversation",
     narrow_to_recipient: "narrow_to_recipient",
+    sent_to_unsubscribed_channel: "sent_to_unsubscribed_channel",
 };
 // Technically, unmute_topic_notification is a message sent banner, but
 // it has distinct behavior / look - it has an associated action button,
@@ -65,7 +63,6 @@ export const CLASSNAMES = {
     deactivated_user: "deactivated_user",
     topic_missing: "topic_missing",
     generic_compose_error: "generic_compose_error",
-    user_not_subscribed: "user_not_subscribed",
     unknown_zoom_user: "unknown_zoom_user",
 };
 
@@ -282,24 +279,6 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
 
     // Open stream select dropdown.
     $("#compose_select_recipient_widget").trigger("click");
-}
-
-export function show_stream_not_subscribed_error(
-    sub: StreamSubscription,
-    banner_text: string,
-): void {
-    const new_row_html = render_compose_banner({
-        banner_type: ERROR,
-        banner_text,
-        button_text: stream_data.can_toggle_subscription(sub)
-            ? $t({defaultMessage: "Subscribe"})
-            : null,
-        classname: CLASSNAMES.user_not_subscribed,
-        // The message cannot be sent until the user subscribes to the stream, so
-        // closing the banner would be more confusing than helpful.
-        hide_close_button: true,
-    });
-    append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
 }
 
 export function show_unknown_zoom_user_error(email: string): void {

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -5,6 +5,7 @@ import render_automatic_new_visibility_policy_banner from "../templates/compose_
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 import render_jump_to_sent_message_conversation_banner from "../templates/compose_banner/jump_to_sent_message_conversation_banner.hbs";
 import render_message_sent_banner from "../templates/compose_banner/message_sent_banner.hbs";
+import render_sent_to_unsubscribed_channel_banner from "../templates/compose_banner/sent_to_unsubscribed_channel.hbs";
 import render_unmute_topic_banner from "../templates/compose_banner/unmute_topic_banner.hbs";
 
 import * as blueslip from "./blueslip.ts";
@@ -74,6 +75,27 @@ export function notify_above_composebox(
     );
     // We pass in include_unmute_banner as false because we don't want to
     // clear any unmute_banner associated with this same message.
+    compose_banner.clear_message_sent_banners(false);
+    compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
+}
+
+export function notify_sent_to_unsubscribed_channel(stream_id: number): void {
+    // Sending to a channel you're not subscribed to is allowed, but you
+    // won't receive replies as notifications, so we warn the user and offer
+    // a one-click way to subscribe.
+    const sub = stream_data.get_sub_by_id(stream_id);
+    if (sub === undefined) {
+        return;
+    }
+    const $notification = $(
+        render_sent_to_unsubscribed_channel_banner({
+            classname: compose_banner.CLASSNAMES.sent_to_unsubscribed_channel,
+            stream: sub,
+            can_subscribe: stream_data.can_toggle_subscription(sub),
+        }),
+    );
+    // We pass include_unmute_banner as false because we don't want to clear
+    // any unmute banner associated with this same message.
     compose_banner.clear_message_sent_banners(false);
     compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
 }
@@ -268,6 +290,14 @@ export function notify_local_mixes(
         }
 
         const link_msg_id = message.id;
+
+        // Sending to a channel you aren't subscribed to shows its own banner
+        // (from compose.send_message_success, after the view is refreshed), so
+        // we suppress the redundant "Sent! Scroll down to view your message."
+        // banner for those messages.
+        const sent_to_unsubscribed_channel =
+            message.type === "stream" && !stream_data.is_subscribed(message.stream_id);
+
         const show_narrow_to_recipient_banner = should_show_narrow_to_recipient_banner(message);
         if (show_narrow_to_recipient_banner) {
             const banner_text = $t({
@@ -286,7 +316,7 @@ export function notify_local_mixes(
 
         const jump_to_sent_message_conversation = should_jump_to_sent_message_conversation(message);
         if (!jump_to_sent_message_conversation) {
-            if (need_user_to_scroll) {
+            if (need_user_to_scroll && !sent_to_unsubscribed_channel) {
                 show_scroll_to_view_banner(link_msg_id);
             }
 

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -5,6 +5,7 @@ import render_automatic_new_visibility_policy_banner from "../templates/compose_
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 import render_jump_to_sent_message_conversation_banner from "../templates/compose_banner/jump_to_sent_message_conversation_banner.hbs";
 import render_message_sent_banner from "../templates/compose_banner/message_sent_banner.hbs";
+import render_sent_to_unsubscribed_channel_banner from "../templates/compose_banner/sent_to_unsubscribed_channel.hbs";
 import render_unmute_topic_banner from "../templates/compose_banner/unmute_topic_banner.hbs";
 
 import * as blueslip from "./blueslip.ts";
@@ -74,6 +75,22 @@ export function notify_above_composebox(
     );
     // We pass in include_unmute_banner as false because we don't want to
     // clear any unmute_banner associated with this same message.
+    compose_banner.clear_message_sent_banners(false);
+    compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
+}
+
+export function notify_sent_to_unsubscribed_channel(stream_id: number): void {
+    const sub = stream_data.get_sub_by_id(stream_id);
+    if (sub === undefined) {
+        return;
+    }
+    const $notification = $(
+        render_sent_to_unsubscribed_channel_banner({
+            classname: compose_banner.CLASSNAMES.sent_to_unsubscribed_channel,
+            stream: sub,
+            can_subscribe: stream_data.can_toggle_subscription(sub),
+        }),
+    );
     compose_banner.clear_message_sent_banners(false);
     compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
 }
@@ -268,6 +285,10 @@ export function notify_local_mixes(
         }
 
         const link_msg_id = message.id;
+
+        const sent_to_unsubscribed_channel =
+            message.type === "stream" && !stream_data.is_subscribed(message.stream_id);
+
         const show_narrow_to_recipient_banner = should_show_narrow_to_recipient_banner(message);
         if (show_narrow_to_recipient_banner) {
             const banner_text = $t({
@@ -286,7 +307,7 @@ export function notify_local_mixes(
 
         const jump_to_sent_message_conversation = should_jump_to_sent_message_conversation(message);
         if (!jump_to_sent_message_conversation) {
-            if (need_user_to_scroll) {
+            if (need_user_to_scroll && !sent_to_unsubscribed_channel) {
                 show_scroll_to_view_banner(link_msg_id);
             }
 

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -38,6 +38,7 @@ import * as rows from "./rows.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
+import * as stream_settings_components from "./stream_settings_components.ts";
 import * as sub_store from "./sub_store.ts";
 import * as subscriber_api from "./subscriber_api.ts";
 import {get_timestamp_for_flatpickr} from "./timerender.ts";
@@ -65,6 +66,12 @@ function setup_compose_actions_hooks(): void {
 export function initialize(): void {
     // Register hooks for compose_actions.
     setup_compose_actions_hooks();
+
+    // Wire up the view refresh for edits in unsubscribed channels here, since
+    // message_edit cannot import message_view directly without a cycle.
+    message_edit.set_reload_unsubscribed_channel_narrow_after_edit(
+        message_view.maybe_reload_unsubscribed_channel_narrow,
+    );
 
     $(".compose-control-buttons-container .video_link").toggle(
         compose_call.compute_show_video_chat_button(),
@@ -181,6 +188,22 @@ export function initialize(): void {
             } else {
                 compose.finish();
             }
+        },
+    );
+
+    $("body").on(
+        "click",
+        `.${CSS.escape(
+            compose_banner.CLASSNAMES.sent_to_unsubscribed_channel,
+        )} .sent_to_unsubscribed_channel_subscribe_button`,
+        (event) => {
+            event.preventDefault();
+            const $button = $(event.currentTarget);
+            const stream_id = Number.parseInt($button.attr("data-stream-id")!, 10);
+            const sub = stream_data.get_sub_by_id(stream_id);
+            assert(sub !== undefined);
+            stream_settings_components.sub_or_unsub(sub);
+            $button.closest(".main-view-banner").remove();
         },
     );
 

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -38,7 +38,6 @@ import * as rows from "./rows.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
-import * as stream_settings_components from "./stream_settings_components.ts";
 import * as sub_store from "./sub_store.ts";
 import * as subscriber_api from "./subscriber_api.ts";
 import {get_timestamp_for_flatpickr} from "./timerender.ts";
@@ -182,26 +181,6 @@ export function initialize(): void {
             } else {
                 compose.finish();
             }
-        },
-    );
-
-    const user_not_subscribed_selector = `.${CSS.escape(
-        compose_banner.CLASSNAMES.user_not_subscribed,
-    )}`;
-    $("body").on(
-        "click",
-        `${user_not_subscribed_selector} .main-view-banner-action-button`,
-        (event) => {
-            event.preventDefault();
-
-            const stream_id = compose_state.stream_id();
-            if (stream_id === undefined) {
-                return;
-            }
-            const sub = stream_data.get_sub_by_id(stream_id);
-            assert(sub !== undefined);
-            stream_settings_components.sub_or_unsub(sub);
-            $(user_not_subscribed_selector).remove();
         },
     );
 

--- a/web/src/compose_setup.ts
+++ b/web/src/compose_setup.ts
@@ -214,23 +214,19 @@ export function initialize(): void {
         },
     );
 
-    const user_not_subscribed_selector = `.${CSS.escape(
-        compose_banner.CLASSNAMES.user_not_subscribed,
-    )}`;
     $("body").on(
         "click",
-        `${user_not_subscribed_selector} .main-view-banner-action-button`,
+        `.${CSS.escape(
+            compose_banner.CLASSNAMES.sent_to_unsubscribed_channel,
+        )} .sent_to_unsubscribed_channel_subscribe_button`,
         (event) => {
             event.preventDefault();
-
-            const stream_id = compose_state.stream_id();
-            if (stream_id === undefined) {
-                return;
-            }
+            const $button = $(event.currentTarget);
+            const stream_id = Number.parseInt($button.attr("data-stream-id")!, 10);
             const sub = stream_data.get_sub_by_id(stream_id);
             assert(sub !== undefined);
             stream_settings_components.sub_or_unsub(sub);
-            $(user_not_subscribed_selector).remove();
+            $button.closest(".main-view-banner").remove();
         },
     );
 

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -73,10 +73,6 @@ export const get_message_too_long_for_compose_error = (): string =>
         {max_length: realm.max_message_length},
     );
 export const NO_MESSAGE_CONTENT_ERROR_MESSAGE = $t({defaultMessage: "Compose a message."});
-export const UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE = $t({
-    defaultMessage:
-        "You're not subscribed to this channel. You will not be notified if other users reply to your message.",
-});
 export const CHANNEL_WILDCARD_ACKNOWLEDGE_MISSING_ERROR_TOOLTIP_MESSAGE = $t({
     defaultMessage: "Please acknowledge the warning to send the message.",
 });
@@ -881,14 +877,6 @@ function validate_permission_to_post_messages_in_stream(sub: StreamSubscription)
         compose_banner.show_stream_does_not_exist_error(sub.name);
         if (is_validating_compose_box) {
             disabled_send_tooltip_message_html = INVALID_CHANNEL_ERROR_TOOLTIP_MESSAGE;
-        }
-        return false;
-    }
-
-    if (!sub.subscribed) {
-        compose_banner.show_stream_not_subscribed_error(sub, UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE);
-        if (is_validating_compose_box) {
-            disabled_send_tooltip_message_html = UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE;
         }
         return false;
     }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -72,10 +72,6 @@ export const get_message_too_long_for_compose_error = (): string =>
         {max_length: realm.max_message_length},
     );
 export const NO_MESSAGE_CONTENT_ERROR_MESSAGE = $t({defaultMessage: "Compose a message."});
-export const UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE = $t({
-    defaultMessage:
-        "You're not subscribed to this channel. You will not be notified if other users reply to your message.",
-});
 export const CHANNEL_WILDCARD_ACKNOWLEDGE_MISSING_ERROR_TOOLTIP_MESSAGE = $t({
     defaultMessage: "Please acknowledge the warning to send the message.",
 });
@@ -871,14 +867,6 @@ function validate_permission_to_post_messages_in_stream(sub: StreamSubscription)
         compose_banner.show_stream_does_not_exist_error(sub.name);
         if (is_validating_compose_box) {
             disabled_send_tooltip_message_html = INVALID_CHANNEL_ERROR_TOOLTIP_MESSAGE;
-        }
-        return false;
-    }
-
-    if (!sub.subscribed) {
-        compose_banner.show_stream_not_subscribed_error(sub, UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE);
-        if (is_validating_compose_box) {
-            disabled_send_tooltip_message_html = UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE;
         }
         return false;
     }

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -291,6 +291,13 @@ export function insert_local_message(
 
     raw_local_message.display_recipient = build_display_recipient(raw_local_message);
 
+    if (
+        raw_local_message.type === "stream" &&
+        !stream_data.is_subscribed(raw_local_message.stream_id)
+    ) {
+        raw_local_message.flags = [...raw_local_message.flags, "historical"];
+    }
+
     const [message] = insert_new_messages({
         type: "local_message",
         raw_messages: [raw_local_message],

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -99,6 +99,19 @@ export let notify_old_thread_default = false;
 
 export let notify_new_thread_default = true;
 
+// Injected by compose_setup to avoid an import cycle with message_view. After
+// a successful edit in a channel you're viewing but not subscribed to, this
+// reloads the narrow, since such channels don't deliver live update events.
+let reload_unsubscribed_channel_narrow_after_edit: (stream_id: number) => void = () => {
+    // No-op until wired up at startup.
+};
+
+export function set_reload_unsubscribed_channel_narrow_after_edit(
+    reload: (stream_id: number) => void,
+): void {
+    reload_unsubscribed_channel_narrow_after_edit = reload;
+}
+
 export function is_topic_editable(message: Message, edit_limit_seconds_buffer = 0): boolean {
     if (!is_message_editable_ignoring_permissions(message)) {
         return false;
@@ -1394,6 +1407,10 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
             if (edit_locally_echoed) {
                 delete message.local_edit_timestamp;
                 currently_echoing_messages.delete(message_id);
+            }
+
+            if (stream_id !== undefined) {
+                reload_unsubscribed_channel_narrow_after_edit(stream_id);
             }
 
             // Ordinarily, in a code path like this, we'd make

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -68,6 +68,11 @@ import * as util from "./util.ts";
 // textarea element which has the modified content.
 // Storing textarea makes it easy to get the current content.
 export const currently_editing_messages = new Map<number, JQuery<HTMLTextAreaElement>>();
+// The raw content each open edit box started from. We can't rely on
+// message.raw_content here, since we deliberately don't cache raw_content for
+// messages in channels the user isn't subscribed to; see
+// message_store.maybe_update_raw_content.
+export const original_raw_content_being_edited = new Map<number, string>();
 const resized_edit_box_height = new Map<number, number>();
 let currently_topic_editing_message_ids: number[] = [];
 const currently_echoing_messages = new Map<number, EchoedMessageData>();
@@ -650,6 +655,7 @@ function edit_message($row: JQuery, raw_content: string): void {
     const $message_edit_content = $form.find<HTMLTextAreaElement>("textarea.message_edit_content");
     assert($message_edit_content.length === 1);
     currently_editing_messages.set(message.id, $message_edit_content);
+    original_raw_content_being_edited.set(message.id, raw_content);
     const previous_height = resized_edit_box_height.get(message.id);
     const do_autosize = previous_height === undefined;
     message_lists.current.show_edit_message($row, $form, do_autosize);
@@ -1144,6 +1150,7 @@ export function end_message_row_edit($row: JQuery): void {
     if (message !== undefined && currently_editing_messages.has(message.id)) {
         typing.stop_message_edit_notifications(message.id);
         currently_editing_messages.delete(message.id);
+        original_raw_content_being_edited.delete(message.id);
         resized_edit_box_height.delete(message.id);
         message_lists.current.hide_edit_message($row);
         compose_call_session_manager.abandon_session(message.id.toString());
@@ -1178,6 +1185,7 @@ export function end_message_edit(message_id: number): void {
         // We should delete the message_id from currently_editing_messages
         // if it exists there but we cannot find the row.
         currently_editing_messages.delete(message_id);
+        original_raw_content_being_edited.delete(message_id);
     }
 }
 
@@ -1319,7 +1327,7 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
     let edit_locally_echoed = false;
 
     let new_content;
-    const old_content = message.raw_content;
+    const old_content = original_raw_content_being_edited.get(message_id) ?? message.raw_content;
     assert(old_content !== undefined);
 
     const $edit_content_input = $row.find<HTMLTextAreaElement>("textarea.message_edit_content");
@@ -1377,7 +1385,7 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
         currently_echoing_messages.set(message_id, {
             raw_content: new_content ?? "",
             orig_content: message.content,
-            orig_raw_content: message.raw_content ?? "",
+            orig_raw_content: old_content,
             starred: message.starred,
             historical: message.historical,
             collapsed: message.collapsed,

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -111,6 +111,16 @@ export function reload_current_narrow(): void {
     });
 }
 
+// After sending or editing a message in a channel you're viewing but not
+// subscribed to, reload the narrow so the change (and any updates missed while
+// unsubscribed) appears. No-op unless that channel is the current narrow.
+export function maybe_reload_unsubscribed_channel_narrow(stream_id: number): void {
+    if (stream_data.is_subscribed(stream_id) || narrow_state.stream_id() !== stream_id) {
+        return;
+    }
+    reload_current_narrow();
+}
+
 export function changehash(
     newhash: string,
     trigger: string,

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -95,6 +95,22 @@ export function reset_ui_state(opts: {trigger?: string}): void {
     compose_banner.clear_message_sent_banners(true, skip_automatic_new_visibility_policy_banner);
 }
 
+// Reload the current narrow from the server, preserving the user's scroll
+// position. This is how we pull in updates for a channel that doesn't deliver
+// live events to this client (e.g. one you're viewing but not subscribed to).
+export function reload_current_narrow(): void {
+    const filter = narrow_state.filter();
+    if (filter === undefined) {
+        return;
+    }
+    show(filter.terms(), {
+        then_select_id: message_lists.current?.selected_id(),
+        then_select_offset: browser_history.current_scroll_offset(),
+        force_rerender: true,
+        trigger: "reload current narrow",
+    });
+}
+
 export function changehash(
     newhash: string,
     trigger: string,

--- a/web/templates/compose_banner/sent_to_unsubscribed_channel.hbs
+++ b/web/templates/compose_banner/sent_to_unsubscribed_channel.hbs
@@ -1,0 +1,14 @@
+<div class="above_compose_banner main-view-banner warning {{classname}}">
+    <p class="banner_content">
+        {{#tr}}
+            Sent! Because you aren't subscribed to <z-channel></z-channel>, you won't be notified if other users reply to your message.
+            {{#*inline "z-channel"}}{{> ../decorated_channel_name stream=stream inline_with_text=true show_colored_icon=false}}{{/inline}}
+        {{/tr}}
+    </p>
+    {{#if can_subscribe}}
+    <button class="action-button action-button-subtle-warning sent_to_unsubscribed_channel_subscribe_button" data-stream-id="{{stream.stream_id}}" type="button">
+        <span class="action-button-label">{{t "Subscribe"}}</span>
+    </button>
+    {{/if}}
+    <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button" tabindex="0" aria-label="{{t 'Dismiss' }}"></a>
+</div>

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -42,6 +42,9 @@ const compose_notifications = mock_esm("../src/compose_notifications");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 const loading = mock_esm("../src/loading");
 const markdown = mock_esm("../src/markdown");
+const message_view = mock_esm("../src/message_view", {
+    maybe_reload_unsubscribed_channel_narrow: noop,
+});
 const narrow_state = mock_esm("../src/narrow_state");
 const rendered_markdown = mock_esm("../src/rendered_markdown");
 const resize = mock_esm("../src/resize");
@@ -174,6 +177,14 @@ function simulate_draft_ui_interactions() {
 
 test_ui("send_message_success", ({override, override_rewire}) => {
     mock_banners();
+
+    // These code paths apply to channels the user is subscribed to; sending to
+    // an unsubscribed channel is covered by a separate test.
+    for (const stream_id of [1, 2]) {
+        const sub = make_stream({stream_id, name: `stream ${stream_id}`});
+        sub.subscribed = true;
+        stream_data.add_sub_for_tests(sub);
+    }
 
     const fake_compose_box = new FakeComposeBox();
 
@@ -418,6 +429,54 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.ok(fake_compose_box.is_textarea_focused());
         assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
     })();
+});
+
+test_ui("send_message_success_to_unsubscribed_channel", ({override, override_rewire, disallow}) => {
+    const subbed = make_stream({stream_id: 201, name: "subbed"});
+    subbed.subscribed = true;
+    const unsubbed = make_stream({stream_id: 202, name: "unsubbed"});
+    unsubbed.subscribed = false;
+    stream_data.add_sub_for_tests(subbed);
+    stream_data.add_sub_for_tests(unsubbed);
+
+    override_rewire(echo, "reify_message_id", noop);
+    override(drafts.draft_model, "deleteDrafts", noop);
+    // Reached only for the subscribed channel; the unsubscribed path returns
+    // before the muted-narrow / visibility-policy handling.
+    override(compose_notifications, "get_muted_narrow", () => undefined);
+    disallow(compose_notifications, "notify_automatic_new_visibility_policy");
+
+    let reloaded_stream_id;
+    let banner_stream_id;
+    override(message_view, "maybe_reload_unsubscribed_channel_narrow", (stream_id) => {
+        reloaded_stream_id = stream_id;
+    });
+    override(compose_notifications, "notify_sent_to_unsubscribed_channel", (stream_id) => {
+        banner_stream_id = stream_id;
+    });
+
+    const base = {
+        type: "stream",
+        topic: "topic",
+        local_id: "123.04",
+        locally_echoed: true,
+        draft_id: 100,
+    };
+
+    // Subscribed channel: the unsubscribed-channel banner and refresh are not used.
+    compose.send_message_success({...base, stream_id: subbed.stream_id}, {id: 1});
+    assert.equal(reloaded_stream_id, undefined);
+    assert.equal(banner_stream_id, undefined);
+
+    // Unsubscribed channel: we refresh the view and warn the user. Passing an
+    // automatic_new_visibility_policy that is then ignored confirms we return
+    // before the normal stream-message handling.
+    compose.send_message_success(
+        {...base, stream_id: unsubbed.stream_id},
+        {id: 2, automatic_new_visibility_policy: 2},
+    );
+    assert.equal(reloaded_stream_id, unsubbed.stream_id);
+    assert.equal(banner_stream_id, unsubbed.stream_id);
 });
 
 test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -175,6 +175,12 @@ function simulate_draft_ui_interactions() {
 test_ui("send_message_success", ({override, override_rewire}) => {
     mock_banners();
 
+    for (const stream_id of [1, 2]) {
+        const sub = make_stream({stream_id, name: `stream ${stream_id}`});
+        sub.subscribed = true;
+        stream_data.add_sub_for_tests(sub);
+    }
+
     const fake_compose_box = new FakeComposeBox();
 
     let draft_deleted;
@@ -418,6 +424,69 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.ok(fake_compose_box.is_textarea_focused());
         assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
     })();
+});
+
+test_ui("send_message_success_to_unsubscribed_channel", ({override, override_rewire}) => {
+    const subbed = make_stream({stream_id: 201, name: "subbed"});
+    subbed.subscribed = true;
+    const unsubbed = make_stream({stream_id: 202, name: "unsubbed"});
+    unsubbed.subscribed = false;
+    stream_data.add_sub_for_tests(subbed);
+    stream_data.add_sub_for_tests(unsubbed);
+
+    override_rewire(echo, "reify_message_id", noop);
+    override(drafts.draft_model, "deleteDrafts", noop);
+    override(
+        onboarding_steps,
+        "ONE_TIME_NOTICES_TO_DISPLAY",
+        new Set(["visibility_policy_banner"]),
+    );
+    override(compose_notifications, "get_muted_narrow", () => undefined);
+
+    let unsubscribed_banner_stream_id;
+    override(compose_notifications, "notify_sent_to_unsubscribed_channel", (stream_id) => {
+        unsubscribed_banner_stream_id = stream_id;
+    });
+    let visibility_policy_stream_id;
+    override(compose_notifications, "notify_automatic_new_visibility_policy", (message) => {
+        visibility_policy_stream_id = message.stream_id;
+    });
+
+    const base = {
+        type: "stream",
+        topic: "topic",
+        local_id: "123.04",
+        locally_echoed: true,
+        draft_id: 100,
+    };
+
+    unsubscribed_banner_stream_id = undefined;
+    compose.send_message_success({...base, stream_id: subbed.stream_id}, {id: 1});
+    assert.equal(unsubscribed_banner_stream_id, undefined);
+
+    unsubscribed_banner_stream_id = undefined;
+    compose.send_message_success({...base, stream_id: unsubbed.stream_id}, {id: 2});
+    assert.equal(unsubscribed_banner_stream_id, unsubbed.stream_id);
+
+    unsubscribed_banner_stream_id = undefined;
+    visibility_policy_stream_id = undefined;
+    compose.send_message_success(
+        {...base, stream_id: unsubbed.stream_id},
+        {id: 3, automatic_new_visibility_policy: 2},
+    );
+    assert.equal(visibility_policy_stream_id, unsubbed.stream_id);
+    assert.equal(unsubscribed_banner_stream_id, undefined);
+
+    mock_banners();
+    const fake_compose_box = new FakeComposeBox();
+
+    unsubscribed_banner_stream_id = undefined;
+    compose.send_message_success(
+        {...base, stream_id: unsubbed.stream_id, locally_echoed: false},
+        {id: 4},
+    );
+    assert.equal(unsubscribed_banner_stream_id, unsubbed.stream_id);
+    assert.equal(fake_compose_box.textarea_val(), "");
 });
 
 test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -452,24 +452,11 @@ test_ui("test_stream_posting_permission", ({mock_template, override}) => {
     compose_state.topic("topic102");
     compose_state.set_stream_id(sub_stream_102.stream_id);
 
+    // Being unsubscribed is no longer a barrier to sending: as long as the
+    // user is allowed to post, validation passes and we let them send. If
+    // they aren't allowed to post, we show the regular no-permission error
+    // regardless of subscription status.
     sub_stream_102.subscribed = false;
-    let user_not_subscribed_rendered = false;
-    mock_template("compose_banner/compose_banner.hbs", false, (data) => {
-        assert.equal(data.classname, compose_banner.CLASSNAMES.user_not_subscribed);
-        assert.equal(
-            data.banner_text,
-            $t({
-                defaultMessage:
-                    "You're not subscribed to this channel. You will not be notified if other users reply to your message.",
-            }),
-        );
-        user_not_subscribed_rendered = true;
-        return "<banner-stub>";
-    });
-    assert.ok(!compose_validate.validate());
-    assert.ok(user_not_subscribed_rendered);
-
-    sub_stream_102.subscribed = true;
 
     let banner_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -453,23 +453,6 @@ test_ui("test_stream_posting_permission", ({mock_template, override}) => {
     compose_state.set_stream_id(sub_stream_102.stream_id);
 
     sub_stream_102.subscribed = false;
-    let user_not_subscribed_rendered = false;
-    mock_template("compose_banner/compose_banner.hbs", false, (data) => {
-        assert.equal(data.classname, compose_banner.CLASSNAMES.user_not_subscribed);
-        assert.equal(
-            data.banner_text,
-            $t({
-                defaultMessage:
-                    "You're not subscribed to this channel. You will not be notified if other users reply to your message.",
-            }),
-        );
-        user_not_subscribed_rendered = true;
-        return "<banner-stub>";
-    });
-    assert.ok(!compose_validate.validate());
-    assert.ok(user_not_subscribed_rendered);
-
-    sub_stream_102.subscribed = true;
 
     let banner_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -354,6 +354,42 @@ run_test("insert_local_message streams", ({override}) => {
     assert.ok(insert_message_called);
 });
 
+run_test("insert_local_message to an unsubscribed channel is historical", ({override}) => {
+    const unsubscribed_sub = make_stream({
+        stream_id: 202,
+        name: "unsubscribed",
+        subscribed: false,
+    });
+    stream_data.add_sub_for_tests(unsubscribed_sub);
+
+    override(markdown, "render", () => ({content: "<p>hi</p>", flags: [], is_me_message: false}));
+    override(markdown, "get_topic_links", () => []);
+
+    function echoed_flags(stream_id, local_id_float) {
+        let flags;
+        const insert_new_messages = (message_data) => {
+            [{flags}] = message_data.raw_messages;
+            return message_data.raw_messages;
+        };
+        echo.insert_local_message(
+            {
+                type: "stream",
+                stream_id,
+                topic: "greeting",
+                sender_email: "iago@zulip.com",
+                sender_full_name: "Iago",
+                sender_id: 123,
+            },
+            local_id_float,
+            insert_new_messages,
+        );
+        return flags;
+    }
+
+    assert.ok(echoed_flags(unsubscribed_sub.stream_id, 102.01).includes("historical"));
+    assert.ok(!echoed_flags(general_sub.stream_id, 103.01).includes("historical"));
+});
+
 run_test("insert_local_message direct message", ({override}) => {
     const local_id_float = 102.01;
 

--- a/web/tests/lib/compose_helpers.cjs
+++ b/web/tests/lib/compose_helpers.cjs
@@ -41,9 +41,6 @@ class FakeComposeBox {
         $(".message-limit-indicator").html("");
         $(".message-limit-indicator").text("");
 
-        $.reset_selector("#compose_banners .user_not_subscribed");
-        $.set_results("#compose_banners .user_not_subscribed", []);
-
         this.$content_textarea.set_height(50);
         this.$content_textarea.val("default message");
         this.$content_textarea.trigger("blur");

--- a/web/tests/message_edit.test.cjs
+++ b/web/tests/message_edit.test.cjs
@@ -4,14 +4,25 @@ const assert = require("node:assert/strict");
 
 const {make_realm} = require("./lib/example_realm.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
+
+const stream_data = mock_esm("../src/stream_data");
+const channel = mock_esm("../src/channel");
+const compose_tooltips = mock_esm("../src/compose_tooltips");
+const compose_validate = mock_esm("../src/compose_validate");
+const markdown = mock_esm("../src/markdown");
+const message_lists = mock_esm("../src/message_lists");
+const rows = mock_esm("../src/rows");
+mock_esm("../src/loading", {show_button_spinner: noop});
+mock_esm("../src/compose_banner", {
+    get_compose_banner_container: () => $.create("banner-container"),
+});
 
 const message_edit = zrequire("message_edit");
 const {set_current_user, set_realm} = zrequire("state_data");
 
 const is_content_editable = message_edit.is_content_editable;
-
-const stream_data = mock_esm("../src/stream_data");
 
 const realm = make_realm();
 set_realm(realm);
@@ -303,4 +314,61 @@ run_test("stream_and_topic_exist_in_edit_history", () => {
         ),
         false,
     );
+});
+
+run_test("save_message_row_edit without cached raw_content", async ({override}) => {
+    // We don't cache raw_content for messages in channels the user isn't
+    // subscribed to, so the edit box's original content is the only copy we
+    // have; saving must not depend on message.raw_content being present.
+    const message_id = 1001;
+    const stream_id = 55;
+    const original_content = "before";
+
+    const message = {
+        id: message_id,
+        type: "stream",
+        stream_id,
+        sent_by_me: true,
+        raw_content: undefined,
+        content: "<p>before</p>",
+    };
+
+    const $textarea = $.create("edit-content-textarea");
+    $textarea.val("after");
+    $textarea.attr("readonly", undefined);
+    const $row = $.create("edit-row");
+    $row.set_find_results("textarea.message_edit_content", $textarea);
+    $row.set_find_results(".message_edit_form textarea", $textarea);
+    $row.set_find_results(".message_edit_save_container", $.create("save-container"));
+    $row.set_find_results(".message_edit_save", $.create("save-button"));
+    $row.set_find_results(".message_edit_save span", $.create("save-button-span"));
+    $row.set_find_results(".message_edit_cancel", $.create("cancel-button"));
+    $row.set_find_results(".loader", $.create("edit-loader"));
+
+    override(compose_tooltips, "hide_compose_control_button_tooltips", noop);
+    override(rows, "id", () => message_id);
+    override(rows, "get_message_recipient_header", () => ({
+        attr: () => stream_id.toString(),
+    }));
+    message_lists.current = {
+        get: () => message,
+    };
+    override(compose_validate, "validate_stream_message_mentions", () => true);
+    override(markdown, "contains_backend_only_syntax", () => true);
+
+    let patched;
+    override(channel, "patch", (opts) => {
+        patched = opts;
+        opts.success({detached_uploads: []});
+    });
+
+    message_edit.original_raw_content_being_edited.set(message_id, original_content);
+
+    await message_edit.save_message_row_edit($row);
+
+    assert.ok(patched !== undefined);
+    assert.equal(patched.url, "/json/messages/" + message_id);
+    assert.equal(patched.data.content, "after");
+
+    message_edit.original_raw_content_being_edited.clear();
 });

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -63,6 +63,7 @@ from zerver.lib.streams import (
     check_stream_access_based_on_can_send_message_group,
     get_stream_topics_policy,
     notify_stream_is_recently_active_update,
+    subscribed_to_stream,
 )
 from zerver.lib.string_validation import check_stream_topic
 from zerver.lib.thumbnail import manifest_and_get_user_upload_previews, rewrite_thumbnailed_images
@@ -1332,6 +1333,18 @@ def do_update_message(
 
         if not sender.is_bot and sender not in users_losing_access and is_target_message_first:
             apply_automatic_unmute_follow_topics_policy(sender, target_stream, target_topic)
+
+    if (
+        all(user["id"] != user_profile.id for user in users_to_be_notified)
+        and not user_profile.is_bot
+        and not subscribed_to_stream(user_profile, stream_being_edited.id)
+    ):
+        # The acting user can edit a message in a channel they aren't
+        # subscribed to, in which case they have no UserMessage row and are
+        # not covered by the subscriber logic above, so they would not hear
+        # about their own edit. Notify them, using the flags that fetching
+        # this message would report.
+        users_to_be_notified.append({"id": user_profile.id, "flags": ["read", "historical"]})
 
     send_event_on_commit(user_profile.realm, event, users_to_be_notified)
 

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1214,6 +1214,20 @@ def do_send_messages(
         user_ids = send_request.active_user_ids | set(user_flags.keys())
         sender_id = send_request.message.sender_id
 
+        if (
+            send_request.message.is_channel_message
+            and sender_id not in user_ids
+            and not send_request.message.sender.is_bot
+        ):
+            # One can send to a channel without being subscribed to it, in
+            # which case the sender gets no UserMessage row and so would not
+            # otherwise hear about their own message. Send them the event
+            # anyway, so their client can display the message without having
+            # to refetch it. We use the flags that fetching this message
+            # would report, since that is what the message is for them.
+            user_ids.add(sender_id)
+            user_flags[sender_id] = ["read", "historical"]
+
         # We make sure the sender is listed first in the `users` list;
         # this results in the sender receiving the message first if
         # there are thousands of recipients, decreasing perceived latency.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1097,6 +1097,12 @@ paths:
                               description: |
                                 Event type for messages.
 
+                                **Changes**: In Zulip 13.0 (feature level ZF-916282),
+                                the sender of a message to a channel they are not
+                                subscribed to receives this event for their own
+                                message; previously they received no event, since
+                                they have no `UserMessage` row for it.
+
                                 **Changes**: In Zulip 3.1 (feature level 26), the
                                 `sender_short_name` field was removed from message
                                 objects.
@@ -2800,6 +2806,12 @@ paths:
                                 message.
 
                                 [inline-url-previews]: https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html#inline-url-previews
+
+                                **Changes**: In Zulip 13.0 (feature level ZF-916282),
+                                a user editing a message in a channel they are not
+                                subscribed to receives this event for their own edit;
+                                previously they received no event, since they have no
+                                `UserMessage` row for the message.
 
                                 **Changes**: In Zulip 10.0 (feature level 284), removed the
                                 `prev_rendered_content_version` field as it is an internal

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -220,6 +220,38 @@ class EditMessageTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(Message.objects.get(id=msg_id).topic_name(), "edited")
 
+    def test_unsubscribed_editor_gets_update_message_event(self) -> None:
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        stream_name = "Test stream"
+        self.subscribe(cordelia, stream_name)
+        self.login("hamlet")
+
+        msg_id = self.send_stream_message(
+            hamlet,
+            stream_name,
+            topic_name="editing",
+            content="before edit",
+            allow_unsubscribed_sender=True,
+        )
+        self.assertFalse(
+            UserMessage.objects.filter(user_profile=hamlet, message_id=msg_id).exists()
+        )
+
+        # Hamlet has no UserMessage row for a channel he isn't subscribed to,
+        # so the subscriber logic doesn't cover him; we notify him anyway, so
+        # his client sees his own edit.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            result = self.client_patch(
+                f"/json/messages/{msg_id}",
+                {"content": "after edit"},
+            )
+        self.assert_json_success(result)
+
+        users = {user["id"]: user for user in events[0]["users"]}
+        self.assertIn(hamlet.id, users)
+        self.assertEqual(sorted(users[hamlet.id]["flags"]), ["historical", "read"])
+
     def test_fetch_message_from_id(self) -> None:
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2195,6 +2195,33 @@ class StreamMessagesTest(ZulipTestCase):
         user_ids = {u["id"] for u in users}
         return user_ids
 
+    def test_unsubscribed_sender_gets_message_event(self) -> None:
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        stream_name = "Test stream"
+        self.subscribe(cordelia, stream_name)
+
+        # Hamlet isn't subscribed, so he gets no UserMessage row for his own
+        # message; we still send him the event, so his client can display it.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            self.send_stream_message(
+                hamlet,
+                stream_name,
+                content="test",
+                allow_unsubscribed_sender=True,
+                skip_capture_on_commit_callbacks=True,
+            )
+
+        users = {user["id"]: user for user in events[0]["users"]}
+        self.assertIn(hamlet.id, users)
+        # These are the flags fetching this message would report for him.
+        self.assertEqual(sorted(users[hamlet.id]["flags"]), ["historical", "read"])
+        self.assertFalse(
+            UserMessage.objects.filter(
+                user_profile=hamlet, message_id=events[0]["event"]["message"]
+            ).exists()
+        )
+
     def test_unsub_mention(self) -> None:
         cordelia = self.example_user("cordelia")
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_muted_users.py
+++ b/zerver/tests/test_muted_users.py
@@ -346,9 +346,13 @@ class MutedUsersTests(ZulipTestCase):
                     ),
                 )
             self.assert_json_success(result)
-            m.assert_called_once()
+            considered_user_ids = {
+                call[1]["user_notifications_data"].user_id for call in m.call_args_list
+            }
             # `maybe_enqueue_notifications` was called for Hamlet after message edit mentioned him.
-            self.assertEqual(m.call_args_list[0][1]["user_notifications_data"].user_id, hamlet.id)
+            # It is also called for Cordelia, who receives the event for her own edit since she
+            # isn't subscribed to the channel, but a user is never notified about their own edit.
+            self.assertEqual(considered_user_ids, {hamlet.id, cordelia.id})
 
         # Hamlet mutes Cordelia.
         self.login("hamlet")


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Fixes: https://github.com/zulip/zulip/issues/35902 ~~https://github.com/zulip/zulip/issues/21433 ~~

**How changes were tested:**
Lets users send messages to channels they aren't subscribed to (the server
already allows this where the posting policy permits). Removes the blocking
"You're not subscribed to this channel." banner and disabled Send button.

After a send (or edit) to a channel you're viewing but not subscribed to, the
view is refreshed these channels get no live updates so your message shows
in context, and a warning banner appears: "Sent! Because you aren't subscribed
to {channel}, you won't be notified if other users reply to your message." with
a Subscribe button. The redundant "Scroll down to view your message." banner is
suppressed. Users who lack posting permission still get the standard
no-permission UI.

Supersedes #34610.

Relevant CZOs:
1. [#mobile > Message sending in unsubscribed channels](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Message.20sending.20in.20unsubscribed.20channels/with/2232562)[#mobile > Message sending in unsubscribed channels](https://chat.zulip.org/#narrow/channel/48-mobile/topic/Message.20sending.20in.20unsubscribed.20channels/with/2232562)
2. [#design > send to unsubscribed stream](https://chat.zulip.org/#narrow/channel/101-design/topic/send.20to.20unsubscribed.20stream/with/1318205)[#design > send to unsubscribed stream](https://chat.zulip.org/#narrow/channel/101-design/topic/send.20to.20unsubscribed.20stream/with/1318205)
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="828" height="1248" alt="image" src="https://github.com/user-attachments/assets/9f921672-6303-40c5-928c-35854a63d8c6" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
