### PR TITLE
[ai] Convert tabs to spaces in topic names.

### DIFF
--- a/zerver/lib/typed_endpoint.py
+++ b/zerver/lib/typed_endpoint.py
@@ -19,7 +19,7 @@ from typing import (
 
 from django.http import HttpRequest
 from django.utils.translation import gettext as _
-from pydantic import Json, StringConstraints, TypeAdapter, ValidationError
+from pydantic import AfterValidator, Json, StringConstraints, TypeAdapter, ValidationError
 from typing_extensions import ParamSpec
 
 from zerver.lib.exceptions import ApiParamValidationError, JsonableError
@@ -109,6 +109,10 @@ PathOnly: TypeAlias = Annotated[T, ApiParamConfig(path_only=True)]
 OptionalTopic: TypeAlias = Annotated[
     str | None,
     StringConstraints(strip_whitespace=True),
+    # Tabs are a disallowed control character in topic names, but
+    # commonly get pasted in from spreadsheets and other external
+    # sources, so replace them with spaces rather than rejecting them.
+    AfterValidator(lambda val: val.replace("\t", " ") if val is not None else None),
     ApiParamConfig(whence="topic", aliases=("subject",)),
 ]
 ApnsAppId: TypeAlias = Annotated[str, StringConstraints(pattern="^[.a-zA-Z0-9-]+$")]

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1280,6 +1280,26 @@ class MessagePOSTTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Missing topic")
 
+    def test_topic_with_tab_is_converted_to_space(self) -> None:
+        """
+        Topics pasted in with tab characters (e.g. from a spreadsheet)
+        should have the tabs converted to spaces rather than being
+        rejected as an invalid character.
+        """
+        self.login("hamlet")
+        result = self.client_post(
+            "/json/messages",
+            {
+                "type": "channel",
+                "to": orjson.dumps("Verona").decode(),
+                "topic": "Alejandra\t27264093835",
+                "content": "Test message",
+            },
+        )
+        self.assert_json_success(result)
+        message = self.get_last_message()
+        self.assertEqual(message.topic_name(), "Alejandra 27264093835")
+
     def test_invalid_topic(self) -> None:
         """
         Sending a message with invalid 'Cc', 'Cs' and 'Cn' category of unicode characters


### PR DESCRIPTION

Topic names are commonly pasted in from spreadsheets or other external sources that use tabs as field separators. Tab is a Cc control character, so check_stream_topic rejected it outright, causing message sends to fail with "Invalid character in topic".

Replace tabs with spaces in OptionalTopic, following the same pattern already used for newlines in ChannelDescription, so pasted topic names are silently normalized instead of blocking the send.

Fixes: #39933

Tab characters in topic names are commonly introduced by pasting
content from spreadsheets or CRM data. `check_stream_topic` rejects
any Unicode `Cc` control character, including tab, so sending a
message to such a topic failed outright with "Invalid character in
topic".

This converts tabs to spaces in `OptionalTopic` (the pydantic type
shared by message send, message edit, scheduled messages, and typing
indicator endpoints), following the same pattern already used for
newlines in `ChannelDescription` (`zerver/views/streams.py`).

## Test plan

- [x] Added `test_topic_with_tab_is_converted_to_space` in
      `zerver/tests/test_message_send.py`, reproducing the reported
      topic (`"Alejandra\t27264"`) and asserting the message
      sends successfully with the tab replaced by a space.
- [ ] `./tools/test-backend zerver.tests.test_message_send` (not run
      in this environment — no provisioned dev environment available)
- [ ] `./tools/lint zerver/lib/typed_endpoint.py zerver/tests/test_message_send.py`

## Self-review checklist

- [x] The PR addresses the issue described
- [ ] All relevant tests pass locally (not verified — no provisioned environment)
- [x] Code follows existing patterns in the codebase
- [x] Names are clear and greppable
- [x] Commit message is well done
- [x] Single, minimal, coherent commit
- [x] No debugging code or unnecessary comments
- [x] Type annotations complete
- [x] No user-facing strings added
- [x] No secrets or credentials
- [x] N/A: no behavior-affecting docs to update
- [x] N/A: no refactor
- [x] Security audit: no XSS/access-control surface touched