### PR TITLE
message_edit: Preparatory fixes for edit-form re-render and banner scoping.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -83,7 +83,10 @@ export function append_compose_banner_to_banner_list(
     $banner: JQuery,
     $list_container: JQuery,
 ): boolean {
-    if ($banner.hasClass("warning") && has_error()) {
+    // Suppress a warning only when its own container already shows an
+    // error; an error elsewhere (e.g. the compose box) must not hide a
+    // warning targeting a different container.
+    if ($banner.hasClass("warning") && has_error($list_container)) {
         return false;
     }
     scroll_util.get_content_element($list_container).append($banner);
@@ -311,8 +314,8 @@ export function show_unknown_zoom_user_error(email: string): void {
     append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
 }
 
-export function has_error(): boolean {
-    return $("#compose_banners .error").length > 0;
+export function has_error($list_container: JQuery): boolean {
+    return $list_container.find(`.${CSS.escape(ERROR)}`).length > 0;
 }
 
 export function show_convert_pasted_text_to_file_banner({

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -216,6 +216,32 @@ export function show_error_message(
     }
 }
 
+export function show_warning_message(
+    message: string,
+    classname: string,
+    $container: JQuery,
+    {
+        button_text = null,
+        stream_id = null,
+        topic_name = null,
+    }: {button_text?: string | null; stream_id?: number | null; topic_name?: string | null} = {},
+): boolean {
+    // The warning counterpart of show_error_message: same classname-dedupe,
+    // and like that function it intentionally does not support HTML messages.
+    // Returns whether the banner was appended.
+    $container.find(`.${CSS.escape(classname)}`).remove();
+
+    const new_row_html = render_compose_banner({
+        banner_type: WARNING,
+        stream_id,
+        topic_name,
+        banner_text: message,
+        button_text,
+        classname,
+    });
+    return append_compose_banner_to_banner_list($(new_row_html), $container);
+}
+
 export function cannot_send_direct_message_error(error_message: string): void {
     // If a banner with this classname already exists, avoid removing
     // and re-creating it.

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -2,7 +2,6 @@ import {$} from "jquery";
 import _ from "lodash";
 import type {ReferenceElement} from "tippy.js";
 
-import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 import render_compose_mention_group_warning from "../templates/compose_banner/compose_mention_group_warning.hbs";
 import render_guest_in_dm_recipient_warning from "../templates/compose_banner/guest_in_dm_recipient_warning.hbs";
 import render_not_subscribed_warning from "../templates/compose_banner/not_subscribed_warning.hbs";
@@ -516,22 +515,14 @@ export function warn_if_topic_resolved(topic_changed: boolean): void {
             ? $t({defaultMessage: "Unresolve topic"})
             : null;
 
-        const context = {
-            banner_type: compose_banner.WARNING,
-            stream_id: sub.stream_id,
-            topic_name,
-            banner_text: $t({
+        const appended = compose_banner.show_warning_message(
+            $t({
                 defaultMessage:
                     "You are sending a message to a resolved topic. You can send as-is or unresolve the topic first.",
             }),
-            button_text,
-            classname: compose_banner.CLASSNAMES.topic_resolved,
-        };
-
-        const new_row_html = render_compose_banner(context);
-        const appended = compose_banner.append_compose_banner_to_banner_list(
-            $(new_row_html),
+            compose_banner.CLASSNAMES.topic_resolved,
             $("#compose_banners"),
+            {button_text, stream_id: sub.stream_id, topic_name},
         );
         if (appended) {
             compose_state.set_recipient_viewed_topic_resolved_banner(true);
@@ -625,18 +616,15 @@ export function inform_if_topic_is_moved(
 export function warn_if_in_search_view(): void {
     const filter = narrow_state.filter();
     if (filter && !filter.contains_no_partial_conversations()) {
-        const context = {
-            banner_type: compose_banner.WARNING,
-            banner_text: $t({
+        compose_banner.show_warning_message(
+            $t({
                 defaultMessage:
                     "This conversation may have additional messages not shown in this view.",
             }),
-            button_text: $t({defaultMessage: "Go to conversation"}),
-            classname: compose_banner.CLASSNAMES.search_view,
-        };
-
-        const new_row_html = render_compose_banner(context);
-        compose_banner.append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
+            compose_banner.CLASSNAMES.search_view,
+            $("#compose_banners"),
+            {button_text: $t({defaultMessage: "Go to conversation"})},
+        );
     }
 }
 

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -347,13 +347,15 @@ export function hide_message_edit_spinner($row: JQuery): void {
     $row.find(".message_edit_cancel").removeClass("message-edit-button-disabled");
 }
 
-export function show_message_edit_spinner($row: JQuery): void {
+export function show_message_edit_spinner($row: JQuery, keep_cancel_enabled = false): void {
     // Always show the white spinner like we
     // do for send button in compose box.
     loading.show_button_spinner($row.find(".loader"), true);
     $row.find(".message_edit_save span").addClass("showing-button-spinner");
     $row.find(".message_edit_save").addClass("message-edit-button-disabled");
-    $row.find(".message_edit_cancel").addClass("message-edit-button-disabled");
+    if (!keep_cancel_enabled) {
+        $row.find(".message_edit_cancel").addClass("message-edit-button-disabled");
+    }
 }
 
 export function show_topic_edit_spinner($row: JQuery): void {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -782,6 +782,16 @@ function start_edit_maintaining_scroll($row: JQuery, content: string): void {
     }
 }
 
+function setup_edit_form_widgets($row: JQuery): void {
+    const row_id = rows.id($row);
+    upload.setup_upload(upload.edit_config(row_id));
+    // Setup dropdown for saved snippets button in the current
+    // message edit control buttons tray.
+    saved_snippets_ui.setup_saved_snippets_dropdown_widget(
+        `.saved-snippets-message-edit-widget[data-message-id="${CSS.escape(row_id.toString())}"]`,
+    );
+}
+
 function start_edit_with_content(
     $row: JQuery,
     content: string,
@@ -791,13 +801,7 @@ function start_edit_with_content(
     if (edit_box_open_callback) {
         edit_box_open_callback();
     }
-    const row_id = rows.id($row);
-    upload.setup_upload(upload.edit_config(row_id));
-    // Setup dropdown for saved snippets button in the current
-    // message edit control buttons tray.
-    saved_snippets_ui.setup_saved_snippets_dropdown_widget(
-        `.saved-snippets-message-edit-widget[data-message-id="${CSS.escape(row_id.toString())}"]`,
-    );
+    setup_edit_form_widgets($row);
 }
 
 export function start($row: JQuery, edit_box_open_callback?: () => void): void {
@@ -1498,6 +1502,11 @@ export function maybe_show_edit($row: JQuery, id: number): void {
     if (currently_editing_messages.has(id)) {
         const $message_edit_content = currently_editing_messages.get(id);
         edit_message($row, $message_edit_content?.val() ?? "");
+        setup_edit_form_widgets($row);
+        if ($row.hasClass("show_preview")) {
+            show_preview_area($row);
+            $row.removeClass("show_preview");
+        }
     }
 }
 

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1864,8 +1864,13 @@ export class MessageListView {
         if (message_content_edited) {
             $rendered_msg.addClass("fade-in-message");
         }
-        this._post_process($rendered_msg);
+        if ($row.hasClass("preview_mode")) {
+            // We'll render the preview area after we've
+            // rendered the message edit content in this new row.
+            $rendered_msg.addClass("show_preview");
+        }
         $row.replaceWith($rendered_msg);
+        this._post_process($rendered_msg);
 
         message_list_hover.reapply_hover_on_row_replace($row, $rendered_msg, message_container.msg);
 
@@ -1989,6 +1994,7 @@ export class MessageListView {
             this.update_sticky_recipient_headers();
             maybe_restore_focus_to_message_edit_form();
         }
+        autosize.update(this.$list.find(".message_edit_content"));
     }
 
     append(

--- a/web/src/scheduled_messages_ui.ts
+++ b/web/src/scheduled_messages_ui.ts
@@ -1,8 +1,6 @@
 import {$} from "jquery";
 import assert from "minimalistic-assert";
 
-import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
-
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_banner from "./compose_banner.ts";
 import {$t} from "./i18n.ts";
@@ -92,17 +90,13 @@ function show_message_unscheduled_banner(scheduled_delivery_timestamp: number): 
         new Date(scheduled_delivery_timestamp * 1000),
         "time",
     );
-    const unscheduled_banner_html = render_compose_banner({
-        banner_type: compose_banner.WARNING,
-        banner_text: $t({
+    compose_banner.show_warning_message(
+        $t({
             defaultMessage: "This message is no longer scheduled to be sent.",
         }),
-        button_text: $t({defaultMessage: "Schedule for {deliver_at}"}, {deliver_at}),
-        classname: compose_banner.CLASSNAMES.unscheduled_message,
-    });
-    compose_banner.append_compose_banner_to_banner_list(
-        $(unscheduled_banner_html),
+        compose_banner.CLASSNAMES.unscheduled_message,
         $("#compose_banners"),
+        {button_text: $t({defaultMessage: "Schedule for {deliver_at}"}, {deliver_at})},
     );
 }
 

--- a/web/tests/lib/compose_banner.cjs
+++ b/web/tests/lib/compose_banner.cjs
@@ -37,4 +37,7 @@ exports.mock_banners = () => {
     $cb.set_find_results(".missing_private_message_recipient", $stub);
     $cb.set_find_results(".subscription_error", $stub);
     $cb.set_find_results(".generic_compose_error", $stub);
+    $cb.set_find_results(".topic_resolved", $stub);
+    $cb.set_find_results(".search_view", $stub);
+    $cb.set_find_results(".unscheduled_message", $stub);
 };

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -345,6 +345,11 @@ test("rerender_messages rebuilds every distinct recipient bar", () => {
         rerendered_group_ids.push(group.message_group_id);
     };
 
+    // rerender_messages re-applies autosize to any open edit textareas; with
+    // no message being edited, the lookup returns an empty set.
+    const empty_list_stub = $.set_results("empty-stub", []);
+    view.$list.set_find_results(".message_edit_content", empty_list_stub);
+
     view.rerender_messages([dm1.msg, dm2.msg, dm3.msg]);
 
     // One header rerender per distinct bar; the rowless message is skipped.


### PR DESCRIPTION
This is a Preparatory PR for #39417 so it can merged independently. The follow-up PR builds on all four commits to keep an
open edit form (and its preview) alive across `update_message` events.

**What's here:**

* `message_edit: Restore edit form setup when its row is re-rendered.` - Rebuilding an open edit form left its paste/file upload handlers inert; re-run that setup so uploads, autosize, and an open preview survive the re-render.

* `message_edit: Let show_message_edit_spinner keep Cancel enabled.` - Adds an opt-in `keep_cancel_enabled` parameter for showing the saving spinner with Save fully disabled but Cancel usable. Its caller is in the follow-up PR.

* `compose_banner: Add show_warning_message helper for warning banners.` - Pure refactor adding the warning counterpart of `show_error_message`, and converting three call sites off duplicated boilerplate. Banners are unchanged.

* `compose_banner: Suppress warnings only for the container with an error.` -`has_error()` queried `#compose_banners` globally, so a compose-box error suppressed warnings in other containers, e.g. an edit form's wildcard-mention warning. The check is now scoped to the banner's own container.

Fixes: part of #29028.

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
