### PR TITLE
fix: Update emoji picker arrow color to match background in dark mode

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2448,7 +2448,7 @@
     /* Same color as background color of header / footer */
     --color-border-emoji-picker-tippy-arrow: light-dark(
         hsl(0deg 0% 93%),
-        hsl(211.58deg 33.33% 11.18%)
+        hsl(0deg 0% 0% / 20%)
     );
 
     /* Dropdown / Typeahead constants */


### PR DESCRIPTION
## Summary
The emoji picker tippy arrow was using a hardcoded dark blue color (`hsl(211.58deg 33.33% 11.18%)`) in dark mode that didn't match the actual emoji picker background color (`hsl(0deg 0% 0% / 20%)`).

## Changes
Updated the `--color-border-emoji-picker-tippy-arrow` CSS variable in `web/styles/app_variables.css` to use the same color as the emoji picker background, ensuring the arrow visually matches the popover in both light and dark modes.

## Testing
- Verified the fix in dark mode - arrow now matches the popover background
- Verified light mode still works correctly (unchanged)

Fixes #38931