### PR TITLE
api-docs: Support multiple examples for events.

### DIFF
--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -48,11 +48,17 @@ TABLE_LINK_TEMPLATE = """
 
 
 @dataclass
+class ExampleData:
+    value: str
+    label: str | None
+
+
+@dataclass
 class EventData:
     type: str
     description: str
     properties: dict[str, Any]
-    example: str
+    examples: list[ExampleData]
     op_type: str | None = None
 
 
@@ -268,10 +274,14 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             )
         event_strings.append(f"\n{event_data.description}\n\n\n")
         event_strings += self.render_table(event_data.properties, 0)
-        event_strings.append("**Example**")
-        event_strings.append("\n```json\n")
-        event_strings.append(event_data.example)
-        event_strings.append("```\n\n")
+        for example in event_data.examples:
+            if example.label is None:
+                event_strings.append("**Example**")
+            else:
+                event_strings.append(f"**Example: {example.label}**")
+            event_strings.append("\n```json\n")
+            event_strings.append(example.value)
+            event_strings.append("```\n\n")
         event_strings.append("<hr>")
         return event_strings
 
@@ -301,11 +311,26 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             op_type: str | None = None
             if op is not None:
                 op_type = op["enum"][0]
+            examples: list[ExampleData]
+            if "x-examples" in event:
+                examples = [
+                    ExampleData(
+                        value=json.dumps(example["value"], indent=4, sort_keys=True),
+                        label=example.get("summary"),
+                    )
+                    for example in event["x-examples"].values()
+                ]
+            else:
+                examples = [
+                    ExampleData(
+                        value=json.dumps(event["example"], indent=4, sort_keys=True), label=None
+                    )
+                ]
             event_data = EventData(
                 type=event["properties"]["type"]["enum"][0],
                 description=event["description"],
                 properties=event["properties"],
-                example=json.dumps(event["example"], indent=4, sort_keys=True),
+                examples=examples,
                 op_type=op_type,
             )
             events += self.generate_event_strings(event_data)

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -316,7 +316,7 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                 examples = [
                     ExampleData(
                         value=json.dumps(example["value"], indent=4, sort_keys=True),
-                        label=example.get("summary"),
+                        label=example.get("label"),
                     )
                     for example in event["x-examples"].values()
                 ]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3085,28 +3085,105 @@ paths:
                                 - flags
                                 - edit_timestamp
                                 - rendering_only
-                              example:
-                                {
-                                  "type": "update_message",
-                                  "user_id": 10,
-                                  "edit_timestamp": 1594825451,
-                                  "message_id": 58,
-                                  "stream_name": "Verona",
-                                  "orig_content": "hello",
-                                  "orig_rendered_content": "<p>hello</p>",
-                                  "content": "new content",
-                                  "rendered_content": "<p>new content</p>",
-                                  "is_me_message": false,
-                                  "propagate_mode": "change_all",
-                                  "stream_id": 5,
-                                  "orig_subject": "test",
-                                  "subject": "new_topic",
-                                  "topic_links": [],
-                                  "message_ids": [57, 58],
-                                  "flags": [],
-                                  "rendering_only": false,
-                                  "id": 0,
-                                }
+                              x-examples:
+                                topic_move:
+                                  label: Message moved to a different topic
+                                  value:
+                                    {
+                                      "type": "update_message",
+                                      "id": 1,
+                                      "user_id": 10,
+                                      "edit_timestamp": 1594825400,
+                                      "message_id": 42,
+                                      "message_ids": [40, 41, 42],
+                                      "flags": [],
+                                      "rendering_only": false,
+                                      "stream_name": "Verona",
+                                      "stream_id": 5,
+                                      "propagate_mode": "change_all",
+                                      "orig_subject": "team sync",
+                                      "subject": "team sync notes",
+                                      "topic_links": [],
+                                    }
+                                channel_move_same_topic:
+                                  label: Message moved to a different channel, topic name unchanged
+                                  value:
+                                    {
+                                      "type": "update_message",
+                                      "id": 2,
+                                      "user_id": 10,
+                                      "edit_timestamp": 1594825500,
+                                      "message_id": 101,
+                                      "message_ids": [99, 100, 101],
+                                      "flags": [],
+                                      "rendering_only": false,
+                                      "stream_name": "Verona",
+                                      "stream_id": 5,
+                                      "new_stream_id": 7,
+                                      "propagate_mode": "change_all",
+                                      "orig_subject": "team sync",
+                                    }
+                                content_edit:
+                                  label: Message content edited
+                                  value:
+                                    {
+                                      "type": "update_message",
+                                      "id": 3,
+                                      "user_id": 10,
+                                      "edit_timestamp": 1594825600,
+                                      "message_id": 205,
+                                      "message_ids": [205],
+                                      "flags": [],
+                                      "rendering_only": false,
+                                      "stream_name": "Denmark",
+                                      "stream_id": 8,
+                                      "orig_content": "hi everyone",
+                                      "orig_rendered_content": "<p>hi everyone</p>",
+                                      "content": "hi there everyone",
+                                      "rendered_content": "<p>hi there everyone</p>",
+                                      "is_me_message": false,
+                                    }
+                                rendering_update:
+                                  label: Rendering-only update, e.g. for an inline URL preview
+                                  value:
+                                    {
+                                      "type": "update_message",
+                                      "id": 4,
+                                      "user_id": null,
+                                      "edit_timestamp": 1594825700,
+                                      "message_id": 310,
+                                      "message_ids": [310],
+                                      "flags": [],
+                                      "rendering_only": true,
+                                      "stream_name": "Denmark",
+                                      "stream_id": 8,
+                                      "content": "Check out https://example.com/",
+                                      "rendered_content": '<p>Check out <a href="https://example.com/">https://example.com/</a></p>',
+                                    }
+                                content_and_topic_edit:
+                                  label: Message content and topic both edited in one action
+                                  value:
+                                    {
+                                      "type": "update_message",
+                                      "id": 5,
+                                      "user_id": 10,
+                                      "edit_timestamp": 1594825451,
+                                      "message_id": 58,
+                                      "message_ids": [57, 58],
+                                      "flags": [],
+                                      "rendering_only": false,
+                                      "stream_name": "Verona",
+                                      "stream_id": 5,
+                                      "propagate_mode": "change_all",
+                                      "orig_content": "hello",
+                                      "orig_rendered_content": "<p>hello</p>",
+                                      "content": "new content",
+                                      "rendered_content": "<p>new content</p>",
+                                      "is_me_message": false,
+                                      "orig_subject": "test",
+                                      "subject": "new_topic",
+                                      "topic_links": [],
+                                    }
                             - type: object
                               additionalProperties: false
                               description: |

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -254,8 +254,8 @@ class APIReturnValuesTablePreprocessorTest(ZulipTestCase):
                     },
                     "example": first_example,
                     "x-examples": {
-                        "case_one": {"summary": "First case", "value": first_example},
-                        "case_two": {"summary": "Second case", "value": second_example},
+                        "case_one": {"label": "First case", "value": first_example},
+                        "case_two": {"label": "Second case", "value": second_example},
                     },
                 }
             ]

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from dataclasses import dataclass
@@ -49,6 +50,7 @@ from zerver.lib.markdown import (
     url_embed_preview_enabled,
     url_to_a,
 )
+from zerver.lib.markdown.api_return_values_table_generator import APIReturnValuesTablePreprocessor
 from zerver.lib.markdown.fenced_code import FencedBlockPreprocessor
 from zerver.lib.markdown.from_html import convert_html_to_markdown
 from zerver.lib.mdiff import diff_strings
@@ -208,6 +210,65 @@ class FencedBlockPreprocessorTest(ZulipTestCase):
         ]
         lines = processor.run(markdown_input)
         self.assertEqual(lines, expected)
+
+
+class APIReturnValuesTablePreprocessorTest(ZulipTestCase):
+    def test_render_events_singular_example(self) -> None:
+        preprocessor = APIReturnValuesTablePreprocessor(Markdown(), {})
+        example = {"type": "test_event", "id": 1}
+        events_dict = {
+            "oneOf": [
+                {
+                    "description": "Test event description",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["test_event"],
+                            "description": "The type of the event.",
+                        },
+                    },
+                    "example": example,
+                }
+            ]
+        }
+
+        result = preprocessor.render_events(events_dict)
+
+        self.assertEqual(result.count("**Example**"), 1)
+        self.assertIn(json.dumps(example, indent=4, sort_keys=True), result)
+
+    def test_render_events_with_x_examples(self) -> None:
+        preprocessor = APIReturnValuesTablePreprocessor(Markdown(), {})
+        first_example = {"type": "test_event", "id": 1}
+        second_example = {"type": "test_event", "id": 2}
+        events_dict = {
+            "oneOf": [
+                {
+                    "description": "Test event description.",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["test_event"],
+                            "description": "The type of the event.",
+                        },
+                    },
+                    "example": first_example,
+                    "x-examples": {
+                        "case_one": {"summary": "First case", "value": first_example},
+                        "case_two": {"summary": "Second case", "value": second_example},
+                    },
+                }
+            ]
+        }
+
+        result = preprocessor.render_events(events_dict)
+
+        self.assertNotIn("**Example**", result)
+        first_index = result.index("**Example: First case**")
+        second_index = result.index("**Example: Second case**")
+        self.assertLess(first_index, second_index)
+        self.assertIn(json.dumps(first_example, indent=4, sort_keys=True), result)
+        self.assertIn(json.dumps(second_example, indent=4, sort_keys=True), result)
 
 
 def markdown_convert_wrapper(content: str) -> str:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -942,19 +942,27 @@ class OpenAPIAttributesTest(ZulipTestCase):
                 for status_code, response in operation["responses"].items():
                     schema = response["content"]["application/json"]["schema"]
                     # Validate the documented examples for each event type
-                    # in api/get-events for the documented event schemas.
+                    # in api/get-events for the documented event schemas,
+                    # including any additional `x-examples` for that event.
                     if path == "/events" and method == "get" and status_code == "200":
                         for event_type in schema["properties"]["events"]["items"]["oneOf"]:
-                            event_array = [event_type["example"]]
-                            content = {
-                                "queue_id": "fb67bf8a-c031-47cc-84cf-ed80accacda8",
-                                "events": event_array,
-                                "msg": "",
-                                "result": "success",
-                            }
-                            assert validate_against_openapi_schema(
-                                content, path, method, status_code
+                            example_values = (
+                                [event_type["example"]] if "example" in event_type else []
                             )
+                            example_values += [
+                                example["value"]
+                                for example in event_type.get("x-examples", {}).values()
+                            ]
+                            for example_value in example_values:
+                                content = {
+                                    "queue_id": "fb67bf8a-c031-47cc-84cf-ed80accacda8",
+                                    "events": [example_value],
+                                    "msg": "",
+                                    "result": "success",
+                                }
+                                assert validate_against_openapi_schema(
+                                    content, path, method, status_code
+                                )
                     if "oneOf" in schema:
                         for subschema in schema["oneOf"]:
                             validate_schema(subschema)


### PR DESCRIPTION
Fixes: #30458

This closes the events-side gap in #30458. #31246 already handled multiple examples for `responses`, but events sit inside a shared `oneOf` with no per-event media type object to hang OpenAPI's standard `examples` off, so they needed a separate fix: an `x-examples` vendor extension, matching the existing pattern of `x-response-description` and friends already in `zulip.yaml`.

`update_message` is the pilot: five examples covering a topic-only move, a channel move with the topic unchanged, a content edit, a rendering-only update, and a combined content-and-topic edit. The
channel-move case is the one worth reading closely - `orig_subject` shows up whenever the topic or channel changed, `subject` only when the topic name itself changed, which the prose alone has previously
confused readers on.

`update_message`'s old singular `example` is removed rather than kept alongside `x-examples`: once an event has `x-examples`, `render_events` never reads the singular field, so leaving it in place would mean its content stops rendering without anyone noticing. Its content becomes the fifth example instead of being
discarded.

<details>
<summary>Screenshots and screen captures:</summary>

Before:

<img width="586" height="458" alt="image" src="https://github.com/user-attachments/assets/1b6f51b7-a628-45ed-bdb3-905c84ac150f" />



After:
Example: Message moved to a different topic and Message moved to a different channel, topic name unchanged:
<img width="862" height="928" alt="image" src="https://github.com/user-attachments/assets/aaba5ec0-1437-4f02-a7ac-ffebad8e0daa" />

Example: Message content edited, Rendering-only update and Message content (all three)
<img width="601" height="1152" alt="image" src="https://github.com/user-attachments/assets/d640573c-7db6-4ed8-8d3a-0136df3e33b1" />

</details>
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
