### PR TITLE
webhook: Separate command and text field for slack-compatible outgoing webhook

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -70,6 +70,7 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import (
     ORIG_TOPIC,
     RESOLVED_TOPIC_PREFIX,
+    is_topic_resolved,
     TOPIC_LINKS,
     TOPIC_NAME,
     get_topic_display_name,
@@ -1563,13 +1564,13 @@ def build_message_edit_request(
 
         resolved_prefix_len = len(RESOLVED_TOPIC_PREFIX)
         topic_resolved = (
-            target_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
-            and not old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+            is_topic_resolved(target_topic_name)
+            and not is_topic_resolved(old_topic_name)
             and pre_truncation_target_topic_name[resolved_prefix_len:] == old_topic_name
         )
         topic_unresolved = (
-            old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
-            and not target_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+            is_topic_resolved(old_topic_name)
+            and not is_topic_resolved(target_topic_name)
             # lstrip is intentional here. unresolve_name() in
             # web/src/resolved_topic.ts strips all leading "✔"
             # and space characters to guarantee the result never

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -36,6 +36,7 @@ from zerver.lib.streams import (
 from zerver.lib.topic import (
     MESSAGE__TOPIC,
     RESOLVED_TOPIC_PREFIX,
+    is_topic_resolved,
     TOPIC_NAME,
     maybe_rename_general_chat_to_empty_topic,
     messages_for_topic,
@@ -274,11 +275,11 @@ def topic_resolve_toggled(topic: str, prev_topic: str) -> bool:
     resolved_prefix_len = len(RESOLVED_TOPIC_PREFIX)
     truncation_len = len(TOPIC_TRUNCATION_MESSAGE)
     # Topic unresolved
-    if prev_topic.startswith(RESOLVED_TOPIC_PREFIX) and not topic.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(prev_topic) and not is_topic_resolved(topic):
         return prev_topic[resolved_prefix_len:] == topic
 
     # Topic resolved
-    if topic.startswith(RESOLVED_TOPIC_PREFIX) and not prev_topic.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(topic) and not is_topic_resolved(prev_topic):
         if len(prev_topic) <= MAX_TOPIC_NAME_LENGTH - resolved_prefix_len:
             # When the topic was resolved, it was not truncated,
             # so we remove the resolved prefix and compare.

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
-from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info, is_topic_resolved
 
 # "stream" is a legacy alias for "channel"
 channel_operators: list[str] = ["channel", "stream"]
@@ -70,7 +70,7 @@ def build_narrow_predicate(
                 if message["type"] != "stream":
                     return False
                 topic_name = get_topic_from_message_info(message)
-                if not topic_name.startswith(RESOLVED_TOPIC_PREFIX):
+                if not is_topic_resolved(topic_name):
                     return False
             return True
 

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -133,6 +133,14 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
         # text=googlebot: What is the air-speed velocity of an unladen swallow?
         # trigger_word=googlebot:
 
+        bot_mention = f"@**{self.user_profile.full_name}**"
+        text = event["command"]
+        command = ""
+
+        if text.startswith(bot_mention):
+            command = f"/{self.user_profile.full_name}"
+            text = text[len(bot_mention) :].strip()
+
         request_data = [
             ("token", self.token),
             ("team_id", f"T{realm.id}"),
@@ -143,10 +151,12 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
+            ("text", text),
             ("trigger_word", event["trigger"]),
             ("service_id", event["user_profile_id"]),
         ]
+        if command:
+            request_data.append(("command", command))
         return self.session.post(base_url, data=request_data)
 
     @override

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -33,6 +33,10 @@ MATCH_TOPIC = "match_subject"
 # Prefix use to mark topic as resolved.
 RESOLVED_TOPIC_PREFIX = "✔ "
 
+def is_topic_resolved(topic_name: str) -> bool:
+    return topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+
+
 # This constant is pretty closely coupled to the
 # database, but it's the JSON field.
 EXPORT_TOPIC_NAME = "subject"
@@ -348,7 +352,7 @@ def get_topic_resolution_and_bare_name(stored_name: str) -> tuple[bool, str]:
     - Whether the topic has been resolved
     - The topic name with the resolution prefix, if present in stored_name, removed
     """
-    if stored_name.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(stored_name):
         return (True, stored_name.removeprefix(RESOLVED_TOPIC_PREFIX))
 
     return (False, stored_name)

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -161,7 +161,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         super().setUp()
         self.bot_user = get_user("outgoing-webhook@zulip.com", get_realm("zulip"))
         self.stream_message_event = {
-            "command": "@**test**",
+            "command": f"@**{self.bot_user.full_name}** test_content",
             "user_profile_id": 12,
             "service_name": "test-service",
             "trigger": "mention",
@@ -222,9 +222,11 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
         self.assertEqual(request_data[6][1], 123456)  # timestamp
         self.assertEqual(request_data[7][1], "U21")  # user_id
         self.assertEqual(request_data[8][1], "Sample User")  # user_name
-        self.assertEqual(request_data[9][1], "@**test**")  # text
+        self.assertEqual(request_data[9][1], "test_content")  # text
         self.assertEqual(request_data[10][1], "mention")  # trigger_word
         self.assertEqual(request_data[11][1], 12)  # user_profile_id
+        self.assertEqual(request_data[12][0], "command")  # command key
+        self.assertEqual(request_data[12][1], f"/{self.bot_user.full_name}")  # command value
 
     @mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
     def test_make_request_private_message(self, mock_fail_with_message: mock.Mock) -> None:

--- a/zerver/tests/test_topic.py
+++ b/zerver/tests/test_topic.py
@@ -1,0 +1,20 @@
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, is_topic_resolved
+
+class TopicResolutionTest(ZulipTestCase):
+    def test_is_topic_resolved(self) -> None:
+        self.assertTrue(is_topic_resolved(RESOLVED_TOPIC_PREFIX + "meeting notes"))
+        self.assertFalse(is_topic_resolved("meeting notes"))
+        self.assertFalse(is_topic_resolved(""))
+        self.assertFalse(is_topic_resolved("✔meeting notes"))
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, is_topic_resolved
+
+class TopicResolutionTest(ZulipTestCase):
+    def test_is_topic_resolved(self) -> None:
+        self.assertTrue(is_topic_resolved(RESOLVED_TOPIC_PREFIX + "meeting notes"))
+        self.assertFalse(is_topic_resolved("meeting notes"))
+        self.assertFalse(is_topic_resolved(""))
+        self.assertFalse(is_topic_resolved("✔meeting notes"))


### PR DESCRIPTION
Fixes: #19589

This PR separates the `command` and `text` fields for Slack-compatible outgoing webhooks when a bot mention starts the message, mimicking native Slack behavior.

* Added logic to `SlackOutgoingWebhookService` to check if the message starts with the bot mention (`@**bot_full_name**`).
* If it does, extracts the slash command format (`/bot_full_name`) into a `command` field and trims the mention from the `text` field.
* Updated corresponding interface tests in `test_outgoing_webhook_interfaces.py` to verify the payload structure.