### PR TITLE
api docs: Document POST /remotes/server/analytics and /billing.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -163,6 +163,7 @@
 * [Deactivate an organization](/api/deactivate-realm)
 * [Deactivate a registered server](/api/deactivate-remote-server)
 * [Check analytics upload status](/api/remote-server-check-analytics)
+* [Upload analytics data](/api/remote-server-post-analytics)
 * [Begin transferring a server registration](/api/transfer-remote-server-registration)
 
 ## Real-time events

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -164,6 +164,7 @@
 * [Deactivate a registered server](/api/deactivate-remote-server)
 * [Check analytics upload status](/api/remote-server-check-analytics)
 * [Upload analytics data](/api/remote-server-post-analytics)
+* [Create a billing session](/api/remote-realm-billing-entry)
 * [Begin transferring a server registration](/api/transfer-remote-server-registration)
 
 ## Real-time events

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -162,6 +162,7 @@
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate an organization](/api/deactivate-realm)
 * [Deactivate a registered server](/api/deactivate-remote-server)
+* [Check analytics upload status](/api/remote-server-check-analytics)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -163,6 +163,7 @@
 * [Deactivate an organization](/api/deactivate-realm)
 * [Deactivate a registered server](/api/deactivate-remote-server)
 * [Check analytics upload status](/api/remote-server-check-analytics)
+* [Begin transferring a server registration](/api/transfer-remote-server-registration)
 
 ## Real-time events
 

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -161,6 +161,7 @@
 * [Get data export consent state](/api/get-realm-export-consents)
 * [Test welcome bot custom message](/api/test-welcome-bot-custom-message)
 * [Deactivate an organization](/api/deactivate-realm)
+* [Deactivate a registered server](/api/deactivate-remote-server)
 
 ## Real-time events
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -271,6 +271,7 @@ INSECURE_OPERATIONS = [
     "/fetch_api_key:post",
     "/jwt/fetch_api_key:post",
     "/dev_list_users:get",
+    "/remotes/server/register/transfer:post",
 ]
 
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -329,6 +329,8 @@ def generate_curl_example(
             raise AssertionError(
                 "Unknown operation without a securityScheme. Please update insecure_operations."
             )
+    elif operation_security == [{"remoteServerAuth": []}]:
+        authentication_required = True
     else:
         raise AssertionError(
             "Unhandled securityScheme. Please update the code to handle this scheme."

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -28,10 +28,11 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     # Requires organization-specific JWT_AUTH_KEYS configuration.
     "jwt-fetch-api-key",
     # Would need push notification bouncer set up to test the
-    # generated curl example for the following three endpoints.
+    # generated curl example for the following endpoints.
     "e2ee-test-notify",
     "test-notify",
     "register-remote-push-device",
+    "deactivate-remote-server",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -33,6 +33,7 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "test-notify",
     "register-remote-push-device",
     "deactivate-remote-server",
+    "remote-server-check-analytics",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -34,6 +34,7 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "register-remote-push-device",
     "deactivate-remote-server",
     "remote-server-check-analytics",
+    "transfer-remote-server-registration",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -36,6 +36,7 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "remote-server-check-analytics",
     "transfer-remote-server-registration",
     "remote-server-post-analytics",
+    "remote-realm-billing-entry",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -35,6 +35,7 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "deactivate-remote-server",
     "remote-server-check-analytics",
     "transfer-remote-server-registration",
+    "remote-server-post-analytics",
     # Having a message for a specific user available to test this endpoint
     # is tricky for testing.
     "delete-reminder",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14129,6 +14129,59 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /remotes/server/analytics/status:
+    get:
+      operationId: remote-server-check-analytics
+      summary: Check analytics upload status
+      tags: ["server_and_organizations"]
+      description: |
+        Fetch the IDs of the most recent analytics rows the [Mobile Push
+        Notification Service][mobile-push] has received from a self-hosted
+        Zulip server.
+
+        A self-hosted server uses this endpoint to determine which
+        analytics rows it still needs to upload via
+        `POST /remotes/server/analytics`. It is not meant to be used by
+        mobile clients directly.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      last_realm_count_id:
+                        type: integer
+                        description: |
+                          The ID of the last `RealmCount` analytics row the
+                          service has received from this server.
+                      last_installation_count_id:
+                        type: integer
+                        description: |
+                          The ID of the last `InstallationCount` analytics row
+                          the service has received from this server.
+                      last_realmauditlog_id:
+                        type: integer
+                        description: |
+                          The ID of the last `RealmAuditLog` row the service has
+                          received from this server.
+                    example:
+                      {
+                        "last_installation_count_id": 0,
+                        "last_realm_count_id": 0,
+                        "last_realmauditlog_id": 0,
+                        "msg": "",
+                        "result": "success",
+                      }
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14012,6 +14012,8 @@ paths:
         It is not meant to be used by mobile clients directly.
 
         **Changes**: New in Zulip 11.0 (feature level 406).
+      security:
+        - remoteServerAuth: []
       requestBody:
         required: true
         content:
@@ -27481,6 +27483,18 @@ components:
         Basic authentication, with the user's email as the username, and the API
         key as the password. The API key can be fetched using the
         `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
+    remoteServerAuth:
+      type: http
+      scheme: basic
+      description: |
+        Basic authentication used by self-hosted Zulip servers to
+        communicate with the [Mobile Push Notification Service][mobile-push].
+        Unlike the user-facing API, the username is the server's
+        `zulip_org_id` (a UUID) and the password is its `zulip_org_key`,
+        both obtained when the server registers with the service using
+        `manage.py register_server`.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
 
   schemas:
     IgnoredParametersUnsupported:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14110,6 +14110,25 @@ paths:
                     description: |
                       An example JSON response for when no realm is registered for
                       the authenticated server on the bouncer for the given `realm_uuid`:
+  /remotes/server/deactivate:
+    post:
+      operationId: deactivate-remote-server
+      summary: Deactivate a registered server
+      tags: ["server_and_organizations"]
+      description: |
+        Deactivate a self-hosted Zulip server's registration with the
+        [Mobile Push Notification Service][mobile-push].
+
+        A self-hosted server uses this endpoint to deactivate its own
+        registration with the service. It is not meant to be used by
+        mobile clients directly.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14182,6 +14182,62 @@ paths:
                         "msg": "",
                         "result": "success",
                       }
+  /remotes/server/register/transfer:
+    post:
+      operationId: transfer-remote-server-registration
+      summary: Begin transferring a server registration
+      tags: ["server_and_organizations"]
+      description: |
+        Begin transferring an existing server's registration with the
+        [Mobile Push Notification Service][mobile-push] to a server that
+        no longer has the original registration credentials.
+
+        The service returns a short-lived `verification_secret` that the
+        requesting server proves it controls by serving it from the
+        registered hostname; the service then reissues the credentials.
+        This endpoint is unauthenticated, since a server performing a
+        transfer does not have valid credentials to authenticate with.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                hostname:
+                  description: |
+                    The hostname of the registration to transfer. It must
+                    already be registered with the service.
+                  type: string
+                  example: "zulip.example.com"
+              required:
+                - hostname
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      verification_secret:
+                        type: string
+                        description: |
+                          The secret the requesting server should serve from
+                          its hostname to prove control of it.
+                    example:
+                      {
+                        "msg": "",
+                        "result": "success",
+                        "verification_secret": "3430...",
+                      }
   /register_client_device:
     post:
       operationId: register-client-device

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14182,6 +14182,169 @@ paths:
                         "msg": "",
                         "result": "success",
                       }
+  /remotes/server/analytics:
+    post:
+      operationId: remote-server-post-analytics
+      summary: Upload analytics data
+      tags: ["server_and_organizations"]
+      description: |
+        Upload analytics and audit-log data for a self-hosted Zulip server
+        and its realms to the [Mobile Push Notification Service][mobile-push].
+
+        A self-hosted server uses this endpoint to periodically push the
+        analytics rows the service has not yet received (see
+        [check analytics upload status](/api/remote-server-check-analytics)).
+        It is not meant to be used by mobile clients directly.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                realm_counts:
+                  type: array
+                  description: |
+                    The `RealmCount` analytics rows to upload.
+                  items:
+                    $ref: "#/components/schemas/RealmCountDataForAnalytics"
+                  example:
+                    - property: "messages_sent:message_type:day"
+                      realm: 2
+                      id: 51
+                      end_time: 1609459200
+                      subgroup: "public_stream"
+                      value: 12
+                installation_counts:
+                  type: array
+                  description: |
+                    The `InstallationCount` analytics rows to upload.
+                  items:
+                    $ref: "#/components/schemas/InstallationCountDataForAnalytics"
+                  example:
+                    - property: "active_users_audit:is_bot:day"
+                      id: 42
+                      end_time: 1609459200
+                      subgroup: "false"
+                      value: 34
+                realmauditlog_rows:
+                  type: array
+                  description: |
+                    The `RealmAuditLog` rows to upload.
+                  items:
+                    $ref: "#/components/schemas/RealmAuditLogDataForAnalytics"
+                  example:
+                    - id: 101
+                      realm: 2
+                      event_time: 1609459200
+                      backfilled: false
+                      extra_data: null
+                      event_type: 105
+                realms:
+                  type: array
+                  description: |
+                    Registration data for the server's realms.
+                  items:
+                    $ref: "#/components/schemas/RealmDataForAnalytics"
+                  example:
+                    - id: 2
+                      host: "zulip.example.com"
+                      url: "https://zulip.example.com"
+                      name: "Example, Inc."
+                      org_type: 10
+                      date_created: 1577836800
+                      deactivated: false
+                      is_system_bot_realm: false
+                      authentication_methods:
+                        Email: true
+                      uuid: "6cde5f7a-1391-4a5b-bdb9-c1a1f6f6a2c9"
+                      uuid_owner_secret: "F4XLSXqburgObydu3EPffsceGE1Yd6Bg"
+                version:
+                  type: string
+                  description: The server's Zulip version string.
+                  example: "9.0"
+                merge_base:
+                  type: string
+                  description: The server's Zulip merge base.
+                  example: "9.0"
+                api_feature_level:
+                  type: integer
+                  description: The server's Zulip API feature level.
+                  example: 383
+              required:
+                - realm_counts
+                - installation_counts
+            encoding:
+              realm_counts:
+                contentType: application/json
+              installation_counts:
+                contentType: application/json
+              realmauditlog_rows:
+                contentType: application/json
+              realms:
+                contentType: application/json
+              version:
+                contentType: application/json
+              merge_base:
+                contentType: application/json
+              api_feature_level:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      realms:
+                        type: object
+                        description: |
+                          Map from each realm's UUID to its current push
+                          notification status.
+                        additionalProperties:
+                          type: object
+                          additionalProperties: false
+                          description: |
+                            The push notification status for the realm with
+                            this UUID.
+                          properties:
+                            can_push:
+                              type: boolean
+                              description: |
+                                Whether the realm is currently allowed to use
+                                the push notification service.
+                            expected_end_timestamp:
+                              type: integer
+                              nullable: true
+                              description: |
+                                UNIX timestamp for when the realm's current
+                                grace period or plan is expected to end, or
+                                null if not applicable.
+                          required:
+                            - can_push
+                            - expected_end_timestamp
+                    example:
+                      {
+                        "msg": "",
+                        "realms":
+                          {
+                            "6cde5f7a-1391-4a5b-bdb9-c1a1f6f6a2c9":
+                              {
+                                "can_push": true,
+                                "expected_end_timestamp": null,
+                              },
+                          },
+                        "result": "success",
+                      }
   /remotes/server/register/transfer:
     post:
       operationId: transfer-remote-server-registration
@@ -27625,6 +27788,158 @@ components:
         [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
 
   schemas:
+    RealmCountDataForAnalytics:
+      type: object
+      additionalProperties: false
+      description: |
+        A `RealmCount` analytics row for a realm on the self-hosted server.
+      properties:
+        property:
+          type: string
+          description: The name of the analytics statistic being reported.
+        realm:
+          type: integer
+          description: The server-local ID of the realm this row belongs to.
+        id:
+          type: integer
+          description: The server-local ID of this `RealmCount` row.
+        end_time:
+          type: number
+          description: |
+            UNIX timestamp for the end of the time interval this row covers.
+        subgroup:
+          type: string
+          nullable: true
+          description: The subgroup this count is broken down by, if any.
+        value:
+          type: integer
+          description: The value of the statistic for this row.
+      required:
+        - property
+        - realm
+        - id
+        - end_time
+        - subgroup
+        - value
+    InstallationCountDataForAnalytics:
+      type: object
+      additionalProperties: false
+      description: |
+        An `InstallationCount` analytics row for the self-hosted server.
+      properties:
+        property:
+          type: string
+          description: The name of the analytics statistic being reported.
+        id:
+          type: integer
+          description: The server-local ID of this `InstallationCount` row.
+        end_time:
+          type: number
+          description: |
+            UNIX timestamp for the end of the time interval this row covers.
+        subgroup:
+          type: string
+          nullable: true
+          description: The subgroup this count is broken down by, if any.
+        value:
+          type: integer
+          description: The value of the statistic for this row.
+      required:
+        - property
+        - id
+        - end_time
+        - subgroup
+        - value
+    RealmAuditLogDataForAnalytics:
+      type: object
+      additionalProperties: false
+      description: |
+        A `RealmAuditLog` row relevant to billing and analytics.
+      properties:
+        id:
+          type: integer
+          description: The server-local ID of this `RealmAuditLog` row.
+        realm:
+          type: integer
+          description: The server-local ID of the realm this row belongs to.
+        event_time:
+          type: number
+          description: UNIX timestamp for when the logged event occurred.
+        backfilled:
+          type: boolean
+          description: Whether this row was backfilled after the original event.
+        extra_data:
+          description: |
+            Additional data about the event: a JSON object, a string
+            encoding one, or null if there is none.
+          oneOf:
+            - type: string
+            - type: object
+              additionalProperties: true
+              nullable: true
+        event_type:
+          type: integer
+          description: The numeric type of the logged event.
+      required:
+        - id
+        - realm
+        - event_time
+        - backfilled
+        - extra_data
+        - event_type
+    RealmDataForAnalytics:
+      type: object
+      additionalProperties: false
+      description: |
+        Registration data and metadata about a realm on the self-hosted
+        server.
+      properties:
+        id:
+          type: integer
+          description: The server-local ID of the realm.
+        host:
+          type: string
+          description: The realm's host.
+        url:
+          type: string
+          description: The realm's URL.
+        name:
+          type: string
+          description: The realm's name.
+        org_type:
+          type: integer
+          description: |
+            The realm's [organization type](/api/get-server-settings).
+        date_created:
+          type: number
+          description: UNIX timestamp for when the realm was created.
+        deactivated:
+          type: boolean
+          description: Whether the realm is deactivated.
+        is_system_bot_realm:
+          type: boolean
+          description: Whether this is the server's system bot realm.
+        authentication_methods:
+          type: object
+          additionalProperties:
+            type: boolean
+          description: |
+            Map from each authentication method to whether it is enabled for
+            the realm.
+        uuid:
+          type: string
+          description: The realm's UUID.
+        uuid_owner_secret:
+          type: string
+          description: The secret associated with the realm's UUID.
+      required:
+        - id
+        - host
+        - url
+        - date_created
+        - deactivated
+        - uuid
+        - uuid_owner_secret
     IgnoredParametersUnsupported:
       type: array
       items:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14345,6 +14345,137 @@ paths:
                           },
                         "result": "success",
                       }
+  /remotes/server/billing:
+    post:
+      operationId: remote-realm-billing-entry
+      summary: Create a billing session
+      tags: ["server_and_organizations"]
+      description: |
+        Begin a billing session for a realm on a self-hosted Zulip server,
+        returning a URL that the server redirects a logged-in administrator
+        to in order to manage the realm's plan with the [Mobile Push
+        Notification Service][mobile-push].
+
+        A self-hosted server uses this endpoint to hand off one of its
+        users to the service's self-hosted billing management. It is not
+        meant to be used by mobile clients directly.
+
+        [mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+      security:
+        - remoteServerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                user:
+                  allOf:
+                    - $ref: "#/components/schemas/UserDataForRemoteBilling"
+                  example:
+                    uuid: "50f4a5a2-5d9a-4f5c-8f2e-1d6d1f9c1a2b"
+                    email: "admin@example.com"
+                    full_name: "Example Admin"
+                realm:
+                  allOf:
+                    - $ref: "#/components/schemas/RealmDataForAnalytics"
+                  example:
+                    id: 2
+                    host: "zulip.example.com"
+                    url: "https://zulip.example.com"
+                    name: "Example, Inc."
+                    org_type: 10
+                    date_created: 1577836800
+                    deactivated: false
+                    is_system_bot_realm: false
+                    authentication_methods:
+                      Email: true
+                    uuid: "6cde5f7a-1391-4a5b-bdb9-c1a1f6f6a2c9"
+                    uuid_owner_secret: "F4XLSXqburgObydu3EPffsceGE1Yd6Bg"
+                uri_scheme:
+                  type: string
+                  enum:
+                    - "http://"
+                    - "https://"
+                  default: "https://"
+                  example: "https://"
+                  description: |
+                    The URI scheme to use in the returned billing access URL.
+                next_page:
+                  type: string
+                  enum:
+                    - sponsorship
+                    - upgrade
+                    - billing
+                    - plans
+                    - deactivate
+                  example: "upgrade"
+                  description: |
+                    The billing page to send the user to after they log in.
+                    If omitted, the user lands on the default billing page.
+              required:
+                - user
+                - realm
+            encoding:
+              user:
+                contentType: application/json
+              realm:
+                contentType: application/json
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      billing_access_url:
+                        type: string
+                        description: |
+                          The URL the server should redirect the user to in
+                          order to manage billing with the service.
+                    example:
+                      {
+                        "billing_access_url": "https://selfhosting.zulipchat.com/remote-billing-login/...",
+                        "msg": "",
+                        "result": "success",
+                      }
+        "403":
+          description: |
+            The realm is not registered to this server, or is not registered
+            with the service at all.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "REMOTE_REALM_SERVER_MISMATCH_ERROR",
+                            "msg": "Your organization is registered to a different Zulip server. Please contact Zulip support for assistance in resolving this issue.",
+                            "result": "error",
+                          }
+                        description: |
+                          The realm's UUID is registered to a different server.
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "MISSING_REMOTE_REALM",
+                            "msg": "Organization not registered",
+                            "result": "error",
+                          }
+                        description: |
+                          No registration exists for the realm's UUID; the
+                          server should upload its realm data (via
+                          [upload analytics data](/api/remote-server-post-analytics))
+                          to create it.
   /remotes/server/register/transfer:
     post:
       operationId: transfer-remote-server-registration
@@ -27940,6 +28071,26 @@ components:
         - deactivated
         - uuid
         - uuid_owner_secret
+    UserDataForRemoteBilling:
+      type: object
+      additionalProperties: false
+      description: |
+        Identifying information about the server administrator initiating
+        the billing session.
+      properties:
+        uuid:
+          type: string
+          description: The user's UUID.
+        email:
+          type: string
+          description: The user's email address.
+        full_name:
+          type: string
+          description: The user's full name.
+      required:
+        - uuid
+        - email
+        - full_name
     IgnoredParametersUnsupported:
       type: array
       items:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -251,7 +251,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/server/register",
         "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
-        "/remotes/server/deactivate",
         "/remotes/server/analytics",
         "/remotes/server/analytics/status",
         "/remotes/server/billing",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -249,7 +249,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/push/e2ee/notify",
         # Lower priority to document
         "/remotes/server/register",
-        "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
         "/remotes/server/analytics",
         "/remotes/server/billing",
@@ -261,6 +260,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "fetch_api_key",
         "dev_fetch_api_key",
         "jwt/fetch_api_key",
+        "remotes/server/register/transfer",
     }
 
     # Endpoints where the documentation is currently failing our

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -252,7 +252,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/remotes/server/register/transfer",
         "/remotes/server/register/verify_challenge",
         "/remotes/server/analytics",
-        "/remotes/server/analytics/status",
         "/remotes/server/billing",
     }
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -250,7 +250,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         # Lower priority to document
         "/remotes/server/register",
         "/remotes/server/register/verify_challenge",
-        "/remotes/server/billing",
     }
 
     # Endpoints in the API documentation that don't use rest_dispatch

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -250,7 +250,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         # Lower priority to document
         "/remotes/server/register",
         "/remotes/server/register/verify_challenge",
-        "/remotes/server/analytics",
         "/remotes/server/billing",
     }
 


### PR DESCRIPTION
Documents the last two undocumented push-notification-bouncer endpoints, both authenticated as a self-hosted server (`remoteServerAuth`):

- `POST /remotes/server/analytics` - a self-hosted server uploads its analytics and audit-log data: `RealmCount`, `InstallationCount`, and `RealmAuditLog` rows plus per-realm registration data. The four row schemas are added as reusable components, and the 200 response maps each realm's UUID to its current push-notification status.
- `POST /remotes/server/billing` - starts a billing session for a realm, returning the URL the server redirects a logged-in administrator to in order to manage the realm's plan. Reuses the realm schema from analytics.

The JSON-encoded form fields are documented via `encoding` blocks (arrays) and object-typed schemas, and every array/object parameter carries a concrete example so the generated curl examples show real request bodies.
Neither endpoint's curl example can run without a configured bouncer, so both join `UNTESTED_GENERATED_CURL_EXAMPLES`.



**How changes were tested:**

- [x] `./tools/test-backend zerver.tests.test_openapi zerver.tests.test_docs.DocPageTest.test_api_doc_endpoints`
- [x] `./tools/lint` on all changed files
- [x] Rendered both pages in the dev app; confirmed the curl examples show
      real JSON request bodies (screenshots below)


<details>
<summary>**Screenshots and screen captures:**</summary>
The rendered doc page: `remotes/server/analytics`:

<img width="852" height="4501" alt="localhost_9991_api_remote-server-post-analytics(A goddamn screen) (1)" src="https://github.com/user-attachments/assets/37b126f7-67ab-417f-87d6-e89f7d292b64" />

The rendered doc page, 'remote-realm-billing-entry':

<img width="1920" height="3258" alt="localhost_9991_api_remote-realm-billing-entry(A goddamn screen)" src="https://github.com/user-attachments/assets/0ed1c7a2-517d-4fba-8fc4-210c4c79bc5b" />

</details>

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
