### PR TITLE
outgoing_webhooks: Parse command and text for Slack webhooks.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import logging
+import re
 from contextlib import suppress
 from dataclasses import dataclass
 from time import perf_counter
@@ -143,10 +144,26 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
-            ("trigger_word", event["trigger"]),
-            ("service_id", event["user_profile_id"]),
         ]
+
+        text = event["command"]
+        command = ""
+
+        bot_mention_match = re.match(r"^@\*\*([^*]+)\*\*", text)
+        if bot_mention_match:
+            command = f"/{bot_mention_match.group(1)}"
+            text = text[bot_mention_match.end() :].lstrip()
+
+        if command:
+            request_data.append(("command", command))
+
+        request_data.extend(
+            [
+                ("text", text),
+                ("trigger_word", event["trigger"]),
+                ("service_id", event["user_profile_id"]),
+            ]
+        )
         return self.session.post(base_url, data=request_data)
 
     @override

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -161,7 +161,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         super().setUp()
         self.bot_user = get_user("outgoing-webhook@zulip.com", get_realm("zulip"))
         self.stream_message_event = {
-            "command": "@**test**",
+            "command": "@**test** help\nmore details",
             "user_profile_id": 12,
             "service_name": "test-service",
             "trigger": "mention",
@@ -222,9 +222,10 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         self.assertEqual(request_data[6][1], 123456)  # timestamp
         self.assertEqual(request_data[7][1], "U21")  # user_id
         self.assertEqual(request_data[8][1], "Sample User")  # user_name
-        self.assertEqual(request_data[9][1], "@**test**")  # text
-        self.assertEqual(request_data[10][1], "mention")  # trigger_word
-        self.assertEqual(request_data[11][1], 12)  # user_profile_id
+        self.assertEqual(request_data[9][1], "/test")  # command
+        self.assertEqual(request_data[10][1], "help\nmore details")  # text
+        self.assertEqual(request_data[11][1], "mention")  # trigger_word
+        self.assertEqual(request_data[12][1], 12)  # user_profile_id
 
     @mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
     def test_make_request_private_message(self, mock_fail_with_message: mock.Mock) -> None:


### PR DESCRIPTION
Fixes #19589.

Slack-compatible outgoing webhooks now separate a leading Zulip bot mention into a Slack-style slash command in `command`, and place the complete remaining message body in `text`.

**How changes were tested:**

- Added coverage for a message body spanning multiple lines after the bot mention.
- Ran `python -m py_compile` for both changed Python files and `git diff --check`.
- The targeted backend test requires Zulip's Unix development environment. It could not run in this Windows checkout because no WSL virtual environment is present; CI has been restarted by the updated commit.

**Screenshots and screen captures:**

Not applicable; this is a backend-only change.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns. No remaining concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>