### PR TITLE
search: Add vertical padding to wrapped search pills.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -71,7 +71,7 @@
     .search-input-and-pills {
         grid-area: search-pills;
         display: flex;
-        padding: 0;
+        padding: 0.2321em 0; /* 3.25px at 14px em */
         flex-wrap: wrap;
         gap: 0.3571em; /* 5px at 14px em, matches pill spacing in typeahead dropdown */
         align-self: center;


### PR DESCRIPTION
When search filter pills wrap onto a second line, they sit flush against the top and bottom edges of the search box, which looks cramped. This adds vertical padding to `.search-input-and-pills` so wrapped rows get consistent breathing room.

Fixes #35426.

<hr>

### **Screenshots and screen captures:**

| Before | After |
|--------|-------|
| <img width="1873" height="144" alt="screenshot-2026-08-01_02-02-22" src="https://github.com/user-attachments/assets/50c2cd51-d97a-40de-940c-a26100427c90" /> | <img width="1869" height="159" alt="screenshot-2026-08-01_02-06-11" src="https://github.com/user-attachments/assets/b7351b89-83f9-45a6-bf4b-20400a5d04f7" /> |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>