### PR TITLE
markdown: Preserve tabs in fenced code blocks.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2173,6 +2173,26 @@ def get_sub_registry(r: markdown.util.Registry[T], keys: list[str]) -> markdown.
 DEFAULT_MARKDOWN_KEY = -1
 
 
+class ZulipNormalizeWhitespace(markdown.preprocessors.Preprocessor):
+    """Normalize whitespace for consistent parsing."""
+
+    @override
+    def run(self, lines: list[str]) -> list[str]:
+        source = "\n".join(lines)
+        source = source.replace(markdown.util.STX, "").replace(markdown.util.ETX, "")
+        source = source.replace("\r\n", "\n").replace("\r", "\n") + "\n\n"
+        source = re.sub(r"(?<=\n) +\n", "\n", source)
+        return source.split("\n")
+
+
+class ExpandTabs(markdown.preprocessors.Preprocessor):
+    @override
+    def run(self, lines: list[str]) -> list[str]:
+        source = "\n".join(lines)
+        source = source.expandtabs(self.md.tab_length)
+        return source.split("\n")
+
+
 class ZulipMarkdown(markdown.Markdown):
     zulip_message: Message | None
     zulip_realm: Realm | None
@@ -2227,10 +2247,9 @@ class ZulipMarkdown(markdown.Markdown):
         # reference - references don't make sense in a chat context.
         preprocessors = markdown.util.Registry[markdown.preprocessors.Preprocessor]()
         preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 35)
-        preprocessors.register(
-            markdown.preprocessors.NormalizeWhitespace(self), "normalize_whitespace", 30
-        )
+        preprocessors.register(ZulipNormalizeWhitespace(self), "normalize_whitespace", 30)
         preprocessors.register(fenced_code.FencedBlockPreprocessor(self), "fenced_code_block", 25)
+        preprocessors.register(ExpandTabs(self), "expand_tabs", 24)
         preprocessors.register(
             AlertWordNotificationProcessor(self), "custom_text_notifications", 20
         )

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -73,6 +73,18 @@
       "text_content": "fenced code\n\ninline code"
     },
     {
+      "name": "codeblock_preserve_tabs",
+      "input": "```\nreal\t0m0.322s\n```",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>real\t0m0.322s\n</code></pre></div>",
+      "text_content": "real\t0m0.322s\n"
+    },
+    {
+      "name": "tab_indented_codeblock",
+      "input": "\tindented",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>indented\n</code></pre></div>",
+      "text_content": "indented\n"
+    },
+    {
       "name": "hanging_multi_codeblock",
       "input": "Hamlet said:\n~~~~\ndef speak(self):\n    x = 1\n# Comment to make this code block longer to test Trac #1162\n~~~~\n\nThen he mentioned ````y = 4 + x**2```` and\n~~~~\ndef foobar(self):\n    return self.baz()",
       "expected_output": "<p>Hamlet said:</p>\n<div class=\"codehilite\"><pre><span></span><code>def speak(self):\n    x = 1\n# Comment to make this code block longer to test Trac #1162\n</code></pre></div>\n<p>Then he mentioned <code>y = 4 + x**2</code> and</p>\n<div class=\"codehilite\"><pre><span></span><code>def foobar(self):\n    return self.baz()\n</code></pre></div>",


### PR DESCRIPTION
<!-- Describe your pull request here.-->

`NormalizeWhitespace` calls `expandtabs()` before `FencedBlockPreprocessor`.  As a result, tabs are converted to spaces before fenced code is processed and cannot be recovered. 

This PR uses a Zulip-specific whitespace preprocessor that omits `expandtabs()` and registers a separate tab-expansion preprocessor, named `ExpandTabs`.

This implementation builds upon PR #39728, with initial normalization occurring without tab expansion in `ZulipNormalizeWhitespace`.  This change by itself had limitations as tab-indented code blocks were being displayed as ordinary text rather than formatted code blocks as a direct result of `expandtabs()` being omitted. 

To address this, `ExpandTabs` is registered as a separate preprocessor to be run after `FencedBlockPreprocessor` which ensures that any content inside fenced code has been preserved. Any tab expansion affects only the remaining Markdown, retaining recognition for tab-indented code blocks.

With the approach relying on the priorities of `FencedBlockPreprocessor` and `ExpandTabs`, could registering tab expansion as its own preprocessor introduce concerns in the ordering as the Markdown pipeline continues to grow / change? 

Fixes: https://github.com/zulip/zulip/issues/17419#issue-817098381

**How changes were tested:**

- Backend Markdown fixture tests: `tools/test-backend zerver.tests.test_markdown.MarkdownFixtureTest.test_markdown_fixtures`
- Full backend markdown tests: `tools/test-backend zerver.tests.test_markdown`
- Frontend markdown tests: `tools/test-js-with-node markdown`
- Linting: `tools/lint zerver/lib/markdown/__init__.py zerver/tests/fixtures/markdown_test_cases.json`
- Manually verified in the development server that the behavior was showing tabs being preserved whenever a message was sent in a fenced code block.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="600" alt="Tabs before" src="https://github.com/user-attachments/assets/cdfd9b03-ec94-4084-bb65-d9b143dbe142"> | <img width="600" alt="Tabs after" src="https://github.com/user-attachments/assets/10da88d4-9c65-4963-a3f8-bdd3f24f850e"> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

**Self Review Notes** 
- **Explains differences from previous plans:** 
Checked, as the PR details why the decision to omit expandtabs() is not sufficient, along with its intended solution by registering ExpandTabs as a separate preprocessor.

- **Highlights technical choices and bugs encountered:**
Checked, as the PR describes the changes being made along with reasoning behind why they're being made

- **Calls out remaining decisions and concerns:** 
Checked.  The primary concern this PR raises has to do with the order in which preprocessors are executed.

- **Each commit is a coherent idea:**
Checked, as although the testing fixtures are not a separate commit by themselves, they are directly responsible for verifying and protecting the behavior as intended for fenced and tab-indented code blocks.

- **Visual appearance of the changes:** 
Checked, tabs are retained as demonstrated in the before and after screen captures, along with inspecting the copied text representation, verifying the intended behavior for both forms of code blocks. 

- **Responsiveness and internationalization:**
Not applicable

- **Strings and tooltips**:
Not applicable

- **End-to-end functionality of buttons, interactions, and flows:**
Checked, as the message being tested both agree through its local echo and authoritative backend rendering, along with both frontend and backend fixtures confirming consistent output

- **Corner cases, error conditions, and easily imagined bugs:**
Checked as both tab-indented code blocks and fenced code blocks are addressed in this PR.


