### PR TITLE
 bots: Pass integration_id via config_data for incoming webhooks.

### DIFF
--- a/api_docs/unmerged.d/ZF-bd614d.md
+++ b/api_docs/unmerged.d/ZF-bd614d.md
@@ -1,0 +1,4 @@
+* `POST /bots`: For incoming webhook bots, the integration to associate
+  with the bot is now specified as the `integration_id` key of the
+  `config_data` parameter, instead of the `service_name` parameter,
+  which is now ignored for this bot type.

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -133,57 +133,60 @@ def validate_short_name_and_construct_bot_email(
     return short_name, email
 
 
-def check_valid_bot_config(
-    bot_type: int, service_name: str, config_data: Mapping[str, str]
+def check_valid_incoming_webhook_bot_config(
+    config_data: Mapping[str, str],
 ) -> None:
-    if bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
-        from zerver.lib.integrations import INCOMING_WEBHOOK_INTEGRATIONS
+    from zerver.lib.integrations import INCOMING_WEBHOOK_INTEGRATIONS
 
-        config_options = None
-        for integration in INCOMING_WEBHOOK_INTEGRATIONS:
-            if integration.name == service_name:
-                # key: validator
-                config_options = {
-                    option.name: option.validator for option in integration.config_options
-                }
-                break
-        if config_options is None:
+    if not (integration_id := config_data["integration_id"]):
+        raise JsonableError(_("Integration name cannot be empty."))
+    config_options = None
+    for integration in INCOMING_WEBHOOK_INTEGRATIONS:
+        if integration.name == integration_id:
+            # key: validator
+            config_options = {
+                option.name: option.validator for option in integration.config_options
+            }
+            break
+    if config_options is None:
+        raise JsonableError(
+            _("Invalid integration '{integration_name}'.").format(integration_name=integration_id)
+        )
+
+    missing_keys = set(config_options.keys()) - set(config_data.keys())
+    if missing_keys:
+        raise JsonableError(
+            _("Missing configuration parameters: {keys}").format(
+                keys=missing_keys,
+            )
+        )
+
+    for key, validator in config_options.items():
+        value = config_data[key]
+        error = validator(key, value)
+        if error is not None:
             raise JsonableError(
-                _("Invalid integration '{integration_name}'.").format(integration_name=service_name)
+                _("Invalid {key} value {value} ({error})").format(key=key, value=value, error=error)
             )
 
-        missing_keys = set(config_options.keys()) - set(config_data.keys())
-        if missing_keys:
-            raise JsonableError(
-                _("Missing configuration parameters: {keys}").format(
-                    keys=missing_keys,
-                )
-            )
 
-        for key, validator in config_options.items():
-            value = config_data[key]
-            error = validator(key, value)
-            if error is not None:
-                raise JsonableError(
-                    _("Invalid {key} value {value} ({error})").format(
-                        key=key, value=value, error=error
-                    )
-                )
+def check_valid_embedded_bot_config(
+    service_name: str,
+    config_data: Mapping[str, str],
+) -> None:
+    try:
+        from zerver.lib.bot_lib import get_bot_handler
 
-    elif bot_type == UserProfile.EMBEDDED_BOT:
-        try:
-            from zerver.lib.bot_lib import get_bot_handler
-
-            bot_handler = get_bot_handler(service_name)
-            if hasattr(bot_handler, "validate_config"):
-                bot_handler.validate_config(config_data)
-        except ConfigValidationError:
-            # The exception provides a specific error message, but that
-            # message is not tagged translatable, because it is
-            # triggered in the external zulip_bots package.
-            # TODO: Think of some clever way to provide a more specific
-            # error message.
-            raise JsonableError(_("Invalid configuration data!"))
+        bot_handler = get_bot_handler(service_name)
+        if hasattr(bot_handler, "validate_config"):
+            bot_handler.validate_config(config_data)
+    except ConfigValidationError:
+        # The exception provides a specific error message, but that
+        # message is not tagged translatable, because it is
+        # triggered in the external zulip_bots package.
+        # TODO: Think of some clever way to provide a more specific
+        # error message.
+        raise JsonableError(_("Invalid configuration data!"))
 
 
 # Adds an outgoing webhook or embedded bot service.

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -2213,14 +2213,15 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(bot_owner_user_ids(new_bot), set())
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_service_name_and_with_keys(self) -> None:
+    def test_create_incoming_webhook_bot_with_integration_id_and_with_keys(self) -> None:
         self.login("hamlet")
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
             "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripe",
-            "config_data": orjson.dumps({"stripe_api_key": "sample-api-key"}).decode(),
+            "config_data": orjson.dumps(
+                {"integration_id": "stripe", "stripe_api_key": "sample-api-key"}
+            ).decode(),
         }
         self.create_bot(**bot_metadata)
         new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
@@ -2230,13 +2231,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_service_name_and_no_config_options(self) -> None:
+    def test_create_incoming_webhook_bot_with_just_integration_id_in_config_options(self) -> None:
         self.login("hamlet")
         bot_metadata = {
             "full_name": "My Hello World Bot",
             "short_name": "my-helloworld",
             "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "helloworld",
+            "config_data": orjson.dumps({"integration_id": "helloworld"}).decode(),
         }
         self.create_bot(**bot_metadata)
         new_bot = UserProfile.objects.get(full_name="My Hello World Bot")
@@ -2244,14 +2245,15 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(config_data, {"integration_id": "helloworld"})
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_service_name_incorrect_keys(self) -> None:
+    def test_create_incoming_webhook_bot_with_integration_id_incorrect_keys(self) -> None:
         self.login("hamlet")
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
             "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripe",
-            "config_data": orjson.dumps({"stripe_api_key": "_invalid_key"}).decode(),
+            "config_data": orjson.dumps(
+                {"integration_id": "stripe", "stripe_api_key": "_invalid_key"}
+            ).decode(),
         }
         response = self.client_post("/json/bots", bot_metadata)
         self.assertEqual(response.status_code, 400)
@@ -2261,13 +2263,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             UserProfile.objects.get(full_name="My Stripe Bot")
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_service_name_without_keys(self) -> None:
+    def test_create_incoming_webhook_bot_with_integration_id_without_keys(self) -> None:
         self.login("hamlet")
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
             "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripe",
+            "config_data": orjson.dumps({"integration_id": "stripe"}).decode(),
         }
         response = self.client_post("/json/bots", bot_metadata)
         self.assertEqual(response.status_code, 400)
@@ -2277,7 +2279,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             UserProfile.objects.get(full_name="My Stripe Bot")
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_without_service_name(self) -> None:
+    def test_create_incoming_webhook_bot_without_integration_id(self) -> None:
         self.login("hamlet")
         bot_metadata = {
             "full_name": "My Stripe Bot",
@@ -2290,17 +2292,47 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             get_bot_config(new_bot)
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_incorrect_service_name(self) -> None:
+    def test_create_incoming_webhook_bot_without_integration_id_with_keys(self) -> None:
         self.login("hamlet")
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
             "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripes",
+            "config_data": orjson.dumps({"stripe_api_key": "sample-api-key"}).decode(),
+        }
+        self.create_bot(**bot_metadata)
+        new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
+        config_data = get_bot_config(new_bot)
+        self.assertEqual(config_data, {"stripe_api_key": "sample-api-key"})
+
+    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
+    def test_create_incoming_webhook_bot_with_incorrect_integration_id(self) -> None:
+        self.login("hamlet")
+        bot_metadata = {
+            "full_name": "My Stripe Bot",
+            "short_name": "my-stripe",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+            "config_data": orjson.dumps({"integration_id": "stripes"}).decode(),
         }
         response = self.client_post("/json/bots", bot_metadata)
         self.assertEqual(response.status_code, 400)
         expected_error_message = "Invalid integration 'stripes'."
+        self.assertEqual(orjson.loads(response.content)["msg"], expected_error_message)
+        with self.assertRaises(UserProfile.DoesNotExist):
+            UserProfile.objects.get(full_name="My Stripe Bot")
+
+    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
+    def test_create_incoming_webhook_bot_with_empty_integration_id(self) -> None:
+        self.login("hamlet")
+        bot_metadata = {
+            "full_name": "My Stripe Bot",
+            "short_name": "my-stripe",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+            "config_data": orjson.dumps({"integration_id": ""}).decode(),
+        }
+        response = self.client_post("/json/bots", bot_metadata)
+        self.assertEqual(response.status_code, 400)
+        expected_error_message = "Integration name cannot be empty."
         self.assertEqual(orjson.loads(response.content)["msg"], expected_error_message)
         with self.assertRaises(UserProfile.DoesNotExist):
             UserProfile.objects.get(full_name="My Stripe Bot")

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -87,8 +87,9 @@ from zerver.lib.users import (
     check_can_access_user,
     check_can_create_bot,
     check_full_name,
-    check_valid_bot_config,
     check_valid_bot_type,
+    check_valid_embedded_bot_config,
+    check_valid_incoming_webhook_bot_config,
     check_valid_interface_type,
     get_users_for_api,
     max_message_id_for_user,
@@ -664,8 +665,7 @@ def add_bot_backend(
                 "Please contact your server administrator."
             )
         )
-    if bot_type != UserProfile.INCOMING_WEBHOOK_BOT:
-        service_name = service_name or short_name
+    service_name = service_name or short_name
     full_name = check_full_name(
         full_name_raw=full_name_raw, user_profile=None, realm=user_profile.realm
     )
@@ -716,8 +716,10 @@ def add_bot_backend(
             user_profile, default_events_register_stream_name
         )
 
-    if bot_type in (UserProfile.INCOMING_WEBHOOK_BOT, UserProfile.EMBEDDED_BOT) and service_name:
-        check_valid_bot_config(bot_type, service_name, config_data)
+    if bot_type == UserProfile.EMBEDDED_BOT and service_name:
+        check_valid_embedded_bot_config(service_name, config_data)
+    if bot_type == UserProfile.INCOMING_WEBHOOK_BOT and "integration_id" in config_data:
+        check_valid_incoming_webhook_bot_config(config_data)
 
     bot_profile = do_create_user(
         email=email,
@@ -748,9 +750,6 @@ def add_bot_backend(
             interface=interface_type,
             token=generate_api_key(),
         )
-
-    if bot_type == UserProfile.INCOMING_WEBHOOK_BOT and service_name:
-        set_bot_config(bot_profile, "integration_id", service_name)
 
     if bot_type in (UserProfile.INCOMING_WEBHOOK_BOT, UserProfile.EMBEDDED_BOT):
         for key, value in config_data.items():


### PR DESCRIPTION
Incoming webhook bots reused the `service_name` parameter to name  the integration they are associated with, even though no `Service` object is created for them; the value was then stored in `BotConfigData` under the `integration_id` key. Reusing the service bot code path this way contributed to the confusion over what a "service bot" is. Since the value ends up in `BotConfigData` like any other bot config, it is better we send it as `config_data["integration_id"]` instead.

This PR also splits `check_valid_bot_config` to `check_valid_incoming_webhook_bot_config` and `check_valid_embedded_bot_config` because priorly the branches shared `service_name` as a common parameter but now since we do not associate `service_name` with `integration_id` for incoming webhook bots, there no common parameters.
The relevant tests are also modified.

`POST /bots` is not part of the documented API, and the web app sends `service_name` only for embedded bots, so the API changelog does not have corresponding "**changes**" field in `zulip.yaml`  and also no frontend change is needed.


<!-- Describe your pull request here.-->

CZO: [#integrations > Refactor SERVICE_BOT_TYPES abstraction](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Refactor.20SERVICE_BOT_TYPES.20abstraction/with/2508531)
This was suggested by @PieterCK in [#integrations > Refactor SERVICE_BOT_TYPES abstraction @ 💬](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Refactor.20SERVICE_BOT_TYPES.20abstraction/near/2505391).
Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [X] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
