### PR TITLE
Use browser locale for date formatting in message timestamp tooltips

### DIFF
--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -540,7 +540,7 @@ export function get_full_datetime_clarification(
     time: Date,
     time_format: TimeFormat = "time_sec",
 ): string {
-    const date_string = time.toLocaleDateString(user_settings.default_language, {
+    const date_string = time.toLocaleDateString(undefined, {
         timeZone: display_time_zone,
     });
     let time_string = get_localized_date_or_time_for_format(time, time_format);


### PR DESCRIPTION
Currently, message, recent conversation and draft timestamp tooltips use the user's 
configured language to determine the date format. This can cause users to see a regional 
date format that does not match their browser locale.

Use the browser's locale instead, while leaving the existing Zulip
time format and timezone settings unchanged.

CZO: [#design > Localized date formatting](https://chat.zulip.org/#narrow/channel/101-design/topic/Localized.20date.20formatting/with/2506943)
<!-- Describe your pull request here.-->

Fixes: Date formatting in those timestamp tooltips should follow the browser locale (Discussed in CZO thread).

**How changes were tested:**

- Ran `./tools/test-js-with-node timerender`.
- Manually verified the message, recent conversations and draft timestamp tooltips with different browser locales.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1903" height="950" alt="image" src="https://github.com/user-attachments/assets/066279f3-92cc-46fb-95ee-a0cae6caf65e" />
<img width="1887" height="943" alt="image" src="https://github.com/user-attachments/assets/78809b8d-7797-484f-a164-68e936d9b8fd" />
<img width="1882" height="912" alt="image" src="https://github.com/user-attachments/assets/3218fc88-e536-4565-8f0d-6eb95adaceae" />

Here, the browser default is set to English (UK) while the default language of zulip is English (US).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
