### PR TITLE
[ai] email_mirror: Strip invalid XML characters from HTML email bodies.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -32,7 +32,7 @@ from zerver.lib.message import normalize_body, truncate_content, truncate_topic
 from zerver.lib.rate_limiter import RateLimitedObject
 from zerver.lib.send_email import FromAddress
 from zerver.lib.streams import access_stream_for_send_message
-from zerver.lib.string_validation import is_character_printable
+from zerver.lib.string_validation import is_character_printable, strip_invalid_xml_characters
 from zerver.lib.upload import upload_message_attachment
 from zerver.models import (
     ChannelEmailAddress,
@@ -321,6 +321,10 @@ def extract_html_body(message: EmailMessage, include_quotes: bool = False) -> st
 
     html_content = get_message_part_by_type(message, "text/html")
     if html_content is not None:
+        # Some emails contain control characters that are valid in the
+        # email's charset but not in XML; these crash the XML-based
+        # parser inside talon, so strip them before parsing.
+        html_content = strip_invalid_xml_characters(html_content)
         if include_quotes:
             return convert_html_to_markdown(html_content)
         else:

--- a/zerver/lib/string_validation.py
+++ b/zerver/lib/string_validation.py
@@ -1,9 +1,17 @@
+import re
 import unicodedata
 
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.models import Stream
+
+# Characters that are valid in an XML 1.0 document, per
+# https://www.w3.org/TR/xml/#charsets:
+#   #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+# The inverse of this class matches characters (such as most C0 control
+# codes) that XML parsers like lxml reject with a ValueError.
+invalid_xml_chars = re.compile("[^\t\n\r\x20-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]")
 
 # There are 66 Unicode non-characters; see
 # https://www.unicode.org/faq/private_use.html#nonchar4
@@ -16,6 +24,10 @@ unicode_non_chars = {
     ]
     for x in r
 }
+
+
+def strip_invalid_xml_characters(text: str) -> str:
+    return invalid_xml_chars.sub("", text)
 
 
 def is_character_printable(char: str) -> bool:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1795,6 +1795,36 @@ class TestReplyExtraction(ZulipTestCase):
         message = most_recent_message(user_profile)
         self.assertEqual(message.content, convert_html_to_markdown(html))
 
+    def test_html_with_invalid_xml_characters(self) -> None:
+        # An HTML email containing control characters that are invalid in
+        # XML previously crashed talon's XML-based parser with a
+        # ValueError; verify such emails are now processed, with the
+        # offending characters stripped.
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        self.subscribe(user_profile, "Denmark")
+        stream = get_stream("Denmark", user_profile.realm)
+
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
+        stream_to_address = encode_email_address(stream.name, email_token)
+        # \x0b (vertical tab) is a C0 control character, and ￾ is a
+        # Unicode noncharacter; both are valid in the email's charset but
+        # are not valid XML characters. Valid characters, including
+        # non-ASCII ones like the emoji here, must be preserved.
+        html = "<html><body><p>Hello\x0b￾world \U0001f600</p></body></html>"
+
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content(html, subtype="html")
+        incoming_valid_message["Subject"] = "TestStreamEmailMessages subject"
+        incoming_valid_message["From"] = user_profile.delivery_email
+        incoming_valid_message["To"] = stream_to_address
+        incoming_valid_message["Reply-to"] = user_profile.delivery_email
+
+        process_message(incoming_valid_message)
+
+        message = most_recent_message(user_profile)
+        self.assertEqual(message.content, "Helloworld \U0001f600")
+
 
 class TestStreamEmailMessagesSubjectStripping(ZulipTestCase):
     def test_process_message_strips_subject(self) -> None:


### PR DESCRIPTION
HTML emails can contain control characters (such as the vertical tab U+000B) that are valid in the message's charset but not permitted in XML. talon parses the HTML body with an XML-based parser (lxml), which rejects these characters by raising a ValueError, crashing the email mirror while processing the message.

Strip characters that are not valid in XML 1.0 from the HTML body before parsing, adding a strip_invalid_xml_characters() helper alongside the existing character-validation helpers. Valid content such as tabs, newlines, and non-ASCII characters is preserved.

Fixes #29301.

<!-- Describe your pull request here.-->

**How changes were tested:**

- Reproduced the crash on `main`: passing an HTML email body containing an
  invalid XML control character (`\x0b`, one of the characters documented in
  html5lib/html5lib-python#96) through `extract_html_body()` raises the reported
  `ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL
  bytes or control characters`, from `talon`'s `lxml`-based parser.

- Added an end-to-end regression test, `test_html_with_invalid_xml_characters`,
  which sends an HTML email through the full `process_message()` pipeline with a
  body containing a C0 control character (`\x0b`), a Unicode noncharacter
  (`U+FFFE`), and a valid emoji. It asserts the message posts successfully with
  the invalid characters are stripped, and the emoji is preserved.

- Verified the new test **fails on `main`** with the exact `ValueError`, and
  **passes** with this fix applied.

- Checked character-level correctness against the XML 1.0 spec: the helper keeps
  valid boundary characters (`\x09`, `\x0a`, `\x0d`, `\x20`, `U+D7FF`, `U+E000`,
  `U+FFFD`, astral characters including emoji, and accented/CJK text) and strips
  the invalid ones (C0 controls and the `U+FFFE`/`U+FFFF` noncharacters). An
  allowlist derived from the spec is used rather than a blocklist, so non-characters
  like `U+FFFE` — which a hand-listed blocklist can miss — are also handled.

- `./tools/test-backend zerver.tests.test_email_mirror` — all 73 tests pass.

- `./tools/lint zerver/lib/email_mirror.py zerver/lib/string_validation.py
  zerver/tests/test_email_mirror.py` — clean.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

- <img width="1917" height="995" alt="image" src="https://github.com/user-attachments/assets/54f720c6-b9ef-45a3-8f61-263604134a97" />
- <img width="1915" height="996" alt="image" src="https://github.com/user-attachments/assets/a7f95b61-5d7b-456c-9d1d-9721fd656bc2" />
- <img width="1917" height="999" alt="image" src="https://github.com/user-attachments/assets/9f9f9399-5ae6-43b9-a883-5b88743822f7" />
- <img width="584" height="858" alt="image" src="https://github.com/user-attachments/assets/3bf98862-96ac-4fc2-9f75-4f885bd45e34" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
