### PR TITLE
Update instructions for creating a WSL2 VM

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -136,7 +136,7 @@ installation method described here. We require version 0.67.6+ of WSL 2.
    previously installed other software like `node` in your WSL environment that
    might conflict with the Zulip environment.
 
-1. It is required to enable `systemd` for WSL 2 to manage the database, cache and other services.
+1. It is required to enable `systemd` for WSL 2 to manage the database, cache and other services. (This is the default setting since the [Ubuntu 23.04 release](https://canonical.com/blog/ubuntu-desktop-23-04-release-roundup#:~:text=Systemd%20becomes%20the%20default%20for%20Ubuntu%20on%20WSL))
    To configure it, please follow [these instructions](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#systemd-support).
    Then, you will need to restart WSL 2 before continuing.
 

--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -180,7 +180,7 @@ installation method described here. We require version 0.67.6+ of WSL 2.
 1. [Create a new SSH key][create-ssh-key] for the WSL 2 virtual
    machine and add it to your GitHub account. Note that SSH keys
    linked to your Windows computer will not work within the virtual
-   machine.
+   machine without additional configuration not covered in this guide.
 
 WSL 2 can be uninstalled by following [Microsoft's documentation][uninstall-wsl]
 

--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -119,8 +119,19 @@ installation method described here. We require version 0.67.6+ of WSL 2.
    which includes installing an Ubuntu WSL distribution.
 
 1. **Create a new WSL instance for Zulip development**.
-   You can refer [this article](https://cloudbytes.dev/snippets/how-to-install-multiple-instances-of-ubuntu-in-wsl2)
-   for instructions on how to do so. Using an existing instance will
+   You can create a dedicated WSL instance with the following command:
+
+   ```console
+   wsl --install Ubuntu --name zulip
+   ```
+
+   To login to that instance, if using [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/install), select it from the new tab dropdown, or run this Windows command:
+
+   ```console
+   wsl -d zulip
+   ```
+
+   Using an existing instance will
    probably work, but a fresh distribution is recommended if you
    previously installed other software like `node` in your WSL environment that
    might conflict with the Zulip environment.


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: Importing a tarball to create a separate WSL distribution is not required circa WSL 2.4.4 (pre) / 2.4.10 (release), circa [November 2024][wsl-rn]. `systemd` has been enabled by default since Ubuntu 23.04. Allude to options for plumbing an SSH agent without going into details. (Two options: [using `ssh.exe`][1p] or [`npiperelay`/`socat`][modern-agent-plumb]; personally, I had Claude Code generate instructions and an install script for me)

[wsl-rn]: (https://devblogs.microsoft.com/commandline/whats-new-in-the-windows-subsystem-for-linux-in-november-2024/)
[1p]: https://www.1password.dev/ssh/integrations/wsl#how-the-integration-works
[modern-agent-plumb]: https://github.com/rupor-github/wsl-ssh-agent#wsl2-compatibility

Possible changes:
1. Open to adding a note somewhere to do `wsl --update` either as a first step or "if commands above fail" note, but we're talking about changes released 2 years ago.

2. Also fine with removing the "enable systemd" step entirely since we're already telling users to install a fresh Ubuntu instance, which defaults to 26.04. Even if the user chooses Debian instead (which would be outside the guide!), `systemd` appears to have been the default there too since [November 2024](https://salsa.debian.org/debian/WSL/-/commit/9ff51567c14166d8983d8980422e8963fee4af6c).

3. I can polish up my`npiperelay`+`systemd` [setup repo][1] and we could link to that. 

[1]: https://github.com/lfaraone/wsl2-npipe-zulip

**How changes were tested:**

Reviewed Markdown preview in VS Code

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
