### PR TITLE
test-stripe: Add some helper functions for LicenseLedger checks.

### DIFF
--- a/corporate/lib/test_stripe_class.py
+++ b/corporate/lib/test_stripe_class.py
@@ -78,6 +78,7 @@ from corporate.lib.stripe import (
     stripe_get_customer,
 )
 from corporate.models.customers import Customer
+from corporate.models.licenses import LicenseLedger
 from corporate.models.plans import CustomerPlan
 from corporate.models.stripe_state import Invoice
 from zerver.actions.users import do_deactivate_user
@@ -1046,3 +1047,12 @@ class StripeTestCase(ZulipTestCase):
         else:
             response = self.client_patch(url, info)
         return response
+
+    def check_last_ledger_entry_license_counts(
+        self, plan: CustomerPlan, licenses: int, licenses_at_next_renewal: int
+    ) -> LicenseLedger:
+        ledger_entry = LicenseLedger.objects.filter(plan=plan).order_by("-id").first()
+        assert ledger_entry is not None
+        self.assertEqual(ledger_entry.licenses, licenses)
+        self.assertEqual(ledger_entry.licenses_at_next_renewal, licenses_at_next_renewal)
+        return ledger_entry

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -763,21 +763,11 @@ class StripeTest(StripeTestCase):
             billing_session = RealmBillingSession(user=user, realm=realm)
             with patch("corporate.lib.stripe.get_latest_seat_count", return_value=12):
                 billing_session.update_license_ledger_if_needed(self.now)
-            self.assertEqual(
-                LicenseLedger.objects.order_by("-id")
-                .values_list("licenses", "licenses_at_next_renewal")
-                .first(),
-                (12, 12),
-            )
+            self.check_last_ledger_entry_license_counts(plan, 12, 12)
 
             with patch("corporate.lib.stripe.get_latest_seat_count", return_value=15):
                 billing_session.update_license_ledger_if_needed(self.next_month)
-            self.assertEqual(
-                LicenseLedger.objects.order_by("-id")
-                .values_list("licenses", "licenses_at_next_renewal")
-                .first(),
-                (15, 15),
-            )
+            self.check_last_ledger_entry_license_counts(plan, 15, 15)
 
             invoice_plans_as_needed(self.next_month)
             self.assertFalse(stripe.Invoice.list(customer=stripe_customer.id))
@@ -818,12 +808,8 @@ class StripeTest(StripeTestCase):
 
             with patch("corporate.lib.stripe.get_latest_seat_count", return_value=19):
                 billing_session.update_license_ledger_if_needed(add_months(free_trial_end_date, 10))
-            self.assertEqual(
-                LicenseLedger.objects.order_by("-id")
-                .values_list("licenses", "licenses_at_next_renewal")
-                .first(),
-                (19, 19),
-            )
+            self.check_last_ledger_entry_license_counts(plan, 19, 19)
+
             # Fast forward next_invoice_date to 10 months from the free_trial_end_date
             plan.next_invoice_date = add_months(free_trial_end_date, 10)
             plan.save(update_fields=["next_invoice_date"])
@@ -1213,14 +1199,10 @@ class StripeTest(StripeTestCase):
                 schedule=None,
                 toggle_license_management=False,
             )
-            self.assertEqual(
-                LicenseLedger.objects.filter(plan=plan).latest("id").licenses_at_next_renewal, 123
-            )
+            self.check_last_ledger_entry_license_counts(plan, 123, 123)
             with time_machine.travel(self.now, tick=False):
                 self.billing_session.do_update_plan(update_plan_request)
-            self.assertEqual(
-                LicenseLedger.objects.filter(plan=plan).latest("id").licenses_at_next_renewal, 125
-            )
+            self.check_last_ledger_entry_license_counts(plan, 123, 125)
 
             invoice_plans_as_needed(free_trial_end_date)
             customer_plan.refresh_from_db()
@@ -1429,10 +1411,9 @@ class StripeTest(StripeTestCase):
             [item.amount for item in additional_license_invoice.lines],
         )
         # Check LicenseLedger has the new amount
-        ledger_entry = LicenseLedger.objects.last()
-        assert ledger_entry is not None
-        self.assertEqual(ledger_entry.licenses, new_seat_count)
-        self.assertEqual(ledger_entry.licenses_at_next_renewal, new_seat_count)
+        plan = get_current_plan_by_customer(customer)
+        assert plan is not None
+        self.check_last_ledger_entry_license_counts(plan, new_seat_count, new_seat_count)
 
     @mock_stripe()
     def test_upgrade_by_card_with_outdated_lower_seat_count(self, *mocks: Mock) -> None:
@@ -1474,10 +1455,9 @@ class StripeTest(StripeTestCase):
             [item.amount for item in upgrade_invoice.lines],
         )
         # Check LicenseLedger has the reduced license count at renewal
-        ledger_entry = LicenseLedger.objects.last()
-        assert ledger_entry is not None
-        self.assertEqual(ledger_entry.licenses, self.seat_count)
-        self.assertEqual(ledger_entry.licenses_at_next_renewal, new_seat_count)
+        plan = get_current_plan_by_customer(customer)
+        assert plan is not None
+        self.check_last_ledger_entry_license_counts(plan, self.seat_count, new_seat_count)
 
         # Check that we informed the support team about the potential billing error.
         from django.core.mail import outbox
@@ -1539,10 +1519,11 @@ class StripeTest(StripeTestCase):
             [item.amount for item in upgrade_invoice.lines],
         )
         # Check LicenseLedger has the minimum license count
-        ledger_entry = LicenseLedger.objects.last()
-        assert ledger_entry is not None
-        self.assertEqual(ledger_entry.licenses, minimum_for_plan_tier)
-        self.assertEqual(ledger_entry.licenses_at_next_renewal, minimum_for_plan_tier)
+        plan = get_current_plan_by_customer(customer)
+        assert plan is not None
+        self.check_last_ledger_entry_license_counts(
+            plan, minimum_for_plan_tier, minimum_for_plan_tier
+        )
 
     @mock_stripe()
     def test_customer_minimum_licenses_for_plan(self, *mocks: Mock) -> None:
@@ -1562,10 +1543,9 @@ class StripeTest(StripeTestCase):
         assert customer is not None
         assert customer.stripe_customer_id is not None
         # Check LicenseLedger has the current seat count.
-        ledger_entry = LicenseLedger.objects.last()
-        assert ledger_entry is not None
-        self.assertEqual(ledger_entry.licenses, self.seat_count)
-        self.assertEqual(ledger_entry.licenses_at_next_renewal, self.seat_count)
+        plan = get_current_plan_by_customer(customer)
+        assert plan is not None
+        self.check_last_ledger_entry_license_counts(plan, self.seat_count, self.seat_count)
 
         # We manually set customer.minimum_licenses to the current seat count,
         # which is below the general Plus plan minimum licenses.
@@ -2612,12 +2592,7 @@ class StripeTest(StripeTestCase):
         billing_session = RealmBillingSession(user=user, realm=user.realm)
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=20):
             billing_session.update_license_ledger_if_needed(self.now)
-        self.assertEqual(
-            LicenseLedger.objects.order_by("-id")
-            .values_list("licenses", "licenses_at_next_renewal")
-            .first(),
-            (20, 20),
-        )
+        self.check_last_ledger_entry_license_counts(plan, 20, 20)
 
         # Verify that we invoice them for the additional users
         mocked = self.setup_mocked_stripe(invoice_plans_as_needed, self.next_month)
@@ -2632,12 +2607,8 @@ class StripeTest(StripeTestCase):
         assert plan is not None
         self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(plan.status, CustomerPlan.ENDED)
-        self.assertEqual(
-            LicenseLedger.objects.order_by("-id")
-            .values_list("licenses", "licenses_at_next_renewal")
-            .first(),
-            (20, 20),
-        )
+        self.check_last_ledger_entry_license_counts(plan, 20, 20)
+
         realm_audit_log = RealmAuditLog.objects.latest("id")
         self.assertEqual(realm_audit_log.event_type, AuditLogEventType.REALM_PLAN_TYPE_CHANGED)
         self.assertEqual(realm_audit_log.acting_user, None)
@@ -2645,12 +2616,7 @@ class StripeTest(StripeTestCase):
         # Verify that we don't write LicenseLedger rows once we've downgraded
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=40):
             billing_session.update_license_ledger_if_needed(self.next_year)
-        self.assertEqual(
-            LicenseLedger.objects.order_by("-id")
-            .values_list("licenses", "licenses_at_next_renewal")
-            .first(),
-            (20, 20),
-        )
+        self.check_last_ledger_entry_license_counts(plan, 20, 20)
 
         # Verify that we call invoice_plan once more after cycle end but
         # don't invoice them for users added after the cycle end
@@ -2721,12 +2687,7 @@ class StripeTest(StripeTestCase):
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=20):
             billing_session.update_license_ledger_if_needed(self.now)
         self.assertEqual(LicenseLedger.objects.filter(plan=monthly_plan).count(), 2)
-        self.assertEqual(
-            LicenseLedger.objects.order_by("-id")
-            .values_list("licenses", "licenses_at_next_renewal")
-            .first(),
-            (20, 20),
-        )
+        self.check_last_ledger_entry_license_counts(monthly_plan, 20, 20)
 
         with (
             time_machine.travel(self.next_month, tick=False),
@@ -3006,12 +2967,7 @@ class StripeTest(StripeTestCase):
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=20):
             billing_session.update_license_ledger_if_needed(self.now)
         self.assertEqual(LicenseLedger.objects.filter(plan=annual_plan).count(), 2)
-        self.assertEqual(
-            LicenseLedger.objects.order_by("-id")
-            .values_list("licenses", "licenses_at_next_renewal")
-            .first(),
-            (20, 20),
-        )
+        self.check_last_ledger_entry_license_counts(annual_plan, 20, 20)
 
         # Check that we don't switch to monthly plan at next invoice date (which is used to charge user for
         # additional licenses) but at the end of current billing cycle.
@@ -3324,10 +3280,7 @@ class StripeTest(StripeTestCase):
             with patch("corporate.lib.stripe.get_latest_seat_count", return_value=21):
                 billing_session.update_license_ledger_if_needed(self.now)
 
-            last_ledger_entry = LicenseLedger.objects.order_by("id").last()
-            assert last_ledger_entry is not None
-            self.assertEqual(last_ledger_entry.licenses, 21)
-            self.assertEqual(last_ledger_entry.licenses_at_next_renewal, 21)
+            last_ledger_entry = self.check_last_ledger_entry_license_counts(plan, 21, 21)
 
             self.login_user(user)
 
@@ -3417,12 +3370,7 @@ class StripeTest(StripeTestCase):
             # part of the cycle
             with patch("corporate.lib.stripe.get_latest_seat_count", return_value=20):
                 billing_session.update_license_ledger_if_needed(self.now)
-            self.assertEqual(
-                LicenseLedger.objects.order_by("-id")
-                .values_list("licenses", "licenses_at_next_renewal")
-                .first(),
-                (20, 20),
-            )
+            self.check_last_ledger_entry_license_counts(plan, 20, 20)
 
             # Verify that we don't invoice them for the additional users during free trial.
             mocked = self.setup_mocked_stripe(invoice_plans_as_needed, self.next_month)
@@ -3438,22 +3386,12 @@ class StripeTest(StripeTestCase):
             self.assertIsNone(plan.next_invoice_date)
             self.assertEqual(plan.status, CustomerPlan.ENDED)
             self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
-            self.assertEqual(
-                LicenseLedger.objects.order_by("-id")
-                .values_list("licenses", "licenses_at_next_renewal")
-                .first(),
-                (20, 20),
-            )
+            self.check_last_ledger_entry_license_counts(plan, 20, 20)
 
             # Verify that we don't write LicenseLedger rows once we've downgraded
             with patch("corporate.lib.stripe.get_latest_seat_count", return_value=40):
                 billing_session.update_license_ledger_if_needed(self.next_year)
-            self.assertEqual(
-                LicenseLedger.objects.order_by("-id")
-                .values_list("licenses", "licenses_at_next_renewal")
-                .first(),
-                (20, 20),
-            )
+            self.check_last_ledger_entry_license_counts(plan, 20, 20)
 
             self.login_user(user)
             response = self.client_get("/billing/")
@@ -3732,24 +3670,26 @@ class StripeTest(StripeTestCase):
         self.login_user(user)
 
         customer = Customer.objects.get_or_create(realm=user.realm)[0]
+        reduced_seat_count = get_latest_seat_count(user.realm) - 2
         customer.exempt_from_license_number_check = True
         customer.save()
 
+        paid_license_count = 100
         with time_machine.travel(self.now, tick=False):
-            self.local_upgrade(100, False, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False)
+            self.local_upgrade(
+                paid_license_count, False, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False
+            )
 
         with time_machine.travel(self.now, tick=False):
             result = self.client_billing_patch(
                 "/billing/plan",
-                {"licenses_at_next_renewal": get_latest_seat_count(user.realm) - 2},
+                {"licenses_at_next_renewal": reduced_seat_count},
             )
 
         self.assert_json_success(result)
-        latest_license_ledger = LicenseLedger.objects.last()
-        assert latest_license_ledger is not None
-        self.assertEqual(
-            latest_license_ledger.licenses_at_next_renewal, get_latest_seat_count(user.realm) - 2
-        )
+        plan = get_current_plan_by_customer(customer)
+        assert plan is not None
+        self.check_last_ledger_entry_license_counts(plan, paid_license_count, reduced_seat_count)
 
     def test_upgrade_exempt_from_license_number_check_realm_less_licenses_than_seat_count(
         self,
@@ -3774,10 +3714,9 @@ class StripeTest(StripeTestCase):
                 reduced_seat_count, False, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False
             )
 
-        latest_license_ledger = LicenseLedger.objects.last()
-        assert latest_license_ledger is not None
-        self.assertEqual(latest_license_ledger.licenses_at_next_renewal, reduced_seat_count)
-        self.assertEqual(latest_license_ledger.licenses, reduced_seat_count)
+        plan = get_current_plan_by_customer(customer)
+        assert plan is not None
+        self.check_last_ledger_entry_license_counts(plan, reduced_seat_count, reduced_seat_count)
 
     def test_update_licenses_of_automatic_plan_from_billing_page(self) -> None:
         user = self.example_user("hamlet")
@@ -3899,10 +3838,7 @@ class StripeTest(StripeTestCase):
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=20):
             billing_session.update_license_ledger_if_needed(self.now)
 
-        last_ledger_entry = LicenseLedger.objects.order_by("id").last()
-        assert last_ledger_entry is not None
-        self.assertEqual(last_ledger_entry.licenses, 20)
-        self.assertEqual(last_ledger_entry.licenses_at_next_renewal, 20)
+        last_ledger_entry = self.check_last_ledger_entry_license_counts(plan, 20, 20)
 
         do_deactivate_realm(
             get_realm("zulip"),
@@ -7033,23 +6969,21 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
             RemoteRealmAuditLog.objects.count(),
             min_licenses + 10 - realm_user_count + audit_log_count,
         )
-        latest_ledger = LicenseLedger.objects.last()
-        assert latest_ledger is not None
-        self.assertEqual(latest_ledger.licenses, min_licenses + 10)
+        paid_license_count = min_licenses + 10
+        self.check_last_ledger_entry_license_counts(plan, paid_license_count, paid_license_count)
 
         with time_machine.travel(self.now + timedelta(days=3), tick=False):
             response = self.client_get(
                 f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
             )
 
-        self.assertEqual(latest_ledger.licenses, 35)
         for substring in [
             "Zulip Business",
             "Number of licenses",
-            f"{latest_ledger.licenses}",
+            f"{paid_license_count}",
             "January 2, 2013",
             "Your plan will automatically renew on",
-            f"${80 * latest_ledger.licenses:,.2f}",
+            f"${80 * paid_license_count:,.2f}",
             "Visa ending in 4242",
             "Update card",
         ]:
@@ -7261,23 +7195,23 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
                 RemoteRealmAuditLog.objects.count(),
                 min_licenses + 10 - realm_user_count + audit_log_count,
             )
-            latest_ledger = LicenseLedger.objects.last()
-            assert latest_ledger is not None
-            self.assertEqual(latest_ledger.licenses, min_licenses + 10)
+            paid_license_count = min_licenses + 10
+            self.check_last_ledger_entry_license_counts(
+                plan, paid_license_count, paid_license_count
+            )
 
             with time_machine.travel(self.now + timedelta(days=3), tick=False):
                 response = self.client_get(
                     f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
                 )
 
-            self.assertEqual(latest_ledger.licenses, min_licenses + 10)
             for substring in [
                 "Zulip Basic",
                 "Number of licenses",
-                f"{latest_ledger.licenses}",
+                f"{paid_license_count}",
                 "February 1, 2012",
                 "Your plan will automatically renew on",
-                f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",
+                f"${3.5 * paid_license_count - flat_discount // 100 * 1:,.2f}",
                 "Visa ending in 4242",
                 "Update card",
             ]:
@@ -7469,23 +7403,21 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
             RemoteRealmAuditLog.objects.count(),
             min_licenses + 10 - realm_user_count + audit_log_count,
         )
-        latest_ledger = LicenseLedger.objects.last()
-        assert latest_ledger is not None
-        self.assertEqual(latest_ledger.licenses, min_licenses + 10)
+        paid_license_count = min_licenses + 10
+        self.check_last_ledger_entry_license_counts(plan, paid_license_count, paid_license_count)
 
         with time_machine.travel(self.now + timedelta(days=3), tick=False):
             response = self.client_get(
                 f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
             )
 
-        self.assertEqual(latest_ledger.licenses, min_licenses + 10)
         for substring in [
             "Zulip Basic",
             "Number of licenses",
-            f"{latest_ledger.licenses}",
+            f"{paid_license_count}",
             "February 2, 2012",
             "Your plan will automatically renew on",
-            f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",
+            f"${3.5 * paid_license_count - flat_discount // 100 * 1:,.2f}",
             "Visa ending in 4242",
             "Update card",
         ]:
@@ -9013,9 +8945,8 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
             RemoteRealmAuditLog.objects.count(),
             audit_log_count + 8,
         )
-        latest_ledger = LicenseLedger.objects.last()
-        assert latest_ledger is not None
-        self.assertEqual(latest_ledger.licenses, server_user_count + 8)
+        paid_license_count = server_user_count + 8
+        self.check_last_ledger_entry_license_counts(plan, paid_license_count, paid_license_count)
 
         # Login again
         result = self.execute_remote_billing_authentication_flow(
@@ -9449,23 +9380,23 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
                 RemoteRealmAuditLog.objects.count(),
                 audit_log_count + 10,
             )
-            latest_ledger = LicenseLedger.objects.last()
-            assert latest_ledger is not None
-            self.assertEqual(latest_ledger.licenses, 28)
+            paid_license_count = realm_user_count + 10
+            self.check_last_ledger_entry_license_counts(
+                plan, paid_license_count, paid_license_count
+            )
 
             with time_machine.travel(self.now + timedelta(days=3), tick=False):
                 response = self.client_get(
                     f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
                 )
 
-            self.assertEqual(latest_ledger.licenses, 28)
             for substring in [
                 "Zulip Basic",
                 "Number of licenses",
-                f"{latest_ledger.licenses}",
+                f"{paid_license_count}",
                 "February 1, 2012",
                 "Your plan will automatically renew on",
-                f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",
+                f"${3.5 * paid_license_count - flat_discount // 100 * 1:,.2f}",
                 "Visa ending in 4242",
                 "Update card",
             ]:
@@ -9659,23 +9590,21 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
             RemoteRealmAuditLog.objects.count(),
             audit_log_count + 10,
         )
-        latest_ledger = LicenseLedger.objects.last()
-        assert latest_ledger is not None
-        self.assertEqual(latest_ledger.licenses, 28)
+        paid_license_count = server_user_count + 10
+        self.check_last_ledger_entry_license_counts(plan, paid_license_count, paid_license_count)
 
         with time_machine.travel(self.now + timedelta(days=3), tick=False):
             response = self.client_get(
                 f"{self.billing_session.billing_base_url}/billing/", subdomain="selfhosting"
             )
 
-        self.assertEqual(latest_ledger.licenses, 28)
         for substring in [
             "Zulip Basic",
             "Number of licenses",
-            f"{latest_ledger.licenses}",
+            f"{paid_license_count}",
             "February 2, 2012",
             "Your plan will automatically renew on",
-            f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",
+            f"${3.5 * paid_license_count - flat_discount // 100 * 1:,.2f}",
             "Visa ending in 4242",
             "Update card",
         ]:

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2549,7 +2549,9 @@ class StripeTest(StripeTestCase):
             self.local_upgrade(
                 self.seat_count, True, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False
             )
-        plan = get_current_plan_by_realm(user.realm)
+        customer = get_customer_by_realm(user.realm)
+        assert customer is not None
+        plan = get_current_plan_by_customer(customer)
         assert plan is not None
         self.assertEqual(plan.licenses(), self.seat_count)
         self.assertEqual(plan.licenses_at_next_renewal(), self.seat_count)
@@ -2561,10 +2563,7 @@ class StripeTest(StripeTestCase):
                 "/billing/plan",
                 {"status": CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE},
             )
-            stripe_customer_id = Customer.objects.get(realm=user.realm).id
-            new_plan = get_current_plan_by_realm(user.realm)
-            assert new_plan is not None
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
             self.assertEqual(m.output[0], expected_log)
             self.assert_json_success(response)
         plan.refresh_from_db()
@@ -2603,8 +2602,7 @@ class StripeTest(StripeTestCase):
         # Check that we downgrade properly if the cycle is over
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=30):
             billing_session.update_license_ledger_if_needed(self.next_year)
-        plan = CustomerPlan.objects.first()
-        assert plan is not None
+        plan.refresh_from_db()
         self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(plan.status, CustomerPlan.ENDED)
         self.check_last_ledger_entry_license_counts(plan, 20, 20)
@@ -2620,8 +2618,7 @@ class StripeTest(StripeTestCase):
 
         # Verify that we call invoice_plan once more after cycle end but
         # don't invoice them for users added after the cycle end
-        plan = CustomerPlan.objects.first()
-        assert plan is not None
+        plan.refresh_from_db()
         self.assertIsNotNone(plan.next_invoice_date)
 
         mocked = self.setup_mocked_stripe(
@@ -2632,8 +2629,7 @@ class StripeTest(StripeTestCase):
         mocked["Invoice"].create.assert_not_called()
 
         # Check that we updated next_invoice_date in invoice_plan
-        plan = CustomerPlan.objects.first()
-        assert plan is not None
+        plan.refresh_from_db()
         self.assertIsNone(plan.next_invoice_date)
 
         # Check that we don't call invoice_plan after that final call
@@ -2655,14 +2651,12 @@ class StripeTest(StripeTestCase):
 
         self.login_user(user)
         self.add_card_and_upgrade(user, schedule="monthly")
-        monthly_plan = get_current_plan_by_realm(user.realm)
+        customer = get_customer_by_realm(user.realm)
+        assert customer is not None
+        monthly_plan = get_current_plan_by_customer(customer)
         assert monthly_plan is not None
         self.assertEqual(monthly_plan.automanage_licenses, True)
         self.assertEqual(monthly_plan.billing_schedule, CustomerPlan.BILLING_SCHEDULE_MONTHLY)
-
-        stripe_customer_id = Customer.objects.get(realm=user.realm).id
-        new_plan = get_current_plan_by_realm(user.realm)
-        assert new_plan is not None
 
         with (
             self.assertLogs("corporate.stripe", "INFO") as m,
@@ -2672,7 +2666,7 @@ class StripeTest(StripeTestCase):
                 "/billing/plan",
                 {"status": CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE},
             )
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE}"
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {monthly_plan.id}, status: {CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE}"
             self.assertEqual(m.output[0], expected_log)
             self.assert_json_success(response)
         monthly_plan.refresh_from_db()
@@ -2832,13 +2826,12 @@ class StripeTest(StripeTestCase):
         self.add_card_and_upgrade(
             user, schedule="monthly", license_management="manual", licenses=num_licenses
         )
-        monthly_plan = get_current_plan_by_realm(user.realm)
+        customer = get_customer_by_realm(user.realm)
+        assert customer is not None
+        monthly_plan = get_current_plan_by_customer(customer)
         assert monthly_plan is not None
         self.assertEqual(monthly_plan.automanage_licenses, False)
         self.assertEqual(monthly_plan.billing_schedule, CustomerPlan.BILLING_SCHEDULE_MONTHLY)
-        stripe_customer_id = Customer.objects.get(realm=user.realm).id
-        new_plan = get_current_plan_by_realm(user.realm)
-        assert new_plan is not None
         with (
             self.assertLogs("corporate.stripe", "INFO") as m,
             time_machine.travel(self.now, tick=False),
@@ -2849,7 +2842,7 @@ class StripeTest(StripeTestCase):
             )
             self.assertEqual(
                 m.output[0],
-                f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE}",
+                f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {monthly_plan.id}, status: {CustomerPlan.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE}",
             )
             self.assert_json_success(response)
         monthly_plan.refresh_from_db()
@@ -2934,14 +2927,12 @@ class StripeTest(StripeTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         self.add_card_and_upgrade(user, schedule="annual")
-        annual_plan = get_current_plan_by_realm(user.realm)
+        customer = get_customer_by_realm(user.realm)
+        assert customer is not None
+        annual_plan = get_current_plan_by_customer(customer)
         assert annual_plan is not None
         self.assertEqual(annual_plan.automanage_licenses, True)
         self.assertEqual(annual_plan.billing_schedule, CustomerPlan.BILLING_SCHEDULE_ANNUAL)
-
-        stripe_customer_id = Customer.objects.get(realm=user.realm).id
-        new_plan = get_current_plan_by_realm(user.realm)
-        assert new_plan is not None
 
         assert self.now is not None
         with (
@@ -2952,7 +2943,7 @@ class StripeTest(StripeTestCase):
                 "/billing/plan",
                 {"status": CustomerPlan.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE},
             )
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE}"
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {annual_plan.id}, status: {CustomerPlan.SWITCH_TO_MONTHLY_AT_END_OF_CYCLE}"
             self.assertEqual(m.output[0], expected_log)
             self.assert_json_success(response)
         annual_plan.refresh_from_db()
@@ -3099,14 +3090,14 @@ class StripeTest(StripeTestCase):
                 "/billing/plan",
                 {"status": CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE},
             )
-            stripe_customer_id = Customer.objects.get(realm=user.realm).id
-            new_plan = get_current_plan_by_realm(user.realm)
-            assert new_plan is not None
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
+            customer = get_customer_by_realm(user.realm)
+            assert customer is not None
+            plan = get_current_plan_by_customer(customer)
+            assert plan is not None
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
             self.assertEqual(m.output[0], expected_log)
             self.assert_json_success(response)
-        plan = CustomerPlan.objects.first()
-        assert plan is not None
+        plan.refresh_from_db()
         self.assertEqual(plan.status, CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE)
         with (
             self.assertLogs("corporate.stripe", "INFO") as m,
@@ -3116,11 +3107,10 @@ class StripeTest(StripeTestCase):
                 "/billing/plan",
                 {"status": CustomerPlan.ACTIVE},
             )
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.ACTIVE}"
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.ACTIVE}"
             self.assertEqual(m.output[0], expected_log)
             self.assert_json_success(response)
-        plan = CustomerPlan.objects.first()
-        assert plan is not None
+        plan.refresh_from_db()
         self.assertEqual(plan.status, CustomerPlan.ACTIVE)
 
     @patch("stripe.Invoice.create")
@@ -3138,28 +3128,26 @@ class StripeTest(StripeTestCase):
             self.local_upgrade(
                 self.seat_count, True, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False
             )
+        customer = get_customer_by_realm(user.realm)
+        assert customer is not None
+        plan = get_current_plan_by_customer(customer)
+        assert plan is not None
         with self.assertLogs("corporate.stripe", "INFO") as m:
-            stripe_customer_id = Customer.objects.get(realm=user.realm).id
-            new_plan = get_current_plan_by_realm(user.realm)
-            assert new_plan is not None
             with time_machine.travel(self.now, tick=False):
                 self.client_billing_patch(
                     "/billing/plan",
                     {"status": CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE},
                 )
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
             self.assertEqual(m.output[0], expected_log)
-
-        plan = CustomerPlan.objects.first()
-        assert plan is not None
+        plan.refresh_from_db()
         self.assertIsNotNone(plan.next_invoice_date)
         self.assertEqual(plan.status, CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE)
         # Fast forward the next_invoice_date to next year.
         plan.next_invoice_date = self.next_year
         plan.save(update_fields=["next_invoice_date"])
         invoice_plans_as_needed(self.next_year)
-        plan = CustomerPlan.objects.first()
-        assert plan is not None
+        plan.refresh_from_db()
         self.assertIsNone(plan.next_invoice_date)
         self.assertEqual(plan.status, CustomerPlan.ENDED)
 
@@ -3320,7 +3308,9 @@ class StripeTest(StripeTestCase):
         with self.settings(CLOUD_FREE_TRIAL_DAYS=60):
             with time_machine.travel(self.now, tick=False):
                 self.add_card_and_upgrade(user, schedule="annual")
-            plan = get_current_plan_by_realm(user.realm)
+            customer = get_customer_by_realm(user.realm)
+            assert customer is not None
+            plan = get_current_plan_by_customer(customer)
             assert plan is not None
             self.assertEqual(plan.next_invoice_date, free_trial_end_date)
             self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
@@ -3337,10 +3327,7 @@ class StripeTest(StripeTestCase):
                     "/billing/plan",
                     {"status": CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL},
                 )
-                stripe_customer_id = Customer.objects.get(realm=user.realm).id
-                new_plan = get_current_plan_by_realm(user.realm)
-                assert new_plan is not None
-                expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL}"
+                expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL}"
                 self.assertEqual(m.output[0], expected_log)
                 self.assert_json_success(response)
             plan.refresh_from_db()
@@ -3381,8 +3368,7 @@ class StripeTest(StripeTestCase):
             # Check that we downgrade properly if the cycle is over
             with patch("corporate.lib.stripe.get_latest_seat_count", return_value=30):
                 billing_session.update_license_ledger_if_needed(free_trial_end_date)
-            plan = CustomerPlan.objects.first()
-            assert plan is not None
+            plan.refresh_from_db()
             self.assertIsNone(plan.next_invoice_date)
             self.assertEqual(plan.status, CustomerPlan.ENDED)
             self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_LIMITED)
@@ -3417,7 +3403,9 @@ class StripeTest(StripeTestCase):
         with self.settings(CLOUD_FREE_TRIAL_DAYS=60):
             with time_machine.travel(self.now, tick=False):
                 self.add_card_and_upgrade(user, schedule="annual")
-            plan = get_current_plan_by_realm(user.realm)
+            customer = get_customer_by_realm(user.realm)
+            assert customer is not None
+            plan = get_current_plan_by_customer(customer)
             assert plan is not None
             self.assertEqual(plan.next_invoice_date, free_trial_end_date)
             self.assertEqual(get_realm("zulip").plan_type, Realm.PLAN_TYPE_STANDARD)
@@ -3434,10 +3422,7 @@ class StripeTest(StripeTestCase):
                     "/billing/plan",
                     {"status": CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL},
                 )
-                stripe_customer_id = Customer.objects.get(realm=user.realm).id
-                new_plan = get_current_plan_by_realm(user.realm)
-                assert new_plan is not None
-                expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL}"
+                expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL}"
                 self.assertEqual(m.output[0], expected_log)
                 self.assert_json_success(response)
             plan.refresh_from_db()
@@ -3456,10 +3441,7 @@ class StripeTest(StripeTestCase):
                     "/billing/plan",
                     {"status": CustomerPlan.FREE_TRIAL},
                 )
-                stripe_customer_id = Customer.objects.get(realm=user.realm).id
-                new_plan = get_current_plan_by_realm(user.realm)
-                assert new_plan is not None
-                expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.FREE_TRIAL}"
+                expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.FREE_TRIAL}"
                 self.assertEqual(m.output[0], expected_log)
                 self.assert_json_success(response)
             plan.refresh_from_db()
@@ -3484,10 +3466,11 @@ class StripeTest(StripeTestCase):
                     "/billing/plan",
                     {"status": CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE},
                 )
-            stripe_customer_id = Customer.objects.get(realm=user.realm).id
-            new_plan = get_current_plan_by_realm(user.realm)
-            assert new_plan is not None
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {stripe_customer_id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
+            customer = get_customer_by_realm(user.realm)
+            assert customer is not None
+            plan = get_current_plan_by_customer(customer)
+            assert plan is not None
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
             self.assertEqual(m.output[0], expected_log)
 
         with (
@@ -3507,8 +3490,8 @@ class StripeTest(StripeTestCase):
         )
 
         # Fast forward the next_invoice_date to next year.
-        new_plan.next_invoice_date = self.next_year
-        new_plan.save(update_fields=["next_invoice_date"])
+        plan.next_invoice_date = self.next_year
+        plan.save(update_fields=["next_invoice_date"])
         invoice_plans_as_needed(self.next_year)
 
         with time_machine.travel(self.next_year, tick=False):
@@ -8964,13 +8947,11 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
                 "/billing/plan",
                 {"status": CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE},
             )
-            customer = Customer.objects.get(remote_server=self.remote_server)
-            new_plan = get_current_plan_by_customer(customer)
-            assert new_plan is not None
-            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {new_plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
+            expected_log = f"INFO:corporate.stripe:Change plan status: Customer.id: {customer.id}, CustomerPlan.id: {plan.id}, status: {CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE}"
             self.assertEqual(m.output[0], expected_log)
             self.assert_json_success(response)
-        self.assertEqual(new_plan.licenses_at_next_renewal(), None)
+        plan.refresh_from_db()
+        self.assertEqual(plan.licenses_at_next_renewal(), None)
 
     @responses.activate
     def test_request_sponsorship(self) -> None:

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -102,6 +102,17 @@ from zilencer.models import (
 
 
 class StripeTest(StripeTestCase):
+    def check_initial_ledger_entry(
+        self, plan: CustomerPlan, licenses_purchased: int
+    ) -> LicenseLedger:
+        return LicenseLedger.objects.get(
+            plan=plan,
+            is_renewal=True,
+            event_time=self.now,
+            licenses=licenses_purchased,
+            licenses_at_next_renewal=licenses_purchased,
+        )
+
     def test_catch_stripe_errors(self) -> None:
         @catch_stripe_errors
         def raise_invalid_request_error() -> None:
@@ -225,13 +236,7 @@ class StripeTest(StripeTestCase):
             tier=CustomerPlan.TIER_CLOUD_PLUS,
             status=CustomerPlan.ACTIVE,
         )
-        LicenseLedger.objects.get(
-            plan=plan,
-            is_renewal=True,
-            event_time=self.now,
-            licenses=licenses_purchased,
-            licenses_at_next_renewal=licenses_purchased,
-        )
+        self.check_initial_ledger_entry(plan, licenses_purchased)
         # Check RealmAuditLog
         audit_log_entries = list(
             RealmAuditLog.objects.filter(acting_user=user)
@@ -348,13 +353,7 @@ class StripeTest(StripeTestCase):
             tier=CustomerPlan.TIER_CLOUD_PLUS,
             status=CustomerPlan.ACTIVE,
         )
-        LicenseLedger.objects.get(
-            plan=plan,
-            is_renewal=True,
-            event_time=self.now,
-            licenses=123,
-            licenses_at_next_renewal=123,
-        )
+        self.check_initial_ledger_entry(plan, 123)
         # Check RealmAuditLog
         audit_log_entries = list(
             RealmAuditLog.objects.filter(acting_user=user)
@@ -474,13 +473,7 @@ class StripeTest(StripeTestCase):
             tier=CustomerPlan.TIER_CLOUD_STANDARD,
             status=CustomerPlan.ACTIVE,
         )
-        LicenseLedger.objects.get(
-            plan=plan,
-            is_renewal=True,
-            event_time=self.now,
-            licenses=self.seat_count,
-            licenses_at_next_renewal=self.seat_count,
-        )
+        self.check_initial_ledger_entry(plan, self.seat_count)
         # Check RealmAuditLog
         audit_log_entries = list(
             RealmAuditLog.objects.filter(acting_user=user)
@@ -608,13 +601,7 @@ class StripeTest(StripeTestCase):
             tier=CustomerPlan.TIER_CLOUD_STANDARD,
             status=CustomerPlan.ACTIVE,
         )
-        LicenseLedger.objects.get(
-            plan=plan,
-            is_renewal=True,
-            event_time=self.now,
-            licenses=123,
-            licenses_at_next_renewal=123,
-        )
+        self.check_initial_ledger_entry(plan, 123)
         # Check RealmAuditLog
         audit_log_entries = list(
             RealmAuditLog.objects.filter(acting_user=user)
@@ -722,13 +709,7 @@ class StripeTest(StripeTestCase):
                 # For payment through card.
                 charge_automatically=True,
             )
-            LicenseLedger.objects.get(
-                plan=plan,
-                is_renewal=True,
-                event_time=self.now,
-                licenses=self.seat_count,
-                licenses_at_next_renewal=self.seat_count,
-            )
+            self.check_initial_ledger_entry(plan, self.seat_count)
             audit_log_entries = list(
                 RealmAuditLog.objects.filter(acting_user=user)
                 .values_list("event_type", "event_time")
@@ -940,13 +921,7 @@ class StripeTest(StripeTestCase):
                 charge_automatically=False,
             )
 
-            LicenseLedger.objects.get(
-                plan=plan,
-                is_renewal=True,
-                event_time=self.now,
-                licenses=123,
-                licenses_at_next_renewal=123,
-            )
+            self.check_initial_ledger_entry(plan, 123)
             audit_log_entries = list(
                 RealmAuditLog.objects.filter(acting_user=user)
                 .values_list("event_type", "event_time")
@@ -1140,13 +1115,7 @@ class StripeTest(StripeTestCase):
                 charge_automatically=False,
             )
 
-            LicenseLedger.objects.get(
-                plan=plan,
-                is_renewal=True,
-                event_time=self.now,
-                licenses=123,
-                licenses_at_next_renewal=123,
-            )
+            self.check_initial_ledger_entry(plan, 123)
             audit_log_entries = list(
                 RealmAuditLog.objects.filter(acting_user=user)
                 .values_list("event_type", "event_time")
@@ -1333,13 +1302,7 @@ class StripeTest(StripeTestCase):
                 charge_automatically=False,
             )
 
-            LicenseLedger.objects.get(
-                plan=plan,
-                is_renewal=True,
-                event_time=self.now,
-                licenses=123,
-                licenses_at_next_renewal=123,
-            )
+            self.check_initial_ledger_entry(plan, 123)
             audit_log_entries = list(
                 RealmAuditLog.objects.filter(acting_user=user)
                 .values_list("event_type", "event_time")
@@ -2258,13 +2221,7 @@ class StripeTest(StripeTestCase):
                 # For payment through card.
                 charge_automatically=True,
             )
-            LicenseLedger.objects.get(
-                plan=plan,
-                is_renewal=True,
-                event_time=self.now,
-                licenses=self.seat_count,
-                licenses_at_next_renewal=self.seat_count,
-            )
+            self.check_initial_ledger_entry(plan, self.seat_count)
 
             realm = get_realm("zulip")
             self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_STANDARD)
@@ -3291,13 +3248,7 @@ class StripeTest(StripeTestCase):
                 status=CustomerPlan.FREE_TRIAL,
                 charge_automatically=True,
             )
-            ledger_entry = LicenseLedger.objects.get(
-                plan=new_plan,
-                is_renewal=True,
-                event_time=self.now,
-                licenses=self.seat_count,
-                licenses_at_next_renewal=self.seat_count,
-            )
+            ledger_entry = self.check_initial_ledger_entry(new_plan, self.seat_count)
             self.assertEqual(new_plan.invoiced_through, ledger_entry)
 
             realm_audit_log = RealmAuditLog.objects.filter(
@@ -3345,13 +3296,7 @@ class StripeTest(StripeTestCase):
                 status=CustomerPlan.FREE_TRIAL,
                 charge_automatically=True,
             )
-            ledger_entry = LicenseLedger.objects.get(
-                plan=new_plan,
-                is_renewal=True,
-                event_time=self.now,
-                licenses=self.seat_count,
-                licenses_at_next_renewal=self.seat_count,
-            )
+            ledger_entry = self.check_initial_ledger_entry(new_plan, self.seat_count)
             self.assertEqual(new_plan.invoiced_through, ledger_entry)
 
             realm_audit_log = RealmAuditLog.objects.filter(


### PR DESCRIPTION
Prep work for the workplace user group billing implementation. @sahil839 would you be up for reviewing these billing test updates?

There's likely more clean up we can do in this vein, but this takes care of a good chunk of references to the `licenses` and `licenses_at_next_renewal` fields, which will likely be renamed as part of that future billing work.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
