### PR TITLE
Notify clients when attachment is deleted 

### DIFF
--- a/web/e2e-tests/attachment-image-preview.test.ts
+++ b/web/e2e-tests/attachment-image-preview.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+
+import type {Page} from "puppeteer";
+
+import * as common from "./lib/common.ts";
+
+const FILENAME = "zulip-icon-128x128.png";
+
+async function test_attachment_delete_updates_image_preview(page: Page): Promise<void> {
+    await common.log_in(page);
+    await page.click("#left-sidebar-navigation-list .top_left_all_messages");
+    await common.get_current_msg_list_id(page, true);
+
+    // Read the image from the filesystem in Node and pass it as base64 into
+    // the browser, so we can POST it to /json/user_uploads without needing
+    // the webpack dev server to be running.
+    const file_base64 = fs.readFileSync(`static/images/logo/${FILENAME}`).toString("base64");
+
+    const {attachment_url, path_id} = await page.evaluate(
+        async (filename: string, b64: string) => {
+            const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+            const blob = new Blob([bytes], {type: "image/png"});
+            const csrf =
+                document.querySelector<HTMLInputElement>('input[name="csrfmiddlewaretoken"]')
+                    ?.value ?? "";
+            const form = new FormData();
+            form.append("csrfmiddlewaretoken", csrf);
+            form.append("file", blob, filename);
+            const resp = await fetch("/json/user_uploads", {
+                method: "POST",
+                body: form,
+            });
+            const data = (await resp.json()) as {url: string};
+            return {
+                attachment_url: data.url,
+                path_id: data.url.replace(/^\/user_uploads\//, ""),
+            };
+        },
+        FILENAME,
+        file_base64,
+    );
+
+    await page.keyboard.press("KeyC");
+    await page.waitForSelector("#compose-textarea", {visible: true});
+    await common.select_stream_in_compose_via_dropdown(page, "Verona");
+    await common.clear_and_type(page, "#stream_message_recipient_topic", "attachment preview test");
+    await common.clear_and_type(page, "#compose-textarea", `[${FILENAME}](${attachment_url})`);
+
+    await page.click("#compose-send-button");
+
+    await page.waitForFunction(
+        () => {
+            const imgs = [
+                ...document.querySelectorAll<HTMLImageElement>("img.media-image-element"),
+            ];
+            return imgs.some((img) => img.complete && img.naturalWidth > 0);
+        },
+        {timeout: 15_000},
+    );
+
+    // Arm the response watcher before deleting so we don't miss the fetch
+    // that update_media_previews_for_deleted_attachment fires.
+    const thumbnail_invalidated = page.waitForResponse(
+        (response) => response.url().includes(path_id) && response.status() === 404,
+        {timeout: 15_000},
+    );
+
+    // Delete the attachment directly via the API, bypassing the settings UI
+    await page.evaluate(async (p_id: string) => {
+        const csrf =
+            document.querySelector<HTMLInputElement>('input[name="csrfmiddlewaretoken"]')?.value ??
+            "";
+        const list_resp = await fetch("/json/attachments");
+        const list_data = (await list_resp.json()) as {
+            attachments: Array<{id: number; path_id: string}>;
+        };
+        const attachment = list_data.attachments.find((a) => a.path_id === p_id);
+        if (!attachment) {
+            throw new Error(`Attachment with path_id ${p_id} not found`);
+        }
+        await fetch(`/json/attachments/${attachment.id}`, {
+            method: "DELETE",
+            headers: {"X-CSRFToken": csrf},
+        });
+    }, path_id);
+
+    await thumbnail_invalidated;
+}
+
+await common.run_test(test_attachment_delete_updates_image_preview);

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -13,6 +13,7 @@ import * as dialog_widget from "./dialog_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as ListWidget from "./list_widget.ts";
 import * as loading from "./loading.ts";
+import * as message_live_update from "./message_live_update.ts";
 import * as scroll_util from "./scroll_util.ts";
 import {message_edit_history_visibility_policy_values} from "./settings_config.ts";
 import * as settings_config from "./settings_config.ts";
@@ -35,7 +36,7 @@ type AttachmentEvent =
       }
     | {
           op: "remove";
-          attachment: {id: number};
+          attachment: {id: number; path_id: string; message_ids: number[]};
           upload_space_used: number;
       };
 
@@ -198,6 +199,12 @@ function format_attachment_data(attachment: ServerAttachment): Attachment {
 }
 
 export function update_attachments(event: AttachmentEvent): void {
+    if (event.op === "remove") {
+        message_live_update.update_media_previews_for_deleted_attachment(
+            event.attachment.message_ids,
+            event.attachment.path_id,
+        );
+    }
     if (attachments === undefined) {
         // If we haven't fetched attachment data yet, there's nothing to do.
         return;

--- a/web/src/message_live_update.ts
+++ b/web/src/message_live_update.ts
@@ -57,6 +57,26 @@ export function update_message_in_all_views(
     }
 }
 
+export function update_media_previews_for_deleted_attachment(
+    message_ids: number[],
+    path_id: string,
+): void {
+    for (const message_id of message_ids) {
+        update_message_in_all_views(message_id, ($row) => {
+            for (const img of $row.find<HTMLImageElement>("img.media-image-element")) {
+                const src = img.getAttribute("src");
+                if (src?.includes(path_id)) {
+                    void (async () => {
+                        await fetch(src, {cache: "reload"});
+                        img.removeAttribute("src");
+                        img.setAttribute("src", src);
+                    })();
+                }
+            }
+        });
+    }
+}
+
 export function update_starred_view(message_id: number, new_value: boolean): void {
     const starred = new_value;
 

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -288,13 +288,14 @@ run_test("saved_snippets", ({override}) => {
 });
 
 run_test("attachments", ({override}) => {
-    const event = event_fixtures.attachment__add;
-    const stub = make_stub();
-    // attachments_ui is hard to test deeply
-    override(attachments_ui, "update_attachments", stub.f);
-    dispatch(event);
-    assert.equal(stub.num_calls, 1);
-    assert_same(stub.get_args("event").event, event);
+    for (const event of [event_fixtures.attachment__add, event_fixtures.attachment__remove]) {
+        const stub = make_stub();
+        // attachments_ui is hard to test deeply
+        override(attachments_ui, "update_attachments", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        assert_same(stub.get_args("event").event, event);
+    }
 });
 
 run_test("user groups", ({override}) => {

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -150,6 +150,17 @@ exports.fixtures = {
         upload_space_used: 90000,
     },
 
+    attachment__remove: {
+        type: "attachment",
+        op: "remove",
+        attachment: {
+            id: 99,
+            path_id: "path_id",
+            message_ids: [1000],
+        },
+        upload_space_used: 90000,
+    },
+
     channel_folder__add: {
         type: "channel_folder",
         op: "add",

--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -4,7 +4,11 @@ from typing import Any
 
 from django.db import transaction
 
-from zerver.lib.attachments import get_old_unclaimed_attachments, validate_attachment_request
+from zerver.lib.attachments import (
+    get_old_unclaimed_attachments,
+    remove_attachment,
+    validate_attachment_request,
+)
 from zerver.lib.markdown import MessageRenderingResult
 from zerver.lib.upload import claim_attachment, delete_message_attachments
 from zerver.models import (
@@ -35,6 +39,13 @@ def notify_attachment_update(
         "upload_space_used": user_profile.realm.currently_used_upload_space_bytes(),
     }
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
+
+
+@transaction.atomic(durable=True)
+def do_delete_attachment(user_profile: UserProfile, attachment: Attachment) -> None:
+    attachment_id = attachment.id
+    remove_attachment(user_profile, attachment)
+    notify_attachment_update(user_profile, "remove", {"id": attachment_id})
 
 
 def do_claim_attachments(

--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -1,10 +1,12 @@
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
 from django.db import transaction
 
 from zerver.lib.attachments import (
+    attachment_update_user_ids,
     get_old_unclaimed_attachments,
     remove_attachment,
     validate_attachment_request,
@@ -30,7 +32,11 @@ class AttachmentChangeResult:
 
 
 def notify_attachment_update(
-    user_profile: UserProfile, op: str, attachment_dict: dict[str, Any]
+    user_profile: UserProfile,
+    op: str,
+    attachment_dict: dict[str, Any],
+    *,
+    users: Iterable[int] | None = None,
 ) -> None:
     event = {
         "type": "attachment",
@@ -38,14 +44,28 @@ def notify_attachment_update(
         "attachment": attachment_dict,
         "upload_space_used": user_profile.realm.currently_used_upload_space_bytes(),
     }
-    send_event_on_commit(user_profile.realm, event, [user_profile.id])
+    if users is None:
+        users = [user_profile.id]
+    send_event_on_commit(user_profile.realm, event, users)
 
 
 @transaction.atomic(durable=True)
 def do_delete_attachment(user_profile: UserProfile, attachment: Attachment) -> None:
+    users = attachment_update_user_ids(attachment)
     attachment_id = attachment.id
+    path_id = attachment.path_id
+    message_ids = list(attachment.messages.values_list("id", flat=True))
     remove_attachment(user_profile, attachment)
-    notify_attachment_update(user_profile, "remove", {"id": attachment_id})
+    notify_attachment_update(
+        user_profile,
+        "remove",
+        {
+            "id": attachment_id,
+            "path_id": path_id,
+            "message_ids": message_ids,
+        },
+        users=users,
+    )
 
 
 def do_claim_attachments(

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -8,6 +8,7 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError, RateLimitedError
+from zerver.lib.message import event_recipient_ids_for_action_on_messages
 from zerver.lib.streams import is_user_in_groups_granting_content_access
 from zerver.lib.upload import delete_message_attachment
 from zerver.lib.user_groups import get_recursive_membership_groups
@@ -28,6 +29,15 @@ from zerver.models import (
 def user_attachments(user_profile: UserProfile) -> list[dict[str, Any]]:
     attachments = Attachment.objects.filter(owner=user_profile).prefetch_related("messages")
     return [a.to_dict() for a in attachments]
+
+
+def attachment_update_user_ids(attachment: Attachment) -> set[int]:
+    user_ids = {attachment.owner_id}
+    for message in attachment.messages.all().select_related("recipient"):
+        user_ids.update(
+            event_recipient_ids_for_action_on_messages([message.id], message.is_channel_message)
+        )
+    return user_ids
 
 
 def access_attachment_by_id(

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -46,6 +46,8 @@ class AttachmentAddEvent(BaseEvent):
 
 class AttachmentFieldForAttachmentRemoveEvent(BaseModel):
     id: int
+    path_id: str
+    message_ids: list[int]
 
 
 class AttachmentRemoveEvent(BaseEvent):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1990,13 +1990,27 @@ paths:
                                 attachment:
                                   type: object
                                   description: |
-                                    Dictionary containing the ID of the deleted attachment.
+                                    Dictionary containing details of the deleted attachment.
                                   additionalProperties: false
+                                  required:
+                                    - id
+                                    - path_id
+                                    - message_ids
                                   properties:
                                     id:
                                       type: integer
                                       description: |
                                         The ID of the deleted attachment.
+                                    path_id:
+                                      type: string
+                                      description: |
+                                        The path_id of the deleted attachment.
+                                    message_ids:
+                                      type: array
+                                      items:
+                                        type: integer
+                                      description: |
+                                        The IDs of the messages that referenced the deleted attachment.
                                 upload_space_used:
                                   type: integer
                                   description: |
@@ -2006,7 +2020,12 @@ paths:
                                 {
                                   "type": "attachment",
                                   "op": "remove",
-                                  "attachment": {"id": 1},
+                                  "attachment":
+                                    {
+                                      "id": 1,
+                                      "path_id": "2/ce/2Xpnnwgh8JWKxBXtTfD6BHKV/zulip.txt",
+                                      "message_ids": [79],
+                                    },
                                   "upload_space_used": 0,
                                   "id": 0,
                                 }

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -52,6 +52,34 @@ class AttachmentsTests(ZulipTestCase):
         attachments = user_attachments(user_profile)
         self.assertEqual(attachments, [])
 
+    def test_remove_attachment_notifies_message_recipients(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        stream = self.make_stream("attachment-delete-notify", invite_only=True)
+        self.subscribe(hamlet, stream.name, invite_only=True)
+        self.subscribe(iago, stream.name, invite_only=True)
+        self.login_user(hamlet)
+
+        with (
+            self.thumbnail_formats(ThumbnailFormat("webp", 100, 75, animated=True)),
+            get_test_image_file("img.png") as image_file,
+        ):
+            response = self.assert_json_success(
+                self.client_post("/json/user_uploads", {"file": image_file})
+            )
+
+        path_id = re.sub(r"/user_uploads/", "", response["url"])
+        body = f"See this file: [img.png]({response['url']})"
+        self.send_stream_message(hamlet, stream.name, body, "test")
+        attachment = Attachment.objects.get(path_id=path_id)
+
+        with mock.patch("zerver.actions.uploads.notify_attachment_update") as mock_notify:
+            result = self.client_delete(f"/json/attachments/{attachment.id}")
+            self.assert_json_success(result)
+
+        mock_notify.assert_called_once()
+        self.assertEqual(set(mock_notify.call_args.kwargs["users"]), {hamlet.id, iago.id})
+
     @mock.patch("zerver.lib.attachments.delete_message_attachment")
     def test_remove_imageattachment(self, ignored: Any) -> None:
         self.login_user(self.example_user("hamlet"))

--- a/zerver/views/attachments.py
+++ b/zerver/views/attachments.py
@@ -1,8 +1,7 @@
-from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 
-from zerver.actions.uploads import notify_attachment_update
-from zerver.lib.attachments import access_attachment_by_id, remove_attachment, user_attachments
+from zerver.actions.uploads import do_delete_attachment
+from zerver.lib.attachments import access_attachment_by_id, user_attachments
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
@@ -17,9 +16,7 @@ def list_by_user(request: HttpRequest, user_profile: UserProfile) -> HttpRespons
     )
 
 
-@transaction.atomic(durable=True)
 def remove(request: HttpRequest, user_profile: UserProfile, attachment_id: int) -> HttpResponse:
     attachment = access_attachment_by_id(user_profile, attachment_id, needs_owner=True)
-    remove_attachment(user_profile, attachment)
-    notify_attachment_update(user_profile, "remove", {"id": attachment_id})
+    do_delete_attachment(user_profile, attachment)
     return json_success(request)


### PR DESCRIPTION
Fixes: [#37425](https://github.com/zulip/zulip/issues/37425)

Currently, on deletion of an attachment, the event is only sent to the sender of the attachment with an aim to update the attachments list in the [Personal Settings > Uploaded Files](https://chat.zulip.org/#settings/uploaded-files). This PR aims to:

1) Send the event to all the users who received the attachment
2) Use the event to reload the image attachment with an aim to remove the preview.

Relevant links:
1) [Initial PR on this issue](https://github.com/zulip/zulip/pull/34299)
2) [Initial CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20thumbnail.20not.20deleted/with/2093824)
3) [API design CZO thread](https://chat.zulip.org/#narrow/channel/378-api-design/topic/attachment.20events.20for.20deletion.20notifications/with/2352864)
4) [PR were some review work was done but eventually went stale](https://github.com/zulip/zulip/pull/38054)

**How changes were tested:**
1. Manual tests
2. Automated Django tests
3. Node tests
4. Puppeteer test with non-deterministic failure check done (two 100x runs).

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/370ca8b1-cf1b-4b41-b31f-ec78d53dcc96


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
