### PR TITLE
microsoft_teams: Don't reuse yielded batch lists in message batching.

### DIFF
--- a/zerver/data_import/microsoft_teams.py
+++ b/zerver/data_import/microsoft_teams.py
@@ -700,7 +700,12 @@ def get_batched_export_message_data(
         for message in sorted(messages, key=lambda m: int(m["Id"])):
             if len(batched_messages) == chunk_size:
                 yield batched_messages
-                batched_messages.clear()
+                # Start a new list rather than clearing the yielded one;
+                # the consumer owns the yielded list, and mutating it here
+                # would corrupt every batch if the generator is materialized
+                # (e.g. with list(...)) or batches are retained across
+                # iterations.
+                batched_messages = []
             batched_messages.append(message)
 
     if batched_messages:

--- a/zerver/tests/test_microsoft_teams_importer.py
+++ b/zerver/tests/test_microsoft_teams_importer.py
@@ -735,6 +735,21 @@ class MicrosoftTeamsImporterUnitTest(MicrosoftTeamsImportTestCase):
                 message_batches += 1
             self.assertTrue(message_batches == expected_batch_amount)
 
+        # Regression test: the generator must hand ownership of each
+        # yielded batch to the consumer. Previously it cleared and
+        # reused the same list object after yielding it, so retaining
+        # batches (e.g. materializing with list(...)) left every batch
+        # except the final one emptied and aliased to the same list.
+        batches = list(get_batched_export_message_data(message_file_paths, 5))
+        self.assertEqual(sum(len(batch) for batch in batches), total_messages)
+        flattened_message_ids = [message["Id"] for batch in batches for message in batch]
+        expected_message_ids = [
+            message["Id"]
+            for path in message_file_paths
+            for message in sorted(get_data_file(path), key=lambda m: int(m["Id"]))
+        ]
+        self.assertEqual(flattened_message_ids, expected_message_ids)
+
     @responses.activate
     def test_process_hosted_content_attachments(self) -> None:
         responses.add(


### PR DESCRIPTION
Fixes: latent data-corruption bug in the Microsoft Teams importer's message
batching (no tracking issue).

`get_batched_export_message_data` yielded its batch list and then cleared and
refilled the same object for the next batch. The current caller consumes each
batch before advancing, so this was latent, but any consumer that retains
batches (e.g., materializing the generator with `list(...)`) would see every
batch except the last emptied and aliased to the same list. The fix hands
ownership of each yielded list to the consumer by starting a new list instead
of clearing the yielded one.

The extended test materializes the generator and asserts both the total
message count and the exact flattened message-ID sequence, so it fails with
the old implementation (only the final batch's contents survive) and guards
against reintroducing the reuse pattern.

**How changes were tested:**

- [x] Verified the new regression assertions fail on the previous
      implementation (`AssertionError: 24 != 29`) and pass with the fix.
- [x] `./tools/test-backend zerver.tests.test_microsoft_teams_importer` (10 tests OK)
- [x] `./tools/lint` and `./tools/run-mypy` on the changed files (clean)
- [x] Confirmed via `test-backend --coverage` that the changed lines are
      exercised by the tests.

**Screenshots and screen captures:**

N/A (backend-only change).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
