### PR TITLE
[ai] uploads: Tolerate filenames with an absurdly long extension.

### DIFF
--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -225,6 +225,31 @@ def store_message_attachment(
     )
 
 
+# Most Linux filesystems limit each component of a path to 255 bytes,
+# and we store uploaded files with their sanitized name as the last
+# component of the path.
+MAX_FILE_NAME_LENGTH = 255
+
+
+def truncate_file_name(file_name: str, max_length: int) -> str:
+    """Truncates a file name to at most max_length bytes, preserving its
+    extension if that leaves room for the rest of the name.
+    """
+    if len(file_name.encode()) <= max_length:
+        return file_name
+
+    stem, extension = os.path.splitext(file_name)
+    if len(extension.encode()) >= max_length:
+        # The extension alone is too long to preserve, so truncate the
+        # name as a whole instead.
+        stem, extension = file_name, ""
+
+    # Slicing the encoded name can cut a multi-byte character in half;
+    # errors="ignore" discards such a partial character.
+    stem_length = max_length - len(extension.encode())
+    return stem.encode()[:stem_length].decode(errors="ignore") + extension
+
+
 def sanitize_name(value: str, *, strict: bool = False) -> str:
     """Sanitizes a value to be safe to store in a Linux filesystem, in
     S3, and in a URL.  So Unicode is allowed, but not special
@@ -239,6 +264,7 @@ def sanitize_name(value: str, *, strict: bool = False) -> str:
     * adding '.' to the list of allowed characters.
     * preserving the case of the value.
     * not stripping trailing dashes and underscores.
+    * limiting the length of the result.
 
     """
     if strict:
@@ -247,6 +273,11 @@ def sanitize_name(value: str, *, strict: bool = False) -> str:
         value = unicodedata.normalize("NFKC", value)
         value = re.sub(r"[^\w\s.-]", "", value).strip()
     value = re.sub(r"[-\s]+", "-", value)
+
+    # NFKC normalization can make the value considerably longer -- a
+    # single character can normalize to dozens of them -- so this has
+    # to happen after normalizing, not to the caller's value.
+    value = truncate_file_name(value, MAX_FILE_NAME_LENGTH)
 
     # Django's MultiPartParser never returns files named this, but we
     # could get them after removing spaces; change the name to a safer

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -2,7 +2,7 @@ import os
 import re
 import tempfile
 from datetime import timedelta
-from io import StringIO
+from io import BytesIO, StringIO
 from unittest import mock
 from unittest.mock import patch
 from urllib.parse import quote
@@ -52,6 +52,7 @@ from zerver.lib.upload.s3 import S3UploadBackend
 from zerver.models import Attachment, Message, OnboardingStep, Realm, RealmDomain, UserProfile
 from zerver.models.realms import get_realm
 from zerver.models.users import get_system_bot, get_user_by_delivery_email
+from zerver.upload_handler import TEMPORARY_FILE_MAX_EXTENSION_LENGTH, truncate_filename_extension
 
 
 class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
@@ -2247,6 +2248,51 @@ class EmojiTest(UploadSerializeMixin, ZulipTestCase):
             result = self.client_post("/json/realm/emoji/new", {"f1": f})
             self.assert_json_error(result, "Image size exceeds limit")
             resize_mock.assert_called_once()
+
+
+class TemporaryFileUploadExtensionTests(ZulipTestCase):
+    def make_file(self, filename: str) -> BytesIO:
+        # We cannot use SimpleUploadedFile here, because Django truncates the
+        # name of an UploadedFile to 255 characters, which is precisely the
+        # sanitization we want to test happening without.
+        uploaded_file = BytesIO(b"zulip!")
+        uploaded_file.name = filename
+        return uploaded_file
+
+    def test_truncate_filename_extension(self) -> None:
+        self.assertEqual(truncate_filename_extension("test.txt"), "test.txt")
+        self.assertEqual(truncate_filename_extension("no_extension"), "no_extension")
+        self.assertEqual(truncate_filename_extension("tarball.tar.gz"), "tarball.tar.gz")
+
+        # A long extension is truncated, leaving the rest of the name alone.
+        truncated = truncate_filename_extension("test." + "a" * 300)
+        self.assertEqual(truncated, "test." + "a" * (TEMPORARY_FILE_MAX_EXTENSION_LENGTH - 1))
+
+        # Truncation happens on encoded bytes, and never leaves a character
+        # partially encoded. Each snowman takes 3 bytes, so 78 of them plus
+        # the "." fit in the 237 bytes available.
+        truncated = truncate_filename_extension("test." + "☃" * 200)
+        self.assertEqual(truncated, "test." + "☃" * 78)
+
+    def test_upload_file_with_long_extension(self) -> None:
+        self.login("hamlet")
+        result = self.client_post(
+            "/json/user_uploads", {"file": self.make_file("test." + "a" * 300)}
+        )
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(
+            "test." + "a" * (TEMPORARY_FILE_MAX_EXTENSION_LENGTH - 1), response_dict["filename"]
+        )
+
+    def test_multipart_request_to_nonexistent_endpoint(self) -> None:
+        # Our logging middleware parses the request body looking for a
+        # "client" parameter before the URL has been resolved, so a filename
+        # too long to spool to disk raised an unhandled OSError (500), rather
+        # than the 404. See #39874 description for details.
+        result = self.client_post(
+            "/json/nonexistent_endpoint", {"file": self.make_file("test." + "a" * 300)}
+        )
+        self.assertEqual(result.status_code, 404)
 
 
 class SanitizeNameTests(ZulipTestCase):

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -45,7 +45,7 @@ from zerver.lib.test_helpers import (
     get_test_image_file,
     ratelimit_rule,
 )
-from zerver.lib.upload import sanitize_name, upload_message_attachment
+from zerver.lib.upload import MAX_FILE_NAME_LENGTH, sanitize_name, upload_message_attachment
 from zerver.lib.upload.base import ZulipUploadBackend
 from zerver.lib.upload.local import LocalUploadBackend
 from zerver.lib.upload.s3 import S3UploadBackend
@@ -2309,6 +2309,15 @@ class SanitizeNameTests(ZulipTestCase):
         self.assertEqual(
             sanitize_name('~/."\\`\\?*"u0`000ssh/test.t**{}ar.gz'), ".u0000sshtest.tar.gz"
         )
+
+    def test_long_file_name(self) -> None:
+        self.assertEqual(sanitize_name("a" * 300 + ".txt"), "a" * 251 + ".txt")
+        self.assertEqual(sanitize_name("test." + "a" * 300), "test." + "a" * 250)
+        # Truncation counts bytes, not characters.
+        self.assertEqual(sanitize_name("테" * 100 + ".txt"), "테" * 83 + ".txt")
+        # A single character can normalize to many more, so the result
+        # has to be measured after normalizing rather than before.
+        self.assertEqual(len(sanitize_name("ﷺ" * 79).encode()), MAX_FILE_NAME_LENGTH)
 
 
 class UploadSpaceTests(UploadSerializeMixin, ZulipTestCase):

--- a/zerver/upload_handler.py
+++ b/zerver/upload_handler.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+
+from django.core.files.uploadhandler import TemporaryFileUploadHandler
+from typing_extensions import override
+
+# Django spools each uploaded file to a temporary file named
+# f"{tempfile.gettempprefix()}{8 random characters}.upload{extension}",
+# where the extension is taken verbatim from the client-provided filename.
+#
+# Since a filename is limited to NAME_MAX (255) bytes, a sufficiently
+# long extension makes creating that temporary file fail with
+# 'OSError: [Errno 36] File name too long', which Django does not handle.
+TEMPORARY_FILE_MAX_EXTENSION_LENGTH = 255 - len(tempfile.gettempprefix()) - 8 - len(".upload")
+
+
+def truncate_filename_extension(filename: str) -> str:
+    """Shortens filename extensions that are too long to fit in the name of
+    the temporary file Django spools an upload to. NAME_MAX limits bytes
+    rather than characters, so we truncate the encoded extension and discard
+    any character left partially encoded at the end.
+    """
+    root, extension = os.path.splitext(filename)
+    encoded_extension = extension.encode()
+    if len(encoded_extension) <= TEMPORARY_FILE_MAX_EXTENSION_LENGTH:
+        return filename
+    return root + encoded_extension[:TEMPORARY_FILE_MAX_EXTENSION_LENGTH].decode(errors="ignore")
+
+
+class ZulipTemporaryFileUploadHandler(TemporaryFileUploadHandler):
+    """Django's TemporaryFileUploadHandler, made tolerant of filenames whose
+    extension alone exceeds what the filesystem allows in a filename.
+
+    Django does sanitize an over-long filename, in UploadedFile._set_name,
+    but only after creating the temporary file whose name embeds the
+    extension; shortening the extension is therefore something we have to do
+    beforehand. The cap is far longer than any extension in practice.
+    """
+
+    @override
+    def new_file(
+        self,
+        field_name: str,
+        file_name: str,
+        content_type: str,
+        content_length: int | None,
+        charset: str | None = None,
+        content_type_extra: dict[str, bytes] | None = None,
+    ) -> None:
+        super().new_file(
+            field_name,
+            truncate_filename_extension(file_name),
+            content_type,
+            content_length,
+            charset,
+            content_type_extra,
+        )

--- a/zerver/upload_handler.py
+++ b/zerver/upload_handler.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+
+from django.core.files.uploadhandler import TemporaryFileUploadHandler
+from typing_extensions import override
+
+# Django spools each uploaded file to a temporary file named
+# f"{tempfile.gettempprefix()}{8 random characters}.upload{extension}",
+# where the extension is taken verbatim from the client-provided filename.
+#
+# Since a filename is limited to NAME_MAX (255) bytes, a sufficiently
+# long extension makes creating that temporary file fail with
+# 'OSError: [Errno 36] File name too long', which Django does not handle.
+TEMPORARY_FILE_MAX_EXTENSION_LENGTH = 255 - len(tempfile.gettempprefix()) - 8 - len(".upload")
+
+
+def truncate_filename_extension(filename: str) -> str:
+    """Shortens filename extensions that are too long to fit in the name of
+    the temporary file Django spools an upload to. NAME_MAX limits bytes
+    rather than characters, so we truncate the encoded extension and discard
+    any character left partially encoded at the end.
+    """
+    root, extension = os.path.splitext(filename)
+    encoded_extension = extension.encode()
+    if len(encoded_extension) <= TEMPORARY_FILE_MAX_EXTENSION_LENGTH:
+        return filename
+    return root + encoded_extension[:TEMPORARY_FILE_MAX_EXTENSION_LENGTH].decode(errors="ignore")
+
+
+class ZulipTemporaryFileUploadHandler(TemporaryFileUploadHandler):
+    """Django's TemporaryFileUploadHandler, made tolerant of filenames whose
+    extension alone exceeds what the filesystem allows in a filename.
+
+    Django does sanitize an over-long filename, in UploadedFile._set_name,
+    but only after creating the temporary file whose name embeds the
+    extension; shortening the extension is therefore something we have to do
+    beforehand. The cap is far longer than any extension in practice.
+
+    This workaround can go away once https://code.djangoproject.com/ticket/37292
+    is fixed upstream.
+    """
+
+    @override
+    def new_file(
+        self,
+        field_name: str,
+        file_name: str,
+        content_type: str,
+        content_length: int | None,
+        charset: str | None = None,
+        content_type_extra: dict[str, bytes] | None = None,
+    ) -> None:
+        super().new_file(
+            field_name,
+            truncate_filename_extension(file_name),
+            content_type,
+            content_length,
+            charset,
+            content_type_extra,
+        )

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -634,6 +634,13 @@ LOCALE_PATHS = (os.path.join(DEPLOY_ROOT, "locale"),)
 # We want all temporary uploaded files to be stored on disk.
 FILE_UPLOAD_MAX_MEMORY_SIZE = 0
 
+# Django's default handlers, with the temporary file handler replaced by our
+# subclass that does not crash on a filename with a very long extension.
+FILE_UPLOAD_HANDLERS = [
+    "django.core.files.uploadhandler.MemoryFileUploadHandler",
+    "zerver.upload_handler.ZulipTemporaryFileUploadHandler",
+]
+
 if DEVELOPMENT or "ZULIP_COLLECTING_STATIC" in os.environ:
     STATICFILES_DIRS = [os.path.join(DEPLOY_ROOT, "static")]
 


### PR DESCRIPTION
### Summary

Middleware processing a request with uploaded file, having a very long filename extension (> 237 bytes) was resulting in `OSError: [Errno 36] File name too long`

To replicate in dev:
```
LONG=$(python3 -c 'print("a"*300)')

curl -sS -o /dev/null -w 'status: %{http_code}\n' \
-F "file=@/etc/hostname;filename=test.$LONG" \
http://localhost:9991/json/nonexistent_endpoint
```

The fix should be included ideally in django upstream - TemporaryUploadedFile.

This PR adds a new handler subclassing `TemporaryFileUploadHandler` which truncates filename extension early on, to avoid error related to it.

---

### Traceback

`LogRequests` middleware parses client using `parse_client(request)`.

`parse_client` has `typed_endpoint` decorator, which looks for `client` in `request.POST`. This line specifically:
```py
if current_alias in request.POST:
```

- `request.POST` getter calls [`_load_post_and_files()`](https://github.com/django/django/blob/5637bec7a033d67407694316bdda74304449488e/django/core/handlers/wsgi.py#L93).
- which calls [`parse_file_upload`](https://github.com/django/django/blob/5637bec7a033d67407694316bdda74304449488e/django/http/request.py#L469), when `content_type == "multipart/form-data"`
- which calls [`handler.new_file()`](https://github.com/django/django/blob/5637bec7a033d67407694316bdda74304449488e/django/http/multipartparser.py#L291) on each handler in `FILE_UPLOAD_HANDLERS`.

With `FILE_UPLOAD_MAX_MEMORY_SIZE = 0`, `TemporaryFileUploadHandler` is the only active handler in `FILE_UPLOAD_HANDLERS`.

- [`TemporaryFileUploadHandler.new_file`](https://github.com/django/django/blob/5637bec7a033d67407694316bdda74304449488e/django/core/files/uploadhandler.py#L167) constructs [`TemporaryUploadedFile`](https://github.com/django/django/blob/5637bec7a033d67407694316bdda74304449488e/django/core/files/uploadedfile.py#L79)

```py
class TemporaryUploadedFile(UploadedFile):
    """
    A file uploaded to a temporary location (i.e. stream-to-disk).
    """

    def __init__(self, name, content_type, size, charset, content_type_extra=None):
        _, ext = os.path.splitext(name)
        file = tempfile.NamedTemporaryFile(
            suffix=".upload" + ext, dir=settings.FILE_UPLOAD_TEMP_DIR
        )
        super().__init__(file, name, content_type, size, charset, content_type_extra)
```

- We pass `suffix=".upload" + ext` to `tempfile.NamedTemporaryFile()` -- see above codeblock.

A long `ext` means long `suffix`.

Bug: `tempfile` [joins "tmp" + 8 random chars + that suffix](https://github.com/python/cpython/blob/5918085bb6f4a3a48193cacb9bb99b044d4e0452/Lib/tempfile.py#L253) to get filename, **a very long suffix results in `OSError` when trying to open the file**.




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
