### PR TITLE
api docs: Document POST /remotes/push/e2ee/notify

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -185,6 +185,7 @@
 * [Send an E2EE test notification to mobile device(s)](/api/e2ee-test-notify)
 * [Register E2EE push device](/api/register-push-device)
 * [Register E2EE push device to bouncer](/api/register-remote-push-device)
+* [Send E2EE push notifications to bouncer](/api/remote-notify-bouncer)
 * [Mobile notifications](/api/mobile-notifications)
 * [Send a test notification to mobile device(s)](/api/test-notify)
 * [Add an APNs device token](/api/add-apns-token)

--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -143,6 +143,11 @@ class APIArgumentsTablePreprocessor(Preprocessor):
         md_engine = markdown.Markdown(extensions=[])
         parameters = sorted(parameters, key=lambda parameter: parameter.deprecated)
         for parameter in parameters:
+            if parameter.kind == "body":
+                # Document the body's fields directly rather than a row for
+                # typed_endpoint's internal "request" name.
+                lines.append(self.render_object_details(parameter.value_schema, "Request body"))
+                continue
             name = parameter.name
             description = parameter.description
             enums = parameter.value_schema.get("enum")

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -245,6 +245,13 @@ cURL example."""
         # We currently don't have any non-JSON encoded arrays.
         assert parameter.json_encoded
         if curl_argument:
+            if parameter.kind == "body":
+                # A whole-body JSON payload is the entire request body, not a
+                # named field, so it's sent with --json rather than a key=value.
+                # Pretty-print it, preserving the documented key order, since a
+                # dense single line is hard to read.
+                pretty_json = json.dumps(parameter.example, indent=4)
+                return "    --json " + shlex.quote(pretty_json)
             return "    --data-urlencode " + shlex.quote(f"{parameter.name}={ordered_ex_val_str}")
         return ordered_ex_val_str  # nocoverage
     else:

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -334,7 +334,7 @@ NO_EXAMPLE = object()
 
 
 class Parameter(BaseModel):
-    kind: Literal["query", "path", "formData"]
+    kind: Literal["query", "path", "formData", "body"]
     name: str
     description: str
     json_encoded: bool
@@ -408,6 +408,26 @@ def get_openapi_parameters(
                     deprecated=schema.get("deprecated", False),
                 )
             )
+
+    if "requestBody" in operation and "application/json" in (
+        content := operation["requestBody"]["content"]
+    ):
+        # typed_endpoint registers a whole-body JsonBodyPayload argument under
+        # the fixed name "request"; match that so the consistency check passes.
+        media_type = content["application/json"]
+        schema = media_type["schema"]
+        parameters.append(
+            Parameter(
+                kind="body",
+                name="request",
+                description=schema["description"],
+                json_encoded=True,
+                value_schema=schema,
+                example=media_type.get("example", NO_EXAMPLE),
+                required=operation["requestBody"].get("required", False),
+                deprecated=False,
+            )
+        )
 
     return parameters
 

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -28,10 +28,11 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     # Requires organization-specific JWT_AUTH_KEYS configuration.
     "jwt-fetch-api-key",
     # Would need push notification bouncer set up to test the
-    # generated curl example for the following three endpoints.
+    # generated curl example for the following endpoints.
     "e2ee-test-notify",
     "test-notify",
     "register-remote-push-device",
+    "remote-notify-bouncer",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14085,6 +14085,274 @@ paths:
                     description: |
                       An example JSON response for when no realm is registered for
                       the authenticated server on the bouncer for the given `realm_uuid`:
+  /remotes/push/e2ee/notify:
+    post:
+      operationId: remote-notify-bouncer
+      summary: Send E2EE push notifications to bouncer
+      tags: ["mobile"]
+      description: |
+        Forward end-to-end encrypted mobile push notifications to the
+        bouncer, which relays them to APNs (Apple) and FCM (Android).
+
+        Self-hosted servers use this endpoint to send already-encrypted
+        push notification payloads to the bouncer for their registered
+        push devices.
+
+        It is not meant to be used by mobile clients directly.
+
+        **Changes**: New in Zulip 11.0 (feature level 406).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              description: |
+                A JSON object with the realm and the list of push
+                notification requests to forward.
+              properties:
+                realm_uuid:
+                  type: string
+                  description: |
+                    The UUID of the realm whose push devices the
+                    notification requests target.
+                push_requests:
+                  type: array
+                  description: |
+                    The push notification requests to forward, one per
+                    target device. Each entry is either an APNs (Apple)
+                    or an FCM (Android) request, distinguished by whether
+                    it carries `http_headers` (APNs) or `fcm_priority`
+                    (FCM).
+                  items:
+                    oneOf:
+                      - type: object
+                        additionalProperties: false
+                        description: |
+                          An APNs (Apple) push notification request.
+                        properties:
+                          token_id:
+                            type: string
+                            description: |
+                              Identifier for the target push device's
+                              registration on the bouncer.
+                          http_headers:
+                            type: object
+                            additionalProperties: false
+                            description: |
+                              The APNs request headers.
+                            properties:
+                              apns_priority:
+                                type: integer
+                                enum: [10, 5, 1]
+                                description: |
+                                  The APNs delivery priority.
+                              apns_push_type:
+                                type: string
+                                enum:
+                                  - alert
+                                  - background
+                                  - voip
+                                  - complication
+                                  - fileprovider
+                                  - mdm
+                                  - liveactivity
+                                description: |
+                                  The APNs push type.
+                            required:
+                              - apns_priority
+                              - apns_push_type
+                          payload:
+                            type: object
+                            additionalProperties: false
+                            description: |
+                              The APNs payload for the notification.
+                            properties:
+                              push_key_id:
+                                type: integer
+                                description: |
+                                  Identifier for the push key used to
+                                  encrypt `encrypted_data`.
+                              encrypted_data:
+                                type: string
+                                description: |
+                                  The end-to-end encrypted notification
+                                  data.
+                              aps:
+                                type: object
+                                additionalProperties: true
+                                description: |
+                                  The unencrypted APNs `aps` dictionary.
+                            required:
+                              - push_key_id
+                              - encrypted_data
+                              - aps
+                        required:
+                          - token_id
+                          - http_headers
+                          - payload
+                      - type: object
+                        additionalProperties: false
+                        description: |
+                          An FCM (Android) push notification request.
+                        properties:
+                          token_id:
+                            type: string
+                            description: |
+                              Identifier for the target push device's
+                              registration on the bouncer.
+                          fcm_priority:
+                            type: string
+                            enum: [high, normal]
+                            description: |
+                              The FCM delivery priority.
+                          payload:
+                            type: object
+                            additionalProperties: false
+                            description: |
+                              The FCM payload for the notification.
+                            properties:
+                              push_key_id:
+                                type: integer
+                                description: |
+                                  Identifier for the push key used to
+                                  encrypt `encrypted_data`.
+                              encrypted_data:
+                                type: string
+                                description: |
+                                  The end-to-end encrypted notification
+                                  data.
+                            required:
+                              - push_key_id
+                              - encrypted_data
+                        required:
+                          - token_id
+                          - fcm_priority
+                          - payload
+              required:
+                - realm_uuid
+                - push_requests
+            example:
+              realm_uuid: "9aa61d0b-8ce5-488d-8e9e-fedc346e6836"
+              push_requests:
+                - token_id: "+wKIhyAx/Eg="
+                  http_headers:
+                    apns_priority: 10
+                    apns_push_type: "alert"
+                  payload:
+                    push_key_id: 42
+                    encrypted_data: "encrypted-apns-data"
+                    aps:
+                      mutable-content: 1
+                - token_id: "cD6Ejhr2/Fg="
+                  fcm_priority: "high"
+                  payload:
+                    push_key_id: 43
+                    encrypted_data: "encrypted-fcm-data"
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    required:
+                      - apple_successfully_sent_count
+                      - android_successfully_sent_count
+                      - delete_token_ids
+                      - realm_push_status
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      apple_successfully_sent_count:
+                        type: integer
+                        description: |
+                          The number of Apple (APNs) devices to which a
+                          push notification was successfully sent.
+                      android_successfully_sent_count:
+                        type: integer
+                        description: |
+                          The number of Android (FCM) devices to which a
+                          push notification was successfully sent.
+                      delete_token_ids:
+                        type: array
+                        items:
+                          type: string
+                        description: |
+                          The `token_id` values whose device registrations
+                          the bouncer no longer considers valid; the
+                          self-hosted server should delete these
+                          registrations.
+                      realm_push_status:
+                        type: object
+                        additionalProperties: false
+                        required:
+                          - can_push
+                          - expected_end_timestamp
+                        properties:
+                          can_push:
+                            type: boolean
+                            description: |
+                              Whether the realm is currently permitted to
+                              send mobile push notifications.
+                          expected_end_timestamp:
+                            type: integer
+                            nullable: true
+                            description: |
+                              UNIX timestamp (UTC) for when the current
+                              push notification service status is expected
+                              to end, or `null` if not applicable.
+                        description: |
+                          The realm's current push notification service
+                          status.
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "apple_successfully_sent_count": 1,
+                        "android_successfully_sent_count": 1,
+                        "delete_token_ids": [],
+                        "realm_push_status":
+                          {"can_push": true, "expected_end_timestamp": null},
+                      }
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "PUSH_NOTIFICATIONS_DISALLOWED",
+                        "msg": "Your plan doesn't allow sending push notifications. Reason provided by the server: Push notifications are not enabled for this realm.",
+                        "result": "error",
+                      }
+                    description: |
+                      An example JSON response for when the realm's plan
+                      does not currently permit sending mobile push
+                      notifications:
+        "403":
+          description: |
+            Forbidden.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "MISSING_REMOTE_REALM",
+                        "msg": "Organization not registered",
+                        "result": "error",
+                      }
+                    description: |
+                      An example JSON response for when no realm is registered for
+                      the authenticated server on the bouncer for the given `realm_uuid`:
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -246,8 +246,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         # Zulip outgoing webhook payload
         "/zulip-outgoing-webhook",
         #### Bouncer endpoints
-        # Higher priority to document
-        "/remotes/push/e2ee/notify",
         # Lower priority to document
         "/remotes/server/register",
         "/remotes/server/register/transfer",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -745,6 +745,37 @@ class TestCurlExampleGeneration(ZulipTestCase):
         },
     }
 
+    spec_mock_using_json_body = {
+        "security": [{"basicAuth": []}],
+        "paths": {
+            "/endpoint": {
+                "post": {
+                    "description": "Send a JSON request body.",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "The JSON request body.",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "age": {"type": "integer"},
+                                    },
+                                    "required": ["name", "age"],
+                                },
+                                "example": {
+                                    "name": "Zulip",
+                                    "age": 10,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
     def curl_example(self, endpoint: str, method: str, *args: Any, **kwargs: Any) -> list[str]:
         return generate_curl_example(endpoint, method, "http://localhost:9991/api", *args, **kwargs)
 
@@ -830,6 +861,19 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint \\",
             "    -u EMAIL_ADDRESS:API_KEY \\",
             '    --data-urlencode \'param1={"key": "value"}\'',
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+    @patch("zerver.openapi.openapi.OpenAPISpec.openapi")
+    def test_generate_and_render_curl_with_json_body(self, spec_mock: MagicMock) -> None:
+        spec_mock.return_value = self.spec_mock_using_json_body
+        generated_curl_example = self.curl_example("/endpoint", "POST")
+        expected_curl_example = [
+            "```curl",
+            "curl -sSX POST http://localhost:9991/api/v1/endpoint \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            '    --json \'{\n    "name": "Zulip",\n    "age": 10\n}\'',
             "```",
         ]
         self.assertEqual(generated_curl_example, expected_curl_example)


### PR DESCRIPTION
Documents the push notification bouncer endpoint `POST/remotes/push/e2ee/notify`

Stacked on #39698 (the JSON-request-body tooling) and can't merge until that lands. This is the first documented endpoint whose request body is awhole-body JSON object (a `JsonBodyPayload`), so the generated curl
example uses `--json`. Since this is a fork branch, the PR is based on `main`, so its first commit is #39698's tooling, that drops out of the diff once #39698 merges.

Two things I'd like a check on:
- **Feature level**: I used "New in Zulip 11.0 (feature level 406)" to match the sibling `register-remote-push-device` endpoint, but notify was never given its own changelog line.
- **Arguments-table rendering** for a whole-body parameter is provisional, pending the open question on [#api documentation > documenting endpoint which uses JsonBodyPayload](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/documenting.20endpoint.20which.20uses.20JsonBodyPayload).

<details>
<summary>**Screenshots and screen captures:**</summary>

Before the tooling PR, `--data-urlencode 'request=…'`, a form field, which is wrong since a `JsonBodyPayload` reads an `application/json` body:

<img width="977" height="474" src="https://github.com/user-attachments/assets/db340bf8-23a7-46eb-8a6c-6a508b1286df" />

After the tooling PR - `--json '…'` sends `Content-Type: application/json`, what the endpoint actually reads:

<img width="700" height="336" src="https://github.com/user-attachments/assets/0d3cdd10-c2f6-4d16-8fd3-dcfeac7a0aad" />

After pretty-printing:

<img width="700" height="756" src="https://github.com/user-attachments/assets/43942b5c-71e5-4a3c-bcfd-c112d7ce445a" />

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
