### PR TITLE
peer_data: Ignore in-flight removals when fetching a user's channels.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -56,7 +56,18 @@ const pending_subscriber_requests = new Map<
     }
 >();
 // Requests for subscriptions for a user
-const pending_subscription_requests = new Map<number, Promise<void>>();
+const pending_subscription_requests = new Map<
+    number,
+    {
+        subscriptions_promise: Promise<void>;
+        // Channels the user was removed from while the request was in
+        // flight. The server may have built its response before those
+        // removals, so we skip these channels instead of re-adding the
+        // user from stale data. We don't need to track additions: the
+        // event already added the user, and re-adding them is harmless.
+        stream_ids_removed_during_fetch: Set<number>;
+    }
+>();
 
 export function clear_for_testing(): void {
     stream_subscribers.clear();
@@ -415,6 +426,7 @@ export function remove_subscriber(stream_id: number, user_id: number): void {
     const subscribers = get_loaded_subscriber_subset(stream_id);
     decrement_subscriber_count(subscribers, stream_id, user_id);
     subscribers.delete(user_id);
+    pending_subscription_requests.get(user_id)?.stream_ids_removed_during_fetch.add(stream_id);
 }
 
 export function bulk_add_subscribers({
@@ -464,6 +476,9 @@ export function bulk_remove_subscribers({
                 decrement_subscriber_count(subscribers, sub.stream_id, user_id);
             }
             subscribers.delete(user_id);
+            pending_subscription_requests
+                .get(user_id)
+                ?.stream_ids_removed_during_fetch.add(stream_id);
         }
 
         if (pending_subscriber_requests.has(stream_id)) {
@@ -537,7 +552,16 @@ async function fetch_subscriptions_for_user_from_server(user_id: number): Promis
             success(raw_data) {
                 const subscriptions =
                     fetch_user_subscriptions_response_schema.parse(raw_data).subscribed_channel_ids;
+                const pending_request = pending_subscription_requests.get(user_id)!;
                 for (const stream_id of subscriptions) {
+                    if (pending_request.stream_ids_removed_during_fetch.has(stream_id)) {
+                        continue;
+                    }
+                    // We already have the exact subscriber set for this
+                    // stream, so a stale response must not re-add the user.
+                    if (fetched_stream_ids.has(stream_id)) {
+                        continue;
+                    }
                     add_subscriber(stream_id, user_id);
                 }
                 fetched_user_subscriptions.add(user_id);
@@ -567,7 +591,7 @@ export async function fetch_subscriptions_for_user(user_id: number): Promise<voi
     }
 
     if (pending_subscription_requests.has(user_id)) {
-        return pending_subscription_requests.get(user_id)!;
+        return pending_subscription_requests.get(user_id)!.subscriptions_promise;
     }
 
     const subscriptions_promise = (async () => {
@@ -577,6 +601,8 @@ export async function fetch_subscriptions_for_user(user_id: number): Promise<voi
                 blueslip.warn("Failure fetching user's subscribed channels. Retrying.", {
                     user_id,
                 });
+                // The retry's response will already reflect these removals.
+                pending_subscription_requests.get(user_id)!.stream_ids_removed_during_fetch.clear();
             }
             const result = await fetch_subscriptions_for_user_from_server(user_id);
             // Bad request, so just give up here.
@@ -604,7 +630,10 @@ export async function fetch_subscriptions_for_user(user_id: number): Promise<voi
         }
     })();
 
-    pending_subscription_requests.set(user_id, subscriptions_promise);
+    pending_subscription_requests.set(user_id, {
+        subscriptions_promise,
+        stream_ids_removed_during_fetch: new Set(),
+    });
     return subscriptions_promise;
 }
 

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -597,6 +597,7 @@ export async function fetch_subscriptions_for_user(user_id: number): Promise<voi
             }
         }
         if (num_attempts === 5) {
+            pending_subscription_requests.delete(user_id);
             blueslip.error("Failure fetching user's subscribed channels. Giving up.", {
                 user_id,
             });

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -56,7 +56,18 @@ const pending_subscriber_requests = new Map<
     }
 >();
 // Requests for subscriptions for a user
-const pending_subscription_requests = new Map<number, Promise<void>>();
+const pending_subscription_requests = new Map<
+    number,
+    {
+        subscriptions_promise: Promise<void>;
+        // Channels the user was removed from while the request was in
+        // flight. The server may have built its response before those
+        // removals, so we skip these channels instead of re-adding the
+        // user from stale data. We don't need to track additions: the
+        // event already added the user, and re-adding them is harmless.
+        stream_ids_removed_during_fetch: Set<number>;
+    }
+>();
 
 export function clear_for_testing(): void {
     stream_subscribers.clear();
@@ -415,6 +426,7 @@ export function remove_subscriber(stream_id: number, user_id: number): void {
     const subscribers = get_loaded_subscriber_subset(stream_id);
     decrement_subscriber_count(subscribers, stream_id, user_id);
     subscribers.delete(user_id);
+    pending_subscription_requests.get(user_id)?.stream_ids_removed_during_fetch.add(stream_id);
 }
 
 export function bulk_add_subscribers({
@@ -464,6 +476,9 @@ export function bulk_remove_subscribers({
                 decrement_subscriber_count(subscribers, sub.stream_id, user_id);
             }
             subscribers.delete(user_id);
+            pending_subscription_requests
+                .get(user_id)
+                ?.stream_ids_removed_during_fetch.add(stream_id);
         }
 
         if (pending_subscriber_requests.has(stream_id)) {
@@ -537,7 +552,11 @@ async function fetch_subscriptions_for_user_from_server(user_id: number): Promis
             success(raw_data) {
                 const subscriptions =
                     fetch_user_subscriptions_response_schema.parse(raw_data).subscribed_channel_ids;
+                const pending_request = pending_subscription_requests.get(user_id);
                 for (const stream_id of subscriptions) {
+                    if (pending_request?.stream_ids_removed_during_fetch.has(stream_id)) {
+                        continue;
+                    }
                     add_subscriber(stream_id, user_id);
                 }
                 fetched_user_subscriptions.add(user_id);
@@ -567,7 +586,7 @@ export async function fetch_subscriptions_for_user(user_id: number): Promise<voi
     }
 
     if (pending_subscription_requests.has(user_id)) {
-        return pending_subscription_requests.get(user_id)!;
+        return pending_subscription_requests.get(user_id)!.subscriptions_promise;
     }
 
     const subscriptions_promise = (async () => {
@@ -603,7 +622,10 @@ export async function fetch_subscriptions_for_user(user_id: number): Promise<voi
         }
     })();
 
-    pending_subscription_requests.set(user_id, subscriptions_promise);
+    pending_subscription_requests.set(user_id, {
+        subscriptions_promise,
+        stream_ids_removed_during_fetch: new Set(),
+    });
     return subscriptions_promise;
 }
 

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -721,3 +721,103 @@ test("fetch_subscriptions_for_user", async () => {
     await peer_data.fetch_subscriptions_for_user(fred.user_id);
     assert.equal(channel_get_calls, 0);
 });
+
+test("fetch_subscriptions_for_user stale response", async () => {
+    people.add_active_user(fred);
+
+    const social = make_stream({
+        stream_id: 2,
+        name: "social",
+        subscribed: true,
+    });
+    stream_data.add_sub_for_tests(social);
+    const rome = make_stream({
+        name: "Rome",
+        subscribed: true,
+        stream_id: 1001,
+    });
+    stream_data.add_sub_for_tests(rome);
+    const devel = make_stream({
+        name: "devel",
+        subscribed: true,
+        stream_id: 1,
+    });
+    stream_data.add_sub_for_tests(devel);
+    const paris = make_stream({
+        name: "Paris",
+        subscribed: true,
+        stream_id: 1002,
+    });
+    stream_data.add_sub_for_tests(paris);
+
+    peer_data.set_subscribers(social.stream_id, [fred.user_id], false);
+    peer_data.set_subscribers(rome.stream_id, [fred.user_id], false);
+    peer_data.set_subscribers(devel.stream_id, [fred.user_id], false);
+    peer_data.set_subscribers(paris.stream_id, [fred.user_id], false);
+
+    // The server computed this response before the removals below.
+    mock_channel_get(channel, (opts) => {
+        opts.success({
+            subscribed_channel_ids: [
+                social.stream_id,
+                rome.stream_id,
+                devel.stream_id,
+                paris.stream_id,
+            ],
+        });
+    });
+
+    // The mocked response is only delivered once we await the promise,
+    // so the removals below arrive while the request is in flight.
+    const promise = peer_data.fetch_subscriptions_for_user(fred.user_id);
+    peer_data.bulk_remove_subscribers({
+        stream_ids: [social.stream_id],
+        user_ids: [fred.user_id],
+    });
+    peer_data.remove_subscriber(devel.stream_id, fred.user_id);
+    // While the request is in flight, we get the exact subscriber set
+    // for Paris, which no longer includes fred.
+    peer_data.set_subscribers(paris.stream_id, [me.user_id]);
+    assert.ok(!peer_data.subscriber_data_loaded_for_user(fred.user_id));
+    await promise;
+
+    // The stale response must not re-add fred to social, devel, or Paris.
+    assert.ok(!stream_data.is_user_loaded_and_subscribed(social.stream_id, fred.user_id));
+    assert.ok(!stream_data.is_user_loaded_and_subscribed(devel.stream_id, fred.user_id));
+    assert.ok(!stream_data.is_user_loaded_and_subscribed(paris.stream_id, fred.user_id));
+    assert.ok(stream_data.is_user_loaded_and_subscribed(rome.stream_id, fred.user_id));
+    assert.ok(peer_data.subscriber_data_loaded_for_user(fred.user_id));
+});
+
+test("fetch_subscriptions_for_user removal before retry", async () => {
+    people.add_active_user(fred);
+
+    const social = make_stream({
+        stream_id: 2,
+        name: "social",
+        subscribed: true,
+    });
+    stream_data.add_sub_for_tests(social);
+    peer_data.set_subscribers(social.stream_id, [fred.user_id], false);
+
+    let num_attempts = 0;
+    mock_channel_get(channel, (opts) => {
+        num_attempts += 1;
+        if (num_attempts === 1) {
+            // fred leaves social while the first attempt is in flight,
+            // and then that attempt fails.
+            peer_data.remove_subscriber(social.stream_id, fred.user_id);
+            opts.error({status: 500});
+            return;
+        }
+        // fred rejoined social before the retry, so the retry's
+        // response lists social and must be applied.
+        opts.success({
+            subscribed_channel_ids: [social.stream_id],
+        });
+    });
+    blueslip.expect("warn", "Failure fetching user's subscribed channels. Retrying.");
+    await peer_data.fetch_subscriptions_for_user(fred.user_id);
+    assert.equal(num_attempts, 2);
+    assert.ok(stream_data.is_user_loaded_and_subscribed(social.stream_id, fred.user_id));
+});

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -663,6 +663,19 @@ test("fetch_subscriptions_for_user", async () => {
     await peer_data.fetch_subscriptions_for_user(fred.user_id);
     blueslip.reset();
 
+    // After giving up, a later call should start a new fetch instead
+    // of returning the finished request's promise.
+    channel_get_calls = 0;
+    mock_channel_get(channel, (opts) => {
+        channel_get_calls += 1;
+        opts.success({
+            subscribed_channel_ids: [india.stream_id],
+        });
+    });
+    await peer_data.fetch_subscriptions_for_user(fred.user_id);
+    assert.equal(channel_get_calls, 1);
+    assert.ok(stream_data.is_user_loaded_and_subscribed(india.stream_id, fred.user_id));
+
     peer_data.clear_for_testing();
     mock_channel_get(channel, (opts) => {
         opts.error({status: 400, responseJSON: {msg: "bad request"}});

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -708,3 +708,53 @@ test("fetch_subscriptions_for_user", async () => {
     await peer_data.fetch_subscriptions_for_user(fred.user_id);
     assert.equal(channel_get_calls, 0);
 });
+
+test("fetch_subscriptions_for_user stale response", async () => {
+    people.add_active_user(fred);
+
+    const social = make_stream({
+        stream_id: 2,
+        name: "social",
+        subscribed: true,
+    });
+    stream_data.add_sub_for_tests(social);
+    const rome = make_stream({
+        name: "Rome",
+        subscribed: true,
+        stream_id: 1001,
+    });
+    stream_data.add_sub_for_tests(rome);
+    const devel = make_stream({
+        name: "devel",
+        subscribed: true,
+        stream_id: 1,
+    });
+    stream_data.add_sub_for_tests(devel);
+
+    peer_data.set_subscribers(social.stream_id, [fred.user_id], false);
+    peer_data.set_subscribers(rome.stream_id, [fred.user_id], false);
+    peer_data.set_subscribers(devel.stream_id, [fred.user_id], false);
+
+    // The server computed this response before the removals below.
+    mock_channel_get(channel, (opts) => {
+        opts.success({
+            subscribed_channel_ids: [social.stream_id, rome.stream_id, devel.stream_id],
+        });
+    });
+
+    // The mocked response is only delivered once we await the promise,
+    // so the removals below arrive while the request is in flight.
+    const promise = peer_data.fetch_subscriptions_for_user(fred.user_id);
+    peer_data.bulk_remove_subscribers({
+        stream_ids: [social.stream_id],
+        user_ids: [fred.user_id],
+    });
+    peer_data.remove_subscriber(devel.stream_id, fred.user_id);
+    await promise;
+
+    // The stale response must not re-add fred to social or devel.
+    assert.ok(!stream_data.is_user_loaded_and_subscribed(social.stream_id, fred.user_id));
+    assert.ok(!stream_data.is_user_loaded_and_subscribed(devel.stream_id, fred.user_id));
+    assert.ok(stream_data.is_user_loaded_and_subscribed(rome.stream_id, fred.user_id));
+    assert.ok(peer_data.subscriber_data_loaded_for_user(fred.user_id));
+});


### PR DESCRIPTION
The server may build its response to GET /users/{user_id}/channels before a removal we have already applied from a peer_remove event. Applying that stale response re-added the user to the channel. No later event cleaned this up.

When such a user was later deactivated, we logged the "The user should have been removed by the `peer_remove` event" error, because the user was still listed as a subscriber of a channel they had already left.

Fix this by recording which channels the user was removed from while the request was in flight, and skipping those channels when applying the response. This is similar to what b0aff0af77 (peer_data: Store peer add/remove events that come during fetch requests.) did for the stream subscribers fetch.

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Generated by Claude:

https://github.com/user-attachments/assets/b85a4334-f0fc-433f-9bd5-afba0a7cc2ff


https://github.com/user-attachments/assets/d36f8538-0fd6-4df3-b30a-ae779651ab4d


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
