### PR TITLE
[ai] search: Fix search suggestions for inaccessible channels.

### DIFF
--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -168,7 +168,14 @@ function maybe_generate_combined_channel_topic_pill(
 
     const sign = search_pill.negated ? "-" : "";
     const channel_operand = search_terms[index - 1]!.operand;
-    const sub = stream_data.get_valid_sub_by_id_string(channel_operand);
+    const sub = stream_data.get_sub_by_id_string(channel_operand);
+    // Pill terms are only validated at pill creation, so a suggestion
+    // can reference a channel this client has no data for, e.g. a
+    // channel deleted while a pill referenced it. Fall back to
+    // separate pills, where the channel term is rendered as invalid.
+    if (sub === undefined) {
+        return undefined;
+    }
     return {
         ...search_pill,
         sign,

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -1001,6 +1001,13 @@ function suggestion_search_string(suggestion_line: SuggestionLine): string {
 }
 
 function suggestions_for_empty_search_query(): SuggestionLine[] {
+    const current_narrow_terms = narrow_state.search_terms();
+    // Don't suggest searching the current conversation when some of
+    // its terms are invalid, e.g. if the user visited a link to a
+    // channel that they can't access, and then opened search.
+    if (current_narrow_terms.some((term) => !Filter.is_valid_canonical_term(term))) {
+        return [];
+    }
     // Since the context here is an **empty** search query, we assume
     // that there is no `near:` operator. So it's safe to use
     // functions like narrowed_by_topic_reply that return false on
@@ -1013,7 +1020,7 @@ function suggestions_for_empty_search_query(): SuggestionLine[] {
                     operand: narrow_state.stream_id()!.toString(),
                 },
             ]),
-            get_default_suggestion_line(narrow_state.search_terms()),
+            get_default_suggestion_line(current_narrow_terms),
         ];
     }
     if (narrow_state.narrowed_by_pm_reply()) {
@@ -1024,10 +1031,10 @@ function suggestions_for_empty_search_query(): SuggestionLine[] {
                     operand: "dm",
                 },
             ]),
-            get_default_suggestion_line(narrow_state.search_terms()),
+            get_default_suggestion_line(current_narrow_terms),
         ];
     }
-    return [get_default_suggestion_line(narrow_state.search_terms())];
+    return [get_default_suggestion_line(current_narrow_terms)];
 }
 
 class Attacher {

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -356,6 +356,32 @@ run_test("create_item_from_search_string with invalid string", () => {
     assert.equal(pills.length, 0);
 });
 
+run_test("generate_pills_html with unknown channel", ({mock_template, override}) => {
+    mock_template("search_list_item.hbs", true, (_data, html) => html);
+    override(realm, "realm_empty_topic_display_name", "general chat");
+
+    // A known channel followed by a topic is rendered as a combined
+    // `#channel > topic` pill.
+    let html = search_pill.generate_pills_html(`channel:${verona.stream_id} topic:lunch`, "");
+    assert.ok(html.includes("decorated-channel-name"));
+
+    // The channel can be unknown to this client, e.g. a channel
+    // deleted while a pill referenced it. We render separate pills,
+    // with the channel term rendered as invalid.
+    const unknown_stream_id_string = "999";
+    assert.equal(stream_data.get_sub_by_id_string(unknown_stream_id_string), undefined);
+    html = search_pill.generate_pills_html(`channel:${unknown_stream_id_string} topic:lunch`, "");
+    assert.ok(!html.includes("decorated-channel-name"));
+    assert.ok(html.includes(`channel:${unknown_stream_id_string}`));
+    assert.ok(html.includes("topic: lunch"));
+
+    // The same, for an empty string topic.
+    html = search_pill.generate_pills_html(`channel:${unknown_stream_id_string} topic:`, "");
+    assert.ok(!html.includes("decorated-channel-name"));
+    assert.ok(html.includes(`channel:${unknown_stream_id_string}`));
+    assert.ok(html.includes("empty-topic-display"));
+});
+
 run_test("set_search_bar_contents with duplicate pills", () => {
     const duplicate_attachment_terms = [
         {

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -1207,3 +1207,39 @@ test("queries_with_spaces", () => {
     expected = [`channel:${dev_help_id}`];
     assert.deepEqual(suggestions, expected);
 });
+
+test("empty query suggestions in an inaccessible narrow", ({override}) => {
+    const office_id = new_stream_id();
+    stream_data.add_sub_for_tests(
+        make_stream({
+            stream_id: office_id,
+            name: "office",
+            subscribed: true,
+        }),
+    );
+    const unknown_stream_id = new_stream_id();
+
+    let narrow_terms;
+    override(narrow_state, "search_terms", () => narrow_terms);
+    override(narrow_state, "narrowed_by_topic_reply", () => false);
+    override(narrow_state, "narrowed_by_pm_reply", () => false);
+
+    // An empty query in an accessible narrow suggests searching the
+    // current conversation.
+    narrow_terms = [
+        {operator: "channel", operand: office_id.toString(), negated: false},
+        {operator: "topic", operand: "lunch", negated: false},
+    ];
+    let suggestions = search.get_suggestions([], [], true);
+    assert.equal(suggestions[0], `channel:${office_id} topic:lunch`);
+
+    // When the narrow's channel is unknown to this client,
+    // we don't suggest searching the current conversation, and the
+    // suggestions are the same as if there were no current filter.
+    narrow_terms = [
+        {operator: "channel", operand: unknown_stream_id.toString(), negated: false},
+        {operator: "topic", operand: "lunch", negated: false},
+    ];
+    suggestions = search.get_suggestions([], [], true);
+    assert.deepEqual(suggestions, search.get_suggestions([], [], false));
+});


### PR DESCRIPTION
Logged-out spectators who followed a message link to a channel that
isn't web-public got an "Error: Assertion failed" banner when opening
search, because it tried adding channel terms for an unknown channel. 

There is no GitHub issue for this; the crash was found while manually
testing #39836 as a spectator.

I haven't confirmed, but Claude says this bug was introduced in 4a12c58f1b
