### PR TITLE
streams: Do not create default setting groups for existing streams.

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Collection, Iterable
+from collections.abc import Callable, Collection, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
@@ -19,6 +19,7 @@ from zerver.lib.exceptions import (
     MissingAuthenticationError,
     OrganizationOwnerRequiredError,
 )
+from zerver.lib.partial import partial
 from zerver.lib.stream_subscription import (
     get_guest_user_ids_for_streams,
     get_subscribed_stream_ids_for_user,
@@ -396,20 +397,32 @@ def create_stream_if_needed(
         invite_only, history_public_to_subscribers
     )
 
-    group_setting_values = {}
+    group_setting_values: dict[str, UserGroup | Callable[[], UserGroup]] = {}
     request_settings_dict = locals()
     # We don't want to calculate this value if no default values are
     # needed.
     system_groups_name_dict = None
+
+    def get_default_group_for_setting(setting_name: str) -> UserGroup:
+        nonlocal system_groups_name_dict
+        if system_groups_name_dict is None:
+            system_groups_name_dict = get_role_based_system_groups_dict(realm)
+        return get_stream_permission_default_group(
+            setting_name, system_groups_name_dict, creator=acting_user
+        )
+
     for setting_name in Stream.stream_permission_group_settings:
         if setting_name not in request_settings_dict:  # nocoverage
             continue
 
         if request_settings_dict[setting_name] is None:
-            if system_groups_name_dict is None:
-                system_groups_name_dict = get_role_based_system_groups_dict(realm)
-            group_setting_values[setting_name] = get_stream_permission_default_group(
-                setting_name, system_groups_name_dict, creator=acting_user
+            # Computing a default is not free: the "channel_creator"
+            # default creates an anonymous group. get_or_create only
+            # resolves callables in `defaults` when it actually
+            # creates the object, so passing one here avoids leaving
+            # an unused group behind when the channel already exists.
+            group_setting_values[setting_name] = partial(
+                get_default_group_for_setting, setting_name
             )
         else:
             group_setting_values[setting_name] = request_settings_dict[setting_name]


### PR DESCRIPTION
`create_stream_if_needed` with `acting_user` not set to None created anonymous group for setting whose default was set to "channel_creator" even when the stream already existed. That resulted in the anonymous group being created not being used.

This resulted in a large number of unused anonymous groups for some cases like "Welcome bot" sending initial realm messages as it uses `internal_prep_stream_message_by_name` which eventually calls `create_stream_if_needed` through `ensure_stream`.

There are still a couple of cases where unused anonymous groups can be created for cases where there are two racing requests for same stream name, but that can be fixed later.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
