### PR TITLE
url_preview: Pass custom headers and timeout to oEmbed requests

### DIFF
--- a/zerver/lib/url_preview/oembed.py
+++ b/zerver/lib/url_preview/oembed.py
@@ -1,9 +1,37 @@
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 
 import requests
+from django.conf import settings
 from pyoembed import PyOembedException, oEmbed
 
+from version import ZULIP_VERSION
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
+
+# Use Chrome User-Agent, since some sites refuse to work on old browsers.
+ZULIP_URL_PREVIEW_USER_AGENT = (
+    f"Mozilla/5.0 (compatible; ZulipURLPreview/{ZULIP_VERSION}; +{settings.ROOT_DOMAIN_URI})"
+)
+HEADERS = {"User-Agent": ZULIP_URL_PREVIEW_USER_AGENT}
+TIMEOUT = 15
+
+
+@contextmanager
+def _patched_oembed_requests() -> Iterator[None]:
+    original_get = requests.get
+
+    def wrapped_get(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("headers", HEADERS)
+        kwargs.setdefault("timeout", TIMEOUT)
+        return original_get(*args, **kwargs)
+
+    requests.get = wrapped_get
+    try:
+        yield
+    finally:
+        requests.get = original_get
 
 
 def get_oembed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> UrlEmbedData | None:
@@ -11,7 +39,8 @@ def get_oembed_data(url: str, maxwidth: int = 640, maxheight: int = 480) -> UrlE
     # but they still go through Smokescreen: requests lib honors the
     # HTTP_proxy/HTTPS_proxy variables we set in every process's environment.
     try:
-        data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
+        with _patched_oembed_requests():
+            data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
     except (PyOembedException, json.decoder.JSONDecodeError, requests.exceptions.ConnectionError):
         return None
 

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -6,14 +6,12 @@ from urllib.parse import urljoin
 
 import magic
 import requests
-from django.conf import settings
 from django.utils.encoding import smart_str
 
-from version import ZULIP_VERSION
 from zerver.lib.cache import cache_with_key, preview_url_cache_key
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.pysa import mark_sanitized
-from zerver.lib.url_preview.oembed import get_oembed_data
+from zerver.lib.url_preview.oembed import HEADERS, TIMEOUT, get_oembed_data
 from zerver.lib.url_preview.parsers import GenericParser, OpenGraphParser
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
 
@@ -26,15 +24,6 @@ link_regex = re.compile(
     r"(?:/?|[/?]\S+)$",
     re.IGNORECASE,
 )
-
-# Use Chrome User-Agent, since some sites refuse to work on old browsers
-ZULIP_URL_PREVIEW_USER_AGENT = (
-    f"Mozilla/5.0 (compatible; ZulipURLPreview/{ZULIP_VERSION}; +{settings.ROOT_DOMAIN_URI})"
-)
-
-# FIXME: This header and timeout are not used by pyoembed, when trying to autodiscover!
-HEADERS = {"User-Agent": ZULIP_URL_PREVIEW_USER_AGENT}
-TIMEOUT = 15
 
 
 class PreviewSession(OutgoingSession):

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -162,6 +162,28 @@ class OembedTestCase(ZulipTestCase):
         data = get_oembed_data(url)
         self.assertIsNone(data)
 
+    @mock.patch("zerver.lib.url_preview.oembed.requests.get")
+    def test_oembed_request_uses_preview_headers_and_timeout(self, mock_get: mock.Mock) -> None:
+        mock_response = mock.Mock()
+        mock_response.ok = True
+        # pyoembed validates rich embeds against a minimal schema, so the mock needs
+        # the fields that the real parser would see from a successful response.
+        mock_response.text = (
+            '{"version": "1.0", "type": "rich", "title": "Example", '
+            '"html": "<p>example</p>", "width": 640, "height": 480}'
+        )
+        mock_response.headers = {"content-type": "application/json"}
+        mock_get.return_value = mock_response
+
+        data = get_oembed_data("http://instagram.com/p/BLtI2WdAymy")
+
+        self.assertIsNotNone(data)
+        self.assertEqual(mock_get.call_count, 1)
+        self.assertIn("headers", mock_get.call_args.kwargs)
+        self.assertIn("timeout", mock_get.call_args.kwargs)
+        self.assertEqual(mock_get.call_args.kwargs["timeout"], 15)
+        self.assertIn("User-Agent", mock_get.call_args.kwargs["headers"])
+
     def test_oembed_html(self) -> None:
         html = '<iframe src="//www.instagram.com/embed.js"></iframe>'
         stripped_html = strip_cdata(html)


### PR DESCRIPTION
Previously, oEmbed preview requests via pyoembed made default HTTP calls that ignored Zulip's custom User-Agent headers and timeout settings. This caused oEmbed requests to behave inconsistently compared to standard link previews.

This commit:
- Unifies User-Agent and timeout definitions in oembed.py.
- Updates pyoembed's request pipeline to use these settings.
- Removes the FIXME comment from preview.py.
- Adds a regression test in test_link_embed.py.

**Zulip thread:** [#backend > oEmbed custom headers and timeout](https://chat.zulip.org/#narrow/channel/3-backend/topic/oEmbed.20custom.20headers.20and.20timeout/with/2506362)

Fixes: Resolves the `FIXME` in `zerver/lib/url_preview/preview.py` regarding missing custom headers/timeout during oEmbed autodiscovery.

**How changes were tested:**

1. Ran `./tools/lint` locally inside the Vagrant VM environment, and passed cleanly with no warnings.
2. Ran `./tools/test-backend zerver/tests/test_link_embed.py`, and all 40 tests passed cleanly (`OK`).

**Screenshots and screen captures:**
N/A (This is a backend refactoring and bug fix with no UI/frontend changes).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
