### PR TITLE
outgoing_webhook: Split command and text for Slack-compat format.

### DIFF
--- a/api_docs/outgoing-webhook-payload.md
+++ b/api_docs/outgoing-webhook-payload.md
@@ -20,6 +20,11 @@ which can help with porting an existing Slack integration to work with
 Zulip, and allows immediate integration with many third-party systems
 that already support Slack outgoing webhooks.
 
+**Changes**: In Zulip 13.0 (feature level ZF-4d8ff9), the
+`command` field was added to requests triggered by a leading bot
+mention, and the leading bot mention is no longer included in `text`
+for those requests.
+
 The following table details how the Zulip server translates a Zulip
 message into the Slack-compatible webhook format.
 
@@ -70,7 +75,18 @@ message into the Slack-compatible webhook format.
         </tr>
         <tr>
             <td><code>text</code></td>
-            <td>The content of the message (in Markdown)</td>
+            <td>The content of the message (in Markdown). When the
+            webhook is triggered by a bot mention at the start of the
+            message, the mention is stripped from <code>text</code>
+            and sent separately in the <code>command</code> field.</td>
+        </tr>
+        <tr>
+            <td><code>command</code></td>
+            <td>Present when the message starts with a mention of the
+            bot. Contains the mention transformed into a
+            slash-command-style string, e.g., <code>/My Bot</code>.
+            Omitted when the message does not start with a bot
+            mention.</td>
         </tr>
         <tr>
             <td><code>trigger_word</code></td>
@@ -95,9 +111,10 @@ The above data is posted as list of tuples (not JSON), here's an example:
  ('timestamp', 1532078950),
  ('user_id', 'U21'),
  ('user_name', 'Full Name'),
- ('text', '@**test**'),
+ ('text', 'do something'),
  ('trigger_word', 'mention'),
- ('service_id', 27)]
+ ('service_id', 27),
+ ('command', '/My Bot')]
 ```
 
 * For successful requests, if data is returned, it returns that data,

--- a/api_docs/unmerged.d/ZF-4d8ff9.md
+++ b/api_docs/unmerged.d/ZF-4d8ff9.md
@@ -1,0 +1,6 @@
+* [Slack-compatible outgoing webhooks](/api/outgoing-webhook-payload#slack-compatible-format):
+  Added a `command` field to the payload. When a message starts with a
+  mention of the bot, the mention is now sent as `command` (transformed
+  to `/My Bot`, for a bot named `My Bot`) and `text` contains only the
+  remainder of the message. Previously, `text` always contained the full
+  message content including the bot mention.

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -15,6 +15,7 @@ from typing_extensions import override
 from version import ZULIP_VERSION
 from zerver.actions.message_send import check_send_message
 from zerver.lib.exceptions import JsonableError, StreamDoesNotExistError
+from zerver.lib.mention import MENTIONS_RE
 from zerver.lib.message_cache import MessageDict
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.queue import retry_event
@@ -110,6 +111,45 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
         return None
 
 
+def get_slack_bot_command(content: str, bot_user: UserProfile) -> tuple[str, str] | None:
+    """If `content` starts with a mention of `bot_user`, return
+    (command, remaining_text) where:
+      - command is the mention transformed into a slash-command-style
+        string, e.g. ``@**My Bot**`` → ``/My Bot``
+      - remaining_text is everything after the mention, stripped of
+        leading/trailing whitespace
+
+    Returns None if the message does not start with a mention of this bot.
+    """
+    # Strip leading whitespace so that messages with accidental
+    # leading spaces or newlines (e.g. from paste or mobile flows)
+    # still get the command/text split.
+    content = content.lstrip()
+    match = MENTIONS_RE.match(content)
+    if match is None:
+        return None
+
+    mention_text = match.group("match")
+
+    # The captured text is either "Full Name" or "Full Name|user_id".
+    if "|" in mention_text:
+        name, id_str = mention_text.rsplit("|", 1)
+        if not id_str.isdigit() or int(id_str) != bot_user.id:
+            return None
+        # If a name is present, verify it matches the bot.
+        if name and name.lower() != bot_user.full_name.lower():
+            return None
+        command_name = name or bot_user.full_name
+    else:
+        if mention_text.lower() != bot_user.full_name.lower():
+            return None
+        command_name = mention_text
+
+    command = f"/{command_name}"
+    remaining_text = content[match.end() :].strip()
+    return (command, remaining_text)
+
+
 class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
     @override
     def make_request(self, base_url: str, event: dict[str, Any], realm: Realm) -> Response | None:
@@ -132,6 +172,15 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
         # user_name=Steve
         # text=googlebot: What is the air-speed velocity of an unladen swallow?
         # trigger_word=googlebot:
+        # command=/googlebot
+
+        text = event["command"]
+        command = None
+
+        if event["trigger"] == "mention":
+            split = get_slack_bot_command(event["command"], self.user_profile)
+            if split is not None:
+                command, text = split
 
         request_data = [
             ("token", self.token),
@@ -143,10 +192,14 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
             ("timestamp", event["message"]["timestamp"]),
             ("user_id", f"U{event['message']['sender_id']}"),
             ("user_name", event["message"]["sender_full_name"]),
-            ("text", event["command"]),
+            ("text", text),
             ("trigger_word", event["trigger"]),
             ("service_id", event["user_profile_id"]),
         ]
+
+        if command is not None:
+            request_data.append(("command", command))
+
         return self.session.post(base_url, data=request_data)
 
     @override

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -160,8 +160,10 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.bot_user = get_user("outgoing-webhook@zulip.com", get_realm("zulip"))
+        bot_name = self.bot_user.full_name  # "Outgoing Webhook"
+
         self.stream_message_event = {
-            "command": "@**test**",
+            "command": f"@**{bot_name}** do something",
             "user_profile_id": 12,
             "service_name": "test-service",
             "trigger": "mention",
@@ -201,30 +203,147 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
             token="abcdef", user_profile=self.bot_user, service_name="test-service"
         )
 
-    def test_make_request_stream_message(self) -> None:
+    def _get_request_data(self, event: dict[str, Any]) -> list[tuple[str, Any]]:
+        """Helper to call make_request and return the posted data."""
         test_url = "https://example.com/example"
         with mock.patch.object(self.handler, "session") as session:
-            self.handler.make_request(
-                test_url,
-                self.stream_message_event,
-                self.bot_user.realm,
-            )
+            self.handler.make_request(test_url, event, self.bot_user.realm)
             session.post.assert_called_once()
             self.assertEqual(session.post.call_args[0], (test_url,))
-            request_data = session.post.call_args[1]["data"]
+            return session.post.call_args[1]["data"]
 
-        self.assertEqual(request_data[0][1], "abcdef")  # token
-        self.assertEqual(request_data[1][1], "T2")  # team_id
-        self.assertEqual(request_data[2][1], "zulip.testserver")  # team_domain
-        self.assertEqual(request_data[3][1], "C123")  # channel_id
-        self.assertEqual(request_data[4][1], "integrations")  # channel_name
-        self.assertEqual(request_data[5][1], 123456)  # thread_id
-        self.assertEqual(request_data[6][1], 123456)  # timestamp
-        self.assertEqual(request_data[7][1], "U21")  # user_id
-        self.assertEqual(request_data[8][1], "Sample User")  # user_name
-        self.assertEqual(request_data[9][1], "@**test**")  # text
-        self.assertEqual(request_data[10][1], "mention")  # trigger_word
-        self.assertEqual(request_data[11][1], 12)  # user_profile_id
+    def test_make_request_stream_message(self) -> None:
+        request_data = self._get_request_data(self.stream_message_event)
+
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["token"], "abcdef")
+        self.assertEqual(request_dict["team_id"], "T2")
+        self.assertEqual(request_dict["team_domain"], "zulip.testserver")
+        self.assertEqual(request_dict["channel_id"], "C123")
+        self.assertEqual(request_dict["channel_name"], "integrations")
+        self.assertEqual(request_dict["thread_ts"], 123456)
+        self.assertEqual(request_dict["timestamp"], 123456)
+        self.assertEqual(request_dict["user_id"], "U21")
+        self.assertEqual(request_dict["user_name"], "Sample User")
+        # The leading bot mention is split into command and stripped from text.
+        self.assertEqual(request_dict["text"], "do something")
+        self.assertEqual(request_dict["command"], f"/{self.bot_user.full_name}")
+        self.assertEqual(request_dict["trigger_word"], "mention")
+        self.assertEqual(request_dict["service_id"], 12)
+
+    def test_make_request_stream_message_silent_mention(self) -> None:
+        """A silent mention (@_**Bot Name**) at the start is split the same way."""
+        event = {
+            **self.stream_message_event,
+            "command": f"@_**{self.bot_user.full_name}** deploy prod",
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["command"], f"/{self.bot_user.full_name}")
+        self.assertEqual(request_dict["text"], "deploy prod")
+
+    def test_make_request_stream_message_id_mention(self) -> None:
+        """A mention with |user_id disambiguation is handled correctly."""
+        event = {
+            **self.stream_message_event,
+            "command": f"@**{self.bot_user.full_name}|{self.bot_user.id}** status",
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["command"], f"/{self.bot_user.full_name}")
+        self.assertEqual(request_dict["text"], "status")
+
+    def test_make_request_stream_message_non_numeric_id_mention(self) -> None:
+        full_content = f"@**{self.bot_user.full_name}|not-a-user-id** status"
+        event = {
+            **self.stream_message_event,
+            "command": full_content,
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["text"], full_content)
+        self.assertNotIn("command", request_dict)
+
+    def test_make_request_stream_message_wrong_id_mention(self) -> None:
+        full_content = f"@**{self.bot_user.full_name}|{self.bot_user.id + 1}** status"
+        event = {
+            **self.stream_message_event,
+            "command": full_content,
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["text"], full_content)
+        self.assertNotIn("command", request_dict)
+
+    def test_make_request_stream_message_wrong_name_with_id_mention(self) -> None:
+        full_content = f"@**Not The Bot|{self.bot_user.id}** status"
+        event = {
+            **self.stream_message_event,
+            "command": full_content,
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["text"], full_content)
+        self.assertNotIn("command", request_dict)
+
+    def test_make_request_stream_message_mention_mid_message(self) -> None:
+        """A bot mention that is NOT at the start → no command, text is full content."""
+        full_content = f"Hey @**{self.bot_user.full_name}** help me"
+        event = {
+            **self.stream_message_event,
+            "command": full_content,
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["text"], full_content)
+        self.assertNotIn("command", request_dict)
+
+    def test_make_request_stream_message_different_user_mention(self) -> None:
+        """A mention of a *different* user at the start → no split."""
+        full_content = "@**Hamlet** do something"
+        event = {
+            **self.stream_message_event,
+            "command": full_content,
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["text"], full_content)
+        self.assertNotIn("command", request_dict)
+
+    def test_make_request_no_mention_trigger(self) -> None:
+        """When trigger is not 'mention', no split is attempted."""
+        full_content = f"@**{self.bot_user.full_name}** hello"
+        event = {
+            **self.stream_message_event,
+            "command": full_content,
+            "trigger": "stream",
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["text"], full_content)
+        self.assertNotIn("command", request_dict)
+
+    def test_make_request_stream_message_leading_whitespace(self) -> None:
+        """Leading whitespace before the mention doesn't prevent the split."""
+        event = {
+            **self.stream_message_event,
+            "command": f"  \n @**{self.bot_user.full_name}** deploy",
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["command"], f"/{self.bot_user.full_name}")
+        self.assertEqual(request_dict["text"], "deploy")
+
+    def test_make_request_stream_message_multiple_mentions(self) -> None:
+        """Only the first mention becomes 'command'; the rest stays in 'text'."""
+        event = {
+            **self.stream_message_event,
+            "command": f"@**{self.bot_user.full_name}** @**Hamlet** do thing",
+        }
+        request_data = self._get_request_data(event)
+        request_dict = dict(request_data)
+        self.assertEqual(request_dict["command"], f"/{self.bot_user.full_name}")
+        self.assertEqual(request_dict["text"], "@**Hamlet** do thing")
 
     @mock.patch("zerver.lib.outgoing_webhook.fail_with_message")
     def test_make_request_private_message(self, mock_fail_with_message: mock.Mock) -> None:


### PR DESCRIPTION
When a Slack-compatible outgoing webhook is triggered by a bot mention at the start of a message, the mention is now split into a separate `command` field (transformed to slash-style, e.g., `/My Bot` ) and `text` contains only the remainder. This matches real Slack outgoing webhook behavior and enables compatibility with third-party services like GitLab slash commands that expect this split.

Relationship to other work: There are several other open PRs addressing
#19589 (#38098, #39481, #39820, #39892). I developed this implementation
independently, without reusing code from any of them.

My approach extracts the matching logic into a standalone
get_slack_bot_command() function that reuses Zulip's existing MENTIONS_RE,
which handles both @** and @_** (silent mention) forms. It validates the
captured bot identity against the bot's actual user record, since bot
display names are mutable, so an ID-first check (falling back to name only
as a secondary guard) is the only way to unambiguously confirm which bot
was mentioned. It also strips leading whitespace before matching, to avoid
silently missing a valid mention that starts with a stray space or newline.

This is covered by eleven test methods, including the happy path, silent
mentions, multiple mentions, and several negative cases (wrong ID, wrong
name, mid-message mention, mention of a different user).

Discussion: https://chat.zulip.org/#narrow/stream/127-integrations/topic/gitlab.20slash.20commands/near/1247658

Fixes: #19589

**How changes were tested:**
- `./tools/test-backend zerver/tests/test_outgoing_webhook_interfaces` -- all 13 tests pass, including 11 new tests covering every branch of `get_slack_bot_command()`.
- `./tools/lint zerver/lib/outgoing_webhook.py zerver/tests/test_outgoing_webhook_interfaces.py` -- clean.
- CI checks pass.

**Screenshots and screen captures:**
N/A (backend-only change, no UI).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
