### PR TITLE
Prevent sidebars from closing on repeated resize events.

### DIFF
--- a/web/src/resize_handler.ts
+++ b/web/src/resize_handler.ts
@@ -7,18 +7,31 @@ import * as message_viewport from "./message_viewport.ts";
 import * as resize from "./resize.ts";
 import * as scroll_bar from "./scroll_bar.ts";
 import * as sidebar_ui from "./sidebar_ui.ts";
+import * as ui_util from "./ui_util.ts";
 import * as util from "./util.ts";
 
 export let _old_width = $(window).width();
+
+let was_left_sidebar_overlay = false;
 
 export function handler(): void {
     const new_width = $(window).width();
     let width_changed = false;
 
     const mobile = util.is_mobile();
-    if (!mobile || new_width !== _old_width) {
+    const left_sidebar_is_overlay = !ui_util.matches_viewport_state("gte_md_min");
+
+    // Only hide sidebars when entering and exiting the smaller viewport state. Repeated resize events
+    // while already narrow (for example, from non-overlay OSKs) should not
+    // close a sidebar the user explicitly opened.
+    if (
+        (!mobile || new_width !== _old_width) &&
+        left_sidebar_is_overlay !== was_left_sidebar_overlay
+    ) {
         sidebar_ui.hide_all();
     }
+
+    was_left_sidebar_overlay = left_sidebar_is_overlay;
 
     if (new_width !== _old_width) {
         _old_width = new_width;


### PR DESCRIPTION
When a resize event occurs while the viewport is already in the narrow layout state, `resize_handler` calls `sidebar_ui.hide_all()`. This can cause a sidebar that the user manually opened to close again.

This was exposed by non-overlay on-screen keyboards, where opening the keyboard can trigger resize events without changing the user's intended layout state.

This change tracks the previous viewport state and only hides sidebars when transitioning into the narrow layout state.

This preserves the existing behavior of hiding sidebars when the viewport becomes narrow, while avoiding closing sidebars that the user explicitly opened during repeated resize events.

Fixes #39805

**How changes were tested:**

* Tested manually in the development environment.
* Verified that sidebars still hide when entering the narrow layout state.
* Verified that repeated resize events while already in the narrow layout state do not close manually opened sidebars.
* Ran `./tools/lint`.

**Screenshots and screen captures:**

See the follow-up comment below for a screencast demonstrating the behavior change.

<details>
<summary>Self-review checklist</summary>

* [x] Self-reviewed the changes for clarity and maintainability
  (variable names, code reuse, readability, etc.).
* [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

* [x] Explains differences from previous plans (e.g., issue description).
* [x] Highlights technical choices and bugs encountered.
* [ ] Calls out remaining decisions and concerns.
* [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see commit discipline).

* [x] Each commit is a coherent idea.
* [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

* [x] Visual appearance of the changes.
* [x] Responsiveness and internationalization.
* [x] Strings and tooltips.
* [x] End-to-end functionality of buttons, interactions and flows.
* [x] Corner cases, error conditions, and easily imagined bugs.

</details>
