### PR TITLE
test_classes: Skip models whose table is absent from the database.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2463,10 +2463,13 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
 def get_row_pks_in_all_tables() -> Iterator[tuple[str, set[int]]]:
     all_models = apps.get_models(include_auto_created=True)
     ignored_tables = {"django_session"}
+    # A test may leave the schema behind the current models, so that a
+    # model's table does not exist yet; see MigrationsTestCase.
+    db_existing_tables = set(connection.introspection.table_names())
 
     for model in all_models:
         table_name = model._meta.db_table
-        if table_name in ignored_tables:
+        if table_name in ignored_tables or table_name not in db_existing_tables:
             continue
         pks = model._default_manager.all().values_list("pk", flat=True)
         yield table_name, set(pks)


### PR DESCRIPTION
This PR is a blocker for #36213

`ZulipTransactionTestCase` snapshots the primary keys of every model in the live app registry in `setUp()` and re-checks them in `tearDown()`, to catch tests that leak rows.  `MigrationsTestCase` takes that snapshot before rewinding the schema to `migrate_from`, then leaves the database at `migrate_to`. So `tearDown()` inspects a schema that can be older than the models: any model whose table is created by a migration newer
than `migrate_to` has no table to query, and the check died with
`UndefinedTable` instead of reporting the test's real result.

Skipping those models is the fix rather than a way to silence the error.

# Testing
Tested this PR locally against the idempotency branch (#36213) and the error is fixed.
