### PR TITLE
[ai] user_card_popover: Keep buddy list user card anchored to its row.

### DIFF
--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -65,8 +65,24 @@ export function clear_for_testing(): void {
     user_filter = undefined;
 }
 
+let user_card_is_open = false;
+let buddy_list_redraw_deferred = false;
+
+export function set_user_card_open(is_open: boolean): void {
+    user_card_is_open = is_open;
+    if (!is_open && buddy_list_redraw_deferred) {
+        buddy_list_redraw_deferred = false;
+        redraw();
+    }
+}
+
 export function redraw_user(user_id: number): void {
     if (realm.realm_presence_disabled) {
+        return;
+    }
+
+    if (user_card_is_open) {
+        buddy_list_redraw_deferred = true;
         return;
     }
 
@@ -104,6 +120,11 @@ export function searching(): boolean {
 
 export let build_user_sidebar = (): number[] | undefined => {
     if (realm.realm_presence_disabled) {
+        return undefined;
+    }
+
+    if (user_card_is_open) {
+        buddy_list_redraw_deferred = true;
         return undefined;
     }
 

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -258,15 +258,6 @@ export const default_popover_props: Partial<tippy.Props> = {
                         $tippy_box.attr("data-reference-hidden") !== undefined;
 
                     if ($tippy_box.hasClass("show-when-reference-hidden")) {
-                        // Show user card popover as an overlay if we are not sure about position of the
-                        // reference. This can happen when popover reference has been replaced or hidden.
-                        if (
-                            is_reference_outside_window &&
-                            $tippy_box.find("#user_card_popover").length > 0
-                        ) {
-                            $("body").append($("<div>").attr("id", "popover-overlay-background"));
-                            instance.setProps(get_props_for_popover_centering(instance.props));
-                        }
                         return;
                     }
 

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -9,6 +9,7 @@ import render_user_card_popover from "../templates/popovers/user_card/user_card_
 import render_user_card_popover_for_deleted_user from "../templates/popovers/user_card/user_card_popover_for_deleted_user.hbs";
 import render_user_card_popover_for_unknown_user from "../templates/popovers/user_card/user_card_popover_for_unknown_user.hbs";
 
+import * as activity_ui from "./activity_ui.ts";
 import * as blueslip from "./blueslip.ts";
 import * as browser_history from "./browser_history.ts";
 import * as buddy_data from "./buddy_data.ts";
@@ -140,6 +141,7 @@ function get_popover_classname(
 user_sidebar.hide = function () {
     PopoverMenu.prototype.hide.call(this);
     current_user_sidebar_user_id = undefined;
+    activity_ui.set_user_card_open(false);
 };
 
 const user_card_popovers = {
@@ -714,6 +716,7 @@ function toggle_sidebar_user_card_popover($target: JQuery): void {
     );
 
     current_user_sidebar_user_id = user.user_id;
+    activity_ui.set_user_card_open(true);
 }
 
 function register_click_handlers(): void {

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -708,11 +708,6 @@ function toggle_sidebar_user_card_popover($target: JQuery): void {
         "compose_private_message",
         "user_sidebar",
         "left",
-        false,
-        (instance) => {
-            /* See comment in get_props_for_popover_centering for explanation of this. */
-            $(instance.popper).find(".tippy-box").addClass("show-when-reference-hidden");
-        },
     );
 
     current_user_sidebar_user_id = user.user_id;

--- a/web/tests/activity_ui.test.cjs
+++ b/web/tests/activity_ui.test.cjs
@@ -25,6 +25,31 @@ run_test("redraw", ({override, override_rewire}) => {
     activity_ui.redraw();
 });
 
+run_test("defer buddy list redraw while a user card is open", ({override, override_rewire}) => {
+    const realm = make_realm();
+    state_data.set_realm(realm);
+    override(realm, "realm_presence_disabled", false);
+    override(pm_list, "update_private_messages", noop);
+    override(buddy_list_presence, "update_indicators", noop);
+    activity_ui.set_cursor_and_filter();
+
+    activity_ui.set_user_card_open(true);
+    assert.equal(activity_ui.build_user_sidebar(), undefined);
+    activity_ui.redraw_user(1);
+
+    let build_count = 0;
+    override_rewire(activity_ui, "build_user_sidebar", () => {
+        build_count += 1;
+        return undefined;
+    });
+    activity_ui.set_user_card_open(false);
+    assert.equal(build_count, 1);
+
+    activity_ui.set_user_card_open(true);
+    activity_ui.set_user_card_open(false);
+    assert.equal(build_count, 1);
+});
+
 run_test("initialize", ({override, override_rewire}) => {
     const realm = make_realm();
     state_data.set_realm(realm);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [<CZO topic link>](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.A4.B7.20User.20popover.20jumps.20to.20center.20when.20scrolling/with/2447009)[#issues > 🤷 User popover jumps to center when scrolling](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.A4.B7.20User.20popover.20jumps.20to.20center.20when.20scrolling/with/2447009).

Opening a user card from the buddy list would sometimes throw the card into
the middle of the screen. The buddy list rebuilds its rows on every presence
change (and on the periodic presence ping), which replaces the row the card
is pinned to. On the next scroll, Popper can't find that row and falls back to
showing the card as a centered overlay. Scrolling the row out of view hits the
same path.

This pins the card to its row by user ID instead of to a specific node, so a
rebuild no longer loses it, and the card still hides when its row scrolls off
(like the user cards in the message feed). The old centering fallback in
popover_menus is then removed.

To reproduce:
1. Keep your chat.zulip.org window short (on a large monitor, shrink the window so the buddy list gets a scrollbar).
2. Open a User Card from the Buddy list.
3. Wait approx 60s for the periodic presence ping(or have another user go idle/active) - this rebuilds the buddy list row and detaches the one the card was anchored to.
4. Scroll the list a little.
5. Bug: The Card jumps to Centre.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
