### PR TITLE
url previews: Render text-only preview when no image is available.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -855,6 +855,27 @@
         .data-container {
             grid-area: data-container;
         }
+
+        /* When no preview image is available, the embed renders
+           as a text-only card. Remove the image column from the
+           grid and let height fit the content naturally. */
+        &:not(:has(.message_embed_image)) {
+            grid-template-columns:
+                [data-container-start] minmax(0, 1fr)
+                [data-container-end];
+            grid-template-rows:
+                [data-container-start] auto
+                [data-container-end];
+            height: auto;
+
+            .data-container {
+                /* On narrow screens the base styles add
+                   margin-top to separate text from the stacked
+                   image above. Reset it here since there is no
+                   image to separate from. */
+                margin-top: 0;
+            }
+        }
     }
 
     & a:not(.icon-button) {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -855,6 +855,19 @@
         .data-container {
             grid-area: data-container;
         }
+
+        /* When no preview image is available, the embed renders
+           as a text-only card. Remove the image column from the
+           grid and let height fit the content naturally. */
+        &:not(:has(.message_embed_image)) {
+            grid-template-columns:
+                [data-container-start] minmax(0, 1fr)
+                [data-container-end];
+            grid-template-rows:
+                [data-container-start] auto
+                [data-container-end];
+            height: auto;
+        }
     }
 
     & a:not(.icon-button) {

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -665,23 +665,28 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             self.add_oembed_data(root, link, extracted_data)
             return
 
-        if extracted_data.image is None:
-            # Don't add an embed if an image is not found
+        if (
+            extracted_data.image is None
+            and not extracted_data.title
+            and not extracted_data.description
+        ):
+            # Don't add an embed if there is no useful data to show.
             return
 
         container = SubElement(root, "div")
         container.set("class", "message_embed")
 
-        img_link = get_camo_url(extracted_data.image)
-        img = SubElement(container, "a")
-        img.set(
-            "style",
-            'background-image: url("'
-            + img_link.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\a ")
-            + '")',
-        )
-        img.set("href", link)
-        img.set("class", "message_embed_image")
+        if extracted_data.image is not None:
+            img_link = get_camo_url(extracted_data.image)
+            img = SubElement(container, "a")
+            img.set(
+                "style",
+                'background-image: url("'
+                + img_link.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\a ")
+                + '")',
+            )
+            img.set("href", link)
+            img.set("class", "message_embed_image")
 
         data_container = SubElement(container, "div")
         data_container.set("class", "data-container")
@@ -1069,7 +1074,9 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
 
                 # If there is data, but it's None, we did process the URL,
                 # but it was not valid to preview. If no image was found,
-                # `add_embed` below will skip building the embed.
+                # `add_embed` below will skip building the embed if
+                # there is no useful metadata (no image, title, or
+                # description).
                 extracted_data = self.zmd.url_embed_data[url]
                 if extracted_data is None:
                     continue

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -857,10 +857,11 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNotNone(cached_data.title)
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
-        self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
-            msg.rendered_content,
-        )
+        assert msg.rendered_content is not None
+        self.assertIn('class="message_embed"', msg.rendered_content)
+        # No image element should be present in the text-only embed.
+        self.assertNotIn("message_embed_image", msg.rendered_content)
+        self.assertIn("The Rock", msg.rendered_content)
 
     @responses.activate
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
@@ -898,10 +899,10 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNotNone(cached_data.title)
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
-        self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
-            msg.rendered_content,
-        )
+        assert msg.rendered_content is not None
+        self.assertIn('class="message_embed"', msg.rendered_content)
+        self.assertNotIn("message_embed_image", msg.rendered_content)
+        self.assertIn("The Rock", msg.rendered_content)
 
     @responses.activate
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
@@ -934,6 +935,36 @@ class PreviewTestCase(ZulipTestCase):
         assert cached_data is not None
         self.assertIsNotNone(cached_data.title)
         self.assertIsNone(cached_data.image)
+        msg = Message.objects.select_related("sender").get(id=msg_id)
+        assert msg.rendered_content is not None
+        self.assertIn('class="message_embed"', msg.rendered_content)
+        self.assertNotIn("message_embed_image", msg.rendered_content)
+        self.assertIn("The Rock", msg.rendered_content)
+
+    @responses.activate
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_link_preview_no_metadata(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        url = "http://test.org/foo.html"
+        with mock_queue_publish("zerver.actions.message_send.queue_event_on_commit") as patched:
+            msg_id = self.send_stream_message(user, "Denmark", topic_name="foo", content=url)
+            patched.assert_called_once()
+            queue = patched.call_args[0][0]
+            self.assertEqual(queue, "embed_links")
+            event = patched.call_args[0][1]
+
+        # HTML with no useful metadata at all.
+        html = "<html><head></head><body></body></html>"
+        self.create_mock_response(url, body=html)
+        with self.settings(TEST_SUITE=False):
+            with self.assertLogs(level="INFO") as info_logs:
+                FetchLinksEmbedData().consume(event)
+            self.assertTrue(
+                "INFO:root:Time spent on get_link_embed_data for http://test.org/foo.html: "
+                in info_logs.output[0]
+            )
+
         msg = Message.objects.select_related("sender").get(id=msg_id)
         self.assertEqual(
             '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1305,18 +1305,30 @@ class MarkdownEmbedsTest(ZulipTestCase):
         self.assertIn("Click to open file.", rendered.rendered_content)
 
         # If the worker could not find an OpenGraph image (the fetch
-        # failed, or the page has no og:image), no embed is produced and
-        # the message renders as a plain link.
-        for missing_image in (None, UrlEmbedData(image=None)):
-            rendered = markdown_convert(
-                url,
-                message_realm=get_realm("zulip"),
-                url_embed_data={url: missing_image},
-            )
-            self.assertEqual(
-                rendered.rendered_content,
-                f'<p><a href="{url}">{url}</a></p>',
-            )
+        # failed, or the page has no og:image):
+        # - If the fetch failed entirely (None), no embed is produced.
+        rendered = markdown_convert(
+            url,
+            message_realm=get_realm("zulip"),
+            url_embed_data={url: None},
+        )
+        self.assertEqual(
+            rendered.rendered_content,
+            f'<p><a href="{url}">{url}</a></p>',
+        )
+
+        # - If the page was fetched but has no og:image, a text-only
+        #   embed is rendered with the Dropbox title and description.
+        rendered = markdown_convert(
+            url,
+            message_realm=get_realm("zulip"),
+            url_embed_data={url: UrlEmbedData(image=None)},
+        )
+        assert rendered.rendered_content is not None
+        self.assertIn('class="message_embed"', rendered.rendered_content)
+        self.assertNotIn("message_embed_image", rendered.rendered_content)
+        self.assertIn("Dropbox file", rendered.rendered_content)
+        self.assertIn("Click to open file.", rendered.rendered_content)
 
     def test_inline_dropbox_no_previews(self) -> None:
         # When previews are disabled (e.g., for channel descriptions),

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1331,18 +1331,30 @@ class MarkdownEmbedsTest(ZulipTestCase):
         self.assertIn("Click to open file.", rendered.rendered_content)
 
         # If the worker could not find an OpenGraph image (the fetch
-        # failed, or the page has no og:image), no embed is produced and
-        # the message renders as a plain link.
-        for missing_image in (None, UrlEmbedData(image=None)):
-            rendered = markdown_convert(
-                url,
-                message_realm=get_realm("zulip"),
-                url_embed_data={url: missing_image},
-            )
-            self.assertEqual(
-                rendered.rendered_content,
-                f'<p><a href="{url}">{url}</a></p>',
-            )
+        # failed, or the page has no og:image):
+        # - If the fetch failed entirely (None), no embed is produced.
+        rendered = markdown_convert(
+            url,
+            message_realm=get_realm("zulip"),
+            url_embed_data={url: None},
+        )
+        self.assertEqual(
+            rendered.rendered_content,
+            f'<p><a href="{url}">{url}</a></p>',
+        )
+
+        # - If the page was fetched but has no og:image, a text-only
+        #   embed is rendered with the Dropbox title and description.
+        rendered = markdown_convert(
+            url,
+            message_realm=get_realm("zulip"),
+            url_embed_data={url: UrlEmbedData(image=None)},
+        )
+        assert rendered.rendered_content is not None
+        self.assertIn('class="message_embed"', rendered.rendered_content)
+        self.assertNotIn("message_embed_image", rendered.rendered_content)
+        self.assertIn("Dropbox file", rendered.rendered_content)
+        self.assertIn("Click to open file.", rendered.rendered_content)
 
     def test_inline_dropbox_no_previews(self) -> None:
         # When previews are disabled (e.g., for channel descriptions),


### PR DESCRIPTION
Fixes #39831.

### Description
Previously, `add_embed()` skipped rendering any preview when `extracted_data.image` was `None`, even when useful title and description metadata was successfully extracted. This caused pages without Open Graph images (technical docs, static sites, older websites) to appear only as bare links.

Now, when a title or description is available but no image is found, Zulip renders a compact text-only preview card. The existing image-based preview remains unchanged when an image is available. If no useful metadata is available at all, the URL remains a bare link.

---

### Visual Comparison

#### 1. Link without image, but with title & description (`https://box2d.org/posts/2026/06/announcing-box3d/`)

| Before | After |
| :---: | :---: |
| <img width="980" alt="text-only preview metadata(Before)" src="https://github.com/user-attachments/assets/a88fde9e-6cdc-42ee-84da-b40ce7a82dfa" /> | <img width="980" alt="text-only preview metadata(After)" src="https://github.com/user-attachments/assets/1955f8a7-319b-4524-898e-0f7ecd37b649" /> |

#### 2. Link with image, title & description (`https://github.com/zulip/zulip`)

| Before | After |
| :---: | :---: |
| <img width="989" alt="full preview metadata(Before)" src="https://github.com/user-attachments/assets/d4c6592a-72b6-4a4e-af23-2747397a3aa1" /> | <img width="989" alt="full preview metadata(After)" src="https://github.com/user-attachments/assets/9400d532-b410-467c-b2d3-b340fb4591ba" /> |

#### 3. Link without any metadata (`https://raw.githubusercontent.com/...`)

| Before | After |
| :---: | :---: |
| <img width="980" alt="Plain URL(Before)" src="https://github.com/user-attachments/assets/fa0c6f8b-a4de-44e7-b8c9-446f82f8aa11" /> | <img width="980" alt="Plain URL(After)" src="https://github.com/user-attachments/assets/49efe140-245d-40ab-8f73-329e0345f274" /> |

---

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
