### PR TITLE
redmine: use journal author for issue update notifications

### DIFF
--- a/zerver/webhooks/redmine/fixtures/issue_updated.json
+++ b/zerver/webhooks/redmine/fixtures/issue_updated.json
@@ -59,11 +59,11 @@
       "author": {
         "icon_url": "http://www.gravatar.com/avatar/example",
         "identity_url": null,
-        "lastname": "user",
-        "firstname": "test",
-        "mail": "test@example.com",
-        "login": "test",
-        "id": 3
+        "lastname": "other",
+        "firstname": "another",
+        "mail": "another@example.com",
+        "login": "another",
+        "id": 9
       },
       "created_on": "2014-03-01T16:17:48Z",
       "id": 1

--- a/zerver/webhooks/redmine/tests.py
+++ b/zerver/webhooks/redmine/tests.py
@@ -24,7 +24,7 @@ I'm having a problem with this.
         self.check_webhook("issue_opened_without_assignee", self.TOPIC_NAME, expected_message)
 
     def test_issue_updated(self) -> None:
-        expected_message = """**test user** updated [#191 Found a bug](https://example.com).
+        expected_message = """**another other** updated [#191 Found a bug](https://example.com).
 
 ~~~ quote
 I've started working on this issue. The problem seems to be in the authentication module.

--- a/zerver/webhooks/redmine/view.py
+++ b/zerver/webhooks/redmine/view.py
@@ -68,7 +68,8 @@ def handle_issue_opened(payload: WildValue) -> str:
 
 def handle_issue_updated(payload: WildValue) -> str:
     issue = payload["issue"]
-    author_name = _get_user_name(issue["author"])
+    journal = payload["journal"]
+    author_name = _get_user_name(journal["author"])
     issue_link = _get_issue_link(payload)
 
     journal_notes = ""


### PR DESCRIPTION
Fixes #39448

For 'updated' events, the actor is the person who added the journal entry, available at \payload.journal.author\, not the original issue creator at \payload.issue.author\.