### PR TITLE
[ai] message_store: Add get_immutable_message and get_mutable_message.

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -86,7 +86,7 @@ export function process_message(message: Message): void {
     }
 
     const updated_content = highlight_alert_words(message.content);
-    message_store.update_message_content(message, updated_content);
+    message_store.update_message_content(message_store.mutable_for(message), updated_content);
 }
 
 export function notifies(message: Message): boolean {

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -221,7 +221,7 @@ export function initialize(): void {
         // compose box.
         const current_filter = narrow_state.filter();
         if (current_filter !== undefined && !current_filter.contains_no_partial_conversations()) {
-            const message = message_store.get(id);
+            const message = message_store.get_immutable_message(id);
 
             if (message === undefined) {
                 // This might happen for locally echoed messages, for example.

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -253,9 +253,7 @@ export function initialize(): void {
         }
 
         const message_id = rows.id($(this).closest(".message_row"));
-        const message = message_store.get(message_id);
-        assert(message !== undefined);
-        starred_messages_ui.toggle_starred_and_update_server(message);
+        starred_messages_ui.toggle_starred_and_update_server(message_id);
     });
 
     $("#main_div").on("click", ".message_reaction", function (this: HTMLElement, e) {

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -619,7 +619,7 @@ export function build_and_process_quote_assets_for_messages(
 ): void {
     const messages: Message[] = [];
     for (const id of message_ids) {
-        const message = message_store.get(id);
+        const message = message_store.get_immutable_message(id);
         assert(message !== undefined);
         messages.push(message);
     }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -791,7 +791,7 @@ export function topic_participant_count_more_than_threshold(
             sender_id,
         );
         for (const message_id of message_ids) {
-            const message = message_store.get(message_id);
+            const message = message_store.get_immutable_message(message_id);
             if (message) {
                 const message_reactions = reactions.get_message_reactions(message);
                 const reactor_ids = message_reactions.flatMap((obj) => obj.user_ids);

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -950,7 +950,7 @@ function get_stream_topic_data(input_element: TypeaheadInputElement): {
     const $message_row = input_element.$element.closest(".message_row");
     if ($message_row.length === 1) {
         // we are editing a message so we try to use its keys.
-        const msg = message_store.get(rows.id($message_row));
+        const msg = message_store.get_immutable_message(rows.id($message_row));
         assert(msg !== undefined);
         if (msg.type === "stream") {
             stream_id = msg.stream_id;

--- a/web/src/desktop_integration.ts
+++ b/web/src/desktop_integration.ts
@@ -34,7 +34,7 @@ export function initialize(): void {
     // to narrow to the message being sent.
     electron_bridge.set_send_notification_reply_message_supported?.(true);
     electron_bridge.on_event("send_notification_reply_message", (message_id, reply) => {
-        const message = message_store.get(message_id);
+        const message = message_store.get_immutable_message(message_id);
         assert(message !== undefined);
         const data = {
             type: message.type,

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -140,7 +140,7 @@ function show_message_failed(message_id: number, _failed_msg: string): void {
 
 function show_failed_message_success(message_id: number): void {
     // Previously failed message succeeded
-    const msg = message_store.get(message_id);
+    const msg = message_store.get_immutable_message(message_id);
     message_live_update.update_message_in_all_views(message_id, ($row) => {
         const $message_controls = $row.find(".message_controls");
         $message_controls.html(render_message_controls({msg}));
@@ -148,7 +148,7 @@ function show_failed_message_success(message_id: number): void {
 }
 
 function failed_message_success(message_id: number): void {
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
     if (message === undefined) {
         // A get-events delivery may already have reconciled the message to its
         // real id, in which case the resend's reify_message_id early-returned
@@ -561,7 +561,7 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
 
         reify_message_id(local_id, message.id);
 
-        if (message_store.get(message.id)?.failed_request) {
+        if (message_store.get_immutable_message(message.id)?.failed_request) {
             failed_message_success(message.id);
         }
 
@@ -635,7 +635,7 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
 
 export let message_send_error = (message_id: number, error_response: string): void => {
     // Error sending message, show inline
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
     if (message === undefined) {
         // The message is no longer in the store -- e.g. it was removed while a
         // (re)send was in flight -- so there is no failed send to surface.

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -170,7 +170,7 @@ export function resend_message(
         send_message: typeof transmit.send_message;
     },
 ): void {
-    message_store.update_message_content(message, message.raw_content!);
+    message_store.update_message_content(message_store.mutable_for(message), message.raw_content!);
     if (show_retry_spinner($row)) {
         // retry already in in progress
         return;
@@ -373,69 +373,70 @@ export function edit_locally(message: Message, request: LocalEditRequest): void 
     // * Restoring the original content should the server return an
     //   error after having locally echoed content-only messages.
     // The details of what should be changed are encoded in the request.
+    const mutable = message_store.mutable_for(message);
     const raw_content = request.raw_content;
-    const message_content_edited = raw_content !== undefined && message.raw_content !== raw_content;
+    const message_content_edited = raw_content !== undefined && mutable.raw_content !== raw_content;
 
     if (request.new_topic !== undefined || request.new_stream_id !== undefined) {
-        assert(message.type === "stream");
+        assert(mutable.type === "stream");
         const new_stream_id = request.new_stream_id;
         const new_topic = request.new_topic;
         stream_topic_history.remove_messages({
-            stream_id: message.stream_id,
-            topic_name: message.topic,
+            stream_id: mutable.stream_id,
+            topic_name: mutable.topic,
             num_messages: 1,
-            max_removed_msg_id: message.id,
+            max_removed_msg_id: mutable.id,
         });
 
         if (new_stream_id !== undefined) {
-            message.stream_id = new_stream_id;
+            mutable.stream_id = new_stream_id;
         }
         if (new_topic !== undefined) {
-            message.topic = new_topic;
+            mutable.topic = new_topic;
         }
 
         stream_topic_history.add_message({
-            stream_id: message.stream_id,
-            topic_name: message.topic,
-            message_id: message.id,
+            stream_id: mutable.stream_id,
+            topic_name: mutable.topic,
+            message_id: mutable.id,
         });
     }
 
     if (message_content_edited) {
-        message_store.maybe_update_raw_content(message.id, raw_content);
+        message_store.maybe_update_raw_content(mutable.id, raw_content);
         if (request.content !== undefined) {
             // This happens in the code path where message editing
             // failed and we're trying to undo the local echo.  We use
             // the saved content and flags rather than rendering; this
             // is important in case
             // markdown.contains_backend_only_syntax(message) is true.
-            message_store.update_message_content(message, request.content);
-            message.mentioned = request.mentioned ?? false;
-            message.mentioned_me_directly = request.mentioned_me_directly ?? false;
-            message.alerted = request.alerted ?? false;
+            message_store.update_message_content(mutable, request.content);
+            mutable.mentioned = request.mentioned ?? false;
+            mutable.mentioned_me_directly = request.mentioned_me_directly ?? false;
+            mutable.alerted = request.alerted ?? false;
         } else {
             // Otherwise, we Markdown-render the message; this resets
             // all flags, so we need to restore those flags that are
             // properties of how the user has interacted with the
             // message, and not its rendering.
             const {content, flags, is_me_message} = markdown.render(raw_content);
-            message_store.update_message_content(message, content);
+            message_store.update_message_content(mutable, content);
             // Recompute the content-driven boolean flags (mentioned,
             // mentioned_me_directly, etc.) from the freshly rendered
             // flags. Without this, the message keeps its stale mention
             // booleans until the server event arrives, which (e.g. when
             // editing away a personal mention) briefly miscolors the
             // message as a group mention.
-            message_store.update_booleans(message, flags);
-            message.is_me_message = is_me_message;
+            message_store.update_booleans(mutable, flags);
+            mutable.is_me_message = is_me_message;
             if (request.starred !== undefined) {
-                message.starred = request.starred;
+                mutable.starred = request.starred;
             }
             if (request.historical !== undefined) {
-                message.historical = request.historical;
+                mutable.historical = request.historical;
             }
             if (request.collapsed !== undefined) {
-                message.collapsed = request.collapsed;
+                mutable.collapsed = request.collapsed;
             }
         }
     }
@@ -565,30 +566,31 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
             failed_message_success(message.id);
         }
 
+        const mutable_client_message = message_store.mutable_for(client_message);
         if (client_message.content !== message.content) {
-            message_store.update_message_content(client_message, message.content);
+            message_store.update_message_content(mutable_client_message, message.content);
             sent_messages.mark_disparity(local_id);
         }
         sent_messages.report_event_received(local_id);
 
-        message_store.update_booleans(client_message, message.flags);
+        message_store.update_booleans(mutable_client_message, message.flags);
 
         // We don't try to highlight alert words locally, so we have to
         // do it now.  (Note that we will indeed highlight alert words in
         // messages that we sent to ourselves, since we might want to test
         // that our alert words are set up correctly.)
-        alert_words.process_message(client_message);
+        alert_words.process_message(mutable_client_message);
 
         // Previously, the message had the "local echo" timestamp set
         // by the browser; if there was some round-trip delay to the
         // server, the actual server-side timestamp could be slightly
         // different.  This corrects the frontend timestamp to match
         // the backend.
-        client_message.timestamp = message.timestamp;
+        mutable_client_message.timestamp = message.timestamp;
 
-        client_message.topic_links = message.topic_links ?? [];
-        client_message.is_me_message = message.is_me_message;
-        client_message.submessages = message.submessages;
+        mutable_client_message.topic_links = message.topic_links ?? [];
+        mutable_client_message.is_me_message = message.is_me_message;
+        mutable_client_message.submessages = message.submessages;
 
         msgs_to_rerender_or_add_to_narrow.push(client_message);
         echo_state.remove_message_from_waiting_for_ack(local_id);

--- a/web/src/emoji_frequency.ts
+++ b/web/src/emoji_frequency.ts
@@ -47,7 +47,7 @@ export function update_frequently_used_emojis_list(): void {
 */
 export function update_emoji_frequency_on_add_reaction_event(event: reactions.ReactionEvent): void {
     const message_id = event.message_id;
-    const message = message_store.get(message_id);
+    const message = message_store.get_immutable_message(message_id);
     if (message === undefined) {
         return;
     }
@@ -77,7 +77,7 @@ export function update_emoji_frequency_on_remove_reaction_event(
     event: reactions.ReactionEvent,
 ): void {
     const message_id = event.message_id;
-    const message = message_store.get(message_id);
+    const message = message_store.get_immutable_message(message_id);
     if (message === undefined) {
         return;
     }
@@ -99,7 +99,7 @@ export function update_emoji_frequency_on_remove_reaction_event(
 
 export function update_emoji_frequency_on_messages_deletion(message_ids: number[]): void {
     for (const message_id of message_ids) {
-        const message = message_store.get(message_id);
+        const message = message_store.get_immutable_message(message_id);
         // It's normal to receive events about the deletion of
         // messages that this client doesn't have locally cached. No
         // action is required, since only messages that are locally

--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -70,7 +70,7 @@ class MessageReactionSession {
 
     toggle_message_reaction(emoji_name: string): boolean {
         const message_id = this.message_id;
-        const message = message_store.get(message_id);
+        const message = message_store.get_immutable_message(message_id);
         if (!message) {
             blueslip.error("reactions: Bad message id", {message_id});
             return false;

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1920,7 +1920,7 @@ export class Filter {
         const predicate = this.predicate();
 
         const first_id = msg_ids.find((msg_id) => {
-            const message = message_store.get(msg_id);
+            const message = message_store.get_immutable_message(msg_id);
 
             if (message === undefined) {
                 return false;
@@ -2073,7 +2073,7 @@ export class Filter {
 
         if (!message) {
             const with_message_id = this.message_id_operand("with")!;
-            message = message_store.get(with_message_id);
+            message = message_store.get_immutable_message(with_message_id);
         }
 
         if (!message) {

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -1407,7 +1407,7 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         case "message_actions":
             return message_actions_popover.toggle_message_actions_menu(msg);
         case "star_message":
-            starred_messages_ui.toggle_starred_and_update_server(msg);
+            starred_messages_ui.toggle_starred_and_update_server(msg.id);
             return true;
         case "toggle_conversation_view":
             if (narrow_state.narrowed_by_topic_reply()) {

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1684,7 +1684,7 @@ export function get_focused_row_message(): {message?: Message | undefined} & (
     if (is_dm) {
         const row_info = dms_dict.get(conversation_key);
         assert(row_info !== undefined);
-        const message = message_store.get(row_info.latest_msg_id);
+        const message = message_store.get_immutable_message(row_info.latest_msg_id);
         if (message === undefined) {
             return {
                 msg_type: "private",

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -513,7 +513,7 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
             return payload;
         }
 
-        const message = message_store.get(message_id);
+        const message = message_store.get_immutable_message(message_id);
         if (message === undefined) {
             blueslip.error("Lightbox for unknown message", {message_id});
         } else {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1417,7 +1417,7 @@ export async function save_message_row_edit($row: JQuery): Promise<void> {
                 message_id = rows.id($row);
 
                 if (edit_locally_echoed) {
-                    const echoed_message = message_store.get(message_id);
+                    const echoed_message = message_store.get_mutable_message(message_id);
                     assert(echoed_message !== undefined);
                     const echo_data = currently_echoing_messages.get(message_id);
                     assert(echo_data !== undefined);
@@ -1539,7 +1539,9 @@ export function edit_last_sent_message(): void {
         return;
     }
 
-    const current_selected_msg = message_store.get(message_lists.current.selected_id());
+    const current_selected_msg = message_store.get_immutable_message(
+        message_lists.current.selected_id(),
+    );
     if (
         current_selected_msg &&
         current_selected_msg.id < last_sent_msg.id &&

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -160,7 +160,7 @@ export let update_views_filtered_on_message_property = (
         const messages_to_fetch: number[] = [];
         const messages: Message[] = [];
         for (const message_id of message_ids) {
-            const message = message_store.get(message_id);
+            const message = message_store.get_immutable_message(message_id);
             if (message !== undefined) {
                 messages.push(message);
             } else {
@@ -212,7 +212,7 @@ export let update_views_filtered_on_message_property = (
                         .parse(data);
                     for (const raw_message of raw_messages) {
                         messages_to_remove.delete(raw_message.id);
-                        const message = message_store.get(raw_message.id);
+                        const message = message_store.get_immutable_message(raw_message.id);
                         messages_to_add.push(
                             message ?? message_helper.process_new_server_message(raw_message),
                         );
@@ -458,7 +458,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
     message_list_data_cache.clear();
 
     for (const event of events) {
-        const anchor_message = message_store.get(event.message_id);
+        const anchor_message = message_store.get_mutable_message(event.message_id);
         if (anchor_message !== undefined) {
             // Logic for updating the specific edited message only
             // needs to run if we had a local copy of the message.
@@ -567,7 +567,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
 
             // Update each message to reflect the new case.
             for (const message_id of event.message_ids) {
-                const message = message_store.get(message_id);
+                const message = message_store.get_mutable_message(message_id);
                 if (message === undefined) {
                     continue;
                 }
@@ -601,7 +601,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
             for (const message_id of event.message_ids) {
                 // We don't need to concern ourselves updating data structures
                 // for messages we don't have stored locally.
-                const message = message_store.get(message_id);
+                const message = message_store.get_mutable_message(message_id);
                 if (message !== undefined) {
                     assert(message.type === "stream");
                     event_messages.push(message);

--- a/web/src/message_fetch_raw_content.ts
+++ b/web/src/message_fetch_raw_content.ts
@@ -16,7 +16,7 @@ export function get_raw_content_for_messages(info: {
 
     // We fill what we can from the store
     for (const [i, id] of message_ids.entries()) {
-        const message = message_store.get(id);
+        const message = message_store.get_immutable_message(id);
         assert(message !== undefined);
         if (message.raw_content) {
             raw_content_arr[i] = message.raw_content;
@@ -66,7 +66,7 @@ export function get_raw_content_for_single_message(info: {
     timeout_ms?: number;
 }): void {
     const {message_id, on_success, on_error, timeout_ms} = info;
-    const message = message_store.get(message_id);
+    const message = message_store.get_immutable_message(message_id);
     assert(message !== undefined);
     if (message.raw_content) {
         on_success(message.raw_content);

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -2336,7 +2336,7 @@ export class MessageListView {
             blueslip.error(`Missing message id for sticky recipient row.`);
             return;
         }
-        const message = message_store.get(msg_id);
+        const message = message_store.get_immutable_message(msg_id);
         if (!message) {
             blueslip.error(
                 `Message not found for the message id identified for sticky header: ${msg_id}.`,

--- a/web/src/message_live_update.ts
+++ b/web/src/message_live_update.ts
@@ -12,7 +12,7 @@ export function rerender_messages_view(): void {
 export function rerender_messages_view_by_message_ids(message_ids: number[]): void {
     const messages_to_render = [];
     for (const id of message_ids) {
-        const message = message_store.get(id);
+        const message = message_store.get_immutable_message(id);
         if (message !== undefined) {
             messages_to_render.push(message);
         }

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -250,6 +250,16 @@ export type ReadonlyMessage =
 
 export type ImmutableMessage = ReadonlyMessage;
 
+/**
+ * Writable cached Message. Callers obtain this from get_mutable_message
+ * or mutable_for so mutation is an explicit opt-in. Same singleton as
+ * the store. Prefer update_* helpers when one exists.
+ *
+ * This is an alias of Message; TypeScript#13347 still lets a
+ * ReadonlyMessage through a Message parameter.
+ */
+export type MutableMessage = Message;
+
 export function update_message_cache(message_data: ProcessedMessage): void {
     // You should only call this from message_helper (or in tests).
     stored_messages.set(message_data.message.id, message_data);
@@ -279,11 +289,20 @@ export function get_immutable_message(message_id: number): ReadonlyMessage | und
 }
 
 /**
- * Return the cached message for mutation. Use update_* helpers when one
- * exists; this is the lookup for remaining in-place writes.
+ * Return the cached message for mutation. Prefer update_* helpers
+ * when one exists.
  */
-export function get_mutable_message(message_id: number): Message | undefined {
+export function get_mutable_message(message_id: number): MutableMessage | undefined {
     return stored_messages.get(message_id)?.message;
+}
+
+/**
+ * Opt into mutation of a Message singleton the caller already holds.
+ * Prefer get_mutable_message when only an id is available. Returns
+ * the cached object when present, otherwise the same object.
+ */
+export function mutable_for(message: Message | ReadonlyMessage): MutableMessage {
+    return get_mutable_message(message.id) ?? message;
 }
 
 /** Alias of get_immutable_message. */

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -414,7 +414,7 @@ export function convert_raw_message_to_message_with_booleans(opts: NewMessage):
     };
 }
 
-export function update_booleans(message: Message, flags: string[]): void {
+export function update_booleans(message: MutableMessage, flags: string[]): void {
     // When we get server flags for local echo or message edits,
     // we are vulnerable to race conditions, so only update flags
     // that are driven by message content.
@@ -497,7 +497,7 @@ export function reify_message_id({old_id, new_id}: {old_id: number; new_id: numb
     }
 }
 
-export function update_message_content(message: Message, new_content: string): void {
+export function update_message_content(message: MutableMessage, new_content: string): void {
     message.content = new_content;
 }
 

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -286,8 +286,9 @@ export function get_mutable_message(message_id: number): Message | undefined {
     return stored_messages.get(message_id)?.message;
 }
 
-export function get(message_id: number): Message | undefined {
-    return stored_messages.get(message_id)?.message;
+/** Alias of get_immutable_message. */
+export function get(message_id: number): ReadonlyMessage | undefined {
+    return get_immutable_message(message_id);
 }
 
 export function set_messages_for_tests(messages: ProcessedMessage[]): void {

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -237,6 +237,19 @@ export type Message = (
           }
     );
 
+/**
+ * Compile-time-only view of a cached Message. Same object as the store
+ * singleton; assigning to fields is a type error.
+ *
+ * Distributed over the stream/PM union so `if (msg.type === "stream")`
+ * still narrows `stream_id` / `topic`. A bare `Readonly<Message>` would
+ * collapse those exclusive fields.
+ */
+export type ReadonlyMessage =
+    Readonly<Extract<Message, {type: "private"}>> | Readonly<Extract<Message, {type: "stream"}>>;
+
+export type ImmutableMessage = ReadonlyMessage;
+
 export function update_message_cache(message_data: ProcessedMessage): void {
     // You should only call this from message_helper (or in tests).
     stored_messages.set(message_data.message.id, message_data);

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -270,6 +270,22 @@ export function clear_for_testing(): void {
 // TODO: If we finish converting to typescript and find that
 // nothing needs LocalMessage, explicitly remove its extra fields
 // here before returning the Message.
+/**
+ * Return the cached message as a Readonly view of the store singleton.
+ * Prefer this (or get()) for read-only callers.
+ */
+export function get_immutable_message(message_id: number): ReadonlyMessage | undefined {
+    return stored_messages.get(message_id)?.message;
+}
+
+/**
+ * Return the cached message for mutation. Use update_* helpers when one
+ * exists; this is the lookup for remaining in-place writes.
+ */
+export function get_mutable_message(message_id: number): Message | undefined {
+    return stored_messages.get(message_id)?.message;
+}
+
 export function get(message_id: number): Message | undefined {
     return stored_messages.get(message_id)?.message;
 }
@@ -484,7 +500,7 @@ export function get_message_ids_in_stream(stream_id: number): number[] {
 }
 
 export function maybe_update_raw_content(id: number, raw_content: string | undefined): void {
-    const message = get(id);
+    const message = get_mutable_message(id);
     // In case the message was deleted from the cache after receiving a delete
     // event.
     if (message === undefined) {

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -112,7 +112,7 @@ export function get_topics_for_message_ids(message_ids: number[]): Map<string, [
     const topics = new Map<string, [number, string]>(); // key = stream_id:topic
     for (const msg_id of message_ids) {
         // message_store still has data on deleted messages when this runs.
-        const message = message_store.get(msg_id);
+        const message = message_store.get_immutable_message(msg_id);
         if (message === undefined) {
             // We may not have the deleted message cached locally in
             // message_store; if so, we can just skip processing it.

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -588,7 +588,7 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
         // created. This ensures near / id links work and will redirect
         // correctly if the topic was moved (including being resolved).
         if (id_info.target_id && filter.has_operator("channel") && filter.has_operator("topic")) {
-            const target_message = message_store.get(id_info.target_id);
+            const target_message = message_store.get_immutable_message(id_info.target_id);
 
             if (target_message) {
                 // If we have the target message ID for the narrow in our
@@ -1596,7 +1596,7 @@ export function narrow_by_topic(
     },
 ): void {
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
-    const original = message_store.get(target_id);
+    const original = message_store.get_immutable_message(target_id);
     assert(original !== undefined);
     if (original.type !== "stream") {
         // Only stream messages have topics, but the
@@ -1631,7 +1631,7 @@ export function narrow_by_recipient(
 ): void {
     const show_opts = {then_select_id: target_id, ...opts};
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
-    const message = message_store.get(target_id);
+    const message = message_store.get_immutable_message(target_id);
     assert(message !== undefined);
 
     switch (message.type) {

--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -42,7 +42,7 @@ export function current_user_has_reacted_to_emoji(message: Message, local_id: st
 }
 
 function get_message(message_id: number): Message | undefined {
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
     if (!message) {
         blueslip.error("reactions: Bad message id", {message_id});
         return undefined;
@@ -275,7 +275,7 @@ export function rewire_set_reaction_vote_text(value: typeof set_reaction_vote_te
 
 export let add_reaction = (event: ReactionEvent): void => {
     const message_id = event.message_id;
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
 
     if (message === undefined) {
         // If we don't have the message in cache, do nothing; if we
@@ -413,7 +413,7 @@ export function rewire_insert_new_reaction(value: typeof insert_new_reaction): v
 export let remove_reaction = (event: ReactionEvent): void => {
     const message_id = event.message_id;
     const user_id = event.user_id;
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
     const local_id = get_local_reaction_id(event);
 
     if (message === undefined) {
@@ -500,7 +500,7 @@ export function rewire_remove_reaction_from_view(value: typeof remove_reaction_f
 export function get_emojis_used_by_user_for_message_id(message_id: number): string[] {
     const user_id = current_user.user_id;
     assert(user_id !== undefined);
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
     assert(message !== undefined);
     update_clean_reactions(message);
 

--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -25,7 +25,7 @@ let interval_id: number | null = null;
 let has_initial_data = false;
 
 export function fetch_read_receipts(message_id: number): void {
-    const message = message_store.get(message_id);
+    const message = message_store.get_immutable_message(message_id);
     assert(message !== undefined, "message is undefined");
 
     if (message.sender_email === "notification-bot@zulip.com") {

--- a/web/src/recent_senders.ts
+++ b/web/src/recent_senders.ts
@@ -174,7 +174,7 @@ export function process_topic_edit(opts: {
     // the messages were moved to another stream or deleted.
 
     for (const message_id of message_ids) {
-        const message = message_store.get(message_id);
+        const message = message_store.get_immutable_message(message_id);
         if (!message) {
             continue;
         }
@@ -189,7 +189,7 @@ export function process_topic_edit(opts: {
 
 export function update_topics_of_deleted_message_ids(message_ids: number[]): void {
     for (const message_id of message_ids) {
-        const message = message_store.get(message_id);
+        const message = message_store.get_immutable_message(message_id);
         if (message?.type !== "stream") {
             continue;
         }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -528,7 +528,7 @@ export function get_focused_row_message(): Message | undefined {
         const last_conversation = recent_view_data.conversations.get(conversation_id);
         assert(last_conversation !== undefined);
         const topic_last_msg_id = last_conversation.last_msg_id;
-        return message_store.get(topic_last_msg_id);
+        return message_store.get_immutable_message(topic_last_msg_id);
     }
     return undefined;
 }
@@ -797,7 +797,7 @@ type ConversationContext = {
 );
 
 function format_conversation(conversation_data: ConversationData): ConversationContext {
-    const last_msg = message_store.get(conversation_data.last_msg_id);
+    const last_msg = message_store.get_immutable_message(conversation_data.last_msg_id);
     assert(last_msg !== undefined);
     const time = new Date(last_msg.timestamp * 1000);
     const type = last_msg.type;
@@ -954,7 +954,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
 }
 
 function get_topic_row(topic_data: ConversationData): JQuery {
-    const msg = message_store.get(topic_data.last_msg_id);
+    const msg = message_store.get_immutable_message(topic_data.last_msg_id);
     assert(msg !== undefined);
     const topic_key = recent_view_util.get_key_from_message(msg);
     return $(`#${CSS.escape(recent_conversation_key_prefix + topic_key)}`);
@@ -1008,7 +1008,7 @@ export function update_topics_of_deleted_message_ids(message_ids: number[]): voi
 
     const dm_conversations_to_rerender = new Set<string>();
     for (const msg_id of message_ids) {
-        const msg = message_store.get(msg_id);
+        const msg = message_store.get_immutable_message(msg_id);
         if (msg === undefined) {
             continue;
         }
@@ -1039,7 +1039,7 @@ export function update_topics_of_deleted_message_ids(message_ids: number[]): voi
 }
 
 export function filters_should_hide_row(topic_data: ConversationData): boolean {
-    const msg = message_store.get(topic_data.last_msg_id);
+    const msg = message_store.get_immutable_message(topic_data.last_msg_id);
     assert(msg !== undefined);
 
     if (msg.type === "stream") {
@@ -1162,7 +1162,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
         if (processed_count >= row_keys.length) {
             break;
         }
-        const msg = message_store.get(topic_data.last_msg_id);
+        const msg = message_store.get_immutable_message(topic_data.last_msg_id);
         assert(msg !== undefined);
         const topic_key = recent_view_util.get_key_from_message(msg);
         if (row_keys.includes(topic_key)) {
@@ -1425,9 +1425,9 @@ function sort_comparator(a: string, b: string): number {
 
 function channel_sort(a: Row, b: Row): number {
     if (a.type === b.type) {
-        const a_msg = message_store.get(a.last_msg_id);
+        const a_msg = message_store.get_immutable_message(a.last_msg_id);
         assert(a_msg !== undefined);
-        const b_msg = message_store.get(b.last_msg_id);
+        const b_msg = message_store.get_immutable_message(b.last_msg_id);
         assert(b_msg !== undefined);
 
         if (a_msg.type === "stream") {
@@ -1461,9 +1461,9 @@ function channel_sort(a: Row, b: Row): number {
 
 function conversation_sort(a: Row, b: Row): number {
     if (a.type === b.type) {
-        const a_msg = message_store.get(a.last_msg_id);
+        const a_msg = message_store.get_immutable_message(a.last_msg_id);
         assert(a_msg !== undefined);
-        const b_msg = message_store.get(b.last_msg_id);
+        const b_msg = message_store.get_immutable_message(b.last_msg_id);
         assert(b_msg !== undefined);
 
         if (a_msg.type === "stream") {
@@ -1485,7 +1485,7 @@ function conversation_sort(a: Row, b: Row): number {
 }
 
 function unread_count(conversation_data: ConversationData): number {
-    const message = message_store.get(conversation_data.last_msg_id);
+    const message = message_store.get_immutable_message(conversation_data.last_msg_id);
     assert(message !== undefined);
     return message_to_conversation_unread_count(message);
 }
@@ -1523,7 +1523,7 @@ function has_visible_unread_conversation(): boolean {
     // Iterate the widget's already-filtered list so we avoid
     // re-evaluating `filters_should_hide_row` per topic.
     for (const topic_data of topics_widget.get_current_list()) {
-        const msg = message_store.get(topic_data.last_msg_id);
+        const msg = message_store.get_immutable_message(topic_data.last_msg_id);
         assert(msg !== undefined);
         if (message_to_conversation_unread_count(msg) > 0) {
             return true;
@@ -1821,7 +1821,7 @@ export function update_recent_view_rendered_time(): void {
     // only update it when the user comes back from idle which has
     // maximum chance of user seeing incorrect rendered time.
     for (const conversation_data of topics_widget.get_rendered_list()) {
-        const last_msg = message_store.get(conversation_data.last_msg_id);
+        const last_msg = message_store.get_immutable_message(conversation_data.last_msg_id);
         assert(last_msg !== undefined);
         const time = new Date(last_msg.timestamp * 1000);
         const updated_time = timerender.relative_time_string_from_date(time, true);
@@ -1918,7 +1918,7 @@ function has_unread(row: number): boolean {
     const current_row = topics_widget.get_current_list()[row];
     assert(current_row !== undefined);
     const last_msg_id = current_row.last_msg_id;
-    const last_msg = message_store.get(last_msg_id);
+    const last_msg = message_store.get_immutable_message(last_msg_id);
     assert(last_msg !== undefined);
     if (last_msg.type === "stream") {
         return unread.num_unread_for_topic(last_msg.stream_id, last_msg.topic) > 0;

--- a/web/src/recent_view_util.ts
+++ b/web/src/recent_view_util.ts
@@ -1,4 +1,4 @@
-import type {Message} from "./message_store.ts";
+import type {ReadonlyMessage} from "./message_store.ts";
 import type {UpdatableStreamProperties} from "./stream_types.ts";
 
 let is_view_visible = false;
@@ -28,7 +28,7 @@ export function get_topic_key(stream_id: number, topic: string): string {
     return stream_id + ":" + topic.toLowerCase();
 }
 
-export function get_key_from_message(msg: Message): string {
+export function get_key_from_message(msg: ReadonlyMessage): string {
     if (msg.type === "private") {
         // The to_user_ids field on a direct message object is a
         // string containing the user IDs involved in the message in

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -122,7 +122,7 @@ function get_message_for_message_content($content: JQuery): Message | undefined 
         return undefined;
     }
     const message_id = rows.id($message_row);
-    return message_store.get(message_id);
+    return message_store.get_immutable_message(message_id);
 }
 
 // Function to safely wrap mentioned names in a DOM element.

--- a/web/src/rows.ts
+++ b/web/src/rows.ts
@@ -154,7 +154,7 @@ export function get_message_recipient_header($message_row: JQuery): JQuery {
 
 export function recipient_from_group($message_group: JQuery): Message | undefined {
     const message_id = id($message_group.children(".message_row").first().expectOne());
-    return message_store.get(message_id);
+    return message_store.get_immutable_message(message_id);
 }
 
 export function is_header_of_row_sticky($recipient_row: JQuery): boolean {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -184,7 +184,7 @@ export function dispatch_normal_event(event) {
             let deleted_dm_user_ids;
             if (event.message_type === "private") {
                 for (const msg_id of msg_ids) {
-                    const message = message_store.get(msg_id);
+                    const message = message_store.get_immutable_message(msg_id);
                     if (message !== undefined) {
                         deleted_dm_user_ids = people.pm_with_user_ids(message);
                         if (deleted_dm_user_ids !== undefined) {

--- a/web/src/starred_messages.ts
+++ b/web/src/starred_messages.ts
@@ -37,7 +37,7 @@ export function get_count_in_topic(stream_id?: number, topic?: string): number {
     }
 
     const messages = [...starred_ids].filter((id) => {
-        const message = message_store.get(id);
+        const message = message_store.get_immutable_message(id);
 
         if (message === undefined) {
             // We know the `id` from the initial data fetch from page_params,

--- a/web/src/starred_messages_ui.ts
+++ b/web/src/starred_messages_ui.ts
@@ -7,7 +7,6 @@ import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts
 import * as message_flags from "./message_flags.ts";
 import * as message_live_update from "./message_live_update.ts";
 import * as message_store from "./message_store.ts";
-import type {Message} from "./message_store.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as starred_messages from "./starred_messages.ts";
 import * as sub_store from "./sub_store.ts";
@@ -15,7 +14,11 @@ import * as unread_ops from "./unread_ops.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
-export function toggle_starred_and_update_server(message: Message): void {
+export function toggle_starred_and_update_server(message_id: number): void {
+    const message = message_store.get_mutable_message(message_id);
+    if (message === undefined) {
+        return;
+    }
     if (message.locally_echoed) {
         // This is defensive code for when you hit the "*" key
         // before we get a server ack.  It's rare that somebody
@@ -46,7 +49,7 @@ export function toggle_starred_and_update_server(message: Message): void {
 // This updates the state of the starred flag in local data
 // structures, and triggers a UI rerender.
 export function update_starred_flag(message_id: number, updated_starred_flag: boolean): void {
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
     if (message === undefined) {
         // If we don't have the message locally, do nothing; if later
         // we fetch it, it'll come with the correct `starred` state.

--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -166,7 +166,7 @@ export function do_process_submessages(message: Message): void {
 
 export function render_submessage(in_opts: {$row: JQuery; message_id: number}): void {
     const message_id = in_opts.message_id;
-    const message = message_store.get(message_id);
+    const message = message_store.get_immutable_message(message_id);
     if (!message) {
         return;
     }
@@ -197,7 +197,7 @@ export function handle_event(submsg: Submessage): void {
     // Update message.submessages in case we haven't actually
     // activated the widget yet, so that when the message does
     // come in view, the data will be complete.
-    const message = message_store.get(submsg.message_id);
+    const message = message_store.get_mutable_message(submsg.message_id);
 
     if (message === undefined) {
         // This is generally not a problem--the server

--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -114,7 +114,7 @@ function send_typing_notification_based_on_message_type(
 }
 
 function message_edit_typing_notifications_enabled(message_id: number): boolean {
-    const message = message_store.get(message_id);
+    const message = message_store.get_immutable_message(message_id);
     assert(message !== undefined);
     if (message.type === "stream") {
         return user_settings.send_stream_typing_notifications;

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -632,7 +632,7 @@ class UnreadTopicCounter {
 const unread_topic_counter = new UnreadTopicCounter();
 
 function add_message_to_unread_mentions(message_id: number): void {
-    const message = message_store.get(message_id);
+    const message = message_store.get_immutable_message(message_id);
     if (message?.type === "stream") {
         const topic_key = recent_view_util.get_topic_key(message.stream_id, message.topic);
         const topic_message_ids = unread_mention_topics.get(topic_key);
@@ -917,7 +917,7 @@ export function mark_as_read(message_id: number): void {
     direct_message_with_mention_count.delete(message_id);
     unread_messages.delete(message_id);
 
-    const message = message_store.get(message_id);
+    const message = message_store.get_mutable_message(message_id);
     if (message) {
         message.unread = false;
     }

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -681,7 +681,7 @@ export function process_read_messages_event(message_ids: number[]): void {
     for (const message_id of message_ids) {
         unread.mark_as_read(message_id);
 
-        const message = message_store.get(message_id);
+        const message = message_store.get_immutable_message(message_id);
 
         // TODO: This ends up doing one in-place rerender operation on
         // recent conversations per message, not a single global
@@ -712,7 +712,7 @@ export function process_unread_messages_event({
     }
 
     for (const message_id of message_ids) {
-        const message = message_store.get(message_id);
+        const message = message_store.get_mutable_message(message_id);
         const message_info = message_details[message_id];
         assert(message_info !== undefined);
         let mentioned_me_directly;

--- a/web/src/zulip_test.ts
+++ b/web/src/zulip_test.ts
@@ -18,7 +18,7 @@ export {initiate as initiate_reload} from "./reload.ts";
 export {page_load_time} from "./setup.ts";
 export {current_user, realm} from "./state_data.ts";
 export {add_user_id_to_new_stream} from "./stream_create_subscribers.ts";
-export {get as get_message} from "./message_store.ts";
+export {get as get_message, get_immutable_message, get_mutable_message} from "./message_store.ts";
 export {is_in_progress, is_pending} from "./reload_state.ts";
 export {show_reaction_data} from "./emoji_frequency_data.ts";
 export {num_unread_for_topic} from "./unread.ts";

--- a/web/src/zulip_test.ts
+++ b/web/src/zulip_test.ts
@@ -18,7 +18,12 @@ export {initiate as initiate_reload} from "./reload.ts";
 export {page_load_time} from "./setup.ts";
 export {current_user, realm} from "./state_data.ts";
 export {add_user_id_to_new_stream} from "./stream_create_subscribers.ts";
-export {get as get_message, get_immutable_message, get_mutable_message} from "./message_store.ts";
+export {
+    get as get_message,
+    get_immutable_message,
+    get_mutable_message,
+    mutable_for,
+} from "./message_store.ts";
 export {is_in_progress, is_pending} from "./reload_state.ts";
 export {show_reaction_data} from "./emoji_frequency_data.ts";
 export {num_unread_for_topic} from "./unread.ts";

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -34,6 +34,7 @@ mock_esm("../src/sent_messages", {
 const message_store = mock_esm("../src/message_store", {
     get_immutable_message: () => ({failed_request: true}),
     get_mutable_message: () => ({failed_request: true}),
+    mutable_for: (message) => message,
 
     update_booleans() {},
 

--- a/web/tests/echo.test.cjs
+++ b/web/tests/echo.test.cjs
@@ -32,7 +32,8 @@ mock_esm("../src/sent_messages", {
 });
 
 const message_store = mock_esm("../src/message_store", {
-    get: () => ({failed_request: true}),
+    get_immutable_message: () => ({failed_request: true}),
+    get_mutable_message: () => ({failed_request: true}),
 
     update_booleans() {},
 
@@ -511,7 +512,8 @@ function make_spinner_row() {
 
 run_test("resend success clears the failed flag", ({override}) => {
     const stored_messages = new Map();
-    override(message_store, "get", (id) => stored_messages.get(id));
+    override(message_store, "get_immutable_message", (id) => stored_messages.get(id));
+    override(message_store, "get_mutable_message", (id) => stored_messages.get(id));
 
     const local_id = "300.01";
     const server_id = 310;
@@ -552,7 +554,7 @@ run_test("resend error re-marks a present message as failed", ({override}) => {
     // When the resend POST fails while the message is still in the store, the
     // error handler surfaces the failure by setting failed_request back to true.
     const stored_messages = new Map();
-    override(message_store, "get", (id) => stored_messages.get(id));
+    override(message_store, "get_mutable_message", (id) => stored_messages.get(id));
 
     const message = {
         id: 280,
@@ -585,7 +587,7 @@ run_test("resend doesn't crash when the message was already reconciled", ({overr
     // message is never stored under the id the response reports, and
     // failed_message_success must tolerate that missing entry.
     const stored_messages = new Map();
-    override(message_store, "get", (id) => stored_messages.get(id));
+    override(message_store, "get_mutable_message", (id) => stored_messages.get(id));
 
     const local_id = "250.01";
     const reconciled_id = 260; // server id the message was reconciled to
@@ -632,7 +634,7 @@ run_test("resend error on a message removed from the store doesn't crash", ({ove
     // (e.g. it was deleted while the resend was in flight), message_send_error
     // must tolerate the missing entry rather than dereference undefined.
     const stored_messages = new Map();
-    override(message_store, "get", (id) => stored_messages.get(id));
+    override(message_store, "get_mutable_message", (id) => stored_messages.get(id));
 
     const message = {
         id: 270,

--- a/web/tests/lib/readonly_message.ts
+++ b/web/tests/lib/readonly_message.ts
@@ -1,4 +1,30 @@
+import {get_immutable_message, get_mutable_message} from "../../src/message_store.ts";
 import type {Message, ReadonlyMessage} from "../../src/message_store.ts";
+
+export function get_returns_readonly_view(id: number): ReadonlyMessage | undefined {
+    return get_immutable_message(id);
+}
+
+export function get_mutable_returns_writable(id: number): Message | undefined {
+    const message = get_mutable_message(id);
+    if (message !== undefined) {
+        message.content = "writable";
+    }
+    return message;
+}
+
+export function cannot_assign_through_immutable_get(id: number): void {
+    const msg = get_immutable_message(id);
+    if (msg === undefined) {
+        return;
+    }
+    // @ts-expect-error ReadonlyMessage forbids assigning content.
+    msg.content = "nope";
+    // @ts-expect-error ReadonlyMessage forbids assigning unread.
+    msg.unread = false;
+    // @ts-expect-error ReadonlyMessage forbids assigning raw_content.
+    msg.raw_content = "x";
+}
 
 function takes_mutable_message(message: Message): void {
     message.content = "rogue";

--- a/web/tests/lib/readonly_message.ts
+++ b/web/tests/lib/readonly_message.ts
@@ -1,8 +1,12 @@
-import {get_immutable_message, get_mutable_message} from "../../src/message_store.ts";
+import {get, get_immutable_message, get_mutable_message} from "../../src/message_store.ts";
 import type {Message, ReadonlyMessage} from "../../src/message_store.ts";
 
 export function get_returns_readonly_view(id: number): ReadonlyMessage | undefined {
     return get_immutable_message(id);
+}
+
+export function get_alias_matches_immutable(id: number): boolean {
+    return get(id) === get_immutable_message(id);
 }
 
 export function get_mutable_returns_writable(id: number): Message | undefined {
@@ -13,8 +17,8 @@ export function get_mutable_returns_writable(id: number): Message | undefined {
     return message;
 }
 
-export function cannot_assign_through_immutable_get(id: number): void {
-    const msg = get_immutable_message(id);
+export function cannot_assign_through_get(id: number): void {
+    const msg = get(id);
     if (msg === undefined) {
         return;
     }

--- a/web/tests/lib/readonly_message.ts
+++ b/web/tests/lib/readonly_message.ts
@@ -1,0 +1,111 @@
+import type {Message, ReadonlyMessage} from "../../src/message_store.ts";
+
+function takes_mutable_message(message: Message): void {
+    message.content = "rogue";
+}
+
+function takes_readonly_message(message: ReadonlyMessage): string {
+    return message.content;
+}
+
+/**
+ * Compile-time tests for ReadonlyMessage. tsc is the runner; this is
+ * never called at runtime.
+ */
+export function readonly_message_type_tests(
+    stream_msg: Extract<ReadonlyMessage, {type: "stream"}>,
+    private_msg: Extract<ReadonlyMessage, {type: "private"}>,
+    msg: ReadonlyMessage,
+): string {
+    const stream_reads =
+        msg.type === "stream"
+            ? [msg.stream_id, msg.topic, msg.stream, String(msg.is_stream)]
+            : [msg.to_user_ids, msg.pm_with_url, msg.display_reply_to, String(msg.is_private)];
+
+    const reads = [
+        msg.id,
+        msg.content,
+        msg.sender_id,
+        msg.sender_email,
+        msg.sender_full_name,
+        String(msg.unread),
+        String(msg.starred),
+        String(msg.mentioned),
+        String(msg.sent_by_me),
+        msg.reply_to,
+        msg.timestamp,
+        msg.raw_content ?? "",
+        String(msg.locally_echoed ?? false),
+        String(msg.clean_reactions.size),
+        stream_msg.stream_id,
+        stream_msg.topic,
+        private_msg.to_user_ids,
+        ...stream_reads,
+    ];
+
+    takes_readonly_message(msg);
+    takes_readonly_message(stream_msg);
+    takes_readonly_message(private_msg);
+
+    // The #13347 hole: this type-checks, then mutates the singleton.
+    takes_mutable_message(msg);
+
+    // @ts-expect-error ReadonlyMessage forbids assigning id.
+    msg.id = 0;
+    // @ts-expect-error ReadonlyMessage forbids assigning content.
+    msg.content = "mutated";
+    // @ts-expect-error ReadonlyMessage forbids assigning raw_content.
+    msg.raw_content = "x";
+    // @ts-expect-error ReadonlyMessage forbids assigning unread.
+    msg.unread = false;
+    // @ts-expect-error ReadonlyMessage forbids assigning starred.
+    msg.starred = true;
+    // @ts-expect-error ReadonlyMessage forbids assigning mentioned.
+    msg.mentioned = true;
+    // @ts-expect-error ReadonlyMessage forbids assigning mentioned_me_directly.
+    msg.mentioned_me_directly = true;
+    // @ts-expect-error ReadonlyMessage forbids assigning collapsed.
+    msg.collapsed = true;
+    // @ts-expect-error ReadonlyMessage forbids assigning sent_by_me.
+    msg.sent_by_me = false;
+    // @ts-expect-error ReadonlyMessage forbids assigning reply_to.
+    msg.reply_to = "";
+    // @ts-expect-error ReadonlyMessage forbids assigning sender_full_name.
+    msg.sender_full_name = "x";
+    // @ts-expect-error ReadonlyMessage forbids assigning sender_id.
+    msg.sender_id = 0;
+    // @ts-expect-error ReadonlyMessage forbids assigning sender_email.
+    msg.sender_email = "x";
+    // @ts-expect-error ReadonlyMessage forbids assigning timestamp.
+    msg.timestamp = 0;
+    // @ts-expect-error ReadonlyMessage forbids assigning locally_echoed.
+    msg.locally_echoed = true;
+    // @ts-expect-error ReadonlyMessage forbids assigning local_edit_timestamp.
+    msg.local_edit_timestamp = 1;
+    // @ts-expect-error ReadonlyMessage forbids assigning flags.
+    msg.flags = [];
+    // @ts-expect-error ReadonlyMessage forbids replacing clean_reactions.
+    msg.clean_reactions = new Map();
+    // @ts-expect-error ReadonlyMessage forbids assigning type.
+    msg.type = "stream";
+
+    // @ts-expect-error topic is not on a private ReadonlyMessage.
+    void private_msg.topic;
+    // @ts-expect-error to_user_ids is not on a stream ReadonlyMessage.
+    void stream_msg.to_user_ids;
+
+    // @ts-expect-error ReadonlyMessage forbids assigning topic.
+    stream_msg.topic = "other";
+    // @ts-expect-error ReadonlyMessage forbids assigning stream_id.
+    stream_msg.stream_id = 0;
+    // @ts-expect-error ReadonlyMessage forbids assigning to_user_ids.
+    private_msg.to_user_ids = "";
+
+    // Shallow Readonly: nested arrays and Maps are still mutable.
+    if (msg.flags !== undefined) {
+        msg.flags.push("read");
+    }
+    msg.clean_reactions.clear();
+
+    return reads.join(",");
+}

--- a/web/tests/lib/readonly_message.ts
+++ b/web/tests/lib/readonly_message.ts
@@ -1,5 +1,10 @@
-import {get, get_immutable_message, get_mutable_message} from "../../src/message_store.ts";
-import type {Message, ReadonlyMessage} from "../../src/message_store.ts";
+import {
+    get,
+    get_immutable_message,
+    get_mutable_message,
+    mutable_for,
+} from "../../src/message_store.ts";
+import type {Message, MutableMessage, ReadonlyMessage} from "../../src/message_store.ts";
 
 export function get_returns_readonly_view(id: number): ReadonlyMessage | undefined {
     return get_immutable_message(id);
@@ -9,12 +14,18 @@ export function get_alias_matches_immutable(id: number): boolean {
     return get(id) === get_immutable_message(id);
 }
 
-export function get_mutable_returns_writable(id: number): Message | undefined {
+export function get_mutable_returns_writable(id: number): MutableMessage | undefined {
     const message = get_mutable_message(id);
     if (message !== undefined) {
         message.content = "writable";
     }
     return message;
+}
+
+export function mutable_for_returns_writable(message: Message): MutableMessage {
+    const mutable = mutable_for(message);
+    mutable.content = "writable";
+    return mutable;
 }
 
 export function cannot_assign_through_get(id: number): void {
@@ -30,7 +41,11 @@ export function cannot_assign_through_get(id: number): void {
     msg.raw_content = "x";
 }
 
-function takes_mutable_message(message: Message): void {
+function takes_message(message: Message): void {
+    message.content = "rogue";
+}
+
+function takes_mutable_message(message: MutableMessage): void {
     message.content = "rogue";
 }
 
@@ -77,7 +92,9 @@ export function readonly_message_type_tests(
     takes_readonly_message(stream_msg);
     takes_readonly_message(private_msg);
 
-    // The #13347 hole: this type-checks, then mutates the singleton.
+    // The #13347 hole: ReadonlyMessage is assignable to Message, and
+    // MutableMessage is an alias of Message, so this type-checks.
+    takes_message(msg);
     takes_mutable_message(msg);
 
     // @ts-expect-error ReadonlyMessage forbids assigning id.

--- a/web/tests/lightbox.test.cjs
+++ b/web/tests/lightbox.test.cjs
@@ -222,7 +222,7 @@ run_test("parse_media_data message row context", () => {
     // Override context to message row instead of overlay.
     rows.is_overlay_row = () => false;
     rows.id = () => 42;
-    message_store.get = () => ({sender_full_name: "Alice"});
+    message_store.get_immutable_message = () => ({sender_full_name: "Alice"});
 
     const result = lightbox.parse_media_data(media);
 
@@ -238,7 +238,7 @@ run_test("parse_media_data unknown message", () => {
 
     rows.is_overlay_row = () => false;
     rows.id = () => 999;
-    message_store.get = () => undefined;
+    message_store.get_immutable_message = () => undefined;
 
     blueslip.expect("error", "Lightbox for unknown message");
     const result = lightbox.parse_media_data(media);
@@ -249,7 +249,7 @@ run_test("parse_media_data unknown message", () => {
 run_test("parse_media_data asset map cache", () => {
     const img_src = "https://example.com/cached.png";
 
-    message_store.get = () => ({sender_full_name: "Bob"});
+    message_store.get_immutable_message = () => ({sender_full_name: "Bob"});
 
     const {media: media1} = make_image({
         img_src,

--- a/web/tests/message_flags.test.cjs
+++ b/web/tests/message_flags.test.cjs
@@ -21,6 +21,7 @@ mock_esm("../src/left_sidebar_navigation_area", {
 });
 
 const message_flags = zrequire("message_flags");
+const message_store = zrequire("message_store");
 const starred_messages_ui = zrequire("starred_messages_ui");
 const {initialize_user_settings} = zrequire("user_settings");
 
@@ -30,6 +31,7 @@ run_test("starred", ({override}) => {
     const message = {
         id: 50,
     };
+    message_store.set_messages_for_tests([{type: "server_message", message}]);
     let ui_updated;
 
     override(message_live_update, "update_starred_view", () => {
@@ -43,7 +45,7 @@ run_test("starred", ({override}) => {
         posted_data = opts.data;
     });
 
-    starred_messages_ui.toggle_starred_and_update_server(message);
+    starred_messages_ui.toggle_starred_and_update_server(message.id);
 
     assert.ok(ui_updated);
 
@@ -60,7 +62,7 @@ run_test("starred", ({override}) => {
 
     ui_updated = false;
 
-    starred_messages_ui.toggle_starred_and_update_server(message);
+    starred_messages_ui.toggle_starred_and_update_server(message.id);
 
     assert.ok(ui_updated);
 
@@ -83,8 +85,11 @@ run_test("starring local echo", () => {
         starred: false,
         locally_echoed: true,
     };
+    message_store.set_messages_for_tests([
+        {type: "server_message", message: locally_echoed_message},
+    ]);
 
-    starred_messages_ui.toggle_starred_and_update_server(locally_echoed_message);
+    starred_messages_ui.toggle_starred_and_update_server(locally_echoed_message.id);
 
     // message_live_update.update_starred_view not called
 

--- a/web/tests/message_store.test.cjs
+++ b/web/tests/message_store.test.cjs
@@ -607,6 +607,8 @@ test("get_immutable_and_mutable_message", () => {
     assert.equal(mutable, processed);
     assert.equal(via_get, processed);
     assert.equal(immutable, mutable);
+    assert.equal(message_store.mutable_for(processed), processed);
+    assert.equal(message_store.mutable_for(processed), mutable);
 
     mutable.starred = true;
     assert.equal(message_store.get_immutable_message(9001).starred, true);

--- a/web/tests/message_store.test.cjs
+++ b/web/tests/message_store.test.cjs
@@ -572,3 +572,50 @@ test("maybe_update_raw_content", () => {
     message_store.maybe_update_raw_content(message1.id, "bye world");
     assert.equal(message1.raw_content, "hello world");
 });
+
+test("get_immutable_and_mutable_message", () => {
+    assert.equal(message_store.get_immutable_message(9001), undefined);
+    assert.equal(message_store.get_mutable_message(9001), undefined);
+    assert.equal(message_store.get(9001), undefined);
+
+    const processed = message_helper.process_new_message({
+        type: "server_message",
+        raw_message: {
+            sender_email: alice.email,
+            sender_id: alice.user_id,
+            type: "stream",
+            display_recipient: devel.name,
+            topic: "readonly-api",
+            subject: "readonly-api",
+            id: 9001,
+            reactions: [],
+            avatar_url: `/avatar/${alice.user_id}`,
+            submessages: [],
+            content: "hello",
+            content_type: "text/html",
+            client: "website",
+            timestamp: 100,
+            flags: [],
+        },
+    }).message;
+
+    const immutable = message_store.get_immutable_message(9001);
+    const mutable = message_store.get_mutable_message(9001);
+    const via_get = message_store.get(9001);
+
+    assert.equal(immutable, processed);
+    assert.equal(mutable, processed);
+    assert.equal(via_get, processed);
+    assert.equal(immutable, mutable);
+
+    mutable.starred = true;
+    assert.equal(message_store.get_immutable_message(9001).starred, true);
+    assert.equal(processed.starred, true);
+
+    message_store.update_message_content(mutable, "updated");
+    assert.equal(message_store.get_immutable_message(9001).content, "updated");
+
+    message_store.remove([9001]);
+    assert.equal(message_store.get_immutable_message(9001), undefined);
+    assert.equal(message_store.get_mutable_message(9001), undefined);
+});

--- a/web/tests/reactions.test.cjs
+++ b/web/tests/reactions.test.cjs
@@ -332,7 +332,7 @@ test("unknown realm emojis (insert)", () => {
 test("sending", ({override, override_rewire}) => {
     const message = sample_message_with_clean_reactions();
     assert.equal(message.id, 1001);
-    override(message_store, "get", (message_id) => {
+    override(message_store, "get_mutable_message", (message_id) => {
         assert.equal(message_id, message.id);
         return message;
     });
@@ -593,7 +593,7 @@ test("get_reaction_sections", () => {
 
 test("emoji_reaction_title", ({override}) => {
     const message = sample_message_with_clean_reactions();
-    override(message_store, "get", () => message);
+    override(message_store, "get_mutable_message", () => message);
     const local_id = "unicode_emoji,1f604";
 
     assert.equal(
@@ -611,7 +611,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
 
     override(user_settings, "display_emoji_reaction_users", true);
 
-    override(message_store, "get", () => message);
+    override(message_store, "get_mutable_message", () => message);
 
     let function_calls = [];
 
@@ -1364,7 +1364,7 @@ test("remove_reaction_from_view (last reaction)", () => {
 test("bogus_event", ({override}) => {
     // We don't expect errors when we process events with
     // bad message ids.
-    override(message_store, "get", noop);
+    override(message_store, "get_mutable_message", noop);
 
     const bogus_event = {
         message_id: 55,
@@ -1381,7 +1381,7 @@ test("remove spurious user", ({override}) => {
     // get coverage for removing non-user (it should just
     // silently fail)
     const message = sample_message_with_clean_reactions();
-    override(message_store, "get", () => message);
+    override(message_store, "get_mutable_message", () => message);
 
     const event = {
         reaction_type: "unicode_emoji",
@@ -1397,7 +1397,7 @@ test("remove spurious user", ({override}) => {
 test("remove last user", ({override, override_rewire}) => {
     const message = sample_message_with_clean_reactions();
 
-    override(message_store, "get", () => message);
+    override(message_store, "get_mutable_message", () => message);
     override_rewire(reactions, "remove_reaction_from_view", noop);
 
     function assert_names(names) {
@@ -1434,7 +1434,7 @@ test("process_reaction_click", ({override, override_rewire}) => {
     override_rewire(reactions, "remove_reaction_from_view", noop);
 
     const message = sample_message_with_clean_reactions();
-    override(message_store, "get", () => message);
+    override(message_store, "get_mutable_message", () => message);
 
     const expected_reaction_info = {
         reaction_type: "unicode_emoji",
@@ -1470,7 +1470,7 @@ test("code coverage", ({override}) => {
         it easy to enforce 100% coverage for more significant
         code additions.
     */
-    override(message_store, "get", (id) => {
+    override(message_store, "get_mutable_message", (id) => {
         assert.equal(id, 42);
         return {
             clean_reactions: new Map(),
@@ -1496,7 +1496,7 @@ test("duplicates", () => {
 });
 
 test("process_reaction_click undefined", ({override}) => {
-    override(message_store, "get", () => undefined);
+    override(message_store, "get_mutable_message", () => undefined);
     blueslip.expect("error", "reactions: Bad message id");
     blueslip.expect("error", "message_id for reaction click is unknown");
     reactions.process_reaction_click(55, "whatever");
@@ -1504,7 +1504,7 @@ test("process_reaction_click undefined", ({override}) => {
 
 test("process_reaction_click bad local id", ({override}) => {
     const stub_message = {id: 4001, clean_reactions: new Map()};
-    override(message_store, "get", () => stub_message);
+    override(message_store, "get_mutable_message", () => stub_message);
     blueslip.expect("error", "Data integrity problem for reaction");
     reactions.process_reaction_click("some-msg-id", "bad-local-id");
 });

--- a/web/tests/submessage.test.cjs
+++ b/web/tests/submessage.test.cjs
@@ -124,7 +124,7 @@ run_test("handle_event", () => {
         post_to_server = opts.post_to_server;
     };
 
-    message_store.get = (msg_id) => {
+    message_store.get_mutable_message = (msg_id) => {
         assert.equal(msg_id, message.id);
         return message;
     };


### PR DESCRIPTION
Supersedes the remaining work on #37951.

Splits `message_store.get` into readonly and mutable lookups. Discussion: [#frontend > Replacing message_store.get](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Replacing.20message_store.2Eget/with/2380774).

**How changes were tested:**

- [x] `./tools/test-js-with-node`
- [x] `./tools/lint` on changed files