### PR TITLE
markdown: Fix channel links pasted into hyperlink URL placeholder.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -152,6 +152,12 @@ def verbose_compile(pattern: str) -> Pattern[str]:
     )
 
 
+# Matches the end of the `](` that opens the URL placeholder of
+# Markdown hyperlink syntax, allowing the whitespace that Markdown
+# permits there. Used to detect a prettified link pasted into that
+# placeholder; see `is_in_link_url_placeholder`.
+LINK_URL_PLACEHOLDER_PREFIX_REGEX = re.compile(r"\]\(\s*\Z")
+
 STREAM_LINK_REGEX = rf"""
                      {BEFORE_LINK_PRODUCING_MENTION_ALLOWED_REGEX} # Start after whitespace or specified chars
                      \#\*\*                         # and after hash sign followed by double asterisks
@@ -1770,6 +1776,17 @@ class StreamTopicMessageProcessor(CompiledInlineProcessor):
         stream_id = db_data.stream_names.get(name)
         return stream_id
 
+    def is_in_link_url_placeholder(self, m: Match[str], data: str) -> bool:
+        # A prettified link like `#**stream**` is normally rendered
+        # as its own `<a>` element. But if it was pasted into the
+        # URL placeholder of Markdown hyperlink syntax, e.g.
+        # `[label](#**stream**)`, it needs to be resolved to a plain
+        # URL string instead, so that the outer `[label](...)` link
+        # (handled separately, at lower priority, by
+        # `LinkInlineProcessor`) renders correctly instead of being
+        # clobbered by a nested `<a>` element.
+        return LINK_URL_PLACEHOLDER_PREFIX_REGEX.search(data, 0, m.start()) is not None
+
 
 class StreamPattern(StreamTopicMessageProcessor):
     @override
@@ -1781,16 +1798,21 @@ class StreamPattern(StreamTopicMessageProcessor):
         stream_id = self.find_stream_id(name)
         if stream_id is None:
             return None, None, None
-        el = Element("a")
-        el.set("class", "stream")
-        el.set("data-stream-id", str(stream_id))
         # TODO: We should quite possibly not be specifying the
         # href here and instead having the browser auto-add the
         # href when it processes a message with one of these, to
         # provide more clarity to API clients.
         # Also do the same for StreamTopicPattern.
         stream_url = encode_channel(stream_id, name)
-        el.set("href", f"/#narrow/channel/{stream_url}")
+        link = f"/#narrow/channel/{stream_url}"
+
+        if self.is_in_link_url_placeholder(m, data):
+            return link, m.start(), m.end()
+
+        el = Element("a")
+        el.set("class", "stream")
+        el.set("data-stream-id", str(stream_id))
+        el.set("href", link)
         text = f"#{name}"
         el.text = markdown.util.AtomicString(text)
         return el, m.start(), m.end()
@@ -1814,9 +1836,6 @@ class StreamTopicPattern(StreamTopicMessageProcessor):
         stream_id = self.find_stream_id(stream_name)
         if stream_id is None or topic_name is None:
             return None, None, None
-        el = Element("a")
-        el.set("class", "stream-topic")
-        el.set("data-stream-id", str(stream_id))
         stream_url = encode_channel(stream_id, stream_name)
         topic_url = encode_hash_component(topic_name)
         channel_topic_object = ChannelTopicInfo(stream_name, topic_name)
@@ -1826,6 +1845,12 @@ class StreamTopicPattern(StreamTopicMessageProcessor):
         else:
             link = f"/#narrow/channel/{stream_url}/topic/{topic_url}"
 
+        if self.is_in_link_url_placeholder(m, data):
+            return link, m.start(), m.end()
+
+        el = Element("a")
+        el.set("class", "stream-topic")
+        el.set("data-stream-id", str(stream_id))
         el.set("href", link)
 
         if topic_name == "":
@@ -1854,11 +1879,15 @@ class StreamTopicMessagePattern(StreamTopicMessageProcessor):
         stream_id = self.find_stream_id(stream_name)
         if stream_id is None or topic_name is None:
             return None, None, None
-        el = Element("a")
-        el.set("class", "message-link")
         stream_url = encode_channel(stream_id, stream_name)
         topic_url = encode_hash_component(topic_name)
         link = f"/#narrow/channel/{stream_url}/topic/{topic_url}/near/{message_id}"
+
+        if self.is_in_link_url_placeholder(m, data):
+            return link, m.start(), m.end()
+
+        el = Element("a")
+        el.set("class", "message-link")
         el.set("href", link)
 
         if topic_name == "":

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3704,6 +3704,80 @@ class MarkdownStreamTopicMentionTests(ZulipTestCase):
             f'<p><a class="message-link" href="/#narrow/channel/{denmark.id}-{denmark.name}/topic//near/123">#{denmark.name} &gt; <em>{Message.EMPTY_TOPIC_FALLBACK_NAME}</em> @ 💬</a></p>',
         )
 
+    def test_stream_in_url_placeholder(self) -> None:
+        # A prettified link like `#**stream**` that was pasted into
+        # the URL placeholder of Markdown hyperlink syntax should
+        # resolve to a plain, working link rather than clobbering
+        # the outer `[label](...)` syntax. See #31985.
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        content = "[denmark stream](#**Denmark**)"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a href="/#narrow/channel/{denmark.id}-Denmark">denmark stream</a></p>',
+        )
+
+    def test_stream_topic_in_url_placeholder(self) -> None:
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        content = "[topic 1](#**Denmark>some topic**)"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a href="/#narrow/channel/{denmark.id}-Denmark/topic/some.20topic">topic 1</a></p>',
+        )
+
+        # Markdown allows whitespace between `](` and the URL, so the
+        # prettified link needs to be resolved there too.
+        content = "[topic 1]( #**Denmark>some topic**)"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a href="/#narrow/channel/{denmark.id}-Denmark/topic/some.20topic">topic 1</a></p>',
+        )
+
+    def test_stream_topic_message_in_url_placeholder(self) -> None:
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        content = "[this message](#**Denmark>danish@123**)"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a href="/#narrow/channel/{denmark.id}-Denmark/topic/danish/near/123">this message</a></p>',
+        )
+
+    def test_stream_link_outside_url_placeholder_unaffected(self) -> None:
+        # A prettified link that is *not* inside the URL placeholder
+        # of Markdown hyperlink syntax should keep rendering as its
+        # own dedicated `<a class="stream">` element, even when a
+        # Markdown link appears right before it.
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        content = "[a link](https://example.com) #**Denmark**"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            '<p><a href="https://example.com">a link</a> '
+            f'<a class="stream" data-stream-id="{denmark.id}" '
+            f'href="/#narrow/channel/{denmark.id}-Denmark">#{denmark.name}</a></p>',
+        )
+
     def test_possible_stream_names(self) -> None:
         content = """#**test here**
             This mentions #**Denmark** too.


### PR DESCRIPTION
Prettified channel/topic/message link syntax (`#**stream**` and its
`>topic`/`@message_id` variants) is meant to render as its own link. But
`StreamPattern`, `StreamTopicPattern`, and `StreamTopicMessagePattern` run at a
higher inline-processor priority than the generic Markdown
`LinkInlineProcessor`, and the `BEFORE_LINK_PRODUCING_MENTION_ALLOWED_REGEX`
guard — `(?<![^\s\'\"\(\{\/<])` — also allows matching right after `(`. So when
this syntax was pasted into the URL placeholder of ordinary hyperlink syntax,
e.g. `[my link](#**stream**)`, it got converted into a nested `<a>` element
before the outer link syntax was considered, silently breaking the link's href.

Detect this case (immediately preceded by `](`, allowing intervening
whitespace) in each pattern's `handleMatch` and return the resolved narrow URL
as plain text instead of building an element, so the lower-priority
`LinkInlineProcessor` renders the outer `[label](url)` link correctly
afterwards.

Fixes #31985.

## Relationship to prior work

This issue has an existing [completion candidate][cc] PR: **#33086** by
@Harshbansal8705. I reviewed that PR and its feedback before writing this one.

**The strategy is the same, and it is the one maintainers endorsed.** In
[#33086 (comment)][tim], @timabbott wrote that "the strategy for this is
correct, but the backend markdown processor changes are rather complex", and
deferred the PR on those grounds. Both PRs resolve the prettified link to a
plain URL inside `handleMatch` and let `LinkInlineProcessor` build the outer
link.

**What differs is how the `](` case is detected**, which is what the complexity
concern was about:

- #33086 splits each of the three link regexes into a `BASE_*` fragment plus a
  wrapper, then builds a second alternation `({BEFORE_MENTION_ALLOWED_REGEX}|\]\(\s*)`
  in each of the three `get_compiled_*` functions, and offsets the returned
  match start by 2 to compensate for the consumed `](`. That's six new
  module-level regex constants and three modified compile functions.
- This PR leaves all three regexes untouched and adds one shared helper,
  `is_in_link_url_placeholder`, on the common `StreamTopicMessageProcessor`
  base class, which inspects the source text immediately before the match.
  The match offsets returned are unchanged.

Net effect on the markdown processor: **+32/−9 here vs. +64/−23 in #33086.**
I believe this directly addresses the complexity feedback that blocked the
earlier PR, which is my reason for proposing a fresh implementation rather
than rebasing #33086.

**Behavior parity.** I checked this PR against #33086's test cases, including
`[topic 1]( #**Denmark>some topic**)` — the variant with whitespace after `](`
that #33086's `\s*` handles. This PR handles it too, and it is covered by a
test.

**Frontend.** #33086 also adds an explanatory comment to
`web/third/marked/lib/marked.cjs` noting that the frontend markdown processor
deliberately does not implement this. I agree with that reasoning — the
mismatch is only visible during local echo, for a moment, before the backend
rendering replaces it — but a comment in vendored third-party code is a
separable concern from the fix, so I have left `marked.cjs` alone here. Happy
to add it if reviewers would prefer.

**Open question carried over from #33086.** In [this thread][kuv], @kuv2707
raised whether the backend stream-name regex should be aligned with the one in
`composebox_typeahead.ts`, and asked for it to be taken to CZO. That question
is about the existing regexes' handling of `*` and `>` in channel names, which
this PR does not touch, so I have treated it as out of scope. Flagging it so it
isn't lost.

[cc]: https://github.com/zulip/zulip/pulls?q=is%3Aopen+is%3Apr+label%3A%22completion+candidate%22
[tim]: https://github.com/zulip/zulip/pull/33086#issuecomment-2680975108
[kuv]: https://github.com/zulip/zulip/pull/33086#discussion_r1924603496

## Before Changes

<!-- screenshots -->
- <img width="1922" height="998" alt="image" src="https://github.com/user-attachments/assets/9cc58c55-5cb6-444e-af47-faba393b8bfd" />
- <img width="1918" height="999" alt="image" src="https://github.com/user-attachments/assets/8154cf4e-f160-41b7-912d-ca9d9bfcfdcb" />
- <img width="1920" height="996" alt="image" src="https://github.com/user-attachments/assets/40d7cd7c-d8b4-4149-9fe1-3c381e176844" />
- <img width="1919" height="994" alt="image" src="https://github.com/user-attachments/assets/1e9f860a-12a7-46a8-8158-4cd3c5ec233e" />

- [issue](https://github.com/user-attachments/assets/44555ac3-52d2-4304-807f-601af6d9099c)

## After Changes

<!-- screenshots -->
- <img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/65b33edd-7a94-49bd-8522-c5f624636e5b" />
- <img width="1919" height="995" alt="image" src="https://github.com/user-attachments/assets/412e0978-8781-4437-89cf-520b904c40e1" />

- [Watch the implemented fix](https://github.com/user-attachments/assets/e753aa54-2f44-46ce-8613-3dfb4cd1420b)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalisation.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>