### PR TITLE
llms_txt: Restrict the endpoint to safe HTTP methods.

### DIFF
--- a/zerver/tests/test_llms_txt.py
+++ b/zerver/tests/test_llms_txt.py
@@ -86,3 +86,12 @@ class LlmsTxtTest(ZulipTestCase):
         self.assertIn("Rome", content)
         # "Scotland" is a private stream — should NOT be listed.
         self.assertNotIn("Scotland", content)
+
+    def test_llms_txt_rejects_unsafe_methods(self) -> None:
+        """
+        /llms.txt only serves GET and HEAD; other methods get 405.
+        """
+        realm = get_realm("zulip")
+        do_set_realm_property(realm, "enable_spectator_access", True, acting_user=None)
+        result = self.client_post("/llms.txt")
+        self.assertEqual(result.status_code, 405)

--- a/zerver/views/llms_txt.py
+++ b/zerver/views/llms_txt.py
@@ -2,11 +2,13 @@ import json
 from urllib.parse import urlencode
 
 from django.http import HttpRequest, HttpResponse
+from django.views.decorators.http import require_safe
 
 from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.streams import get_web_public_streams_queryset
 
 
+@require_safe
 def llms_txt(request: HttpRequest) -> HttpResponse:
     """Serve /llms.txt so that LLMs can discover how to read web-public
     channel messages via the Zulip API without authentication.


### PR DESCRIPTION
Unsafe methods (POST/PUT/PATCH/DELETE) were rejected only incidentally, by Django's CSRF middleware, which returns a misleading 403 rather than reflecting that the method itself isn't supported. Added `@require_safe` -> GET and HEAD, matching the pattern used for similar read-only views like `check_subdomain_available`, rather than `require_GET`, which isn't used anywhere else in the codebase and would've wrongly rejected HEAD requests.

Fixes: part of the review @rht raised in the [CZO thread](https://chat.zulip.org/#narrow/channel/137-feedback/topic/web.20public.20streams.20not.20readable.20by.20agentic.20ai.20tools/near/2450322).

**How changes were tested:**

- [x] `./tools/test-backend zerver.tests.test_llms_txt --coverage`, added a test asserting POST gets 405.
- [x] `./tools/lint zerver/views/llms_txt.py zerver/tests/test_llms_txt.py`


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>