### PR TITLE
smokescreen: Document how we enforce proxying in every process.

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -207,6 +207,10 @@ class zulip::app_frontend_base {
 
   $tusd_server_listen = zulipconf('application_server', 'tusd_server_listen', '127.0.0.1')
 
+  # Supervisor sets this as HTTP_proxy/HTTPS_proxy in every process's
+  # environment, so that all outgoing requests go through Smokescreen;
+  # including those made directly by libraries rather than through
+  # OutgoingSession.
   if $proxy_host != '' and $proxy_port != '' {
     $proxy = "http://${proxy_host}:${proxy_port}"
   } else {

--- a/zerver/lib/url_preview/oembed.py
+++ b/zerver/lib/url_preview/oembed.py
@@ -7,6 +7,9 @@ from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
 
 
 def get_oembed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> UrlEmbedData | None:
+    # pyoembed makes its requests directly, not through OutgoingSession,
+    # but they still go through Smokescreen: requests lib honors the
+    # HTTP_proxy/HTTPS_proxy variables we set in every process's environment.
     try:
         data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
     except (PyOembedException, json.decoder.JSONDecodeError, requests.exceptions.ConnectionError):


### PR DESCRIPTION
The fact that `get_oembed_data` doesn't cause an SSRF vulnerability is non-obvious, as it relies on knowing about the HTTP/HTTPS_proxy vars set in the environment in the supervisor configuration (puppet/zulip/templates/supervisor/zulip.conf.template.erb).

