### PR TITLE
fix unhandled exception on malformed field_data.

### DIFF
--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -112,6 +112,18 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         error_msg = "field_data is not valid JSON"
         self.assert_json_error(result, error_msg)
 
+        data["field_type"] = CustomProfileField.EXTERNAL_ACCOUNT
+        data["field_data"] = orjson.dumps({}).decode()
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_error(result, "subtype key is missing from field_data")
+
+        data["field_data"] = orjson.dumps({"subtype": 123}).decode()
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_error(result, 'field_data["subtype"]["dict[str,str]"] is not a dict')
+
+        # Switch back to DROPDOWN for the remainder of the test
+        data["field_type"] = CustomProfileField.DROPDOWN
+
         data["field_data"] = orjson.dumps(
             {
                 "python": ["1"],
@@ -237,6 +249,16 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             },
         )
         self.assert_json_success(result)
+
+        # Updating a default external account field with any field_data change is
+        # blocked by the default-field guard before field_data validation runs.
+        result = self.client_patch(
+            f"/json/realm/profile_fields/{field.id}",
+            info={
+                "field_data": orjson.dumps({}).decode(),
+            },
+        )
+        self.assert_json_error(result, "Default custom field cannot be updated.")
 
         result = self.client_delete(f"/json/realm/profile_fields/{field.id}")
         self.assert_json_success(result)

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -86,7 +86,8 @@ def validate_use_for_user_matching_field(field_type: int, use_for_user_matching:
 def is_default_external_field(field_type: int, field_data: ProfileFieldData) -> bool:
     if field_type != CustomProfileField.EXTERNAL_ACCOUNT:
         return False
-    if field_data["subtype"] == "custom":
+    subtype = field_data.get("subtype")
+    if not isinstance(subtype, str) or subtype == "custom":
         return False
     return True
 
@@ -201,6 +202,7 @@ def create_realm_custom_profile_field(
     )
     try:
         if is_default_external_field(field_type, field_data):
+            # is_default_external_field guarantees subtype is a non-empty string.
             field_subtype = field_data["subtype"]
             assert isinstance(field_subtype, str)
             field = try_add_realm_default_custom_profile_field(


### PR DESCRIPTION
Fixes an unhandled exception when malformed `field_data` is provided for external account custom profile fields. `is_default_external_field` now safely handles missing or invalid `subtype` values, and `create_realm_custom_profile_field` returns a validation error instead of relying on an `assert`.

Added regression tests covering malformed `POST` and `PATCH` requests for external account fields.

Fixes: #39845