### PR TITLE
filter: add date and has-reaction to sorted_term_types levels array (Fixes #39876)

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -768,6 +768,7 @@ export class Filter {
             "sender",
             "mentions",
             "near",
+            "date",
             "id",
             "is-alerted",
             "is-mentioned",
@@ -781,6 +782,7 @@ export class Filter {
             "has-link",
             "has-image",
             "has-attachment",
+            "has-reaction",
             "search",
         ];
 


### PR DESCRIPTION
Adds the missing Tue Aug  4 15:33:16 CST 2026 and  term types to the `levels` array in `Filter.sorted_term_types()`. Previously these types received the fallback priority (999) instead of an explicit sort order.

Fixes #39876

**Changes:**
- Added `"date"` after `"near"` in the levels array
- Added `"has-reaction"` after `"has-attachment"` in the levels array