### PR TITLE
mattermost: convert threads into seperate topics on import

### DIFF
--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -7,7 +7,9 @@ import logging
 import os
 import re
 import shutil
+from collections import defaultdict
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, TypeAlias
 
 import orjson
@@ -46,9 +48,11 @@ from zerver.lib.export import do_common_export_processes
 from zerver.lib.import_realm import validate_and_resolve_relative_path
 from zerver.lib.markdown import IMAGE_EXTENSIONS
 from zerver.lib.message import truncate_content
+from zerver.lib.topic_link_util import get_stream_topic_link_syntax
 from zerver.lib.upload import sanitize_name
 from zerver.lib.utils import process_list_in_batches
 from zerver.models import Reaction, RealmEmoji, Recipient, UserProfile
+from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 from zerver.models.streams import Stream
 
 
@@ -56,6 +60,7 @@ from zerver.models.streams import Stream
 class ChannelMetadata:
     zulip_channel_id: int
     zulip_recipient_id: int
+    zulip_channel_name: str
 
 
 AddedChannelsT: TypeAlias = dict[str, ChannelMetadata]
@@ -310,7 +315,9 @@ def convert_channel_data(
             zerver_realm[0]["zulip_update_announcements_stream"] = stream_id
 
         added_channels[mattermost_channel_id] = ChannelMetadata(
-            zulip_channel_id=stream_id, zulip_recipient_id=recipient_id
+            zulip_channel_id=stream_id,
+            zulip_recipient_id=recipient_id,
+            zulip_channel_name=channel_display_name,
         )
     return added_channels
 
@@ -508,6 +515,20 @@ def process_message_attachments(
     return content, has_image
 
 
+MAIN_MATTERMOST_IMPORT_TOPIC = "imported from mattermost"
+
+
+def get_mattermost_thread_topic_name(
+    message_content: str, thread_date: str, thread_counter: dict[str, int]
+) -> str:
+    base = f"{thread_date} {message_content}".strip() or "thread"
+    truncated = truncate_content(base, MAX_TOPIC_NAME_LENGTH, "…")
+    collision = thread_counter[truncated]
+    thread_counter[truncated] += 1
+    count = f" ({collision + 1})" if collision > 0 else ""
+    return truncate_content(base, MAX_TOPIC_NAME_LENGTH - len(count), "…") + count
+
+
 def process_raw_message_batch(
     realm_id: int,
     raw_messages: list[dict[str, Any]],
@@ -599,7 +620,7 @@ def process_raw_message_batch(
                 content += "\n\n"
             content += attachment_markdown
 
-        topic_name = "imported from mattermost"
+        topic_name = raw_message["topic_name"]
 
         message = build_message(
             content=content,
@@ -717,25 +738,58 @@ def process_posts(
 
         return message_dict
 
-    raw_messages = []
+    raw_messages: list[dict[str, Any]] = []
+    thread_counter: dict[str, int] = defaultdict(int)
     for post_dict in post_data_list:
         message_dict = message_to_dict(post_dict)
         if message_dict is None:  # nocoverage
             continue
-        raw_messages.append(message_dict)
+
         message_replies = post_dict["replies"]
-        # Replies to a message in Mattermost are stored in the main message object.
-        # For now, we just append the replies immediately after the original message.
-        if message_replies is not None:
+        is_channel_message = "channel_name" in message_dict
+
+        if message_replies and is_channel_message:
+            thread_date = (
+                datetime.fromtimestamp(message_dict["date_sent"], tz=timezone.utc)
+                .date()
+                .isoformat()
+            )
+            thread_topic_name = get_mattermost_thread_topic_name(
+                message_dict["content"], thread_date, thread_counter
+            )
+            number_of_replies = len(message_replies)
+            reply_string = "replies" if number_of_replies > 1 else "reply"
+            channel_meta = added_channels[message_dict["channel_name"]]
+            topic_link = get_stream_topic_link_syntax(
+                channel_meta.zulip_channel_id,
+                channel_meta.zulip_channel_name,
+                thread_topic_name,
+            )
+            message_dict["content"] += f"\n\n*{number_of_replies} {reply_string} in {topic_link}*"
+            message_dict["topic_name"] = MAIN_MATTERMOST_IMPORT_TOPIC
+            raw_messages.append(message_dict)
+
             for reply in message_replies:
-                if "channel" in post_dict:
-                    reply["channel"] = post_dict["channel"]
-                else:  # nocoverage
-                    reply["channel_members"] = post_dict["channel_members"]
+                reply["channel"] = post_dict["channel"]
                 reply_dict = message_to_dict(reply)
                 if reply_dict is None:  # nocoverage
                     continue
+                reply_dict["topic_name"] = thread_topic_name
                 raw_messages.append(reply_dict)
+        else:
+            message_dict["topic_name"] = MAIN_MATTERMOST_IMPORT_TOPIC
+            raw_messages.append(message_dict)
+            if message_replies:
+                for reply in message_replies:
+                    if "channel" in post_dict:
+                        reply["channel"] = post_dict["channel"]
+                    else:  # nocoverage
+                        reply["channel_members"] = post_dict["channel_members"]
+                    reply_dict = message_to_dict(reply)
+                    if reply_dict is None:  # nocoverage
+                        continue
+                    reply_dict["topic_name"] = MAIN_MATTERMOST_IMPORT_TOPIC
+                    raw_messages.append(reply_dict)
 
     def process_batch(lst: list[dict[str, Any]]) -> None:
         process_raw_message_batch(

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -44,6 +44,7 @@ from zerver.lib.emoji import name_to_codepoint
 from zerver.lib.import_realm import do_import_realm
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.thumbnail import THUMBNAIL_ACCEPT_IMAGE_TYPES
+from zerver.lib.topic import EXPORT_TOPIC_NAME
 from zerver.models import Attachment, Message, Reaction, Recipient, UserProfile
 from zerver.models.presence import PresenceSequence
 from zerver.models.realms import Realm, get_realm
@@ -1175,7 +1176,11 @@ class MatterMostImporter(MattermostImportTestBase):
         exported_messages_id = self.get_set(messages["zerver_message"], "id")
         self.assertIn(messages["zerver_message"][0]["sender"], exported_user_ids)
         self.assertIn(messages["zerver_message"][0]["recipient"], exported_recipient_ids)
-        self.assertIn(messages["zerver_message"][0]["content"], "harry joined the channel.\n\n")
+        self.assertEqual(
+            messages["zerver_message"][0]["content"],
+            "harry joined the channel.\n\n"
+            "*1 reply in #**Dumbledores army>2019-03-21 harry joined the channel.***",
+        )
 
         exported_usermessage_userprofiles = self.get_set(
             messages["zerver_usermessage"], "user_profile"
@@ -1204,6 +1209,39 @@ class MatterMostImporter(MattermostImportTestBase):
             self.assertIsNotNone(message.rendered_content)
 
         self.verify_emoji_code_foreign_keys()
+
+    def test_do_convert_data_thread_conversion(self) -> None:
+        mattermost_data_dir = self.fixture_file_name("", "mattermost_fixtures")
+        output_dir = self.make_import_output_dir("mattermost")
+
+        with self.assertLogs(level="WARNING"):
+            do_convert_data(
+                mattermost_data_dir=mattermost_data_dir,
+                output_dir=output_dir,
+                masking_content=False,
+            )
+
+        harry_team_output_dir = self.team_output_dir(output_dir, "gryffindor")
+        messages = self.read_file(harry_team_output_dir, "messages-000001.json")
+
+        # A Mattermost thread is converted into its own Zulip topic. The thread's
+        # root message stays in the main import topic, with a link to the new
+        # thread topic appended to it.
+        thread_root_message = messages["zerver_message"][0]
+        self.assertEqual(thread_root_message[EXPORT_TOPIC_NAME], "imported from mattermost")
+        self.assertEqual(
+            thread_root_message["content"],
+            "harry joined the channel.\n\n"
+            "*1 reply in #**Dumbledores army>2019-03-21 harry joined the channel.***",
+        )
+
+        # The reply is moved into the new per-thread topic.
+        thread_reply_message = messages["zerver_message"][1]
+        self.assertEqual(thread_reply_message["content"], "The weather is so hot!")
+        self.assertEqual(
+            thread_reply_message[EXPORT_TOPIC_NAME],
+            "2019-03-21 harry joined the channel.",
+        )
 
     def test_do_convert_data_with_prefering_direct_messages_for_1_to_1_messages(self) -> None:
         mattermost_data_dir = self.fixture_file_name("direct_channel", "mattermost_fixtures")
@@ -1342,7 +1380,11 @@ class MatterMostImporter(MattermostImportTestBase):
         harry_team_output_dir = self.team_output_dir(output_dir, "gryffindor")
         messages = self.read_file(harry_team_output_dir, "messages-000001.json")
 
-        self.assertIn(messages["zerver_message"][0]["content"], "xxxxx xxxxxx xxx xxxxxxx.\n\n")
+        self.assertEqual(
+            messages["zerver_message"][0]["content"],
+            "xxxxx xxxxxx xxx xxxxxxx.\n\n"
+            "*1 reply in #**Dumbledores army>2019-03-21 xxxxx xxxxxx xxx xxxxxxx.***",
+        )
 
     def test_import_data_to_existing_database(self) -> None:
         mattermost_data_dir = self.fixture_file_name("", "mattermost_fixtures")


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Converts each Mattermost thread into its own Zulip topic on import,
mirroring how the Slack importer handles threads (#27626):

- The thread's root message stays in the main "imported from mattermost"
  topic, with a "N replies in <thread topic>" link appended to it.
- The replies are moved into a new topic named after the root message
  (its date followed by a snippet of its content).

Non-threaded messages and direct messages are unchanged.

This implements the first of the three asks in #38839 (the thread split +
cross-link, format-matched to Slack). The notification-bot quote and the
"also send to channel" echo are not included yet — happy to add them in
this PR or as follow-ups, whichever maintainers prefer.

Fixes: <Part of #38839>

**How changes were tested:**


- `./tools/test-backend zerver.tests.test_mattermost_importer` passes,
  including a new dedicated test for thread conversion, plus updates to
  the existing conversion tests.
- Ran `./tools/lint` and `./tools/run-mypy` on the changed files — clean.
- Manually converted and imported the Mattermost test fixtures and
  verified in the dev app that threads split into their own topics with
  the cross-link, matching Slack's output format.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
The change is not UI so screenshots we not captured
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [x ] Highlights technical choices and bugs encountered.
- [x ] Calls out remaining decisions and concerns.
- [x ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ x] Each commit is a coherent idea.
- [x ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
