### PR TITLE
markdown: Expand tabs to 2 spaces for nested list support.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1431,9 +1431,12 @@ class AutoLink(CompiledPattern):
         return url_to_a(db_data, url)
 
 
+ZULIP_LIST_TAB_LENGTH = 2
+
+
 class OListProcessor(sane_lists.SaneOListProcessor):
     def __init__(self, parser: BlockParser) -> None:
-        parser.md.tab_length = 2
+        parser.md.tab_length = ZULIP_LIST_TAB_LENGTH
         super().__init__(parser)
         parser.md.tab_length = 4
 
@@ -1442,7 +1445,7 @@ class UListProcessor(sane_lists.SaneUListProcessor):
     """Unordered lists, but with 2-space indent"""
 
     def __init__(self, parser: BlockParser) -> None:
-        parser.md.tab_length = 2
+        parser.md.tab_length = ZULIP_LIST_TAB_LENGTH
         super().__init__(parser)
         parser.md.tab_length = 4
 
@@ -1457,7 +1460,7 @@ class ListIndentProcessor(markdown.blockprocessors.ListIndentProcessor):
         # HACK: Set the tab length to 2 just for the initialization of
         # this class, so that bulleted lists (and only bulleted lists)
         # work off 2-space indentation.
-        parser.md.tab_length = 2
+        parser.md.tab_length = ZULIP_LIST_TAB_LENGTH
         super().__init__(parser)
         parser.md.tab_length = 4
 
@@ -1526,6 +1529,94 @@ class Fence:
     is_code: bool
 
 
+LIST_ITEM_REGEX = re.compile(
+    r"""
+    ^(?P<quote>(?:[ ]*>[ ]*)*)
+    (?P<indent>[ \t]*)
+    (?P<marker>[*+-]|\d+\.)
+    [ ]+
+    (?P<content>.*)
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+PREFIXED_FENCE_RE = re.compile(
+    r"""
+    ^[ ]*(?:>[ ]*)*
+    (?P<fence>(?:~{3,}|`{3,}))
+    [ ]*
+    (?:
+        \{?\.?
+        (?P<lang>[a-zA-Z0-9_\+\.-]+)
+        [ ]*
+        (?P<header>[^ ~`][^~`]*)?
+        \}?
+    )?
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+def line_is_in_code_fence(line: str, open_fences: list[Fence]) -> bool:
+    """Update `open_fences` in place based on `line`, and return whether
+    we are currently inside a non-quote fenced code block. Shared by
+    preprocessors that need to skip fenced code while scanning lines."""
+    m = FENCE_RE.match(line) or PREFIXED_FENCE_RE.match(line)
+    if m:
+        fence_str = m.group("fence")
+        lang: str | None = m.group("lang")
+        is_code = lang not in ("quote", "quoted")
+        matches_last_fence = fence_str == open_fences[-1].fence_str if open_fences else False
+        closes_last_fence = not lang and matches_last_fence
+
+        if closes_last_fence:
+            open_fences.pop()
+        else:
+            open_fences.append(Fence(fence_str, is_code))
+
+    return any(fence.is_code for fence in open_fences)
+
+
+class TabIndentedListPreprocessor(markdown.preprocessors.Preprocessor):
+    """Convert leading tabs of tab-indented nested list items to
+    Zulip's 2-space list indentation.
+
+    This is needed because Python-Markdown's NormalizeWhitespace
+    preprocessor, which runs after this one, would expand tabs to
+    4 spaces, preventing the items from nesting under Zulip's 2-space
+    list indentation convention.
+    """
+
+    @override
+    def run(self, lines: list[str]) -> list[str]:
+        copy: list[str] = []
+        open_fences: list[Fence] = []
+        prev_quote_depth = -1
+        for line in lines:
+            in_code_fence = line_is_in_code_fence(line, open_fences)
+            if in_code_fence:
+                prev_quote_depth = -1
+            else:
+                m = LIST_ITEM_REGEX.match(line)
+                if m:
+                    quote_str = m.group("quote")
+                    quote_depth = quote_str.count(">")
+                    indent = m.group("indent")
+
+                    if prev_quote_depth == quote_depth and "\t" in indent:
+                        new_indent = indent.expandtabs(ZULIP_LIST_TAB_LENGTH)
+                        line = quote_str + new_indent + line[len(quote_str) + len(indent) :]
+
+                    prev_quote_depth = quote_depth
+                else:
+                    prev_quote_depth = -1
+            copy.append(line)
+        return copy
+
+
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     """Allows list blocks that come directly after another block
     to be rendered as a list.
@@ -1534,46 +1625,26 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     directly after a line of text, and inserts a newline between
     to satisfy Markdown"""
 
-    LI_RE = re.compile(r"^[ ]*([*+-]|\d\.)[ ]+(.*)", re.MULTILINE)
-
     @override
     def run(self, lines: list[str]) -> list[str]:
         """Insert a newline between a paragraph and ulist if missing"""
         inserts = 0
-        in_code_fence: bool = False
         open_fences: list[Fence] = []
         copy = lines[:]
         for i in range(len(lines) - 1):
-            # Ignore anything that is inside a fenced code block but not quoted.
-            # We ignore all lines where some parent is a non-quote code block.
-            m = FENCE_RE.match(lines[i])
-            if m:
-                fence_str = m.group("fence")
-                lang: str | None = m.group("lang")
-                is_code = lang not in ("quote", "quoted")
-                matches_last_fence = (
-                    fence_str == open_fences[-1].fence_str if open_fences else False
-                )
-                closes_last_fence = not lang and matches_last_fence
-
-                if closes_last_fence:
-                    open_fences.pop()
-                else:
-                    open_fences.append(Fence(fence_str, is_code))
-
-                in_code_fence = any(fence.is_code for fence in open_fences)
-
-            # If we're not in a fenced block and we detect an upcoming list
-            # hanging off any block (including a list of another type), add
-            # a newline.
-            li1 = self.LI_RE.match(lines[i])
-            li2 = self.LI_RE.match(lines[i + 1])
+            in_code_fence = line_is_in_code_fence(lines[i], open_fences)
+            li1 = LIST_ITEM_REGEX.match(lines[i])
+            li2 = LIST_ITEM_REGEX.match(lines[i + 1])
             if (
                 not in_code_fence
                 and lines[i]
                 and (
                     (li2 and not li1)
-                    or (li1 and li2 and (len(li1.group(1)) == 1) != (len(li2.group(1)) == 1))
+                    or (
+                        li1
+                        and li2
+                        and (len(li1.group("marker")) == 1) != (len(li2.group("marker")) == 1)
+                    )
                 )
             ):
                 copy.insert(i + inserts + 1, "")
@@ -2227,6 +2298,7 @@ class ZulipMarkdown(markdown.Markdown):
         # reference - references don't make sense in a chat context.
         preprocessors = markdown.util.Registry[markdown.preprocessors.Preprocessor]()
         preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 35)
+        preprocessors.register(TabIndentedListPreprocessor(self), "tab_indented_lists", 32)
         preprocessors.register(
             markdown.preprocessors.NormalizeWhitespace(self), "normalize_whitespace", 30
         )

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -55,6 +55,18 @@
       "text_content": "Hamlet once said\ndef func():\n    x = 1\n\n    y = 2\n\n    z = 3\n\nAnd all was good."
     },
     {
+      "name": "indented_codeblock",
+      "input": "\tprint(hello_world)",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>print(hello_world)\n</code></pre></div>",
+      "text_content": "print(hello_world)\n"
+    },
+    {
+      "name": "tab_indented_codeblock_after_paragraph",
+      "input": "Here is some code:\n\n\tdef f():\n\t\treturn 1",
+      "expected_output": "<p>Here is some code:</p>\n<div class=\"codehilite\"><pre><span></span><code>def f():\n    return 1\n</code></pre></div>",
+      "text_content": "Here is some code:\ndef f():\n    return 1\n"
+    },
+    {
       "name": "inline_code_spaces",
       "input": "` outer ` ```    space    ```",
       "expected_output": "<p><code> outer </code> <code>    space    </code></p>",
@@ -278,6 +290,19 @@
       "text_content": "Nested list\n\nI am outer list\nI am inner nested list first item\nI am inner nested list second item\n\n\n"
     },
     {
+      "name": "ulist_nested_ulist_tab_indent",
+      "input": "Nested list\n* I am outer list\n\t* I am inner nested list first item\n\t* I am inner nested list second item",
+      "expected_output": "<p>Nested list</p>\n<ul>\n<li>I am outer list<ul>\n<li>I am inner nested list first item</li>\n<li>I am inner nested list second item</li>\n</ul>\n</li>\n</ul>",
+      "text_content": "Nested list\n\nI am outer list\nI am inner nested list first item\nI am inner nested list second item\n\n\n"
+    },
+    {
+      "name": "codeblock_tab_indent",
+      "input": "```python\ndef foo():\n\tprint(\"hello\")\n```",
+      "expected_output": "<div class=\"codehilite\" data-code-language=\"Python\"><pre><span></span><code><span class=\"k\">def</span><span class=\"w\"> </span><span class=\"nf\">foo</span><span class=\"p\">():</span>\n    <span class=\"nb\">print</span><span class=\"p\">(</span><span class=\"s2\">\"hello\"</span><span class=\"p\">)</span>\n</code></pre></div>",
+      "marked_expected_output": "<div class=\"codehilite\" data-code-language=\"Python\"><pre><span></span><code>def foo():\n\tprint(&quot;hello&quot;)\n</code></pre></div>",
+      "text_content": "def foo():\n    print(\"hello\")\n"
+    },
+    {
       "name": "ulist_list_two_space_indent",
       "input": "* I am outer list\n  I am something inside",
       "expected_output": "<ul>\n<li>I am outer list<br>\n  I am something inside</li>\n</ul>",
@@ -398,6 +423,13 @@
       "input": "1. A\n3. B\n  2. C\n1. D",
       "expected_output": "<ol>\n<li>A</li>\n<li>B<ol start=\"2\">\n<li>C</li>\n</ol>\n</li>\n<li>D</li>\n</ol>",
       "text_content": "1. A\n2. B\n  2. C\n3. D"
+    },
+    {
+      "name": "numbered_list_double_digit",
+      "input": "8. eight\n9. nine\n   - sub item\n10. ten",
+      "expected_output": "<ol start=\"8\">\n<li>eight</li>\n<li>\n<p>nine</p>\n<ul>\n<li>sub item</li>\n</ul>\n</li>\n<li>\n<p>ten</p>\n</li>\n</ol>",
+      "marked_expected_output": "<ol start=\"8\">\n<li>eight</li>\n<li>nine<ul>\n<li>sub item</li>\n</ul>\n</li>\n<li>ten</li>\n</ol>",
+      "text_content": "8. eight\n9. nine\n\nsub item\n10. ten"
     },
     {
       "name": "linkify_interference",

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -39,6 +39,7 @@ from zerver.lib.markdown import (
     InlineInterestingLinkProcessor,
     MarkdownListPreprocessor,
     MessageRenderingResult,
+    TabIndentedListPreprocessor,
     clear_web_link_regex_for_testing,
     content_has_emoji_syntax,
     image_preview_enabled,
@@ -477,6 +478,80 @@ class MarkdownMiscTest(ZulipTestCase):
             self.assertEqual(render_tex("foo"), "<i>html</i>")
 
 
+class TabIndentedListPreprocessorTest(ZulipTestCase):
+    def test_single_level_nesting(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["- outer", "\t- inner"]
+        expected = ["- outer", "  - inner"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_multi_level_nesting(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["- outer", "\t- inner", "\t\t- deep"]
+        expected = ["- outer", "  - inner", "    - deep"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_numbered_list(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["1. outer", "\t1. inner"]
+        expected = ["1. outer", "  1. inner"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_numbered_list_with_double_digit_numbers(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["10. outer", "\t10. inner"]
+        expected = ["10. outer", "  10. inner"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_tabs_inside_fence_are_untouched(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["```", "- outer", "\t- inner", "```"]
+        self.assertEqual(preprocessor.run(original), original)
+
+    def test_tabs_for_non_list_item_is_not_converted(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        # An indented code block must be left untouched.
+        original = ["Here is some code:", "", "\tdef f():", "\t\treturn 1"]
+        self.assertEqual(preprocessor.run(original), original)
+
+    def test_tab_list_marker_without_preceding_list_context(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        # A tab + list-marker line is only converted if it directly
+        # continues a preceding list item. Without that context it
+        # must be left untouched so it still renders as an indented
+        # code block.
+        original = ["Some text", "", "\t- text"]
+        self.assertEqual(preprocessor.run(original), original)
+
+    def test_blockquoted_tab_nested_list(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["> - outer", "> \t- inner", "> \t\t- deep"]
+        expected = ["> - outer", ">   - inner", ">     - deep"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_nested_blockquoted_tab_list(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = [">> - outer", ">> \t- inner", ">> \t\t- deep"]
+        expected = [">> - outer", ">>   - inner", ">>     - deep"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_blockquoted_code_fence_tabs_are_untouched(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["> ```python", "> - outer", "> \t- inner", "> ```"]
+        self.assertEqual(preprocessor.run(original), original)
+
+    def test_indented_code_fence_tabs_are_untouched(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["   ```python", "   - outer", "   \t- inner", "   ```"]
+        self.assertEqual(preprocessor.run(original), original)
+
+    def test_mixed_spaces_and_tabs(self) -> None:
+        preprocessor = TabIndentedListPreprocessor()
+        original = ["- outer", "  \t- inner", "  \t\t- deep"]
+        expected = ["- outer", "    - inner", "      - deep"]
+        self.assertEqual(preprocessor.run(original), expected)
+
+
 class MarkdownListPreprocessorTest(ZulipTestCase):
     # We test that the preprocessor inserts blank lines at correct places.
     # We use <> to indicate that we need to insert a blank line here.
@@ -488,6 +563,11 @@ class MarkdownListPreprocessorTest(ZulipTestCase):
     def test_basic_list(self) -> None:
         preprocessor = MarkdownListPreprocessor()
         original, expected = self.split_message("List without a gap\n<>* One\n* Two")
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_basic_list_with_double_digit_numbers(self) -> None:
+        preprocessor = MarkdownListPreprocessor()
+        original, expected = self.split_message("List without a gap\n<>10. One\n11. Two")
         self.assertEqual(preprocessor.run(original), expected)
 
     def test_list_after_quotes(self) -> None:


### PR DESCRIPTION
Fixes #38436.

### Why this change is needed
Zulip uses 2 spaces per indentation level for bullet and numbered lists (`UListProcessor`, `ListIndentProcessor`). When people copy and paste tab-indented lists from editors like VS Code or Obsidian, Python-Markdown's upstream `NormalizeWhitespace` preprocessor turns those tabs into 4 spaces. That makes Zulip's list processor miss the 2-space nesting step or misinterpret items as indented code blocks.

### What this PR does
We add `TabIndentedListPreprocessor` (priority 32) right before `NormalizeWhitespace` (priority 30):
* It looks for lines starting with tabs that continue an active list at the same quote depth, and expands those tabs to 2 spaces.
* It leaves standard indented code blocks alone (e.g. `\tdef foo():` after a paragraph), so `NormalizeWhitespace` can still expand them to 4 spaces according to CommonMark.
* It handles single and multi-digit numbered lists (like `10.` and `100.`).
* It tracks quote depth so tabbed lists inside single (`>`) or nested (`>>`) blockquotes work.
* It skips fenced code blocks (` ``` ` and `~~~`), even when indented or blockquoted, preserving standard 4-space tab stops inside code fences.

### Visual verification
Screenshots taken from local dev server (`http://localhost:9991`):

| Before (4-space expansion breaking nesting) | After (2-space tab expansion nesting properly) |
| :---: | :---: |
| ![Before](https://files.catbox.moe/nx6pz7.png) | ![After](https://files.catbox.moe/c58b3d.png) |

### Testing
Added 12 unit tests in `zerver/tests/test_markdown.py` (`TabIndentedListPreprocessorTest`) covering:
* Single and multi-level tab indentation for bullets and numbers
* Multi-digit numbers
* Plain indented code blocks outside lists
* Blockquoted lists and nested blockquoted lists
* Code fences with leading spaces or blockquote markers
* Mixed spaces and tabs

Also added markdown fixture test cases in `zerver/tests/fixtures/markdown_test_cases.json`.