### PR TITLE
Typing "is:unresolved" in the search bar now works.

### DIFF
--- a/starlight_help/src/content/docs/resolve-a-topic.mdx
+++ b/starlight_help/src/content/docs/resolve-a-topic.mdx
@@ -120,8 +120,8 @@ accident.
   <TabItem label="Desktop/Web">
     <Steps>
       1. Click the **search** (<SearchIcon />) icon in the top bar to open the search box.
-      1. Type `-is:resolved`, or start typing and select **Exclude topics marked as
-         resolved** from the typeahead.
+      1. Type `-is:resolved`, or start typing and select **Unresolved topics**
+         from the typeahead.
       1. *(optional)* Enter additional search terms or
          [filters](/help/search-for-messages).
       1. Press <kbd>Enter</kbd>.
@@ -136,7 +136,7 @@ accident.
 
 <ZulipTip>
   To get a feed of unread messages in all unresolved topics, search for
-  `is:unresolved is:unread`.
+  `-is:resolved is:unread`.
 </ZulipTip>
 
 ## Search for messages in resolved topics
@@ -145,7 +145,7 @@ accident.
   <TabItem label="Desktop/Web">
     <Steps>
       1. Click the **search** (<SearchIcon />) icon in the top bar to open the search box.
-      1. Type `is:resolved`, or start typing and select **Topics marked as resolved**
+      1. Type `is:resolved`, or start typing and select **Resolved topics**
          from the typeahead.
       1. *(optional)* Enter additional search terms or
          [filters](/help/search-for-messages).

--- a/starlight_help/src/content/docs/resolve-a-topic.mdx
+++ b/starlight_help/src/content/docs/resolve-a-topic.mdx
@@ -120,8 +120,8 @@ accident.
   <TabItem label="Desktop/Web">
     <Steps>
       1. Click the **search** (<SearchIcon />) icon in the top bar to open the search box.
-      1. Type `-is:resolved`, or start typing and select **Unresolved topics**
-         from the typeahead.
+      1. Type `-is:resolved` or `is:unresolved`, or start typing and select
+         **Unresolved topics** from the typeahead.
       1. *(optional)* Enter additional search terms or
          [filters](/help/search-for-messages).
       1. Press <kbd>Enter</kbd>.

--- a/starlight_help/src/content/docs/search-for-messages.mdx
+++ b/starlight_help/src/content/docs/search-for-messages.mdx
@@ -155,6 +155,8 @@ filters, to search additional messages.
 * `is:followed`: Search messages in [followed topics](/help/follow-a-topic).
 * `is:resolved`: Search messages in [resolved topics](/help/resolve-a-topic).
 * `-is:resolved`: Search messages in [unresolved topics](/help/resolve-a-topic).
+  In the Zulip web and desktop apps, you can also type `is:unresolved`, which
+  is an alias for this filter.
 * `is:unread`: Search your unread messages.
 * `is:muted`: Search [muted](/help/mute-a-topic) messages.
 * `-is:muted`: Search only [unmuted](/help/mute-a-topic) messages. By default,

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -527,9 +527,20 @@ export class Filter {
                     // terms list. This is done so that the last active filter is correctly
                     // detected by the `get_search_result` function (in search_suggestions.ts).
                     maybe_add_search_terms();
+                    const canonical_operator = filter_util.canonicalize_operator(
+                        parsed_operator.data,
+                    );
+                    // "is:unresolved" is an alias for "-is:resolved". We
+                    // rewrite it here so that the alias works only in
+                    // typed search input; narrow URLs are parsed in
+                    // `hash_util.parse_narrow` and don't accept it.
+                    if (canonical_operator === "is" && operand === "unresolved") {
+                        operand = "resolved";
+                        negated = !negated;
+                    }
                     term = {
                         negated,
-                        operator: filter_util.canonicalize_operator(parsed_operator.data),
+                        operator: canonical_operator,
                         operand,
                     };
                     terms.push(term);

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -818,6 +818,22 @@ function get_is_filter_suggestions(
         ]);
         other_suggestions.push(is_dm);
     }
+    // Suggest "-is:resolved" to anyone typing "is:unresolved".
+    //
+    // We skip a bare "is:" query, since it lists the operands
+    // for "is:" and should not offer a negated filter.
+    if (
+        last.operator === "is" &&
+        last.operand !== "" &&
+        common.phrase_match(last.operand, "unresolved")
+    ) {
+        const is_unresolved = format_as_suggestion([
+            {operator: last.operator, operand: "resolved", negated: !last.negated},
+        ]);
+        if (suggestions.includes(is_unresolved)) {
+            other_suggestions.push(is_unresolved);
+        }
+    }
     const all_suggestions = [...special_filtered_suggestions, ...other_suggestions];
     return all_suggestions;
 }

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -51,6 +51,14 @@ const channels_public_incompatible_patterns: TermPattern[] = [
     {operator: "channels", operand: "web-public"},
 ];
 
+// Shared by the "is:resolved" and "-is:resolved" suggestions.
+const is_resolved_incompatible_patterns: TermPattern[] = [
+    {operator: "is", operand: "resolved"},
+    {operator: "is", operand: "dm"},
+    {operator: "dm"},
+    {operator: "dm-including"},
+];
+
 // TODO: Expand this to support all available filters and its description.
 // Also, we generate some descriptions in filter.ts too, we should look to
 // refactor them together.
@@ -114,18 +122,8 @@ const incompatible_patterns: Record<SearchFilter, TermPattern[]> = {
         {operator: "is", operand: "resolved"},
     ],
     "dm-including": [{operator: "channel"}, {operator: "stream"}, {operator: "channels"}],
-    "is:resolved": [
-        {operator: "is", operand: "resolved"},
-        {operator: "is", operand: "dm"},
-        {operator: "dm"},
-        {operator: "dm-including"},
-    ],
-    "-is:resolved": [
-        {operator: "is", operand: "resolved"},
-        {operator: "is", operand: "dm"},
-        {operator: "dm"},
-        {operator: "dm-including"},
-    ],
+    "is:resolved": is_resolved_incompatible_patterns,
+    "-is:resolved": is_resolved_incompatible_patterns,
     "is:dm": [
         {operator: "is", operand: "dm"},
         {operator: "is", operand: "resolved"},

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -53,11 +53,18 @@ export function get_typeahead_base_options(): TopicFilterTypeaheadOptions {
         },
         matcher(query: string) {
             // This basically only matches if `is:` is in the query.
-            return (item: TopicFilterPill) =>
-                query.includes(":") &&
-                (item.syntax.toLowerCase().startsWith(query.toLowerCase()) ||
-                    (item.syntax.startsWith("-") &&
-                        item.syntax.slice(1).toLowerCase().startsWith(query.toLowerCase())));
+            return (item: TopicFilterPill) => {
+                if (!query.includes(":")) {
+                    return false;
+                }
+                const lowercase_query = query.toLowerCase();
+                const matches_syntax = item.syntax.toLowerCase().startsWith(lowercase_query);
+                // Match "-is:resolved" even if the query has no leading "-".
+                const matches_syntax_without_negation =
+                    item.syntax.startsWith("-") &&
+                    item.syntax.slice(1).toLowerCase().startsWith(lowercase_query);
+                return matches_syntax || matches_syntax_without_negation;
+            };
         },
         sorter(items: TopicFilterPill[], _query: string) {
             // This sort order places "Unresolved topics" first

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -9,6 +9,9 @@ export type TopicFilterPill = {
     type: "topic_filter";
     label: string;
     syntax: string;
+    // An alternate spelling that also matches this option, for
+    // filters that users might reasonably type another way.
+    alias_syntax?: string;
     match_prefix_required?: string;
 };
 
@@ -27,6 +30,7 @@ export const filter_options: TopicFilterPill[] = [
         type: "topic_filter",
         label: $t({defaultMessage: "unresolved"}),
         syntax: "-is:resolved",
+        alias_syntax: "is:unresolved",
     },
     {
         type: "topic_filter",
@@ -63,7 +67,9 @@ export function get_typeahead_base_options(): TopicFilterTypeaheadOptions {
                 const matches_syntax_without_negation =
                     item.syntax.startsWith("-") &&
                     item.syntax.slice(1).toLowerCase().startsWith(lowercase_query);
-                return matches_syntax || matches_syntax_without_negation;
+                const matches_alias =
+                    item.alias_syntax?.toLowerCase().startsWith(lowercase_query) ?? false;
+                return matches_syntax || matches_syntax_without_negation || matches_alias;
             };
         },
         sorter(items: TopicFilterPill[], _query: string) {
@@ -109,14 +115,16 @@ export function create_item_from_syntax(
     syntax: string,
     current_items: TopicFilterPill[],
 ): TopicFilterPill | undefined {
-    const existing_syntaxes = current_items.map((item) => item.syntax);
-    if (existing_syntaxes.includes(syntax)) {
+    // Find the matching filter option
+    const filter_option = filter_options.find(
+        (option) => option.syntax === syntax || option.alias_syntax === syntax,
+    );
+    if (!filter_option) {
         return undefined;
     }
 
-    // Find the matching filter option
-    const filter_option = filter_options.find((option) => option.syntax === syntax);
-    if (!filter_option) {
+    const existing_syntaxes = current_items.map((item) => item.syntax);
+    if (existing_syntaxes.includes(filter_option.syntax)) {
         return undefined;
     }
     return filter_option;

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -164,7 +164,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">-is:resolved</td>
+                        <td class="operator">-is:resolved, is:unresolved</td>
                         <td class="definition">
                             {{t 'Narrow to messages in unresolved topics.'}}
                         </td>

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1748,6 +1748,17 @@ test("parse", () => {
     terms = [{operator: "is", operand: "mentioned", negated: true}];
     _test(true);
 
+    // "is:unresolved" is an alias for "-is:resolved". The rewrite
+    // happens in `parse` so that it applies only to typed search
+    // input, not to terms parsed from narrow URLs.
+    string = "is:unresolved";
+    terms = [{operator: "is", operand: "resolved", negated: true}];
+    _test();
+
+    string = "-is:unresolved";
+    terms = [{operator: "is", operand: "resolved"}];
+    _test();
+
     string = "https://www.google.com";
     terms = [{operator: "search", operand: "https://www.google.com"}];
     _test();
@@ -2351,6 +2362,10 @@ test("convert_suggestion_to_term", () => {
         ["has:nonsense", false],
         ["is:unread", true],
         ["is:nonsense", false],
+        // "is:unresolved" is an alias for "-is:resolved", rewritten
+        // by the `Filter.parse` call below.
+        ["is:unresolved", true, {operator: "is", operand: "resolved", negated: true}],
+        ["-is:unresolved", true, {operator: "is", operand: "resolved", negated: false}],
         ["in:home", true],
         ["in:nowhere", false],
         ["id:4", true],

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -611,9 +611,56 @@ test("check_is_suggestions", ({override}) => {
     ];
     assert.deepEqual(suggestions, expected);
 
+    // A bare "is:" or "-is:" query lists the operands for the
+    // operator the user typed, so the "is:unresolved" alias should
+    // not add a suggestion to either of them.
+    query = "-is:";
+    suggestions = get_suggestions(query);
+    expected = [
+        "-is:dm",
+        "-is:starred",
+        "-is:mentioned",
+        "-is:followed",
+        "-is:alerted",
+        "-is:unread",
+        "-is:muted",
+        "-is:resolved",
+    ];
+    assert.deepEqual(suggestions, expected);
+
     query = "is:st";
     suggestions = get_suggestions(query);
     expected = ["is:starred"];
+    assert.deepEqual(suggestions, expected);
+
+    // "is:unresolved" is an alias for "-is:resolved", so we suggest
+    // "-is:resolved" to anyone typing "is:unresolved".
+    query = "is:unres";
+    suggestions = get_suggestions(query);
+    expected = ["-is:resolved"];
+    assert.deepEqual(suggestions, expected);
+
+    query = "is:unresolved";
+    suggestions = get_suggestions(query);
+    expected = ["-is:resolved"];
+    assert.deepEqual(suggestions, expected);
+
+    query = "-is:unres";
+    suggestions = get_suggestions(query);
+    expected = ["is:resolved"];
+    assert.deepEqual(suggestions, expected);
+
+    query = "is:un";
+    suggestions = get_suggestions(query);
+    expected = ["is:unread", "-is:resolved"];
+    assert.deepEqual(suggestions, expected);
+
+    // The alias suggestion is skipped when "-is:resolved" is
+    // incompatible with another term in the query, just like the
+    // regular "-is:resolved" suggestion.
+    query = "is:dm is:unres";
+    suggestions = get_suggestions(query);
+    expected = [];
     assert.deepEqual(suggestions, expected);
 
     query = "-is:st";


### PR DESCRIPTION
- Typing "is:unresolved" in the search bar now works: the alias is rewritten to a negated "is:resolved" term when parsing typed search input. 
- Narrow URLs do not accept "is:unresolved". 
- The typeahead suggests "Unresolved topics" for "is:unres..." queries, and the left sidebar's topic filter accepts "is:unresolved" too. 
- The search help keeps "-is:resolved" as the primary form and notes "is:unresolved" as an alias.

This is a web app change only. The server doesn't accept "is:unresolved" in a narrow, so API clients still need to use "-is:resolved".

The help center told users to search for "is:unresolved is:unread" to find unread messages in unresolved topics, which did not work before this change. Since this is a frontend only change, that tip applies to mobile and API users too, so it now uses "-is:resolved is:unread".

Reported at https://chat.zulip.org/#narrow/channel/9-issues/topic/Filtering.2C.20hiding.2C.20and.2For.20sorting.20resolved.20topics/with/2507803

The first three commits are small preparatory changes:
- Fixes help center descriptions of the search typeahead's labels for resolved topic search, which had gone stale.
- Shares one incompatibility pattern list between the "is:resolved" and "-is:resolved" suggestions.
- Rewrites the topic filter's typeahead matcher with named conditions, so it is easier to read.


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

Search typeahead:
<img width="680" height="100" alt="01-search-typeahead-is-unres-cropped" src="https://github.com/user-attachments/assets/933199a4-4e32-49dc-9ac3-adfca63ca6d3" />

Succesful search with URL:
<img width="850" height="285" alt="02-search-narrow-canonical-url-browser-cropped" src="https://github.com/user-attachments/assets/565dffda-0a5b-422e-8153-b73f18095d35" />

is/unresolved in URL does not work:
<img width="850" height="285" alt="05-url-is-unresolved-not-accepted-browser-cropped" src="https://github.com/user-attachments/assets/9e555ed2-7570-4f98-aa62-309463f99c37" />

Help:
<img width="660" height="170" alt="04-search-filters-reference-alias-row-cropped" src="https://github.com/user-attachments/assets/69ae115a-918c-458b-958a-4385f68f3951" />

Topic typeahead:
<img width="325" height="210" alt="03a-topic-filter-typeahead-is-unres-cropped" src="https://github.com/user-attachments/assets/d090406d-bb35-4bed-923b-6d7321a84096" />

Topic pill:
<img width="325" height="210" alt="03b-topic-filter-unresolved-pill-cropped" src="https://github.com/user-attachments/assets/12800c7f-2ba1-4f46-a82f-2107e797821f" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
