### PR TITLE
Fix incorrect workplace users count in `USER_CREATED` and `USER_ROLE_CHANGED` audit log entries.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -557,18 +557,6 @@ def do_create_user(
     event_time = user_profile.date_joined
     if not acting_user:
         acting_user = user_profile
-    RealmAuditLog.objects.create(
-        realm=user_profile.realm,
-        acting_user=acting_user,
-        modified_user=user_profile,
-        event_type=AuditLogEventType.USER_CREATED,
-        event_time=event_time,
-        extra_data={
-            RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
-        },
-    )
-    maybe_enqueue_audit_log_upload(user_profile.realm)
-
     if realm_creation:
         # If this user just created a realm, make sure they are
         # properly tagged as the creator of the realm.
@@ -581,22 +569,12 @@ def do_create_user(
         realm_creation_audit_log.acting_user = user_profile
         realm_creation_audit_log.save(update_fields=["acting_user"])
 
-    if settings.BILLING_ENABLED:
-        billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
-        billing_session.update_license_ledger_if_needed(event_time)
-
     system_user_group = get_system_user_group_for_user(user_profile)
     UserGroupMembership.objects.create(user_profile=user_profile, user_group=system_user_group)
-    RealmAuditLog.objects.create(
-        realm=user_profile.realm,
-        modified_user=user_profile,
-        modified_user_group=system_user_group,
-        event_type=AuditLogEventType.USER_GROUP_DIRECT_USER_MEMBERSHIP_ADDED,
-        event_time=event_time,
-        acting_user=acting_user,
+    is_new_full_member = (
+        user_profile.role == UserProfile.ROLE_MEMBER and not user_profile.is_provisional_member
     )
-
-    if user_profile.role == UserProfile.ROLE_MEMBER and not user_profile.is_provisional_member:
+    if is_new_full_member:
         full_members_system_group = NamedUserGroup.objects.get(
             name=SystemGroups.FULL_MEMBERS,
             realm_for_sharding=user_profile.realm,
@@ -605,6 +583,30 @@ def do_create_user(
         UserGroupMembership.objects.create(
             user_profile=user_profile, user_group=full_members_system_group
         )
+
+    # These are recorded only once the system group memberships above
+    # have been created, because realm_user_count_by_role counts the
+    # workplace users from memberships of realm.workplace_users_group,
+    # for cases where we cannot compute it directly from role counts.
+    RealmAuditLog.objects.create(
+        realm=user_profile.realm,
+        acting_user=acting_user,
+        modified_user=user_profile,
+        event_type=AuditLogEventType.USER_CREATED,
+        event_time=event_time,
+        extra_data={
+            RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
+        },
+    )
+    RealmAuditLog.objects.create(
+        realm=user_profile.realm,
+        modified_user=user_profile,
+        modified_user_group=system_user_group,
+        event_type=AuditLogEventType.USER_GROUP_DIRECT_USER_MEMBERSHIP_ADDED,
+        event_time=event_time,
+        acting_user=acting_user,
+    )
+    if is_new_full_member:
         RealmAuditLog.objects.create(
             realm=user_profile.realm,
             modified_user=user_profile,
@@ -613,13 +615,18 @@ def do_create_user(
             event_time=event_time,
             acting_user=acting_user,
         )
+    maybe_enqueue_audit_log_upload(user_profile.realm)
+
+    if settings.BILLING_ENABLED:
+        billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
+        billing_session.update_license_ledger_if_needed(event_time)
 
     # Note that for bots, the caller will send an additional event
     # with bot-specific info like services.
     notify_created_user(user_profile, [])
 
     do_send_user_group_members_update_event("add_members", system_user_group, [user_profile.id])
-    if user_profile.role == UserProfile.ROLE_MEMBER and not user_profile.is_provisional_member:
+    if is_new_full_member:
         do_send_user_group_members_update_event(
             "add_members", full_members_system_group, [user_profile.id]
         )

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -629,7 +629,11 @@ def do_change_user_role(
 
     user_profile.role = value
     user_profile.save(update_fields=["role"])
-    RealmAuditLog.objects.create(
+    # ROLE_COUNT is filled in at the end of this function, once the system
+    # group memberships below have been updated; see the comment there. The
+    # entry itself is created here so that it precedes the audit log entries
+    # for those membership updates.
+    role_changed_audit_log = RealmAuditLog.objects.create(
         realm=user_profile.realm,
         modified_user=user_profile,
         acting_user=acting_user,
@@ -638,15 +642,8 @@ def do_change_user_role(
         extra_data={
             RealmAuditLog.OLD_VALUE: old_value,
             RealmAuditLog.NEW_VALUE: value,
-            RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
         },
     )
-    maybe_enqueue_audit_log_upload(user_profile.realm)
-    if settings.BILLING_ENABLED and UserProfile.ROLE_GUEST in [old_value, value]:
-        from corporate.lib.stripe import RealmBillingSession
-
-        billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
-        billing_session.update_license_ledger_if_needed(timezone_now())
 
     event = dict(
         type="realm_user", op="update", person=dict(user_id=user_profile.id, role=user_profile.role)
@@ -701,6 +698,22 @@ def do_change_user_role(
         update_users_in_full_members_system_group(
             user_profile.realm, [user_profile.id], acting_user=acting_user
         )
+
+    # realm_user_count_by_role counts the workplace users from
+    # memberships of realm.workplace_users_group, for cases where
+    # we cannot compute it directly from role counts. So the count
+    # is only correct once every membership update above has run.
+    role_changed_audit_log.extra_data[RealmAuditLog.ROLE_COUNT] = realm_user_count_by_role(
+        user_profile.realm
+    )
+    role_changed_audit_log.save(update_fields=["extra_data"])
+
+    maybe_enqueue_audit_log_upload(user_profile.realm)
+    if settings.BILLING_ENABLED and UserProfile.ROLE_GUEST in [old_value, value]:
+        from corporate.lib.stripe import RealmBillingSession
+
+        billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
+        billing_session.update_license_ledger_if_needed(timezone_now())
 
     send_stream_events_for_role_update(user_profile, previously_accessible_streams)
 

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -625,7 +625,11 @@ def do_change_user_role(
 
     user_profile.role = value
     user_profile.save(update_fields=["role"])
-    RealmAuditLog.objects.create(
+    # ROLE_COUNT is filled in at the end of this function, once the system
+    # group memberships below have been updated; see the comment there. The
+    # entry itself is created here so that it precedes the audit log entries
+    # for those membership updates.
+    role_changed_audit_log = RealmAuditLog.objects.create(
         realm=user_profile.realm,
         modified_user=user_profile,
         acting_user=acting_user,
@@ -634,15 +638,8 @@ def do_change_user_role(
         extra_data={
             RealmAuditLog.OLD_VALUE: old_value,
             RealmAuditLog.NEW_VALUE: value,
-            RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
         },
     )
-    maybe_enqueue_audit_log_upload(user_profile.realm)
-    if settings.BILLING_ENABLED and UserProfile.ROLE_GUEST in [old_value, value]:
-        from corporate.lib.stripe import RealmBillingSession
-
-        billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
-        billing_session.update_license_ledger_if_needed(timezone_now())
 
     event = dict(
         type="realm_user", op="update", person=dict(user_id=user_profile.id, role=user_profile.role)
@@ -697,6 +694,22 @@ def do_change_user_role(
         update_users_in_full_members_system_group(
             user_profile.realm, [user_profile.id], acting_user=acting_user
         )
+
+    # realm_user_count_by_role counts the workplace users from
+    # memberships of realm.workplace_users_group, for cases where
+    # we cannot compute it directly from role counts. So the count
+    # is only correct once every membership update above has run.
+    role_changed_audit_log.extra_data[RealmAuditLog.ROLE_COUNT] = realm_user_count_by_role(
+        user_profile.realm
+    )
+    role_changed_audit_log.save(update_fields=["extra_data"])
+
+    maybe_enqueue_audit_log_upload(user_profile.realm)
+    if settings.BILLING_ENABLED and UserProfile.ROLE_GUEST in [old_value, value]:
+        from corporate.lib.stripe import RealmBillingSession
+
+        billing_session = RealmBillingSession(user=user_profile, realm=user_profile.realm)
+        billing_session.update_license_ledger_if_needed(timezone_now())
 
     send_stream_events_for_role_update(user_profile, previously_accessible_streams)
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -2007,6 +2007,96 @@ class TestRealmAuditLog(ZulipTestCase):
             .count(),
         )
 
+    def test_workplace_users_count_when_creating_user(self) -> None:
+        """
+        This test checks that the USER_CREATED RealmAuditLog entry
+        is created after the group memberships are updated so that
+        the workplace users count in ROLE_COUNT is correct.
+        """
+        realm = get_realm("zulip")
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are enough to compute workplace
+        # users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", moderators_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        user_profile = do_create_user(
+            "moderators@zulip.com", "password", realm, "Moderators case", acting_user=None
+        )
+        user_created_audit_log = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_CREATED,
+        ).latest("id")
+        self.assertEqual(
+            user_created_audit_log.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are not enough and group membership
+        # is used to compute workplace users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", full_members_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        user_profile = do_create_user(
+            "full-members@zulip.com", "password", realm, "Full members case", acting_user=None
+        )
+        user_created_audit_log = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_CREATED,
+        ).latest("id")
+        self.assertEqual(
+            user_created_audit_log.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check with workplace_users_group set to an anonymous group.
+        do_change_realm_permission_group_setting(
+            realm,
+            "workplace_users_group",
+            self.create_or_update_anonymous_group_for_setting([], [members_group]),
+            acting_user=None,
+        )
+        realm.refresh_from_db()
+        user_profile = do_create_user(
+            "anonymous@zulip.com", "password", realm, "Anonymous group case", acting_user=None
+        )
+        user_created_audit_log = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_CREATED,
+        ).latest("id")
+        self.assertEqual(
+            user_created_audit_log.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
     def test_workplace_users_group_changed_entries_on_updating_group_memberships(self) -> None:
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -2006,6 +2006,95 @@ class TestRealmAuditLog(ZulipTestCase):
             .count(),
         )
 
+    def test_workplace_users_count_when_creating_user(self) -> None:
+        """
+        Verify that the USER_CREATED audit log entry records the
+        correct workplace_users count in its ROLE_COUNT extra_data.
+        """
+        realm = get_realm("zulip")
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are enough to compute workplace
+        # users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", moderators_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        user_profile = do_create_user(
+            "moderators@zulip.com", "password", realm, "Moderators case", acting_user=None
+        )
+        user_created_audit_log = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_CREATED,
+        ).latest("id")
+        self.assertEqual(
+            user_created_audit_log.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are not enough and group membership
+        # is used to compute workplace users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", full_members_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        user_profile = do_create_user(
+            "full-members@zulip.com", "password", realm, "Full members case", acting_user=None
+        )
+        user_created_audit_log = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_CREATED,
+        ).latest("id")
+        self.assertEqual(
+            user_created_audit_log.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check with workplace_users_group set to an anonymous group.
+        do_change_realm_permission_group_setting(
+            realm,
+            "workplace_users_group",
+            self.create_or_update_anonymous_group_for_setting([], [members_group]),
+            acting_user=None,
+        )
+        realm.refresh_from_db()
+        user_profile = do_create_user(
+            "anonymous@zulip.com", "password", realm, "Anonymous group case", acting_user=None
+        )
+        user_created_audit_log = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_CREATED,
+        ).latest("id")
+        self.assertEqual(
+            user_created_audit_log.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
     def test_workplace_users_group_changed_entries_on_updating_group_memberships(self) -> None:
         hamlet = self.example_user("hamlet")
         othello = self.example_user("othello")

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -92,7 +92,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_test_image_file
 from zerver.lib.types import LinkifierDict, RealmPlaygroundDict
 from zerver.lib.upload import get_emoji_url
-from zerver.lib.user_groups import get_group_setting_value_for_api
+from zerver.lib.user_groups import get_group_setting_value_for_api, get_recursive_group_members
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
     Message,
@@ -1918,6 +1918,94 @@ class TestRealmAuditLog(ZulipTestCase):
         self.check_role_count_schema(audit_log_entries[1].extra_data[RealmAuditLog.ROLE_COUNT])
         self.assertNotIn(RealmAuditLog.OLD_VALUE, audit_log_entries[1].extra_data)
         self.assertEqual(audit_log_entries[1].extra_data["trigger"], "setting_changed")
+
+    def test_workplace_users_count_when_changing_role(self) -> None:
+        """
+        This test checks that the ROLE_COUNT data in USER_ROLE_CHANGED
+        RealmAuditLog entry is computed after group memberships are
+        updates so that the workplace users count is correct.
+        """
+        realm = get_realm("zulip")
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
+        )
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are enough to compute workplace
+        # users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", moderators_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        do_change_user_role(
+            user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None, notify=False
+        )
+        role_changed_entry = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_ROLE_CHANGED,
+        ).latest("id")
+        self.assertEqual(
+            role_changed_entry.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are not enough and group membership
+        # is used to compute workplace users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", full_members_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        do_change_user_role(user_profile, UserProfile.ROLE_GUEST, acting_user=None, notify=False)
+        role_changed_entry = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_ROLE_CHANGED,
+        ).latest("id")
+        self.assertEqual(
+            role_changed_entry.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check with workplace_users_group set to an anonymous group.
+        do_change_realm_permission_group_setting(
+            realm,
+            "workplace_users_group",
+            self.create_or_update_anonymous_group_for_setting([], [members_group]),
+            acting_user=None,
+        )
+        realm.refresh_from_db()
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None, notify=False)
+        role_changed_entry = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_ROLE_CHANGED,
+        ).latest("id")
+        self.assertEqual(
+            role_changed_entry.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
 
     def test_workplace_users_group_changed_entries_on_updating_group_memberships(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -92,7 +92,7 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_test_image_file
 from zerver.lib.types import LinkifierDict, RealmPlaygroundDict
 from zerver.lib.upload import get_emoji_url
-from zerver.lib.user_groups import get_group_setting_value_for_api
+from zerver.lib.user_groups import get_group_setting_value_for_api, get_recursive_group_members
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
     Message,
@@ -1918,6 +1918,93 @@ class TestRealmAuditLog(ZulipTestCase):
         self.check_role_count_schema(audit_log_entries[1].extra_data[RealmAuditLog.ROLE_COUNT])
         self.assertNotIn(RealmAuditLog.OLD_VALUE, audit_log_entries[1].extra_data)
         self.assertEqual(audit_log_entries[1].extra_data["trigger"], "setting_changed")
+
+    def test_workplace_users_count_when_changing_role(self) -> None:
+        """
+        Verify that the USER_ROLE_CHANGED audit log entry records the
+        correct workplace_users count in its ROLE_COUNT extra_data.
+        """
+        realm = get_realm("zulip")
+        user_profile = self.example_user("hamlet")
+        self.assertEqual(user_profile.role, UserProfile.ROLE_MEMBER)
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
+        )
+        full_members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.FULL_MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are enough to compute workplace
+        # users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", moderators_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        do_change_user_role(
+            user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None, notify=False
+        )
+        role_changed_entry = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_ROLE_CHANGED,
+        ).latest("id")
+        self.assertEqual(
+            role_changed_entry.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check when workplace_users_group is set to a system group
+        # where just role counts are not enough and group membership
+        # is used to compute workplace users count.
+        do_change_realm_permission_group_setting(
+            realm, "workplace_users_group", full_members_group, acting_user=None
+        )
+        realm.refresh_from_db()
+        do_change_user_role(user_profile, UserProfile.ROLE_GUEST, acting_user=None, notify=False)
+        role_changed_entry = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_ROLE_CHANGED,
+        ).latest("id")
+        self.assertEqual(
+            role_changed_entry.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
+
+        # Check with workplace_users_group set to an anonymous group.
+        do_change_realm_permission_group_setting(
+            realm,
+            "workplace_users_group",
+            self.create_or_update_anonymous_group_for_setting([], [members_group]),
+            acting_user=None,
+        )
+        realm.refresh_from_db()
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None, notify=False)
+        role_changed_entry = RealmAuditLog.objects.filter(
+            realm=realm,
+            modified_user=user_profile,
+            event_type=AuditLogEventType.USER_ROLE_CHANGED,
+        ).latest("id")
+        self.assertEqual(
+            role_changed_entry.extra_data[RealmAuditLog.ROLE_COUNT][
+                RealmAuditLog.ROLE_COUNT_HUMANS
+            ]["workplace_users"],
+            get_recursive_group_members(realm.workplace_users_group_id)
+            .filter(is_bot=False, is_active=True)
+            .count(),
+        )
 
     def test_workplace_users_group_changed_entries_on_updating_group_memberships(self) -> None:
         hamlet = self.example_user("hamlet")


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit fixes the `USER_ROLE_CHANGED` case.
- Second commit fixes the `USER_CREATED` case.

<!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
