### PR TITLE
left_sidebar: Add a filter for checking followed topics.

### DIFF
--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -405,6 +405,8 @@ export let processing_text = (): boolean => {
         $focused_elt.is("input") ||
         $focused_elt.is("select") ||
         $focused_elt.is("textarea") ||
+        $focused_elt.is('[contenteditable="true"]') ||
+        $focused_elt.hasClass("left-sidebar-search-input") ||
         $focused_elt.parents(".pill-container").length > 0 ||
         $focused_elt.attr("id") === "compose-send-button" ||
         $focused_elt.parents(".dropdown-list-container").length > 0

--- a/web/src/inputs.ts
+++ b/web/src/inputs.ts
@@ -5,7 +5,11 @@ $("body").on(
     ".filter-input .input-close-filter-button",
     function (this: HTMLElement, _e: JQuery.Event) {
         const $input = $(this).prev(".input-element");
-        $input.val("").trigger("input");
+        if ($input.attr("contenteditable") === "true") {
+            $input.text("").trigger("input");
+        } else {
+            $input.val("").trigger("input");
+        }
         $input.trigger("blur");
     },
 );

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -613,11 +613,17 @@ function should_show_topic_search_hint(search_term: string): boolean {
 }
 
 function initiate_topic_search(): void {
-    const $search_input = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
-    const current_value = ($search_input.val() ?? "").trim();
+    const $search_input = $<HTMLDivElement>("div.left-sidebar-search-input").expectOne();
+    const current_value = ($search_input.text() ?? "").trim();
     const new_value = ui_util.TOPIC_SEARCH_PREFIX + " " + current_value;
     $search_input.val(new_value);
-    util.the($search_input).setSelectionRange(new_value.length, new_value.length);
+    const el = util.the($search_input);
+    if (el instanceof HTMLInputElement) {
+        el.setSelectionRange(new_value.length, new_value.length);
+    } else {
+        el.focus();
+    }
+    // util.the($search_input).setSelectionRange(new_value.length, new_value.length);
     $search_input.trigger("focus").trigger("input");
 }
 
@@ -901,7 +907,7 @@ export function set_event_handlers(): void {
         }
         // Clear search input so that there is no confusion
         // about which search input is active.
-        $search_input.val("");
+        $search_input.text("");
         const $nearest_link = $row.find("a").first();
         if ($nearest_link.length > 0) {
             // If the row has a link, we click it.

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1739,8 +1739,8 @@ export function searching(): boolean {
 
 export function clear_search(): void {
     const $filter = $(".left-sidebar-search-input").expectOne();
-    if ($filter.val() !== "") {
-        $filter.val("");
+    if ($filter.text() !== "") {
+        $filter.text("");
         $filter.trigger("input");
     }
     $filter.trigger("blur");

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -41,6 +41,7 @@ import * as stream_topic_history_util from "./stream_topic_history_util.ts";
 import * as sub_store from "./sub_store.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import {LONG_HOVER_DELAY} from "./tippyjs.ts";
+import * as topic_filter_pill from "./topic_filter_pill.ts";
 import * as topic_list from "./topic_list.ts";
 import * as topic_list_data from "./topic_list_data.ts";
 import * as ui_util from "./ui_util.ts";
@@ -430,9 +431,14 @@ export function build_stream_list(force_rerender: boolean): void {
     //
     // The main logic to build the list is in stream_list_sort.ts
     const streams = stream_data.subscribed_stream_ids();
-    const search_term =
-        ui_util.get_left_sidebar_topic_search_term() ?? ui_util.get_left_sidebar_search_term();
-    const stream_groups = stream_list_sort.sort_groups(streams, search_term);
+    const topic_search_term = ui_util.get_left_sidebar_topic_search_term();
+    const raw_search_term = ui_util.get_left_sidebar_search_term();
+    const topics_filter_state =
+        topic_search_term === undefined
+            ? topic_filter_pill.parse_topics_filter_state(raw_search_term)
+            : "";
+    const search_term = topic_search_term ?? (topics_filter_state ? "" : raw_search_term);
+    const stream_groups = stream_list_sort.sort_groups(streams, search_term, topics_filter_state);
 
     if (stream_groups.same_as_before && !force_rerender) {
         return;

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -122,6 +122,7 @@ type StreamListSortResult = {
 export function sort_groups(
     all_subscribed_stream_ids: number[],
     search_term: string,
+    topics_state = "",
 ): StreamListSortResult {
     const pinned_section: StreamListSection = {
         id: "pinned-streams",
@@ -149,10 +150,14 @@ export function sort_groups(
     // channel in it, rather than filtering by name. User-defined
     // folder names get analogous treatment below.
     const show_all_channels =
-        !is_topic_search && util.prefix_match({value: normal_section.section_title, search_term});
+        !is_topic_search &&
+        !topics_state &&
+        util.prefix_match({value: normal_section.section_title, search_term});
     const include_all_pinned_channels =
         show_all_channels ||
-        (!is_topic_search && util.prefix_match({value: pinned_section.section_title, search_term}));
+        (!is_topic_search &&
+            !topics_state &&
+            util.prefix_match({value: pinned_section.section_title, search_term}));
     const search_term_prefix_matches_other_section_title =
         !is_topic_search &&
         search_term &&
@@ -165,6 +170,8 @@ export function sort_groups(
     // Use -, _, : and / as word separators apart from the default space character
     let matching_stream_ids: number[];
     if (is_topic_search) {
+        matching_stream_ids = [];
+    } else if (topics_state) {
         matching_stream_ids = [];
     } else if (show_all_channels) {
         matching_stream_ids = all_subscribed_stream_ids;
@@ -186,6 +193,10 @@ export function sort_groups(
     let channels_to_check_topic_matches: number[] = [];
     if (is_topic_search) {
         channels_to_check_topic_matches = all_subscribed_stream_ids;
+    } else if (topics_state) {
+        if (current_channel_id !== undefined && stream_data.is_subscribed(current_channel_id)) {
+            channels_to_check_topic_matches = [current_channel_id];
+        }
     } else if (current_channel_id !== undefined && stream_data.is_subscribed(current_channel_id)) {
         channels_to_check_topic_matches = [current_channel_id];
     }
@@ -198,7 +209,12 @@ export function sort_groups(
         // term, or a muted topic matches the current topic, we include
         // the channel in the list of matches.
         const topics = topic_list_data.get_filtered_topic_names(stream_id, (topic_names) =>
-            topic_list_data.filter_topics_by_search_term(stream_id, topic_names, search_term),
+            topic_list_data.filter_topics_by_search_term(
+                stream_id,
+                topic_names,
+                search_term,
+                topics_state,
+            ),
         );
         if (
             topics.some(

--- a/web/src/topic_filter_pill.ts
+++ b/web/src/topic_filter_pill.ts
@@ -98,6 +98,16 @@ export function get_matching_filter_options({
     });
 }
 
+export function parse_topics_filter_state(search_term: string): string {
+    const normalized = search_term.toLowerCase().trim();
+    for (const option of filter_options) {
+        if (normalized === option.syntax) {
+            return option.syntax;
+        }
+    }
+    return "";
+}
+
 export function create_item_from_syntax(
     syntax: string,
     current_items: TopicFilterPill[],

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -451,14 +451,28 @@ function filter_topics_left_sidebar(topic_names: string[], stream_id: number): s
     // This runs both for the zoomed-in topic list and the inline
     // topic lists under streams, so we read the search term from
     // whichever input is in use.
-    const search_term = zoomed
-        ? get_zoomed_topic_search_term()
-        : (ui_util.get_left_sidebar_topic_search_term() ?? ui_util.get_left_sidebar_search_term());
+
+    if (zoomed) {
+        return topic_list_data.filter_topics_by_search_term(
+            stream_id,
+            topic_names,
+            get_zoomed_topic_search_term(),
+            get_typeahead_search_pills_syntax(),
+        );
+    }
+
+    const topic_search_term = ui_util.get_left_sidebar_topic_search_term();
+    const raw_search_term = ui_util.get_left_sidebar_search_term();
+    const topics_filter_state =
+        topic_search_term === undefined
+            ? topic_filter_pill.parse_topics_filter_state(raw_search_term)
+            : "";
+    const search_term = topic_search_term ?? (topics_filter_state ? "" : raw_search_term);
     return topic_list_data.filter_topics_by_search_term(
         stream_id,
         topic_names,
         search_term,
-        get_typeahead_search_pills_syntax(),
+        topics_filter_state,
     );
 }
 

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -338,8 +338,8 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
 }
 
 export let get_left_sidebar_search_term = function (): string {
-    const $search_box = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
-    const search_term = $search_box.val();
+    const $search_box = $<HTMLDivElement>("div.left-sidebar-search-input").expectOne();
+    const search_term = $search_box.text().trim();
     assert(search_term !== undefined);
     return search_term.trim();
 };

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -339,9 +339,13 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
 
 export let get_left_sidebar_search_term = function (): string {
     const $search_box = $<HTMLDivElement>("div.left-sidebar-search-input").expectOne();
-    const search_term = $search_box.text().trim();
+    const raw_text = $search_box[0]!.textContent ?? "";
+    const search_term = raw_text
+        .replaceAll(/[\u{200B}-\u{200D}\u{FEFF}]/gu, "")
+        .replaceAll("\u{A0}", " ")
+        .trim();
     assert(search_term !== undefined);
-    return search_term.trim();
+    return search_term;
 };
 
 export function rewire_get_left_sidebar_search_term(

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -2,7 +2,7 @@
     <div id="left-sidebar-search">
         <div class="input-wrapper-for-tooltip tippy-zulip-delayed-tooltip" data-tooltip-template-id="filter-left-sidebar-tooltip-template">
             {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section" icon="search" input_button_icon="close"}}
-                <input type="text" class="input-element left-sidebar-search-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
+                <div class="input-element left-sidebar-search-input" contenteditable="true" data-placeholder="{{t 'Filter left sidebar' }}" ></div>
             {{/components/input_wrapper}}
         </div>
         <span id="add_streams_button" class="add-stream-icon-container hidden-for-spectators" tabindex="0">

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -43,6 +43,7 @@ mock_esm("../src/unread", {
 const {Filter} = zrequire("../src/filter");
 const left_sidebar_navigation_area = zrequire("left_sidebar_navigation_area");
 const stream_data = zrequire("stream_data");
+const ui_util = zrequire("ui_util");
 const stream_list = zrequire("stream_list");
 stream_list.set_update_inbox_channel_view_callback(noop);
 const stream_list_sort = zrequire("stream_list_sort");
@@ -164,6 +165,9 @@ function test_ui(label, f) {
 test_ui("create_sidebar_row", ({override, override_rewire, mock_template}) => {
     // Make a couple calls to create_sidebar_row() and make sure they
     // generate the right markup as well as play nice with get_stream_li().
+
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "");
+
     override(user_settings, "demote_inactive_streams", 1);
     const appended_sections = [];
     override_rewire(stream_list, "stream_list_section_container_html", (section) => {
@@ -246,6 +250,7 @@ test_ui("create_sidebar_row", ({override, override_rewire, mock_template}) => {
 });
 
 test_ui("pinned_streams_never_inactive", ({mock_template, override_rewire}) => {
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "");
     override_rewire(stream_list, "update_stream_section_mention_indicators", noop);
     override_rewire(stream_list, "update_dom_with_unread_counts", noop);
     override_rewire(left_sidebar_navigation_area, "update_dom_with_unread_counts", noop);
@@ -429,6 +434,7 @@ test_ui("narrowing", ({override_rewire}) => {
 });
 
 test_ui("sort_streams", ({override_rewire, mock_template}) => {
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "");
     override_rewire(stream_list, "update_dom_with_unread_counts", noop);
     override_rewire(stream_list, "update_stream_section_mention_indicators", noop);
     override_rewire(left_sidebar_navigation_area, "update_dom_with_unread_counts", noop);
@@ -495,6 +501,7 @@ test_ui("sort_streams", ({override_rewire, mock_template}) => {
 });
 
 test_ui("separators_only_pinned_and_dormant", ({override_rewire}) => {
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "");
     override_rewire(stream_list, "update_dom_with_unread_counts", noop);
     override_rewire(stream_list, "update_stream_section_mention_indicators", noop);
     override_rewire(left_sidebar_navigation_area, "update_dom_with_unread_counts", noop);
@@ -604,6 +611,7 @@ test_ui("rename_stream", ({mock_template, override, override_rewire}) => {
 });
 
 test_ui("refresh_pin", ({override_rewire}) => {
+    override_rewire(ui_util, "get_left_sidebar_search_term", () => "");
     override_rewire(stream_list, "update_stream_section_mention_indicators", noop);
     override_rewire(stream_list, "update_dom_with_unread_counts", noop);
     override_rewire(stream_list, "maybe_hide_topic_bracket", noop);

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -603,16 +603,17 @@ test("initialize", ({override}) => {
     assert.ok(!stream_list_sort.is_filtering_inactives());
 });
 
-test("topics_state filter", () => {
-    add_all_subs();
+test("topics_state_filter", () => {
+    stream_data.clear_subscriptions();
+    const stream_id = 1;
+    const verona = make_stream({name: "verona", stream_id});
+    stream_data.add_sub_for_tests(verona);
 
     message_lists.set_current(
-        make_message_list([{operator: "stream", operand: scalene.stream_id.toString()}]),
+        make_message_list([{operator: "stream", operand: stream_id.toString()}]),
     );
 
-    const streams = stream_data.subscribed_stream_ids();
+    const result = stream_list_sort.sort_groups([stream_id], "", "is:followed");
 
-    const sorted_sections = stream_list_sort.sort_groups(streams, "", "is:followed").sections;
-
-    assert.ok(sorted_sections.length > 0);
+    assert.ok(result.sections.length > 0);
 });

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -602,3 +602,17 @@ test("initialize", ({override}) => {
 
     assert.ok(!stream_list_sort.is_filtering_inactives());
 });
+
+test("topics_state filter", () => {
+    add_all_subs();
+
+    message_lists.set_current(
+        make_message_list([{operator: "stream", operand: scalene.stream_id.toString()}]),
+    );
+
+    const streams = stream_data.subscribed_stream_ids();
+
+    const sorted_sections = stream_list_sort.sort_groups(streams, "", "is:followed").sections;
+
+    assert.ok(sorted_sections.length > 0);
+});


### PR DESCRIPTION
**Fixes:**

This PR fixes the left sidebar search so that filtering via state operators (e.g., `is:followed`) correctly filters and expands topics within their respective channels.

CZO Discussion: Filtering, hiding, and/or sorting resolved topics ||  https://chat.zulip.org/#narrow/channel/101-design/topic/Filtering.2C.20hiding.2C.20and.2For.20sorting.20resolved.20topics

 Summary of Changes:

1. **Converted `.left-sidebar-search-input` to a `contenteditable` container:** Prevents global hotkeys from firing while typing and ensures standard text actions (clearing, pasting, and text selection) work reliably.
2. **Fixed search operator handling (`is:followed`):** Fixed an issue where operator syntax was treated as literal text, misrecognizing it as a channel/topic name and clearing the typeahead matcher before filtering rules ran. Updated parsing logic so operator syntax is stripped prior to title matching.
3. **Fixed inline topic list filtering for exact state matches:** Fixed an issue where typing state filters (`is:followed`, `is:resolved`) into the global left sidebar search bar expanded channels without filtering the rendered topics. Fixed `filter_topics_left_sidebar` to consume `topics_filter_state` directly from the raw left sidebar query rather than erroneously relying on the zoomed-view's pill widget.
4. **Resolved `contenteditable` side effects:**
   - Updated the clear search button to properly empty the container.
   - Fixed hotkey guard rails to keep focus inside the search container while active.
   
 5. Fixed Sidebar Search Filtering: Browsers and test environments (like Puppeteer) sometimes insert invisible characters (like zero-width spaces or non-breaking spaces) into contenteditable fields. Updated the search extraction logic to strictly sanitize these hidden characters so string matching works reliably.  
 

Fixes #<36878>

**How changes were tested:**
- Passed `tools/lint` cleanly.
- Passed `tools/test-js-with-node stream_list`.
- Manually tested search filtering, clear button, and hotkey behavior in the browser.

**Screenshots and screen captures:**

<!-- Drag and drop your completed video upload / screenshot here -->

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>





https://github.com/user-attachments/assets/88f152c3-e756-414a-9c12-e6a7a72ed49b
<img width="1920" height="1030" alt="Inbox - Zulip Dev - Zulip - Brave 12-08-2026 21_02_53" src="https://github.com/user-attachments/assets/2b3ec532-2f2a-4250-a6d1-e2e2142e0e7c" />

