### PR TITLE
run-dev: Fix shutdown crash with --only-help-center

### DIFF
--- a/tools/run-dev
+++ b/tools/run-dev
@@ -438,7 +438,7 @@ def print_listeners(external_host_url: str) -> None:
     print()
 
 
-runner: web.AppRunner
+runner: web.AppRunner | None = None
 children: list["subprocess.Popen[bytes]"] = []
 
 
@@ -501,8 +501,9 @@ try:
         loop.add_signal_handler(s, loop.stop)
     loop.run_forever()
 finally:
-    loop.run_until_complete(runner.cleanup())
-    loop.run_until_complete(session.close())
+    if runner is not None:
+        loop.run_until_complete(runner.cleanup())
+        loop.run_until_complete(session.close())
 
     for child in children:
         child.terminate()


### PR DESCRIPTION
In this mode, the help center dev server listens on the proxy port itself, so `serve()` returns before creating the `ClientSession` and the `AppRunner`.  Shutting down then failed with `NameError: name 'runner' is not defined`, aborting the rest of our cleanup: `run-dev` exited with status 1 and left `var/run/run_dev.pid` behind, where a later `tools/stop-run-dev` would find it and signal a stale process group.