### PR TITLE
notifications: Fix `AssertionError` on moving messages with bot mentions. 

### DIFF
--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -134,7 +134,7 @@ class UserMessageNotificationsData:
         #
         # Remove the `if` block when one can no longer directly upgrade from 11.x to main.
         if push_device_registered_user_ids is None:
-            push_device_registered = True
+            push_device_registered = True  # nocoverage
         else:
             push_device_registered = user_id in push_device_registered_user_ids
 

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -30,7 +30,10 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             content=content,
         )
 
-        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m:
+        with (
+            mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
             result = self.client_patch(url, request)
 
         self.assert_json_success(result)

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -23,7 +23,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         self.register_push_device(cordelia.id)
 
-    def _assert_update_does_not_notify_anybody(self, message_id: int, **request: str) -> None:
+    def _assert_update_does_not_notify_anybody(self, message_id: int, **request: str | int) -> None:
         url = "/json/messages/" + str(message_id)
 
         with (
@@ -727,3 +727,58 @@ class EditMessageSideEffectsTest(ZulipTestCase):
 
         self.assertEqual(get_apns_badge_count(mentioned_user), 0)
         self.assertEqual(get_apns_badge_count_future(mentioned_user), 1)
+
+    def _send_notifiable_message_and_login_editor(self) -> int:
+        message_id = self._login_and_send_original_stream_message(
+            content="hello @**Cordelia, Lear's daughter**",
+        )
+
+        iago = self.example_user("iago")
+        self.subscribe(iago, "Scotland")
+        self.login_user(iago)
+        return message_id
+
+    # The next three tests cover notifications for topic and channel
+    # edits. It seems obvious that such edits cannot notify anyone,
+    # but historically we had such bugs - see #39888.
+    def test_topic_edit_does_not_notify_anybody(self) -> None:
+        message_id = self._send_notifiable_message_and_login_editor()
+
+        self._assert_update_does_not_notify_anybody(
+            message_id=message_id,
+            topic="new topic",
+        )
+
+    def test_channel_edit_does_not_notify_anybody(self) -> None:
+        message_id = self._send_notifiable_message_and_login_editor()
+
+        self._assert_update_does_not_notify_anybody(
+            message_id=message_id,
+            stream_id=self.get_stream_id("Denmark"),
+        )
+
+    def test_content_edit_that_also_moves_topic_notifies(self) -> None:
+        message_id = self._login_and_send_original_stream_message(content="no mention")
+
+        info = self._get_queued_data_for_message_update(
+            message_id=message_id,
+            content="now we mention @**Cordelia, Lear's daughter**",
+            topic="new topic",
+        )
+
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        expected_enqueue_kwargs = self.get_maybe_enqueue_notifications_parameters(
+            user_id=cordelia.id,
+            acting_user_id=hamlet.id,
+            message_id=message_id,
+            mention_email_notify=True,
+            mention_push_notify=True,
+            already_notified={},
+        )
+        self.assertEqual(info["enqueue_kwargs"], expected_enqueue_kwargs)
+
+        queue_names = [queue_message["queue_name"] for queue_message in info["queue_messages"]]
+        self.assertEqual(
+            queue_names, ["missedmessage_mobile_notifications", "missedmessage_emails"]
+        )

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -23,12 +23,8 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         self.register_push_device(cordelia.id)
 
-    def _assert_update_does_not_notify_anybody(self, message_id: int, content: str) -> None:
+    def _assert_update_does_not_notify_anybody(self, message_id: int, **request: str) -> None:
         url = "/json/messages/" + str(message_id)
-
-        request = dict(
-            content=content,
-        )
 
         with (
             mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m,
@@ -85,7 +81,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         return message_id
 
     def _get_queued_data_for_message_update(
-        self, message_id: int, content: str, expect_short_circuit: bool = False
+        self, *, message_id: int, expect_short_circuit: bool = False, **request: str
     ) -> dict[str, Any]:
         """
         This function updates a message with a post to
@@ -105,10 +101,6 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         queuing the final messages.
         """
         url = "/json/messages/" + str(message_id)
-
-        request = dict(
-            content=content,
-        )
 
         with (
             mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m,

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1503,7 +1503,7 @@ def process_message_update_event(
     online_push_user_ids = set(event_template.pop("online_push_user_ids", []))
     stream_name = event_template.get("stream_name")
     message_id = event_template["message_id"]
-    rendering_only_update = event_template["rendering_only"]
+    content_edited = "orig_content" in event_template
 
     # TODO/compatibility: We need to set `push_device_registered_user_ids` to None
     # for update_message events prior to the introduction of `push_device_registered_user_ids`
@@ -1523,15 +1523,11 @@ def process_message_update_event(
             if key != "id":
                 user_event[key] = user_data[key]
 
-        # Events where `rendering_only_update` is True come from the
-        # do_update_embedded_data code path, and represent rendering
-        # previews; there should be no real content changes.
-        # Therefore, we know only events where `rendering_only_update`
-        # is False possibly send notifications.
-        if not rendering_only_update:
-            # The user we'll get here will be the sender if the message's
-            # content was edited, and the editor for topic edits. That's
-            # the correct "acting_user" for both cases.
+        # Only events where content edit is involved possibly send notifications.
+        # Skip it for topic and/or channel edit or when a message's content
+        # has a rendering update.
+        if content_edited:
+            # Message's sender is the acting user here, because only they can edit content.
             acting_user_id = event_template["user_id"]
 
             flags: Collection[str] = user_event["flags"]


### PR DESCRIPTION
* Commit 1: A small bug I noticed.
* Commit 2: Prep commit.
* Commit 3: Fixes the bug. Read the commit message for details.

Fixes: #39888 

**How changes were tested:**

* Run replication steps listed in #39888, before and after the fix.
* We've new backend tests as well.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
