### PR TITLE
custom_profile_fields: return 400 for non-string subtype

### DIFF
--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -252,6 +252,10 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_error(result, "field_data is not valid JSON")
 
+        data["field_data"] = orjson.dumps({"subtype": {"a": "b"}}).decode()
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_error(result, "field_data['subtype'] must be a string")
+
         data["field_data"] = orjson.dumps({}).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_error(result, "subtype key is missing from field_data")

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -202,7 +202,8 @@ def create_realm_custom_profile_field(
     try:
         if is_default_external_field(field_type, field_data):
             field_subtype = field_data["subtype"]
-            assert isinstance(field_subtype, str)
+            if not isinstance(field_subtype, str):
+                raise JsonableError(_("field_data['subtype'] must be a string"))
             field = try_add_realm_default_custom_profile_field(
                 realm=user_profile.realm,
                 field_subtype=field_subtype,


### PR DESCRIPTION
Fixes #39845

Replaces the \ssert isinstance(field_subtype, str)\ with a JsonableError so invalid requests get a 400 instead of a 500. A dict subtype passes the ProfileFieldData type and previously crashed on the assert.