### PR TITLE
topic: Centralize topic resolution check into is_topic_resolved helper.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -73,6 +73,7 @@ from zerver.lib.topic import (
     TOPIC_LINKS,
     TOPIC_NAME,
     get_topic_display_name,
+    is_topic_resolved,
     maybe_rename_general_chat_to_empty_topic,
     messages_for_topic,
     participants_for_topic,
@@ -1563,13 +1564,13 @@ def build_message_edit_request(
 
         resolved_prefix_len = len(RESOLVED_TOPIC_PREFIX)
         topic_resolved = (
-            target_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
-            and not old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+            is_topic_resolved(target_topic_name)
+            and not is_topic_resolved(old_topic_name)
             and pre_truncation_target_topic_name[resolved_prefix_len:] == old_topic_name
         )
         topic_unresolved = (
-            old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
-            and not target_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+            is_topic_resolved(old_topic_name)
+            and not is_topic_resolved(target_topic_name)
             # lstrip is intentional here. unresolve_name() in
             # web/src/resolved_topic.ts strips all leading "✔"
             # and space characters to guarantee the result never

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -37,6 +37,7 @@ from zerver.lib.topic import (
     MESSAGE__TOPIC,
     RESOLVED_TOPIC_PREFIX,
     TOPIC_NAME,
+    is_topic_resolved,
     maybe_rename_general_chat_to_empty_topic,
     messages_for_topic,
 )
@@ -274,11 +275,11 @@ def topic_resolve_toggled(topic: str, prev_topic: str) -> bool:
     resolved_prefix_len = len(RESOLVED_TOPIC_PREFIX)
     truncation_len = len(TOPIC_TRUNCATION_MESSAGE)
     # Topic unresolved
-    if prev_topic.startswith(RESOLVED_TOPIC_PREFIX) and not topic.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(prev_topic) and not is_topic_resolved(topic):
         return prev_topic[resolved_prefix_len:] == topic
 
     # Topic resolved
-    if topic.startswith(RESOLVED_TOPIC_PREFIX) and not prev_topic.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(topic) and not is_topic_resolved(prev_topic):
         if len(prev_topic) <= MAX_TOPIC_NAME_LENGTH - resolved_prefix_len:
             # When the topic was resolved, it was not truncated,
             # so we remove the resolved prefix and compare.

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -5,7 +5,10 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
-from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
+from zerver.lib.topic import (
+    get_topic_from_message_info,
+    is_topic_resolved,
+)
 
 # "stream" is a legacy alias for "channel"
 channel_operators: list[str] = ["channel", "stream"]
@@ -70,7 +73,7 @@ def build_narrow_predicate(
                 if message["type"] != "stream":
                     return False
                 topic_name = get_topic_from_message_info(message)
-                if not topic_name.startswith(RESOLVED_TOPIC_PREFIX):
+                if not is_topic_resolved(topic_name):
                     return False
             return True
 

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -340,6 +340,10 @@ def get_topic_history_for_stream(
     return generate_topic_history_from_db_rows(rows, allow_empty_topic_name)
 
 
+def is_topic_resolved(topic_name: str) -> bool:
+    return topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+
+
 def get_topic_resolution_and_bare_name(stored_name: str) -> tuple[bool, str]:
     """
     Resolved topics are denoted only by a title change, not by a boolean toggle in a database column. This
@@ -348,7 +352,7 @@ def get_topic_resolution_and_bare_name(stored_name: str) -> tuple[bool, str]:
     - Whether the topic has been resolved
     - The topic name with the resolution prefix, if present in stored_name, removed
     """
-    if stored_name.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(stored_name):
         return (True, stored_name.removeprefix(RESOLVED_TOPIC_PREFIX))
 
     return (False, stored_name)


### PR DESCRIPTION
<!-- Describe your pull request here.-->

## Summary

Adds a shared `is_topic_resolved()` helper to `zerver/lib/topic.py` and refactors existing call sites to use it instead of directly checking `topic_name.startswith(RESOLVED_TOPIC_PREFIX)`.

This centralizes the logic for determining whether a topic is resolved, improves readability, and removes duplicated prefix checks without changing behavior.

Fixes: #39809

**How changes were tested:**

- Ran the relevant test suite.
- Verified that all existing behavior remains unchanged after replacing direct prefix checks with the helper.
- Confirmed that resolved topic detection continues to work as before.

**Screenshots and screen captures:**

N/A (backend-only refactoring with no UI changes).

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>