### PR TITLE
message feed: Add icons to "show more"/"show less" buttons

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -115,7 +115,10 @@ export function initialize(): void {
         }
 
         // Widget for adjusting the height of a message.
-        if ($target.is("button.message_expander") || $target.is("button.message_condenser")) {
+        if (
+            $target.closest("button.message_expander").length > 0 ||
+            $target.closest("button.message_condenser").length > 0
+        ) {
             return true;
         }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -316,8 +316,8 @@
 
     .message_length_toggle {
         width: 100%;
-        height: 1.714em; /* 24px / 14px em */
         margin-bottom: var(--message-box-markdown-aligned-vertical-space);
+        padding: 0.5rem 1rem;
         color: var(--color-text-show-more-less-button);
         background-color: var(--color-show-more-less-button-background);
         border-radius: 4px;
@@ -326,9 +326,15 @@
         overflow: hidden;
         text-overflow: ellipsis;
         overflow-wrap: normal;
-        font-variant: all-small-caps;
         font-family: inherit;
-        font-size: inherit;
+        font-size: 0.75rem;
+        font-weight: 500;
+        text-transform: uppercase;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
 
         &:hover {
             background-color: var(

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -326,9 +326,14 @@
         overflow: hidden;
         text-overflow: ellipsis;
         overflow-wrap: normal;
-        font-variant: all-small-caps;
         font-family: inherit;
-        font-size: inherit;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
 
         &:hover {
             background-color: var(

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -5,7 +5,8 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
-    {{ label_text }}
+    <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
+    <span>{{ label_text }}</span>
 </button>
 {{else if (eq toggle_type "condenser")}}
 <button type="button" class="message_condenser message_length_toggle"
@@ -14,6 +15,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
-    {{ label_text }}
+    <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
+    <span>{{ label_text }}</span>
 </button>
 {{/if}}


### PR DESCRIPTION
This adds collapse and expand icons to "show more"/"show less" buttons on long/collapsed messages. It makes it easy to see what clicking will do.

Fixes #38844


### Screenshots and screen captures:
| Before | After
| --- | --- |
|<img width="544" height="27" alt="show-more-before" src="https://github.com/user-attachments/assets/b5369939-8275-4e33-ada7-bdbcd6603dcf" />|<img width="544" height="32" alt="show-more-after-2" src="https://github.com/user-attachments/assets/1fa5f36c-431a-4319-b11d-434997cd73b9" />
|<img width="544" height="27" alt="show-less-before" src="https://github.com/user-attachments/assets/0b05c6cf-5354-49ec-9181-c6bff751fa49" />|<img width="544" height="32" alt="show-less-after-2" src="https://github.com/user-attachments/assets/d331dd42-171a-4709-a897-350a1a64fc01" />
|<img width="742" height="175" alt="message-box-before" src="https://github.com/user-attachments/assets/6c2c511a-ef50-4a5c-9883-659704bd0be1" />|<img width="742" height="179" alt="message-box-after-2" src="https://github.com/user-attachments/assets/6636421b-2b9f-4d9d-ad91-e73db7aa4011" />

### Why replace `font-variant: all-small-caps`?
By keeping the `all-small-caps` the text is not centered properly. This happens because there is more space above the text than below it as shown in the table below. [`all-small-caps` shrinks the uppercase letters to match the size of lowercase letters](https://en.wikipedia.org/wiki/Small_caps) but the line height stays the same.

By replacing `all-small-caps` with `text-transform: uppercase` and reducing the `font-size: 0.75rem`, the space is evenly distributed and the text is centered properly.

**Issue with `font-variant: all-small-caps`**:
| Before<br>`font-variant: all-small-caps` | After <br>`text-transform: uppercase`<br>`font-size: 0.75rem`|
| --- | --- |
|<img width="80" height="24" alt="space-before" src="https://github.com/user-attachments/assets/75e7cc58-ad52-480b-a917-de49732f9d6a" />|<img width="67" height="19" alt="space-after" src="https://github.com/user-attachments/assets/51dab20c-f884-434e-8453-0a463cc11b4a" />
|<img width="341" height="91" alt="center-before" src="https://github.com/user-attachments/assets/97530466-4fb7-4583-9819-629526d12e42" />|<img width="288" height="72" alt="center-after" src="https://github.com/user-attachments/assets/74de210d-5e17-483e-906c-4f0f55c6e131" />

[text-box](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-box) can solve this issue but it's not well supported.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
