### PR TITLE
compose: Migrate topic-missing banner to the modern banner component.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -1,11 +1,13 @@
+import Handlebars from "handlebars/runtime.js";
 import $ from "jquery";
 
+import render_banner from "../templates/components/banner.hbs";
 import render_cannot_send_direct_message_error from "../templates/compose_banner/cannot_send_direct_message_error.hbs";
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 import render_long_paste_options from "../templates/compose_banner/long_paste_options.hbs";
 import render_stream_does_not_exist_error from "../templates/compose_banner/stream_does_not_exist_error.hbs";
-import render_topics_required_error_banner from "../templates/compose_banner/topics_required_error_banner.hbs";
 import render_unknown_zoom_user_error from "../templates/compose_banner/unknown_zoom_user_error.hbs";
+import render_topics_required_error_message from "../templates/topics_required_error_message.hbs";
 
 import {$t} from "./i18n.ts";
 import * as scroll_util from "./scroll_util.ts";
@@ -233,10 +235,16 @@ export function cannot_send_direct_message_error(error_message: string): void {
 }
 
 export function topic_missing_error(empty_string_topic_display_name: string): void {
-    const new_row_html = render_topics_required_error_banner({
-        banner_type: ERROR,
-        empty_string_topic_display_name,
-        classname: CLASSNAMES.topic_missing,
+    const new_row_html = render_banner({
+        intent: "danger",
+        label: new Handlebars.SafeString(
+            render_topics_required_error_message({empty_string_topic_display_name}),
+        ),
+        buttons: [],
+        close_button: true,
+        // Preserve legacy classes so has_error() / clear_validation_errors()
+        // keep matching this banner after the markup change.
+        custom_classes: `${ERROR} ${CLASSNAMES.topic_missing}`,
     });
     append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
     hide_compose_spinner();

--- a/web/templates/compose_banner/topics_required_error_banner.hbs
+++ b/web/templates/compose_banner/topics_required_error_banner.hbs
@@ -1,5 +1,0 @@
-{{#> compose_banner . }}
-    <p class="banner_message">
-        {{> ../topics_required_error_message .}}
-    </p>
-{{/compose_banner}}

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -300,8 +300,9 @@ test_ui("validate", ({mock_template, override}) => {
     compose_state.set_stream_id(denmark.stream_id);
     override(realm, "realm_topics_policy", "disable_empty_topic");
     let missing_topic_error_rendered = false;
-    mock_template("compose_banner/compose_banner.hbs", false, (data) => {
-        assert.equal(data.classname, compose_banner.CLASSNAMES.topic_missing);
+    mock_template("topics_required_error_message.hbs", false, () => "<topic-required-stub>");
+    mock_template("components/banner.hbs", false, (data) => {
+        assert.ok(data.custom_classes.includes(compose_banner.CLASSNAMES.topic_missing));
         missing_topic_error_rendered = true;
         return "<banner-stub>";
     });


### PR DESCRIPTION
The "topic is required" banner used the legacy `.main-view-banner` markup via the `topics_required_error_banner` template. Migrate it to the modern banner component (`web/templates/components/banner.hbs`), reusing the existing `topics_required_error_message` partial for the label.

The legacy `error` and `topic_missing` classes are preserved via `custom_classes` so that `has_error()` and `clear_validation_errors()` continue to match this banner, and rendering still goes through `append_compose_banner_to_banner_list` rather than `banners.open`, so sibling compose banners are not cleared.

The full migration is being done incrementally (one banner type at a time, as discussed in the issue), so this PR intentionally covers only the `topic_missing` banner.

**Design questions (for discussion):** The remaining compose banners rely on `data-user-id` / `data-stream-id` / `data-topic-name` attributes on the banner root, and `data-*` attributes on action buttons (the schedule trigger and the onboarding "Got it" button), which the modern banner component doesn't support yet. Should we (a) extend `Banner` / `ActionButton` to support data attributes, or (b) rewire the handlers to read the ids from elsewhere? I'm starting with the banners that need neither. Opening as a draft per the suggestion in the issue.

Part of #39794.

**How changes were tested:**

- `./tools/test-js-with-node compose_validate` passes.
- Manual: set the organization's general-chat topic policy to "No general chat topic", then sent a message to a channel with an empty topic. The banner renders correctly with the modern component and closes via the ✕.

**Screenshots and screen captures:**

The banner now renders via the modern banner component. Appearance is essentially unchanged (same text, error styling, close button).

<img width="1919" height="958" alt="Screenshot 2026-07-24 124119" src="https://github.com/user-attachments/assets/f3cab59a-d213-43e6-a7f7-d5850e5ea37f" />


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>