### PR TITLE
Add confirmation for message reports

### DIFF
--- a/starlight_help/src/content/docs/report-a-message.mdx
+++ b/starlight_help/src/content/docs/report-a-message.mdx
@@ -27,7 +27,9 @@ that you report, not other DMs in the same thread.
          are [disabled](/help/enable-moderation-requests) in this organization.
       1. Fill out the requested information. Moderators will see the message
          you're reporting when they review your report.
-      1. Click **Submit** to report the message.
+      1. Click **Submit** to report the message. You will receive a direct
+         message from Notification Bot confirming that your report was
+         submitted.
     </FlattenedSteps>
   </TabItem>
 </Tabs>

--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from django.utils.translation import gettext as _
+from django.utils.translation import override as override_language
 
-from zerver.actions.message_send import internal_send_stream_message
+from zerver.actions.message_send import internal_send_private_message, internal_send_stream_message
 from zerver.lib.display_recipient import get_display_recipient
 from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
@@ -13,7 +14,7 @@ from zerver.lib.message import (
 )
 from zerver.lib.timestamp import datetime_to_global_time
 from zerver.lib.topic_link_util import get_message_link_syntax
-from zerver.lib.url_encoding import pm_message_url
+from zerver.lib.url_encoding import pm_message_url, stream_message_url
 from zerver.models import Message, Realm, UserProfile
 from zerver.models.recipients import Recipient
 from zerver.models.streams import StreamTopicsPolicyEnum
@@ -156,4 +157,50 @@ def send_message_report(
         topic_name=topic_name,
         content=content,
         acting_user=reporting_user,
+    )
+
+
+def send_report_confirmation_dm(
+    reporting_user: UserProfile,
+    realm: Realm,
+    reported_message: Message,
+    report_type: str,
+) -> None:
+    """Send a Notification Bot DM to the reporting user confirming their
+    report was submitted.
+
+    The message intentionally does not include the reported message's
+    content — some reports involve content that should not become an
+    indelible archive in the user's account.  A link is provided so the
+    user can navigate back to the message if needed.
+    """
+    if reported_message.is_channel_message:
+        message_url = stream_message_url(
+            realm=realm,
+            message=dict(
+                id=reported_message.id,
+                stream_id=reported_message.recipient.type_id,
+                display_recipient=reported_message.recipient.label(),
+                subject=reported_message.topic_name(),
+            ),
+        )
+    else:
+        message_url = pm_message_url(
+            realm,
+            dict(
+                id=reported_message.id,
+                display_recipient=get_display_recipient(reported_message.recipient),
+            ),
+        )
+
+    with override_language(reporting_user.default_language):
+        reason = str(Realm.REPORT_MESSAGE_REASONS[report_type]).lower()
+        content = _(
+            "You reported [a message]({message_url}) for {reason}."
+        ).format(message_url=message_url, reason=reason)
+
+    internal_send_private_message(
+        get_system_bot(settings.NOTIFICATION_BOT, realm.id),
+        reporting_user,
+        content,
     )

--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -195,9 +195,9 @@ def send_report_confirmation_dm(
 
     with override_language(reporting_user.default_language):
         reason = str(Realm.REPORT_MESSAGE_REASONS[report_type]).lower()
-        content = _(
-            "You reported [a message]({message_url}) for {reason}."
-        ).format(message_url=message_url, reason=reason)
+        content = _("You reported [a message]({message_url}) for {reason}.").format(
+            message_url=message_url, reason=reason
+        )
 
     internal_send_private_message(
         get_system_bot(settings.NOTIFICATION_BOT, realm.id),

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -14,6 +14,7 @@ from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.message import get_user_mentions_for_display, truncate_content
 from zerver.lib.message_report import MAX_REPORT_MESSAGE_SNIPPET_LENGTH
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import most_recent_message
 from zerver.lib.timestamp import datetime_to_global_time
 from zerver.lib.topic_link_util import (
     get_message_link_syntax,
@@ -588,7 +589,94 @@ class ReportMessageTest(ZulipTestCase):
             report_type="harassment",
         )
         self.assert_json_success(result)
-        report_msg = self.get_last_message()
+        # The moderation channel post is now the second-to-last message because
+        # send_report_confirmation_dm() sends a DM after it.  Use the filtered
+        # query to get the channel post specifically.
+        reports = self.get_submitted_moderation_requests()
+        report_msg = reports.last()
+        assert report_msg is not None
         self.assertEqual(report_msg.sender_id, notification_bot.id)
         self.assertEqual(report_msg.topic_name(), "")
         self.assertIn("reported", report_msg.content)
+
+    def test_report_sends_confirmation_dm(self) -> None:
+        reporting_user = self.example_user("hamlet")
+        report_type = "spam"
+        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, self.realm.id)
+
+        result = self.report_message(
+            reporting_user,
+            self.reported_message_id,
+            report_type=report_type,
+        )
+        self.assert_json_success(result)
+
+        # The confirmation DM is sent after the moderation channel post, so it
+        # is the most recent message seen by the reporting user.
+        confirmation_dm = most_recent_message(reporting_user)
+        self.assertEqual(confirmation_dm.sender_id, notification_bot.id)
+
+        # Must include the lower-cased report reason and a link to the
+        # reported message, but not the message content.
+        realm = get_realm("zulip")
+        expected_url = stream_message_url(
+            realm=realm,
+            message=dict(
+                id=self.reported_message.id,
+                stream_id=self.reported_message.recipient.type_id,
+                display_recipient=self.reported_message.recipient.label(),
+                subject=self.reported_message.topic_name(),
+            ),
+        )
+        self.assertIn(expected_url, confirmation_dm.content)
+        self.assertIn("spam", confirmation_dm.content)
+        self.assertNotIn(self.reported_message.content, confirmation_dm.content)
+
+    @time_machine.travel(MOCKED_DATE_SENT, tick=False)
+    def test_dm_report_sends_confirmation_dm(self) -> None:
+        reporting_user = self.example_user("hamlet")
+        reported_dm_id = self.send_personal_message(
+            self.reported_user,
+            reporting_user,
+            content="I eat pizza with a fork",
+        )
+        reported_dm = self.get_last_message()
+        assert reported_dm.id == reported_dm_id
+
+        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, self.realm.id)
+        result = self.report_message(reporting_user, reported_dm_id, report_type="harassment")
+        self.assert_json_success(result)
+
+        confirmation_dm = most_recent_message(reporting_user)
+        self.assertEqual(confirmation_dm.sender_id, notification_bot.id)
+
+        # Must include the lower-cased report reason and a link to the
+        # reported DM, but not the DM content.
+        realm = get_realm("zulip")
+        expected_url = pm_message_url(
+            realm,
+            dict(
+                id=reported_dm.id,
+                display_recipient=get_display_recipient(reported_dm.recipient),
+            ),
+        )
+        self.assertIn(expected_url, confirmation_dm.content)
+        self.assertIn("harassment", confirmation_dm.content)
+        self.assertNotIn(reported_dm.content, confirmation_dm.content)
+
+    def test_failed_report_sends_no_confirmation_dm(self) -> None:
+        # When a report is rejected (e.g. moderation disabled), no
+        # confirmation DM should be sent.
+        do_set_realm_moderation_request_channel(
+            self.hamlet.realm, None, -1, acting_user=self.hamlet
+        )
+        message_count_before = Message.objects.count()
+
+        result = self.report_message(
+            self.hamlet,
+            self.reported_message_id,
+            report_type="spam",
+        )
+        self.assert_json_error(result, "Message reporting is not enabled in this organization.")
+        # No new messages of any kind should have been created.
+        self.assertEqual(Message.objects.count(), message_count_before)

--- a/zerver/views/message_report.py
+++ b/zerver/views/message_report.py
@@ -7,7 +7,7 @@ from pydantic import StringConstraints
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message
-from zerver.lib.message_report import send_message_report
+from zerver.lib.message_report import send_message_report, send_report_confirmation_dm
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.lib.typed_endpoint_validators import check_string_in_validator
@@ -40,5 +40,7 @@ def report_message_backend(
             report_type,
             description,
         )
+
+    send_report_confirmation_dm(user_profile, user_profile.realm, reported_message, report_type)
 
     return json_success(request)


### PR DESCRIPTION
### Fixes

Fixes #39912

---

### How changes were tested:

**Automated Tests**: Added and updated unit tests in `zerver/tests/test_message_report.py`:

- `test_report_sends_confirmation_dm`: Verifies that reporting a channel message sends a localized confirmation DM with the lower-cased reason (`spam`) and the correct link, without including the original message content.
- `test_dm_report_sends_confirmation_dm`: Verifies that reporting a direct message sends a localized confirmation DM with the lower-cased reason (`harassment`) and the correct direct message link.
- `test_failed_report_sends_no_confirmation_dm`: Verifies that if the report submission fails, no confirmation DM is sent.
- Adjusted `test_message_report_to_channel_with_topics_disabled` because the moderation stream message is no longer the globally latest message in the test setup after the confirmation DM is sent.

These backend tests were not run locally because the development environment is Windows-based.

**Linter / Style Checks**: Ran Ruff formatting and linting checks locally on Windows:

```bash
uvx ruff check zerver/lib/message_report.py zerver/views/message_report.py zerver/tests/test_message_report.py
uvx ruff format zerver/lib/message_report.py zerver/views/message_report.py zerver/tests/test_message_report.py