### PR TITLE
docs: Move osxfs settings advice to a note.

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -184,8 +184,13 @@ WSL 2 can be uninstalled by following [Microsoft's documentation][uninstall-wsl]
 
 1. Install [Vagrant][vagrant-dl] (latest).
 2. Install [Docker Desktop](https://docs.docker.com/desktop/mac/install/) (latest).
-3. Open the Docker desktop app's settings panel, and uncheck "Use gRPC FUSE for file sharing" to use the `osxfs (legacy)` file sharing instead.
-   :::
+
+:::{note}
+We recommend installing the latest version of Docker Desktop. If for some
+reason you must run an older version of Docker Desktop, you might need to uncheck
+"Use gRPC FUSE for file sharing" to use `osxfs (legacy)` file sharing before
+attempting to provision.
+:::
 
 :::{tab-item} Ubuntu/Debian
 :sync: os-ubuntu


### PR DESCRIPTION
Legacy file-sharing settings are evidently no longer required for dev setup on macOS. This change reflects that, while preserving a note for devs who might be running an older version of Docker Desktop.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1400" height="1200" alt="docs--macos-prereqs-before" src="https://github.com/user-attachments/assets/58282252-3acb-4d9f-8070-30493ab32e87" /> | <img width="1400" height="1200" alt="docs--macos-prereqs-after" src="https://github.com/user-attachments/assets/f5510140-0736-42fb-8806-938dd2fd7490" /> |