### PR TITLE
slack_importer: Skip messages with invalid timestamps.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -897,6 +898,17 @@ def get_messages_iterator(
                     # and we don't have a clean way to import at the
                     # moment.  We skip them on import.
                     continue
+                if not message_has_valid_timestamp(message):
+                    # `ts` is used as the sort key below and as
+                    # `date_sent` later; one malformed value would
+                    # abort the entire import.  Skip such messages
+                    # with a warning instead.
+                    logging.warning(
+                        "Skipping Slack message with invalid ts %r in %s",
+                        message.get("ts"),
+                        message_dir,
+                    )
+                    continue
                 if dir_name in added_channels:
                     message["channel_name"] = dir_name
                 elif dir_name in added_mpims:
@@ -1459,6 +1471,21 @@ def get_message_sending_user(message: ZerverFieldsT) -> str | None:
 
 def get_timestamp_from_message(message: ZerverFieldsT) -> float:
     return float(message["ts"])
+
+
+def message_has_valid_timestamp(message: ZerverFieldsT) -> bool:
+    """Whether `ts` is present and parses to a finite float.
+
+    `get_timestamp_from_message` is used both as a sort key and for
+    `date_sent`, so a missing or malformed `ts` on a single message
+    would otherwise abort the entire import — and a non-finite value
+    like "NaN" would not even raise, instead silently producing an
+    inconsistent sort order.
+    """
+    try:
+        return math.isfinite(float(message["ts"]))
+    except (KeyError, TypeError, ValueError):
+        return False
 
 
 def is_integration_bot_message(message: ZerverFieldsT) -> bool:

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -57,6 +57,7 @@ from zerver.data_import.slack import (
     get_admin,
     get_guest,
     get_message_sending_user,
+    get_messages_iterator,
     get_owner,
     get_slack_api_data,
     get_subscription,
@@ -528,6 +529,32 @@ class SlackImporter(ZulipTestCase):
         self.assertEqual(get_user_timezone(user_chicago_timezone), "America/Chicago")
         self.assertEqual(get_user_timezone(user_timezone_none), "America/New_York")
         self.assertEqual(get_user_timezone(user_no_timezone), "America/New_York")
+
+    def test_get_messages_iterator_skips_invalid_timestamps(self) -> None:
+        # A single message with a missing or malformed `ts` used to
+        # abort the entire import with KeyError/ValueError when `ts`
+        # was used as the sort key, and a non-finite value like "NaN"
+        # silently produced an inconsistent sort order.
+        messages: list[dict[str, Any]] = [
+            {"ts": "1434139102.000002", "text": "valid later"},
+            {"text": "no ts field"},
+            {"ts": "not-a-number", "text": "malformed ts"},
+            {"ts": "NaN", "text": "non-finite ts"},
+            {"ts": "1434139101.000001", "text": "valid earlier"},
+        ]
+        with tempfile.TemporaryDirectory() as slack_data_dir:
+            os.makedirs(os.path.join(slack_data_dir, "general"))
+            with open(os.path.join(slack_data_dir, "general", "2015-06-12.json"), "wb") as f:
+                f.write(orjson.dumps(messages))
+
+            added_channels: AddedChannelsT = {"general": ("C061A0GJG", 1)}
+            with self.assertLogs(level="WARNING") as mock_log:
+                result = list(get_messages_iterator(slack_data_dir, added_channels, {}, {}))
+
+        self.assertEqual([message["text"] for message in result], ["valid earlier", "valid later"])
+        self.assert_length(mock_log.output, 3)
+        for log_line in mock_log.output:
+            self.assertIn("Skipping Slack message with invalid ts", log_line)
 
     @mock.patch("zerver.data_import.slack.get_data_file")
     @mock.patch("zerver.data_import.slack.get_messages_iterator")


### PR DESCRIPTION
Fixes: Slack import aborting entirely when a single message in the export has
a missing or malformed `ts` (no tracking issue).

`get_timestamp_from_message` is used as the message sort key in
`get_messages_iterator` and later for `date_sent`, so one message with a
missing `ts` raised `KeyError`, and a malformed value like `"not-a-number"`
raised `ValueError`, aborting the whole import. A non-finite value like
`"NaN"` was worse: it did not raise at all, silently producing an
inconsistent sort order.

Skip such messages with a warning instead, following the existing pattern in
`get_messages_iterator` for other unimportable messages. The guard requires
`ts` to parse to a *finite* float (`math.isfinite`) specifically to cover the
`"NaN"`/`"inf"` case, which a plain `float()` try/except would accept.

The new test feeds valid, missing-`ts`, malformed, and `"NaN"` messages
through `get_messages_iterator` and asserts that only the valid ones survive,
in correct timestamp order, with one warning logged per skipped message. It
fails with `KeyError: 'ts'` without the fix.

Remaining decision I'd like reviewer input on: whether skipping (rather than,
say, synthesizing a fallback timestamp) is the preferred behavior for
otherwise-valid messages with a broken `ts`.

**How changes were tested:**

- [x] Verified the new test fails on the previous implementation
      (`KeyError: 'ts'` from the sort in `get_messages_iterator`) and passes
      with the fix.
- [x] `./tools/test-backend zerver.tests.test_slack_importer` (56 tests OK)
- [x] `./tools/lint` and `./tools/run-mypy` on the changed files (clean)
- [x] Confirmed via `test-backend --coverage` that `zerver/data_import/slack.py`
      has no uncovered lines, including the new guard and skip path.

**Screenshots and screen captures:**

N/A (backend-only change).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>