### PR TITLE
message_flags: Filter by realm when marking muted user messages read.

### DIFF
--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -161,7 +161,13 @@ def do_mark_muted_user_messages_as_read(
 ) -> int:
     query = (
         UserMessage.select_for_update_query()
-        .filter(user_profile=user_profile, message__sender=muted_user)
+        .filter(
+            user_profile=user_profile,
+            message__sender=muted_user,
+            # Filtering by message.realm_id is redundant, but required to use index:
+            # zerver_message_realm_sender_recipient
+            message__realm_id=user_profile.realm_id,
+        )
         .extra(where=[UserMessage.where_unread()])  # noqa: S610
     )
     message_ids = list(query.values_list("message_id", flat=True))


### PR DESCRIPTION
do_mark_muted_user_messages_as_read selects UserMessage rows by user_profile and message sender, and no index combines those columns: the only zerver_message index with sender_id leads with realm_id. PostgreSQL falls back to scanning every unread UserMessage row for the user. For a user with 372,595 unread messages the query took 162 seconds to return 24 rows.

Constraining realm_id makes zerver_message_realm_sender_recipient index usable, which takes the same query to 110 ms.

