### PR TITLE
registration: Handle realm creation subdomain races.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2,7 +2,8 @@ import re
 import time
 from collections.abc import Sequence
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Union
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, Union, cast
 from unittest.mock import MagicMock, patch
 from urllib.parse import quote, urlencode, urlsplit
 
@@ -95,6 +96,14 @@ from zproject.backends import ExternalAuthDataDict, ExternalAuthResult, email_au
 
 if TYPE_CHECKING:
     from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
+
+
+def realm_integrity_error(constraint_name: str) -> IntegrityError:
+    error = IntegrityError()
+    cause = Exception()
+    cast(Any, cause).diag = SimpleNamespace(constraint_name=constraint_name)
+    error.__cause__ = cause
+    return error
 
 
 class RedirectAndLogIntoSubdomainTestCase(ZulipTestCase):
@@ -1876,6 +1885,88 @@ class UserSignUpTest(ZulipTestCase):
                 f"/accounts/login/?email={quote(email)}&already_registered=1"
             )
         )
+
+    def check_realm_creation_with_subdomain_race(self, constraint_name: str) -> None:
+        """
+        The availability check for a realm subdomain can race with another
+        realm creation. Verify that the resulting database integrity error is
+        displayed on the registration form without consuming the confirmation
+        link.
+        """
+        email = self.nonreg_email("newguy")
+        realm_subdomain = "custom-test"
+        realm_name = "Race organization"
+
+        self.submit_realm_creation_form(
+            email,
+            realm_subdomain=realm_subdomain,
+            realm_name=realm_name,
+        )
+        confirmation_url = self.get_confirmation_url_from_outbox(email)
+        self.client_get(confirmation_url)
+
+        with patch(
+            "zerver.views.registration.do_create_realm",
+            side_effect=realm_integrity_error(constraint_name),
+        ):
+            result = self.submit_reg_form_for_user(
+                email,
+                "password",
+                realm_subdomain=realm_subdomain,
+                realm_name=realm_name,
+            )
+
+        self.assertEqual(result.status_code, 400)
+        self.assert_in_response(
+            "Subdomain is already in use. Please choose a different one.", result
+        )
+        self.assert_in_response('id="registration"', result)
+        self.assert_in_response('name="realm_subdomain"', result)
+        self.assert_in_response(f'value="{realm_subdomain}"', result)
+        self.assert_in_response(f'value="{realm_name}"', result)
+
+        # The user can retry with the same confirmation link and only a new
+        # organization URL.
+        result = self.submit_reg_form_for_user(
+            email,
+            "password",
+            realm_subdomain="custom-test-2",
+            realm_name=realm_name,
+        )
+        self.assertEqual(result.status_code, 302)
+
+    def test_realm_creation_with_historical_subdomain_race(self) -> None:
+        self.check_realm_creation_with_subdomain_race("zerver_realm_subdomain_key")
+
+    def test_realm_creation_with_subdomain_race(self) -> None:
+        self.check_realm_creation_with_subdomain_race("zerver_realm_string_id_key")
+
+    def test_realm_creation_with_unexpected_integrity_error(self) -> None:
+        email = self.nonreg_email("newguy")
+        realm_subdomain = "custom-test"
+
+        self.submit_realm_creation_form(
+            email,
+            realm_subdomain=realm_subdomain,
+            realm_name="Zulip test",
+        )
+        confirmation_url = self.get_confirmation_url_from_outbox(email)
+        self.client_get(confirmation_url)
+
+        with (
+            patch(
+                "zerver.views.registration.do_create_realm",
+                side_effect=realm_integrity_error("some_other_constraint"),
+            ),
+            self.assertRaises(IntegrityError),
+            self.assertLogs("django.request", "ERROR"),
+        ):
+            self.submit_reg_form_for_user(
+                email,
+                "password",
+                realm_subdomain=realm_subdomain,
+                realm_name="Zulip test",
+            )
 
     def test_signup_with_weak_password(self) -> None:
         """

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -156,6 +156,14 @@ ldap_logger = logging.getLogger("zulip.ldap")
 logger = logging.getLogger("zulip.registration")
 
 
+def is_string_id_unique_violation(error: IntegrityError) -> bool:
+    diag = getattr(error.__cause__, "diag", None)
+    return getattr(diag, "constraint_name", None) in {
+        "zerver_realm_string_id_key",
+        "zerver_realm_subdomain_key",
+    }
+
+
 @typed_endpoint
 def get_prereg_key_and_redirect(
     request: HttpRequest,
@@ -263,6 +271,66 @@ def get_selected_realm_default_language_name(
         return None
 
     return get_language_name(prereg_realm.default_language)
+
+
+def render_registration_form(
+    request: HttpRequest,
+    *,
+    form: RegistrationForm,
+    email: str,
+    key: str,
+    name_validated: bool,
+    realm: Realm | None,
+    realm_creation: bool,
+    password_required: bool,
+    require_ldap_password: bool,
+    prereg_realm: PreregistrationRealm | None,
+    next_url: str,
+    status: int = 200,
+) -> TemplateResponse:
+    default_email_address_visibility = None
+    if realm is not None:
+        realm_user_default = RealmUserDefault.objects.get(realm=realm)
+        default_email_address_visibility = realm_user_default.email_address_visibility
+
+    context = {
+        "form": form,
+        "email": email,
+        "key": key,
+        "full_name": request.session.get("authenticated_full_name", None),
+        "lock_name": name_validated and name_changes_disabled(realm),
+        # password_auth_enabled is normally set via our context processor,
+        # but for the registration form, there is no logged in user yet, so
+        # we have to set it here.
+        "creating_new_realm": realm_creation,
+        "password_required": password_auth_enabled(realm) and password_required,
+        "require_ldap_password": require_ldap_password,
+        "password_auth_enabled": password_auth_enabled(realm),
+        "default_stream_groups": [] if realm is None else get_default_stream_groups(realm),
+        "accounts": get_accounts_for_email(email),
+        "MAX_NAME_LENGTH": str(UserProfile.MAX_NAME_LENGTH),
+        "MAX_PASSWORD_LENGTH": str(form.MAX_PASSWORD_LENGTH),
+        "corporate_enabled": settings.CORPORATE_ENABLED,
+        "default_email_address_visibility": default_email_address_visibility,
+        "selected_realm_type_name": get_selected_realm_type_name(prereg_realm),
+        "selected_realm_default_language_name": get_selected_realm_default_language_name(
+            prereg_realm
+        ),
+        "email_address_visibility_admins_only": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+        "email_address_visibility_moderators": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
+        "email_address_visibility_nobody": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_NOBODY,
+        "email_address_visibility_options_dict": UserProfile.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP,
+        "how_realm_creator_found_zulip_options": RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS.items(),
+        "next": next_url,
+    }
+
+    if realm_creation:
+        # Add context for realm creation part of the form.
+        context.update(get_realm_create_form_context())
+
+    return TemplateResponse(
+        request, "zerver/create_user/register.html", context=context, status=status
+    )
 
 
 @add_google_analytics
@@ -726,17 +794,39 @@ def registration_helper(
                 extra_context_field = HOW_FOUND_ZULIP_EXTRA_CONTEXT[how_found_zulip]
                 how_found_zulip_extra_context = form.cleaned_data[extra_context_field]
 
-            realm = do_create_realm(
-                string_id,
-                realm_name,
-                org_type=realm_type,
-                default_language=realm_default_language,
-                prereg_realm=prereg_realm,
-                how_realm_creator_found_zulip=RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS[
-                    how_found_zulip
-                ],
-                how_realm_creator_found_zulip_extra_context=how_found_zulip_extra_context,
-            )
+            try:
+                realm = do_create_realm(
+                    string_id,
+                    realm_name,
+                    org_type=realm_type,
+                    default_language=realm_default_language,
+                    prereg_realm=prereg_realm,
+                    how_realm_creator_found_zulip=RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS[
+                        how_found_zulip
+                    ],
+                    how_realm_creator_found_zulip_extra_context=how_found_zulip_extra_context,
+                )
+            except IntegrityError as error:
+                if not is_string_id_unique_violation(error):
+                    raise
+                form.add_error(
+                    "realm_subdomain",
+                    _("Subdomain is already in use. Please choose a different one."),
+                )
+                return render_registration_form(
+                    request,
+                    form=form,
+                    email=email,
+                    key=key,
+                    name_validated=name_validated,
+                    realm=realm,
+                    realm_creation=realm_creation,
+                    password_required=password_required,
+                    require_ldap_password=require_ldap_password,
+                    prereg_realm=prereg_realm,
+                    next_url=next,
+                    status=400,
+                )
         assert realm is not None
 
         full_name = form.cleaned_data["full_name"]
@@ -950,47 +1040,19 @@ def registration_helper(
         assert isinstance(auth_result, UserProfile)
         return login_and_redirect(request, auth_result, next)
 
-    default_email_address_visibility = None
-    if realm is not None:
-        realm_user_default = RealmUserDefault.objects.get(realm=realm)
-        default_email_address_visibility = realm_user_default.email_address_visibility
-
-    context = {
-        "form": form,
-        "email": email,
-        "key": key,
-        "full_name": request.session.get("authenticated_full_name", None),
-        "lock_name": name_validated and name_changes_disabled(realm),
-        # password_auth_enabled is normally set via our context processor,
-        # but for the registration form, there is no logged in user yet, so
-        # we have to set it here.
-        "creating_new_realm": realm_creation,
-        "password_required": password_auth_enabled(realm) and password_required,
-        "require_ldap_password": require_ldap_password,
-        "password_auth_enabled": password_auth_enabled(realm),
-        "default_stream_groups": [] if realm is None else get_default_stream_groups(realm),
-        "accounts": get_accounts_for_email(email),
-        "MAX_NAME_LENGTH": str(UserProfile.MAX_NAME_LENGTH),
-        "MAX_PASSWORD_LENGTH": str(form.MAX_PASSWORD_LENGTH),
-        "corporate_enabled": settings.CORPORATE_ENABLED,
-        "default_email_address_visibility": default_email_address_visibility,
-        "selected_realm_type_name": get_selected_realm_type_name(prereg_realm),
-        "selected_realm_default_language_name": get_selected_realm_default_language_name(
-            prereg_realm
-        ),
-        "email_address_visibility_admins_only": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_ADMINS,
-        "email_address_visibility_moderators": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
-        "email_address_visibility_nobody": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_NOBODY,
-        "email_address_visibility_options_dict": UserProfile.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP,
-        "how_realm_creator_found_zulip_options": RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS.items(),
-    }
-    context["next"] = next
-
-    if realm_creation:
-        # Add context for realm creation part of the form.
-        context.update(get_realm_create_form_context())
-
-    return TemplateResponse(request, "zerver/create_user/register.html", context=context)
+    return render_registration_form(
+        request,
+        form=form,
+        email=email,
+        key=key,
+        name_validated=name_validated,
+        realm=realm,
+        realm_creation=realm_creation,
+        password_required=password_required,
+        require_ldap_password=require_ldap_password,
+        prereg_realm=prereg_realm,
+        next_url=next,
+    )
 
 
 def login_and_redirect(


### PR DESCRIPTION
Two concurrent realm creation requests can both pass subdomain availability
validation before either creates the realm. The second request then raises
an `IntegrityError` for the `Realm.string_id` unique constraint.

Catch violations of the current and historical subdomain constraints and
re-render the existing registration form with a field-level error and an
HTTP 400 response. Preserve the submitted form values and confirmation link
so the user can retry with a different organization URL. Allow unrelated
`IntegrityError`s to continue to propagate normally.

This approach deliberately avoids redirecting to the organization created by
the first request, since that organization may belong to a different
registration flow and user creation may still be in progress.

Fixes #21160.

**How changes were tested:**

- Ran the focused backend tests for both the current and historical realm
  subdomain constraint names.
- Verified that unrelated `IntegrityError`s continue to propagate.
- Verified that the registration form is rendered with HTTP 400, submitted
  organization values are preserved, and the user can retry with another
  organization URL.
- Ran `./tools/lint -m`.
- Manually reproduced the race using a temporary `time.sleep(5)` between
  the subdomain availability check and realm creation.
- Verified that the first request creates the organization successfully.
- Verified that the second request re-renders the registration form and
  displays:
  `Subdomain is already in use. Please choose a different one.`
- Removed the temporary delay after completing the manual test.

**Screenshots and screen captures:**

<img width="993" height="1008" alt="Screenshot from 2026-08-02 16-29-44" src="https://github.com/user-attachments/assets/832fc161-5bab-481c-8d9a-44e6787751d7" />

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)
      the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

