### PR TITLE
events: Filter deactivated-group update events for all properties.

### DIFF
--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -259,11 +259,12 @@ def do_send_user_group_update_event(
     user_group: NamedUserGroup, data: dict[str, str | int | UserGroupMembersDict]
 ) -> None:
     event = dict(type="user_group", op="update", group_id=user_group.id, data=data)
-    if "name" in data:
-        # This field will be popped eventually before sending the event
-        # to client, but is needed to make sure we do not send the
-        # name update event for deactivated groups to client with
-        # 'include_deactivated_groups' client capability set to false.
+    if "deactivated" not in data:
+        # This field is popped before sending the event to the client,
+        # but is needed to make sure we do not send update events for
+        # deactivated groups to clients with 'include_deactivated_groups'
+        # set to false. Applies to updates of any property (name,
+        # description, permission settings, etc.), not just name.
         event["deactivated"] = user_group.deactivated
     send_event_on_commit(user_group.realm, event, active_user_ids(user_group.realm_id))
 

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1689,12 +1689,13 @@ def process_user_group_creation_event(event: Mapping[str, Any], users: Iterable[
                 client.add_event(group_creation_event)
 
 
-def process_user_group_name_update_event(event: Mapping[str, Any], users: Iterable[int]) -> None:
+def process_user_group_update_event(event: Mapping[str, Any], users: Iterable[int]) -> None:
     user_group_event = dict(event)
     # 'deactivated' field is no longer needed and can be popped, as we now
-    # know whether the group that was renamed is deactivated or not and can
-    # avoid sending the event to client with 'include_deactivated_groups'
-    # client capability set to false.
+    # know whether the group that was updated is deactivated or not and can
+    # avoid sending the event to clients with 'include_deactivated_groups'
+    # client capability set to false. Applies to updates of any property,
+    # not just name.
     event_for_deactivated_group = user_group_event.pop("deactivated", False)
     for user_profile_id in users:
         for client in get_client_descriptors_for_user(user_profile_id):
@@ -1802,11 +1803,11 @@ def process_notification(notice: Mapping[str, Any]) -> None:
         process_custom_profile_fields_event(event, cast(list[int], users))
     elif event["type"] == "realm_user" and event["op"] == "add":
         process_realm_user_add_event(event, cast(list[int], users))
-    elif event["type"] == "user_group" and event["op"] == "update" and "name" in event["data"]:
-        # Only name can be changed for deactivated groups, so we handle the
-        # event sent for updating name separately for clients with different
-        # capabilities.
-        process_user_group_name_update_event(event, cast(list[int], users))
+    elif event["type"] == "user_group" and event["op"] == "update" and "deactivated" in event:
+        # Any update to a deactivated group's properties (name, description,
+        # permissions, etc.) carries this tag, and must be filtered for
+        # clients whose 'include_deactivated_groups' capability is false.
+        process_user_group_update_event(event, cast(list[int], users))
     elif event["type"] == "user_group" and event["op"] == "add":
         process_user_group_creation_event(event, cast(list[int], users))
     elif event["type"] == "user_topic":


### PR DESCRIPTION
Previously `do_send_user_group_update_event` and the Tornado event router only attached/checked the `deactivated` tag when the `name` property was updated, so updates to other properties (description, permission settings, etc.) on deactivated groups were incorrectly broadcast to clients with `include_deactivated_groups=False`.

This change makes `do_send_user_group_update_event` attach the `deactivated` tag for any property update (not just name), and updates the Tornado event router to dispatch based on the presence of that tag rather than checking specifically for `"name" in event["data"]`. The handler function `process_user_group_name_update_event` is renamed to `process_user_group_update_event` since its filtering logic is no longer name-specific.

Fixes #39789.

**How changes were tested:**

Reviewed the event-generation and event-routing logic by tracing through both the name-update and non-name-update code paths to confirm the `deactivated` tag is now consistently attached and filtered on. A regression test covering description/permission updates on deactivated groups is still needed and will follow in a subsequent commit.

**Screenshots and screen captures:**

N/A — backend-only change with no UI impact.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>