### PR TITLE
playgrounds: match custom languages case-insensitively

### DIFF
--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -30,7 +30,20 @@ export function update_playgrounds(playgrounds_data: RealmPlayground[]): void {
 }
 
 export function get_playground_info_for_languages(lang: string): RealmPlayground[] | undefined {
-    return map_language_to_playground_info.get(lang);
+    // The backend lowercases code fence language tags before writing the
+    // data-code-language attribute, so match playgrounds case-insensitively
+    // to ensure custom language names containing uppercase letters work.
+    const exact = map_language_to_playground_info.get(lang);
+    if (exact !== undefined) {
+        return exact;
+    }
+    const lang_lower = lang.toLowerCase();
+    for (const [language, playground_info] of map_language_to_playground_info) {
+        if (language.toLowerCase() === lang_lower) {
+            return playground_info;
+        }
+    }
+    return undefined;
 }
 
 export function get_aliases_for_pretty_name(pretty_name: string): string[] {

--- a/web/tests/realm_playground.test.cjs
+++ b/web/tests/realm_playground.test.cjs
@@ -119,3 +119,42 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     assert.equal(iterator.next().value[1], "quote (quote, quote)");
     assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
 });
+
+run_test("get_playground_info_for_languages", () => {
+    const playground_data = [
+        {
+            id: 1,
+            name: "Uppercase Lang",
+            pygments_language: "Myownlanguage",
+            url_template: "https://example.com/?q={code}",
+        },
+        {
+            id: 2,
+            name: "Python",
+            pygments_language: "Python",
+            url_template: "https://example.com/?q={code}",
+        },
+    ];
+    realm_playground.initialize({
+        playground_data,
+        pygments_comparator_func: typeahead_helper.compare_language,
+    });
+
+    // A playground configured with an uppercase custom language name must be
+    // matched even when the code fence tag (and thus the backend's
+    // data-code-language attribute) is lowercased.
+    const lowercase_match = realm_playground.get_playground_info_for_languages("myownlanguage");
+    assert.equal(lowercase_match?.length, 1);
+    assert.equal(lowercase_match?.[0]?.id, 1);
+
+    // The original casing and exact matches must still work.
+    const exact_match = realm_playground.get_playground_info_for_languages("Myownlanguage");
+    assert.equal(exact_match?.[0]?.id, 1);
+
+    const python_match = realm_playground.get_playground_info_for_languages("python");
+    assert.equal(python_match?.[0]?.id, 2);
+
+    // Unrelated languages must not match.
+    const no_match = realm_playground.get_playground_info_for_languages("ruby");
+    assert.equal(no_match, undefined);
+});


### PR DESCRIPTION
Fixes #39847

The backend lowercases code fence language tags before writing the data-code-language attribute, so a playground configured with an uppercase custom language name (e.g. Myownlanguage) could never be looked up with the lowercased key. Fall back to a case-insensitive lookup when an exact match is not found.