### PR TITLE
topic: Centralize topic resolution check into is_topic_resolved helper

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -70,6 +70,7 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import (
     ORIG_TOPIC,
     RESOLVED_TOPIC_PREFIX,
+    is_topic_resolved,
     TOPIC_LINKS,
     TOPIC_NAME,
     get_topic_display_name,
@@ -1563,13 +1564,13 @@ def build_message_edit_request(
 
         resolved_prefix_len = len(RESOLVED_TOPIC_PREFIX)
         topic_resolved = (
-            target_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
-            and not old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+            is_topic_resolved(target_topic_name)
+            and not is_topic_resolved(old_topic_name)
             and pre_truncation_target_topic_name[resolved_prefix_len:] == old_topic_name
         )
         topic_unresolved = (
-            old_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
-            and not target_topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+            is_topic_resolved(old_topic_name)
+            and not is_topic_resolved(target_topic_name)
             # lstrip is intentional here. unresolve_name() in
             # web/src/resolved_topic.ts strips all leading "✔"
             # and space characters to guarantee the result never

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -36,6 +36,7 @@ from zerver.lib.streams import (
 from zerver.lib.topic import (
     MESSAGE__TOPIC,
     RESOLVED_TOPIC_PREFIX,
+    is_topic_resolved,
     TOPIC_NAME,
     maybe_rename_general_chat_to_empty_topic,
     messages_for_topic,
@@ -274,11 +275,11 @@ def topic_resolve_toggled(topic: str, prev_topic: str) -> bool:
     resolved_prefix_len = len(RESOLVED_TOPIC_PREFIX)
     truncation_len = len(TOPIC_TRUNCATION_MESSAGE)
     # Topic unresolved
-    if prev_topic.startswith(RESOLVED_TOPIC_PREFIX) and not topic.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(prev_topic) and not is_topic_resolved(topic):
         return prev_topic[resolved_prefix_len:] == topic
 
     # Topic resolved
-    if topic.startswith(RESOLVED_TOPIC_PREFIX) and not prev_topic.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(topic) and not is_topic_resolved(prev_topic):
         if len(prev_topic) <= MAX_TOPIC_NAME_LENGTH - resolved_prefix_len:
             # When the topic was resolved, it was not truncated,
             # so we remove the resolved prefix and compare.

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
-from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info, is_topic_resolved
 
 # "stream" is a legacy alias for "channel"
 channel_operators: list[str] = ["channel", "stream"]
@@ -70,7 +70,7 @@ def build_narrow_predicate(
                 if message["type"] != "stream":
                     return False
                 topic_name = get_topic_from_message_info(message)
-                if not topic_name.startswith(RESOLVED_TOPIC_PREFIX):
+                if not is_topic_resolved(topic_name):
                     return False
             return True
 

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -33,6 +33,10 @@ MATCH_TOPIC = "match_subject"
 # Prefix use to mark topic as resolved.
 RESOLVED_TOPIC_PREFIX = "✔ "
 
+def is_topic_resolved(topic_name: str) -> bool:
+    return topic_name.startswith(RESOLVED_TOPIC_PREFIX)
+
+
 # This constant is pretty closely coupled to the
 # database, but it's the JSON field.
 EXPORT_TOPIC_NAME = "subject"
@@ -348,7 +352,7 @@ def get_topic_resolution_and_bare_name(stored_name: str) -> tuple[bool, str]:
     - Whether the topic has been resolved
     - The topic name with the resolution prefix, if present in stored_name, removed
     """
-    if stored_name.startswith(RESOLVED_TOPIC_PREFIX):
+    if is_topic_resolved(stored_name):
         return (True, stored_name.removeprefix(RESOLVED_TOPIC_PREFIX))
 
     return (False, stored_name)

--- a/zerver/tests/test_topic.py
+++ b/zerver/tests/test_topic.py
@@ -1,0 +1,20 @@
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, is_topic_resolved
+
+class TopicResolutionTest(ZulipTestCase):
+    def test_is_topic_resolved(self) -> None:
+        self.assertTrue(is_topic_resolved(RESOLVED_TOPIC_PREFIX + "meeting notes"))
+        self.assertFalse(is_topic_resolved("meeting notes"))
+        self.assertFalse(is_topic_resolved(""))
+        self.assertFalse(is_topic_resolved("✔meeting notes"))
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, is_topic_resolved
+
+class TopicResolutionTest(ZulipTestCase):
+    def test_is_topic_resolved(self) -> None:
+        self.assertTrue(is_topic_resolved(RESOLVED_TOPIC_PREFIX + "meeting notes"))
+        self.assertFalse(is_topic_resolved("meeting notes"))
+        self.assertFalse(is_topic_resolved(""))
+        self.assertFalse(is_topic_resolved("✔meeting notes"))


### PR DESCRIPTION
Fixes #39809. Refactors the scattered `topic.startswith(RESOLVED_TOPIC_PREFIX)` string-matching logic into a single `is_topic_resolved` utility function in `zerver/lib/topic.py`.