### PR TITLE
left-sidebar: Refactor topics shown left sidebar logic.

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -71,10 +71,34 @@ function build_topic_info_item(
     return topic_info;
 }
 
+function show_all_topics(
+    stream_id: number,
+    topic_names: string[],
+    topic_choice_state: TopicChoiceState,
+): void {
+    for (const topic_name of topic_names) {
+        const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
+        const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
+        const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
+        // Important: Topics are lower-case in this set.
+        const contains_unread_mention = topic_choice_state.topics_with_unread_mentions.has(
+            topic_name.toLowerCase(),
+        );
+        const topic_info = build_topic_info_item(
+            stream_id,
+            topic_name,
+            num_unread,
+            is_topic_muted,
+            is_active_topic,
+            contains_unread_mention,
+        );
+        topic_choice_state.items.push(topic_info);
+    }
+}
+
 function choose_topics(
     stream_id: number,
     topic_names: string[],
-    zoomed: boolean,
     topic_choice_state: TopicChoiceState,
 ): void {
     for (const topic_name of topic_names) {
@@ -86,67 +110,63 @@ function choose_topics(
             topic_name.toLowerCase(),
         );
 
-        if (!zoomed) {
-            function should_show_topic(topics_selected: number): boolean {
-                // This function exists just for readability, to
-                // avoid long chained conditionals to determine
-                // which topics to include.
+        function should_show_topic(topics_selected: number): boolean {
+            // This function exists just for readability, to
+            // avoid long chained conditionals to determine
+            // which topics to include.
 
-                // We always show the active topic.  Ideally, this
-                // logic would first check whether the active
-                // topic is in the set of those with unreads to
-                // avoid ending up with MAX_TOPICS_WITH_UNREAD + 1
-                // total topics if the active topic comes after
-                // the first several topics with unread messages.
-                if (is_active_topic) {
-                    return true;
-                }
+            // We always show the active topic.  Ideally, this
+            // logic would first check whether the active
+            // topic is in the set of those with unreads to
+            // avoid ending up with MAX_TOPICS_WITH_UNREAD + 1
+            // total topics if the active topic comes after
+            // the first several topics with unread messages.
+            if (is_active_topic) {
+                return true;
+            }
 
-                // We unconditionally skip showing muted topics
-                // when not zoomed, even if they have unread
-                // messages.
-                if (is_topic_muted) {
-                    return false;
-                }
-
-                // We include the most recent, unmuted MAX_TOPICS topics,
-                // even if there are no unread messages.
-                if (topics_selected < MAX_TOPICS) {
-                    return true;
-                }
-
-                // We include older topics with unread messages up
-                // until MAX_TOPICS_WITH_UNREAD total topics have
-                // been included.
-                if (num_unread > 0 && topics_selected < MAX_TOPICS_WITH_UNREAD) {
-                    return true;
-                }
-
-                // Otherwise, we don't show the topic in the
-                // unzoomed view.  We might display its unread
-                // count in "show all topics" if it is not muted.
+            // We unconditionally skip showing muted topics
+            // when not zoomed, even if they have unread
+            // messages.
+            if (is_topic_muted) {
                 return false;
             }
 
-            const show_topic = should_show_topic(topic_choice_state.topics_selected);
-            if (!show_topic) {
-                if (!is_topic_muted) {
-                    topic_choice_state.more_topics_unmuted_unreads += num_unread;
-                    if (contains_unread_mention) {
-                        topic_choice_state.more_topics_have_unread_mention_messages = true;
-                    }
-                } else {
-                    topic_choice_state.more_topics_muted_unreads += num_unread;
-                    if (contains_unread_mention) {
-                        topic_choice_state.more_topics_have_muted_unread_mention_messages = true;
-                    }
-                }
-                continue;
+            // We include the most recent, unmuted MAX_TOPICS topics,
+            // even if there are no unread messages.
+            if (topics_selected < MAX_TOPICS) {
+                return true;
             }
-            topic_choice_state.topics_selected += 1;
-            // We fall through to rendering the topic, using the
-            // same code we do when zoomed.
+
+            // We include older topics with unread messages up
+            // until MAX_TOPICS_WITH_UNREAD total topics have
+            // been included.
+            if (num_unread > 0 && topics_selected < MAX_TOPICS_WITH_UNREAD) {
+                return true;
+            }
+
+            // Otherwise, we don't show the topic in the
+            // unzoomed view.  We might display its unread
+            // count in "show all topics" if it is not muted.
+            return false;
         }
+
+        const show_topic = should_show_topic(topic_choice_state.topics_selected);
+        if (!show_topic) {
+            if (!is_topic_muted) {
+                topic_choice_state.more_topics_unmuted_unreads += num_unread;
+                if (contains_unread_mention) {
+                    topic_choice_state.more_topics_have_unread_mention_messages = true;
+                }
+            } else {
+                topic_choice_state.more_topics_muted_unreads += num_unread;
+                if (contains_unread_mention) {
+                    topic_choice_state.more_topics_have_muted_unread_mention_messages = true;
+                }
+            }
+            continue;
+        }
+        topic_choice_state.topics_selected += 1;
 
         const topic_info = build_topic_info_item(
             stream_id,
@@ -258,7 +278,9 @@ export function get_list_info(
 
     const topic_names = get_filtered_topic_names(stream_id, filter_topics);
 
-    if (stream_muted && !zoomed) {
+    if (zoomed) {
+        show_all_topics(stream_id, topic_names, topic_choice_state);
+    } else if (stream_muted) {
         const unmuted_or_followed_topics = topic_names.filter((topic) =>
             user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
@@ -266,9 +288,9 @@ export function get_list_info(
             (topic) => !user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
         const reordered_topics = [...unmuted_or_followed_topics, ...other_topics];
-        choose_topics(stream_id, reordered_topics, zoomed, topic_choice_state);
+        choose_topics(stream_id, reordered_topics, topic_choice_state);
     } else {
-        choose_topics(stream_id, topic_names, zoomed, topic_choice_state);
+        choose_topics(stream_id, topic_names, topic_choice_state);
     }
 
     if (

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -428,6 +428,35 @@ test("get_list_info unreads", ({override}) => {
         ],
     );
 
+    // If there is an active topic, then it's shown, even
+    // if it's an older topic with no unread messages.
+    override(narrow_state, "stream_id", () => 556);
+    override(narrow_state, "topic", () => "topic 15");
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 11);
+    assert.equal(list_info.more_topics_unreads, 2);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 16);
+
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 4",
+            "topic 5",
+            "topic 10",
+            "topic 11",
+            "topic 12",
+            "topic 13",
+            "topic 15",
+        ],
+    );
+
+    override(narrow_state, "topic", () => {});
+
     add_unreads("topic 9", 1);
 
     add_unreads("topic 4", 1);


### PR DESCRIPTION
Pulls out some of the refactor prep commits from #37904, which seem helpful for any future work that we might want to do in this area. There are no changes to what topics are shown in the left sidebar, whether zoomed in to all topics or showing the max recent/unread topics.

**Notes**:
- The first commit adds a missing corner case to our node test for this code.
- The second commit pulls out a helper function for building the `TopicInfo` items, which may have a slight performance improvement as some of the topic information isn't needed in the initial filter for whether to show a topic (e.g., if the topic is muted, resolved topic prefix).
- The third commit pulls out a helper function for when the left sidebar is zoomed in to show all topics. This separation of the show all topics and choose topics logic could be helpful for any future efforts to change how the max topics shown are selected for the non-zoomed case.

@amanagr would you be up for looking at this since you reviewed the previous PR where these were prep commits?

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
