### PR TITLE
user_message: sort bulk inserts by message_id to avoid import deadlock

### DIFF
--- a/zerver/lib/user_message.py
+++ b/zerver/lib/user_message.py
@@ -60,6 +60,11 @@ def bulk_insert_ums(ums: list[UserMessageLite]) -> None:
         return
 
     vals = [(um.user_profile_id, um.message_id, um.flags) for um in ums]
+    # Sort by message_id so the FK check's FOR KEY SHARE locks on
+    # zerver_message are taken in ascending ID order, matching
+    # process_fts_updates' "ORDER BY id FOR UPDATE"; otherwise the
+    # two can deadlock during realm import.
+    vals.sort(key=lambda val: val[1])
     query = SQL(
         """
         INSERT into


### PR DESCRIPTION
Fixes #39743

Sort rows by message_id in bulk_insert_ums so the FK check's FOR KEY SHARE locks on zerver_message are taken in ascending ID order, matching process_fts_updates' ORDER BY id FOR UPDATE. This prevents deadlocks during realm import.