### PR TITLE
Fix issue 24040: Hide compose spinner on failed message send

### DIFF
--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -255,6 +255,7 @@ export let send_message = (): void => {
 
     function error(response: string, server_error_code: string): void {
         // Error callback for failed message send attempts.
+        compose_ui.hide_compose_spinner();
         if (!locally_echoed) {
             if (server_error_code === "TOPIC_WILDCARD_MENTION_NOT_ALLOWED") {
                 // The topic wildcard mention permission code path has
@@ -276,13 +277,6 @@ export let send_message = (): void => {
                 );
             }
 
-            // For messages that were not locally echoed, we're
-            // responsible for hiding the compose spinner to restore
-            // the compose box so one can send a next message.
-            //
-            // (Restoring this state is handled by clear_compose_box
-            // for locally echoed messages.)
-            compose_ui.hide_compose_spinner();
             return;
         }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes #24040

**How changes were tested:**

Refactored the error handler in `compose.ts` to ensure the UI unlocks (`hide_compose_spinner`) on any network failure by moving the instruction outside the `locally_echoed` conditional block.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
