### PR TITLE
rendered_markdown: Underline links and update their colors.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1881,18 +1881,39 @@
     --color-text-search-highlight: light-dark(currentcolor, hsl(0deg 0% 0%));
     --color-text-alert-word: light-dark(currentcolor, hsl(0deg 0% 0%));
     --color-markdown-link: light-dark(
-        hsl(200deg 100% 40%),
-        var(--color-text-generic-link)
+        hsl(200deg 100% 36%),
+        hsl(200deg 100% 50%)
+    );
+    --color-markdown-link-decoration: light-dark(
+        hsl(200deg 100% 36% / 30%),
+        hsl(200deg 100% 50% / 30%)
     );
     --color-markdown-code-link: var(--color-markdown-link);
     --color-markdown-link-hover: light-dark(
-        hsl(200deg 100% 25%),
-        var(--color-text-generic-link-interactive)
+        hsl(200deg 100% 33%),
+        hsl(200deg 100% 66%)
+    );
+    --color-markdown-link-decoration-hover: light-dark(
+        hsl(200deg 100% 33% / 70%),
+        hsl(200deg 100% 66% / 70%)
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
+    --color-markdown-link-active: light-dark(
+        hsl(200deg 100% 30%),
+        hsl(200deg 100% 55%)
+    );
+    --color-markdown-link-decoration-active: light-dark(
+        hsl(200deg 100% 30%),
+        hsl(200deg 100% 50% / 70%)
+    );
+    --color-markdown-code-link-active: var(--color-markdown-link-active);
     --color-markdown-link-highlight: light-dark(
         hsl(200deg 100% 40%),
         hsl(210deg 100% 25%)
+    );
+    --color-markdown-link-highlight-decoration: light-dark(
+        hsl(200deg 100% 40% / 30%),
+        hsl(210deg 100% 25% / 30%)
     );
     --color-markdown-link-highlight-hover: light-dark(
         hsl(200deg 100% 25%),
@@ -1901,6 +1922,10 @@
     --color-markdown-link-alert-word: light-dark(
         hsl(200deg 100% 40%),
         hsl(210deg 100% 25%)
+    );
+    --color-markdown-link-alert-word-decoration: light-dark(
+        hsl(200deg 100% 40% / 30%),
+        hsl(210deg 100% 25% / 30%)
     );
     --color-markdown-link-alert-word-hover: light-dark(
         hsl(200deg 100% 25%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1884,18 +1884,44 @@
     --color-text-search-highlight: light-dark(currentcolor, hsl(0deg 0% 0%));
     --color-text-alert-word: light-dark(currentcolor, hsl(0deg 0% 0%));
     --color-markdown-link: light-dark(
-        hsl(200deg 100% 40%),
-        var(--color-text-generic-link)
+        hsl(200deg 100% 36%),
+        hsl(200deg 100% 50%)
+    );
+    --color-markdown-link-decoration: color-mix(
+        in oklch,
+        var(--color-markdown-link) 30%,
+        transparent
     );
     --color-markdown-code-link: var(--color-markdown-link);
     --color-markdown-link-hover: light-dark(
-        hsl(200deg 100% 25%),
-        var(--color-text-generic-link-interactive)
+        hsl(200deg 100% 33%),
+        hsl(200deg 100% 66%)
+    );
+    --color-markdown-link-decoration-hover: color-mix(
+        in oklch,
+        var(--color-markdown-link-hover) 70%,
+        transparent
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
+    --color-markdown-link-active: light-dark(
+        hsl(200deg 100% 30%),
+        hsl(200deg 100% 55%)
+    );
+    --color-markdown-link-decoration-active: light-dark(
+        hsl(200deg 100% 30%),
+        hsl(200deg 100% 50% / 70%)
+    );
+    --color-markdown-code-link-active: var(--color-markdown-link-active);
     --color-markdown-link-highlight: light-dark(
         hsl(200deg 100% 40%),
         hsl(210deg 100% 25%)
+    );
+    /* Alert words share this underline color, since they share the
+       link color it is mixed from. */
+    --color-markdown-link-highlight-decoration: color-mix(
+        in oklch,
+        var(--color-markdown-link-highlight) 30%,
+        transparent
     );
     --color-markdown-link-highlight-hover: light-dark(
         hsl(200deg 100% 25%),

--- a/web/styles/message_edit_history.css
+++ b/web/styles/message_edit_history.css
@@ -72,6 +72,64 @@
         }
     }
 
+    /* A link that was added or removed outright is wrapped by the
+       highlight, so its own underline takes the diff color. */
+    .highlight_text_inserted > a {
+        --color-message-edit-history-diff-text: var(
+            --color-message-edit-history-text-inserted
+        );
+    }
+
+    .highlight_text_deleted > a {
+        --color-message-edit-history-diff-text: var(
+            --color-message-edit-history-text-deleted
+        );
+    }
+
+    .highlight_text_inserted > a,
+    .highlight_text_deleted > a {
+        text-decoration-color: color-mix(
+            in oklch,
+            var(--color-message-edit-history-diff-text) 30%,
+            transparent
+        );
+
+        &:hover,
+        &:focus {
+            text-decoration-color: color-mix(
+                in oklch,
+                var(--color-message-edit-history-diff-text) 70%,
+                transparent
+            );
+        }
+
+        &:active {
+            text-decoration-color: var(--color-message-edit-history-diff-text);
+        }
+    }
+
+    /* When only part of a link changed, the highlights sit inside
+       the link, which keeps its own underline under the unchanged
+       text. Each changed run underlines itself in its own color,
+       drawn over the link's underline. */
+    a > .highlight_text_inserted,
+    a > .highlight_text_deleted {
+        text-decoration-thickness: 1px;
+        /* 3px at 14px em */
+        text-underline-offset: 0.2143em;
+    }
+
+    a > .highlight_text_inserted {
+        text-decoration-line: underline;
+    }
+
+    /* This run is already struck through, and both lines share one
+       color, so leaving the color alone keeps the strikethrough as
+       it was. */
+    a > .highlight_text_deleted {
+        text-decoration-line: underline line-through;
+    }
+
     /* Show `Link:` text of media beside it
        to clarify click area for opening media
        in new tab vs in lightbox. */

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -828,6 +828,16 @@
                    unless we set the anchor to display as
                    a block. */
                 display: block;
+                /* A clamped title's ellipsis can't take an
+                   underline, so we keep this to hover only,
+                   as it was before. Only the line is toggled,
+                   so the color and thickness above still apply. */
+                text-decoration-line: none;
+
+                &:hover,
+                &:focus {
+                    text-decoration-line: underline;
+                }
             }
         }
 
@@ -859,7 +869,11 @@
 
     & a:not(.icon-button) {
         color: var(--color-markdown-link);
-        text-decoration: none;
+        text-decoration: underline;
+        text-decoration-color: var(--color-markdown-link-decoration);
+        text-decoration-thickness: 1px;
+        /* 3px at 14px em */
+        text-underline-offset: 0.2143em;
 
         & code {
             color: var(--color-markdown-code-link);
@@ -868,17 +882,36 @@
         &:hover,
         &:focus {
             color: var(--color-markdown-link-hover);
-            text-decoration: underline;
+            text-decoration-color: var(--color-markdown-link-decoration-hover);
 
             & code {
                 color: var(--color-markdown-code-link-hover);
             }
         }
 
+        &:active {
+            color: var(--color-markdown-link-active);
+            text-decoration-color: var(--color-markdown-link-decoration-active);
+
+            & code {
+                color: var(--color-markdown-code-link-active);
+            }
+        }
+
         /* Link styles that are also related to alert words */
         &:has(.alert-word) {
+            text-decoration-color: var(
+                --color-markdown-link-highlight-decoration
+            );
+
             &:hover,
             &:focus {
+                text-decoration-color: var(
+                    --color-markdown-link-alert-word-hover
+                );
+            }
+
+            &:active {
                 text-decoration-color: var(
                     --color-markdown-link-alert-word-hover
                 );
@@ -894,6 +927,15 @@
         &:focus .alert-word {
             color: var(--color-markdown-link-alert-word-hover);
         }
+    }
+
+    /* An underline would be drawn across the media. The last two
+       selectors cover legacy Twitter and Dropbox preview markup,
+       which predates the media-anchor-element class. */
+    & a.media-anchor-element,
+    .twitter-image > a,
+    .message_inline_ref > a {
+        text-decoration: none;
     }
 
     & pre {
@@ -1111,8 +1153,14 @@
 /* Link styles that are also related to search highlights */
 a:not(.icon-button) {
     &:has(.highlight) {
+        text-decoration-color: var(--color-markdown-link-highlight-decoration);
+
         &:hover,
         &:focus {
+            text-decoration-color: var(--color-markdown-link-highlight-hover);
+        }
+
+        &:active {
             text-decoration-color: var(--color-markdown-link-highlight-hover);
         }
     }
@@ -1135,6 +1183,12 @@ a:not(.icon-button) {
     code,
     .stream-topic {
         white-space: nowrap;
+    }
+
+    /* These contexts clip their overflow, and have no room below
+       the baseline for the offset links take elsewhere. */
+    a:not(.icon-button) {
+        text-underline-offset: auto;
     }
 }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -828,6 +828,9 @@
                    unless we set the anchor to display as
                    a block. */
                 display: block;
+                /* A clamped title's ellipsis can't take an
+                   underline, per the comment above. */
+                text-decoration: none;
             }
         }
 
@@ -859,7 +862,11 @@
 
     & a:not(.icon-button) {
         color: var(--color-markdown-link);
-        text-decoration: none;
+        text-decoration: underline;
+        text-decoration-color: var(--color-markdown-link-decoration);
+        text-decoration-thickness: 1px;
+        /* 3px at 14px em */
+        text-underline-offset: 0.2143em;
 
         & code {
             color: var(--color-markdown-code-link);
@@ -868,15 +875,33 @@
         &:hover,
         &:focus {
             color: var(--color-markdown-link-hover);
-            text-decoration: underline;
+            text-decoration-color: var(--color-markdown-link-decoration-hover);
 
             & code {
                 color: var(--color-markdown-code-link-hover);
             }
         }
 
+        &:active {
+            color: var(--color-markdown-link-active);
+            text-decoration-color: var(--color-markdown-link-decoration-active);
+
+            & code {
+                color: var(--color-markdown-code-link-active);
+            }
+        }
+
+        /* An underline would be drawn across the media. */
+        &.media-anchor-element {
+            text-decoration: none;
+        }
+
         /* Link styles that are also related to alert words */
         &:has(.alert-word) {
+            text-decoration-color: var(
+                --color-markdown-link-alert-word-decoration
+            );
+
             &:hover,
             &:focus {
                 text-decoration-color: var(
@@ -1111,6 +1136,8 @@
 /* Link styles that are also related to search highlights */
 a:not(.icon-button) {
     &:has(.highlight) {
+        text-decoration-color: var(--color-markdown-link-highlight-decoration);
+
         &:hover,
         &:focus {
             text-decoration-color: var(--color-markdown-link-highlight-hover);


### PR DESCRIPTION
Links in the message feed are distinguished only by color today, which is a weak cue against the many backgrounds they appear on. This adds a faint permanent underline that gains contrast on hover and gains contrast on hover, and more again when pressed, and applies the blues from the design proposal in the issue.

**Scope Control:**
Ensured that error banners and UI buttons (like the close "X" icon) remain completely unaffected.

Fixes #24877.
<hr>
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

### **Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="1013" height="98" alt="image" src="https://github.com/user-attachments/assets/7f973530-7062-487b-83e3-51a3e9ecafed" />|<img width="1013" height="98" alt="image" src="https://github.com/user-attachments/assets/a2e1e835-bd01-4e1f-82f3-edf8d7505dae" />|

| Before | After |
|--------|-------|
|<img width="1013" height="98" alt="image" src="https://github.com/user-attachments/assets/9980dff8-a1e9-4257-be7e-220c6aa8f920" />|<img width="1013" height="98" alt="image" src="https://github.com/user-attachments/assets/ad1f51c9-6013-45c2-9e6c-48bcfd98d2ab" />|

| On Hover Before | On Hover After |
|--------|-------|
|<img width="1013" height="95" alt="image" src="https://github.com/user-attachments/assets/ef365fce-8988-4c82-bbfb-22cb2fe98f2f" />|<img width="1013" height="95" alt="image" src="https://github.com/user-attachments/assets/2219e7fc-5eb4-4e92-b6db-5b4ce53d7893" />|

| On Hover Before | On Hover After |
|--------|-------|
|<img width="1013" height="95" alt="image" src="https://github.com/user-attachments/assets/d9856ec9-b7a6-476a-8e6a-57ffaec31748" />|<img width="1013" height="95" alt="image" src="https://github.com/user-attachments/assets/7f13d5ff-820d-4453-b567-014f48bb8a5d" />|

| Before | After |
|--------|-------|
|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/514d59c9-b3d0-453c-9b88-d21e72613236" />|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/5a0df4a2-463b-4f35-9951-d0247c5699ad" />|

| Before | After |
|--------|-------|
|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/d4edaf48-3eb1-4efc-9bd8-bfef01b95811" />|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/f582e666-c215-497b-9c54-bbaaff675eab" />|

| On Hover Before | On Hover After |
|--------|-------|
|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/33ed8884-4615-495b-a14f-5fa1651deb87" />|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/5eada48d-50c5-44b7-a4df-84e541b7461e" />|

| On Hover Before | On Hover After |
|--------|-------|
|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/8c45fddb-d6b8-439f-ba2b-b6632a10e998" />|<img width="1013" height="56" alt="image" src="https://github.com/user-attachments/assets/a8d42571-115e-43bd-8b22-af837a8da228" />|



| Before | After |
|--------|-------|
|<img width="1920" height="878" alt="image" src="https://github.com/user-attachments/assets/d7da0666-58fd-4967-99d4-729cad7ec4f0" />|<img width="1920" height="878" alt="image" src="https://github.com/user-attachments/assets/ba8380f6-59df-4757-a2e0-1e1202661be6" />|

| Before | After |
|--------|-------|
|<img width="1920" height="878" alt="image" src="https://github.com/user-attachments/assets/c3e1c29d-42b3-42ab-ab53-b9439b843c5c" />|<img width="1920" height="878" alt="image" src="https://github.com/user-attachments/assets/58881fec-30b7-4c62-99cb-0af5322bc904" />|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
