### PR TITLE
message_report: Add confirmation message.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 13.0
 
+**Feature level 511**
+
+* [`POST /messages/{message_id}/report`](/api/report-message): This endpoint
+  now returns an error if the message report fails to be sent to the
+  moderation request channel.
+
 **Feature level 510**
 
 * [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),

--- a/api_docs/unmerged.d/ZF-f6b664.md
+++ b/api_docs/unmerged.d/ZF-f6b664.md
@@ -1,0 +1,3 @@
+* [`POST /messages/{message_id}/report`](/api/report-message): This endpoint
+  now returns an error if the message report fails to be sent to the
+  moderation request channel.

--- a/api_docs/unmerged.d/ZF-f6b664.md
+++ b/api_docs/unmerged.d/ZF-f6b664.md
@@ -1,3 +1,0 @@
-* [`POST /messages/{message_id}/report`](/api/report-message): This endpoint
-  now returns an error if the message report fails to be sent to the
-  moderation request channel.

--- a/starlight_help/src/content/docs/report-a-message.mdx
+++ b/starlight_help/src/content/docs/report-a-message.mdx
@@ -27,7 +27,9 @@ that you report, not other DMs in the same thread.
          organization.
       1. Fill out the requested information. Moderators will see the message
          you're reporting when they review your report.
-      1. Click **Submit** to report the message.
+      1. Click **Submit** to report the message. You will receive a direct
+         message from Notification Bot confirming that your report was
+         submitted.
     </FlattenedSteps>
   </TabItem>
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # https://zulip.readthedocs.io/en/latest/documentation/api.html#step-by-step-guide
 # Also available at docs/documentation/api.md.
 
-API_FEATURE_LEVEL = 510
+API_FEATURE_LEVEL = 511
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from django.utils.translation import gettext as _
+from django.utils.translation import override as override_language
 
-from zerver.actions.message_send import internal_send_stream_message
+from zerver.actions.message_send import internal_send_private_message, internal_send_stream_message
 from zerver.lib.display_recipient import get_display_recipient
 from zerver.lib.markdown.fenced_code import get_unused_fence
 from zerver.lib.mention import silent_mention_syntax_for_user
@@ -13,7 +14,7 @@ from zerver.lib.message import (
 )
 from zerver.lib.timestamp import datetime_to_global_time
 from zerver.lib.topic_link_util import get_message_link_syntax
-from zerver.lib.url_encoding import pm_message_url
+from zerver.lib.url_encoding import pm_message_url, stream_message_url
 from zerver.models import Message, Realm, UserProfile
 from zerver.models.recipients import Recipient
 from zerver.models.streams import StreamTopicsPolicyEnum
@@ -156,4 +157,42 @@ def send_message_report(
         topic_name=topic_name,
         content=content,
         acting_user=reporting_user,
+    )
+
+
+def send_report_confirmation_dm(
+    reporting_user: UserProfile,
+    realm: Realm,
+    reported_message: Message,
+    report_type: str,
+) -> None:
+    if reported_message.is_channel_message:
+        message_url = stream_message_url(
+            realm=realm,
+            message=dict(
+                id=reported_message.id,
+                stream_id=reported_message.recipient.type_id,
+                display_recipient=reported_message.recipient.label(),
+                topic=reported_message.topic_name(),
+            ),
+        )
+    else:
+        message_url = pm_message_url(
+            realm,
+            dict(
+                id=reported_message.id,
+                display_recipient=get_display_recipient(reported_message.recipient),
+            ),
+        )
+
+    with override_language(reporting_user.default_language):
+        reason = str(Realm.REPORT_MESSAGE_REASONS[report_type]).lower()
+        content = _("You reported [a message]({message_url}) for {reason}.").format(
+            message_url=message_url, reason=reason
+        )
+
+    internal_send_private_message(
+        get_system_bot(settings.NOTIFICATION_BOT, realm.id),
+        reporting_user,
+        content,
     )

--- a/zerver/lib/message_report.py
+++ b/zerver/lib/message_report.py
@@ -34,7 +34,7 @@ def send_message_report(
     reported_message: Message,
     report_type: str,
     description: str,
-) -> None:
+) -> int | None:
     moderation_request_channel = realm.moderation_request_channel
     assert moderation_request_channel is not None
 
@@ -150,7 +150,7 @@ def send_message_report(
     if moderation_request_channel.topics_policy == StreamTopicsPolicyEnum.empty_topic_only.value:
         topic_name = ""
 
-    internal_send_stream_message(
+    return internal_send_stream_message(
         sender=get_system_bot(settings.NOTIFICATION_BOT, moderation_request_channel.realm.id),
         stream=moderation_request_channel,
         topic_name=topic_name,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10982,7 +10982,7 @@ paths:
         parameter is required. Clients should also enforce and communicate this
         behavior in the UI.
 
-        **Changes**: In Zulip 13.0 (feature level ZF-f6b664), this endpoint
+        **Changes**: In Zulip 13.0 (feature level 511), this endpoint
         now returns an error if the message report fails to be sent to the
         moderation request channel.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10982,6 +10982,10 @@ paths:
         parameter is required. Clients should also enforce and communicate this
         behavior in the UI.
 
+        **Changes**: In Zulip 13.0 (feature level ZF-f6b664), this endpoint
+        now returns an error if the message report fails to be sent to the
+        moderation request channel.
+
         **Changes**: New in Zulip 11.0 (feature level 382). This API builds on
         the `moderation_request_channel` realm setting, which was added in
         feature level 331.

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -588,7 +588,9 @@ class ReportMessageTest(ZulipTestCase):
             report_type="harassment",
         )
         self.assert_json_success(result)
-        report_msg = self.get_last_message()
+        reports = self.get_submitted_moderation_requests()
+        report_msg = reports.first()
+        assert report_msg is not None
         self.assertEqual(report_msg.sender_id, notification_bot.id)
         self.assertEqual(report_msg.topic_name(), "")
         self.assertIn("reported", report_msg.content)

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -15,6 +15,7 @@ from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.message import get_user_mentions_for_display, truncate_content
 from zerver.lib.message_report import MAX_REPORT_MESSAGE_SNIPPET_LENGTH
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import most_recent_message
 from zerver.lib.timestamp import datetime_to_global_time
 from zerver.lib.topic_link_util import (
     get_message_link_syntax,
@@ -595,6 +596,83 @@ class ReportMessageTest(ZulipTestCase):
         self.assertEqual(report_msg.sender_id, notification_bot.id)
         self.assertEqual(report_msg.topic_name(), "")
         self.assertIn("reported", report_msg.content)
+
+    def test_report_sends_confirmation_dm(self) -> None:
+        reporting_user = self.example_user("hamlet")
+        report_type = "spam"
+        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, self.realm.id)
+
+        result = self.report_message(
+            reporting_user,
+            self.reported_message_id,
+            report_type=report_type,
+        )
+        self.assert_json_success(result)
+
+        # The confirmation DM is sent after the moderation channel post, so it
+        # is the most recent message seen by the reporting user.
+        confirmation_dm = most_recent_message(reporting_user)
+        self.assertEqual(confirmation_dm.sender_id, notification_bot.id)
+
+        realm = get_realm("zulip")
+        expected_url = stream_message_url(
+            realm=realm,
+            message=dict(
+                id=self.reported_message.id,
+                stream_id=self.reported_message.recipient.type_id,
+                display_recipient=self.reported_message.recipient.label(),
+                topic=self.reported_message.topic_name(),
+            ),
+        )
+        self.assertEqual(
+            confirmation_dm.content,
+            f"You reported [a message]({expected_url}) for spam.",
+        )
+
+    @time_machine.travel(MOCKED_DATE_SENT, tick=False)
+    def test_dm_report_sends_confirmation_dm(self) -> None:
+        reporting_user = self.example_user("hamlet")
+        reported_dm_id = self.send_personal_message(
+            self.reported_user,
+            reporting_user,
+            content="I eat pizza with a fork",
+        )
+        reported_dm = self.get_last_message()
+        assert reported_dm.id == reported_dm_id
+
+        notification_bot = get_system_bot(settings.NOTIFICATION_BOT, self.realm.id)
+        result = self.report_message(reporting_user, reported_dm_id, report_type="harassment")
+        self.assert_json_success(result)
+
+        confirmation_dm = most_recent_message(reporting_user)
+        self.assertEqual(confirmation_dm.sender_id, notification_bot.id)
+
+        realm = get_realm("zulip")
+        expected_url = pm_message_url(
+            realm,
+            dict(
+                id=reported_dm.id,
+                display_recipient=get_display_recipient(reported_dm.recipient),
+            ),
+        )
+        self.assertEqual(
+            confirmation_dm.content,
+            f"You reported [a message]({expected_url}) for harassment.",
+        )
+
+    def test_failed_report_sends_no_confirmation_dm(self) -> None:
+        do_set_realm_moderation_request_channel(
+            self.hamlet.realm, None, -1, acting_user=self.hamlet
+        )
+        message_count_before = Message.objects.count()
+
+        result = self.report_message(
+            self.hamlet,
+            self.reported_message_id,
+            report_type="spam",
+        )
+        self.assert_json_error(result, "Message reporting is not enabled in this organization.")
+        self.assertEqual(Message.objects.count(), message_count_before)
 
     def test_failed_internal_send_raises_error(self) -> None:
         with mock.patch(

--- a/zerver/tests/test_message_report.py
+++ b/zerver/tests/test_message_report.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import mock
 
 import time_machine
 from django.conf import settings
@@ -594,3 +595,15 @@ class ReportMessageTest(ZulipTestCase):
         self.assertEqual(report_msg.sender_id, notification_bot.id)
         self.assertEqual(report_msg.topic_name(), "")
         self.assertIn("reported", report_msg.content)
+
+    def test_failed_internal_send_raises_error(self) -> None:
+        with mock.patch(
+            "zerver.lib.message_report.internal_send_stream_message",
+            return_value=None,
+        ):
+            result = self.report_message(
+                self.hamlet,
+                self.reported_message_id,
+                report_type="spam",
+            )
+        self.assert_json_error(result, "Failed to send the message report.")

--- a/zerver/views/message_report.py
+++ b/zerver/views/message_report.py
@@ -7,7 +7,7 @@ from pydantic import StringConstraints
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message
-from zerver.lib.message_report import send_message_report
+from zerver.lib.message_report import send_message_report, send_report_confirmation_dm
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.lib.typed_endpoint_validators import check_string_in_validator
@@ -43,4 +43,7 @@ def report_message_backend(
 
     if message_report_id is None:
         raise JsonableError(_("Failed to send the message report."))
+
+    send_report_confirmation_dm(user_profile, user_profile.realm, reported_message, report_type)
+
     return json_success(request)

--- a/zerver/views/message_report.py
+++ b/zerver/views/message_report.py
@@ -33,7 +33,7 @@ def report_message_backend(
 
     reported_message = access_message(user_profile, message_id, is_modifying_message=False)
     with override_language(user_profile.realm.default_language):
-        send_message_report(
+        message_report_id = send_message_report(
             user_profile,
             user_profile.realm,
             reported_message,
@@ -41,4 +41,6 @@ def report_message_backend(
             description,
         )
 
+    if message_report_id is None:
+        raise JsonableError(_("Failed to send the message report."))
     return json_success(request)


### PR DESCRIPTION
Fixes: #39912

Previously, reporters received no indication that a message report
had been successfully submitted. This sends a Notification Bot DM
to the reporter after a successful report, including a direct link
to the reported message.

**Screenshots and screen captures:**

<img width="984" height="540" alt="image" src="https://github.com/user-attachments/assets/bad1f54a-f7b1-4256-bb41-923f1e920e37" />


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
