### PR TITLE
send_email: Use formataddr() to RFC 2047-encode non-ASCII From display names

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -209,11 +209,18 @@ def build_email(
         from_address = FromAddress.SUPPORT
 
     # Set the "From" that is displayed separately from the envelope-from.
-    extra_headers["From"] = str(Address(display_name=from_name, addr_spec=from_address))
+    # We use formataddr() rather than str(Address()) here because
+    # str(Address(display_name=..., addr_spec=...)) leaves non-ASCII
+    # characters (e.g. accented letters in translated sender names like
+    # the French "Sécurité du compte Zulip Server") as raw Unicode in
+    # the header value.  Strict SMTP servers (e.g. Proton SMTP) reject
+    # messages whose headers are not pure ASCII, so we must RFC 2047-
+    # encode the display name.  formataddr() does this automatically.
+    extra_headers["From"] = formataddr((from_name, from_address))
     # As above, with the "To" line, we drop the name part if it would
     # result in an address which is longer than 320 bytes.
     if len(sanitize_address(extra_headers["From"], "utf-8")) > 320:
-        extra_headers["From"] = str(Address(addr_spec=from_address))
+        extra_headers["From"] = from_address
 
     # If we have an unsubscribe link for this email, configure it for
     # "Unsubscribe" buttons in email clients via the List-Unsubscribe header.

--- a/zerver/tests/test_send_email.py
+++ b/zerver/tests/test_send_email.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from email.utils import formataddr
 from smtplib import (
     SMTP,
     SMTPDataError,
@@ -105,6 +106,83 @@ class TestBuildEmail(ZulipTestCase):
         self.assertNotIn("\r", email.subject)
         self.assertNotIn("\n", email.subject)
         self.assertEqual(email.subject, "SubjectBcc: attacker@example.com")
+
+    def test_accented_from_name(self) -> None:
+        """Password-reset emails whose translated sender name contains
+        non-ASCII characters (e.g. French "Sécurité du compte Zulip Server")
+        must have an RFC 2047-encoded From header so that strict SMTP
+        servers (e.g. Proton SMTP) don't reject the message.
+
+        Regression test for https://github.com/zulip/zulip/issues/39649.
+        """
+        hamlet = self.example_user("hamlet")
+        # A sender name with accented characters, as produced by the
+        # French translation of "{service_name} account security".
+        # We pass it directly as from_name so the test does not depend
+        # on compiled translation files being present.
+        accented_name = "Sécurité du compte Zulip Server"
+        mail = build_email(
+            "zerver/emails/password_reset",
+            to_emails=[hamlet.email],
+            from_name=accented_name,
+            from_address=FromAddress.NOREPLY,
+            language="en",
+        )
+        from_header = mail.extra_headers["From"]
+        # The From header must be pure ASCII (RFC 2047-encoded).
+        self.assertTrue(
+            from_header.isascii(),
+            f"From header contains non-ASCII characters: {from_header!r}",
+        )
+        # It must match what formataddr() produces, not a raw Unicode string.
+        expected = formataddr((accented_name, FromAddress.NOREPLY))
+        self.assertEqual(from_header, expected)
+
+    def test_security_email_from_name(self) -> None:
+        """FromAddress.security_email_from_name returns a translated string
+        whose result, when containing non-ASCII characters, must still be
+        correctly RFC 2047-encoded by build_email().
+
+        We mock gettext to simulate a translated name with accented characters
+        without depending on compiled translation (.mo) files being present.
+        """
+        hamlet = self.example_user("hamlet")
+        # Simulate a translated sender name with accents (as in French).
+        simulated_translation = "Sécurité du compte {service_name}"
+
+        with (
+            mock.patch(
+                "zerver.lib.send_email._",
+                side_effect=lambda s: simulated_translation,
+            ),
+            override_settings(INSTALLATION_NAME="Zulip Server"),
+        ):
+            from_name = FromAddress.security_email_from_name(language="fr")
+
+        # The returned string must be a plain Unicode str (not pre-encoded).
+        self.assertIsInstance(from_name, str)
+        self.assertGreater(len(from_name), 0)
+        # It should contain accented characters (non-ASCII).
+        self.assertFalse(
+            from_name.isascii(),
+            f"Expected accented sender name, got: {from_name!r}",
+        )
+
+        # When build_email() uses this from_name, the From header must
+        # be RFC 2047-encoded (pure ASCII).
+        mail = build_email(
+            "zerver/emails/password_reset",
+            to_emails=[hamlet.email],
+            from_name=from_name,
+            from_address=FromAddress.NOREPLY,
+            language="en",
+        )
+        from_header = mail.extra_headers["From"]
+        self.assertTrue(
+            from_header.isascii(),
+            f"From header is not ASCII after encoding: {from_header!r}",
+        )
+        self.assertEqual(from_header, formataddr((from_name, FromAddress.NOREPLY)))
 
 
 class TestSendEmail(ZulipTestCase):


### PR DESCRIPTION
Fixes: #39649

Password-reset emails fail for users whose default language produces an
accented sender name — for example, the French translation of
`{service_name} account security` is `Sécurité du compte {service_name}`,
which contains non-ASCII characters.

## Root cause

In `build_email()`, the `From` display header was constructed with:

```python
extra_headers["From"] = str(Address(display_name=from_name, addr_spec=from_address))
```

`email.headerregistry.Address.__str__` leaves non-ASCII characters **as
raw Unicode** in the returned string. For a French sender name, this
produces:

```
Sécurité du compte Zulip Server <noreply@example.com>
```

This is **not pure ASCII**, which violates RFC 5322. Strict SMTP servers
(the reporter is using Proton SMTP) reject messages whose `From` header
contains non-ASCII characters.

The same codepath is exercised by every email that uses
`FromAddress.security_email_from_name()` — password reset, email
change confirmation, login notification, realm reactivation/deactivation,
and Stripe billing emails — so any non-English user with an SMTP server
that enforces ASCII headers is affected.

## Fix

Replace `str(Address(display_name=..., addr_spec=...))` with
`formataddr((from_name, from_address))` from `email.utils`.

`formataddr()` automatically RFC 2047-encodes the display name when it
contains non-ASCII characters, producing:

```
=?utf-8?q?S=C3=A9curit=C3=A9_du_compte_Zulip_Server?= <noreply@example.com>
```

which is valid ASCII accepted by all compliant SMTP servers. For
ASCII-only display names the output is **identical** to the previous
format (`Name <addr>`), so there is no regression for the English case.

`formataddr` was already imported and already used for the `List-Id`
header on the line above, so this is a consistent and minimal change.

The 320-byte truncation fallback is simplified to assign `from_address`
directly, which is equivalent to the previous `str(Address(addr_spec=...))`.

## How changes were tested

Two new tests added to `TestBuildEmail` in `zerver/tests/test_send_email.py`:

- **`test_accented_from_name`** — passes an accented display name
  (`"Sécurité du compte Zulip Server"`) directly as `from_name` and
  asserts that the resulting `From` header is pure ASCII and equals
  `formataddr((accented_name, noreply_address))`.  The test does not
  depend on compiled translation files being present.

- **`test_security_email_from_name`** — mocks `gettext` in
  `send_email.py` to return a simulated French-style translation with
  accents, calls `FromAddress.security_email_from_name()`, confirms the
  returned string is plain (non-pre-encoded) Unicode, then feeds it
  through `build_email()` and asserts the `From` header is ASCII.

All existing tests in `TestBuildEmail` and `TestSendEmail` continue to
pass: `formataddr()` produces the identical `"Name <addr>"` format for
ASCII-only display names, so `test_limited_from_length`,
`test_send_email_exceptions`, and the `email_display_from` assertions in
`test_email_change.py` and `test_management_commands.py` are unaffected.

**Screenshots and screen captures:**

N/A — backend-only change with no UI impact.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Responsiveness and internationalization.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
