### PR TITLE
message overlays: Enable keyboard navigation for row action buttons.

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -216,8 +216,8 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
     id_attribute_name: "data-draft-id",
 };
 
-export function handle_keyboard_events(event_key: string): void {
-    messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
+export function handle_keyboard_events(event_key: string, event_target?: EventTarget | null): void {
+    messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context, event_target);
 }
 
 function format_drafts(data: Record<string, LocalStorageDraft>): FormattedDraft[] {
@@ -401,9 +401,10 @@ function setup_event_handlers(): void {
         update_bulk_delete_ui();
     });
 
-    $("#drafts_table .overlay_message_controls .draft-selection-checkbox").on("click", (e) => {
-        const is_checked = is_checkbox_icon_checked($(e.target));
-        toggle_checkbox_icon_state($(e.target), !is_checked);
+    $("#drafts_table .overlay_message_controls .draft-selection-tooltip").on("click", (e) => {
+        const $checkbox = $(e.currentTarget).find(".draft-selection-checkbox");
+        const is_checked = is_checkbox_icon_checked($checkbox);
+        toggle_checkbox_icon_state($checkbox, !is_checked);
         update_bulk_delete_ui();
     });
 }
@@ -540,8 +541,8 @@ export function initialize(): void {
             return;
         }
         const draft_row = e.target.closest(".overlay-message-info-box");
-        if (draft_row instanceof HTMLElement) {
-            // A draft gained focus; mark it as the selected draft.
+        if (draft_row instanceof HTMLElement && e.target === draft_row) {
+            // A draft row gained focus; mark it as the selected draft.
             messages_overlay_ui.activate_element(draft_row, keyboard_handling_context);
         } else if (e.target.matches(overlay_util.OVERLAY_FOCUSABLE_SELECTOR)) {
             // Another focusable element (e.g. a header button) gained focus;

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -673,7 +673,11 @@ function process_enter_key(e: JQuery.KeyDownEvent): boolean {
     // It restores draft that is focused.
     if (overlays.drafts_open()) {
         const $draft_overlay = $("#draft_overlay");
-        if ($draft_overlay.find("a:focus, button:focus, input:focus").length > 0) {
+        if (
+            $draft_overlay.find(
+                "a:focus, button:focus, input:focus, [role='button']:focus, [role='checkbox']:focus",
+            ).length > 0
+        ) {
             return false;
         }
         drafts_overlay_ui.handle_keyboard_events("enter");
@@ -905,6 +909,7 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
 
     // TODO: break out specific handlers for up_arrow,
     //       down_arrow, and backspace
+    const event_target = e.target instanceof HTMLElement ? e.target : undefined;
     switch (event_name) {
         case "up_arrow":
         case "down_arrow":
@@ -913,15 +918,15 @@ function process_hotkey(e: JQuery.KeyDownEvent, hotkey: Hotkey): boolean {
         case "backspace":
         case "delete":
             if (overlays.drafts_open()) {
-                drafts_overlay_ui.handle_keyboard_events(event_name);
+                drafts_overlay_ui.handle_keyboard_events(event_name, event_target);
                 return true;
             }
             if (overlays.scheduled_messages_open()) {
-                scheduled_messages_overlay_ui.handle_keyboard_events(event_name);
+                scheduled_messages_overlay_ui.handle_keyboard_events(event_name, event_target);
                 return true;
             }
             if (overlays.reminders_open()) {
-                reminders_overlay_ui.handle_keyboard_events(event_name);
+                reminders_overlay_ui.handle_keyboard_events(event_name, event_target);
                 return true;
             }
             if (overlays.message_edit_history_open()) {

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -66,7 +66,25 @@ export function focus_on_sibling_element(context: Context): void {
     }
 }
 
-export function modals_handle_events(event_key: string, context: Context): void {
+export function modals_handle_events(
+    event_key: string,
+    context: Context,
+    event_target?: EventTarget | null,
+): void {
+    if (
+        (event_key === "up_arrow" || event_key === "down_arrow") &&
+        event_target instanceof HTMLElement
+    ) {
+        const focused_row = event_target.closest<HTMLElement>(
+            `.${CSS.escape(context.box_item_selector)}`,
+        );
+        if (focused_row !== null && event_target !== focused_row) {
+            // An action control has focus, so use its row as the starting
+            // point before moving to the adjacent row.
+            activate_element(focused_row, context);
+        }
+    }
+
     initialize_focus(event_key, context);
 
     // This detects up arrow key presses when the overlay

--- a/web/src/reminders_overlay_ui.ts
+++ b/web/src/reminders_overlay_ui.ts
@@ -55,8 +55,8 @@ function sort_reminders(reminders: Map<number, Reminder>): Reminder[] {
     return sorted_reminders;
 }
 
-export function handle_keyboard_events(event_key: string): void {
-    messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
+export function handle_keyboard_events(event_key: string, event_target?: EventTarget | null): void {
+    messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context, event_target);
 }
 
 function format(reminders: Map<number, Reminder>): ReminderRenderContext[] {
@@ -149,7 +149,14 @@ export function initialize(): void {
         e.preventDefault();
     });
 
-    $("body").on("focus", ".reminder-info-box", function (this: HTMLElement) {
+    $("body").on("focus", ".reminder-info-box", function (this: HTMLElement, e) {
+        if (e.target !== this) {
+            if (e.target instanceof HTMLElement && e.target.matches(":focus-visible")) {
+                $(".reminder-info-box").removeClass("active");
+            }
+            return;
+        }
+
         messages_overlay_ui.activate_element(this, keyboard_handling_context);
     });
 

--- a/web/src/scheduled_messages_overlay_ui.ts
+++ b/web/src/scheduled_messages_overlay_ui.ts
@@ -81,8 +81,8 @@ function sort_scheduled_messages(scheduled_messages: ScheduledMessage[]): Schedu
     );
 }
 
-export function handle_keyboard_events(event_key: string): void {
-    messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
+export function handle_keyboard_events(event_key: string, event_target?: EventTarget | null): void {
+    messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context, event_target);
 }
 
 function format(scheduled_messages: ScheduledMessage[]): ScheduledMessageRenderContext[] {
@@ -217,7 +217,14 @@ export function initialize(): void {
         e.preventDefault();
     });
 
-    $("body").on("focus", ".scheduled-message-info-box", function (this: HTMLElement) {
+    $("body").on("focus", ".scheduled-message-info-box", function (this: HTMLElement, e) {
+        if (e.target !== this) {
+            if (e.target instanceof HTMLElement && e.target.matches(":focus-visible")) {
+                $(".scheduled-message-info-box").removeClass("active");
+            }
+            return;
+        }
+
         messages_overlay_ui.activate_element(this, keyboard_handling_context);
     });
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -948,6 +948,9 @@ input.settings_text_input {
         }
 
         .overlay_message_controls {
+            --draft-overlay-action-control-size: calc(
+                1em + var(--icon-button-padding) + var(--icon-button-padding)
+            );
             display: flex;
             align-items: center;
             justify-content: center;
@@ -957,10 +960,6 @@ input.settings_text_input {
             [data-tippy-root] {
                 width: max-content;
                 overflow-wrap: unset;
-            }
-
-            .copy-overlay-message {
-                font-size: 1.2em;
             }
 
             .restore-overlay-message {
@@ -977,11 +976,36 @@ input.settings_text_input {
                 cursor: pointer;
                 color: hsl(357deg 52% 57%);
                 opacity: 0.7;
-                padding: 0;
-                font-size: 1.2em;
 
-                &:hover {
+                &:hover,
+                &:focus-visible,
+                &:active {
                     opacity: 1;
+                }
+            }
+
+            :is(
+                .copy-overlay-message,
+                .delete-overlay-message,
+                .draft-selection-tooltip
+            ) {
+                box-sizing: border-box;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                width: var(--draft-overlay-action-control-size);
+                height: var(--draft-overlay-action-control-size);
+                min-width: var(--draft-overlay-action-control-size);
+                min-height: var(--draft-overlay-action-control-size);
+                flex: 0 0 var(--draft-overlay-action-control-size);
+                padding: var(--icon-button-padding);
+                font-size: 1.2em;
+                line-height: 1;
+
+                &:hover,
+                &:focus-visible,
+                &:active {
+                    background-color: transparent;
                 }
             }
         }

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -44,10 +44,6 @@
                 }
             }
 
-            .select-state-indicator {
-                width: 15px;
-            }
-
             @media (width < $lg_min) {
                 margin-top: 5px;
                 width: 100%;
@@ -68,11 +64,14 @@
         }
     }
 
-    .draft-selection-checkbox {
-        margin-top: 0.25em;
+    :is(.draft-selection-checkbox, .select-state-indicator) {
+        display: block;
+        line-height: 1;
+        text-align: center;
+        margin: 0 auto;
         /* Required to make sure that the checkbox icon stays inside
            the grid. Any value greater than 13px (original width of
            the checkbox icon) will work. */
-        width: 15px;
+        width: 13px;
     }
 }

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -47,13 +47,13 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="overlay_message_controls">
-                            <span class="copy-button copy-overlay-message tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}" role="button">
+                            <button type="button" class="copy-button copy-button-square copy-overlay-message icon-button icon-button-square icon-button-neutral tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}" tabindex="0">
                                 <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
-                            </span>
-                            {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-draft-tooltip-template" aria-label=(t "Delete") }}
-                            <div class="draft-selection-tooltip">
-                                <i class="fa fa-square-o fa-lg draft-selection-checkbox" aria-hidden="true"></i>
-                            </div>
+                            </button>
+                            {{> ./components/icon_button intent="danger" squared=true custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-draft-tooltip-template" aria-label=(t "Delete") }}
+                            <button type="button" class="draft-selection-tooltip icon-button icon-button-square icon-button-neutral" role="checkbox" aria-checked="false" aria-label="{{t 'Select draft' }}" tabindex="0">
+                                <i class="fa fa-square-o draft-selection-checkbox" aria-hidden="true"></i>
+                            </button>
                         </div>
                     </div>
                     <div class="message_content rendered_markdown restore-overlay-message">{{rendered_markdown content}}</div>

--- a/web/templates/reminder_list.hbs
+++ b/web/templates/reminder_list.hbs
@@ -15,7 +15,7 @@
                     <div class="messagebox-content">
                         <div class="message_top_line">
                             <div class="overlay_message_controls">
-                                {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-reminder-tooltip-template" aria-label=(t "Delete") }}
+                                {{> ./components/icon_button intent="danger" squared=true custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-reminder-tooltip-template" aria-label=(t "Delete") }}
                             </div>
                         </div>
                         <div class="message_content rendered_markdown restore-overlay-message">{{rendered_markdown rendered_content}}</div>

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -40,7 +40,7 @@
                     <div class="messagebox-content">
                         <div class="message_top_line">
                             <div class="overlay_message_controls">
-                                {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-scheduled-message-tooltip-template" aria-label=(t "Delete") }}
+                                {{> ./components/icon_button intent="danger" squared=true custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-scheduled-message-tooltip-template" aria-label=(t "Delete") }}
                             </div>
                         </div>
                         <div class="message_content rendered_markdown restore-overlay-message">{{rendered_markdown rendered_content}}</div>

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -335,6 +335,47 @@ test("initialize", ({override_rewire}) => {
     drafts_overlay_ui.initialize();
 });
 
+test("draft row focus ignores child controls", ({override}) => {
+    drafts_overlay_ui.initialize();
+
+    let activated_element;
+    override(messages_overlay_ui, "activate_element", (element) => {
+        activated_element = element;
+    });
+
+    const draft_row = Object.create(window.HTMLElement.prototype);
+    draft_row.closest = () => draft_row;
+    const draft_child_control = Object.create(window.HTMLElement.prototype);
+    draft_child_control.closest = () => draft_row;
+    draft_child_control.matches = (selector) => selector !== ":focus-visible";
+    const focus_handler = $("body").get_on_handler("focus", "#draft_overlay");
+
+    focus_handler({target: draft_child_control});
+    assert.equal(activated_element, undefined);
+
+    focus_handler({target: draft_row});
+    assert.equal(activated_element, draft_row);
+});
+
+test("draft arrow navigation forwards focused child control", ({override}) => {
+    const draft_child_control = Object.create(window.HTMLElement.prototype);
+
+    for (const event_key of ["up_arrow", "down_arrow"]) {
+        let handled_event;
+        override(messages_overlay_ui, "modals_handle_events", (key, context, event_target) => {
+            handled_event = {key, box_item_selector: context.box_item_selector, event_target};
+        });
+
+        drafts_overlay_ui.handle_keyboard_events(event_key, draft_child_control);
+
+        assert.deepEqual(handled_event, {
+            key: event_key,
+            box_item_selector: "draft-message-info-box",
+            event_target: draft_child_control,
+        });
+    }
+});
+
 test("update_draft", ({override}) => {
     compose_state.set_message_type(undefined);
     let draft_id = drafts.update_draft();

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -86,6 +86,8 @@ const popovers = mock_esm("../src/user_card_popover", {
 });
 const reactions = mock_esm("../src/reactions");
 const read_receipts = mock_esm("../src/read_receipts");
+const reminders_overlay_ui = mock_esm("../src/reminders_overlay_ui");
+const scheduled_messages_overlay_ui = mock_esm("../src/scheduled_messages_overlay_ui");
 const search = mock_esm("../src/search");
 const settings_data = mock_esm("../src/settings_data");
 const sidebar_ui = mock_esm("../src/sidebar_ui");
@@ -646,10 +648,12 @@ test_while_not_editing_text("motion_keys", () => {
         spacebar: " ",
         up_arrow: "ArrowUp",
     };
+    const event_target_stub = Object.create(window.HTMLElement.prototype);
 
     function process(name) {
         const e = {
             key: keys[name],
+            target: event_target_stub,
         };
 
         try {
@@ -729,11 +733,27 @@ test_while_not_editing_text("motion_keys", () => {
     delete overlays.settings_open;
 
     delete overlays.any_active;
-    overlays.drafts_open = () => true;
-    assert_mapping("up_arrow", drafts_overlay_ui, "handle_keyboard_events");
-    assert_mapping("down_arrow", drafts_overlay_ui, "handle_keyboard_events");
-    delete overlays.any_active;
-    delete overlays.drafts_open;
+    function assert_overlay_arrow_navigation(overlay_module, open_overlay) {
+        open_overlay();
+        for (const key_name of ["up_arrow", "down_arrow"]) {
+            stubbing(overlay_module, "handle_keyboard_events", (stub) => {
+                assert.ok(process(key_name));
+                assert.deepEqual(stub.last_call_args, [key_name, event_target_stub]);
+            });
+        }
+    }
+
+    assert_overlay_arrow_navigation(drafts_overlay_ui, () => {
+        overlays.drafts_open = () => true;
+    });
+    overlays.drafts_open = () => false;
+    assert_overlay_arrow_navigation(scheduled_messages_overlay_ui, () => {
+        overlays.scheduled_messages_open = () => true;
+    });
+    overlays.scheduled_messages_open = () => false;
+    assert_overlay_arrow_navigation(reminders_overlay_ui, () => {
+        overlays.reminders_open = () => true;
+    });
 });
 
 run_test("test new user input hook called", () => {

--- a/web/tests/message_overlay_focus.test.cjs
+++ b/web/tests/message_overlay_focus.test.cjs
@@ -1,0 +1,87 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
+
+const messages_overlay_ui = mock_esm("../src/messages_overlay_ui");
+
+const reminders_overlay_ui = zrequire("reminders_overlay_ui");
+const scheduled_messages_overlay_ui = zrequire("scheduled_messages_overlay_ui");
+
+function assert_focus_handler_updates_row_selection({
+    box_item_selector,
+    handle_keyboard_events,
+    handler_selector,
+    initialize,
+    override,
+}) {
+    initialize();
+
+    let activated_element;
+    override(messages_overlay_ui, "activate_element", (element) => {
+        activated_element = element;
+    });
+
+    const $row = $.create(`${handler_selector}-row`);
+    const $active_row = $.create(`${handler_selector}-active-row`);
+    $active_row.addClass("active");
+    $.set_results(handler_selector, [$active_row[0]]);
+
+    const keyboard_focused_child = Object.create(window.HTMLElement.prototype);
+    keyboard_focused_child.matches = (selector) => {
+        assert.equal(selector, ":focus-visible");
+        return true;
+    };
+    const focus_handler = $("body").get_on_handler("focus", handler_selector);
+
+    focus_handler.call($row[0], {target: keyboard_focused_child});
+    assert.equal(activated_element, undefined);
+    assert.equal($active_row.hasClass("active"), false);
+
+    const pointer_focused_child = Object.create(window.HTMLElement.prototype);
+    pointer_focused_child.matches = (selector) => {
+        assert.equal(selector, ":focus-visible");
+        return false;
+    };
+    $active_row.addClass("active");
+    focus_handler.call($row[0], {target: pointer_focused_child});
+    assert.equal(activated_element, undefined);
+    assert.equal($active_row.hasClass("active"), true);
+
+    focus_handler.call($row[0], {target: $row[0]});
+    assert.equal(activated_element, $row[0]);
+
+    let handled_event;
+    override(messages_overlay_ui, "modals_handle_events", (key, context, event_target) => {
+        handled_event = {key, box_item_selector: context.box_item_selector, event_target};
+    });
+    handle_keyboard_events("up_arrow", keyboard_focused_child);
+    assert.deepEqual(handled_event, {
+        key: "up_arrow",
+        box_item_selector,
+        event_target: keyboard_focused_child,
+    });
+}
+
+run_test("scheduled message row focus updates row selection", ({override}) => {
+    assert_focus_handler_updates_row_selection({
+        box_item_selector: "scheduled-message-info-box",
+        handle_keyboard_events: scheduled_messages_overlay_ui.handle_keyboard_events,
+        handler_selector: ".scheduled-message-info-box",
+        initialize: scheduled_messages_overlay_ui.initialize,
+        override,
+    });
+});
+
+run_test("reminder row focus updates row selection", ({override}) => {
+    assert_focus_handler_updates_row_selection({
+        box_item_selector: "reminder-info-box",
+        handle_keyboard_events: reminders_overlay_ui.handle_keyboard_events,
+        handler_selector: ".reminder-info-box",
+        initialize: reminders_overlay_ui.initialize,
+        override,
+    });
+});


### PR DESCRIPTION
Fixes: #39005

Currently, it's not possible to navigate to message action buttons in Drafts, Scheduled messages, and Message reminders with the keyboard.

This PR makes keyboard navigation work with Tab/Shift+Tab for all message action buttons and checkboxes in message overlays, and ensures arrow keys navigate relative to the currently focused row control.

## Changes

1. **Accessible semantic buttons in templates**:
   - `web/templates/draft.hbs`: Replaced `span.copy-button` with a focusable semantic `<button type="button" class="copy-button ...">` and converted `.draft-selection-tooltip` from `<div>` to `<button type="button" role="checkbox" ...>`.
   - `web/templates/scheduled_message.hbs` & `web/templates/reminder_list.hbs`: Added `squared=true` to delete icon button for consistent square dimensions and focus ring outline.

2. **Focus management and child control handling**:
   - `web/src/drafts_overlay_ui.ts`: In `#draft_overlay` focus handler, only activate the row container if `e.target === draft_row`. When child action controls receive keyboard focus (`:focus-visible`), clear the `.active` row highlight rather than stealing focus back to the row.
   - `web/src/scheduled_messages_overlay_ui.ts` & `web/src/reminders_overlay_ui.ts`: Updated `.scheduled-message-info-box` and `.reminder-info-box` focus handlers to ignore focus events originating from child controls (`e.target !== this`).

3. **Arrow key navigation from action buttons**:
   - `web/src/hotkey.ts`: Passed `event_target` on arrow key presses (`up_arrow`, `down_arrow`, `vim_up`, `vim_down`) to `handle_keyboard_events` for drafts, scheduled messages, and reminders.
   - `web/src/messages_overlay_ui.ts`: In `modals_handle_events`, when an arrow key is pressed while an action button is focused, activated its parent row before computing the adjacent row so navigation moves relative to the current item.

4. **Enter key behavior**:
   - `web/src/hotkey.ts`: In `process_enter_key`, added `[role='button']:focus, [role='checkbox']:focus` to the selector check so pressing `Enter` on a focused button or checkbox triggers the control's action instead of restoring the draft.

5. **Styling and focus rings**:
   - `web/styles/app_components.css`: Added `--draft-overlay-action-control-size` and styled `.copy-overlay-message`, `.delete-overlay-message`, and `.draft-selection-tooltip` with consistent box-sizing, dimensions, and transparent hover/focus backgrounds.
   - `web/styles/drafts.css`: Centered and aligned checkbox and selection indicator icons.

## How changes were tested

- Added unit test in `web/tests/drafts.test.cjs`: `draft row focus ignores child controls` and `draft arrow navigation forwards focused child control`.
- Added unit tests in `web/tests/hotkey.test.cjs`: `assert_overlay_arrow_navigation` for drafts, scheduled messages, and reminders overlays.
- Added unit tests in `web/tests/message_overlay_focus.test.cjs`: `scheduled message row focus updates row selection` and `reminder row focus updates row selection`.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
