### PR TITLE
[ai] upload: Don't hold a read open on S3 objects during self-copy.

### DIFF
--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -70,8 +70,11 @@ def needs_charset_detection(content_type: str) -> bool:
 
 
 def maybe_add_charset(content_type: str, file_data: bytes | StreamingSourceWithSize) -> str:
-    if not needs_charset_detection(content_type):
-        return content_type
+    # Callers must gate on needs_charset_detection(content_type) first,
+    # so that they can avoid opening file_data at all when it won't be
+    # inspected -- with the S3 backend, opening a source starts an open
+    # GetObject read immediately, rather than lazily on first read.
+    assert needs_charset_detection(content_type)
     fake_msg = EmailMessage()
     fake_msg["content-type"] = content_type
 
@@ -81,23 +84,25 @@ def maybe_add_charset(content_type: str, file_data: bytes | StreamingSourceWithS
     else:
         chunk_size = 4096
         reader = file_data.reader()
-        detector = chardet.UniversalDetector()
-        total_read = 0
-        while True:
-            data = reader.read(chunk_size)
-            detector.feed(data)
-            if detector.done or len(data) < chunk_size:
-                break
-            total_read += chunk_size
-            if total_read >= 32 * 1024:
-                # If there's no BOM and no high bytes, the detector
-                # never says "done" before EOF -- we bail out
-                # arbitrarily at 32k.
-                early_abort = True
-                break
-        detector.close()
-        reader.close()
-        detected = detector.result
+        try:
+            detector = chardet.UniversalDetector()
+            total_read = 0
+            while True:
+                data = reader.read(chunk_size)
+                detector.feed(data)
+                if detector.done or len(data) < chunk_size:
+                    break
+                total_read += chunk_size
+                if total_read >= 32 * 1024:
+                    # If there's no BOM and no high bytes, the detector
+                    # never says "done" before EOF -- we bail out
+                    # arbitrarily at 32k.
+                    early_abort = True
+                    break
+            detector.close()
+            detected = detector.result
+        finally:
+            reader.close()
     if early_abort and detected["confidence"] == 1.0 and detected["encoding"] == "ascii":
         # An early abort which didn't see high-byte characters is not
         # a confident "ASCII", as they may come later in the file; we

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -263,7 +263,8 @@ def upload_message_attachment(
     path_id = get_upload_backend().generate_message_upload_path(
         str(target_realm.id), sanitize_name(uploaded_file_name)
     )
-    content_type = maybe_add_charset(content_type, file_data)
+    if needs_charset_detection(content_type):
+        content_type = maybe_add_charset(content_type, file_data)
 
     # NULL bytes are the one thing we can't store in the original
     # filename column, due to PostgreSQL limitations

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -57,17 +57,23 @@ def check_upload_within_quota(realm: Realm, uploaded_file_size: int) -> None:
         raise RealmUploadQuotaError(_("Upload would exceed your organization's upload quota."))
 
 
-def maybe_add_charset(content_type: str, file_data: bytes | StreamingSourceWithSize) -> str:
+def needs_charset_detection(content_type: str) -> bool:
     # We only add a charset if it doesn't already have one, and is a
     # text type which we serve inline; currently, this is only text/plain.
     fake_msg = EmailMessage()
     fake_msg["content-type"] = content_type
-    if (
-        fake_msg.get_content_maintype() != "text"
-        or fake_msg.get_content_type() not in INLINE_MIME_TYPES
-        or fake_msg.get_content_charset() is not None
-    ):
+    return (
+        fake_msg.get_content_maintype() == "text"
+        and fake_msg.get_content_type() in INLINE_MIME_TYPES
+        and fake_msg.get_content_charset() is None
+    )
+
+
+def maybe_add_charset(content_type: str, file_data: bytes | StreamingSourceWithSize) -> str:
+    if not needs_charset_detection(content_type):
         return content_type
+    fake_msg = EmailMessage()
+    fake_msg["content-type"] = content_type
 
     early_abort = False
     if isinstance(file_data, bytes):

--- a/zerver/tests/test_tusd.py
+++ b/zerver/tests/test_tusd.py
@@ -12,6 +12,7 @@ from zerver.lib.test_helpers import create_s3_buckets, find_key_by_email, use_s3
 from zerver.lib.upload import (
     create_attachment,
     generate_message_upload_path,
+    get_upload_backend,
     sanitize_name,
     store_message_attachment,
     upload_message_attachment,
@@ -729,6 +730,103 @@ class TusdPreFinishTest(ZulipTestCase):
         self.assertEqual(attachment.size, 40 * 1024)
         self.assertEqual(attachment.content_type, "text/plain")
         self.assertEqual(bucket.Object(path_id).get()["ContentType"], "text/plain")
+
+    @use_s3_backend
+    def test_s3_upload_no_read_open_during_self_copy(self) -> None:
+        # Regression test for the pre-finish hook holding a read of
+        # the object open while issuing the self-CopyObject which sets
+        # the object's Content-Type. S3 itself does not mind, but
+        # S3-compatible backends which lock per object (e.g. MinIO)
+        # hold a read lock for the duration of an open GetObject, so
+        # the copy blocked until the idle reader hit the backend's
+        # write deadline, tens of seconds later.
+        assert settings.LOCAL_FILES_DIR is None
+        self.login("hamlet")
+        hamlet = self.example_user("hamlet")
+        create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)
+        upload_backend = get_upload_backend()
+        assert isinstance(upload_backend, S3UploadBackend)
+        bucket = upload_backend.uploads_bucket
+
+        def upload_file(filename: str, filetype: str) -> list[str]:
+            path_id = upload_backend.generate_message_upload_path(
+                str(hamlet.realm.id), sanitize_name(filename, strict=True)
+            )
+            info = TusUpload(
+                id=path_id,
+                size=len("zulip!"),
+                offset=0,
+                size_is_deferred=False,
+                meta_data={
+                    "filename": filename,
+                    "filetype": filetype,
+                    "name": filename,
+                    "type": filetype,
+                },
+                is_final=False,
+                is_partial=False,
+                partial_uploads=None,
+                storage=None,
+            )
+            bucket.Object(path_id).put(
+                Body=b"zulip!",
+                ContentType="application/octet-stream",
+                Metadata={
+                    k: v.encode("ascii", "replace").decode() for k, v in info.meta_data.items()
+                },
+            )
+            bucket.Object(f"{path_id}.info").put(
+                Body=info.model_dump_json().encode(),
+            )
+
+            # Reads of the object and the self-copy of it go through
+            # unrelated objects, so we attach both to one parent mock
+            # to observe the order they happen in.
+            calls = mock.Mock()
+            client = bucket.meta.client
+            with (
+                mock.patch("zerver.views.tusd.attachment_source") as mock_attachment_source,
+                mock.patch.object(
+                    client, "copy_object", wraps=client.copy_object
+                ) as mock_copy_object,
+            ):
+                calls.attach_mock(mock_attachment_source, "attachment_source")
+                calls.attach_mock(mock_copy_object, "copy_object")
+                mock_attachment_source.return_value.size = len("zulip!")
+                mock_attachment_source.return_value.reader.return_value.read.return_value = b""
+                result = self.client_post(
+                    "/api/internal/tusd",
+                    self.request(info).model_dump(),
+                    content_type="application/json",
+                )
+            self.assertEqual(result.status_code, 200)
+            return [name for name, _args, _kwargs in calls.mock_calls]
+
+        # A bare text/plain needs sniffing, so the object is opened
+        # before the copy -- but that read is closed again before the
+        # copy is issued, and a fresh one opened for create_attachment
+        # and maybe_thumbnail afterwards.
+        self.assertEqual(
+            upload_file("zulip.txt", "text/plain"),
+            [
+                "attachment_source",
+                "attachment_source().reader",
+                "attachment_source().reader().read",
+                "attachment_source().reader().close",
+                "copy_object",
+                "attachment_source",
+            ],
+        )
+
+        # A Content-Type which already declares a charset needs no
+        # sniffing, so the object is not opened until after the copy.
+        # This is the case where nothing but the read being skipped
+        # keeps it from spanning the copy, since maybe_add_charset is
+        # not called at all.
+        self.assertEqual(
+            upload_file("utf8.txt", 'text/plain; charset="utf-8"'),
+            ["copy_object", "attachment_source"],
+        )
 
 
 class TusdPreTerminateTest(ZulipTestCase):

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -26,6 +26,7 @@ from zerver.lib.upload import (
     generate_message_upload_path,
     get_upload_backend,
     maybe_add_charset,
+    needs_charset_detection,
     sanitize_name,
 )
 from zerver.models import ArchivedAttachment, Attachment, PreregistrationRealm, Realm, UserProfile
@@ -156,8 +157,16 @@ def handle_upload_pre_finish_hook(
         content_type = guess_type(filename)[0]
         if content_type is None:
             content_type = "application/octet-stream"
-    file_data = attachment_source(path_id)
-    content_type = maybe_add_charset(content_type, file_data)
+
+    # Only open the object at all when charset detection actually needs to
+    # inspect its bytes. With the S3 backend, opening it starts a
+    # GetObject read that we'd otherwise hold open across the self-copy
+    # below. AWS S3 doesn't mind, but S3-compatible backends that lock per
+    # object (e.g. MinIO) hold a read lock for the life of an open
+    # GetObject, so the copy would block until that idle reader is torn
+    # down -- tens of seconds later.
+    if needs_charset_detection(content_type):
+        content_type = maybe_add_charset(content_type, attachment_source(path_id))
 
     if settings.LOCAL_UPLOADS_DIR is None:
         # We "copy" the file to itself to update the Content-Type,
@@ -199,6 +208,10 @@ def handle_upload_pre_finish_hook(
                 MetadataDirective="COPY",
                 StorageClass=settings.S3_UPLOADS_STORAGE_CLASS,
             )
+
+    # Open a fresh source for create_attachment/maybe_thumbnail to
+    # read from, now that the self-copy above (if any) has finished.
+    file_data = attachment_source(path_id)
 
     with transaction.atomic(durable=True):
         create_attachment(

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -41,6 +41,7 @@ from zerver.lib.upload import (
     check_upload_within_quota,
     get_public_upload_root_url,
     maybe_add_charset,
+    needs_charset_detection,
     upload_message_attachment_from_request,
 )
 from zerver.lib.upload.local import assert_is_local_storage_path
@@ -96,10 +97,11 @@ def serve_s3(
     # (as nginx does by default with the `slice` directive) for a
     # 0-byte file.
     if attachment.size == 0:
-        content_type = maybe_add_charset(
-            attachment.content_type or guess_type(filename)[0] or "application/octet-stream",
-            attachment_source(path_id),
+        content_type = (
+            attachment.content_type or guess_type(filename)[0] or "application/octet-stream"
         )
+        if needs_charset_detection(content_type):
+            content_type = maybe_add_charset(content_type, attachment_source(path_id))
         download = force_download or bare_content_type(content_type) not in INLINE_MIME_TYPES
 
         response = HttpResponse("", content_type=content_type)
@@ -154,7 +156,8 @@ def serve_local(
     if content_type is None:
         content_type = guess_type(filename)[0] or "application/octet-stream"
 
-    content_type = maybe_add_charset(content_type, attachment_source(path_id))
+    if needs_charset_detection(content_type):
+        content_type = maybe_add_charset(content_type, attachment_source(path_id))
     download = force_download or bare_content_type(content_type) not in INLINE_MIME_TYPES
 
     if settings.DEVELOPMENT:


### PR DESCRIPTION
Fixes: #39752

Re-submission of #39764, which @amanagr accidentally merged (and
then reverted) while intending to merge a different PR; see
[the comment thread](https://github.com/zulip/zulip/pull/39764#issuecomment-5031876561).
No changes from that PR other than rebasing onto current `main` —
the commit is an unmodified cherry-pick of the one already reviewed
and tested there.

Zulip's S3 upload backend opens a `GetObject` on an object while the
tusd pre-finish hook simultaneously issues a self-`CopyObject` on
that same object, to update its Content-Type and Content-Disposition
after upload. AWS S3 doesn't mind this, but S3-compatible backends
that use per-object locking for consistency (MinIO, as reported in
the issue) hold a read lock for the duration of the open
`GetObject`. The concurrent `CopyObject` then blocks until MinIO's
write-deadline timeout tears down the idle reader, which is a
constant ~30 second stall on every upload above roughly 100 KB.

The object was only ever opened to sniff its charset, and that
sniffing only applies to `text/plain` content. So the fix opens the
object at all only when that's actually needed, explicitly closes
that read before the self-copy runs, and opens a fresh, unrelated
read afterwards for attachment creation/thumbnailing. This keeps no
read open across the self-copy, regardless of backend.

**How changes were tested:**

- Same regression test as #39764, asserting the pre-finish hook
  opens the object twice (once to sniff, once fresh afterwards) and
  explicitly closes the sniffing read, rather than holding a single
  read open across the self-copy.
- This commit is an unmodified cherry-pick of the one already merged
  and reviewed on #39764, where full CI (backend tests on Debian
  12/13 and Ubuntu 22.04/24.04/26.04, mypy, CodeQL) passed and
  @amanagr confirmed manual testing looked good. It applied cleanly
  onto current `main` with no conflicts.

**Screenshots and screen captures:**

N/A -- this is a backend-only change with no UI surface.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>