### PR TITLE
scim: Run user update operations in a single transaction.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -497,6 +497,10 @@ python_rules = RuleList(
                     "zproject/backends.py",
                     "@transaction.atomic(savepoint=True)  # intentional use of savepoint=True",
                 ),
+                (
+                    "zerver/lib/scim.py",
+                    "with transaction.atomic(savepoint=True):  # intentional use of savepoint=True",
+                ),
             },
         },
         *whitespace_rules,

--- a/zerver/lib/scim.py
+++ b/zerver/lib/scim.py
@@ -399,30 +399,29 @@ class ZulipSCIMUser(SCIMUser):
                 )
             return
 
-        # TODO: The below operations should ideally be executed in a single
-        # atomic block to avoid failing with partial changes getting saved.
-        # This can be fixed once we figure out how do_deactivate_user can be run
-        # inside an atomic block.
+        # We create a savepoint here, unlike the savepoint=False
+        # convention followed by the action functions below, so that a
+        # failure rolls back only our own changes when this runs nested
+        # inside an outer atomic block during tests in Django's TestCase.
+        with transaction.atomic(savepoint=True):  # intentional use of savepoint=True
+            if full_name_new_value:
+                check_change_full_name(self.obj, full_name_new_value, acting_user=None)
 
-        # We process full_name first here, since it's the only one that can fail.
-        if full_name_new_value:
-            check_change_full_name(self.obj, full_name_new_value, acting_user=None)
+            if email_new_value is not None:
+                do_change_user_delivery_email(self.obj, email_new_value, acting_user=None)
 
-        if email_new_value is not None:
-            do_change_user_delivery_email(self.obj, email_new_value, acting_user=None)
+            if role_new_value is not None:
+                do_change_user_role(self.obj, role_new_value, acting_user=None, notify=True)
 
-        if role_new_value is not None:
-            do_change_user_role(self.obj, role_new_value, acting_user=None, notify=True)
+            if is_active_new_value is not None and is_active_new_value:
+                do_reactivate_user(self.obj, acting_user=None)
+            elif is_active_new_value is not None and not is_active_new_value:
+                do_deactivate_user(self.obj, acting_user=None)
 
-        if is_active_new_value is not None and is_active_new_value:
-            do_reactivate_user(self.obj, acting_user=None)
-        elif is_active_new_value is not None and not is_active_new_value:
-            do_deactivate_user(self.obj, acting_user=None)
-
-        if custom_profile_data:
-            do_update_user_custom_profile_data_if_changed(
-                self.obj, custom_profile_data, None, notify=True
-            )
+            if custom_profile_data:
+                do_update_user_custom_profile_data_if_changed(
+                    self.obj, custom_profile_data, None, notify=True
+                )
 
     def delete(self) -> None:
         """

--- a/zerver/lib/scim.py
+++ b/zerver/lib/scim.py
@@ -399,30 +399,44 @@ class ZulipSCIMUser(SCIMUser):
                 )
             return
 
-        # TODO: The below operations should ideally be executed in a single
-        # atomic block to avoid failing with partial changes getting saved.
-        # This can be fixed once we figure out how do_deactivate_user can be run
-        # inside an atomic block.
+        # We run the update in a single transaction so that if any of
+        # these operations fails partway through, none of the changes
+        # from this SCIM request are persisted. This used to not be
+        # possible because do_deactivate_user independently deleted
+        # the user's sessions outside of any atomic block, but it now
+        # defers that via transaction.on_commit, which correctly waits
+        # for the outermost transaction to commit.
+        #
+        # We intentionally use a savepoint here, unlike the action
+        # functions called below (which use savepoint=False).
+        # django_scim.views.SCIMView.dispatch wraps view calls in a
+        # bare "except Exception", logs it, and returns a normal error
+        # HttpResponse without re-raising -- so request processing
+        # continues normally after a failure here. Without a
+        # savepoint, that failure would otherwise leave the
+        # connection's outer transaction needing a rollback that
+        # nothing later in the request performs, breaking any further
+        # database access for the rest of the request.
+        with transaction.atomic(savepoint=True):  # intentional use of savepoint=True
+            # We process full_name first here, since it's the only one that can fail.
+            if full_name_new_value:
+                check_change_full_name(self.obj, full_name_new_value, acting_user=None)
 
-        # We process full_name first here, since it's the only one that can fail.
-        if full_name_new_value:
-            check_change_full_name(self.obj, full_name_new_value, acting_user=None)
+            if email_new_value is not None:
+                do_change_user_delivery_email(self.obj, email_new_value, acting_user=None)
 
-        if email_new_value is not None:
-            do_change_user_delivery_email(self.obj, email_new_value, acting_user=None)
+            if role_new_value is not None:
+                do_change_user_role(self.obj, role_new_value, acting_user=None, notify=True)
 
-        if role_new_value is not None:
-            do_change_user_role(self.obj, role_new_value, acting_user=None, notify=True)
+            if is_active_new_value is not None and is_active_new_value:
+                do_reactivate_user(self.obj, acting_user=None)
+            elif is_active_new_value is not None and not is_active_new_value:
+                do_deactivate_user(self.obj, acting_user=None)
 
-        if is_active_new_value is not None and is_active_new_value:
-            do_reactivate_user(self.obj, acting_user=None)
-        elif is_active_new_value is not None and not is_active_new_value:
-            do_deactivate_user(self.obj, acting_user=None)
-
-        if custom_profile_data:
-            do_update_user_custom_profile_data_if_changed(
-                self.obj, custom_profile_data, None, notify=True
-            )
+            if custom_profile_data:
+                do_update_user_custom_profile_data_if_changed(
+                    self.obj, custom_profile_data, None, notify=True
+                )
 
     def delete(self) -> None:
         """

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -685,6 +685,39 @@ class TestSCIMUser(SCIMTestCase):
         expected_response_schema = self.generate_user_schema(hamlet)
         self.assertEqual(output_data, expected_response_schema)
 
+    def test_put_change_fails_atomically(self) -> None:
+        """
+        If one of the changes requested in a SCIM update fails partway
+        through, none of the other changes in that same request should
+        be persisted either.
+        """
+        hamlet = self.example_user("hamlet")
+        original_email = hamlet.delivery_email
+        self.assertEqual(hamlet.role, UserProfile.ROLE_MEMBER)
+
+        # This payload changes both the email and the role. We simulate
+        # the role change failing after the email change has already run,
+        # to verify the email change gets rolled back too.
+        payload = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            "id": hamlet.id,
+            "userName": "bjensen@zulip.com",
+            "role": "administrator",
+        }
+        with (
+            mock.patch(
+                "zerver.lib.scim.do_change_user_role", side_effect=Exception("simulated failure")
+            ),
+            self.assertLogs("django_scim.views", "ERROR"),
+            self.assertLogs("django.request", "ERROR"),
+        ):
+            result = self.json_put(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
+        self.assertEqual(result.status_code, 500)
+
+        hamlet.refresh_from_db()
+        self.assertEqual(hamlet.delivery_email, original_email)
+        self.assertEqual(hamlet.role, UserProfile.ROLE_MEMBER)
+
     def test_put_deactivate_reactivate_user(self) -> None:
         hamlet = self.example_user("hamlet")
         # This payload flips the active attribute to deactivate the user.

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -687,6 +687,40 @@ class TestSCIMUser(SCIMTestCase):
         expected_response_schema = self.generate_user_schema(hamlet)
         self.assertEqual(output_data, expected_response_schema)
 
+    def test_put_change_fails_atomically(self) -> None:
+        """
+        If one of the changes requested in a SCIM update fails partway
+        through, none of the other changes in that same request should
+        be persisted either.
+        """
+        hamlet = self.example_user("hamlet")
+        original_email = hamlet.delivery_email
+        self.assertEqual(hamlet.role, UserProfile.ROLE_MEMBER)
+
+        # This payload changes both the email and the role. We simulate
+        # the role change failing after the email change has already run,
+        # to verify the email change gets rolled back too.
+        payload = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            "id": hamlet.id,
+            "userName": "bjensen@zulip.com",
+            "role": "administrator",
+        }
+        with (
+            mock.patch(
+                "zerver.lib.scim.do_change_user_role", side_effect=Exception("simulated failure")
+            ),
+            self.assertLogs("django_scim.views", "ERROR") as mock_scim_logger,
+            self.assertLogs("django.request", "ERROR"),
+        ):
+            result = self.json_put(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
+        self.assertEqual(result.status_code, 500)
+        self.assertIn("simulated failure", mock_scim_logger.output[0])
+
+        hamlet.refresh_from_db()
+        self.assertEqual(hamlet.delivery_email, original_email)
+        self.assertEqual(hamlet.role, UserProfile.ROLE_MEMBER)
+
     def test_put_deactivate_reactivate_user(self) -> None:
         hamlet = self.example_user("hamlet")
         # This payload flips the active attribute to deactivate the user.


### PR DESCRIPTION
<!-- Describe your pull request here.-->

`ZulipSCIMUser.save()` applied a SCIM update (full name, email, role,
active status, custom profile fields) as a sequence of independently
committed calls instead of one transaction. The code had a TODO
explaining this was intentional, because `do_deactivate_user` used to
delete the user's sessions in a way that was unsafe to nest inside an
outer transaction. That's no longer true: `do_deactivate_user` now
defers the session deletion via `transaction.on_commit`, which
correctly waits for the outermost transaction to commit. I checked
every other function called from `save()` and confirmed they're
already decorated with `@transaction.atomic(savepoint=False)` and
only send events via `send_event_on_commit`, so they compose safely
under an outer transaction.

I wrap the update path in `transaction.atomic(savepoint=True)`,
explicitly using a savepoint rather than `savepoint=False` (the
convention used by the action functions above). That's because
`django_scim.views.SCIMView.dispatch` catches any exception raised
from `save()`, logs it, and returns a normal error `HttpResponse`
without re-raising -- request processing continues normally
afterward. Without a savepoint, a failure here would leave the
connection's outer transaction needing a rollback that nothing later
in the request performs, breaking any further database access for
the rest of the request. This mirrors the existing precedent in
`zproject/backends.py`'s `_get_or_create_user` for the same reason.

Fixes: #39869

**How changes were tested:**

I don't have a provisioned Zulip dev environment in my current
sandbox (no Postgres/RabbitMQ available), so I wasn't able to run
`./tools/test-backend` or `./tools/lint` locally. Instead I:

- Read through every function called from the new `atomic()` block
  (`do_change_user_delivery_email`, `do_change_user_role`,
  `do_reactivate_user`, `do_deactivate_user`,
  `do_update_user_custom_profile_data_if_changed`) to confirm none of
  them depend on running as the outermost transaction.
- Added `test_put_change_fails_atomically`, which forces
  `do_change_user_role` to raise after the email change has already
  run, and asserts neither change was persisted.
- Fetched the actual `django-scim2` v0.19.1 source (the version
  pinned in `uv.lock`) to confirm `SCIMView.dispatch`'s exception
  handling, rather than guessing at it -- this is what led me to use
  `savepoint=True` instead of `savepoint=False`.
- Ran `ruff check` and `ruff format --check` on the changed files
  directly (both pass).
- Iterated against CI on this PR: an earlier version of this change
  used `savepoint=False`, which passed locally-available checks but
  failed backend tests with `TransactionManagementError`, exposing
  the issue described above. All backend test jobs (Debian 12/13,
  Ubuntu 22.04/24.04/26.04) now pass, along with the custom lint rule
  in `tools/linter_lib/custom_check.py` that requires an explicit
  `durable=` or `savepoint=` argument on `transaction.atomic()`.

**Screenshots and screen captures:**

N/A -- backend-only change, no UI affected.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
