### PR TITLE
modals: Use scrollbar-gutter to prevent layout shift when opening modals.

### DIFF
--- a/web/src/overlay_util.ts
+++ b/web/src/overlay_util.ts
@@ -6,12 +6,11 @@ export function disable_scrolling(): void {
     // they overflow their defined container. Since fixed / absolute elements are not treated
     // as part of the document flow, we cannot capture `scroll` events on them and prevent propagation
     // as event bubbling doesn't work naturally.
-    const scrollbar_width = window.innerWidth - document.documentElement.clientWidth;
-    $(":root").css({"overflow-y": "hidden", "--disabled-scrollbar-width": `${scrollbar_width}px`});
+    $(":root").css("overflow-y", "hidden");
 }
 
 export function enable_scrolling(): void {
-    $(":root").css({"overflow-y": "scroll", "--disabled-scrollbar-width": "0px"});
+    $(":root").css("overflow-y", "scroll");
 }
 
 export const OVERLAY_FOCUSABLE_SELECTOR =

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -633,13 +633,6 @@
     --flatpickr-confirm-button-font-size: 18px;
 
     /*
-    Width to be reserved for document scrollbar when scrolling is disabled.
-    Using `scrollbar-gutter` would be more appropriate but doesn't has wide
-    support and doesn't work for `fixed` elements.
-    */
-    --disabled-scrollbar-width: 0px;
-
-    /*
     Right offset of simplebar scrollbar for `.column-right` when browser has
     overlay scrollbars which don't occupy any space. Currently only
     known to present on Mac (all browsers) and Firefox (all OS?). This seems

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -4,8 +4,8 @@
 
 html {
     overflow: hidden scroll;
+    scrollbar-gutter: stable;
     overscroll-behavior-y: none;
-    width: calc(100% - var(--disabled-scrollbar-width));
 }
 
 body,
@@ -360,7 +360,7 @@ p.n-margin {
    the background when a overlay / modal is open. */
 #navbar-fixed-container,
 #compose {
-    width: calc(100% - var(--disabled-scrollbar-width));
+    width: 100%;
 }
 
 .header {


### PR DESCRIPTION
Replace the `--disabled-scrollbar-width` compensation hack with `scrollbar-gutter: stable` on `html` to prevent layout shift when opening modals.

Previously, when a modal or overlay opened, `disable_scrolling()` set `overflow-y: hidden` on the root element, which hid the browser scrollbar. The old approach compensated by setting a `--disabled-scrollbar-width` CSS variable and applying `width: calc(100% - var(--disabled-scrollbar-width))` to `html`, `#navbar-fixed-container`, and `#compose`. However, this did not cover all elements (e.g., the right sidebar / buddy list), causing a subtle horizontal shift when a modal opened.

Replace the manual scrollbar-width compensation with `scrollbar-gutter: stable` on `html`, which reserves space for the scrollbar regardless of whether it is visible. This eliminates the need for the `--disabled-scrollbar-width` variable and prevents the layout shift across all elements.

Fixes #36998.

**Screenshots and screen captures:**

<details>
<summary>Before (layout shift when opening modal)</summary>

<img width="800" height="376" alt="screenrecording-2026-07-31_19-36-10-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/f55d14c3-d9fe-4a9c-902f-eef9cdf0beac" />

</details>

<details>
<summary>After (no layout shift when opening modal)</summary>

<img width="800" height="378" alt="screenrecording-2026-07-31_19-59-06-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/19891f7d-2bc5-4814-8823-154578687f23" />

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>