### PR TITLE
code_playground: Normalize language names on creation to fix case mismatch

### DIFF
--- a/starlight_help/src/content/docs/code-blocks.mdx
+++ b/starlight_help/src/content/docs/code-blocks.mdx
@@ -184,6 +184,15 @@ languages:
 * You can also use a custom language name to implement simple integrations.
   For example, a code block tagged with the "language" `send_tweet` could be
   used with a "playground" that sends the content of the code block as a Tweet.
+* Language names are automatically normalized when creating a playground:
+  * For known programming languages, any alias or variation (e.g., `rs`,
+    `rust`, `RUST`) is automatically stored as the standard name (e.g.,
+    `Rust`). You can use the typeahead dropdown to see the standard name.
+  * For custom language names, the name is stored in lowercase (e.g.,
+    `MyLang` becomes `mylang`).
+  * Users can write the language tag in any case in their code blocks, and
+    it will match the correct playground automatically (e.g., `rust`,
+    `Rust`, or `RUST` will all trigger the Rust playground).
 
 If you have any trouble setting up a code playground, please [contact
 us](/help/contact-support) with details on what you're trying to do, and we'll

--- a/web/e2e-tests/realm-playground.test.ts
+++ b/web/e2e-tests/realm-playground.test.ts
@@ -51,7 +51,7 @@ async function test_successful_playground_creation(page: Page): Promise<void> {
         url_template: "https://python.example.com?code={code}",
     };
     const status = await _add_playground_and_return_status(page, payload);
-    assert.strictEqual(status, "Custom playground added!");
+    assert.strictEqual(status, "Custom playground added! Language recognized as Python.");
     await page.waitForSelector(".playground_row", {visible: true});
     assert.strictEqual(
         await common.get_text_from_selector(

--- a/web/e2e-tests/realm-playground.test.ts
+++ b/web/e2e-tests/realm-playground.test.ts
@@ -70,6 +70,65 @@ async function test_successful_playground_creation(page: Page): Promise<void> {
     );
 }
 
+async function test_mixed_case_standard_language_normalization(page: Page): Promise<void> {
+    await page.click("#playground_pygments_language");
+    await page.type("#playground_pygments_language", "RuST");
+
+    await common.fill_form(page, "form.admin-playground-form", {
+        playground_name: "Mixed case Rust playground",
+        url_template: "https://play.rust-lang.org/?code={code}",
+    });
+
+    await page.$eval("button#submit_playground_button", (el) => {
+        el.click();
+    });
+
+    await page.waitForSelector("button#submit_playground_button:not([disabled])", {
+        visible: true,
+    });
+
+    await page.waitForSelector("div#admin-playground-status", {visible: true});
+
+    const status = await common.get_text_from_selector(page, "div#admin-playground-status");
+
+    assert.strictEqual(status, "Custom playground added! Language recognized as Rust.");
+    await delete_first_playground(page);
+}
+
+async function test_uppercase_custom_language_normalization(page: Page): Promise<void> {
+    await page.click("#playground_pygments_language");
+    await page.type("#playground_pygments_language", "MYCUSTOMLANG");
+
+    await common.fill_form(page, "form.admin-playground-form", {
+        playground_name: "Uppercase custom playground",
+        url_template: "https://example.com/?code={code}",
+    });
+
+    await page.$eval("button#submit_playground_button", (el) => {
+        el.click();
+    });
+
+    await page.waitForSelector("button#submit_playground_button:not([disabled])", {
+        visible: true,
+    });
+
+    await page.waitForSelector("div#admin-playground-status", {visible: true});
+
+    const status = await common.get_text_from_selector(page, "div#admin-playground-status");
+
+    assert.strictEqual(status, "Custom playground added! Language names are stored in lowercase.");
+    await delete_first_playground(page);
+}
+
+async function delete_first_playground(page: Page): Promise<void> {
+    await page.waitForSelector(".playground_row button.delete", {visible: true});
+    await page.click(".playground_row button.delete");
+
+    await common.wait_for_micromodal_to_open(page);
+    await page.click("#confirm_delete_code_playgrounds_modal .dialog_submit_button");
+    await common.wait_for_micromodal_to_close(page);
+}
+
 async function test_invalid_playground_parameters(page: Page): Promise<void> {
     const payload = {
         pygments_language: "Python",
@@ -102,6 +161,8 @@ async function playground_test(page: Page): Promise<void> {
     await page.click("li[data-section='playground-settings']");
 
     await test_successful_playground_creation(page);
+    await test_mixed_case_standard_language_normalization(page);
+    await test_uppercase_custom_language_normalization(page);
     await test_invalid_playground_parameters(page);
     await test_successful_playground_deletion(page);
 }

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -9,6 +9,7 @@ import * as confirm_dialog from "./confirm_dialog.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t_html} from "./i18n.ts";
 import * as ListWidget from "./list_widget.ts";
+import * as pygments_data from "./pygments_data.ts";
 import * as realm_playground from "./realm_playground.ts";
 import type {RealmPlayground} from "./realm_playground.ts";
 import * as scroll_util from "./scroll_util.ts";
@@ -118,22 +119,40 @@ function build_page(): void {
             $playground_status.hide();
             const data = {
                 name: $("#playground_name").val(),
-                pygments_language: $("#playground_pygments_language").val(),
+                pygments_language: (() => {
+                    const raw_lang = String(
+                        $("#playground_pygments_language").val() ?? "",
+                    ).toLowerCase();
+                    return pygments_data.langs[raw_lang]?.pretty_name ?? raw_lang;
+                })(),
                 url_template: $("#playground_url_template").val(),
             };
             void channel.post({
                 url: "/json/realm/playgrounds",
                 data,
                 success() {
+                    const raw_lang = String(
+                        $("#playground_pygments_language").val() ?? "",
+                    ).toLowerCase();
+                    const normalized = pygments_data.langs[raw_lang]?.pretty_name;
+                    const success_msg =
+                        normalized !== undefined
+                            ? $t_html(
+                                  {
+                                      defaultMessage:
+                                          "Custom playground added! Language recognized as {language}.",
+                                  },
+                                  {language: normalized},
+                              )
+                            : $t_html({
+                                  defaultMessage:
+                                      "Custom playground added! Language names are stored in lowercase.",
+                              });
                     $("#playground_pygments_language").val("");
                     $("#playground_name").val("");
                     $("#playground_url_template").val("");
                     $add_playground_button.prop("disabled", false);
-                    ui_report.success(
-                        $t_html({defaultMessage: "Custom playground added!"}),
-                        $playground_status,
-                        3000,
-                    );
+                    ui_report.success(success_msg, $playground_status, 3000);
                     // FIXME: One thing to note here is that the "view code in playground"
                     // option for an already rendered code block (tagged with this newly added
                     // language) would not be visible without a re-render. To fix this, we should

--- a/zerver/tests/test_realm_playgrounds.py
+++ b/zerver/tests/test_realm_playgrounds.py
@@ -115,6 +115,15 @@ class RealmPlaygroundTests(ZulipTestCase):
         result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_error(result, "Language 'math' is not allowed.")
 
+        # Test that restricted keywords cannot bypass validation using uppercase letters
+        payload = {
+            "name": "Uppercase restricted keyword",
+            "pygments_language": "MATH",
+            "url_template": "https://example.com/{code}",
+        }
+        result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
+        self.assert_json_error(result, "Language 'math' is not allowed.")
+
     def test_language_normalization(self) -> None:
         iago = self.example_user("iago")
 

--- a/zerver/tests/test_realm_playgrounds.py
+++ b/zerver/tests/test_realm_playgrounds.py
@@ -115,6 +115,43 @@ class RealmPlaygroundTests(ZulipTestCase):
         result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_error(result, "Language 'math' is not allowed.")
 
+    def test_language_normalization(self) -> None:
+        iago = self.example_user("iago")
+
+        # Standard language alias is normalized to canonical Pygments name
+        payload = {
+            "name": "Rust playground",
+            "pygments_language": "rs",
+            "url_template": "https://play.rust-lang.org/?code={code}",
+        }
+        result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
+        self.assert_json_success(result)
+        playground = RealmPlayground.objects.get(id=result.json()["id"])
+        self.assertEqual(playground.pygments_language, "Rust")
+
+        # Custom language is stored in lowercase
+        payload = {
+            "name": "Custom playground",
+            "pygments_language": "MyCustomLang",
+            "url_template": "https://example.com/?code={code}",
+        }
+        result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
+        self.assert_json_success(result)
+        playground = RealmPlayground.objects.get(id=result.json()["id"])
+        self.assertEqual(playground.pygments_language, "mycustomlang")
+
+        # Standard language whose canonical name contains invalid characters
+        # (e.g., "Python 2.x" has a space) falls back to lowercase alias
+        payload = {
+            "name": "Python2 playground",
+            "pygments_language": "Python2",
+            "url_template": "https://python2.example.com/?code={code}",
+        }
+        result = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
+        self.assert_json_success(result)
+        playground = RealmPlayground.objects.get(id=result.json()["id"])
+        self.assertEqual(playground.pygments_language, "python2")
+
     def test_create_already_existing_playground(self) -> None:
         iago = self.example_user("iago")
 

--- a/zerver/views/realm_playgrounds.py
+++ b/zerver/views/realm_playgrounds.py
@@ -4,6 +4,8 @@ from typing import Annotated
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 from pydantic import AfterValidator
+from pygments.lexers import find_lexer_class_by_name
+from pygments.util import ClassNotFound
 
 from zerver.actions.realm_playgrounds import check_add_realm_playground, do_remove_realm_playground
 from zerver.actions.realm_settings import do_set_realm_property
@@ -30,7 +32,13 @@ def check_pygments_language(var_name: str, val: object) -> str:
                 )
     if s in RealmPlayground.RESTRICTED_KEYWORDS:
         raise JsonableError(_("Language '{language}' is not allowed.").format(language=s))
-    return s
+    try:
+        canonical_name = find_lexer_class_by_name(s.lower()).name
+        if re.match(rf"^{PLAYGROUND_LANGUAGE_REGEX}$", canonical_name):
+            return canonical_name
+        return s.lower()
+    except ClassNotFound:
+        return s.lower()
 
 
 def access_playground_by_id(realm: Realm, playground_id: int) -> RealmPlayground:

--- a/zerver/views/realm_playgrounds.py
+++ b/zerver/views/realm_playgrounds.py
@@ -30,8 +30,8 @@ def check_pygments_language(var_name: str, val: object) -> str:
                 raise JsonableError(
                     _("Invalid character in language: {character}").format(character=char)
                 )
-    if s in RealmPlayground.RESTRICTED_KEYWORDS:
-        raise JsonableError(_("Language '{language}' is not allowed.").format(language=s))
+    if s.lower() in RealmPlayground.RESTRICTED_KEYWORDS:
+        raise JsonableError(_("Language '{language}' is not allowed.").format(language=s.lower()))
     try:
         canonical_name = find_lexer_class_by_name(s.lower()).name
         if re.match(rf"^{PLAYGROUND_LANGUAGE_REGEX}$", canonical_name):


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #24044 
Fixes: #39847
Fixes: #24046

**Problem:**
The backend Markdown renderer lowercases all code block language tags when matching them to configured playgrounds, but the database stored playground language names exactly as the admin typed them into the code playground creation form, without any normalization. This mismatch caused two distinct problems:
- Standard languages: if the admin entered a lowercase name or a non-canonical alias in the creation form (e.g., rust or rs instead of Rust), the stored value wouldn't match the canonical name the renderer expects, so the playground would never trigger from a code block.
- Custom languages: if the name entered in the creation form contained any uppercase letters (e.g., MyLang), it wouldn't match the lowercased tag produced by the renderer (mylang), so the playground would similarly fail to trigger.

**Solution:**
Language names are now normalized on the backend at creation time, so normalization is enforced consistently regardless of whether the playground is created by an admin through the settings UI or directly via the API:
- Standard languages: resolved via Pygments' lexer lookup and stored as the canonical name (e.g., rs, rust, RUST → Rust).
- Custom languages (no matching Pygments lexer): stored in lowercase (e.g., MyLang → mylang), since they have no canonical form to resolve against.
The frontend creation form now also normalizes the language name before submission (using the local pygments_data lookup), so the admin sees an accurate success message immediately after creating the playground. The backend remains the source of truth and re-normalizes independently, ensuring API requests that skip the frontend form are still normalized correctly.


**Technical choices:**

- Chose to resolve standard language names using Pygments' built-in `find_lexer_class_by_name` lookup rather than maintaining a custom alias-to-canonical-name mapping. Pygments already tracks this data and is used elsewhere in the codebase for syntax highlighting, so reusing it avoids introducing a second list of aliases that could drift out of sync over time.

- Considered normalizing the language name only on the frontend (in `settings_playgrounds.ts`), since that's where the original bug appeared to live. However, this would leave the backend accepting un-normalized values from any request that doesn't go through the settings UI (e.g., a direct API call), silently reintroducing the same matching bug. Moved the authoritative normalization to `zerver/views/realm_playgrounds.py` instead, and kept the frontend normalization only for immediate user feedback.

- Used a `try`/`except ClassNotFound` pattern to distinguish standard languages from custom ones, rather than checking membership in a predefined list of known languages. This keeps the standard/custom distinction automatically in sync with whatever languages Pygments currently supports, without needing to update this code when Pygments adds new lexers.

- Updated the success message shown after playground creation to inform admins when a language name has been normalized. Standard languages show the resolved canonical name (e.g., "Language recognized as Rust."), and custom languages note that names are stored in lowercase. Without this, an admin entering `rs` or `MyLang` would have no way of knowing the name was silently changed on save, and could be confused later when the stored value doesn't match what they typed. This gives admins immediate feedback without requiring them to check the playground list to see what was actually saved.


**How changes were tested:**
- Backend tests (`./tools/test-backend zerver/tests/test_realm_playgrounds.py`) — all 8 tests passed.
- Frontend unit tests (`./tools/test-js-with-node`) — passed.
- TypeScript type check (`tsc --noEmit`) — no errors.
- Manual testing in local development environment.


**Screenshots and screen captures:**


### Table 1: Creating playground with `rs`

Before | After
-- | --
<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 33 46 PM" src="https://github.com/user-attachments/assets/cc35fc62-6cc4-4b62-922f-4c81527e094e" /> | <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 49 13 PM" src="https://github.com/user-attachments/assets/9dfd9728-6454-4800-a999-5df652174c06" />
<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 33 54 PM" src="https://github.com/user-attachments/assets/ede8e748-d89e-435c-8eeb-b82f4cde8408" /> | <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 49 20 PM" src="https://github.com/user-attachments/assets/26e7fdd3-f6cd-4c91-a4f8-16404229d8f3" />

### Table 2: Creating playground with `rust`

Before | After
-- | --
<img width="400" alt="Screenshot 2026-08-11 at 5 34 34 PM" src="https://github.com/user-attachments/assets/57d462cf-267f-4507-8cae-6c88c3f52917" /> | <img width="400" alt="Screenshot 2026-08-11 at 5 49 36 PM" src="https://github.com/user-attachments/assets/436356ba-9709-4bf2-ba68-155ef9012e91" />
<img width="400" alt="Screenshot 2026-08-11 at 5 34 43 PM" src="https://github.com/user-attachments/assets/3d7bbbe5-8ee2-4512-9900-01e341d2aa8e" /> | <img width="400" alt="Screenshot 2026-08-11 at 5 50 09 PM" src="https://github.com/user-attachments/assets/9c1b29a2-93b3-4147-9ce3-a684551ebcc6" />


### Table 3: Creating playground with `ruST`

Before | After
-- | --
<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 35 24 PM" src="https://github.com/user-attachments/assets/588045d4-8ecb-4c86-9e5b-ea9678dc1ca8" /> | <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 50 01 PM" src="https://github.com/user-attachments/assets/2aa0ba04-e76d-4cd4-88e6-b6426126bab8" />
<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 35 32 PM" src="https://github.com/user-attachments/assets/fb048754-478f-43b0-b630-f89e0b3cd392" /> | <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 50 09 PM" src="https://github.com/user-attachments/assets/8b421c7a-920e-4c60-b6d4-94036db3f11c" />


### Table 4: Playground List

Before | After
-- | --
 <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 36 36 PM" src="https://github.com/user-attachments/assets/4b623766-9f94-487f-b38d-13d7504ceb56" /> | <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 50 56 PM" src="https://github.com/user-attachments/assets/a27b7c82-4881-42b5-85b1-f2ad8b136da0" />


### Table 5: Code block tagged with `rs` triggers the playground

Before | After
-- | --
 <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 37 01 PM" src="https://github.com/user-attachments/assets/decae3a0-ce5e-4d0e-81cc-23da8608dd84" /> |<img width="1512" height="982" alt="Screenshot 2026-08-11 at 4 35 58 PM" src="https://github.com/user-attachments/assets/d1149f5f-437a-40cb-a01c-d1bde1950bb5" />
<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 37 09 PM" src="https://github.com/user-attachments/assets/384b6e40-e4db-44b9-ac40-9fa1b3d030d1" /> | <img width="1512" height="982" alt="Screenshot 2026-08-11 at 4 36 10 PM" src="https://github.com/user-attachments/assets/e7e3efb3-1e6f-4335-98bc-4773e6b3fe98" />


### Table 6: Code block tagged with `rust` triggers the playground

Before | After
-- | --
<img width="400" alt="Screenshot 2026-08-11 at 5 37 33 PM" src="https://github.com/user-attachments/assets/6b7f49ad-9239-4ece-b5be-196443c9c1c5" /> | <img width="400" alt="Screenshot 2026-08-11 at 4 36 54 PM" src="https://github.com/user-attachments/assets/6e44115e-cb34-49a4-8228-bf145ec4d854" />
<img width="400" alt="Screenshot 2026-08-11 at 5 37 41 PM" src="https://github.com/user-attachments/assets/c1a8e3a8-bc78-4ec2-90aa-b38e834a334f" /> | <img width="400" alt="Screenshot 2026-08-11 at 4 36 59 PM" src="https://github.com/user-attachments/assets/50989922-c907-4405-af1a-6f571cbb7088" />

### Table 7: Code block tagged with `ruST` triggers the playground

Before | After
-- | --
<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 38 08 PM" src="https://github.com/user-attachments/assets/cd6257b9-7c39-4678-8146-55bf27ea3ea2" /> |<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 02 52 PM" src="https://github.com/user-attachments/assets/393ca785-a55d-4d39-84e0-d2be5245ae3a" />
<img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 38 13 PM" src="https://github.com/user-attachments/assets/9f9f9e70-eeab-41a7-8c48-ccf35db7480d" /> | <img width="1512" height="982" alt="Screenshot 2026-08-11 at 5 03 01 PM" src="https://github.com/user-attachments/assets/fb397f02-ae04-4d2c-97a2-2286ae104530" />


### Table 8: Creating playground with `MyLang`

Before | After
-- | --
<img width="1512" alt="Screenshot 2026-08-11 at 5 39 04 PM" src="https://github.com/user-attachments/assets/78564980-8379-4232-86ee-3d7c5395f0e9" /> | <img width="1512" alt="Screenshot 2026-08-11 at 5 39 04 PM" src="https://github.com/user-attachments/assets/4a30757c-a6e3-4c0d-be6f-be3bbcb35f9c" />
<img width="1512" alt="Screenshot 2026-08-11 at 5 39 11 PM" src="https://github.com/user-attachments/assets/47f7a560-58ff-4014-81d0-287852c343e5" /> | <img width="1512" alt="Screenshot 2026-08-11 at 5 06 14 PM" src="https://github.com/user-attachments/assets/01af8205-94d8-4bb3-b2fa-76bcdfc821af" />


### Table 9: Code block tagged with `MyLang` triggers the playground

Before | After
-- | --
<img width="400" alt="Screenshot 2026-08-11 at 5 39 58 PM" src="https://github.com/user-attachments/assets/4bc7fc92-3154-42b7-9f80-505b8a2fb679" /> | <img width="400" alt="Screenshot 2026-08-11 at 5 07 30 PM" src="https://github.com/user-attachments/assets/474cff19-fe51-41f6-82b5-678f5b67e8d7" />
<img width="400" alt="Screenshot 2026-08-11 at 5 40 07 PM" src="https://github.com/user-attachments/assets/ac6b13b3-40f7-461a-816b-9f78702fe05b" /> | <img width="400" alt="Screenshot 2026-08-11 at 5 07 49 PM" src="https://github.com/user-attachments/assets/ef866262-5bd3-4f11-9569-694d200ae50c" />


<summary>Self-review checklist</summary>
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
