### PR TITLE
compose paste: Multi message quote selection

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -654,9 +654,30 @@ export function build_and_process_quote_assets_for_messages(
 function quote_multiple_messages(opts: QuoteMessageOpts): void {
     const highlighted_message_ids = opts.highlighted_message_ids;
     assert(highlighted_message_ids !== undefined && highlighted_message_ids.length > 1);
+
+    // Read the bookend selection before the async fetch clears it; middle
+    // messages are always quoted in full.
+    const selection = window.getSelection();
+    const partial_markdown_by_id = new Map<number, string>();
+    if (selection !== null) {
+        const bookend_ids = [highlighted_message_ids[0]!, highlighted_message_ids.at(-1)!];
+        for (const message_id of bookend_ids) {
+            const markdown = get_selection_markdown_for_message(message_id, selection);
+            if (markdown !== undefined && markdown !== "") {
+                partial_markdown_by_id.set(message_id, markdown);
+            }
+        }
+    }
+
     build_and_process_quote_assets_for_messages(
         highlighted_message_ids,
         (quote_assets: QuoteAsset[]) => {
+            for (const asset of quote_assets) {
+                const partial_markdown = partial_markdown_by_id.get(asset.message.id);
+                if (partial_markdown !== undefined) {
+                    asset.quote_content = partial_markdown;
+                }
+            }
             const msg_for_compose_box = quote_assets[0]!.message;
             const messages = quote_assets.map((asset) => asset.message);
             const status = get_multi_message_quote_status(messages);
@@ -821,6 +842,52 @@ function get_range_intersection_with_element(range: Range, element: Node): Range
     }
 
     return intersection;
+}
+
+function get_selection_markdown_for_message(
+    message_id: number,
+    selection: Selection,
+): string | undefined {
+    // Markdown of the selected part of a partially-selected bookend message;
+    // undefined if the whole content, or none of it, is selected.
+    if (message_lists.current === undefined) {
+        return undefined;
+    }
+    const message_content = message_lists.current.get_row(message_id).find(".message_content")[0];
+    if (message_content === undefined) {
+        return undefined;
+    }
+
+    const full_content_range = document.createRange();
+    full_content_range.selectNodeContents(message_content);
+
+    let html_to_convert = "";
+    for (let i = 0; i < selection.rangeCount; i += 1) {
+        const range = selection.getRangeAt(i);
+        if (!range.intersectsNode(message_content)) {
+            continue;
+        }
+        // A fresh range, so expanding it doesn't mutate the visible selection.
+        const intersection = get_range_intersection_with_element(range, message_content);
+        copy_messages.improve_special_element_selection_range(intersection);
+        if (
+            intersection.compareBoundaryPoints(Range.START_TO_START, full_content_range) <= 0 &&
+            intersection.compareBoundaryPoints(Range.END_TO_END, full_content_range) >= 0
+        ) {
+            // The selection spans this message's content in full.
+            return undefined;
+        }
+        // Preserve ancestors when the selection sits inside a nested block
+        // (e.g. a code block or list) to keep its structure in the markdown.
+        const preserve_ancestors =
+            $(intersection.commonAncestorContainer).parents(".message_content").length > 0;
+        html_to_convert += extract_range_html(intersection, preserve_ancestors);
+    }
+
+    if (html_to_convert === "") {
+        return undefined;
+    }
+    return compose_paste.paste_handler_converter(html_to_convert).trim();
 }
 
 export let get_message_selection = (selection = window.getSelection()): string => {

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -833,7 +833,7 @@ export let get_message_selection = (selection = window.getSelection()): string =
     // in one selection), and also compute their combined bounding rect.
     for (let i = 0; i < selection.rangeCount; i += 1) {
         let range = selection.getRangeAt(i);
-        copy_messages.improve_mention_selection_range(range);
+        copy_messages.improve_special_element_selection_range(range);
         const range_common_ancestor = range.commonAncestorContainer;
         let html_to_convert;
         let message_content;

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -422,7 +422,7 @@ function improve_time_selection_range(range: Range): void {
     }
 }
 
-export function improve_mention_selection_range(range: Range): void {
+function improve_mention_selection_range(range: Range): void {
     const start_element = get_nearest_html_element(range.startContainer);
     const end_element = get_nearest_html_element(range.endContainer);
     if (!start_element || !end_element) {
@@ -487,6 +487,13 @@ function improve_katex_selection_range(range: Range): void {
 
     expand_range_based_on_katex_parent(start_element, true, range);
     expand_range_based_on_katex_parent(end_element, false, range);
+}
+
+export function improve_special_element_selection_range(range: Range): void {
+    // Expand a boundary landing inside a mention, timestamp or KaTeX span.
+    improve_time_selection_range(range);
+    improve_mention_selection_range(range);
+    improve_katex_selection_range(range);
 }
 
 function maybe_update_range_for_code_blocks(range: Range, ev: ClipboardEvent): boolean {
@@ -578,9 +585,7 @@ export function copy_handler(ev: ClipboardEvent): boolean {
         // we process all ranges individually.
         let custom_handle_copy = false;
         for (let i = 0; i < selection.rangeCount; i += 1) {
-            improve_time_selection_range(selection.getRangeAt(i));
-            improve_mention_selection_range(selection.getRangeAt(i));
-            improve_katex_selection_range(selection.getRangeAt(i));
+            improve_special_element_selection_range(selection.getRangeAt(i));
 
             if (maybe_update_range_for_code_blocks(selection.getRangeAt(i), ev)) {
                 // This will not disturb katex expansions because the clipboard


### PR DESCRIPTION
Quoting a multi-message selection fetched each message's full `raw_content` and quoted each message in full, ignoring how much of the first and last messages was actually selected.

This quotes just the selected portion of those bookend messages instead, mirroring what copy already does; messages fully inside the selection keep their `raw_content`, which round-trips more faithfully. The bookend range is expanded for mentions/timestamps/KaTeX.

Fixes: #39631.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
|<img width="1920" height="878" alt="image" src="https://github.com/user-attachments/assets/7268b1ef-ee6d-4bb9-b24b-7d8f2636f507" />|<img width="1920" height="878" alt="image" src="https://github.com/user-attachments/assets/e2098a49-569c-41eb-8df2-c1743f1f7bdc" />|



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
