### PR TITLE
todo widget: todo task reordering via drag-and-drop.

### DIFF
--- a/web/src/todo_data.ts
+++ b/web/src/todo_data.ts
@@ -17,7 +17,7 @@ export type TodoWidgetExtraData = z.infer<typeof todo_widget_extra_data_schema>;
 
 const todo_widget_inbound_data = z.intersection(
     z.object({
-        type: z.enum(["new_task", "new_task_list_title", "strike"]),
+        type: z.enum(["new_task", "new_task_list_title", "strike", "reorder_tasks"]),
     }),
     z.record(z.string(), z.unknown()),
 );
@@ -46,6 +46,12 @@ type TaskStrikeOutboundData = {
     key: string;
 };
 
+type TaskReorderOutboundData = {
+    type: "reorder_tasks";
+    key: string;
+    after_key: string | null;
+};
+
 type TodoTask = {
     task: string;
     desc: string;
@@ -60,7 +66,10 @@ type Task = {
 };
 
 export type TodoWidgetOutboundData =
-    NewTaskTitleOutboundData | NewTaskOutboundData | TaskStrikeOutboundData;
+    | NewTaskTitleOutboundData
+    | NewTaskOutboundData
+    | TaskStrikeOutboundData
+    | TaskReorderOutboundData;
 
 export class TaskData {
     message_sender_id: number;
@@ -202,6 +211,50 @@ export class TaskData {
                 item.completed = !item.completed;
             },
         },
+
+        reorder_tasks: {
+            outbound(key: string, after_key: string | null): TaskReorderOutboundData {
+                const event = {
+                    type: "reorder_tasks" as const,
+                    key,
+                    after_key,
+                };
+                return event;
+            },
+
+            inbound: (_sender_id: number, raw_data: unknown): void => {
+                const task_reorder_inbound_data_schema = z.object({
+                    type: z.literal("reorder_tasks"),
+                    key: z.string(),
+                    after_key: z.nullable(z.string()),
+                });
+                const parsed = task_reorder_inbound_data_schema.safeParse(raw_data);
+                if (!parsed.success) {
+                    blueslip.warn("todo widget: bad type for inbound reorder_tasks data", {
+                        error: parsed.error,
+                    });
+                    return;
+                }
+
+                const {key, after_key} = parsed.data;
+                if (key === after_key) {
+                    blueslip.warn("todo widget: reorder_tasks key cannot follow itself: " + key);
+                    return;
+                }
+                if (!this.task_map.has(key)) {
+                    blueslip.warn("todo widget: reorder_tasks refers to unknown key: " + key);
+                    return;
+                }
+                if (after_key !== null && !this.task_map.has(after_key)) {
+                    blueslip.warn(
+                        "todo widget: reorder_tasks refers to unknown after_key: " + after_key,
+                    );
+                    return;
+                }
+
+                this.reorder(key, after_key);
+            },
+        },
     };
 
     constructor({
@@ -262,11 +315,17 @@ export class TaskData {
         return this.input_mode;
     }
 
+    reorder_tasks(key: string, after_key: string | null): void {
+        if (!this.task_map.has(key) || (after_key !== null && !this.task_map.has(after_key))) {
+            return;
+        }
+        this.reorder(key, after_key);
+    }
+
     get_widget_data(): {
         all_tasks: Task[];
     } {
         const all_tasks = this.task_map.values().toArray();
-
         const widget_data = {
             all_tasks,
         };
@@ -292,5 +351,27 @@ export class TaskData {
 
         const {data} = parsed;
         this.handle[data.type].inbound(sender_id, data);
+    }
+
+    private reorder(key: string, after_key: string | null): void {
+        const moved_task = this.task_map.get(key);
+        if (moved_task === undefined) {
+            return;
+        }
+
+        const new_task_map = new Map<string, Task>();
+        if (after_key === null) {
+            new_task_map.set(key, moved_task);
+        }
+        for (const [existing_key, task] of this.task_map) {
+            if (existing_key === key) {
+                continue;
+            }
+            new_task_map.set(existing_key, task);
+            if (existing_key === after_key) {
+                new_task_map.set(key, moved_task);
+            }
+        }
+        this.task_map = new_task_map;
     }
 }

--- a/web/src/todo_widget.ts
+++ b/web/src/todo_widget.ts
@@ -1,6 +1,7 @@
 import {$} from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
+import SortableJS from "sortablejs";
 
 import render_message_hidden_dialog from "../templates/message_hidden_dialog.hbs";
 import render_widgets_todo_widget from "../templates/widgets/todo_widget.hbs";
@@ -13,6 +14,7 @@ import type {Message} from "./message_store.ts";
 import {page_params} from "./page_params.ts";
 import type {TodoWidgetOutboundData} from "./todo_data.ts";
 import {TaskData} from "./todo_data.ts";
+import * as util from "./util.ts";
 import type {Event} from "./widget_data.ts";
 import type {AnyWidgetData, WidgetData} from "./widget_schema.ts";
 
@@ -146,6 +148,27 @@ export function render({
         }
     }
 
+    function handle_task_reorder(dragged_item: HTMLElement): void {
+        const dragged_key = dragged_item.dataset["key"];
+        if (dragged_key === undefined) {
+            return;
+        }
+
+        const key_order = $elem
+            .find("li.todo-task-row")
+            .map(function () {
+                return $(this).attr("data-key")!;
+            })
+            .toArray();
+        const new_index = key_order.indexOf(dragged_key);
+        if (new_index === -1) {
+            return;
+        }
+        const after_key = new_index > 0 ? key_order[new_index - 1]! : null;
+
+        callback(task_data.handle.reorder_tasks.outbound(dragged_key, after_key));
+    }
+
     function build_widget(): void {
         const html = render_widgets_todo_widget();
         $elem.html(html);
@@ -203,6 +226,16 @@ export function render({
                 add_task();
             }
         });
+
+        if (!page_params.is_spectator) {
+            SortableJS.create(util.the($elem.find("ul.todo-widget")), {
+                handle: ".todo-drag-handle",
+                animation: 150,
+                onUpdate(evt: {item: HTMLElement}): void {
+                    handle_task_reorder(evt.item);
+                },
+            });
+        }
     }
 
     function update_add_task_button(): void {
@@ -231,7 +264,10 @@ export function render({
 
     function render_results(): void {
         const widget_data = task_data.get_widget_data();
-        const html = render_widgets_todo_widget_tasks(widget_data);
+        const html = render_widgets_todo_widget_tasks({
+            ...widget_data,
+            can_reorder: !page_params.is_spectator,
+        });
         $elem.find("ul.todo-widget").html(html);
         $elem.find(".widget-error").text("");
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -109,6 +109,29 @@
             }
         }
     }
+
+    li.todo-task-row {
+        display: flex;
+        align-items: baseline;
+        gap: 5px;
+    }
+
+    .todo-drag-handle {
+        display: inline-flex;
+        align-self: center;
+        align-items: center;
+        color: hsl(0deg 0% 75%);
+        cursor: grab;
+        user-select: none;
+
+        &:active {
+            cursor: grabbing;
+        }
+    }
+
+    li.todo-task-row.sortable-ghost {
+        opacity: 0.4;
+    }
 }
 
 .todo-widget,

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -1,5 +1,10 @@
 {{#each all_tasks}}
-    <li>
+    <li class="todo-task-row" data-key="{{ key }}">
+        {{#if ../can_reorder}}
+        <span class="todo-drag-handle" aria-label="{{t 'Drag to reorder' }}">
+            <i class="zulip-icon zulip-icon-grip-vertical" aria-hidden="true"></i>
+        </span>
+        {{/if}}
         <label class="checkbox">
             <span class="todo-checkbox">
                 <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}}/>

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -567,6 +567,17 @@ def validate_todo_data(todo_data: object, is_widget_author: bool) -> None:
         checker("todo data", todo_data)
         return
 
+    if todo_data["type"] == "reorder_tasks":
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("key", check_string),
+                ("after_key", check_none_or(check_string)),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
     raise ValidationError(f"Unknown type for todo data: {todo_data['type']}")
 
 

--- a/zerver/tests/test_validators.py
+++ b/zerver/tests/test_validators.py
@@ -29,6 +29,7 @@ from zerver.lib.validator import (
     check_url,
     equals,
     to_wild_value,
+    validate_todo_data,
 )
 
 if settings.ZILENCER_ENABLED:
@@ -233,6 +234,36 @@ class ValidatorTestCase(ZulipTestCase):
         }
         with self.assertRaisesRegex(ValidationError, r'x\["food"\] is not a list'):
             check_dict_only(keys, optional_keys)("x", x)
+
+    def test_validate_todo_data_reorder_tasks(self) -> None:
+        valid_reorder = {
+            "type": "reorder_tasks",
+            "key": "2,10",
+            "after_key": "1,10",
+        }
+        validate_todo_data(valid_reorder, is_widget_author=True)
+
+        valid_reorder_to_front = {
+            "type": "reorder_tasks",
+            "key": "2,10",
+            "after_key": None,
+        }
+        validate_todo_data(valid_reorder_to_front, is_widget_author=True)
+
+        non_author_reorder = {
+            "type": "reorder_tasks",
+            "key": "2,10",
+            "after_key": "1,10",
+        }
+        validate_todo_data(non_author_reorder, is_widget_author=False)
+
+        invalid_key_type = {
+            "type": "reorder_tasks",
+            "key": 2,
+            "after_key": "1,10",
+        }
+        with self.assertRaisesRegex(ValidationError, r'.*"key".*is not a string'):
+            validate_todo_data(invalid_key_type, is_widget_author=True)
 
     def test_encapsulation(self) -> None:
         # There might be situations where we want deep


### PR DESCRIPTION
Allow everyone to manually reorder todo tasks by dragging and dropping them in the widget, addressing the third bullet under "Sorting" in #20213.

Fixes part of zulip#20213

<!-- Describe your pull request here.-->

Drag-and-drop uses SortableJS, which the codebase already uses elsewhere rather than introducing a new pattern.
Reordering broadcasts a `{key, after_key}` rather than the whole task order, so a task added by someone else mid-drag can't be silently dropped from the list.

**How changes were tested:**

- Manually tested dragging tasks up/down as the task list author
- Ran the full backend and frontend test suites locally

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

**After**
<img width="823" height="454" alt="Screenshot 2026-08-04 at 22 17 32" src="https://github.com/user-attachments/assets/c97e7361-8c70-4ca4-86d2-07f30b3fe6aa" />**Before**
<img width="828" height="458" alt="Screenshot 2026-08-04 at 22 08 38" src="https://github.com/user-attachments/assets/428d7288-d5e2-41f5-8151-6b5244eaeb48" />

https://github.com/user-attachments/assets/5fb26f3a-4042-42dd-9c81-0dc9adf48a9c

<details>
<summary> Before / After (for other folks who have not created todo task list)</summary>

**Before**
<img width="832" height="454" alt="Screenshot 2026-08-08 at 16 21 11" src="https://github.com/user-attachments/assets/0879a106-d4f0-40a0-b9b7-4e9a453a24bb" />

**After**
<img width="829" height="457" alt="Screenshot 2026-08-08 at 16 05 18" src="https://github.com/user-attachments/assets/123b59b0-6902-4095-8016-3d5e1a8190cf" />
 Screen Recording

https://github.com/user-attachments/assets/f2df4712-04bd-4e05-abc1-23d3921a84d1

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
