### PR TITLE
popovers: Fix emoji picker popover arrow color in dark mode.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2448,7 +2448,7 @@
     /* Same color as background color of header / footer */
     --color-border-emoji-picker-tippy-arrow: light-dark(
         hsl(0deg 0% 93%),
-        hsl(211.58deg 33.33% 11.18%)
+        hsl(0deg 0% 0% / 20%)
     );
 
     /* Dropdown / Typeahead constants */

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -493,6 +493,10 @@ ul.popover-group-menu-member-list {
     .tippy-box[data-placement="left"] .tippy-arrow::before {
         border-left-color: var(--color-border-emoji-picker-tippy-arrow);
     }
+
+    .tippy-box[data-placement="right"] .tippy-arrow::before {
+        border-right-color: var(--color-border-emoji-picker-tippy-arrow);
+    }
 }
 
 .modal__overlay #set-user-status-modal + .emoji-popover-root {


### PR DESCRIPTION
﻿@laurynmm Thanks for the pointer! I have reviewed the guide and updated the PR.

### Overview

The `--color-border-emoji-picker-tippy-arrow` CSS variable had an incorrect dark mode value that did not match the emoji picker popover header/footer background.

Before: `hsl(211.58deg 33.33% 11.18%)`  
After: `hsl(0deg 0% 0% / 20%)` — matching `--color-background-emoji-picker-popover`

The existing comment already said "Same color as background color of header / footer" — the value was just wrong.

### Changes

- `web/styles/app_variables.css`: Fixed dark mode value of `--color-border-emoji-picker-tippy-arrow`
- `web/styles/popovers.css`: Added missing `data-placement="right"` arrow color override (only top/bottom/left were previously covered)

### Testing

This is a CSS color value fix. The emoji picker already uses `--color-border-emoji-picker-tippy-arrow` for arrow colors in `.emoji-popover-root`. The fix ensures the variable value matches the actual header/footer background in dark mode.

---
### Self-review checklist

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Followed the AI use policy and guidelines
- [x] Visual appearance of the changes
- [x] Corner cases, error conditions, and easily imagined bugs
