### PR TITLE
messsage-list-data: Add comment do all_messages_after_mute_filtering.

### DIFF
--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -92,6 +92,9 @@ export class MessageListData {
         this.add_messages_callback = callback;
     }
 
+    // Mute filtering for MessageListData objects depends on the values
+    // of this.excludes_muted_topics and this.excludes_muted_users. Note
+    // `recent_view_messages_data` never excludes anything by definition.
     all_messages_after_mute_filtering(): Message[] {
         return this._items;
     }


### PR DESCRIPTION
Documents that there may not be any messages filtered from MessageListData._items since that depends on the two boolean fields for excluding messages from muted topics and users.

Discussed in this PR comment thread: https://github.com/zulip/zulip/pull/39436#discussion_r3654298498. @sahil839 flagging you for review.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
