### PR TITLE
css: Remove dead selectors from dark_theme.css and related files.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -353,10 +353,10 @@ input.settings_text_input {
     line-height: 38px;
 }
 
-.tip,
-.invite-stream-notice {
+.tip {
     position: relative;
     display: block;
+    margin: 10px 0;
     background-color: var(--color-background-tip);
     border: 1px solid var(--color-border-tip);
     border-radius: 4px;
@@ -367,15 +367,13 @@ input.settings_text_input {
     color: hsl(0deg 0% 40%);
 
     &::before {
+        content: "\f0a2";
         display: inline;
+        margin-right: 8px;
 
         font-family: FontAwesome;
         font-weight: 600;
     }
-}
-
-.tip {
-    margin: 10px 0;
 }
 
 .demo-organization-add-email-banner {
@@ -407,15 +405,6 @@ input.settings_text_input {
             flex-wrap: nowrap;
         }
     }
-}
-
-.invite-stream-notice {
-    margin-bottom: 20px;
-}
-
-.tip::before {
-    content: "\f0a2";
-    margin-right: 8px;
 }
 
 .demo-organization-warning {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -99,12 +99,6 @@
         opacity: 0.2;
     }
 
-    #recent_view_table {
-        .zulip-icon-user {
-            opacity: 0.7;
-        }
-    }
-
     #recent-view-content-table {
         border-bottom-width: 1px;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -128,8 +128,7 @@
         box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 40%);
     }
 
-    .tip,
-    .invite-stream-notice {
+    .tip {
         color: inherit;
     }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -191,13 +191,6 @@
         padding-left: 0.1428em; /* Legacy 2px size at 14px/1em. */
     }
 
-    .zulip-icon-user {
-        /* Legacy 11.2px size at 14px/1em. */
-        font-size: 0.8em;
-        text-align: center;
-        opacity: 0.6;
-    }
-
     .table_fix_head {
         padding: 0 !important;
         border: 1px solid var(--color-border-recent-view-table);


### PR DESCRIPTION
In `dark_theme.css`, some selectors were left behind after the UI components they styled were removed or redesigned:
* `#recent_view_table .zulip-icon-user`: The user icon was removed from the recent view table in commit 7ef85370ba31 ("recent_view: Redesign table."). This removes the dead selector from both `dark_theme.css` and `recent_view.css`.
* `.invite-stream-notice`: The stream notice banner was removed from the invite modal in commit a76042ce395b ("invite: Any combination of default streams should be subscribe-able."). This removes the dead selector from `dark_theme.css` and consolidates the remaining `.tip` rules in `app_components.css`.

Fixes part of #39354.

<!-- Describe your pull request here.-->
This PR conducts a line-by-line audit of `dark_theme.css` against the client (`web/`) and server (`templates/`) codebase to eliminate dead and unreachable CSS selectors left over from prior UI refactorings.

Fixes: part of #39354

**How changes were tested:**
* Verified that CSS stylelint and unused CSS checks pass cleanly with 0 errors (`./tools/lint --only=css` and `./tools/find-unused-css`).
* Verified via `git grep` and git history that no remaining selectors in `dark_theme.css` are dead (confirmed that dynamic selectors such as `.cropper-modal` from Uppy and server-rendered classes such as `.home-error-bar` remain active).

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
No visual changes (pure code cleanup removing dead selectors).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
