### PR TITLE
webhooks: Use journal author for Redmine issue update notifications.

### DIFF
--- a/zerver/webhooks/redmine/fixtures/issue_updated.json
+++ b/zerver/webhooks/redmine/fixtures/issue_updated.json
@@ -59,11 +59,11 @@
       "author": {
         "icon_url": "http://www.gravatar.com/avatar/example",
         "identity_url": null,
-        "lastname": "user",
-        "firstname": "test",
-        "mail": "test@example.com",
-        "login": "test",
-        "id": 3
+        "lastname": "Doe",
+        "firstname": "Jane",
+        "mail": "jane@example.com",
+        "login": "jane",
+        "id": 7
       },
       "created_on": "2014-03-01T16:17:48Z",
       "id": 1

--- a/zerver/webhooks/redmine/tests.py
+++ b/zerver/webhooks/redmine/tests.py
@@ -24,7 +24,7 @@ I'm having a problem with this.
         self.check_webhook("issue_opened_without_assignee", self.TOPIC_NAME, expected_message)
 
     def test_issue_updated(self) -> None:
-        expected_message = """**test user** updated [#191 Found a bug](https://example.com).
+        expected_message = """**Jane Doe** updated [#191 Found a bug](https://example.com).
 
 ~~~ quote
 I've started working on this issue. The problem seems to be in the authentication module.

--- a/zerver/webhooks/redmine/view.py
+++ b/zerver/webhooks/redmine/view.py
@@ -68,12 +68,16 @@ def handle_issue_opened(payload: WildValue) -> str:
 
 def handle_issue_updated(payload: WildValue) -> str:
     issue = payload["issue"]
-    author_name = _get_user_name(issue["author"])
+    journal = payload.get("journal")
+    if journal and journal.get("author"):
+        author_name = _get_user_name(journal["author"])
+    else:
+        author_name = _get_user_name(issue["author"])
     issue_link = _get_issue_link(payload)
 
     journal_notes = ""
     if (
-        (journal := payload.get("journal"))
+        journal
         and (notes := journal.get("notes"))
         and (tamed_notes := notes.tame(check_string).strip())
     ):


### PR DESCRIPTION
Redmine webhook payloads for issue updates include a `journal` object whose `author` is the person who made the change, while `issue.author` is the original creator. `handle_issue_updated` used the issue creator, so update notifications showed the wrong name whenever a different person edited the issue.

Changed the handler to read `journal.author` when present, falling back to `issue.author` if the payload has no journal (matching the existing defensive handling of the journal for notes).

Updated the `issue_updated` fixture so the journal author differs from the issue author; previously they were identical, so the test could not detect this bug.

Fixes: https://github.com/zulip/zulip/issues/39448

**How changes were tested:**

- Verified the parsing logic against the fixture with a standalone script (journal author is used, and the fallback path works when `journal` is absent).
- The `test_issue_updated` webhook test in `zerver/webhooks/redmine/tests.py` now asserts the journal author is used; it runs on CI (full Zulip Django suite not runnable locally on my Windows setup).

**Screenshots and screen captures:**

None (no UI changes).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines). (This PR was prepared with AI assistance; the change is small, I understand and verified it as described above.)

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description). (Added a fallback to `issue.author` when the journal is absent, mirroring the existing optional-journal handling; the issue proposed reading the journal unconditionally.)
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>