### PR TITLE
message_edit: Preserve topic visibility policy on a case-only rename.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -697,6 +697,14 @@ def update_user_topic_visibility_policies_on_move(
         visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
     )
 
+    # A case-only rename within the same channel resolves to the
+    # same UserTopic rows for both the original and target topic,
+    # since topic matching is case-insensitive.
+    topics_share_user_topic_rows = (
+        stream_being_edited.id == target_stream.id
+        and orig_topic_name.lower() == target_topic_name.lower()
+    )
+
     # If the messages are being moved to a stream the user _can_
     # access, we move the user topic records, by removing the old
     # topic visibility_policy and creating a new one.
@@ -738,7 +746,12 @@ def update_user_topic_visibility_policies_on_move(
             new_visibility_policy = get_visibility_policy_after_merge(
                 orig_topic_visibility_policy, target_topic_visibility_policy
             )
-            if new_visibility_policy == target_topic_visibility_policy:
+            if (
+                new_visibility_policy == target_topic_visibility_policy
+                # If topics share the UserTopic rows, we need to
+                # recreate because we deleted the rows above.
+                and not topics_share_user_topic_rows
+            ):
                 continue
             bulk_do_set_user_topic_visibility_policy(
                 user_profiles,

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -424,6 +424,97 @@ class MessageMoveTopicTest(ZulipTestCase):
         do_update_message_topic_success(hamlet, message, "Change again", users_to_be_notified)
 
     @mock.patch("zerver.actions.user_topics.send_event_on_commit")
+    def test_case_only_topic_rename_preserves_visibility_policy(
+        self, mock_send_event_on_commit: mock.MagicMock
+    ) -> None:
+        # Renaming a topic with only a case change is, for matching
+        # purposes, the same topic; each user's visibility policy must
+        # survive the rename rather than being reset to inherit.
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        stream = self.make_stream("case rename stream")
+        self.subscribe(hamlet, stream.name)
+        self.subscribe(cordelia, stream.name)
+        self.login_user(hamlet)
+
+        message_id = self.send_stream_message(hamlet, stream.name, topic_name="Test Topic")
+        do_set_user_topic_visibility_policy(
+            hamlet, stream, "Test Topic", visibility_policy=UserTopic.VisibilityPolicy.MUTED
+        )
+        do_set_user_topic_visibility_policy(
+            cordelia, stream, "Test Topic", visibility_policy=UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        mock_send_event_on_commit.reset_mock()
+
+        result = self.client_patch(
+            f"/json/messages/{message_id}",
+            {"topic": "test topic", "propagate_mode": "change_all"},
+        )
+        self.assert_json_success(result)
+
+        # Each affected user is notified just like for a regular move: a
+        # user_topic event removing the old row, one adding the row under
+        # the new casing, and a muted_topics event with the full updated
+        # set of muted topics.
+        user_topic_events: dict[int, list[tuple[str, int]]] = {hamlet.id: [], cordelia.id: []}
+        muted_topics_events: dict[int, list[list[list[str | int]]]] = {
+            hamlet.id: [],
+            cordelia.id: [],
+        }
+        for call_args in mock_send_event_on_commit.call_args_list:
+            (_arg_realm, arg_event, arg_notified_users) = call_args[0]
+            [notified_user_id] = arg_notified_users
+            if arg_event["type"] == "user_topic":
+                self.assertEqual(arg_event["stream_id"], stream.id)
+                user_topic_events[notified_user_id].append(
+                    (arg_event["topic_name"], arg_event["visibility_policy"])
+                )
+            elif arg_event["type"] == "muted_topics":
+                muted_topics_events[notified_user_id].append(arg_event["muted_topics"])
+        self.assertEqual(
+            user_topic_events[hamlet.id],
+            [
+                ("Test Topic", UserTopic.VisibilityPolicy.INHERIT),
+                ("test topic", UserTopic.VisibilityPolicy.MUTED),
+            ],
+        )
+        self.assertEqual(
+            user_topic_events[cordelia.id],
+            [
+                ("Test Topic", UserTopic.VisibilityPolicy.INHERIT),
+                ("test topic", UserTopic.VisibilityPolicy.FOLLOWED),
+            ],
+        )
+        self.assertEqual(muted_topics_events[hamlet.id], [[[stream.name, "test topic", mock.ANY]]])
+        self.assertEqual(muted_topics_events[cordelia.id], [[]])
+
+        # The policies survive and still apply to the renamed topic
+        # (matched case-insensitively).
+        self.assertTrue(
+            topic_has_visibility_policy(
+                hamlet, stream.id, "test topic", UserTopic.VisibilityPolicy.MUTED
+            )
+        )
+        self.assertTrue(
+            topic_has_visibility_policy(
+                cordelia, stream.id, "test topic", UserTopic.VisibilityPolicy.FOLLOWED
+            )
+        )
+        # The stored topic name is updated to the new casing, and no row
+        # is duplicated or lost.
+        self.assertEqual(
+            sorted(
+                UserTopic.objects.filter(stream_id=stream.id).values_list(
+                    "topic_name", "visibility_policy"
+                )
+            ),
+            [
+                ("test topic", UserTopic.VisibilityPolicy.MUTED),
+                ("test topic", UserTopic.VisibilityPolicy.FOLLOWED),
+            ],
+        )
+
+    @mock.patch("zerver.actions.user_topics.send_event_on_commit")
     def test_edit_muted_topic(self, mock_send_event_on_commit: mock.MagicMock) -> None:
         stream_name = "Stream 123"
         stream = self.make_stream(stream_name)


### PR DESCRIPTION
PR addresses the review comments on #39568

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
