### PR TITLE
drafts: Enable keyboard navigation for draft action buttons

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -14,6 +14,7 @@ import {show_copied_confirmation} from "./copied_tooltip.ts";
 import type {FormattedDraft, LocalStorageDraft} from "./drafts.ts";
 import * as drafts from "./drafts.ts";
 import {$t} from "./i18n.ts";
+import * as keydown_util from "./keydown_util.ts";
 import * as markdown from "./markdown.ts";
 import {message_render_response_schema} from "./message_store.ts";
 import * as message_view from "./message_view.ts";
@@ -406,6 +407,24 @@ function setup_event_handlers(): void {
         toggle_checkbox_icon_state($(e.target), !is_checked);
         update_bulk_delete_ui();
     });
+    $("#drafts_table .overlay_message_controls .copy-overlay-message").on("keydown", function (e) {
+        if (keydown_util.is_enter_event(e) || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            $(this).trigger("click");
+        }
+    });
+
+    $("#drafts_table .overlay_message_controls .draft-selection-tooltip").on(
+        "keydown",
+        function (e) {
+            if (keydown_util.is_enter_event(e) || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                $(this).find(".draft-selection-checkbox").trigger("click");
+            }
+        },
+    );
 }
 
 function setup_bulk_actions_handlers(): void {
@@ -539,10 +558,10 @@ export function initialize(): void {
         if (!(e.target instanceof HTMLElement)) {
             return;
         }
-        const draft_row = e.target.closest(".overlay-message-info-box");
-        if (draft_row instanceof HTMLElement) {
+        // const draft_row = e.target.closest(".overlay-message-info-box");
+        if (e.target.matches(".overlay-message-info-box")) {
             // A draft gained focus; mark it as the selected draft.
-            messages_overlay_ui.activate_element(draft_row, keyboard_handling_context);
+            messages_overlay_ui.activate_element(e.target, keyboard_handling_context);
         } else if (e.target.matches(overlay_util.OVERLAY_FOCUSABLE_SELECTOR)) {
             // Another focusable element (e.g. a header button) gained focus;
             // draft info-boxes are already handled by the branch above, so

--- a/web/src/overlay_util.ts
+++ b/web/src/overlay_util.ts
@@ -15,7 +15,7 @@ export function enable_scrolling(): void {
 }
 
 export const OVERLAY_FOCUSABLE_SELECTOR =
-    "input, button, select, .input, .sidebar-item, .ind-tab.first, a[href], a[tabindex='0'], .overlay-message-info-box";
+    "input, button, select, .input, .sidebar-item, .ind-tab.first, a[href], a[tabindex='0'], .overlay-message-info-box, .copy-overlay-message, .draft-selection-tooltip";
 
 export function get_visible_focusable_elements_in_overlay_container(
     $container: JQuery,

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -1,3 +1,4 @@
+
 <div class="draft-message-row overlay-message-row" data-draft-id="{{draft_id}}">
     <div class="draft-message-info-box overlay-message-info-box" tabindex="0">
         {{#if is_stream}}
@@ -47,11 +48,11 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="overlay_message_controls">
-                            <span class="copy-button copy-overlay-message tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}" role="button">
+                            <span class="copy-button copy-overlay-message tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}" role="button" tabindex="0">
                                 <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
                             </span>
                             {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-draft-tooltip-template" aria-label=(t "Delete") }}
-                            <div class="draft-selection-tooltip">
+                            <div class="draft-selection-tooltip" role="checkbox" tabindex="0" aria-checked="false" aria-label="{{t 'Select draft' }}">
                                 <i class="fa fa-square-o fa-lg draft-selection-checkbox" aria-hidden="true"></i>
                             </div>
                         </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Enable keyboard navigation for action buttons in the Drafts overlay.

This change allows users to navigate from a focused draft row to its associated action buttons (Copy, Delete, and Select) using Tab/Shift+Tab, improving keyboard accessibility.

Root cause:  (`web/src/drafts_overlay_ui.ts `)delegates a focus listener on body for #draft_overlay
Changes made: 
1)(`web/src/drafts_overlay_ui.ts:)` Updated the focus handling so a draft row is activated only when the row itself receives focus. Previously, using `closest()` could cause the row to be treated as focused even when one of its action buttons had focus. Now, when a child action control receives focus, the `row’s .active` state is cleared instead of being applied to the row.
2)`web/src/overlay_util.ts:` Adjusted the shared focusable-element logic used by the overlay’s focus and tab navigation. This ensures that action controls inside a row are treated as separate focus targets rather than being considered part of the parent row.
3`web/templates/draft.hbs:` Changed the copy control from a non-focusable <span> to a semantic `<button type="button">`, making it keyboard accessible. Also changed the draft selection tooltip from a `<div>` to a `<button type="button" role="checkbox">`, so it can be reached using Tab and is properly exposed to assistive technologies.

Fixes: <!-- Issue link, or clear description.-->issue-#39005




**How changes were tested:**
- Ran frontend lint checks.
- Ran JavaScript tests (`./tools/test-js-with-node`).
- Manually tested the Drafts overlay in the development environment.
- Verified that keyboard navigation works with Tab and Shift+Tab, allowing focus to move from a draft row to the Copy, Delete, and Select action buttons.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<img width="800" height="431" alt="ScreenRecording2026-08-05211530-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/7b2ee037-3ab9-4efc-8bf9-d4547a9e633c" />





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
