### PR TITLE
import: Reset module-level id maps at the start of each realm import.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -242,6 +242,17 @@ message_id_to_attachments: dict[str, dict[int, list[str]]] = {
 }
 
 
+def reset_import_state() -> None:
+    for id_map in ID_MAP.values():
+        id_map.clear()
+    for id_list_map in id_map_to_list.values():
+        id_list_map.clear()
+    for path_map in path_maps.values():
+        path_map.clear()
+    for attachment_map in message_id_to_attachments.values():
+        attachment_map.clear()
+
+
 def map_messages_to_attachments(data: ImportedTableData) -> None:
     for attachment in data["zerver_attachment"]:
         for message_id in attachment["messages"]:
@@ -1461,6 +1472,11 @@ def do_import_realm(
     # The self-serve Slack import uses this to record which realm an import
     # owns, atomically with its creation, so a redelivered import can later
     # recognize and clean up its own half-imported realm.
+    #
+    # Start from a clean slate: the module-level id maps below persist across
+    # imports in a long-lived worker, so reset them before touching anything.
+    reset_import_state()
+
     logging.info("Importing realm dump %s", import_dir)
     if not os.path.exists(import_dir):
         raise Exception("Missing import directory!")

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -42,7 +42,7 @@ from zerver.actions.user_settings import do_change_user_delivery_email, do_chang
 from zerver.actions.user_status import do_update_user_status
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.actions.users import do_deactivate_user
-from zerver.lib import upload
+from zerver.lib import import_realm, upload
 from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.bot_config import set_bot_config
 from zerver.lib.bot_lib import StateHandler
@@ -54,7 +54,12 @@ from zerver.lib.export import (
     do_export_user,
     get_consented_user_ids,
 )
-from zerver.lib.import_realm import do_import_realm, get_db_table, get_incoming_message_ids
+from zerver.lib.import_realm import (
+    do_import_realm,
+    get_db_table,
+    get_incoming_message_ids,
+    reset_import_state,
+)
 from zerver.lib.migration_status import STALE_MIGRATIONS, AppMigrations, MigrationStatusJson
 from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
@@ -2801,6 +2806,32 @@ class RealmImportExportTest(ExportFile):
                     realm=imported_realm, event_type=AuditLogEventType.REALM_PLAN_TYPE_CHANGED
                 ).exists()
             )
+
+    def test_import_realm_clears_leftover_module_state(self) -> None:
+        self.addCleanup(reset_import_state)
+        # Plant stale mappings.
+        import_realm.ID_MAP["user_profile"][999_999_999] = 888_888_888
+        import_realm.id_map_to_list["huddle_to_user_list"][999_999_999] = [888_888_888]
+        import_realm.path_maps["old_attachment_path_to_new_path"]["stale/old/path"] = (
+            "stale/new/path"
+        )
+        import_realm.message_id_to_attachments["zerver_message"][999_999_999].append(
+            "stale/old/path"
+        )
+
+        original_realm = Realm.objects.get(string_id="zulip")
+        self.export_realm_and_create_auditlog(original_realm)
+        # reset_import_state doesn't crash import.
+        with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"):
+            do_import_realm(get_output_dir(), "test-zulip")
+
+        # Planted items are cleared by do_import_realm.
+        self.assertNotIn(999_999_999, import_realm.ID_MAP["user_profile"])
+        self.assertNotIn(999_999_999, import_realm.id_map_to_list["huddle_to_user_list"])
+        self.assertNotIn(
+            "stale/old/path", import_realm.path_maps["old_attachment_path_to_new_path"]
+        )
+        self.assertNotIn(999_999_999, import_realm.message_id_to_attachments["zerver_message"])
 
     def test_system_usergroup_audit_logs(self) -> None:
         realm = get_realm("zulip")


### PR DESCRIPTION
The self-serve import flow runs in a long-lived DeferredWorker. Since
do_import_realm writes but never clears its module-level dicts (ID_MAP,
path_maps, etc.), every import's mappings pile up for the life of the
worker, and each run can read leftover state from earlier ones.

This adds a process that re-initialize these dicts at the very start of
every import.
Fixes part of #39650.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
