### PR TITLE
webhooks/slack: Handle missing file metadata for Slack Connect channels.

### DIFF
--- a/zerver/webhooks/slack/fixtures/message_with_inaccessible_file.json
+++ b/zerver/webhooks/slack/fixtures/message_with_inaccessible_file.json
@@ -1,0 +1,43 @@
+{
+  "token": "CqCsBJmXoNSHaNCt3wGWYSEe",
+  "team_id": "T06NRA6HM3P",
+  "context_team_id": "T06NRA6HM3P",
+  "context_enterprise_id": null,
+  "api_app_id": "A0757RM31HN",
+  "event": {
+    "text": "Message with a file shared from a Slack Connect channel",
+    "files": [
+      {
+        "id": "F12345678",
+        "mode": "file_access",
+        "file_access": "check_file_info",
+        "created": 0,
+        "timestamp": 0,
+        "user": ""
+      }
+    ],
+    "upload": false,
+    "user": "U06NU4E26M9",
+    "type": "message",
+    "ts": "1719209815.105159",
+    "client_msg_id": "15117486-b4e1-42a9-a553-ca2886d94222",
+    "channel": "C06NRA6JLER",
+    "subtype": "file_share",
+    "event_ts": "1719209815.105159",
+    "channel_type": "channel"
+  },
+  "type": "event_callback",
+  "event_id": "Ev079GJ5KG5A",
+  "event_time": 1719209815,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "T06NRA6HM3P",
+      "user_id": "U074G5E1ANR",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": true,
+  "event_context": "4-eyJldCI6Im1lc3NhZ2UiLCJ0aWQiOiJUMDZOUkE2SE0zUCIsImFpZCI6IkEwNzU3Uk0zMUhOIiwiY2lkIjoiQzA2TlJBNkpMRVIifQ"
+}

--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -255,6 +255,13 @@ class SlackWebhookTests(WebhookTestCase):
         )
 
     @mock_slack_api_calls
+    def test_message_with_inaccessible_file(self) -> None:
+        message_body = """Message with a file shared from a Slack Connect channel
+*Slack file F12345678*"""
+        expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
+        self.check_webhook("message_with_inaccessible_file", EXPECTED_TOPIC, expected_message)
+
+    @mock_slack_api_calls
     def test_message_with_inline_code(self) -> None:
         message_body = "`asdasda this is a code block`"
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -28,6 +28,7 @@ from zerver.lib.webhooks.common import check_send_webhook_message, get_setup_web
 from zerver.models import UserProfile
 
 FILE_LINK_TEMPLATE = "\n*[{file_name}]({file_link})*"
+FILE_ID_TEMPLATE = "\n*Slack file {file_id}*"
 ZULIP_MESSAGE_TEMPLATE = "**{sender}**: {text}"
 VALID_OPTIONS = {"SHOULD_NOT_BE_MAPPED": "0", "SHOULD_BE_MAPPED": "1"}
 
@@ -117,10 +118,13 @@ def convert_to_zulip_markdown(text: str, slack_app_token: str) -> str:
 
 
 def convert_raw_file_data(file_dict: WildValue) -> SlackFileListT:
+    # Files uploaded to Slack Connect channels arrive without their
+    # metadata. See https://docs.slack.dev/reference/objects/file-object/#slack_connect_files.
     files = [
         {
-            "file_link": file.get("permalink").tame(check_string),
-            "file_name": file.get("title").tame(check_string),
+            "file_link": file.get("permalink").tame(check_none_or(check_string)) or "",
+            "file_name": file.get("title").tame(check_none_or(check_string)) or "",
+            "file_id": file["id"].tame(check_string),
         }
         for file in file_dict
     ]
@@ -130,7 +134,8 @@ def convert_raw_file_data(file_dict: WildValue) -> SlackFileListT:
 def get_message_body(text: str, sender: str, files: SlackFileListT) -> str:
     body = ZULIP_MESSAGE_TEMPLATE.format(sender=sender, text=text)
     for file in files:
-        body += FILE_LINK_TEMPLATE.format(**file)
+        file_template = FILE_LINK_TEMPLATE if file["file_link"] else FILE_ID_TEMPLATE
+        body += file_template.format(**file)
     return body
 
 


### PR DESCRIPTION
- Sentry Error: [ValidationError: payload['event']['files'][0]['permalink'] is not a string](https://sentry.io/organizations/zulip/issues/7649439434/events/cc49ca2e8cbf4553b76245f01ac1594c/)
- Suspected cause: Files uploaded to Slack Connect channels will arrive without metadata. See https://docs.slack.dev/reference/objects/file-object/#slack_connect_files.
- Fix: Use file ID when the file metadata is missing.

Possible follow-up:
To fetch the missing file metadata, we'd need to make calls to the [`files.info`](https://docs.slack.dev/reference/methods/files.info/) endpoint, one call for each file ID. The endpoint needs the `files:read` scope, and existing Slack apps would need to be reinstalled to utilize the `SLACK_INTEGRATION_TOKEN_SCOPES`. I'm not sure if that's needed.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
