### PR TITLE
channel_settings: Use standard subsection header for advanced config.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -669,13 +669,11 @@ input[type="checkbox"] {
 .advanced-configurations-container {
     .advance-config-toggle-area {
         cursor: pointer;
-        display: flex;
-        align-items: center;
-        gap: 0 0.625em;
-
-        .settings-subsection-title {
-            margin: 4px 0;
-        }
+        /* Unlike other subsection headers, which wrap their save/discard
+           widget below the title, this row is just a caret and a title;
+           a long translated title should wrap within the title rather
+           than dropping below the caret. */
+        flex-wrap: nowrap;
 
         .toggle-advanced-configurations-icon {
             font-size: 1.4286em; /* 20px at 14px / em */

--- a/web/templates/stream_settings/new_stream_configuration.hbs
+++ b/web/templates/stream_settings/new_stream_configuration.hbs
@@ -22,11 +22,9 @@
   }}
 
 <div class="advanced-configurations-container">
-    <div class="advance-config-title-container">
-        <div class="advance-config-toggle-area">
-            <i class="fa fa-sm fa-caret-right toggle-advanced-configurations-icon" aria-hidden="true"></i>
-            <h3 class="settings-subsection-title"><span>{{t 'Advanced configuration' }}</span></h3>
-        </div>
+    <div class="subsection-header advance-config-toggle-area">
+        <i class="fa fa-sm fa-caret-right toggle-advanced-configurations-icon" aria-hidden="true"></i>
+        <h3 class="settings-subsection-title">{{t 'Advanced configuration' }}</h3>
     </div>
     <div class="advanced-configurations-collapase-view hide">
         {{> channel_permissions .


### PR DESCRIPTION
The advanced configuration toggle row reimplemented .subsection-header with its own flex layout and a hardcoded 4px title margin, making it the only subsection heading not using the shared spacing, which scales with the information density setting.

Reuse .subsection-header, and drop the wrapper div and span that nothing styled or selected. The title moves down 1px and the row grows to the standard 46px. Wrapping is disabled since, unlike other subsection headers, this row has no save/discard widget to wrap; a long translated title should wrap within the title, not below the caret.

Follow up of #39639 (https://github.com/zulip/zulip/pull/39639#issuecomment-4858335511)

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
|Before | After |
| ------ | ------ |
|<img width="1188" height="1288" alt="image" src="https://github.com/user-attachments/assets/536b61f7-0183-4ad5-88ea-b28fa2470a01" /> | <img width="1188" height="1288" alt="image" src="https://github.com/user-attachments/assets/f1607fb5-b678-46e6-9e34-399010fc4f97" /> |
|<img width="1188" height="1288" alt="image" src="https://github.com/user-attachments/assets/4d6a632e-f1b4-4e46-bc77-c6431b2e634f" /> | <img width="1188" height="1288" alt="image" src="https://github.com/user-attachments/assets/1bea2fdd-df0f-4f60-b9ef-aa22547ff2f1" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
