### PR TITLE
Abbreviate long user names in reaction pills

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -7,6 +7,8 @@
     }
 
     .message_reaction_container {
+        max-width: 100%;
+
         &.disabled {
             cursor: not-allowed;
         }
@@ -19,6 +21,7 @@
         padding: 1.5px 4px 1.5px 3px;
         box-sizing: border-box;
         min-width: 44px;
+        max-width: 200px;
         cursor: pointer;
         color: var(--color-message-reaction-text);
         background-color: var(--color-message-reaction-background);
@@ -90,6 +93,10 @@
            count/name.
            13px at 12.6/1em */
         line-height: 1.0317em;
+        min-width: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .message_reaction:hover .message_reaction_count {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

When a reaction pill displays a long user name, it expands indefinitely and disrupts the right side of the message feed layout. 
This PR sets a responsive `max-width: 200px` on `.message_reaction` and `text-overflow: ellipsis` on `.message_reaction_count` so long user names abbreviate cleanly.

Fixes: #38594 

- **How changes were tested:**

Manually tested by reacting to messages with long user names in the local development environment (`./tools/run-dev`).

- **Screenshots and screen captures:**

Before :
<img width="1110" height="144" alt="save2" src="https://github.com/user-attachments/assets/81f6b444-5061-48e1-a56c-ef0593a91901" />

 
After :
<img width="703" height="63" alt="Screenshot From 2026-07-29 10-27-09" src="https://github.com/user-attachments/assets/993ebc75-b487-4e9c-a653-755a28a528f4" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

-  [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
