### PR TITLE
css: Use input focus variables for popover filter input.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -63,12 +63,6 @@
         opacity: 0.4;
     }
 
-    .popover-filter-input-wrapper .popover-filter-input:focus {
-        background-color: hsl(225deg 6% 7%);
-        border: 1px solid hsl(0deg 0% 100% / 50%);
-        box-shadow: 0 0 5px hsl(0deg 0% 100% / 40%);
-    }
-
     & select option {
         background-color: var(--color-background);
         color: hsl(236deg 33% 90%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2205,9 +2205,9 @@ body:not(.spectator-view) {
         margin: 4px 4px 2px;
 
         &:focus {
-            background: hsl(0deg 0% 100%);
-            border: 1px solid hsl(229.09deg 21.57% 10% / 80%);
-            box-shadow: 0 0 6px hsl(228deg 9.8% 20% / 30%);
+            background: var(--color-background-input-focus);
+            border: 1px solid var(--color-outline-input-focus);
+            box-shadow: 0 0 6px var(--color-box-shadow-input-focus);
         }
     }
 }


### PR DESCRIPTION
This PR makes progress on the `dark_theme.css` cleanup by removing the
`.popover-filter-input:focus` dark-theme override.

The light theme rule in `zulip.css` becomes the single authoritative
declaration, using the existing input focus variables
(`--color-background-input-focus`, `--color-outline-input-focus`,
`--color-box-shadow-input-focus`), which carry both themes' values via
`light-dark()`. This also acts on the TODO comment above
`--color-background-input` in `app_variables.css`, which asks for these
variables to be extended to clean up "a lingering stack of selectors in
dark_theme.css."

The variables' values match the previous hardcoded colors exactly in dark
theme, and up to insignificant rounding in light theme
(`hsl(229.09deg 21.57% 10% / 80%)` → `hsl(229deg 22% 10%)` at 80% via
`color-mix`). One deliberate minor change: the box-shadow blur radius is
unified at 6px; dark theme previously used 5px. I've kept that difference
visible in the screenshots below so reviewers can judge it.

Fixes part of #39354.

**How changes were tested:**

- `./tools/lint web/styles/zulip.css web/styles/dark_theme.css` passes.
- Manually verified the focused filter input in the emoji picker popover
  in both light and dark themes, before and after the change (screenshots
  below).


**Screenshots and screen captures:**

| Theme | Before | After |
|---|---|---|
| Light | ![before-light](https://raw.githubusercontent.com/hk2166/zulip/d0132b1687cd219825dd1d713eedfdfe6ebd7423/before-light.png) | ![after-light](https://raw.githubusercontent.com/hk2166/zulip/d0132b1687cd219825dd1d713eedfdfe6ebd7423/after-light.png) |
| Dark | ![before-dark](https://raw.githubusercontent.com/hk2166/zulip/d0132b1687cd219825dd1d713eedfdfe6ebd7423/before-dark.png) | ![after-dark](https://raw.githubusercontent.com/hk2166/zulip/d0132b1687cd219825dd1d713eedfdfe6ebd7423/after-dark.png) |

A pixel diff of the captures confirms the light theme is unchanged
(only the blinking text caret differs), and the dark theme differences
are confined to the input's box-shadow — the 6px blur unification
noted above.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
