### PR TITLE
css: Migrate inline colors in dark theme to CSS variables.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -548,7 +548,7 @@ input.settings_text_input {
     display: flex;
     justify-content: center;
     background-color: var(--color-background-animated-button);
-    color: hsl(0deg 0% 0%);
+    color: var(--color-animated-button-text);
     border-radius: 4px;
 
     .color-animated-button-text {
@@ -683,6 +683,11 @@ input.settings_text_input {
 
     & td {
         border-top: 1px solid var(--color-border-table-striped);
+    }
+
+    & tbody tr:nth-child(even) td {
+        border-color: var(--color-border-table-striped);
+        background-color: var(--color-background-table-striped-even);
     }
 }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1019,7 +1019,7 @@
         hsl(0deg 0% 0% / 19%),
         hsl(0deg 0% 100% / 19%)
     );
-    --color-outline-focus: hsl(215deg 47% 50%);
+    --color-outline-focus: light-dark(hsl(215deg 47% 50%), hsl(0deg 0% 67%));
     --focus-ring-width-in-views: 1.5px;
     /* Standard focus ring stroke; used by `:focus-visible`
        outlines on inbox rows, recent-view rows, action-button
@@ -1086,6 +1086,14 @@
     --color-border-popover-menu: light-dark(
         hsl(0deg 0% 0% / 40%),
         hsl(0deg 0% 0%)
+    );
+    --color-border-popover-filter-input-focus: light-dark(
+        hsl(229.09deg 21.57% 10% / 80%),
+        hsl(0deg 0% 100% / 50%)
+    );
+    --color-box-shadow-popover-filter-input-focus: light-dark(
+        0 0 6px hsl(228deg 9.8% 20% / 30%),
+        0 0 5px hsl(0deg 0% 100% / 40%)
     );
     --color-border-personal-menu-avatar: light-dark(
         hsl(0deg 0% 0% / 10%),
@@ -1562,6 +1570,7 @@
         hsl(0deg 0% 13.33%),
         hsl(0deg 0% 95%)
     );
+    --color-text-select-option: light-dark(currentcolor, hsl(236deg 33% 90%));
     --color-text-self-direct-mention: light-dark(
         hsl(240deg 52% 45% / 100%),
         hsl(240deg 100% 88% / 100%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1304,6 +1304,10 @@
         hsl(232deg 30% 92%),
         hsl(228deg 11% 17%)
     );
+    --color-background-drafts-button-focus: light-dark(
+        hsl(0deg 0% 93%),
+        hsl(228deg 11% 17%)
+    );
     --color-compose-message-content-background: light-dark(
         hsl(0deg 0% 100%),
         color-mix(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1857,7 +1857,18 @@
         hsl(0deg 0% 87%),
         hsl(0deg 0% 0% / 20%)
     );
-
+    --color-background-table-striped-even: light-dark(
+        transparent,
+        color-mix(in srgb, hsl(0deg 0% 0%) 20%, var(--color-background-modal))
+    );
+    --color-background-rendered-timestamp: light-dark(
+        hsl(0deg 0% 93%),
+        hsl(0deg 0% 0% / 20%)
+    );
+    --color-box-shadow-rendered-timestamp: light-dark(
+        0 0 0 1px hsl(0deg 0% 80%),
+        0 0 0 1px hsl(0deg 0% 0% / 40%)
+    );
     --color-background-simplebar-scrollbar: light-dark(
         hsl(0deg 0% 0%),
         hsl(0deg 0% 100%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1877,6 +1877,10 @@
         0 0 0 1px hsl(0deg 0% 100% / 33%),
         0 0 0 1px hsl(0deg 0% 0% / 33%)
     );
+    --color-fill-loading-indicator: light-dark(
+        hsl(0deg 0% 0%),
+        hsl(0deg 0% 100%)
+    );
 
     /* Markdown code colors */
     --color-markdown-code-text: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1770,6 +1770,10 @@
     --color-kbd-border: light-dark(hsl(0deg 0% 80%), hsl(211deg 29% 14%));
     --color-kbd-text: light-dark(hsl(0deg 0% 20%), hsl(236deg 33% 90%));
     --color-kbd-enter-sends: light-dark(hsl(0deg 0% 40%), hsl(236deg 33% 90%));
+    --color-kbd-enter-sends-minor: light-dark(
+        var(--color-text-popover-menu),
+        hsl(0deg 0% 80%)
+    );
 
     /* Settings */
     --color-realm-enable-spectator-access-link: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1850,6 +1850,15 @@
         hsl(0deg 0% 0% / 20%)
     );
 
+    --color-background-simplebar-scrollbar: light-dark(
+        hsl(0deg 0% 0%),
+        hsl(0deg 0% 100%)
+    );
+    --color-box-shadow-simplebar-scrollbar: light-dark(
+        0 0 0 1px hsl(0deg 0% 100% / 33%),
+        0 0 0 1px hsl(0deg 0% 0% / 33%)
+    );
+
     /* Markdown code colors */
     --color-markdown-code-text: light-dark(
         hsl(0deg 0% 0%),

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -75,8 +75,8 @@ a.no-underline:focus {
 
 .simplebar-track {
     .simplebar-scrollbar::before {
-        background-color: hsl(0deg 0% 0%);
-        box-shadow: 0 0 0 1px hsl(0deg 0% 100% / 33%);
+        background-color: var(--color-background-simplebar-scrollbar);
+        box-shadow: var(--color-box-shadow-simplebar-scrollbar);
     }
 
     &.simplebar-vertical {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1497,7 +1497,7 @@ textarea.new_message_textarea {
 .enter_sends_choices {
     display: flex;
     flex-direction: column;
-    color: var(--color-text-popover-menu);
+    color: var(--color-kbd-enter-sends);
 
     .enter_sends_choice {
         padding: 4px 10px;
@@ -1578,6 +1578,7 @@ textarea.new_message_textarea {
     .enter_sends_minor {
         /* 12px at 14px/1em */
         font-size: 0.8571em;
+        color: var(--color-kbd-enter-sends-minor);
 
         .popover-menu-hotkey-hint {
             /* 12px at 14px/1em */

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -195,12 +195,6 @@
         color: hsl(200deg 79% 66%);
     }
 
-    #loading_older_messages_indicator,
-    #recent_view_loading_messages_indicator {
-        & path {
-            fill: hsl(0deg 0% 100%);
-        }
-    }
 
     & a:not(:active):focus,
     button:not(.action-button, .icon-button):focus-visible,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -217,11 +217,6 @@
         filter: invert(100%);
     }
 
-    .simplebar-track .simplebar-scrollbar::before {
-        background-color: hsl(0deg 0% 100%);
-        box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 33%);
-    }
-
     .collapse-settings-button:hover {
         color: hsl(200deg 79% 66%);
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -163,17 +163,6 @@
         filter: invert(100%);
     }
 
-    .collapse-settings-button:hover {
-        color: hsl(200deg 79% 66%);
-    }
-
-
-    .color_animated_button {
-        .zulip-icon {
-            color: hsl(0deg 0% 100%);
-        }
-    }
-
     .panel_user_list > .pill-container,
     .creator_details > .display_only_pill {
         &:hover {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -95,25 +95,11 @@
         border-bottom-width: 1px;
     }
 
-    .table-striped tbody tr:nth-child(even) td {
-        border-color: hsl(0deg 0% 0% / 20%);
-        background-color: color-mix(
-            in srgb,
-            hsl(0deg 0% 0%) 20%,
-            var(--color-background-modal)
-        );
-    }
-
     .overlay-message-row
         .message_header_private_message
         .message_label_clickable {
         padding: 4px 6px 3px;
         color: inherit;
-    }
-
-    & time {
-        background: hsl(0deg 0% 0% / 20%);
-        box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 40%);
     }
 
     .tip {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -19,19 +19,6 @@
         }
     }
 
-    .dropdown-list-delete {
-        /* hsl(7deg 100% 74%) corresponds to var(--red-250) */
-        color: color-mix(
-            in oklch,
-            hsl(7deg 100% 74%) 70%,
-            transparent
-        ) !important;
-
-        &:hover {
-            color: hsl(7deg 100% 74%) !important;
-        }
-    }
-
     /* this one is because in the app we have blue and in dark-theme it should be white. */
     .popover a {
         color: inherit;
@@ -55,17 +42,6 @@
         opacity: 0.4;
     }
 
-    .popover-filter-input-wrapper .popover-filter-input:focus {
-        background-color: hsl(225deg 6% 7%);
-        border: 1px solid hsl(0deg 0% 100% / 50%);
-        box-shadow: 0 0 5px hsl(0deg 0% 100% / 40%);
-    }
-
-    & select option {
-        background-color: var(--color-background);
-        color: hsl(236deg 33% 90%);
-    }
-
     .pill-container.not-editable-by-user,
     .group_setting_disabled .pill-container {
         opacity: 0.5;
@@ -80,10 +56,6 @@
             .search_icon {
             opacity: 0.75;
         }
-    }
-
-    textarea.schedule-reminder-note:focus {
-        border-color: hsl(0deg 0% 0% / 90%);
     }
 
     .popover hr,
@@ -195,14 +167,6 @@
         color: hsl(200deg 79% 66%);
     }
 
-
-    & a:not(:active):focus,
-    button:not(.action-button, .icon-button):focus-visible,
-    i.fa:focus,
-    i.zulip-icon:focus,
-    [role="button"]:focus {
-        outline-color: hsl(0deg 0% 67%);
-    }
 
     .color_animated_button {
         .zulip-icon {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -95,10 +95,6 @@
         border-bottom-width: 1px;
     }
 
-    .drafts-container .header-body .delete-drafts-group > *:focus {
-        background-color: hsl(228deg 11% 17%);
-    }
-
     .table-striped tbody tr:nth-child(even) td {
         border-color: hsl(0deg 0% 0% / 20%);
         background-color: color-mix(

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -19,14 +19,6 @@
         }
     }
 
-    .enter_sends_choices {
-        color: hsl(236deg 33% 90%);
-
-        .enter_sends_minor {
-            color: hsl(0deg 0% 80%);
-        }
-    }
-
     .dropdown-list-delete {
         /* hsl(7deg 100% 74%) corresponds to var(--red-250) */
         color: color-mix(

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -27,7 +27,9 @@
 
             .delete-selected-drafts-button {
                 &:focus {
-                    background-color: hsl(0deg 0% 93%);
+                    background-color: var(
+                        --color-background-drafts-button-focus
+                    );
                 }
             }
 
@@ -40,7 +42,9 @@
                 padding-right: 15px;
 
                 &:focus {
-                    background-color: hsl(0deg 0% 93%);
+                    background-color: var(
+                        --color-background-drafts-button-focus
+                    );
                 }
             }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -921,6 +921,10 @@
         right: 0;
         margin: auto;
 
+        & path {
+            fill: var(--color-fill-loading-indicator);
+        }
+
         .loading_indicator_spinner {
             position: relative;
             top: -7px;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -354,9 +354,9 @@
 
     /* Timestamps */
     & time {
-        background: hsl(0deg 0% 93%);
+        background: var(--color-background-rendered-timestamp);
         border-radius: 3px;
-        box-shadow: 0 0 0 1px hsl(0deg 0% 80%);
+        box-shadow: var(--color-box-shadow-rendered-timestamp);
         white-space: nowrap;
         margin: 0 2px;
         /* Reduce the font-size to reduce the

--- a/web/styles/scheduled_messages.css
+++ b/web/styles/scheduled_messages.css
@@ -36,6 +36,10 @@
 
     background-color: var(--background-color-textarea);
 
+    &:focus {
+        border-color: var(--color-border-legacy-input-focus);
+    }
+
     font-size: 1em;
     line-height: var(--base-line-height-unitless);
     font-family: inherit;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -708,6 +708,10 @@ i.zulip-icon:focus-visible,
     /* TODO: change solid to auto once the Chromium bug #1105822 is fixed */
 }
 
+select option {
+    color: var(--color-text-select-option);
+}
+
 /* List of text-like input types taken from Bootstrap */
 input:not(.input-element) {
     &[type="text"],
@@ -1232,6 +1236,10 @@ nav {
 #loading_older_messages_indicator,
 #loading_more_indicator {
     margin: 10px;
+
+    & path {
+        fill: var(--color-fill-loading-indicator);
+    }
 }
 
 #loading_older_messages_indicator_box_container,
@@ -2204,9 +2212,9 @@ body:not(.spectator-view) {
         margin: 4px 4px 2px;
 
         &:focus {
-            background: hsl(0deg 0% 100%);
-            border: 1px solid hsl(229.09deg 21.57% 10% / 80%);
-            box-shadow: 0 0 6px hsl(228deg 9.8% 20% / 30%);
+            background: var(--color-background-input-focus);
+            border: 1px solid var(--color-border-popover-filter-input-focus);
+            box-shadow: var(--color-box-shadow-popover-filter-input-focus);
         }
     }
 }
@@ -2368,6 +2376,14 @@ body:not(.spectator-view) {
             .dropdown-list-edit,
             .dropdown-list-manage-folder {
                 visibility: visible;
+            }
+        }
+
+        .dropdown-list-delete {
+            color: color-mix(in oklch, var(--red-250) 70%, transparent);
+
+            &:hover {
+                color: var(--red-250);
             }
         }
     }


### PR DESCRIPTION
In `dark_theme.css`, many components previously relied on hardcoded inline HSL colors rather than central CSS variables. This made maintaining consistent color schemes across light and dark themes more difficult.

This commit defines semantic `light-dark()` variables in `app_variables.css` and updates `dark_theme.css` to use these variables for:
* Focus rings and input borders (`--color-outline-focus`, `--color-border-popover-filter-input-focus`, etc.).
* Keyboard shortcut choice badges (`--color-kbd-enter-sends-minor`).
* Interactive buttons and hover text (`--color-background-drafts-button-focus`, `--color-text-url-hover`).
* Table striping and timestamps (`--color-border-table-striped`, `--color-background-rendered-timestamp`, etc.).
* Scrollbars and dropdown option text (`--color-background-simplebar-scrollbar`, `--color-text-select-option`).

This is the first step in cleaning up `dark_theme.css` as part of issue #39354.

Fixes part of #39354

**How changes were tested:**

* Verified that CSS stylelint and unused CSS checks pass (`./tools/lint --only=css`, `./tools/find-unused-css`).
* Ran frontend Node test suite (`./tools/test-js-with-node`) and confirmed 0 errors.
* Started the local development server (`./tools/run-dev`), logged in as a test user, toggled Dark Theme, and visually inspected all affected components (Inbox, Drafts, Settings, Search bar focus, Compose box) to verify contrast, focus rings, and table borders.

**Screenshots and screen captures:**

Since this is a pure CSS refactoring that migrates hardcoded inline HSL colors in `dark_theme.css` to semantic `light-dark()` variables in `app_variables.css`, the visual appearance and component styling in Dark Theme remain 100% identical before and after the migration:

| Component | Before (Main Branch) | After (This PR) |
| :--- | :--- | :--- |
| **Interactive component walkthrough (Video)**<br>*(Focus rings, hovering, and scrolling)* | <video src="https://github.com/user-attachments/assets/a4044a18-5628-4e40-9020-f33d6f2c7d3c" width="400" controls></video> | <video src="https://github.com/user-attachments/assets/54969e80-d6a2-4fa7-8f42-ae213a41f0b1" width="400" controls></video> |
| **Focus rings and input borders**<br>*(e.g. `--color-outline-focus`)* | <img width="517" height="217" alt="image" src="https://github.com/user-attachments/assets/049ec94d-d8c2-4256-bd03-312398e400e6" /> | <img width="517" height="217" alt="image" src="https://github.com/user-attachments/assets/e34e7c73-48c5-46aa-880e-c72ee41d4f78" /> |
| **Keyboard shortcut choice badges**<br>*(e.g. `--color-kbd-enter-sends-minor`)* | <img width="838" height="446" alt="image" src="https://github.com/user-attachments/assets/ab3b0378-daf1-458d-a01b-d30d14157887" /> | <img width="838" height="446" alt="image" src="https://github.com/user-attachments/assets/fa9e5ade-331f-4783-948f-4488c8eb8a91" /> |
| **Interactive buttons and URL hover text**<br>*(e.g. `--color-text-url-hover`)* | <img width="1113" height="160" alt="image" src="https://github.com/user-attachments/assets/066e48eb-42e5-4aa0-b68e-2aad1df91fd4" /> | <img width="1113" height="160" alt="image" src="https://github.com/user-attachments/assets/0adb0be1-d4fe-4802-9dd6-ea6cb5221526" /> |
| **Table striping and row borders**<br>*(e.g. `--color-border-table-striped`)* | <img width="877" height="700" alt="image" src="https://github.com/user-attachments/assets/6e4a4078-473b-4ed5-8cae-7543117953d1" /> | <img width="877" height="700" alt="image" src="https://github.com/user-attachments/assets/6e4a4078-473b-4ed5-8cae-7543117953d1" /> |
| **Message timestamps and date bar**<br>*(e.g. `--color-background-rendered-timestamp`)* | <img width="1113" height="245" alt="image" src="https://github.com/user-attachments/assets/0dfbc155-f415-40e9-8e0d-9075ebb9be8e" /> | <img width="1113" height="245" alt="image" src="https://github.com/user-attachments/assets/adeb184c-247f-450f-99ae-34152d645866" /> |
| **Scrollbars and dropdown option text**<br>*(e.g. `--color-text-select-option`)* | <img width="290" height="514" alt="image" src="https://github.com/user-attachments/assets/2638ce84-4cdc-46e3-a21b-5e4d5b481d83" /> | <img width="290" height="514" alt="image" src="https://github.com/user-attachments/assets/eaafc46b-76b3-4f87-8b43-84aa269d6a77" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
