### PR TITLE
search: Fix caret overlapping text in search bar.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -212,8 +212,8 @@
 
         color: var(--color-text-search);
 
-        display: flex;
-        align-items: center;
+        display: block;
+        align-self: center;
 
         &:empty::before {
             content: attr(data-placeholder-text);


### PR DESCRIPTION
`display: flex` on `.search-input` makes the text an anonymous flex item, and Chrome positions the caret at the flex item's edge instead of the text's insertion point — overlapping the first typed character (`f`, `r`, `v`, `c`) at smaller zoom levels (#38919).

Switch to `display: block` with `align-self: center`. Preserves vertical centering, fixes the caret. Side effect: restores `text-overflow: ellipsis`, which silently didn't apply under flex.

Previous attempt (#35672) used `inline-block`, which fixed the caret but broke vertical centering when pills wrap.

Fixes: #38919

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| _<img width="1860" height="106" alt="image" src="https://github.com/user-attachments/assets/94a7706b-90c3-4a4c-8666-97e3d8d36a9c" />_ | _<img width="1861" height="102" alt="screenshot-2026-07-31_18-14-12" src="https://github.com/user-attachments/assets/e032d9ff-04db-4d31-9ddc-6ee19b4adce6" />_ |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Explains differences from previous plans.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
</details>