### PR TITLE
[ai] checks: Error at startup on an unusable FAKE_EMAIL_DOMAIN.

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -15,7 +15,12 @@ _Unreleased_
 
 ### Upgrade notes for 13.0
 
-- None yet.
+- Zulip now verifies, at startup and before upgrading, that
+  `FAKE_EMAIL_DOMAIN` (which defaults to `EXTERNAL_HOST`) can be used
+  to form email addresses. If your server is hosted at a bare IP
+  address, set `FAKE_EMAIL_DOMAIN` in `/etc/zulip/settings.py` to a
+  domain name before upgrading; using a hostname for `EXTERNAL_HOST`
+  is strongly recommended for new installations.
 
 ## Zulip Server 12.x series
 

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -102,7 +102,10 @@ of the failure, you can just rerun the script. For more information, see
 
 - `--hostname=zulip.example.com`: The user-accessible domain name for this Zulip
   server, i.e., what users will type in their web browser. This becomes
-  `EXTERNAL_HOST` in the Zulip [settings][doc-settings].
+  `EXTERNAL_HOST` in the Zulip [settings][doc-settings]. It should be a
+  domain name, not an IP address; if the server has no name in DNS, invent
+  one, and configure it in `/etc/hosts` on every machine that will access
+  Zulip.
 
 - `--certbot`: With this option, the Zulip installer automatically obtains an
   SSL certificate for the server [using Certbot][doc-certbot], and configures a

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -72,10 +72,10 @@ fi
 # Install
 if [ -z "$TEST_CUSTOM_DB" ]; then
     echo "Testing production install with default database name and user."
-    "$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname 127.0.0.1 --email ci@example.com
+    "$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname localhost.localdomain --email ci@example.com
 else
     echo "Testing production install with custom database name and user."
-    "$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname 127.0.0.1 --email ci@example.com --postgresql-database-user zulipcustomuser --postgresql-database-name zulipcustomdb
+    "$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname localhost.localdomain --email ci@example.com --postgresql-database-user zulipcustomuser --postgresql-database-name zulipcustomdb
 fi
 
 if [ -n "${POSTGRESQL_VERSION:-}" ]; then

--- a/tools/ci/production-upgrade
+++ b/tools/ci/production-upgrade
@@ -29,5 +29,12 @@ export DEBIAN_FRONTEND=noninteractive
 # scripts/lib/upgrade-zulip instead.
 UPGRADE_SCRIPT=/home/zulip/deployments/current/scripts/lib/upgrade-zulip
 
+# The container's Zulip was installed with `--hostname 127.0.0.1` (see
+# Dockerfile.prod); newer Zulip versions refuse to run when
+# EXTERNAL_HOST is an IP address, unless FAKE_EMAIL_DOMAIN is set.
+# Setting it here also makes this a test of upgrading such a
+# deployment.
+echo 'FAKE_EMAIL_DOMAIN = "fake-domain.example.com"' >>/etc/zulip/settings.py
+
 # Execute the upgrade.
 sudo "$UPGRADE_SCRIPT" /tmp/zulip-server-test.tar.gz

--- a/zerver/apps.py
+++ b/zerver/apps.py
@@ -13,6 +13,7 @@ from typing_extensions import override
 from zerver.checks import (
     check_auth_settings,
     check_external_host_setting,
+    check_fake_email_domain_setting,
     check_required_settings,
     check_uploads_settings,
 )
@@ -58,6 +59,7 @@ class ZerverConfig(AppConfig):
     def ready(self) -> None:
         register(check_required_settings)
         register(check_external_host_setting)
+        register(check_fake_email_domain_setting)
         register(check_auth_settings)
         register(check_uploads_settings)
 

--- a/zerver/checks.py
+++ b/zerver/checks.py
@@ -8,6 +8,20 @@ from django.conf import settings
 from django.core import checks
 
 
+def setting_name_and_location(setting_name: str) -> tuple[str, str]:
+    # Describe a setting the way the administrator knows it, along
+    # with where they should adjust it.  Even in Docker,
+    # MANUAL_CONFIGURATION means the admin manages
+    # /etc/zulip/settings.py themselves, so the SETTING_* environment
+    # variables are not where to make changes.
+    if settings.RUNNING_IN_HELM:
+        return ("zulip.environment.SETTING_" + setting_name, "your Helm values")
+    elif settings.RUNNING_IN_DOCKER and os.environ.get("MANUAL_CONFIGURATION") != "True":
+        return ("SETTING_" + setting_name, "your Docker environment configuration")
+    else:
+        return (setting_name, "/etc/zulip/settings.py")
+
+
 def check_required_settings(
     app_configs: Sequence[AppConfig] | None,
     databases: Sequence[str] | None,
@@ -31,18 +45,7 @@ def check_required_settings(
         if value and value != default:
             continue
 
-        # Even in Docker, MANUAL_CONFIGURATION means the admin
-        # manages /etc/zulip/settings.py themselves, so the SETTING_*
-        # environment variables are not where to make changes.
-        if settings.RUNNING_IN_HELM:
-            settings_location = "your Helm values"
-            setting_display_name = "zulip.environment.SETTING_" + setting_name
-        elif settings.RUNNING_IN_DOCKER and os.environ.get("MANUAL_CONFIGURATION") != "True":
-            settings_location = "your Docker environment configuration"
-            setting_display_name = "SETTING_" + setting_name
-        else:
-            settings_location = "/etc/zulip/settings.py"
-            setting_display_name = setting_name
+        setting_display_name, settings_location = setting_name_and_location(setting_name)
         if value:
             # The setting is still the example value from the
             # documentation, which the admin must replace -- saying

--- a/zerver/checks.py
+++ b/zerver/checks.py
@@ -1,11 +1,15 @@
+import ipaddress
 import os
 import re
 from collections.abc import Iterable, Sequence
+from email.headerregistry import Address
 from typing import Any
 
 from django.apps.config import AppConfig
 from django.conf import settings
 from django.core import checks
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 
 
 def setting_name_and_location(setting_name: str) -> tuple[str, str]:
@@ -132,6 +136,82 @@ def check_external_host_setting(
             )
         )
     return errors
+
+
+def check_fake_email_domain_setting(
+    app_configs: Sequence[AppConfig] | None,
+    databases: Sequence[str] | None,
+    **kwargs: Any,
+) -> Iterable[checks.CheckMessage]:
+    if not hasattr(settings, "FAKE_EMAIL_DOMAIN"):  # nocoverage
+        return []
+
+    fake_email_domain = settings.FAKE_EMAIL_DOMAIN
+    try:
+        # The same invariant get_fake_email_domain relies on: the
+        # fallback domain for generated email addresses must itself
+        # form valid addresses.  Address() rejects some malformed
+        # domains with ValueError before validate_email sees them.
+        validate_email(Address(username="bot", domain=fake_email_domain).addr_spec)
+        return []
+    except (ValidationError, ValueError):
+        pass
+
+    fake_display_name, settings_location = setting_name_and_location("FAKE_EMAIL_DOMAIN")
+    # Users have tried IP addresses and URLs here, so the advice
+    # spells out what shape of value is valid.
+    advice = (
+        f"{fake_display_name} in {settings_location} to a domain name (not an "
+        'IP address or URL), like "fake-domain.example.com".  The email '
+        "addresses which Zulip generates for bots and users include this "
+        "domain and are stored permanently, so it should not change later."
+    )
+
+    if fake_email_domain != settings.EXTERNAL_HOST_WITHOUT_PORT:
+        return [
+            checks.Error(
+                f"{fake_display_name} ({fake_email_domain}) cannot be used to form email addresses",
+                hint="Set " + advice,
+                obj="settings.FAKE_EMAIL_DOMAIN",
+                id="zulip.E007",
+            )
+        ]
+
+    # FAKE_EMAIL_DOMAIN was defaulted from EXTERNAL_HOST, so the
+    # advice depends on what is wrong with that setting.
+    external_host_display_name, _ = setting_name_and_location("EXTERNAL_HOST")
+    try:
+        ipaddress.ip_address(fake_email_domain)
+    except ValueError:
+        # EXTERNAL_HOST is malformed in some way other than being an
+        # IP address; check_external_host_setting likely also has a
+        # complaint about it.
+        return [
+            checks.Error(
+                f"{fake_display_name}, which defaults to {external_host_display_name} "
+                f"({fake_email_domain}), cannot be used to form email addresses",
+                hint="Set " + advice,
+                obj="settings.FAKE_EMAIL_DOMAIN",
+                id="zulip.E007",
+            )
+        ]
+
+    return [
+        checks.Error(
+            f"{external_host_display_name} ({fake_email_domain}) is an IP address, "
+            "which cannot be used in the email addresses Zulip generates for bots "
+            "and users",
+            hint=(
+                f"Using a hostname for {external_host_display_name} is strongly "
+                "recommended: if the server has no name in DNS, invent one (like "
+                "zulip.internal), and map it to the server's IP address in "
+                "/etc/hosts on every machine that will access Zulip.  To keep the "
+                "IP address instead, set " + advice
+            ),
+            obj="settings.EXTERNAL_HOST",
+            id="zulip.E007",
+        )
+    ]
 
 
 def check_auth_settings(

--- a/zerver/tests/test_checks.py
+++ b/zerver/tests/test_checks.py
@@ -164,6 +164,73 @@ class TestChecks(ZulipTestCase):
             PRODUCTION=True,
         )
 
+    def test_checks_fake_email_domain(self) -> None:
+        self.assert_check_with_error(None, FAKE_EMAIL_DOMAIN="fake-domain.example.com")
+
+        # An explicitly-set FAKE_EMAIL_DOMAIN which cannot form email
+        # addresses; a URL is a mistake users have actually made here.
+        self.assert_check_with_error(
+            re.compile(
+                re.escape(
+                    "(zulip.E007) FAKE_EMAIL_DOMAIN (http://fake.example.com) "
+                    "cannot be used to form email addresses"
+                )
+                + r"\s*HINT: Set FAKE_EMAIL_DOMAIN in /etc/zulip/settings\.py to a domain name"
+            ),
+            FAKE_EMAIL_DOMAIN="http://fake.example.com",
+        )
+
+        # FAKE_EMAIL_DOMAIN defaulted from an EXTERNAL_HOST which is an
+        # IP address.
+        self.assert_check_with_error(
+            re.compile(
+                re.escape(
+                    "(zulip.E007) EXTERNAL_HOST (192.168.0.79) is an IP address, "
+                    "which cannot be used in the email addresses Zulip generates "
+                    "for bots and users"
+                )
+                + r"\s*HINT: Using a hostname for EXTERNAL_HOST is strongly "
+                + r"recommended: if the server has no name in DNS, invent one "
+                + r"\(like zulip\.internal\), and map it to the server's IP address "
+                + r"in /etc/hosts"
+            ),
+            EXTERNAL_HOST="192.168.0.79",
+            EXTERNAL_HOST_WITHOUT_PORT="192.168.0.79",
+            FAKE_EMAIL_DOMAIN="192.168.0.79",
+        )
+        self.assert_check_with_error(
+            "(zulip.E007) EXTERNAL_HOST (192.168.0.79) is an IP address",
+            EXTERNAL_HOST="192.168.0.79:8443",
+            EXTERNAL_HOST_WITHOUT_PORT="192.168.0.79",
+            FAKE_EMAIL_DOMAIN="192.168.0.79",
+        )
+
+        # FAKE_EMAIL_DOMAIN defaulted from an EXTERNAL_HOST which is
+        # malformed in some non-IP way.
+        self.assert_check_with_error(
+            "(zulip.E007) FAKE_EMAIL_DOMAIN, which defaults to EXTERNAL_HOST "
+            "(bogus_host), cannot be used to form email addresses",
+            EXTERNAL_HOST="bogus_host",
+            EXTERNAL_HOST_WITHOUT_PORT="bogus_host",
+            FAKE_EMAIL_DOMAIN="bogus_host",
+        )
+
+    @override_settings(RUNNING_IN_DOCKER=True)
+    def test_checks_fake_email_domain_docker(self) -> None:
+        self.assert_check_with_error(
+            re.compile(
+                re.escape(
+                    "(zulip.E007) SETTING_EXTERNAL_HOST (192.168.0.79) is an IP "
+                    "address, which cannot be used in the email addresses Zulip "
+                    "generates for bots and users"
+                )
+                + r"\s*HINT: .*set SETTING_FAKE_EMAIL_DOMAIN in your Docker environment configuration"
+            ),
+            EXTERNAL_HOST="192.168.0.79",
+            EXTERNAL_HOST_WITHOUT_PORT="192.168.0.79",
+            FAKE_EMAIL_DOMAIN="192.168.0.79",
+        )
+
     def test_checks_auth(self) -> None:
         self.assert_check_with_error(
             (

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -33,8 +33,10 @@ ZULIP_ADMINISTRATOR = "zulip-admin@example.com"
 
 ## The user-accessible Zulip hostname for this installation, e.g.
 ## zulip.example.com.  This should match what users will put in their
-## web browser.  If you want to allow multiple hostnames, add the rest
-## to ALLOWED_HOSTS.
+## web browser, and should be a domain name, not an IP address -- if
+## the server has no name in DNS, invent one, and configure it in
+## /etc/hosts on the machines that will access Zulip.  If you want to
+## allow multiple hostnames, add the rest to ALLOWED_HOSTS.
 ##
 ## If you need to access the server on a specific port, you should set
 ## EXTERNAL_HOST to e.g. zulip.example.com:1234 here.
@@ -53,9 +55,13 @@ EXTERNAL_HOST = "zulip.example.com"
 ## Note that these should just be hostnames, without port numbers.
 # ALLOWED_HOSTS = ["zulip-alias.example.com", "192.0.2.1"]
 
-## If EXTERNAL_HOST is not a valid domain name (e.g. an IP address),
-## set FAKE_EMAIL_DOMAIN below to a domain that Zulip can use when
-## generating (fake) email addresses for bots, dummy users, etc.
+## Zulip generates (fake) email addresses for bots, dummy users,
+## etc., in a domain which defaults to EXTERNAL_HOST.  If your
+## EXTERNAL_HOST cannot be used to form email addresses (for example,
+## because it is an IP address), set FAKE_EMAIL_DOMAIN below to a
+## domain name -- not an IP address or URL.  The generated email
+## addresses are stored permanently, so this value should not change
+## later.
 # FAKE_EMAIL_DOMAIN = "fake-domain.example.com"
 
 


### PR DESCRIPTION
Fixes: The recurring "Internal server error on every page when EXTERNAL_HOST is an IP address" support trap, most recently [this #production help thread](https://chat.zulip.org/#narrow/channel/31-production-help/topic/Debian.20.2B.20Docker.20Installation.20.2B.20Internal.20Server.20Error).

When `FAKE_EMAIL_DOMAIN` (which defaults to `EXTERNAL_HOST`) cannot form valid email addresses — most commonly a bare-IP `EXTERNAL_HOST` — the failure today is an `InvalidFakeEmailDomainError` 500 on every realm page, with the actionable message buried in server logs. This PR validates the invariant as a Django system check (`zulip.E007`), so the installer, upgrades, and the Docker entrypoint — which all run `manage.py check` — fail at configuration time instead.

An explicitly-set-but-invalid `FAKE_EMAIL_DOMAIN` also errors, even though it is only consulted when a realm's host can't form addresses — it's a latent misconfiguration either way.

**How changes were tested:**

- [x] `./tools/test-backend zerver.tests.test_checks` (covers all three error variants, the Docker setting-name spelling, and valid configs)
- [x] `./tools/test-backend --coverage`: `zerver/checks.py` has no uncovered lines
- [x] `./tools/lint` on changed files

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
- [x] Followed the AI use policy
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
</details>
