### PR TITLE
webhooks: Added GitHub signature verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@types/convert-source-map": "^2.0.3",
     "@types/css-tree": "^3.2.0",
     "@types/eslint-config-prettier": "^6.11.3",
+    "@types/estree": "^1.0.9",
     "@types/gtag.js": "^0.0.20",
     "@types/is-url": "^1.2.32",
     "@types/jquery": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,9 @@ importers:
       '@types/eslint-config-prettier':
         specifier: ^6.11.3
         version: 6.11.3
+      '@types/estree':
+        specifier: ^1.0.9
+        version: 1.0.9
       '@types/gtag.js':
         specifier: ^0.0.20
         version: 0.0.20

--- a/web/src/portico/integrations_dev_panel.ts
+++ b/web/src/portico/integrations_dev_panel.ts
@@ -231,6 +231,7 @@ function update_url(): void {
                 params.set("topic", topic_name);
             }
         }
+        const webhook_secret = $<HTMLInputElement>("input#webhook_secret").val()!;
         const url = `${url_base}${integration_name}?${params.toString()}`;
         url_field!.value = url;
     }

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -14,7 +14,6 @@ import {
     EMBEDDED_BOT_TYPE,
     GENERIC_BOT_TYPE,
     INCOMING_WEBHOOK_BOT_TYPE,
-    INCOMING_WEBHOOK_BOT_TYPE,
     INCOMING_WEBHOOK_BOT_TYPE_INT,
     OUTGOING_WEBHOOK_BOT_TYPE,
     OUTGOING_WEBHOOK_BOT_TYPE_INT,
@@ -381,8 +380,7 @@ export function add_a_new_bot(): void {
             $("#create_payload_url").removeClass("required");
 
             $("#webhook_secret_inputbox").hide();
-
-            $("#webhook_secret_inputbox").hide();
+            
             switch (bot_type) {
                 case INCOMING_WEBHOOK_BOT_TYPE: {
                     $("#webhook_secret_inputbox").show();

--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -12,7 +12,9 @@ import type {Bot} from "./bot_data.ts";
 import * as bot_helper from "./bot_helper.ts";
 import {
     EMBEDDED_BOT_TYPE,
-    GENERIC_BOT_TYPE_INT,
+    GENERIC_BOT_TYPE,
+    INCOMING_WEBHOOK_BOT_TYPE,
+    INCOMING_WEBHOOK_BOT_TYPE,
     INCOMING_WEBHOOK_BOT_TYPE_INT,
     OUTGOING_WEBHOOK_BOT_TYPE,
     OUTGOING_WEBHOOK_BOT_TYPE_INT,
@@ -298,6 +300,20 @@ export function add_a_new_bot(): void {
                 formData.append("interface_type", interface_type);
                 break;
             }
+            case INCOMING_WEBHOOK_BOT_TYPE: {
+                const config_data: Record<string, string> = {};
+                $<HTMLInputElement>("#webhook_secret_inputbox input").each(function () {
+                    const key = $(this).attr("name")!;
+                    const value = $(this).val()?.trim();
+                    if (value) {
+                        config_data[key] = value;
+                    }
+                });
+                if (Object.keys(config_data).length > 0) {
+                    formData.append("config_data", JSON.stringify(config_data));
+                }
+                break;
+            }
             case EMBEDDED_BOT_TYPE: {
                 formData.append("service_name", service_name);
                 const config_data: Record<string, string> = {};
@@ -336,7 +352,8 @@ export function add_a_new_bot(): void {
     }
 
     function set_up_form_fields(): void {
-        $("#create_bot_type").val(INCOMING_WEBHOOK_BOT_TYPE_INT);
+        $("#create_bot_type").val(INCOMING_WEBHOOK_BOT_TYPE).trigger("change");
+        $("#create_bot_type").val(INCOMING_WEBHOOK_BOT_TYPE).trigger("change");
         $("#payload_url_inputbox").hide();
         $("#create_payload_url").val("");
         $("#service_name_list").hide();
@@ -362,7 +379,19 @@ export function add_a_new_bot(): void {
 
             $("#payload_url_inputbox").hide();
             $("#create_payload_url").removeClass("required");
+
+            $("#webhook_secret_inputbox").hide();
+
+            $("#webhook_secret_inputbox").hide();
             switch (bot_type) {
+                case INCOMING_WEBHOOK_BOT_TYPE: {
+                    $("#webhook_secret_inputbox").show();
+                    break;
+                }
+                case INCOMING_WEBHOOK_BOT_TYPE: {
+                    $("#webhook_secret_inputbox").show();
+                    break;
+                }
                 case OUTGOING_WEBHOOK_BOT_TYPE: {
                     $("#payload_url_inputbox").show();
                     $("#create_payload_url").addClass("required");
@@ -377,7 +406,8 @@ export function add_a_new_bot(): void {
                 }
             }
         });
-
+        $("#create_bot_type").val(INCOMING_WEBHOOK_BOT_TYPE).trigger("change");
+        $("#create_bot_type").val(INCOMING_WEBHOOK_BOT_TYPE).trigger("change");
         $("#select_service_name").on("change", () => {
             $("#config_inputbox").children().hide();
             const selected_bot = $<HTMLSelectOneElement>(

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -28,6 +28,18 @@
               maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
         </div>
+        {{> ../dropdown_widget_with_label
+          widget_name="integration-name"
+          label=(t "Integration")}}
+
+        <div id="webhook_secret_inputbox" class="input-group">
+            <label for="create_webhook_secret" class="modal-field-label">
+                {{t "Webhook secret" }}
+                <span class="modal-field-optional">({{t "optional" }})</span>
+            </label>
+            <input type="text" name="webhook_secret" id="create_webhook_secret" class="modal_text_input" value="" />
+            <div><label for="create_webhook_secret" generated="true" class="text-error"></label></div>
+        </div>
         <div class="input-group">
             <label for="create_bot_short_name" class="modal-field-label">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part modal_text_input"

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -28,18 +28,6 @@
               maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
         </div>
-        {{> ../dropdown_widget_with_label
-          widget_name="integration-name"
-          label=(t "Integration")}}
-
-        <div id="webhook_secret_inputbox" class="input-group">
-            <label for="create_webhook_secret" class="modal-field-label">
-                {{t "Webhook secret" }}
-                <span class="modal-field-optional">({{t "optional" }})</span>
-            </label>
-            <input type="text" name="webhook_secret" id="create_webhook_secret" class="modal_text_input" value="" />
-            <div><label for="create_webhook_secret" generated="true" class="text-error"></label></div>
-        </div>
         <div class="input-group">
             <label for="create_bot_short_name" class="modal-field-label">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part modal_text_input"
@@ -67,8 +55,8 @@
         </div>
         <div id="webhook_secret_inputbox">
             <div class="input-group">
-                <label for="create_webhook_secret" class="modal-field-label">{{t "Webhook secret" }}</label>
-                <input type="password" name="webhook_secret" id="create_webhook_secret" class="modal_text_input" placeholder="{{ t 'Optional secret' }}" value=""/>
+                <label for="create_webhook_secret" class="modal-field-label">{{t "Webhook secret (optional)" }}</label>
+                <input type="password" name="webhook_secret" id="create_webhook_secret" class="modal_text_input" placeholder="{{t 'ZulipSecret123' }}" value=""/>
                 <div><label for="create_webhook_secret" generated="true" class="text-error"></label></div>
             </div>
         </div>

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -65,6 +65,13 @@
                 <div><label for="create_interface_type" generated="true" class="text-error"></label></div>
             </div>
         </div>
+        <div id="webhook_secret_inputbox">
+            <div class="input-group">
+                <label for="create_webhook_secret" class="modal-field-label">{{t "Webhook secret" }}</label>
+                <input type="password" name="webhook_secret" id="create_webhook_secret" class="modal_text_input" placeholder="{{ t 'Optional secret' }}" value=""/>
+                <div><label for="create_webhook_secret" generated="true" class="text-error"></label></div>
+            </div>
+        </div>
         <div id="config_inputbox">
             {{#each realm_embedded_bots}}
                 {{#each (object_entries config) as |entry|}}

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -41,6 +41,12 @@
 
         <div id="service_data">
         </div>
+        {{#if is_incoming_webhook_bot}}
+        <div class="input-group edit_bot_webhook_secret_container">
+            <label for="edit_webhook_secret" class="modal-field-label">{{t "Webhook secret" }}</label>
+            <input type="password" name="webhook_secret" id="edit_webhook_secret" class="modal_text_input" placeholder="{{t 'Leave blank to keep current secret' }}" value=""/>
+        </div>
+        {{/if}}
         <div class="input-group edit-avatar-section">
             <label class="modal-field-label">{{t "Avatar" }}</label>
             {{!-- Shows the current avatar --}}

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -72,16 +72,6 @@
             <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
         </div>
     </form>
-    {{#if is_incoming_webhook_bot}}
-    <div class="input-group">
-        {{> ../components/action_button
-          label=(t "Generate URL for an integration")
-          variant="subtle"
-          intent="neutral"
-          custom_classes="generate_url_for_integration"
-          }}
-    </div>
-    {{/if}}
     {{#if (and is_active is_bot_owner_current_user)}}
     <div id="zuliprc-section" class="input-group">
         <div class="zuliprc-container">

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -54,7 +54,9 @@ from zerver.lib.users import is_2fa_verified
 from zerver.lib.utils import has_api_key_format
 from zerver.lib.webhooks.common import (
     MissingHTTPEventHeaderError,
+    WebhookSignatureConfig,
     notify_bot_owner_about_invalid_json,
+    validate_webhook_signature,
 )
 from zerver.models import UserProfile
 from zerver.models.clients import get_client
@@ -372,6 +374,7 @@ def webhook_view(
     webhook_client_name: str,
     notify_bot_owner_on_invalid_json: bool = True,
     all_event_types: Sequence[str] | None = None,
+    signature_config: WebhookSignatureConfig | None = None,
 ) -> Callable[[Callable[..., HttpResponse]], Callable[..., HttpResponse]]:
     # Unfortunately, callback protocols are insufficient for this:
     # https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols
@@ -389,6 +392,11 @@ def webhook_view(
                 api_key,
                 allow_webhook_access=True,
                 client_name=full_webhook_client_name(webhook_client_name),
+            )
+            validate_webhook_signature(
+                request,
+                user_profile,
+                signature_config,
             )
 
             request_notes = RequestNotes.get_notes(request)

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -12,7 +12,12 @@ from django.views.decorators.csrf import csrf_exempt
 from typing_extensions import override
 
 from zerver.lib.storage import static_path
-from zerver.lib.webhooks.common import PresetUrlOption, WebhookConfigOption, WebhookUrlOption
+from zerver.lib.webhooks.common import (
+    PresetUrlOption,
+    WebhookConfigOption,
+    WebhookSignatureConfig,
+    WebhookUrlOption,
+)
 from zerver.webhooks import fixtureless_integrations
 
 """This module declares all of the (documented) integrations available
@@ -1195,6 +1200,15 @@ INTEGRATIONS_MISSING_SCREENSHOT_CONFIG = (
     | {"slack"}
     | hubot_integration_names
 )
+
+WEBHOOK_SIGNATURE_CONFIGS: dict[str, WebhookSignatureConfig] = {
+    "github": WebhookSignatureConfig(
+        integration_name="github",
+        header="X_HUB_SIGNATURE_256",
+        algorithm="sha256",
+        prefix="sha256=",
+    ),
+}
 
 # Add integrations that are not meant to have example screenshots here
 INTEGRATIONS_WITHOUT_SCREENSHOTS = (

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -35,6 +35,7 @@ from django.test.client import BOUNDARY, MULTIPART_CONTENT, ClientHandler, encod
 from django.test.testcases import SerializeMixin
 from django.urls import resolve
 from django.utils import translation
+from django.utils.encoding import force_bytes
 from django.utils.module_loading import import_string
 from django.utils.timezone import now as timezone_now
 from fakeldap import MockLDAP
@@ -54,9 +55,11 @@ from zerver.actions.streams import bulk_add_subscriptions, bulk_remove_subscript
 from zerver.actions.user_settings import do_change_full_name, do_change_user_setting
 from zerver.actions.users import do_change_user_role
 from zerver.decorator import do_two_factor_login
+from zerver.lib.bot_config import set_bot_config
 from zerver.lib.cache import bounce_key_prefix_for_testing
 from zerver.lib.email_notifications import MissedMessageData, handle_missedmessage_emails
 from zerver.lib.initial_password import initial_password
+from zerver.lib.integrations import WEBHOOK_SIGNATURE_CONFIGS
 from zerver.lib.mdiff import diff_strings
 from zerver.lib.message import access_message
 from zerver.lib.notification_data import UserMessageNotificationsData
@@ -92,8 +95,10 @@ from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.lib.upload import upload_message_attachment_from_request
 from zerver.lib.user_groups import get_system_user_group_for_user
 from zerver.lib.webhooks.common import (
+    WEBHOOK_SECRET_TOKEN_KEY,
     call_fixture_to_headers,
     check_send_webhook_message,
+    compute_webhook_signature,
     standardize_headers,
 )
 from zerver.models import (
@@ -2547,6 +2552,8 @@ class WebhookTestCase(ZulipTestCase):
     DEFAULT_URL_TEMPLATE: str = (
         "/api/v1/external/{webhook_dir_name}?stream={stream}&api_key={api_key}"
     )
+    WEBHOOK_TEST_SECRET: str | None = None
+    VERIFY_WEBHOOK_SIGNATURES: bool = True
 
     def get_webhook_dir_name(self) -> str:
         module_parts = self.__module__.split(".")
@@ -2562,6 +2569,19 @@ class WebhookTestCase(ZulipTestCase):
         self.channel_name = self.webhook_dir_name
         self.url_template = self.URL_TEMPLATE or self.DEFAULT_URL_TEMPLATE
         self.url = self.build_webhook_url()
+
+        if self.WEBHOOK_TEST_SECRET is not None:
+            config = WEBHOOK_SIGNATURE_CONFIGS.get(self.webhook_dir_name.lower())
+            if config is None:
+                raise AssertionError(
+                    f"WEBHOOK_TEST_SECRET was set for  '{self.webhook_dir_name}', "
+                    f"but no WebhookSignatureConfig is registered in WEBHOOK_SIGNATURE_CONFIGS."
+                )
+            set_bot_config(
+                self.test_user,
+                WEBHOOK_SECRET_TOKEN_KEY.format(integration_name=self.webhook_dir_name.lower()),
+                self.WEBHOOK_TEST_SECRET,
+            )
 
         function = import_string(
             f"zerver.webhooks.{self.webhook_dir_name}.view.api_{self.webhook_dir_name}_webhook"
@@ -2653,26 +2673,38 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         """
         self.subscribe(self.test_user, self.channel_name)
 
+        url = self.url
+        webhook_secret = self.WEBHOOK_TEST_SECRET
+        config = WEBHOOK_SIGNATURE_CONFIGS.get(self.webhook_dir_name.lower())
+
         payload = self.get_payload(fixture_name)
         if content_type is not None:
             extra["content_type"] = content_type
+
+        if webhook_secret is not None and config is not None:
+            header_val = compute_webhook_signature(
+                force_bytes(webhook_secret),
+                force_bytes(payload),
+                config,
+            )
+
+            django_header = "HTTP_" + config.header.upper().replace("-", "_")
+            if django_header not in extra:
+                extra[django_header] = header_val
+
         headers = call_fixture_to_headers(self.webhook_dir_name, fixture_name)
         headers = standardize_headers(headers)
         extra.update(headers)
-        try:
-            msg = self.send_webhook_payload(
-                self.test_user,
-                self.url,
-                payload,
-                **extra,
-            )
-        except EmptyResponseError:
-            if expect_noop:
-                return
-            else:
-                raise AssertionError(
-                    "No message was sent. Pass expect_noop=True if this is intentional."
-                )
+        with self.settings(VERIFY_WEBHOOK_SIGNATURES=self.VERIFY_WEBHOOK_SIGNATURES):
+            try:
+                msg = self.send_webhook_payload(self.test_user, url, payload, **extra)
+            except EmptyResponseError:
+                if expect_noop:
+                    return
+                else:
+                    raise AssertionError(
+                        "No message was sent. Pass expect_noop=True if this is intentional."
+                    )
 
         if expect_noop:
             raise Exception(
@@ -2718,6 +2750,7 @@ one or more new messages.
         Most webhooks send to streams, and you will want to look at
         check_webhook.
         """
+
         payload = self.get_payload(fixture_name)
         extra["content_type"] = content_type
 
@@ -2728,12 +2761,13 @@ one or more new messages.
         if sender is None:
             sender = self.test_user
 
-        msg = self.send_webhook_payload(
-            sender,
-            self.url,
-            payload,
-            **extra,
-        )
+        with self.settings(VERIFY_WEBHOOK_SIGNATURES=self.VERIFY_WEBHOOK_SIGNATURES):
+            msg = self.send_webhook_payload(
+                sender,
+                self.url,
+                payload,
+                **extra,
+            )
         self.assertEqual(msg.content, expected_message)
 
         return msg

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -57,6 +57,7 @@ from zerver.actions.users import do_change_user_role
 from zerver.decorator import do_two_factor_login
 from zerver.lib.bot_config import set_bot_config
 from zerver.lib.cache import bounce_key_prefix_for_testing
+from zerver.lib.bot_config import set_bot_config
 from zerver.lib.email_notifications import MissedMessageData, handle_missedmessage_emails
 from zerver.lib.initial_password import initial_password
 from zerver.lib.integrations import WEBHOOK_SIGNATURE_CONFIGS
@@ -2673,9 +2674,13 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         """
         self.subscribe(self.test_user, self.channel_name)
 
-        url = self.url
-        webhook_secret = self.WEBHOOK_TEST_SECRET
-        config = WEBHOOK_SIGNATURE_CONFIGS.get(self.webhook_dir_name.lower())
+        url = getattr(self, "url", None)
+        if url is None:
+            url = self.build_webhook_url()
+
+        webhook_secret = getattr(self, "WEBHOOK_TEST_SECRET", None)
+        if webhook_secret is not None:
+            set_bot_config(self.test_user, "webhook_secret", webhook_secret)
 
         payload = self.get_payload(fixture_name)
         if content_type is not None:
@@ -2751,6 +2756,10 @@ one or more new messages.
         check_webhook.
         """
 
+        webhook_secret = getattr(self, "WEBHOOK_TEST_SECRET", None)
+        if webhook_secret is not None:
+            set_bot_config(self.test_user, "webhook_secret", webhook_secret)
+            
         payload = self.get_payload(fixture_name)
         extra["content_type"] = content_type
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -57,7 +57,6 @@ from zerver.actions.users import do_change_user_role
 from zerver.decorator import do_two_factor_login
 from zerver.lib.bot_config import set_bot_config
 from zerver.lib.cache import bounce_key_prefix_for_testing
-from zerver.lib.bot_config import set_bot_config
 from zerver.lib.email_notifications import MissedMessageData, handle_missedmessage_emails
 from zerver.lib.initial_password import initial_password
 from zerver.lib.integrations import WEBHOOK_SIGNATURE_CONFIGS
@@ -2759,7 +2758,7 @@ one or more new messages.
         webhook_secret = getattr(self, "WEBHOOK_TEST_SECRET", None)
         if webhook_secret is not None:
             set_bot_config(self.test_user, "webhook_secret", webhook_secret)
-            
+
         payload = self.get_payload(fixture_name)
         extra["content_type"] = content_type
 

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -25,6 +25,7 @@ from zerver.actions.message_send import (
     check_send_stream_message_by_id,
     send_rate_limited_pm_notification_to_bot_owner,
 )
+from zerver.lib.bot_config import ConfigError, get_bot_config
 from zerver.lib.exceptions import (
     AnomalousWebhookPayloadError,
     ErrorCode,
@@ -58,6 +59,8 @@ that this integration expects!
 SETUP_MESSAGE_TEMPLATE = "{integration} webhook has been successfully configured"
 SETUP_MESSAGE_USER_PART = " by {user_name}"
 
+WEBHOOK_SECRET_TOKEN_KEY = "{integration_name}:webhook_secret_token"
+
 OptionalUserSpecifiedTopicStr: TypeAlias = Annotated[str | None, ApiParamConfig("topic")]
 
 
@@ -72,6 +75,16 @@ class WebhookConfigOption:
     name: str
     label: str
     validator: Callable[[str, str], str | bool | None]
+
+
+@dataclass(frozen=True)
+class WebhookSignatureConfig:
+    integration_name: str
+    header: str
+    algorithm: str = "sha256"
+    prefix: str = ""
+    # This will override the default compute_webhook_signature function if provided for unique formats
+    custom_formatter: Callable[[str], str] | None = None
 
 
 @dataclass
@@ -321,34 +334,63 @@ def parse_multipart_string(body: str) -> dict[str, str]:
 
 
 def validate_webhook_signature(
-    request: HttpRequest, payload: str, signature: str, algorithm: str = "sha256"
+    request: HttpRequest,
+    user_profile: UserProfile,
+    config: WebhookSignatureConfig | None,
 ) -> None:
-    if not settings.VERIFY_WEBHOOK_SIGNATURES:  # nocoverage
+    if not settings.VERIFY_WEBHOOK_SIGNATURES or not config:
         return
 
-    if algorithm not in hashlib.algorithms_available:
+    if config.algorithm not in hashlib.algorithms_available:
         raise AssertionError(
-            _("The algorithm '{algorithm}' is not supported.").format(algorithm=algorithm)
+            _("The algorithm '{algorithm}' is not supported.").format(algorithm=config.algorithm)
         )
 
-    webhook_secret: str | None = request.GET.get("webhook_secret")
-    if webhook_secret is None:
-        raise JsonableError(
-            _(
-                "The webhook secret is missing. Please set the webhook_secret while generating the URL."
-            )
-        )
-    webhook_secret_bytes = force_bytes(webhook_secret)
-    payload_bytes = force_bytes(payload)
+    signature_header = request.headers.get(config.header)
+    if not signature_header:
+        return
 
-    signed_payload = hmac.new(
-        webhook_secret_bytes,
-        payload_bytes,
-        algorithm,
-    ).hexdigest()
+    try:
+        bot_config = get_bot_config(user_profile)
+    except ConfigError:
+        return
 
-    if not constant_time_compare(signed_payload, signature):
+    webhook_secret = bot_config.get(
+        WEBHOOK_SECRET_TOKEN_KEY.format(integration_name=config.integration_name.lower())
+    )
+
+    if not webhook_secret or not webhook_secret.strip():
+        raise JsonableError(_("Webhook secret is not configured for this bot."))
+
+    payload = request.body.decode("utf-8")
+
+    expected_header_val = compute_webhook_signature(
+        force_bytes(webhook_secret),
+        force_bytes(payload),
+        config,
+    )
+    if not constant_time_compare(expected_header_val, signature_header):
         raise JsonableError(_("Webhook signature verification failed."))
+
+
+def compute_webhook_signature(
+    secret_bytes: bytes,
+    payload_bytes: bytes,
+    config: WebhookSignatureConfig,
+) -> str:
+    """Computes and formats the HMAC signature for a webhook payload."""
+    signer = hmac.new(
+        secret_bytes,
+        payload_bytes,
+        config.algorithm,
+    )
+    digest = signer.hexdigest()
+
+    if config.custom_formatter is not None:
+        digest = config.custom_formatter(digest)
+    if config.prefix:
+        return f"{config.prefix}{digest}"
+    return digest
 
 
 def guess_zulip_user_from_external_account(

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -345,7 +345,7 @@ def validate_webhook_delivery(
 
     if not webhook_secret:
         raise JsonableError(_("Webhook secret is not configured for this bot."))
-    
+
     signature_header = request.headers.get(signature_header_name, "")
     signature = signature_header.split("=")[-1] if "=" in signature_header else signature_header
 

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -26,6 +26,7 @@ from zerver.actions.message_send import (
     send_rate_limited_pm_notification_to_bot_owner,
 )
 from zerver.lib.bot_config import ConfigError, get_bot_config
+from zerver.lib.bot_config import ConfigError, get_bot_config
 from zerver.lib.exceptions import (
     AnomalousWebhookPayloadError,
     ErrorCode,
@@ -333,10 +334,38 @@ def parse_multipart_string(body: str) -> dict[str, str]:
     return data
 
 
+def validate_webhook_delivery(
+    request: HttpRequest, signature_header_name: str, algorithm: str = "sha256"
+) -> None:
+    try:
+        config = get_bot_config(request.user)
+        webhook_secret = config.get("webhook_secret", "")
+    except ConfigError:
+        webhook_secret = ""
+
+    if not webhook_secret:
+        raise JsonableError(_("Webhook secret is not configured for this bot."))
+    
+    signature_header = request.headers.get(signature_header_name, "")
+    signature = signature_header.split("=")[-1] if "=" in signature_header else signature_header
+
+    payload = request.body.decode("utf-8")
+
+    try:
+        validate_webhook_signature(
+            request=request, payload=payload, signature=signature, algorithm=algorithm
+        )
+    except JsonableError:
+        raise
+    except Exception as err:  # nocoverage
+        raise JsonableError(str(err))
+
+
 def validate_webhook_signature(
-    request: HttpRequest,
-    user_profile: UserProfile,
-    config: WebhookSignatureConfig | None,
+    payload: str,
+    signature: str,
+    secret: str,
+    algorithm: str = "sha256",
 ) -> None:
     if not settings.VERIFY_WEBHOOK_SIGNATURES or not config:
         return
@@ -346,30 +375,19 @@ def validate_webhook_signature(
             _("The algorithm '{algorithm}' is not supported.").format(algorithm=config.algorithm)
         )
 
-    signature_header = request.headers.get(config.header)
-    if not signature_header:
-        return
-
-    try:
-        bot_config = get_bot_config(user_profile)
-    except ConfigError:
-        return
-
-    webhook_secret = bot_config.get(
-        WEBHOOK_SECRET_TOKEN_KEY.format(integration_name=config.integration_name.lower())
-    )
-
-    if not webhook_secret or not webhook_secret.strip():
+    if not secret:
         raise JsonableError(_("Webhook secret is not configured for this bot."))
 
-    payload = request.body.decode("utf-8")
+    webhook_secret_bytes = force_bytes(secret)
+    payload_bytes = force_bytes(payload)
 
-    expected_header_val = compute_webhook_signature(
-        force_bytes(webhook_secret),
-        force_bytes(payload),
-        config,
-    )
-    if not constant_time_compare(expected_header_val, signature_header):
+    signed_payload = hmac.new(
+        webhook_secret_bytes,
+        payload_bytes,
+        algorithm,
+    ).hexdigest()
+
+    if not constant_time_compare(signed_payload, signature):
         raise JsonableError(_("Webhook signature verification failed."))
 
 

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -1,5 +1,3 @@
-import hashlib
-import hmac
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +12,7 @@ from version import ZULIP_VERSION
 from zerver.actions.custom_profile_fields import try_add_realm_custom_profile_field
 from zerver.actions.streams import do_rename_stream
 from zerver.decorator import webhook_view
+from zerver.lib.bot_config import ConfigError, set_bot_config
 from zerver.lib.exceptions import InvalidJSONError, JsonableError
 from zerver.lib.request import RequestNotes
 from zerver.lib.send_email import FromAddress
@@ -22,9 +21,12 @@ from zerver.lib.test_helpers import HostRequestMock
 from zerver.lib.webhooks.common import (
     INVALID_JSON_MESSAGE,
     MISSING_EVENT_HEADER_MESSAGE,
+    WEBHOOK_SECRET_TOKEN_KEY,
     MissingHTTPEventHeaderError,
+    WebhookSignatureConfig,
     call_fixture_to_headers,
     check_send_webhook_message,
+    compute_webhook_signature,
     get_event_header,
     get_service_api_data,
     guess_zulip_user_from_external_account,
@@ -152,34 +154,95 @@ class WebhooksCommonTestCase(ZulipTestCase):
 
     @override_settings(VERIFY_WEBHOOK_SIGNATURES=True)
     def test_validate_webhook_signature(self) -> None:
-        request = HostRequestMock()
-        request.GET = QueryDict("", mutable=True)
-
-        # Valid signature
+        webhook_bot = get_user("webhook-bot@zulip.com", get_realm("zulip"))
         webhook_secret = "test_secret"
+        config = WebhookSignatureConfig(
+            integration_name="github",
+            header="X-Hub-Signature-256",
+            algorithm="sha256",
+            prefix="sha256=",
+        )
         payload = '{"key": "value"}'
-        signature = hmac.new(
-            force_bytes(webhook_secret), force_bytes(payload), hashlib.sha256
-        ).hexdigest()
+        signature = compute_webhook_signature(
+            force_bytes(webhook_secret), force_bytes(payload), config
+        )
 
-        request.GET.update({"webhook_secret": webhook_secret})
-        validate_webhook_signature(request, payload, signature)
+        # Missing header early return check
+        request = HostRequestMock(meta_data={})
+        request.user = webhook_bot
+        request.GET = QueryDict("", mutable=True)
+        request._body = force_bytes(payload)
+        validate_webhook_signature(request, webhook_bot, config)
 
-        # Invalid signature
-        invalid_signature = "invalid_signature"
+        # ConfigError early return check
+        request = HostRequestMock(meta_data={"HTTP_X_HUB_SIGNATURE_256": signature})
+        request.user = webhook_bot
+        request.GET = QueryDict("", mutable=True)
+        request._body = force_bytes(payload)
+        with patch("zerver.lib.webhooks.common.get_bot_config", side_effect=ConfigError):
+            validate_webhook_signature(request, webhook_bot, config)
+
+        # Unconfigured secret initial pass
+        request = HostRequestMock(meta_data={"HTTP_X_HUB_SIGNATURE_256": signature})
+        request.user = webhook_bot
+        request.GET = QueryDict("", mutable=True)
+        request._body = force_bytes(payload)
+        validate_webhook_signature(request, webhook_bot, config)
+
+        # Valid signature with configured token key
+        set_bot_config(
+            webhook_bot, WEBHOOK_SECRET_TOKEN_KEY.format(integration_name="github"), webhook_secret
+        )
+        request = HostRequestMock(meta_data={"HTTP_X_HUB_SIGNATURE_256": signature})
+        request.user = webhook_bot
+        request.GET = QueryDict("", mutable=True)
+        request._body = force_bytes(payload)
+        validate_webhook_signature(request, webhook_bot, config)
+
+        # Invalid signature check
+        request.META["HTTP_X_HUB_SIGNATURE_256"] = "sha256=invalid_signature"
+        del request.headers
         with self.assertRaisesRegex(
             JsonableError,
             "Webhook signature verification failed.",
         ):
-            validate_webhook_signature(request, payload, invalid_signature)
+            validate_webhook_signature(request, webhook_bot, config)
 
-        # No webhook_secret parameter
-        request.GET.clear()
+        # Missing secret check using token key
+        set_bot_config(webhook_bot, WEBHOOK_SECRET_TOKEN_KEY.format(integration_name="github"), "")
+        request.META["HTTP_X_HUB_SIGNATURE_256"] = signature
+        del request.headers
         with self.assertRaisesRegex(
             JsonableError,
-            "The webhook secret is missing. Please set the webhook_secret while generating the URL.",
+            "Webhook secret is not configured for this bot.",
         ):
-            validate_webhook_signature(request, payload, signature)
+            validate_webhook_signature(request, webhook_bot, config=config)
+
+    def test_compute_webhook_signature_formatter_and_prefix(self) -> None:
+        # Tests the custom_formatter
+        config_formatter = WebhookSignatureConfig(
+            integration_name="test",
+            header="X-Test-Signature",
+            custom_formatter=lambda d: f"sha256={d.upper()}",
+        )
+        sig_formatter = compute_webhook_signature(b"secret", b"payload", config_formatter)
+        self.assertTrue(sig_formatter.startswith("sha256="))
+
+        # Tests prefix
+        config_prefix = WebhookSignatureConfig(
+            integration_name="test",
+            header="X-Test-Signature",
+            prefix="sha256=",
+        )
+        sig_prefix = compute_webhook_signature(b"secret", b"payload", config_prefix)
+        self.assertTrue(sig_prefix.startswith("sha256="))
+
+        config_default = WebhookSignatureConfig(
+            integration_name="test",
+            header="X-Test-Signature",
+        )
+        sig_default = compute_webhook_signature(b"secret", b"payload", config_default)
+        self.assertFalse(sig_default.startswith("sha256="))
 
     def test_check_send_webhook_message_returns_id(self) -> None:
         webhook_bot = get_user("webhook-bot@zulip.com", get_realm("zulip"))

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 
 import orjson
+from django.test import override_settings
 
+from zerver.lib.bot_config import set_bot_config
 from zerver.lib.message import truncate_topic
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.lib.webhooks.git import COMMITS_LIMIT
@@ -22,6 +24,8 @@ TOPIC_SPONSORS = "sponsors"
 
 
 class GitHubWebhookTest(WebhookTestCase):
+    WEBHOOK_TEST_SECRET = "testingthis"
+
     def test_ping_event(self) -> None:
         expected_message = "GitHub webhook has been successfully configured by TomaszKolek."
         self.check_webhook("ping", TOPIC_REPO, expected_message)
@@ -850,6 +854,52 @@ A temporary team so that I can get some webhook fixtures!
         )
         expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/issues/2#issuecomment-99262140) on [issue #2](https://github.com/baxterthehacker/public-repo/issues/2):\n\n``` quote\nYou are totally right! I'll get this fixed right away.\n```"
         self.check_webhook("issue_comment", TOPIC_ISSUE, expected_message)
+
+    def test_github_webhook_bad_signature(self) -> None:
+        with override_settings(VERIFY_WEBHOOK_SIGNATURES=True):
+            url = self.build_webhook_url()
+            set_bot_config(self.test_user, "github:webhook_secret_token", self.WEBHOOK_TEST_SECRET)
+
+            result = self.client_post(
+                url,
+                self.get_payload("ping"),
+                content_type="application/json",
+                HTTP_X_HUB_SIGNATURE_256="sha256=completely_invalid_hash_value",
+            )
+            self.assert_json_error(result, "Webhook signature verification failed.")
+
+    def test_github_webhook_signature_disabled_skips_validation(self) -> None:
+        """Verifies that when VERIFY_WEBHOOK_SIGNATURES is explicitly disabled,
+        requests pass through even if the signature value is completely bogus.
+        """
+        self.VERIFY_WEBHOOK_SIGNATURES = False
+        try:
+            expected_message = "GitHub webhook has been successfully configured by TomaszKolek."
+            self.check_webhook(
+                "ping",
+                TOPIC_REPO,
+                expected_message,
+                HTTP_X_HUB_SIGNATURE_256="sha256=invalid_hash",
+            )
+        finally:
+            self.VERIFY_WEBHOOK_SIGNATURES = True
+
+    def test_github_webhook_valid_signature_success(self) -> None:
+        """Verifies that a mathematically correct HMAC signature passes
+        cleanly when verification enforcement is active."""
+        expected_message = "GitHub webhook has been successfully configured by TomaszKolek."
+        self.check_webhook("ping", TOPIC_REPO, expected_message)
+
+    def test_github_webhook_missing_secret(self) -> None:
+        """Verifies that if no webhook secret is configured for the bot,
+        the request is processed normally without requiring signature verification."""
+        self.WEBHOOK_TEST_SECRET = None  # type: ignore[assignment] # Allows testing missing secrets
+        try:
+            set_bot_config(self.test_user, "github:webhook_secret_token", "")
+            expected_message = "GitHub webhook has been successfully configured by TomaszKolek."
+            self.check_webhook("ping", TOPIC_REPO, expected_message)
+        finally:
+            self.WEBHOOK_TEST_SECRET = "testingthis"
 
 
 class GitHubSponsorsHookTests(WebhookTestCase):

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -4,6 +4,7 @@ import orjson
 from django.test import override_settings
 
 from zerver.lib.bot_config import set_bot_config
+from zerver.lib.bot_config import set_bot_config
 from zerver.lib.message import truncate_topic
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.lib.webhooks.git import COMMITS_LIMIT
@@ -858,8 +859,8 @@ A temporary team so that I can get some webhook fixtures!
     def test_github_webhook_bad_signature(self) -> None:
         with override_settings(VERIFY_WEBHOOK_SIGNATURES=True):
             url = self.build_webhook_url()
-            set_bot_config(self.test_user, "github:webhook_secret_token", self.WEBHOOK_TEST_SECRET)
-
+            set_bot_config(self.test_user, "webhook_secret", self.WEBHOOK_TEST_SECRET)
+            
             result = self.client_post(
                 url,
                 self.get_payload("ping"),
@@ -891,15 +892,22 @@ A temporary team so that I can get some webhook fixtures!
         self.check_webhook("ping", TOPIC_REPO, expected_message)
 
     def test_github_webhook_missing_secret(self) -> None:
-        """Verifies that if no webhook secret is configured for the bot,
-        the request is processed normally without requiring signature verification."""
-        self.WEBHOOK_TEST_SECRET = None  # type: ignore[assignment] # Allows testing missing secrets
-        try:
-            set_bot_config(self.test_user, "github:webhook_secret_token", "")
-            expected_message = "GitHub webhook has been successfully configured by TomaszKolek."
-            self.check_webhook("ping", TOPIC_REPO, expected_message)
-        finally:
-            self.WEBHOOK_TEST_SECRET = "testingthis"
+        """Verifies that the backend drops the request if the webhook secret
+        is not configured in BotConfigData."""
+        with override_settings(VERIFY_WEBHOOK_SIGNATURES=True):
+            url = self.build_webhook_url()
+            set_bot_config(self.test_user, "webhook_secret", "")
+
+            result = self.client_post(
+                url,
+                self.get_payload("ping"),
+                content_type="application/json",
+                HTTP_X_HUB_SIGNATURE_256="sha256=somehash",
+            )
+            self.assert_json_error(
+                result,
+                "Webhook secret is not configured for this bot.",
+            )
 
 
 class GitHubSponsorsHookTests(WebhookTestCase):

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -860,7 +860,7 @@ A temporary team so that I can get some webhook fixtures!
         with override_settings(VERIFY_WEBHOOK_SIGNATURES=True):
             url = self.build_webhook_url()
             set_bot_config(self.test_user, "webhook_secret", self.WEBHOOK_TEST_SECRET)
-            
+
             result = self.client_post(
                 url,
                 self.get_payload("ping"),

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from zerver.decorator import log_unsupported_webhook_event, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
 from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
+from zerver.lib.integrations import WEBHOOK_SIGNATURE_CONFIGS
 from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.partial import partial
@@ -1196,7 +1197,12 @@ IGNORED_TEAM_ACTIONS = [
 ALL_EVENT_TYPES = list(EVENT_FUNCTION_MAPPER.keys())
 
 
-@webhook_view("GitHub", notify_bot_owner_on_invalid_json=True, all_event_types=ALL_EVENT_TYPES)
+@webhook_view(
+    "GitHub",
+    notify_bot_owner_on_invalid_json=True,
+    all_event_types=ALL_EVENT_TYPES,
+    signature_config=WEBHOOK_SIGNATURE_CONFIGS["github"],
+)
 @typed_endpoint
 def api_github_webhook(
     request: HttpRequest,


### PR DESCRIPTION
<!-- Describe your pull request here.--> 
Authors: Akshaj Katkuri, Isaiah Marte, Srinandha Murugesan

Description:

We implemented GitHub HMAC-256 webhook verification and generalized it for third-party integrations that support validation in the future. We implemented automated test cases for the functions we wrote and modified the WebhookTestCase class for better inheritance/generalization. We also modified the Integrations Developer panel and the Bot generate integration URL frontend to allow for optional webhook secrets to be added to the payload URL as per Zulip’s existing structure. We also added a dynamic signature recalculation endpoint for the Integrations Developer panel to automatically update the Custom HTTPs Header section with correct signatures based on the form fields.

Our biggest concern is Zulip’s existing structure with placing the webhook secrets directly in the URL. We saw how test_validate_webhook_signature and validate_webhook_signature from this PR (https://github.com/zulip/zulip/pull/34306) assume that the secret is a parameter in the integration URL. Through this conversation (https://chat.zulip.org/#narrow/channel/127-integrations/topic/Stripe.3A.20Verify.20webhook.20signatures.20in.20incoming.20payloads/near/2151361), we also saw how there were plans to move it to BotConfigData but as of now, we have not found any implementation for this feature in the codebase. We raised our concerns here (https://chat.zulip.org/#narrow/channel/127-integrations/topic/Storing.20Github.20secrets/with/2496841) and proceeded to continue with the existing framework.

Fixes: <!-- Issue link, or clear description.--> 
[Verify webhook payloads before processing #19773](https://github.com/zulip/zulip/issues/19773)

How changes were tested: <!-- If the PR makes UI changes, you must include screenshots. Detailed guide:[ https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html](https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html) --> 

GitHub-specific webhook verification was tested through automated test cases such as missing signatures and invalid headers and the parser function was also tested with valid, malformed, and missing signatures. This was also verified thoroughly with the Integrations developer panel.

Changes to the UI of the Developer Integrations Panel were tested visually extensively and testing for the new recalculate_signature endpoint was done automatically with different cases such as the signature hash being modified, the webhook secret field being empty (which removes the header from the Custom HTTP headers section), and the fixture body being modified. 

For the Bot Configuration UI, we tested it manually to ensure that webhook secret is an optional parameter that doesn’t disrupt existing generated links and that the new form input keeps the UI responsive/clean for different screen sizes.

**Screenshots and screen captures**:
<table>
  <tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/da84bb0f-665b-4b6b-a7eb-06051f8faa3f" width="100%" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/7fc95016-d371-4df8-bf45-d1d5cab9b302" width="100%" />
    </td>
  </tr>
  <tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/19cb2146-57fc-4dd5-9a28-f3f889dd3661" width="100%" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/c371020d-7a7b-40f5-95ec-79758fb04f39" width="100%" />
    </td>
  </tr>
</table>

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [✓] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [✓] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [✓] Explains differences from previous plans (e.g., issue description).
- [✓] Highlights technical choices and bugs encountered.
- [✓] Calls out remaining decisions and concerns.
- [✓] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [✓] Each commit is a coherent idea.
- [✓] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [✓] Visual appearance of the changes.
- [✓] Responsiveness and internationalization.
- [✓] Strings and tooltips.
- [✓] End-to-end functionality of buttons, interactions and flows.
- [✓] Corner cases, error conditions, and easily imagined bugs.
</details>
