### PR TITLE
compose_ui: Don't let edit boxes overwrite compose_textarea_typeahead.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -225,7 +225,11 @@ export class Typeahead<ItemType extends string | object> {
     $container: JQuery;
     $menu: JQuery;
     $footer: JQuery;
-    source: (query: string, input_element: TypeaheadInputElement) => ItemType[];
+    source: (
+        query: string,
+        input_element: TypeaheadInputElement,
+        typeahead: Typeahead<ItemType>,
+    ) => ItemType[];
     dropup: boolean;
     automated: () => boolean;
     trigger_selection: (event: JQuery.KeyDownEvent) => boolean;
@@ -553,7 +557,7 @@ export class Typeahead<ItemType extends string | object> {
             return this.shown ? this.hide() : this;
         }
 
-        const items = this.source(this.query, this.input_element);
+        const items = this.source(this.query, this.input_element, this);
 
         if (items.length === 0 && this.shown) {
             this.hide();
@@ -954,10 +958,17 @@ export class Typeahead<ItemType extends string | object> {
 /* TYPEAHEAD PLUGIN DEFINITION
  * =========================== */
 
-type TypeaheadOptions<ItemType> = {
+type TypeaheadOptions<ItemType extends string | object> = {
     item_html: (query: string) => (item: ItemType) => string | undefined;
     items?: number;
-    source: (query: string, input_element: TypeaheadInputElement) => ItemType[];
+    // The typeahead passes itself to source, so the callback can
+    // consult the state (e.g. `shown`) of the specific typeahead
+    // instance it is generating candidates for.
+    source: (
+        query: string,
+        input_element: TypeaheadInputElement,
+        typeahead: Typeahead<ItemType>,
+    ) => ItemType[];
     // optional options
     advanceKeys?: string[];
     automated?: () => boolean;

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -80,7 +80,15 @@ export let compose_textarea_typeahead: Typeahead<TypeaheadSuggestion> | undefine
 let full_size_status = false; // true or false
 let expanded_status = false; // true or false
 
-export function set_compose_textarea_typeahead(typeahead: Typeahead<TypeaheadSuggestion>): void {
+export function maybe_set_compose_textarea_typeahead(
+    typeahead: Typeahead<TypeaheadSuggestion>,
+): void {
+    // initialize_compose_typeahead also creates the typeaheads for
+    // message-edit boxes; ignore those so that this variable always
+    // points at the main compose box's typeahead.
+    if (!typeahead.input_element.$element.is("textarea#compose-textarea")) {
+        return;
+    }
     compose_textarea_typeahead = typeahead;
 }
 

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -981,6 +981,7 @@ const ALLOWED_MARKDOWN_FEATURES = {
 export function get_candidates(
     query: string,
     input_element: TypeaheadInputElement,
+    typeahead_instance: Typeahead<TypeaheadSuggestion>,
 ): TypeaheadSuggestion[] {
     const split = split_at_cursor(query, input_element.$element);
     let current_token: string | boolean = tokenize_compose_str(split[0]);
@@ -1009,7 +1010,7 @@ export function get_candidates(
         if (
             current_token.length === 3 &&
             !compose_ui.code_formatting_button_triggered &&
-            !compose_ui.compose_textarea_typeahead?.shown
+            !typeahead_instance.shown
         ) {
             return [];
         }
@@ -1703,7 +1704,7 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
         type: "textarea",
     };
 
-    compose_ui.set_compose_textarea_typeahead(
+    compose_ui.maybe_set_compose_textarea_typeahead(
         new Typeahead(bootstrap_typeahead_input, {
             items: max_num_items,
             dropup: true,

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -1571,3 +1571,24 @@ run_test("handle_list_indent", ({override}) => {
         assert.equal($t[0].value, "  1. Item 1");
     }
 });
+
+run_test("maybe_set_compose_textarea_typeahead ignores edit box typeaheads", () => {
+    // First, set up the compose box's typeahead.
+    const $compose_textarea = $("textarea#compose-textarea");
+    $compose_textarea.set_matches("textarea#compose-textarea", true);
+    const compose_typeahead = {
+        input_element: {$element: $compose_textarea, type: "textarea"},
+    };
+    compose_ui.maybe_set_compose_textarea_typeahead(compose_typeahead);
+    assert.equal(compose_ui.compose_textarea_typeahead, compose_typeahead);
+
+    // A message-edit box's typeahead must not overwrite the compose
+    // box's typeahead.
+    const $message_edit_content = $(".message_edit_content");
+    $message_edit_content.set_matches("textarea#compose-textarea", false);
+    const edit_typeahead = {
+        input_element: {$element: $message_edit_content, type: "textarea"},
+    };
+    compose_ui.maybe_set_compose_textarea_typeahead(edit_typeahead);
+    assert.equal(compose_ui.compose_textarea_typeahead, compose_typeahead);
+});

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -28,7 +28,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
     },
     cursor_inside_code_block: () => false,
     set_code_formatting_button_triggered: noop,
-    set_compose_textarea_typeahead: noop,
+    maybe_set_compose_textarea_typeahead: noop,
 });
 const compose_validate = mock_esm("../src/compose_validate", {
     validate_message_length: () => true,
@@ -2287,7 +2287,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     function get_values(input, rest) {
         // Stub out split_at_cursor that uses $(':focus')
         override_rewire(ct, "split_at_cursor", () => [input, rest]);
-        const values = ct.get_candidates(input, input_element);
+        const values = ct.get_candidates(input, input_element, {shown: false});
         return values;
     }
 
@@ -2669,6 +2669,12 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("test ```a", []);
     assert_typeahead_equals("test\n```", []);
     assert_typeahead_equals("``c", []);
+    // But if the typeahead is already open (e.g. the user typed ```py
+    // and then deleted the "py"), a bare ``` keeps it open.
+    override_rewire(ct, "split_at_cursor", () => ["```", ""]);
+    const shown_typeahead_values = ct.get_candidates("```", input_element, {shown: true});
+    assert.ok(shown_typeahead_values.length > 0);
+    assert.equal(shown_typeahead_values[0].type, "syntax");
     // Languages filtered by a single letter is a very long list.
     // The typeahead displays languages sorted by popularity, so to
     // avoid typing out all of them here we'll just test that the


### PR DESCRIPTION
`compose_ui.compose_textarea_typeahead` should always point at the main compose box's typeahead. But message-edit boxes also create their typeaheads through `initialize_compose_typeahead`. So opening an edit box overwrote the variable with the edit box's typeahead.

This broke the language typeahead for code fences. If the user types ```py and deletes the "py", the typeahead should stay open. `get_candidates` checked `compose_textarea_typeahead.shown` for this. After opening an edit box, that variable pointed at the edit box's closed typeahead, so the compose box's typeahead closed instead of staying open.

The first commit passes the typeahead instance to source callbacks. The second commit uses it in `get_candidates`, and makes `set_compose_textarea_typeahead` ignore edit-box typeaheads so the variable always points at the compose box's typeahead.

We also need this for #39571. There, we only insert a complete channel link while the typeahead is already open, and we check the same variable for that. 


**How changes were tested:**


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/fd11401c-926b-49f7-bee5-3ee101ffb6c1


https://github.com/user-attachments/assets/a279fe41-dff5-4a93-8912-eb14eec785c8


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
