### PR TITLE
webhooks: Allow incoming webhook URL option labels to be translated.

### DIFF
--- a/api_docs/unmerged.d/ZF-d62977.md
+++ b/api_docs/unmerged.d/ZF-d62977.md
@@ -1,0 +1,4 @@
+* [`POST /register`](/api/register-queue): The `label` field in the
+  `url_options` array of the `realm_incoming_webhook_bots` object array
+  is now returned in the user's language. Previously, it was always
+  returned in English.

--- a/docs/webhooks/incoming-webhooks-reference.md
+++ b/docs/webhooks/incoming-webhooks-reference.md
@@ -95,7 +95,7 @@ These URL options can be declared as follows:
         url_options=[
           WebhookUrlOption(
             name='ignore_private_repositories',
-            label='Exclude notifications from private repositories',
+            label=gettext_lazy('Exclude notifications from private repositories'),
             input_type='checkbox',
           ),
         ],
@@ -108,7 +108,10 @@ offer when generating the integration URL:
 - `name`: The parameter name that is used to encode the user input in the
   integration's webhook URL.
 - `label`: A short descriptive label for this URL parameter in the web
-  app UI.
+  app UI. Since this string is displayed to users, mark it for
+  translation with `gettext_lazy` from `django.utils.translation`,
+  which is resolved in the user's language when the web app fetches
+  its initial state.
 - `input_type`: The type of input field this option maps to in the UI.
   The web app UI currently supports the following input types:
   - `checkbox`: A checkbox input for presence-only values (true or absent),

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -20,6 +20,7 @@ IGNORED_PHRASES = [
     r"DevAuthBackend",
     r"DSN",
     r"Esc",
+    r"European",
     r"GCM",
     r"GitHub",
     r"GitLab",
@@ -38,6 +39,7 @@ IGNORED_PHRASES = [
     r"Markdown",
     r"OAuth",
     r"OTP",
+    r"Opsgenie",
     r"Recent conversations",
     r"DM",
     r"DMs",
@@ -64,6 +66,10 @@ IGNORED_PHRASES = [
     r"BigBlueButton",
     r"Constructor Groups",
     r"Nextcloud Talk",
+    # "dbt Access URL" is dbt's own product terminology, including the
+    # lower-case styling of its name. "URL" is substituted above, so it
+    # cannot be part of this phrase.
+    r"dbt Access",
     # Code things
     r"\.zuliprc",
     # BeautifulSoup will remove <z-user> which is horribly confusing,

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -797,7 +797,7 @@ def fetch_initial_state_data(
                 "url_options": [
                     {
                         "key": c.name,
-                        "label": c.label,
+                        "label": str(c.label),
                         "input_type": c.input_type,
                     }
                     for c in integration.url_options

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -8,6 +8,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpRequest, HttpResponseBase
 from django.urls import URLPattern, path
 from django.utils.module_loading import import_string
+from django.utils.translation import gettext_lazy
 from django.views.decorators.csrf import csrf_exempt
 from typing_extensions import override
 
@@ -590,7 +591,11 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
         [WebhookScreenshotConfig("job_run_completed_errored.json")],
         display_name="dbt",
         url_options=[
-            WebhookUrlOption(name="access_url", label="dbt Access URL", input_type="text")
+            WebhookUrlOption(
+                name="access_url",
+                label=gettext_lazy("dbt Access URL"),
+                input_type="text",
+            )
         ],
     ),
     IncomingWebhookIntegration(
@@ -659,12 +664,12 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
             WebhookUrlOption.build_preset_config(PresetUrlOption.IGNORE_PRIVATE_REPOSITORIES),
             WebhookUrlOption(
                 name="include_repository_name",
-                label="Include repository name in the notifications",
+                label=gettext_lazy("Include repository name in the notifications"),
                 input_type="checkbox",
             ),
             WebhookUrlOption(
                 name="include_emoji_indicators",
-                label="Include emoji indicators in the notifications",
+                label=gettext_lazy("Include emoji indicators in the notifications"),
                 input_type="checkbox_enabled",
             ),
         ],
@@ -691,12 +696,12 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
             WebhookUrlOption.build_preset_config(PresetUrlOption.BRANCHES),
             WebhookUrlOption(
                 name="ignore_private_projects",
-                label="Exclude notifications from private projects",
+                label=gettext_lazy("Exclude notifications from private projects"),
                 input_type="checkbox",
             ),
             WebhookUrlOption(
                 name="use_merge_request_title",
-                label="Include merge request titles in topics",
+                label=gettext_lazy("Include merge request titles in topics"),
                 input_type="checkbox_enabled",
             ),
         ],
@@ -720,27 +725,29 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
         url_options=[
             WebhookUrlOption(
                 "include_trackers",
-                label="Include primary trackers in the notifications",
+                label=gettext_lazy("Include primary trackers in the notifications"),
                 input_type="checkbox_enabled",
             ),
             WebhookUrlOption(
                 "include_topics",
-                label="Include primary topics in the notifications",
+                label=gettext_lazy("Include primary topics in the notifications"),
                 input_type="checkbox_enabled",
             ),
             WebhookUrlOption(
                 "include_participants",
-                label="Include participant names in the notifications",
+                label=gettext_lazy("Include participant names in the notifications"),
                 input_type="checkbox_enabled",
             ),
             WebhookUrlOption(
                 "include_participant_contacts",
-                label="Include participant contact information (requires participant names)",
+                label=gettext_lazy(
+                    "Include participant contact information (requires participant names)"
+                ),
                 input_type="checkbox_enabled",
             ),
             WebhookUrlOption(
                 "include_public_comments",
-                label="Include public comments in the notifications",
+                label=gettext_lazy("Include public comments in the notifications"),
                 input_type="checkbox",
             ),
         ],
@@ -844,7 +851,7 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
         url_options=[
             WebhookUrlOption(
                 name="eu_region",
-                label="Use Opsgenie's European service region",
+                label=gettext_lazy("Use Opsgenie's European service region"),
                 input_type="checkbox",
             )
         ],

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -15,6 +15,7 @@ from django.http import HttpRequest
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_bytes
 from django.utils.translation import gettext as _
+from django_stubs_ext import StrPromise
 from pydantic import Json
 from typing_extensions import override
 
@@ -77,7 +78,7 @@ class WebhookConfigOption:
 @dataclass
 class WebhookUrlOption:
     name: str
-    label: str
+    label: str | StrPromise
     input_type: str
 
     @classmethod

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -15,6 +15,7 @@ from django.http import HttpRequest
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_bytes
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 from django_stubs_ext import StrPromise
 from pydantic import Json
 from typing_extensions import override
@@ -100,7 +101,7 @@ class WebhookUrlOption:
             case PresetUrlOption.IGNORE_PRIVATE_REPOSITORIES:
                 return cls(
                     name=config.value,
-                    label="Exclude notifications from private repositories",
+                    label=gettext_lazy("Exclude notifications from private repositories"),
                     input_type="checkbox",
                 )
             case PresetUrlOption.CHANNEL_MAPPING:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27997,7 +27997,11 @@ components:
           label:
             type: string
             description: |
-              The label used for the input field in the UI.
+              The label used for the input field in the UI, in the user's
+              language.
+
+              **Changes**: Before Zulip 13.0 (feature level ZF-d62977),
+              this label was always in English.
           input_type:
             type: string
             description: |


### PR DESCRIPTION
This PR adds support for internationalization of URL options. The text is translated at server side using `gettext_lazy`. This PR also updates the realted documentation.

The `BRANCHES` and `CHANNEL_MAPPING` presets are intentionally skipped: they carry `label=""`, and their special-cased UI supplies its own strings from the web app's translation catalog, which were already translated.

56de025b5f recently removed `gettext_lazy` from `CATEGORIES` in this same file. That does not conflict with this change as URL option labels are display-only and the web app keys all of its logic off `name` and every neighbouring string in the modal is already translated.

CZO: [#integrations > internationalization of URL options](https://chat.zulip.org/#narrow/channel/127-integrations/topic/internationalization.20of.20URL.20options/with/2500752)
**How changes were tested:**
* Ran `./manage.py makemessages -l de` and confirmed all 12 labels are extracted into `locale/de/LC_MESSAGES/django.po`.
* Filled in German translations locally, compiled with `compilemessages`, and confirmed every label renders in German in the modal.
<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
| :--- | :--- |
| <img width="380" alt="Generate integration URL modal in German, with three URL option labels still in English" src="https://github.com/user-attachments/assets/fd6da552-1fbf-4021-8034-9e099a829f48" /> | <img width="380" alt="The same modal with all URL option labels rendered in German" src="https://github.com/user-attachments/assets/ca5fbaf1-7451-4716-86e8-ca5a98f7ef04" /> |
| <img width="758" height="839" alt="image" src="https://github.com/user-attachments/assets/f6443029-96ae-41c4-8003-d2fee88501d5" />|<img width="760" height="837" alt="image" src="https://github.com/user-attachments/assets/1b16adc0-f733-4dc0-9daf-852512d47266" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
