### PR TITLE
openapi: Fix details about include_deactivated_groups.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3808,9 +3808,19 @@ paths:
                                 Event sent to all users in a Zulip organization
                                 when a property of a user group is changed.
 
-                                For group deactivation, this event is only sent
-                                if `include_deactivated_groups` client capability
-                                is set to `true`.
+                                For group deactivation and reactivation, this event
+                                is only sent if `include_deactivated_groups` client
+                                capability is set to `true`.
+
+                                Apart from the reactivation event described above,
+                                for an already deactivated group only the event for
+                                renaming the group is affected by the
+                                `include_deactivated_groups` client capability. It
+                                is not sent to clients with the capability set to
+                                `false`. Events for other property changes to a
+                                deactivated group, such as description and permission
+                                settings, are sent to every client regardless of the
+                                `include_deactivated_groups` client capability.
 
                                 This event is also sent when deactivating or reactivating
                                 a user for settings set to anonymous user groups which the
@@ -18265,10 +18275,13 @@ paths:
 
                     - `include_deactivated_groups`: Boolean for whether the client can handle
                       deactivated user groups by themselves. If false, then the `realm_user_groups`
-                      array in the `/register` response will only include active groups, clients
-                      will receive a `remove` event instead of `update` event when a group is
-                      deactivated and no `update` event will be sent to the client if a deactivated
-                      user group is renamed.
+                      array in the `/register` response will only include active groups, and clients
+                      will receive a `remove` event instead of an `update` event when a group is
+                      deactivated, and an `add` event instead of an `update` event when a group is
+                      reactivated. Additionally, when a deactivated user group is renamed, no
+                      `update` event is sent to the client. Other `update` events for a
+                      deactivated group, such as changes to its description and permission
+                      settings, are still sent.
                       <br />
                       **Changes**: New in Zulip 10.0 (feature level 294). This
                       capability is for backwards-compatibility.

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1803,9 +1803,8 @@ def process_notification(notice: Mapping[str, Any]) -> None:
     elif event["type"] == "realm_user" and event["op"] == "add":
         process_realm_user_add_event(event, cast(list[int], users))
     elif event["type"] == "user_group" and event["op"] == "update" and "name" in event["data"]:
-        # Only name can be changed for deactivated groups, so we handle the
-        # event sent for updating name separately for clients with different
-        # capabilities.
+        # We handle the event sent for updating a user group name
+        # separately for clients with different capabilities.
         process_user_group_name_update_event(event, cast(list[int], users))
     elif event["type"] == "user_group" and event["op"] == "add":
         process_user_group_creation_event(event, cast(list[int], users))


### PR DESCRIPTION
This PR updates API documentation to make it clear that 'include_deactivated_groups' client
capability only decides if the group rename, deactivation and reactivation events are sent or
not and other user group update events, such as those for updating the description and
group settings, are always sent.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->[#api design > events for deactivated channels and groups @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/events.20for.20deactivated.20channels.20and.20groups/near/2499643)


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<img width="1566" height="438" alt="image" src="https://github.com/user-attachments/assets/8e3c39ff-591f-4c8b-9bb6-903c964dabd3" />

<img width="1604" height="888" alt="image" src="https://github.com/user-attachments/assets/1b2f0a72-e23c-49bb-87d3-ac8a72096c3e" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
