### PR TITLE
hotkey: Support macOS Ctrl-N/P navigation in dropdowns

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -157,6 +157,7 @@ import {insertTextIntoField} from "text-field-edit";
 import getCaretCoordinates from "textarea-caret";
 import * as tippy from "tippy.js";
 
+import * as keydown_util from "./keydown_util.ts";
 import * as mouse_drag from "./mouse_drag.ts";
 import * as scroll_util from "./scroll_util.ts";
 import {get_string_diff, the} from "./util.ts";
@@ -195,6 +196,14 @@ const CONTAINER_HTML = '<div class="typeahead dropdown-menu"></div>';
 const MENU_HTML = '<ul class="typeahead-menu" data-simplebar></ul>';
 const ITEM_HTML = '<li class="typeahead-item"><a class="typeahead-item-link"></a></li>';
 const MIN_LENGTH = 1;
+
+function get_typeahead_key(event: JQuery.KeyboardEventBase): string {
+    return keydown_util.get_mac_ctrl_navigation_key(event) ?? event.key;
+}
+
+function is_ctrl_navigation_letter(event: JQuery.KeyboardEventBase): boolean {
+    return ["n", "p"].includes(event.key.toLowerCase()) || ["KeyN", "KeyP"].includes(event.code);
+}
 
 export type TypeaheadInputElement =
     | {
@@ -235,6 +244,7 @@ export class Typeahead<ItemType extends string | object> {
     // returns a string to show in typeahead items or false.
     option_label: (matching_items: ItemType[], item: ItemType) => string | false;
     suppressKeyPressRepeat = false;
+    suppressKeyUpAfterMacCtrlNavigation = false;
     query = "";
     mouse_moved_since_typeahead = false;
     shown = false;
@@ -725,7 +735,9 @@ export class Typeahead<ItemType extends string | object> {
             return;
         }
 
-        switch (e.key) {
+        const key = get_typeahead_key(e);
+
+        switch (key) {
             case "Tab":
                 if (!this.tabIsEnter) {
                     return;
@@ -769,6 +781,8 @@ export class Typeahead<ItemType extends string | object> {
             e.preventDefault();
             this.select(e);
         }
+        this.suppressKeyUpAfterMacCtrlNavigation =
+            keydown_util.get_mac_ctrl_navigation_key(e) !== undefined;
         this.suppressKeyPressRepeat = !["ArrowDown", "ArrowUp", "Tab", "Enter", "Escape"].includes(
             e.key,
         );
@@ -785,14 +799,23 @@ export class Typeahead<ItemType extends string | object> {
 
     keyup(e: JQuery.KeyUpEvent): void {
         this.mouse_moved_since_typeahead = false;
+        const key = get_typeahead_key(e);
+        const suppressMacCtrlNavigationKeyUp =
+            this.suppressKeyUpAfterMacCtrlNavigation &&
+            (["ArrowDown", "ArrowUp"].includes(key) || is_ctrl_navigation_letter(e));
         // NOTE: Ideally we can ignore meta keyup calls here but
         // it's better to just trigger the lookup call to update the list in case
         // it did modify the query. For example, `Command + delete` on Mac
         // doesn't trigger a keyup event but when `Command` is released, it
         // triggers a keyup event which correctly updates the list.
-        switch (e.key) {
+        switch (key) {
             case "ArrowDown":
             case "ArrowUp":
+                this.suppressKeyUpAfterMacCtrlNavigation = false;
+                break;
+            case "Control":
+                // Ctrl itself does not change the query. Ignoring this keyup
+                // avoids re-rendering after macOS Ctrl-N/Ctrl-P navigation.
                 break;
 
             case "Tab":
@@ -845,6 +868,10 @@ export class Typeahead<ItemType extends string | object> {
                 if (e.key === "Backspace") {
                     this.lookup(this.hideOnEmptyAfterBackspace);
                     return;
+                }
+                if (suppressMacCtrlNavigationKeyUp) {
+                    this.suppressKeyUpAfterMacCtrlNavigation = false;
+                    break;
                 }
                 this.lookup(false);
         }

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -31,6 +31,7 @@ import {$t} from "./i18n.ts";
 import * as inbox_ui from "./inbox_ui.ts";
 import * as inbox_util from "./inbox_util.ts";
 import * as info_overlay from "./info_overlay.ts";
+import * as keydown_util from "./keydown_util.ts";
 import * as lightbox from "./lightbox.ts";
 import * as list_util from "./list_util.ts";
 import * as message_actions_popover from "./message_actions_popover.ts";
@@ -365,6 +366,11 @@ export function get_keydown_hotkey(e: JQuery.KeyDownEvent): Hotkey | Hotkey[] | 
         } else {
             return undefined;
         }
+    }
+
+    const mac_ctrl_navigation_key = keydown_util.get_mac_ctrl_navigation_key(e);
+    if (popover_menus.get_visible_instance() && mac_ctrl_navigation_key !== undefined) {
+        return KEYDOWN_MAPPINGS[mac_ctrl_navigation_key];
     }
 
     if (common.has_mac_keyboard() && e.ctrlKey && key !== "[") {

--- a/web/src/keydown_util.ts
+++ b/web/src/keydown_util.ts
@@ -2,6 +2,8 @@
     See hotkey.ts for handlers that are more app-wide.
 */
 
+import * as common from "./common.ts";
+
 export const vim_left = "h";
 export const vim_down = "j";
 export const vim_up = "k";
@@ -28,6 +30,31 @@ export function handle(opts: {
             e.stopPropagation();
         }
     });
+}
+
+export function get_mac_ctrl_navigation_key(
+    event: JQuery.KeyboardEventBase,
+): "ArrowUp" | "ArrowDown" | undefined {
+    const is_mac_ctrl_without_other_modifiers =
+        common.has_mac_keyboard() &&
+        event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        !event.shiftKey;
+
+    if (!is_mac_ctrl_without_other_modifiers) {
+        return undefined;
+    }
+
+    if (event.key.toLowerCase() === "n" || event.code === "KeyN") {
+        return "ArrowDown";
+    }
+
+    if (event.key.toLowerCase() === "p" || event.code === "KeyP") {
+        return "ArrowUp";
+    }
+
+    return undefined;
 }
 
 export function is_enter_event(event: JQuery.KeyboardEventBase): boolean {

--- a/web/src/keydown_util.ts
+++ b/web/src/keydown_util.ts
@@ -2,6 +2,8 @@
     See hotkey.ts for handlers that are more app-wide.
 */
 
+import * as common from "./common.ts";
+
 export const vim_left = "h";
 export const vim_down = "j";
 export const vim_up = "k";
@@ -28,6 +30,30 @@ export function handle(opts: {
             e.stopPropagation();
         }
     });
+}
+
+export function get_mac_ctrl_navigation_key(
+    event: JQuery.KeyboardEventBase,
+): "ArrowUp" | "ArrowDown" | undefined {
+    if (
+        !common.has_mac_keyboard() ||
+        !event.ctrlKey ||
+        event.altKey ||
+        event.metaKey ||
+        event.shiftKey
+    ) {
+        return undefined;
+    }
+
+    if (event.key.toLowerCase() === "n" || event.code === "KeyN") {
+        return "ArrowDown";
+    }
+
+    if (event.key.toLowerCase() === "p" || event.code === "KeyP") {
+        return "ArrowUp";
+    }
+
+    return undefined;
 }
 
 export function is_enter_event(event: JQuery.KeyboardEventBase): boolean {

--- a/web/tests/bootstrap_typeahead.test.cjs
+++ b/web/tests/bootstrap_typeahead.test.cjs
@@ -1,0 +1,316 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const navigator = set_global("navigator", {platform: ""});
+
+mock_esm("../src/scroll_util", {
+    scroll_element_into_container() {},
+});
+
+const bootstrap_typeahead = zrequire("bootstrap_typeahead");
+
+class FakeCollection {
+    constructor(items) {
+        this.items = items;
+        this.length = items.length;
+        for (const [index, item] of items.entries()) {
+            this[index] = item;
+        }
+    }
+
+    addClass(class_name) {
+        for (const item of this.items) {
+            item.classes.add(class_name);
+        }
+        return this;
+    }
+
+    removeClass(class_name) {
+        for (const item of this.items) {
+            item.classes.delete(class_name);
+        }
+        return this;
+    }
+
+    next() {
+        return new FakeCollection(this.items.flatMap((item) => item.next ?? []));
+    }
+
+    prev() {
+        return new FakeCollection(this.items.flatMap((item) => item.prev ?? []));
+    }
+
+    first() {
+        return new FakeCollection(this.items.slice(0, 1));
+    }
+
+    last() {
+        return new FakeCollection(this.items.slice(-1));
+    }
+}
+
+function make_menu(names) {
+    const items = names.map((name) => ({
+        classes: new Set(),
+        name,
+        next: undefined,
+        prev: undefined,
+    }));
+
+    for (const [index, item] of items.entries()) {
+        item.prev = items[index - 1];
+        item.next = items[index + 1];
+    }
+
+    return {
+        find(selector) {
+            switch (selector) {
+                case ".active":
+                    return new FakeCollection(items.filter((item) => item.classes.has("active")));
+                case "li":
+                    return new FakeCollection(items);
+                /* istanbul ignore next */
+                default:
+                    throw new Error(`unexpected selector: ${selector}`);
+            }
+        },
+        items,
+    };
+}
+
+function make_typeahead({active_index = 0} = {}) {
+    const $menu = make_menu(["first", "second", "third"]);
+    $menu.items[active_index].classes.add("active");
+
+    const typeahead = Object.create(bootstrap_typeahead.Typeahead.prototype);
+    Object.assign(typeahead, {
+        $menu,
+        advanceKeys: [],
+        lookup_count: 0,
+        mouse_moved_since_typeahead: false,
+        shown: true,
+        stopAdvance: false,
+        suppressKeyPressRepeat: false,
+        suppressKeyUpAfterMacCtrlNavigation: false,
+        tabIsEnter: true,
+        trigger_selection: () => false,
+        lookup() {
+            this.lookup_count += 1;
+        },
+    });
+
+    return {typeahead, $menu};
+}
+
+function active_item_name($menu) {
+    const active_items = $menu.items.filter((item) => item.classes.has("active"));
+    assert.equal(active_items.length, 1);
+    return active_items[0].name;
+}
+
+function make_keyboard_event(overrides) {
+    return {
+        altKey: false,
+        code: "",
+        ctrlKey: false,
+        default_prevented: false,
+        key: "",
+        metaKey: false,
+        propagation_stopped: false,
+        shiftKey: false,
+        type: "keydown",
+        preventDefault() {
+            this.default_prevented = true;
+        },
+        stopPropagation() {
+            this.propagation_stopped = true;
+        },
+        ...overrides,
+    };
+}
+
+run_test("move supports mac ctrl navigation keys", () => {
+    navigator.platform = "MacIntel";
+    const {typeahead, $menu} = make_typeahead();
+
+    const ctrl_n = make_keyboard_event({
+        code: "KeyN",
+        ctrlKey: true,
+        key: "т",
+    });
+    typeahead.move(ctrl_n);
+    assert.equal(active_item_name($menu), "second");
+    assert.equal(ctrl_n.default_prevented, true);
+    assert.equal(ctrl_n.propagation_stopped, true);
+
+    const ctrl_p = make_keyboard_event({
+        code: "KeyP",
+        ctrlKey: true,
+        key: "з",
+    });
+    typeahead.move(ctrl_p);
+    assert.equal(active_item_name($menu), "first");
+    assert.equal(ctrl_p.default_prevented, true);
+    assert.equal(ctrl_p.propagation_stopped, true);
+
+    // Navigation wraps at both ends when the menu requires a highlight.
+    typeahead.requireHighlight = true;
+    typeahead.move(ctrl_p);
+    assert.equal(active_item_name($menu), "third");
+    typeahead.move(ctrl_n);
+    assert.equal(active_item_name($menu), "first");
+
+    navigator.platform = "";
+});
+
+run_test("move ignores mac ctrl navigation keys with extra modifiers", () => {
+    navigator.platform = "MacIntel";
+
+    for (const modifier of [{shiftKey: true}, {altKey: true}, {metaKey: true}]) {
+        const {typeahead, $menu} = make_typeahead();
+        const event = make_keyboard_event({
+            code: "KeyN",
+            ctrlKey: true,
+            key: "n",
+            ...modifier,
+        });
+
+        typeahead.move(event);
+        assert.equal(active_item_name($menu), "first");
+        assert.equal(event.default_prevented, false);
+    }
+
+    navigator.platform = "";
+});
+
+run_test("move ignores ctrl-n and ctrl-p on non-mac keyboards", () => {
+    navigator.platform = "Linux x86_64";
+
+    for (const key_event of [
+        {code: "KeyN", key: "n"},
+        {code: "KeyP", key: "p"},
+    ]) {
+        const {typeahead, $menu} = make_typeahead();
+        const event = make_keyboard_event({
+            ctrlKey: true,
+            ...key_event,
+        });
+
+        typeahead.move(event);
+        assert.equal(active_item_name($menu), "first");
+        assert.equal(event.default_prevented, false);
+    }
+
+    navigator.platform = "";
+});
+
+run_test("mac ctrl navigation keyup does not re-render typeahead", () => {
+    navigator.platform = "MacIntel";
+
+    for (const key_event of [
+        {active_index: 0, code: "KeyN", key: "n", selected_item: "second"},
+        {active_index: 1, code: "KeyP", key: "p", selected_item: "first"},
+    ]) {
+        const {typeahead, $menu} = make_typeahead({active_index: key_event.active_index});
+
+        typeahead.keydown(
+            make_keyboard_event({
+                code: key_event.code,
+                ctrlKey: true,
+                key: key_event.key,
+            }),
+        );
+        assert.equal(active_item_name($menu), key_event.selected_item);
+        assert.equal(typeahead.lookup_count, 0);
+
+        const letter_keyup = make_keyboard_event({
+            code: key_event.code,
+            ctrlKey: true,
+            key: key_event.key,
+            type: "keyup",
+        });
+        typeahead.keyup(letter_keyup);
+        assert.equal(active_item_name($menu), key_event.selected_item);
+        assert.equal(typeahead.lookup_count, 0);
+        assert.equal(letter_keyup.default_prevented, true);
+
+        const ctrl_keyup = make_keyboard_event({
+            code: "ControlLeft",
+            key: "Control",
+            type: "keyup",
+        });
+        typeahead.keyup(ctrl_keyup);
+        assert.equal(active_item_name($menu), key_event.selected_item);
+        assert.equal(typeahead.lookup_count, 0);
+        assert.equal(ctrl_keyup.default_prevented, true);
+    }
+
+    navigator.platform = "";
+});
+
+run_test("mac ctrl navigation keyup ignores control-first release order", () => {
+    navigator.platform = "MacIntel";
+    const {typeahead, $menu} = make_typeahead();
+
+    typeahead.keydown(
+        make_keyboard_event({
+            code: "KeyN",
+            ctrlKey: true,
+            key: "n",
+        }),
+    );
+    assert.equal(active_item_name($menu), "second");
+
+    typeahead.keyup(
+        make_keyboard_event({
+            code: "ControlLeft",
+            key: "Control",
+            type: "keyup",
+        }),
+    );
+    assert.equal(active_item_name($menu), "second");
+    assert.equal(typeahead.lookup_count, 0);
+
+    const letter_keyup = make_keyboard_event({
+        code: "KeyN",
+        key: "n",
+        type: "keyup",
+    });
+    typeahead.keyup(letter_keyup);
+    assert.equal(active_item_name($menu), "second");
+    assert.equal(typeahead.lookup_count, 0);
+    assert.equal(letter_keyup.default_prevented, true);
+
+    navigator.platform = "";
+});
+
+run_test("non-mac and modified ctrl navigation keyup keeps normal lookup behavior", () => {
+    for (const test_case of [
+        {
+            keydown_platform: "Linux x86_64",
+            keyup_platform: "Linux x86_64",
+            event: {code: "KeyN", ctrlKey: true, key: "n"},
+        },
+        {
+            keydown_platform: "MacIntel",
+            keyup_platform: "MacIntel",
+            event: {code: "KeyN", ctrlKey: true, key: "n", shiftKey: true},
+        },
+    ]) {
+        navigator.platform = test_case.keydown_platform;
+        const {typeahead, $menu} = make_typeahead();
+        typeahead.keydown(make_keyboard_event(test_case.event));
+        assert.equal(active_item_name($menu), "first");
+
+        navigator.platform = test_case.keyup_platform;
+        typeahead.keyup(make_keyboard_event({...test_case.event, type: "keyup"}));
+        assert.equal(active_item_name($menu), "first");
+        assert.equal(typeahead.lookup_count, 1);
+    }
+
+    navigator.platform = "";
+});

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -84,6 +84,15 @@ const popovers = mock_esm("../src/user_card_popover", {
         is_open: () => false,
     },
 });
+const popover_menus = mock_esm("../src/popover_menus", {
+    get_visible_instance: () => undefined,
+    is_color_picker_popover_displayed: () => false,
+    is_gear_menu_popover_displayed: () => false,
+    is_help_menu_popover_displayed: () => false,
+    is_personal_menu_popover_displayed: () => false,
+    is_stream_actions_popover_displayed: () => false,
+    sidebar_menu_instance_handle_keyboard() {},
+});
 const reactions = mock_esm("../src/reactions");
 const read_receipts = mock_esm("../src/read_receipts");
 const search = mock_esm("../src/search");
@@ -267,6 +276,15 @@ run_test("mappings", () => {
     assert.equal(map_down(".", false, true, false), undefined);
     assert.equal(map_down("p", false, false, true).name, "print");
     assert.equal(map_down("p", false, true, false), undefined);
+
+    with_overrides(({override}) => {
+        override(popover_menus, "get_visible_instance", () => ({}));
+        assert.equal(map_down("n", false, true, false).name, "down_arrow");
+        assert.equal(map_down("p", false, true, false).name, "up_arrow");
+        assert.equal(map_down("n", true, true, false), undefined);
+        assert.equal(map_down("n", false, true, true), undefined);
+        assert.equal(map_down("n", false, true, false, true), undefined);
+    });
     // Reset platform
     navigator.platform = "";
 
@@ -349,6 +367,12 @@ run_test("mappings non-latin keyboard", () => {
     assert.equal(map_down("ы", "KeyS", false, true, false), undefined);
     assert.equal(map_down("з", "KeyP", false, false, true).name, "print");
     assert.equal(map_down("з", "KeyP", false, true, false), undefined);
+
+    with_overrides(({override}) => {
+        override(popover_menus, "get_visible_instance", () => ({}));
+        assert.equal(map_down("т", "KeyN", false, true, false).name, "down_arrow");
+        assert.equal(map_down("з", "KeyP", false, true, false).name, "up_arrow");
+    });
     // Reset platform
     navigator.platform = "";
 

--- a/web/tests/keydown_util.test.cjs
+++ b/web/tests/keydown_util.test.cjs
@@ -2,9 +2,11 @@
 
 const assert = require("node:assert/strict");
 
-const {zrequire} = require("./lib/namespace.cjs");
+const {set_global, zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const {$} = require("./lib/zjquery.cjs");
+
+const navigator = set_global("navigator", {platform: ""});
 
 const keydown_util = zrequire("keydown_util");
 
@@ -43,6 +45,70 @@ run_test("test_early_returns", () => {
     };
 
     $stub.trigger(e3);
+});
+
+run_test("get_mac_ctrl_navigation_key", () => {
+    navigator.platform = "MacIntel";
+
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({key: "n", code: "KeyN", ctrlKey: true}),
+        "ArrowDown",
+    );
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({key: "p", code: "KeyP", ctrlKey: true}),
+        "ArrowUp",
+    );
+
+    // Caps Lock and non-Latin keyboard layouts should not affect the shortcuts.
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({key: "N", code: "KeyN", ctrlKey: true}),
+        "ArrowDown",
+    );
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({key: "т", code: "KeyN", ctrlKey: true}),
+        "ArrowDown",
+    );
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({key: "з", code: "KeyP", ctrlKey: true}),
+        "ArrowUp",
+    );
+
+    // Ctrl must be the only modifier key pressed.
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({
+            key: "n",
+            code: "KeyN",
+            ctrlKey: true,
+            shiftKey: true,
+        }),
+        undefined,
+    );
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({
+            key: "n",
+            code: "KeyN",
+            ctrlKey: true,
+            altKey: true,
+        }),
+        undefined,
+    );
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({
+            key: "n",
+            code: "KeyN",
+            ctrlKey: true,
+            metaKey: true,
+        }),
+        undefined,
+    );
+
+    navigator.platform = "Linux x86_64";
+    assert.equal(
+        keydown_util.get_mac_ctrl_navigation_key({key: "n", code: "KeyN", ctrlKey: true}),
+        undefined,
+    );
+
+    navigator.platform = "";
 });
 
 run_test("test_ime_enter_events", () => {


### PR DESCRIPTION
Support Ctrl-N and Ctrl-P as down/up navigation shortcuts in search suggestions, message-action menus, and gear menus on macOS.

The shortcuts are normalized through a shared helper and then use the existing ArrowDown and ArrowUp navigation paths. For Typeahead, the matching keyup is suppressed to avoid rerendering the suggestions and resetting the highlighted result.

This PR handles the search, message-action, and gear dropdowns together because all three use one-dimensional vertical navigation: Ctrl-N and Ctrl-P can directly reuse their existing ArrowDown and ArrowUp behavior through a shared normalization helper.

The emoji picker is intentionally excluded because it is a two-dimensional grid. Complete macOS-style navigation there also requires Ctrl-F and Ctrl-B for horizontal movement, and the picker uses a separate grid-navigation implementation. Supporting only Ctrl-N/P would be incomplete, so we thought the emoji picker is better handled in a dedicated follow PR.

This was implemented in collaboration with @johnnelsan .

Fixes: #10884

**How changes were tested:**
- `tools/test-js-with-node bootstrap_typeahead hotkey keydown_util`
- Complete `tools/test-js-with-node` suite
- `tools/lint` on all six changed files
- Manually tested search suggestions, message actions, and gear menus on macOS by @johnnelsan
- Manually tested using a macOS keyboard simulation on Linux

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/cf7b4f5f-7ee3-40d4-bb9b-409f24edcad7

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
