### PR TITLE
message_edit: Improve `PATCH /messages/{message_id}`.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 13.0
 
+**Feature level 509**
+
+**Feature level ZF-25c66e**
+
+* [`PATCH /messages/{message_id}`](/api/update-message): Fixed a bug where
+  passing the `stream_id` that the message is already in was processed as
+  a channel move.
+
 **Feature level 508**
 
 * [`POST /messages`](/api/send-message): Added `message_url` and

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 508
+API_FEATURE_LEVEL = 509
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1686,6 +1686,13 @@ def check_update_message(
         if topic_name == message.topic_name():
             topic_name = None
 
+    if (
+        stream_id is not None
+        and message.is_channel_message
+        and stream_id == message.recipient.type_id
+    ):
+        stream_id = None
+
     validate_message_edit_payload(
         message, stream_id, topic_name, propagate_mode, content, prev_content_sha256
     )

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -144,7 +144,7 @@ def validate_message_edit_payload(
             raise JsonableError(_("Direct messages cannot have topics."))
 
     if propagate_mode != "change_one" and topic_name is None and stream_id is None:
-        raise JsonableError(_("Invalid propagate_mode without topic edit"))
+        raise JsonableError(_("Invalid propagate_mode without topic or channel edit"))
 
     if topic_name in {
         RESOLVED_TOPIC_PREFIX.strip(),

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10704,6 +10704,10 @@ paths:
                     same time, so sending both `content` and `stream_id` parameters will
                     throw an error.
 
+                    **Changes**: In Zulip 13.0 (feature level 509), fixed a bug where
+                    passing the channel ID that the message is already in was processed as
+                    a channel move.
+
                     **Changes**: New in Zulip 3.0 (feature level 1).
                   type: integer
                   example: 43

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -26,6 +26,7 @@ from zerver.lib.topic import RESOLVED_TOPIC_PREFIX
 from zerver.lib.types import UserGroupMembersData
 from zerver.lib.url_encoding import stream_message_url
 from zerver.lib.user_groups import UserGroupMembershipDetails
+from zerver.lib.utils import assert_is_not_none
 from zerver.models import Message, NamedUserGroup, Stream, UserMessage, UserProfile
 from zerver.models.groups import SystemGroups
 from zerver.models.realms import get_realm
@@ -157,6 +158,34 @@ class MessageMoveStreamTest(ZulipTestCase):
 
         messages = get_topic_messages(user_profile, new_stream, "test")
         self.assert_length(messages, 0)
+
+    def test_move_message_to_same_channel_is_not_a_move(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        channel = get_stream("Denmark", user_profile.realm)
+
+        # Request moving message to the channel it's already in.
+        msg_id = self.send_stream_message(user_profile, channel.name, topic_name="topic1")
+        result = self.client_patch(
+            "/json/messages/" + str(msg_id),
+            {"stream_id": channel.id},
+        )
+        self.assert_json_error(result, "Nothing to change")
+
+        # Alongside a topic change, it is a plain topic edit; the edit
+        # history must not claim the channel changed.
+        result = self.client_patch(
+            "/json/messages/" + str(msg_id),
+            {"stream_id": channel.id, "topic": "topic2", "propagate_mode": "change_all"},
+        )
+        self.assert_json_success(result)
+        [edit_history_entry] = orjson.loads(
+            assert_is_not_none(Message.objects.get(id=msg_id).edit_history)
+        )
+        self.assertEqual(edit_history_entry["prev_topic"], "topic1")
+        self.assertEqual(edit_history_entry["topic"], "topic2")
+        self.assertNotIn("prev_stream", edit_history_entry)
+        self.assertNotIn("stream", edit_history_entry)
 
     def test_change_all_propagate_mode_for_moving_old_messages(self) -> None:
         user_profile = self.example_user("hamlet")

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -135,7 +135,7 @@ class MessageMoveTopicTest(ZulipTestCase):
                 "propagate_mode": "change_all",
             },
         )
-        self.assert_json_error(result, "Invalid propagate_mode without topic edit")
+        self.assert_json_error(result, "Invalid propagate_mode without topic or channel edit")
         self.check_topic(id1, topic_name="topic1")
 
     def test_edit_message_empty_topic_with_extra_space(self) -> None:


### PR DESCRIPTION
* Commit 1: Error message improvement. Read commit message for details.
* Commit 2: Bug fix as discussed in [#api design > PATCH /messages/{message_id}](https://chat.zulip.org/#narrow/channel/378-api-design/topic/PATCH.20.2Fmessages.2F.7Bmessage_id.7D/with/2507912). Read commit message for more details.

I noticed these while reviewing #39568, so this is kinda prep work for that as well.

---

**How changes were tested:**

* Added test and did manual testing as well using an API client.

Request:

```sh
PATCH http://localhost:9991/api/v1/messages/189

Accept: application/json, text/plain, */*
Content-Type: application/x-www-form-urlencoded
User-Agent: bruno-runtime/2.3.0
Authorization: Basic cHJha2hhcjExNDRAZ21haWwuY29tOnpHdlAwdlFISGZuQTJpalNUMkd0eUNzR0hYanJwUXR1

propagate_mode=change_all&stream_id=13
```


Response before:

```json
{
  "result": "success",
  "msg": "",
  "detached_uploads": []
}
```
and various bugs listed in the 2nd commit message.

Response after:

```json
{
  "result": "error",
  "msg": "Nothing to change",
  "code": "BAD_REQUEST"
}
```

**Screenshots and screen captures:**

<img width="688" height="308" alt="Screenshot 2026-08-12 at 4 15 15 PM" src="https://github.com/user-attachments/assets/25ecd50b-9a10-4176-a857-1508d59471e4" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
