### PR TITLE
echo: Clear failed local echoes from echo_state on abort.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -652,7 +652,7 @@ export function rewire_message_send_error(value: typeof message_send_error): voi
     message_send_error = value;
 }
 
-function abort_message(message: Message): void {
+export function abort_message(message: LocalMessage): void {
     // Update the rendered data first since it is most user visible.
     for (const msg_list of message_lists.all_rendered_message_lists()) {
         msg_list.remove_and_rerender([message.id]);
@@ -661,6 +661,9 @@ function abort_message(message: Message): void {
     for (const msg_list_data of message_lists.non_rendered_data()) {
         msg_list_data.remove([message.id]);
     }
+
+    echo_state.remove_message_from_waiting_for_id(message.local_id);
+    echo_state.remove_message_from_waiting_for_ack(message.local_id);
 }
 
 export function display_slow_send_loading_spinner(message: Message): void {

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -64,6 +64,7 @@ message_lists.current = {
     },
     change_message_id: noop,
     add_messages: noop,
+    remove_and_rerender: noop,
 };
 const home_msg_list = {
     view: {
@@ -80,6 +81,7 @@ const home_msg_list = {
     preserver_rendered_state: true,
     change_message_id: noop,
     add_messages: noop,
+    remove_and_rerender: noop,
 };
 message_lists.all_rendered_message_lists = () => [home_msg_list, message_lists.current];
 message_lists.non_rendered_data = () => [];
@@ -659,6 +661,34 @@ run_test("resend error on a message removed from the store doesn't crash", ({ove
     // The detached message was left untouched, since there was no stored entry
     // to mark as failed.
     assert.equal(message.failed_request, false);
+});
+
+run_test("abort_message clears the failed echo from echo_state", ({override}) => {
+    const local_id = "77.01";
+    const message = {
+        id: 77,
+        local_id,
+        type: "stream",
+        stream_id: general_sub.stream_id,
+        topic: "test",
+        locally_echoed: true,
+        failed_request: true,
+    };
+    echo_state._patch_waiting_for_ack(new Map());
+    echo.track_local_message(message);
+    assert.equal(echo_state.get_message_waiting_for_id(local_id), message);
+    assert.equal(echo_state.get_message_waiting_for_ack(local_id), message);
+
+    const removed_ids = [];
+    override(message_lists.current, "remove_and_rerender", (ids) => {
+        removed_ids.push(...ids);
+    });
+
+    echo.abort_message(message);
+
+    assert.deepEqual(removed_ids, [77]);
+    assert.equal(echo_state.get_message_waiting_for_id(local_id), undefined);
+    assert.equal(echo_state.get_message_waiting_for_ack(local_id), undefined);
 });
 
 run_test("reify_message_id counts a sent direct message", ({override}) => {


### PR DESCRIPTION
`abort_message` - the handler behind the X that dismisses a failed message from the feed - removed the message from the message lists, but `track_local_message` records every local echo in *both* of `echo_state`'s maps and abort undid neither. So a dismissed send lingered in `waiting_for_ack` and in `waiting_for_id` until the next page reload.

`waiting_for_ack` is read elsewhere as live-echo state: it keeps an otherwise-empty DM conversation in the sidebar, and keeps the echo's topic in the channel's topic list, sorted above every delivered topic. `waiting_for_id` is only ever cleared by `reify_message_id`, which an aborted send never reaches.

Fix: drop both entries at the end of `abort_message`, mirroring the other local-echo teardown paths. Exported the function (and narrowed its parameter to `LocalMessage`) so it can be unit-tested directly, like `resend_message`.

Found [during review](https://github.com/zulip/zulip/pull/38356#discussion_r3619055103) in #38356, but independent of the Outbox feature. No UI changes.


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
