### PR TITLE
Fix cases for creating unused anonymous groups and add migration to delete existing unused anonymous groups.

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1769,6 +1769,18 @@ def list_to_streams(
         )
         existing_streams += dup_streams
 
+        # We can delete the anonymous groups created for the streams
+        # that weren't created.
+        used_group_ids = {
+            getattr(stream, setting_name + "_id")
+            for stream in created_streams
+            for setting_name in Stream.stream_permission_group_settings
+        }
+        unused_group_ids = [
+            group_id for group_id in anonymous_group_membership if group_id not in used_group_ids
+        ]
+        UserGroup.objects.filter(id__in=unused_group_ids).delete()
+
     return existing_streams, created_streams
 
 

--- a/zerver/migrations/0810_delete_unused_anonymous_groups.py
+++ b/zerver/migrations/0810_delete_unused_anonymous_groups.py
@@ -1,0 +1,135 @@
+from django.db import connection, migrations, transaction
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from psycopg2.sql import SQL, Literal
+
+
+def delete_unused_anonymous_groups(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    Realm = apps.get_model("zerver", "Realm")
+
+    query = """
+        WITH user_group_ids AS (
+            SELECT table_cols.value
+            FROM zerver_stream
+            CROSS JOIN LATERAL (
+                VALUES
+                    (can_add_subscribers_group_id),
+                    (can_administer_channel_group_id),
+                    (can_create_topic_group_id),
+                    (can_delete_any_message_group_id),
+                    (can_delete_own_message_group_id),
+                    (can_move_messages_out_of_channel_group_id),
+                    (can_move_messages_within_channel_group_id),
+                    (can_remove_subscribers_group_id),
+                    (can_send_message_group_id),
+                    (can_subscribe_group_id),
+                    (can_resolve_topics_group_id)
+            ) AS table_cols(value)
+            WHERE realm_id = %s
+
+            UNION ALL
+
+            SELECT table_cols.value
+            FROM zerver_namedusergroup
+            CROSS JOIN LATERAL (
+                VALUES
+                    (can_add_members_group_id),
+                    (can_join_group_id),
+                    (can_leave_group_id),
+                    (can_manage_group_id),
+                    (can_mention_group_id),
+                    (can_remove_members_group_id)
+            ) AS table_cols(value)
+            WHERE realm_id = %s
+
+            UNION ALL
+
+            SELECT realm_cols.value
+            FROM zerver_realm
+            CROSS JOIN LATERAL (
+                VALUES
+                    (create_multiuse_invite_group_id),
+                    (can_access_all_users_group_id),
+                    (can_add_subscribers_group_id),
+                    (can_add_custom_emoji_group_id),
+                    (can_create_bots_group_id),
+                    (can_create_groups_id),
+                    (can_create_public_channel_group_id),
+                    (can_create_private_channel_group_id),
+                    (can_create_web_public_channel_group_id),
+                    (can_create_write_only_bots_group_id),
+                    (can_delete_any_message_group_id),
+                    (can_delete_own_message_group_id),
+                    (can_invite_users_group_id),
+                    (can_manage_all_groups_id),
+                    (can_manage_billing_group_id),
+                    (can_mention_many_users_group_id),
+                    (can_move_messages_between_channels_group_id),
+                    (can_move_messages_between_topics_group_id),
+                    (can_resolve_topics_group_id),
+                    (can_set_delete_message_policy_group_id),
+                    (can_set_topics_policy_group_id),
+                    (can_summarize_topics_group_id),
+                    (direct_message_initiator_group_id),
+                    (direct_message_permission_group_id),
+                    (workplace_users_group_id)
+            ) AS realm_cols(value)
+            WHERE id = %s
+        )
+
+        SELECT ug.id
+        FROM zerver_usergroup ug
+        LEFT JOIN zerver_namedusergroup ng
+          ON ng.usergroup_ptr_id = ug.id
+        WHERE ug.realm_id = %s
+          AND ng.usergroup_ptr_id IS NULL
+
+        EXCEPT
+
+        SELECT value FROM user_group_ids
+    """
+
+    BATCH_SIZE = 1000
+
+    with connection.cursor() as cursor:
+        for realm_id in Realm.objects.values_list("id", flat=True).iterator():
+            cursor.execute(query, [realm_id, realm_id, realm_id, realm_id])
+            unused_ids = [row[0] for row in cursor.fetchall()]
+
+            while unused_ids:
+                unused_id_str = SQL(",").join(map(Literal, unused_ids[:BATCH_SIZE]))
+                unused_ids = unused_ids[BATCH_SIZE:]
+                with transaction.atomic():
+                    cursor.execute(
+                        SQL(
+                            "DELETE FROM zerver_usergroupmembership WHERE user_group_id IN ({unused_ids})"
+                        ).format(unused_ids=unused_id_str)
+                    )
+                    cursor.execute(
+                        SQL(
+                            "DELETE FROM zerver_groupgroupmembership WHERE supergroup_id IN ({unused_ids})"
+                        ).format(unused_ids=unused_id_str)
+                    )
+                    cursor.execute(
+                        SQL("DELETE FROM zerver_usergroup WHERE id IN ({unused_ids})").format(
+                            unused_ids=unused_id_str
+                        )
+                    )
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0809_remove_message_nulls_last_topic_indexes"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_unused_anonymous_groups,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25858,6 +25858,10 @@ paths:
                 contentType: application/json
               can_create_topic_group:
                 contentType: application/json
+              can_delete_any_message_group:
+                contentType: application/json
+              can_delete_own_message_group:
+                contentType: application/json
               can_administer_channel_group:
                 contentType: application/json
               can_move_messages_out_of_channel_group:

--- a/zerver/tests/test_channel_creation.py
+++ b/zerver/tests/test_channel_creation.py
@@ -285,24 +285,36 @@ class TestCreateStreams(ZulipTestCase):
         channel_folder = check_add_channel_folder(
             user_profile.realm, "sports", "", acting_user=user_profile
         )
+        extra_post_data = {
+            "description": "test channel",
+            "folder_id": orjson.dumps(channel_folder.id).decode(),
+        }
+        for setting_name in Stream.stream_permission_group_settings:
+            extra_post_data[setting_name] = orjson.dumps(
+                {
+                    "direct_members": [cordelia.id],
+                    "direct_subgroups": [nobody_group.id],
+                }
+            ).decode()
+
         result = self.create_channel_via_post(
             user_profile,
             name="testchannel",
-            extra_post_data=dict(
-                description="test channel",
-                can_administer_channel_group=orjson.dumps(
-                    {
-                        "direct_members": [cordelia.id],
-                        "direct_subgroups": [nobody_group.id],
-                    }
-                ).decode(),
-                folder_id=orjson.dumps(channel_folder.id).decode(),
-            ),
+            extra_post_data=extra_post_data,
         )
         self.assert_json_success(result)
         stream = get_stream("testchannel", user_profile.realm)
         self.assertEqual(stream.name, "testchannel")
         self.assertEqual(stream.description, "test channel")
+        for setting_name in Stream.stream_permission_group_settings:
+            setting_value = getattr(stream, setting_name)
+            self.assertEqual(
+                list(setting_value.direct_members.all().values_list("id", flat=True)), [cordelia.id]
+            )
+            self.assertEqual(
+                list(setting_value.direct_subgroups.all().values_list("id", flat=True)),
+                [nobody_group.id],
+            )
 
         # Confirm channel created notification message in channel events topic.
         message = self.get_last_message()

--- a/zerver/tests/test_channel_creation.py
+++ b/zerver/tests/test_channel_creation.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import orjson
 
 from zerver.actions.channel_folders import check_add_channel_folder
@@ -21,12 +23,15 @@ from zerver.lib.test_classes import ZulipTestCase, get_topic_messages
 from zerver.lib.test_helpers import reset_email_visibility_to_everyone_in_zulip_realm
 from zerver.lib.types import UserGroupMembersData, UserGroupMembersDict
 from zerver.models import (
+    GroupGroupMembership,
     Message,
     NamedUserGroup,
     Realm,
     Recipient,
     Stream,
     Subscription,
+    UserGroup,
+    UserGroupMembership,
     UserMessage,
     UserProfile,
 )
@@ -1319,6 +1324,103 @@ class TestCreateStreams(ZulipTestCase):
         self.assertNotEqual(
             stream_1.can_add_subscribers_group_id, stream_2.can_add_subscribers_group_id
         )
+
+    def test_no_unused_anonymous_groups_for_names_differing_in_case(self) -> None:
+        """
+        Channel names are compared case-insensitively, so a single request
+        asking for names differing only in case creates just one channel.
+        The anonymous groups created for the other name are unused and are
+        deleted.
+        """
+        realm = get_realm("zulip")
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        extra_post_data = {
+            "can_add_subscribers_group": orjson.dumps(
+                {"direct_members": [cordelia.id], "direct_subgroups": []}
+            ).decode(),
+        }
+        original_group_ids = set(UserGroup.objects.filter(realm=realm).values_list("id", flat=True))
+
+        self.assert_json_success(
+            self.subscribe_via_post(hamlet, ["Design", "design"], extra_post_data)
+        )
+
+        # Every group created while processing the request is used by the
+        # one channel that was created.
+        stream = get_stream("Design", realm)
+        referenced_group_ids = {
+            getattr(stream, setting_name + "_id")
+            for setting_name in Stream.stream_permission_group_settings
+        }
+        new_group_ids = (
+            set(UserGroup.objects.filter(realm=realm).values_list("id", flat=True))
+            - original_group_ids
+        )
+        self.assertEqual(new_group_ids - referenced_group_ids, set())
+
+    def test_no_unused_anonymous_groups_when_channel_creation_races(self) -> None:
+        """
+        Two racing channel creation requests should not leave behind the
+        anonymous groups created by the request that loses the race.
+        """
+        realm = get_realm("zulip")
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
+        )
+
+        # Both direct members and direct subgroups, so that the memberships
+        # of the unused groups need to be cleaned up too.
+        extra_post_data = {
+            "can_add_subscribers_group": orjson.dumps(
+                {"direct_members": [cordelia.id], "direct_subgroups": [moderators_group.id]}
+            ).decode(),
+        }
+        self.assert_json_success(self.subscribe_via_post(hamlet, ["new_stream"], extra_post_data))
+        stream = get_stream("new_stream", realm)
+        original_setting_ids = (
+            stream.can_administer_channel_group_id,
+            stream.can_add_subscribers_group_id,
+        )
+        original_group_ids = set(UserGroup.objects.filter(realm=realm).values_list("id", flat=True))
+        original_user_membership_count = UserGroupMembership.objects.count()
+        original_group_membership_count = GroupGroupMembership.objects.count()
+
+        # Simulate the race for the subscribe endpoint by making the
+        # existence check not see the channel that is already there.
+        with mock.patch("zerver.lib.streams.bulk_get_streams", return_value={}):
+            result = self.subscribe_via_post(hamlet, ["new_stream"], extra_post_data)
+        self.assert_json_success(result)
+
+        # And for the "/channels/create" endpoint, by making the name
+        # availability check not see it.
+        with mock.patch("zerver.views.streams.check_stream_name_available"):
+            result = self.api_post(
+                hamlet,
+                "/api/v1/channels/create",
+                {
+                    "name": "new_stream",
+                    "subscribers": orjson.dumps([hamlet.id]).decode(),
+                    **extra_post_data,
+                },
+            )
+        self.assert_json_success(result)
+        self.assertEqual(result.json()["id"], stream.id)
+
+        stream.refresh_from_db()
+        self.assertEqual(
+            (stream.can_administer_channel_group_id, stream.can_add_subscribers_group_id),
+            original_setting_ids,
+        )
+        self.assertEqual(
+            set(UserGroup.objects.filter(realm=realm).values_list("id", flat=True)),
+            original_group_ids,
+        )
+        self.assertEqual(UserGroupMembership.objects.count(), original_user_membership_count)
+        self.assertEqual(GroupGroupMembership.objects.count(), original_group_membership_count)
 
     def test_create_stream_with_default_push_notifications(self) -> None:
         """An admin can set default_push_notifications=True when creating a stream.

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -770,6 +770,9 @@ def create_channel(
         acting_user=user_profile,
         can_add_subscribers_group=group_settings_map["can_add_subscribers_group"],
         can_administer_channel_group=group_settings_map["can_administer_channel_group"],
+        can_create_topic_group=group_settings_map["can_create_topic_group"],
+        can_delete_any_message_group=group_settings_map["can_delete_any_message_group"],
+        can_delete_own_message_group=group_settings_map["can_delete_own_message_group"],
         can_move_messages_out_of_channel_group=group_settings_map[
             "can_move_messages_out_of_channel_group"
         ],

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -112,7 +112,7 @@ from zerver.lib.user_groups import (
 from zerver.lib.user_topics import get_users_with_user_topic_visibility_policy
 from zerver.lib.users import access_bot_by_id, bulk_access_users_by_email, bulk_access_users_by_id
 from zerver.lib.utils import assert_is_not_none
-from zerver.models import ChannelFolder, Stream, UserMessage, UserProfile, UserTopic
+from zerver.models import ChannelFolder, Stream, UserGroup, UserMessage, UserProfile, UserTopic
 from zerver.models.groups import SystemGroups
 from zerver.models.streams import StreamTopicsPolicyEnum
 from zerver.models.users import get_system_bot
@@ -786,6 +786,16 @@ def create_channel(
         folder=folder,
         topics_policy=topics_policy_value,
     )
+
+    if not created:
+        # The anonymous groups created above can be deleted since
+        # they are not being used.
+        unused_group_ids = [
+            setting_value.id
+            for setting_value in group_settings_map.values()
+            if setting_value.id in anonymous_group_membership
+        ]
+        UserGroup.objects.filter(id__in=unused_group_ids).delete()
 
     if is_default_stream:
         do_add_default_stream(new_channel)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to handle unused anonymous groups generated due to setting values not being passed
to the stream creation function when creating stream using `POST /channels/create` endpoint.
- Second commit is to fix unused anonymous groups due to race between creating streams with same name.
- Third commit is to add migration to delete existing unused anonymous groups.

 <!-- Issue link, or clear description.-->



<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
