### PR TITLE
echo: Snapshot a resent message before transmitting it.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -178,13 +178,17 @@ export function resend_message(
 
     message.resend = true;
 
+    // A resend's message event can arrive before its response, and reifying
+    // converts the message in place, so snapshot what we actually sent.
+    const sent_message = {...message};
+
     function on_success(raw_data: unknown): void {
         const data = send_message_api_response_schema.parse(raw_data);
         const message_id = data.id;
 
         hide_retry_spinner($row);
 
-        on_send_message_success(message, data);
+        on_send_message_success(sent_message, data);
 
         // Resend succeeded, so mark as no longer failed
         failed_message_success(message_id);

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -530,13 +530,13 @@ run_test("resend success clears the failed flag", ({override}) => {
     // local id, waiting to be retried.
     stored_messages.set(message.id, message);
 
-    const on_send_message_success = (msg, data) => {
+    const on_send_message_success = (_sent_message, data) => {
         // Mirror the store re-keying that compose.send_message_success ->
         // echo.reify_message_id performs once the server acks the resend.
-        stored_messages.delete(msg.id);
-        msg.id = data.id;
-        msg.locally_echoed = false;
-        stored_messages.set(data.id, msg);
+        stored_messages.delete(message.id);
+        message.id = data.id;
+        message.locally_echoed = false;
+        stored_messages.set(data.id, message);
     };
     const send_message = (_msg, on_success) => {
         on_success({id: server_id});
@@ -546,6 +546,67 @@ run_test("resend success clears the failed flag", ({override}) => {
 
     assert.equal(message.failed_request, false);
     assert.equal(stored_messages.get(server_id), message);
+});
+
+run_test("resend gives the success path a pre-send snapshot", ({override}) => {
+    // The resent message's event can beat its send response, and
+    // process_from_server reifies on arrival -- converting the message in
+    // place, so it no longer describes what we sent.
+    const stored_messages = new Map();
+    override(message_store, "get", (id) => stored_messages.get(id));
+    override(compose_notifications, "reify_message_id", noop);
+    override(hash_util, "search_terms_to_hash", noop);
+    override(browser_history, "update_current_history_state_data", noop);
+    override(message_lists, "all_rendered_message_lists", () => [
+        {
+            view: {rerender_messages: noop, change_message_id: noop},
+            data: {filter: {can_apply_locally: () => true}},
+            change_message_id: noop,
+            add_messages: noop,
+        },
+    ]);
+
+    const local_id = "320.01";
+    const server_id = 330;
+    const message = {
+        id: Number.parseFloat(local_id),
+        local_id,
+        type: "stream",
+        stream_id: general_sub.stream_id,
+        topic: "test",
+        raw_content: "retry me",
+        content: "<p>retry me</p>",
+        draft_id: "draft-320",
+        locally_echoed: true,
+        failed_request: true,
+    };
+    stored_messages.set(message.id, message);
+    echo_state.set_message_waiting_for_id(local_id, message);
+    echo_state._patch_waiting_for_ack(new Map([[local_id, message]]));
+
+    override(message_store, "reify_message_id", ({old_id, new_id}) => {
+        // Mirror the real conversion: re-key, and drop the local-echo fields.
+        delete message.draft_id;
+        stored_messages.delete(old_id);
+        stored_messages.set(new_id, message);
+    });
+
+    let sent_message;
+    const on_send_message_success = (msg) => {
+        sent_message = msg;
+    };
+    const send_message = (_request, on_success) => {
+        echo.process_from_server([{id: server_id, local_id, content: message.content}]);
+        on_success({id: server_id});
+    };
+
+    echo.resend_message(message, make_spinner_row(), {on_send_message_success, send_message});
+
+    // Confirm the ordering under test: reification ran before the response.
+    assert.equal(message.draft_id, undefined);
+    assert.equal(message.locally_echoed, false);
+    assert.equal(sent_message.draft_id, "draft-320");
+    assert.equal(sent_message.locally_echoed, true);
 });
 
 run_test("resend error re-marks a present message as failed", ({override}) => {


### PR DESCRIPTION
Fixes a bug where resending a message that failed to send left its draft behind in the drafts overlay. Split out of #38356, where it was found [during review](https://github.com/zulip/zulip/pull/38356#discussion_r3786243126).

`reify_message_id` converts a locally echoed message into a server message in place, which deletes its `draft_id` and clears `locally_echoed`. `send_message_success` read `sent_message.draft_id` after that call, and a resend passes the stored `LocalMessage` itself rather than a copy of the request, so the call became `deleteDrafts([undefined])`: the message was sent, but its draft stayed.

This is reachable on `main` today, without any of the changes in #38356: `on_failed_action` wires the feed's retry button straight to this path, and a failed send never clears the message from `waiting_for_id` (only `reify_message_id` itself and `abort_message` do), so on retry `reify_message_id` does not early-return and does drop `draft_id`.

The send response is not the only thing that reifies: `process_from_server` reifies too, so the message event can arrive first and strip `draft_id` before the response lands. In that ordering the cleared `locally_echoed` also makes `send_message_success` clear a compose box that has nothing to do with the resend. The fix snapshots the message in `echo.resend_message` before transmitting, so the success path sees what was actually sent regardless of which arrives first.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
