### PR TITLE
openapi: Document required parameters for the reminders endpoint.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -31,8 +31,8 @@
 
 ## Message reminders
 
-* [Create a message reminder](/api/create-message-reminder)
 * [Get reminders](/api/get-reminders)
+* [Create a reminder](/api/create-message-reminder)
 * [Delete a reminder](/api/delete-reminder)
 
 ## Drafts

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8187,9 +8187,8 @@ paths:
                       scheduled_messages:
                         type: array
                         description: |
-                          Returns all of the current user's undelivered scheduled
-                          messages, ordered by `scheduled_delivery_timestamp`
-                          (ascending).
+                          Returns all of the current user's undelivered scheduled messages,
+                          in ascending order by `scheduled_delivery_timestamp`.
                         items:
                           $ref: "#/components/schemas/ScheduledMessage"
                     example:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8013,11 +8013,11 @@ paths:
       tags: ["reminders"]
       summary: Get reminders
       description: |
-        Fetch all [reminders](/help/schedule-a-reminder) for the
+        Fetch all scheduled [reminders](/help/schedule-a-reminder) for the
         current user.
 
         Reminders are messages the user has scheduled to be sent in the
-        future to themself.
+        future that reference another previously sent target message.
 
         **Changes**: New in Zulip 11.0 (feature level 399).
       responses:
@@ -8037,7 +8037,7 @@ paths:
                         type: array
                         description: |
                           Returns all of the current user's undelivered reminders,
-                          ordered by `scheduled_delivery_timestamp` (ascending).
+                          in ascending order by `scheduled_delivery_timestamp`.
                         items:
                           $ref: "#/components/schemas/Reminder"
                     example:
@@ -8050,8 +8050,8 @@ paths:
                               "reminder_id": 27,
                               "to": [6],
                               "type": "private",
-                              "content": "Hi",
-                              "rendered_content": "<p>Hi</p>",
+                              "content": "You requested a reminder for the following message.\n\n```quote\nHi\n```",
+                              "rendered_content": "<p>You requested a reminder for the following message.</p>\n\n<blockquote>\n<p>Hi</p>\n</blockquote>",
                               "scheduled_delivery_timestamp": 1681662420,
                               "failed": false,
                               "reminder_target_message_id": 42,
@@ -8061,9 +8061,11 @@ paths:
     post:
       operationId: create-message-reminder
       tags: ["reminders"]
-      summary: Create a message reminder
+      summary: Create a reminder
       description: |
-        Schedule a reminder to be sent to the current user at the specified time. The reminder will link the relevant message.
+        Schedule a [reminder](/help/schedule-a-reminder) to be sent to the current
+        user at the specified time. The reminder will reference a previously
+        sent message.
 
         **Changes**: New in Zulip 11.0 (feature level 381).
       requestBody:
@@ -8087,7 +8089,9 @@ paths:
                 note:
                   type: string
                   description: |
-                    A note associated with the reminder shown in the Notification Bot message.
+                    A note to include in the reminder message when it is sent, in
+                    [Zulip-flavored Markdown](/help/format-your-message-using-markdown)
+                    format.
 
                     **Changes**: New in Zulip 11.0 (feature level 415).
                   example: "This is a reminder note."
@@ -8119,8 +8123,8 @@ paths:
       tags: ["reminders"]
       summary: Delete a reminder
       description: |
-        Delete, and therefore cancel sending, a previously [scheduled
-        reminder](/help/schedule-a-reminder).
+        Delete, and therefore cancel sending, a previously scheduled
+        [reminder](/help/schedule-a-reminder) message.
 
         **Changes**: New in Zulip 11.0 (feature level 399).
       parameters:
@@ -29703,13 +29707,13 @@ components:
       type: object
       additionalProperties: false
       description: |
-        Object containing details of the scheduled message.
+        Object containing details of the scheduled reminder message.
       properties:
         reminder_id:
           type: integer
           description: |
             The unique ID of the reminder, which can be used to
-            delete the reminder.
+            [delete the reminder](/api/delete-reminder).
 
             This is different from the unique ID that the message would have
             after being sent.
@@ -29729,13 +29733,16 @@ components:
         content:
           type: string
           description: |
-            The content/body of the reminder, in [Zulip-flavored Markdown](/help/format-your-message-using-markdown) format.
+            The content/body of the reminder message, in
+            [Zulip-flavored Markdown](/help/format-your-message-using-markdown)
+            format.
 
-            See [Markdown message formatting](/api/message-formatting) for details on Zulip's HTML format.
+            See [Markdown message formatting](/api/message-formatting) for details on
+            Zulip's HTML format.
         rendered_content:
           type: string
           description: |
-            The content/body of the reminder rendered in HTML.
+            The content/body of the reminder message rendered in HTML.
         scheduled_delivery_timestamp:
           type: integer
           description: |
@@ -29756,7 +29763,8 @@ components:
         reminder_target_message_id:
           type: integer
           description: |
-            The ID of the message that the reminder is created for.
+            The ID of the message that the reminder was created for and will
+            reference.
       required:
         - reminder_id
         - type

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8091,6 +8091,9 @@ paths:
 
                     **Changes**: New in Zulip 11.0 (feature level 415).
                   example: "This is a reminder note."
+              required:
+                - message_id
+                - scheduled_delivery_timestamp
       responses:
         "200":
           description: Success.


### PR DESCRIPTION
The API documentation for `POST /reminders` presents `message_id` and `scheduled_delivery_timestamp` as optional, because the request schema has no `required` array. Both are declared without a default in `create_reminders_message_backend`, so `@typed_endpoint` returns a 400 when either is omitted — `note` is the only genuinely optional parameter. The neighbouring `create-scheduled-message` schema already lists its no-default parameters under `required`, so this brings the reminders endpoint in line with it.

Fixes: no issue — noticed while reading the reminders endpoint documentation.

**How changes were tested:**

Rendered the `POST /reminders` parameter block from `zulip.yaml` before and after the change using Zulip's own `zerver/lib/markdown/api_arguments_table_generator.py`, and confirmed that only the two badges change and `note` stays optional. I don't have the full development environment running, so the images below are that generated block styled with `web/styles/portico/legacy_portico.css` rather than screenshots of a running docs server. Currently published page for comparison: <https://zulip.com/api/create-message-reminder>

**Screenshots and screen captures:**

Before (current `zulip.yaml`):

![before](https://raw.githubusercontent.com/LuShadowX/zulip/pr-39822-screenshots/before.png)

After (this PR):

![after](https://raw.githubusercontent.com/LuShadowX/zulip/pr-39822-screenshots/after.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
