### PR TITLE
push_notifications: skip bot users gracefully

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1694,7 +1694,11 @@ def handle_push_notification(user_profile_id: int, missed_message: dict[str, Any
         return
 
     user_profile = get_user_profile_by_id(user_profile_id)
-    assert not user_profile.is_bot
+    if user_profile.is_bot:
+        # Bots cannot have mobile push notifications; an event may still be
+        # queued for one when a message mentioning a bot is moved or edited.
+        logger.info("Skipping push notification for bot user %s", user_profile.id)
+        return
 
     if not (
         user_profile.enable_offline_push_notifications

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2164,6 +2164,21 @@ class TestSendNotificationsToBouncer(PushNotificationTestCase):
             self.assertEqual(m.call_args.args[1], apns_expected_payload)
             self.assertEqual(m.call_args.args[2], fcm_expected_payload)
 
+    @mock.patch("zerver.lib.push_notifications.send_push_notifications_legacy")
+    def test_send_notification_to_bot_user_skipped(
+        self, mock_send: mock.MagicMock
+    ) -> None:
+        bot = self.create_test_bot("pushbot", self.example_user("hamlet"))
+        with self.assertLogs("zerver.lib.push_notifications", level="INFO") as mock_logging_info:
+            handle_push_notification(bot.id, {})
+            mock_send.assert_not_called()
+        self.assertEqual(
+            mock_logging_info.output,
+            [
+                f"INFO:zerver.lib.push_notifications:Skipping push notification for bot user {bot.id}"
+            ],
+        )
+
 
 @activate_push_notification_service()
 class TestSendToPushBouncer(ZulipTestCase):


### PR DESCRIPTION
Fixes #39888

An event can be queued for a bot user when a message mentioning the bot is moved or edited. Replace the assertion with a graceful skip and log instead of crashing the worker.