### PR TITLE
[Backport] mattermost: Do not use `convert_html_to_text`.

### DIFF
--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -32,7 +32,6 @@ from zerver.data_import.import_util import (
     build_stream_subscriptions,
     build_user_profile,
     build_zerver_realm,
-    convert_html_to_text,
     create_converted_data_files,
     get_attachment_path_and_content,
     get_domain_name_for_import,
@@ -541,12 +540,6 @@ def process_raw_message_batch(
             mention_user_ids=mention_user_ids,
         )
 
-        try:
-            content = convert_html_to_text(content)
-        except Exception:  # nocoverage
-            logging.warning("Error converting HTML to text for message: '%s'; continuing", content)
-            logging.warning(str(raw_message))
-
         date_sent = raw_message["date_sent"]
         sender_user_id = raw_message["sender_id"]
         if "channel_name" in raw_message:
@@ -591,6 +584,8 @@ def process_raw_message_batch(
                 output_dir=output_dir,
             )
 
+            if content:
+                content += "\n\n"
             content += attachment_markdown
 
         topic_name = "imported from mattermost"

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -2,7 +2,6 @@ import filecmp
 import json
 import os
 import shutil
-import sys
 import tempfile
 from collections import defaultdict
 from collections.abc import Sequence
@@ -1087,15 +1086,6 @@ class MatterMostImporter(MattermostImportTestBase):
             warn_log.output,
             [
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
-                *(
-                    [
-                        # Check error log when trying to process a message with faulty HTML.
-                        "WARNING:root:Error converting HTML to text for message: 'This will crash html2text!!! <g:brand><![CDATSALOMON NORTH AMERICA, IN}}]]></g:brand>'; continuing",
-                        "WARNING:root:{'sender_id': 2, 'content': 'This will crash html2text!!! <g:brand><![CDATSALOMON NORTH AMERICA, IN}}]]></g:brand>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
-                    ]
-                    if sys.version_info < (3, 13)
-                    else []
-                ),
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
             ],
         )
@@ -1306,7 +1296,7 @@ class MatterMostImporter(MattermostImportTestBase):
 
         self.assertEqual(group_direct_messages[1].sender.email, "ginny@zulip.com")
         self.assertEqual(
-            group_direct_messages[1].content, "Who is going to Hogsmeade this weekend?\n\n"
+            group_direct_messages[1].content, "Who is going to Hogsmeade this weekend?"
         )
         self.assertEqual(group_direct_messages[1].topic_name(), Message.DM_TOPIC)
 
@@ -1325,14 +1315,6 @@ class MatterMostImporter(MattermostImportTestBase):
             warn_log.output,
             [
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
-                *(
-                    [
-                        "WARNING:root:Error converting HTML to text for message: 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>'; continuing",
-                        "WARNING:root:{'sender_id': 2, 'content': 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
-                    ]
-                    if sys.version_info < (3, 13)
-                    else []
-                ),
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
             ],
         )
@@ -1356,14 +1338,6 @@ class MatterMostImporter(MattermostImportTestBase):
             warn_log.output,
             [
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
-                *(
-                    [
-                        "WARNING:root:Error converting HTML to text for message: 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>'; continuing",
-                        "WARNING:root:{'sender_id': 2, 'content': 'Xxxx xxxx xxxxx xxxx2xxxx!!! <x:xxxxx><![XXXXXXXXXXX XXXXX XXXXXXX, XX}}]]></x:xxxxx>', 'date_sent': 1553166657, 'reactions': [], 'channel_name': 'dumbledores-army'}",
-                    ]
-                    if sys.version_info < (3, 13)
-                    else []
-                ),
                 "WARNING:root:Skipping importing direct message groups and DMs since there are multiple teams in the export",
             ],
         )


### PR DESCRIPTION
Backport of https://github.com/zulip/zulip/pull/39602