### PR TITLE
bots: Fix `PATCH /bots/{bot_id}` endpoint

### DIFF
--- a/api_docs/unmerged.d/ZF-334371.md
+++ b/api_docs/unmerged.d/ZF-334371.md
@@ -1,0 +1,5 @@
+* `PATCH /bots/{bot_id}`: `config_data` is now validated against
+  the integration or embedded-bot handler's schema, merged with
+  the bot's existing config so partial updates still work.
+  Previously, arbitrary keys and values were accepted without
+  validation.

--- a/api_docs/unmerged.d/ZF-3e042a.md
+++ b/api_docs/unmerged.d/ZF-3e042a.md
@@ -1,0 +1,5 @@
+* `PATCH /bots/{bot_id}`: The `service_interface` and
+  `service_payload_url` parameters are now applied independently.
+  Previously, `service_interface` was ignored unless
+  `service_payload_url` was also sent, and sending
+  `service_payload_url` alone reset the interface to Generic.

--- a/api_docs/unmerged.d/ZF-6deecc.md
+++ b/api_docs/unmerged.d/ZF-6deecc.md
@@ -1,0 +1,11 @@
+* `PATCH /bots/{bot_id}`: Sending `service_interface` or
+  `service_payload_url` for a bot that is not an outgoing-webhook
+  bot now returns an HTTP 400 error. Previously,
+  `service_payload_url` triggered an unhandled HTTP 500 error for
+  default and incoming-webhook bots and was silently accepted for
+  embedded bots.
+* `PATCH /bots/{bot_id}`: The `config_data` parameter is now only
+  accepted for incoming-webhook and embedded bots; sending it for
+  other bot types returns an HTTP 400 error. Previously, entries
+  were written to `BotConfigData` for any bot type, though only
+  these two types use them.

--- a/api_docs/unmerged.d/ZF-ca956b.md
+++ b/api_docs/unmerged.d/ZF-ca956b.md
@@ -1,0 +1,3 @@
+* `PATCH /bots/{bot_id}`: The endpoint no longer returns a body
+  describing the applied changes; the response is now empty on
+  success.

--- a/zerver/lib/bot_config.py
+++ b/zerver/lib/bot_config.py
@@ -2,6 +2,7 @@ import configparser
 import importlib
 import os
 from collections import defaultdict
+from collections.abc import Mapping
 
 from django.conf import settings
 from django.db.models import F, Sum
@@ -19,6 +20,16 @@ def get_bot_config(bot_profile: UserProfile) -> dict[str, str]:
     if not entries:
         raise ConfigError("No config data available.")
     return {entry.key: entry.value for entry in entries}
+
+
+def get_merged_bot_config(
+    bot_profile: UserProfile, config_data: Mapping[str, str]
+) -> dict[str, str]:
+    try:
+        existing_config_data = get_bot_config(bot_profile)
+    except ConfigError:
+        existing_config_data = {}
+    return {**existing_config_data, **config_data}
 
 
 def get_bot_configs(bot_profile_ids: list[int]) -> dict[int, dict[str, str]]:

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -137,6 +137,11 @@ def check_valid_bot_config(
     if bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
         from zerver.lib.integrations import INCOMING_WEBHOOK_INTEGRATIONS
 
+        # integration_id is stored alongside the integration's own
+        # config options to identify which integration this bot is for,
+        # but is not itself one of them; exclude it from validation.
+        config_data = {k: v for k, v in config_data.items() if k != "integration_id"}
+
         config_options = None
         for integration in INCOMING_WEBHOOK_INTEGRATIONS:
             if integration.name == service_name:

--- a/zerver/migrations/0812_delete_stale_bot_config_data.py
+++ b/zerver/migrations/0812_delete_stale_bot_config_data.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+# Copied from zerver/models/users.py.
+INCOMING_WEBHOOK_BOT = 2
+EMBEDDED_BOT = 4
+
+
+def delete_stale_bot_config_data(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    # Before the fix, PATCH /bots/{bot_id} accepted config_data for any bot
+    # type and wrote rows into BotConfigData. Only INCOMING_WEBHOOK_BOT and
+    # EMBEDDED_BOT have config_data, so any rows attached to other bot types
+    # are dead weight.
+    BotConfigData = apps.get_model("zerver", "BotConfigData")
+    BotConfigData.objects.exclude(
+        bot_profile__bot_type__in=[INCOMING_WEBHOOK_BOT, EMBEDDED_BOT],
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0811_usermessage_add_hide_link_previews"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_stale_bot_config_data,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1128,9 +1128,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual("Fred", response_dict["full_name"])
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual("Fred", bot["full_name"])
@@ -1341,10 +1339,10 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
+        self.assert_json_success(result)
 
         # Test bot's owner has been changed successfully.
-        self.assertEqual(response_dict["bot_owner"], othello.email)
+        self.assertEqual(self.get_bot_user(email).bot_owner, othello)
 
         self.login("othello")
         bot = self.get_bot()
@@ -1599,9 +1597,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual("Denmark", response_dict["default_sending_stream"])
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual("Denmark", bot["default_sending_stream"])
@@ -1619,9 +1615,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual("Rome", response_dict["default_sending_stream"])
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual("Rome", bot["default_sending_stream"])
@@ -1717,9 +1711,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual("Denmark", response_dict["default_sending_stream"])
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual("Denmark", bot["default_sending_stream"])
@@ -1784,9 +1776,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         stream_name = "Denmark"
         bot_info = dict(default_events_register_stream=stream_name)
         result = self.client_patch(url, bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual(stream_name, response_dict["default_events_register_stream"])
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual(stream_name, bot["default_events_register_stream"])
@@ -1835,9 +1825,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual("Denmark", response_dict["default_events_register_stream"])
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual("Denmark", bot["default_events_register_stream"])
@@ -1921,9 +1909,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual(response_dict["default_all_public_streams"], True)
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual(bot["default_all_public_streams"], True)
@@ -1941,9 +1927,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        response_dict = self.assert_json_success(result)
-
-        self.assertEqual(response_dict["default_all_public_streams"], False)
+        self.assert_json_success(result)
 
         bot = self.get_bot()
         self.assertEqual(bot["default_all_public_streams"], False)
@@ -1968,7 +1952,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         # TODO: The "method" parameter is not currently tracked as a processed parameter
         # by typed_endpoint. Assert it is returned as an ignored parameter.
-        response_dict = self.assert_json_success(result, ignored_parameters=["method"])
+        self.assert_json_success(result, ignored_parameters=["method"])
 
         request_notes = RequestNotes.get_notes(result.wsgi_request)
 
@@ -1981,8 +1965,6 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
                 )
             ],
         )
-
-        self.assertEqual("Fred", response_dict["full_name"])
 
         bot = self.get_bot()
         self.assertEqual("Fred", bot["full_name"])
@@ -2015,14 +1997,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "service_interface": Service.SLACK,
         }
         email = "hambot-bot@zulip.testserver"
-        result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
+        bot = self.get_bot_user(email)
+        result = self.client_patch(f"/json/bots/{bot.id}", bot_info)
         self.assert_json_success(result)
 
-        service_interface = orjson.loads(result.content)["service_interface"]
-        self.assertEqual(service_interface, Service.SLACK)
-
-        service_payload_url = orjson.loads(result.content)["service_payload_url"]
-        self.assertEqual(service_payload_url, "http://foo.bar2.com")
+        [service] = get_bot_services(bot.id)
+        self.assertEqual(service.interface, Service.SLACK)
+        self.assertEqual(service.base_url, "http://foo.bar2.com")
 
     def test_patch_outgoing_webhook_bot_interface_only(self) -> None:
         self.login("hamlet")
@@ -2287,10 +2268,10 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
         bot_info = {"config_data": orjson.dumps({"key": "87654321"}).decode()}
         email = "test-bot@zulip.testserver"
-        result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
+        bot = self.get_bot_user(email)
+        result = self.client_patch(f"/json/bots/{bot.id}", bot_info)
         self.assert_json_success(result)
-        config_data = orjson.loads(result.content)["config_data"]
-        self.assertEqual(config_data, orjson.loads(bot_info["config_data"]))
+        self.assertEqual(get_bot_config(bot), {"key": "87654321"})
 
     def test_outgoing_webhook_invalid_interface(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -2024,12 +2024,60 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         service_payload_url = orjson.loads(result.content)["service_payload_url"]
         self.assertEqual(service_payload_url, "http://foo.bar2.com")
 
+    def test_patch_outgoing_webhook_bot_interface_only(self) -> None:
+        self.login("hamlet")
+        bot_info = {
+            "full_name": "The Bot of Hamlet",
+            "short_name": "hambot",
+            "bot_type": UserProfile.OUTGOING_WEBHOOK_BOT,
+            "payload_url": orjson.dumps("http://foo.bar.com").decode(),
+            "interface_type": Service.GENERIC,
+        }
+        result = self.client_post("/json/bots", bot_info)
+        self.assert_json_success(result)
+
+        bot = self.get_bot_user("hambot-bot@zulip.testserver")
+        patch_info = {"service_interface": Service.SLACK}
+        result = self.client_patch(f"/json/bots/{bot.id}", patch_info)
+        self.assert_json_success(result)
+
+        [service] = get_bot_services(bot.id)
+        self.assertEqual(service.interface, Service.SLACK)
+        self.assertEqual(service.base_url, "http://foo.bar.com")
+
+    def test_patch_outgoing_webhook_bot_url_only_preserves_interface(self) -> None:
+        self.login("hamlet")
+        bot_info = {
+            "full_name": "The Bot of Hamlet",
+            "short_name": "hambot",
+            "bot_type": UserProfile.OUTGOING_WEBHOOK_BOT,
+            "payload_url": orjson.dumps("http://foo.bar.com").decode(),
+            "interface_type": Service.SLACK,
+        }
+        result = self.client_post("/json/bots", bot_info)
+        self.assert_json_success(result)
+
+        bot = self.get_bot_user("hambot-bot@zulip.testserver")
+        patch_info = {"service_payload_url": orjson.dumps("http://foo.bar2.com").decode()}
+        result = self.client_patch(f"/json/bots/{bot.id}", patch_info)
+        self.assert_json_success(result)
+
+        [service] = get_bot_services(bot.id)
+        self.assertEqual(service.base_url, "http://foo.bar2.com")
+        self.assertEqual(service.interface, Service.SLACK)
+
     def test_patch_default_bot_rejects_service_and_config_fields(self) -> None:
         self.login("hamlet")
         self.create_bot()
         bot = self.get_bot_user("hambot-bot@zulip.testserver")
 
         expected_error = "Generic bots have no service or config data to update."
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"service_interface": Service.SLACK},
+        )
+        self.assert_json_error(result, expected_error)
 
         result = self.client_patch(
             f"/json/bots/{bot.id}",
@@ -2053,11 +2101,19 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
         bot = self.get_bot_user("embeddedservicebot-bot@zulip.testserver")
 
+        expected_error = "Service fields cannot be updated on embedded bots."
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"service_interface": Service.SLACK},
+        )
+        self.assert_json_error(result, expected_error)
+
         result = self.client_patch(
             f"/json/bots/{bot.id}",
             {"service_payload_url": orjson.dumps("http://embedded.example.com").decode()},
         )
-        self.assert_json_error(result, "Service fields cannot be updated on embedded bots")
+        self.assert_json_error(result, expected_error)
 
     def test_patch_incoming_webhook_bot_rejects_service_fields(self) -> None:
         self.login("hamlet")
@@ -2068,11 +2124,19 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
         bot = self.get_bot_user("mybot-bot@zulip.testserver")
 
+        expected_error = "Incoming-webhook bots have no service fields to update."
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"service_interface": Service.SLACK},
+        )
+        self.assert_json_error(result, expected_error)
+
         result = self.client_patch(
             f"/json/bots/{bot.id}",
             {"service_payload_url": orjson.dumps("http://foo.bar.com").decode()},
         )
-        self.assert_json_error(result, "Incoming-webhook bots have no service fields to update.")
+        self.assert_json_error(result, expected_error)
 
     def test_patch_outgoing_webhook_bot_rejects_config_data(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -2157,6 +2157,124 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
         self.assert_json_error(result, "Outgoing-webhook bots have no config data to update.")
 
+    def test_patch_incoming_webhook_bot_config_data_without_integration(self) -> None:
+        self.login("hamlet")
+        self.create_bot(
+            full_name="My Bot",
+            short_name="mybot",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+        )
+        bot = self.get_bot_user("mybot-bot@zulip.testserver")
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"config_data": orjson.dumps({"key": "value"}).decode()},
+        )
+        self.assert_json_success(result)
+
+    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
+    def test_patch_incoming_webhook_bot_rejects_invalid_config_data(self) -> None:
+        self.login("hamlet")
+        self.create_bot(
+            full_name="My Stripe Bot",
+            short_name="my-stripe",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            service_name="stripe",
+            config_data=orjson.dumps({"stripe_api_key": "sample-api-key"}).decode(),
+        )
+        bot = self.get_bot_user("my-stripe-bot@zulip.testserver")
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"config_data": orjson.dumps({"stripe_api_key": "_invalid_key"}).decode()},
+        )
+        self.assert_json_error(
+            result,
+            "Invalid stripe_api_key value _invalid_key "
+            '(stripe_api_key starts with a "_" and is hence invalid.)',
+        )
+
+    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
+    def test_patch_incoming_webhook_bot_change_integration_id_missing_config(self) -> None:
+        self.login("hamlet")
+        self.create_bot(
+            full_name="My Hello Bot",
+            short_name="my-hello",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            service_name="helloworld",
+        )
+        bot = self.get_bot_user("my-hello-bot@zulip.testserver")
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"config_data": orjson.dumps({"integration_id": "stripe"}).decode()},
+        )
+        self.assert_json_error(
+            result,
+            "Missing configuration parameters: {'stripe_api_key'}",
+        )
+        self.assertEqual(get_bot_config(bot)["integration_id"], "helloworld")
+
+    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
+    def test_patch_incoming_webhook_bot_change_integration_id_success(self) -> None:
+        self.login("hamlet")
+        self.create_bot(
+            full_name="My Hello Bot",
+            short_name="my-hello",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            service_name="helloworld",
+        )
+        bot = self.get_bot_user("my-hello-bot@zulip.testserver")
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {
+                "config_data": orjson.dumps(
+                    {"integration_id": "stripe", "stripe_api_key": "sample-api-key"}
+                ).decode()
+            },
+        )
+        self.assert_json_success(result)
+        stored_config = get_bot_config(bot)
+        self.assertEqual(stored_config["integration_id"], "stripe")
+        self.assertEqual(stored_config["stripe_api_key"], "sample-api-key")
+
+    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
+    def test_patch_incoming_webhook_bot_integration_id_alone_is_not_a_config_option(
+        self,
+    ) -> None:
+        self.login("hamlet")
+        self.create_bot(
+            full_name="My Stripe Bot",
+            short_name="my-stripe",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            service_name="stripe",
+            config_data=orjson.dumps({"stripe_api_key": "sample-api-key"}).decode(),
+        )
+        bot = self.get_bot_user("my-stripe-bot@zulip.testserver")
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"config_data": orjson.dumps({"integration_id": "stripe"}).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertEqual(get_bot_config(bot)["integration_id"], "stripe")
+
+    def test_patch_embedded_bot_config_data_without_existing_config(self) -> None:
+        self.create_test_bot(
+            short_name="embeddedbot",
+            user_profile=self.example_user("hamlet"),
+            bot_type=UserProfile.EMBEDDED_BOT,
+            service_name="followup",
+        )
+        bot = self.get_bot_user("embeddedbot-bot@zulip.testserver")
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"config_data": orjson.dumps({"key": "value"}).decode()},
+        )
+        self.assert_json_success(result)
+        self.assertEqual(get_bot_config(bot)["key"], "value")
+
     @patch("zulip_bots.bots.giphy.giphy.GiphyHandler.validate_config")
     def test_patch_bot_config_data(self, mock_validate_config: MagicMock) -> None:
         self.create_test_bot(

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -2024,6 +2024,75 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         service_payload_url = orjson.loads(result.content)["service_payload_url"]
         self.assertEqual(service_payload_url, "http://foo.bar2.com")
 
+    def test_patch_default_bot_rejects_service_and_config_fields(self) -> None:
+        self.login("hamlet")
+        self.create_bot()
+        bot = self.get_bot_user("hambot-bot@zulip.testserver")
+
+        expected_error = "Generic bots have no service or config data to update."
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"service_payload_url": orjson.dumps("http://foo.bar.com").decode()},
+        )
+        self.assert_json_error(result, expected_error)
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"config_data": orjson.dumps({"key": "value"}).decode()},
+        )
+        self.assert_json_error(result, expected_error)
+
+    def test_patch_embedded_bot_rejects_service_fields(self) -> None:
+        self.create_test_bot(
+            short_name="embeddedservicebot",
+            user_profile=self.example_user("hamlet"),
+            bot_type=UserProfile.EMBEDDED_BOT,
+            service_name="followup",
+            config_data=orjson.dumps({"key": "value"}).decode(),
+        )
+        bot = self.get_bot_user("embeddedservicebot-bot@zulip.testserver")
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"service_payload_url": orjson.dumps("http://embedded.example.com").decode()},
+        )
+        self.assert_json_error(result, "Service fields cannot be updated on embedded bots")
+
+    def test_patch_incoming_webhook_bot_rejects_service_fields(self) -> None:
+        self.login("hamlet")
+        self.create_bot(
+            full_name="My Bot",
+            short_name="mybot",
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+        )
+        bot = self.get_bot_user("mybot-bot@zulip.testserver")
+
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"service_payload_url": orjson.dumps("http://foo.bar.com").decode()},
+        )
+        self.assert_json_error(result, "Incoming-webhook bots have no service fields to update.")
+
+    def test_patch_outgoing_webhook_bot_rejects_config_data(self) -> None:
+        self.login("hamlet")
+        bot_info = {
+            "full_name": "The Bot of Hamlet",
+            "short_name": "hambot",
+            "bot_type": UserProfile.OUTGOING_WEBHOOK_BOT,
+            "payload_url": orjson.dumps("http://foo.bar.com").decode(),
+            "interface_type": Service.GENERIC,
+        }
+        result = self.client_post("/json/bots", bot_info)
+        self.assert_json_success(result)
+
+        bot = self.get_bot_user("hambot-bot@zulip.testserver")
+        result = self.client_patch(
+            f"/json/bots/{bot.id}",
+            {"config_data": orjson.dumps({"key": "value"}).decode()},
+        )
+        self.assert_json_error(result, "Outgoing-webhook bots have no config data to update.")
+
     @patch("zulip_bots.bots.giphy.giphy.GiphyHandler.validate_config")
     def test_patch_bot_config_data(self, mock_validate_config: MagicMock) -> None:
         self.create_test_bot(

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -41,7 +41,7 @@ from zerver.context_processors import get_valid_realm_from_request
 from zerver.decorator import require_human_non_guest_user, require_realm_admin
 from zerver.forms import PASSWORD_TOO_WEAK_ERROR, CreateUserForm
 from zerver.lib.avatar import avatar_url, get_avatar_for_inaccessible_user, get_gravatar_url
-from zerver.lib.bot_config import set_bot_config
+from zerver.lib.bot_config import get_merged_bot_config, set_bot_config
 from zerver.lib.demo_organizations import check_demo_organization_has_set_email
 from zerver.lib.email_validation import email_allowed_for_realm, validate_email_not_already_in_realm
 from zerver.lib.exceptions import (
@@ -97,6 +97,7 @@ from zerver.lib.users import (
 )
 from zerver.lib.utils import generate_api_key
 from zerver.models import Service, Stream, UserProfile
+from zerver.models.bots import get_bot_services
 from zerver.models.realms import (
     DisposableEmailError,
     DomainNotAllowedForRealmError,
@@ -572,11 +573,26 @@ def patch_bot_backend(
             if service_interface is not None or service_payload_url is not None:
                 raise JsonableError(_("Service fields cannot be updated on embedded bots."))
             if config_data is not None:
+                merged_config_data = get_merged_bot_config(bot, config_data)
+                existing_service = get_bot_services(bot.id)[0]
+                check_valid_bot_config(
+                    bot.bot_type,
+                    existing_service.name,
+                    merged_config_data,
+                )
                 do_update_bot_config_data(bot, config_data)
         case UserProfile.INCOMING_WEBHOOK_BOT:
             if service_interface is not None or service_payload_url is not None:
                 raise JsonableError(_("Incoming-webhook bots have no service fields to update."))
             if config_data is not None:
+                merged_config_data = get_merged_bot_config(bot, config_data)
+                proposed_integration_id = merged_config_data.get("integration_id")
+                if proposed_integration_id is not None:
+                    check_valid_bot_config(
+                        bot.bot_type,
+                        proposed_integration_id,
+                        merged_config_data,
+                    )
                 do_update_bot_config_data(bot, config_data)
         case UserProfile.DEFAULT_BOT:
             if (

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -555,18 +555,33 @@ def patch_bot_backend(
             bot, default_all_public_streams, acting_user=user_profile
         )
 
-    if service_payload_url is not None:
-        check_valid_interface_type(service_interface)
-        assert service_interface is not None
-        do_update_outgoing_webhook_service(
-            bot,
-            interface=service_interface,
-            base_url=service_payload_url,
-            acting_user=user_profile,
-        )
-
-    if config_data is not None:
-        do_update_bot_config_data(bot, config_data)
+    match bot.bot_type:
+        case UserProfile.OUTGOING_WEBHOOK_BOT:
+            if config_data is not None:
+                raise JsonableError(_("Outgoing-webhook bots have no config data to update."))
+            if service_payload_url is not None:
+                check_valid_interface_type(service_interface)
+                do_update_outgoing_webhook_service(
+                    bot,
+                    interface=service_interface,
+                    base_url=service_payload_url,
+                    acting_user=user_profile,
+                )
+        case UserProfile.EMBEDDED_BOT:
+            if service_payload_url is not None:
+                raise JsonableError(_("Service fields cannot be updated on embedded bots."))
+            if config_data is not None:
+                do_update_bot_config_data(bot, config_data)
+        case UserProfile.INCOMING_WEBHOOK_BOT:
+            if service_payload_url is not None:
+                raise JsonableError(_("Incoming-webhook bots have no service fields to update."))
+            if config_data is not None:
+                do_update_bot_config_data(bot, config_data)
+        case UserProfile.DEFAULT_BOT:
+            if service_payload_url is not None or config_data is not None:
+                raise JsonableError(_("Generic bots have no service or config data to update."))
+        case _:  # nocoverage
+            raise JsonableError(_("Unexpected bot type."))
 
     if len(request.FILES) == 0:
         pass

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -481,7 +481,7 @@ def patch_bot_backend(
     default_sending_stream: str | None = None,
     full_name: str | None = None,
     role: Json[RoleParamType] | None = None,
-    service_interface: Json[int] = 1,
+    service_interface: Json[int] | None = None,
     service_payload_url: Json[Annotated[str, AfterValidator(check_url)]] | None = None,
     short_name: str | None = None,
 ) -> HttpResponse:
@@ -559,8 +559,9 @@ def patch_bot_backend(
         case UserProfile.OUTGOING_WEBHOOK_BOT:
             if config_data is not None:
                 raise JsonableError(_("Outgoing-webhook bots have no config data to update."))
-            if service_payload_url is not None:
+            if service_interface is not None:
                 check_valid_interface_type(service_interface)
+            if service_interface is not None or service_payload_url is not None:
                 do_update_outgoing_webhook_service(
                     bot,
                     interface=service_interface,
@@ -568,17 +569,21 @@ def patch_bot_backend(
                     acting_user=user_profile,
                 )
         case UserProfile.EMBEDDED_BOT:
-            if service_payload_url is not None:
+            if service_interface is not None or service_payload_url is not None:
                 raise JsonableError(_("Service fields cannot be updated on embedded bots."))
             if config_data is not None:
                 do_update_bot_config_data(bot, config_data)
         case UserProfile.INCOMING_WEBHOOK_BOT:
-            if service_payload_url is not None:
+            if service_interface is not None or service_payload_url is not None:
                 raise JsonableError(_("Incoming-webhook bots have no service fields to update."))
             if config_data is not None:
                 do_update_bot_config_data(bot, config_data)
         case UserProfile.DEFAULT_BOT:
-            if service_payload_url is not None or config_data is not None:
+            if (
+                service_interface is not None
+                or service_payload_url is not None
+                or config_data is not None
+            ):
                 raise JsonableError(_("Generic bots have no service or config data to update."))
         case _:  # nocoverage
             raise JsonableError(_("Unexpected bot type."))

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -617,23 +617,7 @@ def patch_bot_backend(
     else:
         raise JsonableError(_("You may only upload one file at a time"))
 
-    json_result = dict(
-        full_name=bot.full_name,
-        avatar_url=avatar_url(bot),
-        service_interface=service_interface,
-        service_payload_url=service_payload_url,
-        config_data=config_data,
-        default_sending_stream=get_stream_name(bot.default_sending_stream),
-        default_events_register_stream=get_stream_name(bot.default_events_register_stream),
-        default_all_public_streams=bot.default_all_public_streams,
-    )
-
-    # Don't include the bot owner in case it is not set.
-    # Default bots have no owner.
-    if bot.bot_owner is not None:
-        json_result["bot_owner"] = bot.bot_owner.email
-
-    return json_success(request, data=json_result)
+    return json_success(request)
 
 
 @require_human_non_guest_user


### PR DESCRIPTION
Three-commit series cleaning up PATCH /bots/{bot_id}, which had several silent bugs and a confusing response shape:

1. **`bots: Apply service_interface and service_payload_url independently.`**: Fixes two silent bugs in the outgoing-webhook update path: sending `service_interface` alone was ignored, and sending `service_payload_url` alone silently reset the interface back to Generic regardless of the bot's current setting. Also makes the endpoint return HTTP 400 when either parameter is sent for a bot that isn't an outgoing-webhook bot; previously the request silently no-oped.
CZO: [#api design > outgoing bot &#96;service_interface&#96; silently ignored](https://chat.zulip.org/#narrow/channel/378-api-design/topic/outgoing.20bot.20.60service_interface.60.20silently.20ignored/with/2502117)


2. **`bots: Fix config_data updates.`**: Restricts the `config_data` parameter to incoming-webhook and embedded bots (returning HTTP 400 for other bot types), and validates the submitted `config_data` against the integration's / embedded-bot handler's schema (merged with the bot's existing config, so partial updates still work). Previously the endpoint silently wrote arbitrary keys into `BotConfigData` for any bot type, without any validation.
CZO:[#api design > outgoing bot &#96;service_interface&#96; silently ignored](https://chat.zulip.org/#narrow/channel/378-api-design/topic/outgoing.20bot.20.60service_interface.60.20silently.20ignored/with/2502117)


3. **`bots: Return only actually-updated parameters in PATCH response.`**: Reshapes response so that each entry appears only when the request actually modified that parameter, with the value reflecting the current post-update database state. Follows the pattern already established by PATCH /realm. Along the way, fixes hidden behaviors in the old response: 
    - `service_interface`, `service_payload_url`, and `config_data` used to echo the request values (or null when omitted), which hid that `config_data` merges with the bot's existing keys rather than replacing them.
    - Adds the bot's new email to the response when short_name changes, since the client can't otherwise derive it from what it sent.
CZO: [#api design > PATCH /bots/{bot_id} response echoes request params](https://chat.zulip.org/#narrow/channel/378-api-design/topic/PATCH.20.2Fbots.2F.7Bbot_id.7D.20response.20echoes.20request.20params/with/2502826)

**Related PR that adds endpoint documentation:** #39454

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
