### PR TITLE
narrow_banner: Show capitalized stop words as excluded from search.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -130,7 +130,7 @@ function empty_search_query_banner(
 
     // Gather information about each query word
     for (const query_word of query_words) {
-        if (realm.stop_words.includes(query_word)) {
+        if (realm.stop_words.includes(query_word.toLowerCase())) {
             search_string_result.has_stop_word = true;
             search_string_result.query_words.push({
                 query_word,

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -891,6 +891,30 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
             expected_search_data,
         ),
     );
+
+    // Stop word exclusion is case insensitive.
+    const expected_search_data_capitalization_case = {
+        has_stop_word: true,
+        query_words: [
+            {query_word: "What", is_stop_word: true},
+            {query_word: "ABOUT", is_stop_word: true},
+            {query_word: "Grail", is_stop_word: false},
+        ],
+    };
+    current_filter = set_filter([
+        ["stream", streamA_id.toString()],
+        ["search", "What ABOUT Grail"],
+    ]);
+    narrow_banner.show_empty_narrow_message(current_filter);
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: No search results.",
+            undefined,
+            undefined,
+            expected_search_data_capitalization_case,
+        ),
+    );
 });
 
 run_test("show_invalid_narrow_message", ({mock_template}) => {


### PR DESCRIPTION
The server's full-text search lowercases query words before applying the stopword dictionary, so capitalized common words (e.g. "The") are excluded from searches just like lowercase ones. However, the empty-search-results banner compared query words against realm.stop_words case-sensitively, so capitalized stop words were not struck through, and the "Common words were excluded" notice could be omitted entirely.
<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| <img width="914" height="311" alt="Screenshot 2026-07-23 at 4 14 40 PM" src="https://github.com/user-attachments/assets/cfe34af8-3bc6-4d95-8511-77503c576b1a" /> | <img width="914" height="311" alt="Screenshot 2026-07-23 at 4 05 51 PM" src="https://github.com/user-attachments/assets/50ee40a9-bddc-4ef7-86b2-a8eadac132ab" /> |
| <img width="914" height="311" alt="Screenshot 2026-07-23 at 4 06 00 PM" src="https://github.com/user-attachments/assets/4e564352-c2fc-423f-a6af-8c88b6f735d4" /> | <img width="914" height="311" alt="Screenshot 2026-07-23 at 4 14 33 PM" src="https://github.com/user-attachments/assets/66f7a534-c808-4aaa-ab54-fde2ce942b72" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
