### PR TITLE
 dispatch: Update collapsed messages from update_message_flags events.

### DIFF
--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -77,14 +77,22 @@ function uncondense_row($row: JQuery): void {
     show_message_condenser($row);
 }
 
-export function uncollapse(message: Message): void {
-    // Uncollapse a message, restoring the condensed message "Show more" or
-    // "Show less" button if necessary.
-    message.collapsed = false;
-    message_flags.save_uncollapsed(message);
+// Callers that change the collapsed flag are responsible for saving it.
+export function update_collapsed_view(message: Message): void {
+    for (const list of message_lists.all_rendered_message_lists()) {
+        const $row = list.get_row(message.id);
+        if ($row.length === 0) {
+            continue;
+        }
 
-    const process_row = function process_row($row: JQuery): void {
         const $content = $row.find(".message_content");
+
+        if (message.collapsed) {
+            $content.addClass("collapsed");
+            show_message_expander($row);
+            continue;
+        }
+
         $content.removeClass("collapsed");
 
         if (message.condensed === true) {
@@ -102,14 +110,13 @@ export function uncollapse(message: Message): void {
             // This was a short message, no more need for a [More] link.
             hide_message_length_toggle($row);
         }
-    };
-
-    for (const list of message_lists.all_rendered_message_lists()) {
-        const $rendered_row = list.get_row(message.id);
-        if ($rendered_row.length > 0) {
-            process_row($rendered_row);
-        }
     }
+}
+
+export function uncollapse(message: Message): void {
+    message.collapsed = false;
+    message_flags.save_uncollapsed(message);
+    update_collapsed_view(message);
 }
 
 export function collapse(message: Message): void {
@@ -124,18 +131,7 @@ export function collapse(message: Message): void {
     }
 
     message_flags.save_collapsed(message);
-
-    const process_row = function process_row($row: JQuery): void {
-        $row.find(".message_content").addClass("collapsed");
-        show_message_expander($row);
-    };
-
-    for (const list of message_lists.all_rendered_message_lists()) {
-        const $rendered_row = list.get_row(message.id);
-        if ($rendered_row.length > 0) {
-            process_row($rendered_row);
-        }
-    }
+    update_collapsed_view(message);
 }
 
 export function toggle_collapse(message: Message): void {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -17,6 +17,7 @@ import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_validate from "./compose_validate.ts";
+import * as condense from "./condense.ts";
 import {electron_bridge} from "./electron_bridge.ts";
 import * as emoji from "./emoji.ts";
 import * as emoji_frequency from "./emoji_frequency.ts";
@@ -1183,6 +1184,19 @@ export function dispatch_normal_event(event) {
                         "is-unread",
                         new_value,
                     );
+                    break;
+                case "collapsed":
+                    for (const message_id of event.messages) {
+                        const message = message_store.get(message_id);
+                        if (message === undefined) {
+                            // If we don't have the message locally, do
+                            // nothing; if later we fetch it, it'll come
+                            // with the correct `collapsed` state.
+                            continue;
+                        }
+                        message.collapsed = new_value;
+                        condense.update_collapsed_view(message);
+                    }
                     break;
             }
             break;

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -43,6 +43,7 @@ mock_esm("../src/compose_validate", {
     validate_and_update_send_button_status: noop,
     warn_if_guest_in_dm_recipient: noop,
 });
+const condense = mock_esm("../src/condense");
 const message_events = mock_esm("../src/message_events", {
     update_views_filtered_on_message_property: noop,
     update_current_view_for_topic_visibility: noop,
@@ -1536,6 +1537,40 @@ run_test("update_message (remove star)", () => {
     dispatch(event);
     const msg = message_store.get(test_message.id);
     assert.equal(msg.starred, false);
+});
+
+run_test("update_message (collapse)", ({override}) => {
+    const updated_messages = [];
+    override(condense, "update_collapsed_view", (message) => {
+        updated_messages.push(message);
+    });
+
+    const event = event_fixtures.update_message_flags__collapsed_add;
+    dispatch(event);
+    const msg = message_store.get(test_message.id);
+    assert.equal(msg.collapsed, true);
+    assert.deepEqual(updated_messages, [msg]);
+
+    // A cached flag that already matches doesn't mean the rendered rows
+    // do, so we re-render them regardless of the flag's previous value.
+    dispatch(event);
+    assert.deepEqual(updated_messages, [msg, msg]);
+
+    // We don't have this message locally, so there's no view to update.
+    dispatch({...event, messages: [0]});
+    assert.deepEqual(updated_messages, [msg, msg]);
+});
+
+run_test("update_message (uncollapse)", ({override}) => {
+    const updated_messages = [];
+    override(condense, "update_collapsed_view", (message) => {
+        updated_messages.push(message);
+    });
+
+    dispatch(event_fixtures.update_message_flags__collapsed_remove);
+    const msg = message_store.get(test_message.id);
+    assert.equal(msg.collapsed, false);
+    assert.deepEqual(updated_messages, [msg]);
 });
 
 run_test("update_message (wrong data)", () => {

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -947,6 +947,24 @@ exports.fixtures = {
         recipients: [typing_person2],
     },
 
+    update_message_flags__collapsed_add: {
+        type: "update_message_flags",
+        op: "add",
+        operation: "add",
+        flag: "collapsed",
+        messages: [exports.test_message.id],
+        all: false,
+    },
+
+    update_message_flags__collapsed_remove: {
+        type: "update_message_flags",
+        op: "remove",
+        operation: "remove",
+        flag: "collapsed",
+        messages: [exports.test_message.id],
+        all: false,
+    },
+
     update_message_flags__read: {
         type: "update_message_flags",
         op: "add",


### PR DESCRIPTION
Found [during review](https://github.com/zulip/zulip/pull/38241#discussion_r3710191752) in #38241.

Collapsing a message saves the `collapsed` flag to the server, which sends an `update_message_flags` event to all of the user's clients. The web app handles `starred` and `read` there, but never handled `collapsed` - so collapsing or expanding a message in one client left it unchanged in the user's other clients until a reload.

This handles `collapsed` the same way `starred` is handled: update the cached message and re-render its rows. The first commit is a no-op refactor extracting the row rendering shared by `collapse()` and `uncollapse()` so the event path can reuse it; the second adds the dispatcher case and its tests.

**Screenshots and screen captures:**

No new UI; the change makes an existing message state stay in sync across a user's clients.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
