### PR TITLE
compose: Reject control characters in topics

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -63,6 +63,7 @@ export const CLASSNAMES = {
     invalid_recipient: "invalid_recipient",
     invalid_recipients: "invalid_recipients",
     deactivated_user: "deactivated_user",
+    invalid_topic: "invalid_topic",
     topic_missing: "topic_missing",
     generic_compose_error: "generic_compose_error",
     user_not_subscribed: "user_not_subscribed",

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -917,7 +917,7 @@ function validate_permission_to_post_messages_in_stream(sub: StreamSubscription)
 }
 
 function get_invalid_topic_character_position(topic: string): number | undefined {
-    for (const [index, character] of Array.from(topic).entries()) {
+    for (const [index, character] of [...topic].entries()) {
         const code_point = character.codePointAt(0)!;
         if (
             (code_point >= 0 && code_point <= 0x1f) ||
@@ -966,7 +966,9 @@ function validate_stream_message(scheduling_message: boolean, show_banner = true
         compose_state.topic(),
     );
     if (invalid_topic_character_position !== undefined) {
-        const error_message = get_invalid_topic_error_message(invalid_topic_character_position);
+        const error_message = get_invalid_topic_error_message(
+            invalid_topic_character_position,
+        );
         if (show_banner) {
             compose_banner.show_error_message(
                 error_message,

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -966,9 +966,7 @@ function validate_stream_message(scheduling_message: boolean, show_banner = true
         compose_state.topic(),
     );
     if (invalid_topic_character_position !== undefined) {
-        const error_message = get_invalid_topic_error_message(
-            invalid_topic_character_position,
-        );
+        const error_message = get_invalid_topic_error_message(invalid_topic_character_position);
         if (show_banner) {
             compose_banner.show_error_message(
                 error_message,

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -73,10 +73,7 @@ export const get_message_too_long_for_compose_error = (): string =>
         {max_length: realm.max_message_length},
     );
 export const get_invalid_topic_error_message = (position: number): string =>
-    $t(
-        {defaultMessage: "Invalid character in topic, at position {position}!"},
-        {position},
-    );
+    $t({defaultMessage: "Invalid character in topic, at position {position}!"}, {position});
 export const NO_MESSAGE_CONTENT_ERROR_MESSAGE = $t({defaultMessage: "Compose a message."});
 export const UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE = $t({
     defaultMessage:
@@ -919,10 +916,7 @@ function validate_permission_to_post_messages_in_stream(sub: StreamSubscription)
 function get_invalid_topic_character_position(topic: string): number | undefined {
     for (const [index, character] of [...topic].entries()) {
         const code_point = character.codePointAt(0)!;
-        if (
-            (code_point >= 0 && code_point <= 0x1f) ||
-            (code_point >= 0x7f && code_point <= 0x9f)
-        ) {
+        if ((code_point >= 0 && code_point <= 0x1f) || (code_point >= 0x7f && code_point <= 0x9f)) {
             return index + 1;
         }
     }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -72,6 +72,11 @@ export const get_message_too_long_for_compose_error = (): string =>
         {defaultMessage: "Message length shouldn't be greater than {max_length} characters."},
         {max_length: realm.max_message_length},
     );
+export const get_invalid_topic_error_message = (position: number): string =>
+    $t(
+        {defaultMessage: "Invalid character in topic, at position {position}!"},
+        {position},
+    );
 export const NO_MESSAGE_CONTENT_ERROR_MESSAGE = $t({defaultMessage: "Compose a message."});
 export const UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE = $t({
     defaultMessage:
@@ -911,6 +916,19 @@ function validate_permission_to_post_messages_in_stream(sub: StreamSubscription)
     return true;
 }
 
+function get_invalid_topic_character_position(topic: string): number | undefined {
+    for (const [index, character] of Array.from(topic).entries()) {
+        const code_point = character.codePointAt(0)!;
+        if (
+            (code_point >= 0 && code_point <= 0x1f) ||
+            (code_point >= 0x7f && code_point <= 0x9f)
+        ) {
+            return index + 1;
+        }
+    }
+    return undefined;
+}
+
 function validate_stream_message(scheduling_message: boolean, show_banner = true): boolean {
     const $banner_container = $("#compose_banners");
     const stream_id = compose_state.stream_id();
@@ -942,6 +960,25 @@ function validate_stream_message(scheduling_message: boolean, show_banner = true
             }
             return false;
         }
+    }
+
+    const invalid_topic_character_position = get_invalid_topic_character_position(
+        compose_state.topic(),
+    );
+    if (invalid_topic_character_position !== undefined) {
+        const error_message = get_invalid_topic_error_message(invalid_topic_character_position);
+        if (show_banner) {
+            compose_banner.show_error_message(
+                error_message,
+                compose_banner.CLASSNAMES.invalid_topic,
+                $banner_container,
+                $("#stream_message_recipient_topic"),
+            );
+        }
+        if (is_validating_compose_box) {
+            disabled_send_tooltip_message_html = error_message;
+        }
+        return false;
     }
 
     const sub = stream_data.get_sub_by_id(stream_id);

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -435,36 +435,42 @@ test_ui("validate_stream_message", ({override, mock_template}) => {
     assert.ok(wildcards_not_allowed_rendered);
 });
 
-test_ui("validate_stream_message rejects control characters in topics", ({mock_template, override}) => {
-    mock_banners();
-    override(current_user, "user_id", 30);
-    const sub = {
-        stream_id: 101,
-        name: "special",
-        subscribed: true,
-        can_send_message_group: everyone.id,
-        topics_policy: "inherit",
-        can_create_topic_group: everyone.id,
-    };
-    stream_data.add_sub_for_tests(sub);
-    compose_state.set_message_type("stream");
-    compose_state.set_stream_id(sub.stream_id);
-    compose_state.topic("topic\twith tab");
-    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
+test_ui(
+    "validate_stream_message rejects control characters in topics",
+    ({mock_template, override}) => {
+        mock_banners();
+        override(current_user, "user_id", 30);
+        const sub = {
+            stream_id: 101,
+            name: "special",
+            subscribed: true,
+            can_send_message_group: everyone.id,
+            topics_policy: "inherit",
+            can_create_topic_group: everyone.id,
+        };
+        stream_data.add_sub_for_tests(sub);
+        compose_state.set_message_type("stream");
+        compose_state.set_stream_id(sub.stream_id);
+        compose_state.topic("topic\twith tab");
+        $("#send_message_form").set_find_results(
+            ".message-textarea",
+            $("textarea#compose-textarea"),
+        );
 
-    let error_message;
-    mock_template("compose_banner/compose_banner.hbs", false, (data) => {
-        assert.equal(data.classname, compose_banner.CLASSNAMES.invalid_topic);
-        error_message = data.banner_text;
-        return "<banner-stub>";
-    });
+        let error_message;
+        mock_template("compose_banner/compose_banner.hbs", false, (data) => {
+            assert.equal(data.classname, compose_banner.CLASSNAMES.invalid_topic);
+            error_message = data.banner_text;
+            return "<banner-stub>";
+        });
 
-    assert.ok(!compose_validate.validate());
-    assert.equal(error_message, "translated: Invalid character in topic, at position 6!");
+        assert.ok(!compose_validate.validate());
+        assert.equal(error_message, "translated: Invalid character in topic, at position 6!");
 
-    compose_state.topic("topic without tab");
-    assert.ok(compose_validate.validate());
-});
+        compose_state.topic("topic without tab");
+        assert.ok(compose_validate.validate());
+    },
+);
 
 test_ui("test_stream_posting_permission", ({mock_template, override}) => {
     mock_banners();

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -438,7 +438,6 @@ test_ui("validate_stream_message", ({override, mock_template}) => {
 test_ui("validate_stream_message rejects control characters in topics", ({mock_template, override}) => {
     mock_banners();
     override(current_user, "user_id", 30);
-    stream_data.set_channel_has_locally_available_topic(() => false);
     const sub = {
         stream_id: 101,
         name: "special",

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -435,6 +435,38 @@ test_ui("validate_stream_message", ({override, mock_template}) => {
     assert.ok(wildcards_not_allowed_rendered);
 });
 
+test_ui("validate_stream_message rejects control characters in topics", ({mock_template, override}) => {
+    mock_banners();
+    override(current_user, "user_id", 30);
+    stream_data.set_channel_has_locally_available_topic(() => false);
+    const sub = {
+        stream_id: 101,
+        name: "special",
+        subscribed: true,
+        can_send_message_group: everyone.id,
+        topics_policy: "inherit",
+        can_create_topic_group: everyone.id,
+    };
+    stream_data.add_sub_for_tests(sub);
+    compose_state.set_message_type("stream");
+    compose_state.set_stream_id(sub.stream_id);
+    compose_state.topic("topic\twith tab");
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
+
+    let error_message;
+    mock_template("compose_banner/compose_banner.hbs", false, (data) => {
+        assert.equal(data.classname, compose_banner.CLASSNAMES.invalid_topic);
+        error_message = data.banner_text;
+        return "<banner-stub>";
+    });
+
+    assert.ok(!compose_validate.validate());
+    assert.equal(error_message, "translated: Invalid character in topic, at position 6!");
+
+    compose_state.topic("topic without tab");
+    assert.ok(compose_validate.validate());
+});
+
 test_ui("test_stream_posting_permission", ({mock_template, override}) => {
     mock_banners();
 

--- a/web/tests/lib/compose_banner.cjs
+++ b/web/tests/lib/compose_banner.cjs
@@ -32,6 +32,7 @@ exports.mock_banners = () => {
     $cb.set_find_results(".wildcards_not_allowed", $stub);
     $cb.set_find_results(".wildcard_warning", $stub);
     $cb.set_find_results(".topic_missing", $stub);
+    $cb.set_find_results(".invalid_topic", $stub);
     $cb.set_find_results(".missing_stream", $stub);
     $cb.set_find_results(".deactivated_user", $stub);
     $cb.set_find_results(".missing_private_message_recipient", $stub);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #39933

This validates topic names in the compose box before sending a message. Control characters such as tabs are rejected with the same position-aware error used by the server, preventing unusable topics from being created in the UI.

**How changes were tested:**

- `node --check web/tests/compose_validate.test.cjs`
- `git diff --check`
- Added a frontend regression test covering a tab in a topic name and the valid-topic path.
- The full frontend test suite will run in CI; local dependencies were not installed because the checkout has less than 1 GiB of free disk space.

**Screenshots and screen captures:**

Not applicable; this reuses the existing compose error banner and does not change layout or styling.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (the client now validates the same control-character rule as the server).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
