### PR TITLE
gitlab: Handle blocked, approved and rejected deployment statuses.

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/deployment_hook__approved.json
+++ b/zerver/webhooks/gitlab/fixtures/deployment_hook__approved.json
@@ -1,0 +1,64 @@
+{
+  "object_kind": "deployment",
+  "status": "approved",
+  "status_changed_at": "2026-08-02T10:41:35.000+00:00",
+  "deployment_id": 1503250272,
+  "deployable_id": 15664214926,
+  "deployable_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/jobs/15664214926",
+  "environment": "production",
+  "environment_tier": "production",
+  "environment_slug": "production",
+  "environment_external_url": null,
+  "project": {
+    "id": 85038800,
+    "name": "deployment-webhook-test",
+    "description": null,
+    "web_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+    "git_http_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test.git",
+    "namespace": "Pritesh-30-group",
+    "visibility_level": 0,
+    "path_with_namespace": "pritesh-30-group/deployment-webhook-test",
+    "default_branch": "main",
+    "ci_config_path": "",
+    "homepage": "https://gitlab.com/pritesh-30-group/deployment-webhook-test",
+    "url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+    "ssh_url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+    "http_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test.git"
+  },
+  "short_sha": "2166d75e",
+  "user": {
+    "id": 32548944,
+    "name": "Pritesh-30",
+    "username": "Pritesh-30",
+    "avatar_url": "https://secure.gravatar.com/avatar/ebe8e7ec7c6cc50451c04e29b9c8b0bf7c439b71fb4c19b778b64e35fa66165e?s=80&d=identicon",
+    "email": "[REDACTED]"
+  },
+  "user_url": "https://gitlab.com/Pritesh-30",
+  "commit_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/commit/2166d75e44d9b13be5d7fc739fd40e7ba8a8eece",
+  "commit_title": "Edit .gitlab-ci.yml",
+  "ref": "main",
+  "approver": {
+    "id": 32548944,
+    "name": "Pritesh-30",
+    "username": "Pritesh-30",
+    "avatar_url": "https://secure.gravatar.com/avatar/ebe8e7ec7c6cc50451c04e29b9c8b0bf7c439b71fb4c19b778b64e35fa66165e?s=80&d=identicon",
+    "email": "[REDACTED]"
+  },
+  "approval": {
+    "id": 4218110,
+    "status": "approved",
+    "comment": "Approval granted",
+    "created_at": "2026-08-02T10:41:35.573Z",
+    "approval_rule": {
+      "id": 3790807,
+      "user_id": 32548944,
+      "group_id": null,
+      "access_level": null,
+      "access_level_description": "Pritesh-30",
+      "required_approvals": 1,
+      "group_inheritance_type": 0
+    }
+  }
+}

--- a/zerver/webhooks/gitlab/fixtures/deployment_hook__blocked.json
+++ b/zerver/webhooks/gitlab/fixtures/deployment_hook__blocked.json
@@ -1,0 +1,42 @@
+{
+    "object_kind": "deployment",
+    "status": "blocked",
+    "status_changed_at": "2026-08-02T07:59:54.000+00:00",
+    "deployment_id": 1503204389,
+    "deployable_id": 15663409982,
+    "deployable_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/jobs/15663409982",
+    "environment": "production",
+    "environment_tier": "production",
+    "environment_slug": "production",
+    "environment_external_url": null,
+    "project": {
+        "id": 85038800,
+        "name": "deployment-webhook-test",
+        "description": null,
+        "web_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test",
+        "avatar_url": null,
+        "git_ssh_url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+        "git_http_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test.git",
+        "namespace": "Pritesh-30-group",
+        "visibility_level": 0,
+        "path_with_namespace": "pritesh-30-group/deployment-webhook-test",
+        "default_branch": "main",
+        "ci_config_path": "",
+        "homepage": "https://gitlab.com/pritesh-30-group/deployment-webhook-test",
+        "url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+        "ssh_url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+        "http_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test.git"
+    },
+    "short_sha": "2166d75e",
+    "user": {
+        "id": 32548944,
+        "name": "Pritesh-30",
+        "username": "Pritesh-30",
+        "avatar_url": "https://secure.gravatar.com/avatar/ebe8e7ec7c6cc50451c04e29b9c8b0bf7c439b71fb4c19b778b64e35fa66165e?s=80&d=identicon",
+        "email": "[REDACTED]"
+    },
+    "user_url": "https://gitlab.com/Pritesh-30",
+    "commit_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/commit/2166d75e44d9b13be5d7fc739fd40e7ba8a8eece",
+    "commit_title": "Edit .gitlab-ci.yml",
+    "ref": "main"
+}

--- a/zerver/webhooks/gitlab/fixtures/deployment_hook__rejected.json
+++ b/zerver/webhooks/gitlab/fixtures/deployment_hook__rejected.json
@@ -1,0 +1,64 @@
+{
+    "object_kind": "deployment",
+    "status": "rejected",
+    "status_changed_at": "2026-08-02T08:06:26.000+00:00",
+    "deployment_id": 1503206035,
+    "deployable_id": 15663435853,
+    "deployable_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/jobs/15663435853",
+    "environment": "production",
+    "environment_tier": "production",
+    "environment_slug": "production",
+    "environment_external_url": null,
+    "project": {
+        "id": 85038800,
+        "name": "deployment-webhook-test",
+        "description": null,
+        "web_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test",
+        "avatar_url": null,
+        "git_ssh_url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+        "git_http_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test.git",
+        "namespace": "Pritesh-30-group",
+        "visibility_level": 0,
+        "path_with_namespace": "pritesh-30-group/deployment-webhook-test",
+        "default_branch": "main",
+        "ci_config_path": "",
+        "homepage": "https://gitlab.com/pritesh-30-group/deployment-webhook-test",
+        "url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+        "ssh_url": "git@gitlab.com:pritesh-30-group/deployment-webhook-test.git",
+        "http_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test.git"
+    },
+    "short_sha": "2166d75e",
+    "user": {
+        "id": 32548944,
+        "name": "Pritesh-30",
+        "username": "Pritesh-30",
+        "avatar_url": "https://secure.gravatar.com/avatar/ebe8e7ec7c6cc50451c04e29b9c8b0bf7c439b71fb4c19b778b64e35fa66165e?s=80&d=identicon",
+        "email": "[REDACTED]"
+    },
+    "user_url": "https://gitlab.com/Pritesh-30",
+    "commit_url": "https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/commit/2166d75e44d9b13be5d7fc739fd40e7ba8a8eece",
+    "commit_title": "Edit .gitlab-ci.yml",
+    "ref": "main",
+    "approver": {
+        "id": 32548944,
+        "name": "Pritesh-30",
+        "username": "Pritesh-30",
+        "avatar_url": "https://secure.gravatar.com/avatar/ebe8e7ec7c6cc50451c04e29b9c8b0bf7c439b71fb4c19b778b64e35fa66165e?s=80&d=identicon",
+        "email": "[REDACTED]"
+    },
+    "approval": {
+        "id": 4218093,
+        "status": "rejected",
+        "comment": "rejected",
+        "created_at": "2026-08-02T08:06:26.269Z",
+        "approval_rule": {
+            "id": 3790807,
+            "user_id": 32548944,
+            "group_id": null,
+            "access_level": null,
+            "access_level_description": "Pritesh-30",
+            "required_approvals": 1,
+            "group_inheritance_type": 0
+        }
+    }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -778,6 +778,39 @@ A trivial change that should probably be ignored.
             HTTP_X_GITLAB_EVENT="Deployment Hook",
         )
 
+    def test_deployment_blocked_event_message(self) -> None:
+        expected_topic_name = "deployment-webhook-test / production"
+        expected_message = "The [deployment](https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/jobs/15663409982) is blocked and waiting for approval."
+
+        self.check_webhook(
+            "deployment_hook__blocked",
+            expected_topic_name,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Deployment Hook",
+        )
+
+    def test_deployment_approved_event_message(self) -> None:
+        expected_topic_name = "deployment-webhook-test / production"
+        expected_message = "Pritesh-30 approved the [deployment](https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/jobs/15664214926).\n``` quote\nApproval granted\n```"
+
+        self.check_webhook(
+            "deployment_hook__approved",
+            expected_topic_name,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Deployment Hook",
+        )
+
+    def test_deployment_rejected_event_message(self) -> None:
+        expected_topic_name = "deployment-webhook-test / production"
+        expected_message = "Pritesh-30 rejected the [deployment](https://gitlab.com/pritesh-30-group/deployment-webhook-test/-/jobs/15663435853).\n``` quote\nrejected\n```"
+
+        self.check_webhook(
+            "deployment_hook__rejected",
+            expected_topic_name,
+            expected_message,
+            HTTP_X_GITLAB_EVENT="Deployment Hook",
+        )
+
     def test_emoji_award_in_snippet(self) -> None:
         expected_topic_name = "sample / snippet #4831194 Sample Snippet"
         expected_message = "Varun Kolanu added the emoji :thumbsup:."

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -499,12 +499,40 @@ def get_resource_access_token_expiry_event_body(
     )
 
 
+def get_deployment_approval_event_body(
+    payload: WildValue, deployment_status: str, deployment_text: str, realm: Realm
+) -> str:
+    approver = payload["approver"]
+    approver_text = get_user_mention(
+        realm,
+        approver["username"].tame(check_string),
+        approver["name"].tame(check_string),
+    )
+
+    body = f"{approver_text} {deployment_status} the {deployment_text}."
+
+    # GitLab sends an empty string when the approver left no comment.
+    comment = payload["approval"]["comment"].tame(check_string)
+    if comment:
+        body += CONTENT_MESSAGE_TEMPLATE.format(message=comment, fence=get_unused_fence(comment))
+
+    return body
+
+
 def get_deployment_event_body(payload: WildValue, include_title: bool, realm: Realm) -> str:
     user_text = f"[{get_user_name(payload, realm)}]({payload['user_url'].tame(check_string)})"
 
     deployment_status = payload["status"].tame(check_string)
     deployable_url = payload.get("deployable_url", "").tame(check_string)
     deployment_text = f"[deployment]({deployable_url})" if deployable_url else "deployment"
+
+    # Approval events include `approver`/`approval` fields that other
+    # events lack, so they can't use deployment_event_body_map because
+    # its values are eagerly evaluated.
+    if deployment_status in ("approved", "rejected"):
+        return get_deployment_approval_event_body(
+            payload, deployment_status, deployment_text, realm
+        )
 
     commit_title = payload["commit_title"].tame(check_string)
     commit_url = payload["commit_url"].tame(check_string)
@@ -515,6 +543,7 @@ def get_deployment_event_body(payload: WildValue, include_title: bool, realm: Re
         "success": f"The {deployment_text} was successful.",
         "failed": f"The {deployment_text} failed.",
         "canceled": f"The {deployment_text} was canceled.",
+        "blocked": f"The {deployment_text} is blocked and waiting for approval.",
     }
 
     return deployment_event_body_map[deployment_status]


### PR DESCRIPTION
GitLab emits `blocked` when a deployment is waiting for approval or a manual action, and `approved` or `rejected` once someone acts on it. The handler recognized only four statuses, so these raised a KeyError and the notification was dropped.
Approval events are the only ones carrying `approver` and `approval` sections, so they get their own helper rather than an entry in the eagerly evaluated message map, whose values are all built before one is selected.

<!-- Describe your pull request here.-->

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/127-integrations/topic/gitlab/with/658247)[#integrations > gitlab](https://chat.zulip.org/#narrow/channel/127-integrations/topic/gitlab/with/658247)

**How changes were tested:**
- Added tests and ran `./tools/test-backend zerver/webhooks/gitlab` all test pass. 
- Manually verified in development environment by POSTing each fixture with `curl` and checking the rendered message and topic.

The fixtures `deployment_hook__approved.json`, `deployment_hook__blocked.json`, `deployment_hook__rejected.json` are are real payloads captured from a GitLab project.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

Note: Multiple required approvals need no special handling. GitLab sends a separate `deployment` event for each approver, each containing a single approval object. Since `required_approvals` only indicates the rule's requirement not current progress each approval or rejection is reported as its own message.

**Screenshots and screen captures:**
`Blocked`
<img width="1129" height="147" alt="image" src="https://github.com/user-attachments/assets/522380f8-3416-4114-8ee0-c0d31d2bcb01" />
`Approved`
<img width="1129" height="95" alt="image" src="https://github.com/user-attachments/assets/95af38d0-3742-449e-8131-23ea31e2dc18" />
`Rejected`
<img width="1129" height="102" alt="image" src="https://github.com/user-attachments/assets/7f41da69-adce-4936-880d-2b0200155186" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
