### PR TITLE
left_sidebar: Offer resolved/unresolved filter in top left sidebar filter.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -142,6 +142,7 @@ EXEMPT_FILES = make_set(
         "web/src/invite.ts",
         "web/src/invite_stream_picker_pill.ts",
         "web/src/klipy_network.ts",
+        "web/src/left_sidebar_filter.ts",
         "web/src/left_sidebar_navigation_area.ts",
         "web/src/left_sidebar_navigation_area_popovers.ts",
         "web/src/left_sidebar_tooltips.ts",

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -301,7 +301,7 @@ async function arrow(page: Page, direction: "Up" | "Down"): Promise<void> {
 }
 
 async function test_search_venice(page: Page): Promise<void> {
-    await common.clear_and_type(page, ".left-sidebar-search-input", "vEnI"); // Must be case insensitive.
+    await common.clear_and_type(page, "#left-sidebar-filter-query", "vEnI"); // Must be case insensitive.
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {hidden: true});
     await arrow(page, "Down");
@@ -310,7 +310,7 @@ async function test_search_venice(page: Page): Promise<void> {
     });
 
     // Clearing list gives back all the streams in the list
-    await common.clear_and_type(page, ".left-sidebar-search-input", "");
+    await common.clear_and_type(page, "#left-sidebar-filter-query", "");
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {visible: true});
     await page.waitForSelector(await get_stream_li(page, "Venice"), {visible: true});
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
@@ -327,7 +327,7 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
 
     // Enter the search box and test highlighted suggestion
-    await page.click(".left-sidebar-search-input");
+    await page.click("#left-sidebar-filter-query");
 
     // Selection is not highlighted until user wants to move the cursor.
     await page.waitForSelector(".top_left_inbox.top_left_row.highlighted_row", {hidden: true});
@@ -372,14 +372,14 @@ async function test_stream_search_filters_stream_list(page: Page): Promise<void>
     await test_search_venice(page);
 
     // Search for beginning of "Verona".
-    await page.type(".left-sidebar-search-input", "ver");
+    await page.type("#left-sidebar-filter-query", "ver");
     await page.waitForSelector(await get_stream_li(page, "core team"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {hidden: true});
     await page.waitForSelector(await get_stream_li(page, "Venice"), {hidden: true});
     await page.click(await get_stream_li(page, "Verona"));
     await expect_verona_stream_top_topic(page);
     assert.strictEqual(
-        await common.get_text_from_selector(page, ".left-sidebar-search-input"),
+        await common.get_text_from_selector(page, "#left-sidebar-filter-query"),
         "",
         "Clicking on stream didn't clear search",
     );

--- a/web/src/left_sidebar_filter.ts
+++ b/web/src/left_sidebar_filter.ts
@@ -1,0 +1,180 @@
+import {$} from "jquery";
+import assert from "minimalistic-assert";
+
+import * as blueslip from "./blueslip.ts";
+import {Typeahead} from "./bootstrap_typeahead.ts";
+import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
+import {$t} from "./i18n.ts";
+import * as narrow_state from "./narrow_state.ts";
+import * as stream_data from "./stream_data.ts";
+import * as stream_topic_history from "./stream_topic_history.ts";
+import * as topic_filter_pill from "./topic_filter_pill.ts";
+import type {TopicFilterPill, TopicFilterPillWidget} from "./topic_filter_pill.ts";
+
+let left_sidebar_filter_pill_widget: TopicFilterPillWidget | null = null;
+let left_sidebar_filter_typeahead: Typeahead<TopicFilterPill> | undefined;
+
+function get_narrowed_subscribed_stream_id(): number | undefined {
+    const stream_id = narrow_state.stream_id(narrow_state.filter(), true);
+    if (stream_id === undefined || !stream_data.is_subscribed(stream_id)) {
+        return undefined;
+    }
+
+    return stream_id;
+}
+
+export function get_raw_topics_state(): string {
+    const pills = left_sidebar_filter_pill_widget?.items() ?? [];
+    if (pills.length === 0) {
+        return "";
+    }
+
+    if (pills.length > 1) {
+        blueslip.warn("Multiple pills found in left sidebar filter input.");
+    }
+
+    return pills[0]!.syntax;
+}
+
+export function get_effective_topics_state_for_search(): string {
+    const topics_state = get_raw_topics_state();
+    if (topics_state === "" || get_narrowed_subscribed_stream_id() === undefined) {
+        return "";
+    }
+
+    // Existing topic-state pills stay active in subscribed-stream narrows,
+    // even when the current narrow is too limited to offer them in typeahead.
+    return topics_state;
+}
+
+const filter_placeholder_text = $t({defaultMessage: "Filter"});
+const default_filter_placeholder_text = $t({defaultMessage: "Filter left sidebar"});
+
+function update_left_sidebar_filter_placeholder(): void {
+    const $input = $("#left-sidebar-filter-query");
+    const has_filter_pill = (left_sidebar_filter_pill_widget?.items().length ?? 0) > 0;
+    const has_search_term = $input.text().trim() !== "";
+    if (has_search_term) {
+        $input.attr("data-placeholder", "");
+        return;
+    }
+    $input.attr(
+        "data-placeholder",
+        has_filter_pill ? filter_placeholder_text : default_filter_placeholder_text,
+    );
+}
+
+export function has_left_sidebar_filter_value(): boolean {
+    return $("#left-sidebar-filter-query").text().trim() !== "" || get_raw_topics_state() !== "";
+}
+
+function notify_left_sidebar_filter_changed(): void {
+    $("#left-sidebar-filter-input").trigger("input");
+}
+
+export function clear_query_text(): void {
+    $("#left-sidebar-filter-query").empty();
+    update_left_sidebar_filter_placeholder();
+}
+
+export function clear_query(): void {
+    clear_query_text();
+    notify_left_sidebar_filter_changed();
+}
+
+function update_left_sidebar_filter_after_content_change(): void {
+    update_left_sidebar_filter_placeholder();
+    // Left-sidebar filtering listens to the pill container's `input` event.
+    // Trigger it after pill add/remove so the sidebar recomputes visible
+    // rows immediately.
+    notify_left_sidebar_filter_changed();
+}
+
+export function clear_left_sidebar_filter(): void {
+    left_sidebar_filter_typeahead?.hide();
+    left_sidebar_filter_pill_widget?.clear(true);
+    clear_query();
+    $("#left-sidebar-filter-query").trigger("blur");
+}
+
+export function handle_clear_left_sidebar_filter_click(e: JQuery.Event): void {
+    e.stopPropagation();
+    clear_left_sidebar_filter();
+}
+
+export function is_typeahead_shown(): boolean {
+    return left_sidebar_filter_typeahead?.shown ?? false;
+}
+
+function handle_typeahead_keydown(e: JQuery.KeyDownEvent): void {
+    if (e.key === "Enter") {
+        // Reserve Enter for the typeahead and left-sidebar keyboard navigation.
+        // Do not let other handlers process it here.
+        e.preventDefault();
+        e.stopPropagation();
+    } else if (e.key === ",") {
+        // input_pill.ts converts comma-separated text into pills by default.
+        // Topic-state filters only allow a single pill, so we block that
+        // generic comma handling and keep pill creation on the typeahead path.
+        e.stopPropagation();
+    }
+}
+
+export function setup_left_sidebar_filter_typeahead(): void {
+    left_sidebar_filter_typeahead?.unlisten();
+    left_sidebar_filter_typeahead = undefined;
+    left_sidebar_filter_pill_widget = null;
+
+    const $input = $("#left-sidebar-filter-query");
+    const $pill_container = $("#left-sidebar-filter-input");
+
+    if ($input.length === 0 || $pill_container.length === 0) {
+        return;
+    }
+
+    left_sidebar_filter_pill_widget = topic_filter_pill.create_pills($pill_container);
+    left_sidebar_filter_pill_widget.onPillCreate(update_left_sidebar_filter_after_content_change);
+    left_sidebar_filter_pill_widget.onTextInputHook(update_left_sidebar_filter_placeholder);
+
+    const typeahead_input: TypeaheadInputElement = {
+        $element: $input,
+        type: "contenteditable",
+    };
+
+    const options = {
+        ...topic_filter_pill.get_typeahead_base_options(),
+        source() {
+            const stream_id = get_narrowed_subscribed_stream_id();
+            if (stream_id === undefined) {
+                return [];
+            }
+
+            const pills = left_sidebar_filter_pill_widget?.items() ?? [];
+            const query = $input.text().trim();
+
+            const has_locally_available_resolved_topics =
+                stream_topic_history.stream_has_locally_available_resolved_topics(stream_id);
+            return topic_filter_pill.get_matching_filter_options({
+                current_items: pills,
+                query,
+                allow_resolved_topic_filters: has_locally_available_resolved_topics,
+            });
+        },
+        updater(item: TopicFilterPill) {
+            assert(left_sidebar_filter_pill_widget !== null);
+            left_sidebar_filter_pill_widget.clear(true);
+            left_sidebar_filter_pill_widget.appendValue(item.syntax);
+            $input.text("");
+            $input.trigger("focus");
+            return $input.text().trim();
+        },
+    };
+
+    left_sidebar_filter_typeahead = new Typeahead(typeahead_input, options);
+
+    $input.on("keydown", handle_typeahead_keydown);
+
+    left_sidebar_filter_pill_widget.onPillRemove(update_left_sidebar_filter_after_content_change);
+
+    update_left_sidebar_filter_placeholder();
+}

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -57,6 +57,7 @@ import {
     message_edit_history_visibility_policy_values,
     web_mark_read_on_scroll_policy_values,
 } from "./settings_config.ts";
+import * as sidebar_ui from "./sidebar_ui.ts";
 import * as spectators from "./spectators.ts";
 import type {NarrowTerm} from "./state_data.ts";
 import {realm} from "./state_data.ts";

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -12,11 +12,13 @@ import * as channel from "./channel.ts";
 import * as compose_ui from "./compose_ui.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as left_sidebar_filter from "./left_sidebar_filter.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import {ListCursor} from "./list_cursor.ts";
 import {localstorage} from "./localstorage.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_reminder from "./message_reminder.ts";
+import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -36,7 +38,7 @@ import * as util from "./util.ts";
 
 const LEFT_SIDEBAR_NAVIGATION_AREA_TITLE = $t({defaultMessage: "VIEWS"});
 
-export let left_sidebar_cursor: ListCursor<JQuery>;
+export let left_sidebar_cursor: ListCursor<JQuery> | undefined;
 
 // Toggling a sidebar changes the message feed's width, causing rows to
 // reflow and shift vertically. Preserve the selected row's viewport
@@ -340,8 +342,8 @@ export function update_expanded_views_for_search(search_term: string): void {
         $("#left-sidebar-navigation-area, #left-sidebar-navigation-list .top_left_row").removeClass(
             "hidden-by-filters",
         );
-        left_sidebar_navigation_area.update_scheduled_messages_row();
-        left_sidebar_navigation_area.update_reminders_row();
+        left_sidebar_navigation_area.update_scheduled_messages_row?.();
+        left_sidebar_navigation_area.update_reminders_row?.();
         return;
     }
 
@@ -393,6 +395,7 @@ export function initialize_left_sidebar(): void {
     left_sidebar_navigation_area.reorder_left_sidebar_navigation_list(user_settings.web_home_view);
     stream_list.update_unread_counts_visibility();
     initialize_left_sidebar_cursor();
+    left_sidebar_filter.setup_left_sidebar_filter_typeahead();
     set_event_handlers();
 }
 
@@ -613,11 +616,10 @@ function should_show_topic_search_hint(search_term: string): boolean {
 }
 
 function initiate_topic_search(): void {
-    const $search_input = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
-    const current_value = ($search_input.val() ?? "").trim();
+    const $search_input = $("#left-sidebar-filter-query").expectOne();
+    const current_value = ($search_input.text() ?? "").trim();
     const new_value = ui_util.TOPIC_SEARCH_PREFIX + " " + current_value;
-    $search_input.val(new_value);
-    util.the($search_input).setSelectionRange(new_value.length, new_value.length);
+    $search_input.text(new_value);
     $search_input.trigger("focus").trigger("input");
 }
 
@@ -688,7 +690,7 @@ export function initialize_left_sidebar_cursor(): void {
 function actually_update_left_sidebar_for_search(): void {
     const search_value = ui_util.get_left_sidebar_search_term();
     const is_left_sidebar_search_active = search_value !== "";
-    left_sidebar_cursor.set_is_highlight_visible(is_left_sidebar_search_active);
+    left_sidebar_cursor?.set_is_highlight_visible(is_left_sidebar_search_active);
 
     // Update left sidebar navigation area.
     update_expanded_views_for_search(search_value);
@@ -717,40 +719,133 @@ function actually_update_left_sidebar_for_search(): void {
         );
     }
     $("#left-sidebar-topic-search-hint").toggleClass("hidden", !show_topic_search_hint);
-    left_sidebar_cursor.reset();
+    left_sidebar_cursor?.reset();
     $("#left-sidebar-empty-list-message").toggleClass(
         "hidden",
         !is_left_sidebar_search_active || all_rows().length > 0,
     );
 }
 
+type LeftSidebarSearchState = {
+    search_term: string;
+    topics_state: string;
+    narrow_stream_id: number | undefined;
+    narrow_topic: string | undefined;
+};
+
 // Scroll position before user started searching.
 let pre_search_scroll_position = 0;
-let previous_search_term = "";
+let previous_search_state: LeftSidebarSearchState = {
+    search_term: "",
+    topics_state: "",
+    narrow_stream_id: undefined,
+    narrow_topic: undefined,
+};
+
+// Current narrow affects which topic matches keep a stream visible during search.
+function get_left_sidebar_search_state(): LeftSidebarSearchState {
+    return {
+        search_term: ui_util.get_left_sidebar_search_term(),
+        topics_state: left_sidebar_filter.get_effective_topics_state_for_search(),
+        narrow_stream_id: narrow_state.stream_id(),
+        narrow_topic: narrow_state.topic(),
+    };
+}
+
+function same_left_sidebar_search_state(
+    search_state: LeftSidebarSearchState,
+    other_search_state: LeftSidebarSearchState,
+): boolean {
+    const is_search_active =
+        search_state.search_term !== "" || search_state.topics_state !== "";
+    const was_search_active =
+        other_search_state.search_term !== "" || other_search_state.topics_state !== "";
+
+    if (!is_search_active && !was_search_active) {
+        return true;
+    }
+
+    return (
+        search_state.search_term === other_search_state.search_term &&
+        search_state.topics_state === other_search_state.topics_state &&
+        search_state.narrow_stream_id === other_search_state.narrow_stream_id &&
+        search_state.narrow_topic === other_search_state.narrow_topic
+    );
+}
+
+function restore_left_sidebar_after_text_search(): void {
+    left_sidebar_navigation_area.restore_views_state();
+    scroll_util.get_left_sidebar_scroll_container().scrollTop(pre_search_scroll_position);
+}
+
+function apply_left_sidebar_search_ui_transition({
+    search_state,
+    was_left_sidebar_search_active,
+    use_request_animation_frame,
+}: {
+    search_state: LeftSidebarSearchState;
+    was_left_sidebar_search_active: boolean;
+    use_request_animation_frame: boolean;
+}): void {
+    const is_left_sidebar_search_active = search_state.search_term !== "";
+    const left_sidebar_scroll_container = scroll_util.get_left_sidebar_scroll_container();
+
+    if (is_left_sidebar_search_active && !was_left_sidebar_search_active) {
+        // Store original scroll position to be restored later.
+        pre_search_scroll_position = left_sidebar_scroll_container.scrollTop() ?? 0;
+    }
+
+    const apply_update = (): void => {
+        actually_update_left_sidebar_for_search();
+
+        if (!is_left_sidebar_search_active) {
+            if (was_left_sidebar_search_active) {
+                restore_left_sidebar_after_text_search();
+            }
+            return;
+        }
+
+        // Always scroll to top during stream-name search.
+        left_sidebar_scroll_container.scrollTop(0);
+    };
+
+    if (use_request_animation_frame) {
+        requestAnimationFrame(apply_update);
+        return;
+    }
+
+    apply_update();
+}
+
+function save_and_apply_left_sidebar_search_state({
+    search_state,
+    was_left_sidebar_search_active,
+    use_request_animation_frame,
+}: {
+    search_state: LeftSidebarSearchState;
+    was_left_sidebar_search_active: boolean;
+    use_request_animation_frame: boolean;
+}): void {
+    previous_search_state = search_state;
+    apply_left_sidebar_search_ui_transition({
+        search_state,
+        was_left_sidebar_search_active,
+        use_request_animation_frame,
+    });
+}
 
 const update_left_sidebar_for_search = _.throttle(() => {
-    const search_term = ui_util.get_left_sidebar_search_term();
-    const is_previous_search_term_empty = previous_search_term === "";
-    previous_search_term = search_term;
-
-    const left_sidebar_scroll_container = scroll_util.get_left_sidebar_scroll_container();
-    if (search_term === "") {
-        requestAnimationFrame(() => {
-            actually_update_left_sidebar_for_search();
-            // Restore previous scroll position.
-            left_sidebar_scroll_container.scrollTop(pre_search_scroll_position);
-        });
-    } else {
-        if (is_previous_search_term_empty) {
-            // Store original scroll position to be restored later.
-            pre_search_scroll_position = left_sidebar_scroll_container.scrollTop()!;
-        }
-        requestAnimationFrame(() => {
-            actually_update_left_sidebar_for_search();
-            // Always scroll to top when there is a search term present.
-            left_sidebar_scroll_container.scrollTop(0);
-        });
+    const search_state = get_left_sidebar_search_state();
+    const was_left_sidebar_search_active = previous_search_state.search_term !== "";
+    if (same_left_sidebar_search_state(search_state, previous_search_state)) {
+        return;
     }
+
+    save_and_apply_left_sidebar_search_state({
+        search_state,
+        was_left_sidebar_search_active,
+        use_request_animation_frame: true,
+    });
 }, 50);
 
 function focus_left_sidebar_row($row: JQuery): void {
@@ -824,7 +919,7 @@ function handle_left_sidebar_arrow_navigation(e: JQuery.KeyDownEvent): void {
     // Search inputs have their own arrow key handlers.
     const $active = $(document.activeElement);
     if (
-        $active.is(".left-sidebar-search-input, .direct-messages-list-filter, #topic_filter_query")
+        $active.is("#left-sidebar-filter-query, .direct-messages-list-filter, #topic_filter_query")
     ) {
         return;
     }
@@ -871,9 +966,13 @@ export function focus_pm_search_filter(): void {
 }
 
 export function set_event_handlers(): void {
-    const $search_input = $(".left-sidebar-search-input").expectOne();
+    const $search_input = $("#left-sidebar-filter-query").expectOne();
+    const $filter_input_container = $("#left-sidebar-filter-input").expectOne();
 
     function keydown_enter_key(): void {
+        if (left_sidebar_filter.is_typeahead_shown()) {
+            return;
+        }
         const $row = left_sidebar_cursor.get_key();
 
         if ($row === undefined) {
@@ -901,7 +1000,7 @@ export function set_event_handlers(): void {
         }
         // Clear search input so that there is no confusion
         // about which search input is active.
-        $search_input.val("");
+        left_sidebar_filter.clear_query_text();
         const $nearest_link = $row.find("a").first();
         if ($nearest_link.length > 0) {
             // If the row has a link, we click it.
@@ -925,10 +1024,16 @@ export function set_event_handlers(): void {
                 return true;
             },
             ArrowUp() {
+                if (left_sidebar_filter.is_typeahead_shown()) {
+                    return false;
+                }
                 left_sidebar_cursor.prev();
                 return true;
             },
             ArrowDown() {
+                if (left_sidebar_filter.is_typeahead_shown()) {
+                    return false;
+                }
                 left_sidebar_cursor.next();
                 return true;
             },
@@ -949,7 +1054,11 @@ export function set_event_handlers(): void {
     $search_input.on("focusout", () => {
         left_sidebar_cursor.clear();
     });
-    $search_input.on("input", update_left_sidebar_for_search);
+    $filter_input_container.on("input", update_left_sidebar_for_search);
+    $("#left-sidebar-search .input-close-filter-button").on(
+        "click",
+        left_sidebar_filter.handle_clear_left_sidebar_filter_click,
+    );
 
     // Handle arrow key navigation when a sidebar element has Tab
     // focus, so that Tab and arrow key navigation stay in sync.
@@ -965,7 +1074,7 @@ export function set_event_handlers(): void {
 export function initiate_search(): void {
     popovers.hide_all();
 
-    const $filter = $(".left-sidebar-search-input").expectOne();
+    const $filter = $("#left-sidebar-filter-query").expectOne();
 
     show_left_sidebar();
     $filter.trigger("focus");

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -20,6 +20,7 @@ import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as left_sidebar_filter from "./left_sidebar_filter.ts";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area.ts";
 import {localstorage} from "./localstorage.ts";
 import type {Message} from "./message_store.ts";
@@ -432,9 +433,13 @@ export function build_stream_list(force_rerender: boolean): void {
     const streams = stream_data.subscribed_stream_ids();
     const search_term =
         ui_util.get_left_sidebar_topic_search_term() ?? ui_util.get_left_sidebar_search_term();
-    const stream_groups = stream_list_sort.sort_groups(streams, search_term);
+    const topics_state = left_sidebar_filter.get_effective_topics_state_for_search();
+    const stream_groups = stream_list_sort.sort_groups(streams, search_term, topics_state);
+    const is_stream_name_search_active = search_term !== "";
 
     if (stream_groups.same_as_before && !force_rerender) {
+        set_sections_states();
+        $("#streams_list").toggleClass("is_searching", is_stream_name_search_active);
         return;
     }
 
@@ -502,10 +507,10 @@ export function build_stream_list(force_rerender: boolean): void {
                 section.id !== "pinned-streams",
             );
         }
-        // If a section appears empty, due to only having inactive or muted channels,
-        // we collapse it, since there's nothing to easily see. But don't do this during
-        // search, since sections can enter that state temporarily.
-        if (!searching()) {
+        // If a section appears empty due to only having inactive or muted channels,
+        // we collapse it. But don't do this while stream-name search is active,
+        // since sections can enter that state temporarily.
+        if (!is_stream_name_search_active) {
             if (!is_empty && section.default_visible_streams.length === 0) {
                 collapsed_sections.add(section.id);
                 sections_with_only_inactive_or_muted.add(section.id);
@@ -522,8 +527,8 @@ export function build_stream_list(force_rerender: boolean): void {
     update_stream_section_mention_indicators();
     update_unread_counts_visibility();
     set_sections_states();
-    // Show inactive channels when user starts typing.
-    $("#streams_list").toggleClass("is_searching", ui_util.get_left_sidebar_search_term() !== "");
+    // Show inactive channels only during stream-name search.
+    $("#streams_list").toggleClass("is_searching", is_stream_name_search_active);
 }
 
 export function mention_counts_by_section(): Map<
@@ -1498,7 +1503,13 @@ export function on_sidebar_channel_click(
         const topic_list_info = topic_list_data.get_list_info(
             stream_id,
             false,
-            (topic_names: string[]) => topic_names,
+            (topic_names: string[]) =>
+                topic_list_data.filter_topics_by_search_term(
+                    stream_id,
+                    topic_names,
+                    "",
+                    left_sidebar_filter.get_effective_topics_state_for_search(),
+                ),
         );
         // This initial value handles both the top_topic_in_channel
         // mode as well as the top_unread_topic_in_channel fallback
@@ -1728,14 +1739,21 @@ function toggle_inactive_or_muted_channels($section_container: JQuery): void {
 }
 
 export function searching(): boolean {
-    return $(".left-sidebar-search-input").expectOne().is(":focus");
+    const $pills = $("#left-sidebar-filter-input .pill");
+    return (
+        $("#left-sidebar-filter-query").is(":focus") ||
+        ($pills.length > 0 && $pills.is(":focus"))
+    );
 }
 
 export function clear_search(): void {
-    const $filter = $(".left-sidebar-search-input").expectOne();
-    if ($filter.val() !== "") {
-        $filter.val("");
-        $filter.trigger("input");
+    if (left_sidebar_filter.get_raw_topics_state() !== "") {
+        left_sidebar_filter.clear_left_sidebar_filter();
+        return;
+    }
+    const $filter = $("#left-sidebar-filter-query");
+    if ($filter.text().trim() !== "") {
+        left_sidebar_filter.clear_query();
     }
     $filter.trigger("blur");
 }

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -119,9 +119,38 @@ type StreamListSortResult = {
     sections: StreamListSection[];
 };
 
+function stream_has_matching_topics({
+    stream_id,
+    topic_search_term,
+    topics_state,
+    current_topic_name,
+    is_current_channel,
+}: {
+    stream_id: number;
+    topic_search_term: string;
+    topics_state: string;
+    current_topic_name: string | undefined;
+    is_current_channel: boolean;
+}): boolean {
+    const topics = topic_list_data.get_filtered_topic_names(stream_id, (topic_names) =>
+        topic_list_data.filter_topics_by_search_term(
+            stream_id,
+            topic_names,
+            topic_search_term,
+            topics_state,
+        ),
+    );
+    return topics.some(
+        (topic) =>
+            (is_current_channel && topic.toLowerCase() === current_topic_name) ||
+            !user_topics.is_topic_muted(stream_id, topic),
+    );
+}
+
 export function sort_groups(
     all_subscribed_stream_ids: number[],
     search_term: string,
+    topics_state = "",
 ): StreamListSortResult {
     const pinned_section: StreamListSection = {
         id: "pinned-streams",
@@ -194,19 +223,14 @@ export function sort_groups(
         if (matching_stream_ids.includes(stream_id)) {
             continue;
         }
-        // If any of the unmuted topics of the channel match the search
-        // term, or a muted topic matches the current topic, we include
-        // the channel in the list of matches.
-        const topics = topic_list_data.get_filtered_topic_names(stream_id, (topic_names) =>
-            topic_list_data.filter_topics_by_search_term(stream_id, topic_names, search_term),
-        );
         if (
-            topics.some(
-                (topic) =>
-                    (current_channel_id === stream_id &&
-                        topic.toLowerCase() === current_topic_name) ||
-                    !user_topics.is_topic_muted(stream_id, topic),
-            )
+            stream_has_matching_topics({
+                stream_id,
+                topic_search_term: search_term,
+                topics_state,
+                current_topic_name,
+                is_current_channel: current_channel_id === stream_id,
+            })
         ) {
             matching_stream_ids.push(stream_id);
         }

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -10,6 +10,7 @@ import render_topic_list_new_topic from "../templates/topic_list_new_topic.hbs";
 import * as blueslip from "./blueslip.ts";
 import {Typeahead} from "./bootstrap_typeahead.ts";
 import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
+import * as left_sidebar_filter from "./left_sidebar_filter.ts";
 import {ListCursor} from "./list_cursor.ts";
 import * as mouse_drag from "./mouse_drag.ts";
 import * as popover_menus from "./popover_menus.ts";
@@ -651,6 +652,10 @@ function get_zoomed_topic_search_term(): string {
 
 export function get_typeahead_search_pills_syntax(): string {
     const pills = topic_filter_pill_widget?.items() ?? [];
+
+    if (!zoomed) {
+        return left_sidebar_filter.get_effective_topics_state_for_search();
+    }
 
     if (pills.length === 0) {
         return "";

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -338,10 +338,7 @@ export function enable_element_and_remove_tooltip($element: JQuery): void {
 }
 
 export let get_left_sidebar_search_term = function (): string {
-    const $search_box = $<HTMLInputElement>("input.left-sidebar-search-input").expectOne();
-    const search_term = $search_box.val();
-    assert(search_term !== undefined);
-    return search_term.trim();
+    return $("#left-sidebar-filter-query").expectOne().text().trim();
 };
 
 export function rewire_get_left_sidebar_search_term(
@@ -365,8 +362,8 @@ export function is_topic_search(): boolean {
 }
 
 export function disable_left_sidebar_search(): void {
-    if ($<HTMLInputElement>("#left-sidebar-search input").val()) {
-        // Triggle click on the close button to clear the search term and
+    if (get_left_sidebar_search_term() !== "" || $("#left-sidebar-filter-input .pill").length > 0) {
+        // Trigger click on the close button to clear the search term and
         // update the left sidebar.
         $("#left-sidebar-search .input-close-filter-button").trigger("click");
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -482,6 +482,48 @@
             outline-offset: -2px;
         }
     }
+
+    .left-sidebar-search-section.has-input-pills {
+        .pill-container {
+            grid-area: input-element;
+            padding-left: calc(
+                var(--input-icon-starting-offset) + var(--input-icon-width) +
+                    var(--input-icon-content-gap)
+            );
+            padding-right: calc(
+                var(--input-button-content-gap) + var(--input-button-width) +
+                    var(--input-button-ending-offset)
+            );
+        }
+
+        /* Match the empty filter-input state for the pill container: hide the
+           clear button and remove its reserved padding when there is no value. */
+        &:not(:has(.pill)):has(.input:empty) {
+            .input-element,
+            .pill-container {
+                padding-right: 0.5em;
+            }
+
+            .input-close-filter-button {
+                visibility: hidden;
+            }
+        }
+
+        &:has(.pill),
+        &:has(.input:not(:empty)) {
+            .input-element,
+            .pill-container {
+                padding-right: calc(
+                    var(--input-button-content-gap) + var(--input-button-width) +
+                        var(--input-button-ending-offset)
+                );
+            }
+
+            .input-close-filter-button {
+                visibility: visible;
+            }
+        }
+    }
 }
 
 .stream-list-subsection-header {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,8 +1,10 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-search">
         <div class="input-wrapper-for-tooltip tippy-zulip-delayed-tooltip" data-tooltip-template-id="filter-left-sidebar-tooltip-template">
-            {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section" icon="search" input_button_icon="close"}}
-                <input type="text" class="input-element left-sidebar-search-input" autocomplete="off" placeholder="{{t 'Filter left sidebar' }}" />
+            {{#> components/input_wrapper input_type="filter-input" custom_classes="left-sidebar-search-section has-input-pills" icon="search" input_button_icon="close"}}
+                <div class="input-element pill-container" id="left-sidebar-filter-input">
+                    <div class="input" contenteditable="true" id="left-sidebar-filter-query" data-placeholder="{{t 'Filter left sidebar' }}"></div>
+                </div>
             {{/components/input_wrapper}}
         </div>
         <span id="add_streams_button" class="add-stream-icon-container hidden-for-spectators" tabindex="0">

--- a/web/tests/left_sidebar_filter.test.cjs
+++ b/web/tests/left_sidebar_filter.test.cjs
@@ -1,0 +1,279 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {$t} = require("./lib/i18n.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
+
+const bootstrap_typeahead = mock_esm("../src/bootstrap_typeahead");
+const input_pill = mock_esm("../src/input_pill");
+const state = {
+    narrowed_stream_id: undefined,
+    is_subscribed: false,
+    has_resolved_topics: false,
+    clear_called_with: undefined,
+    append_called_with: undefined,
+    hide_called: false,
+    captured_input: undefined,
+    captured_config: undefined,
+};
+mock_esm("../src/narrow_state", {
+    filter: () => ({}),
+    stream_id: () => state.narrowed_stream_id,
+});
+mock_esm("../src/stream_data", {
+    is_subscribed: () => state.is_subscribed,
+});
+
+mock_esm("../src/stream_topic_history", {
+    stream_has_locally_available_resolved_topics: () => state.has_resolved_topics,
+});
+
+const blueslip = zrequire("blueslip");
+const topic_filter_pill = zrequire("topic_filter_pill");
+const filter_options = topic_filter_pill.filter_options;
+const left_sidebar_filter = zrequire("left_sidebar_filter");
+const filter_placeholder = $t({defaultMessage: "Filter"});
+const default_placeholder = $t({defaultMessage: "Filter left sidebar"});
+
+function set_up(
+    {override},
+    {narrowed_stream_id = undefined, is_subscribed = true, has_resolved_topics = true} = {},
+) {
+    $.reset_selector("#left-sidebar-filter-query");
+    $.reset_selector("#left-sidebar-filter-input");
+    const $input = $("#left-sidebar-filter-query");
+    const $pill_container = $("#left-sidebar-filter-input");
+    $input.text("");
+
+    Object.assign(state, {
+        narrowed_stream_id,
+        is_subscribed,
+        has_resolved_topics,
+        clear_called_with: undefined,
+        append_called_with: undefined,
+        hide_called: false,
+        captured_input: undefined,
+        captured_config: undefined,
+    });
+    const pill_items = [];
+    const handlers = {
+        on_pill_create: noop,
+        on_pill_remove: noop,
+        on_text_input: noop,
+    };
+    const pill_widget = {
+        items() {
+            return pill_items;
+        },
+        clear(suppress) {
+            state.clear_called_with = suppress;
+            pill_items.length = 0;
+        },
+        appendValue(syntax) {
+            state.append_called_with = syntax;
+            pill_items.push({syntax});
+            handlers.on_pill_create();
+        },
+        onPillCreate(callback) {
+            handlers.on_pill_create = callback;
+        },
+        onPillRemove(callback) {
+            handlers.on_pill_remove = callback;
+        },
+        onTextInputHook(callback) {
+            handlers.on_text_input = callback;
+        },
+        createPillonPaste: noop,
+    };
+
+    override(input_pill, "create", (opts) => {
+        assert.equal(opts.$container.selector, "#left-sidebar-filter-input");
+        return pill_widget;
+    });
+
+    function FakeTypeahead(input_element, config) {
+        state.captured_input = input_element;
+        state.captured_config = config;
+        return {
+            hide() {
+                state.hide_called = true;
+            },
+            unlisten: noop,
+        };
+    }
+    override(bootstrap_typeahead, "Typeahead", FakeTypeahead);
+
+    left_sidebar_filter.setup_left_sidebar_filter_typeahead();
+
+    return {
+        $input,
+        $pill_container,
+        pill_items,
+        state,
+        handlers,
+    };
+}
+
+run_test("get_raw_topics_state", ({override}) => {
+    const {pill_items} = set_up({override});
+    assert.equal(left_sidebar_filter.get_raw_topics_state(), "");
+
+    pill_items.push({syntax: "is:resolved"});
+    assert.equal(left_sidebar_filter.get_raw_topics_state(), "is:resolved");
+
+    let warning_message;
+    override(blueslip, "warn", (message) => {
+        warning_message = message;
+    });
+    pill_items.push({syntax: "is:followed"});
+    assert.equal(left_sidebar_filter.get_raw_topics_state(), "is:resolved");
+    assert.equal(warning_message, "Multiple pills found in left sidebar filter input.");
+});
+
+run_test("effective_topics_state_for_search", ({override}) => {
+    const info = set_up({override}, {is_subscribed: false});
+    assert.equal(left_sidebar_filter.get_effective_topics_state_for_search(), "");
+
+    info.pill_items.push({syntax: "is:followed"});
+    info.state.narrowed_stream_id = 5;
+    assert.equal(left_sidebar_filter.get_effective_topics_state_for_search(), "");
+
+    info.state.is_subscribed = true;
+    assert.equal(left_sidebar_filter.get_effective_topics_state_for_search(), "is:followed");
+});
+
+run_test("clear_left_sidebar_filter", ({override}) => {
+    const info = set_up({override});
+    const {$input, $pill_container, state} = info;
+    $input.html("filter");
+
+    const input_events = [];
+    $input.on("blur", () => {
+        input_events.push("blur");
+    });
+
+    const container_events = [];
+    $pill_container.on("input", () => {
+        container_events.push("input");
+    });
+
+    let stop_called = false;
+    const event = {
+        stopPropagation() {
+            stop_called = true;
+        },
+    };
+
+    left_sidebar_filter.handle_clear_left_sidebar_filter_click(event);
+    assert.ok(stop_called);
+    assert.ok(state.hide_called);
+    assert.equal(state.clear_called_with, true);
+    assert.equal($input.html(), "");
+    assert.deepEqual(container_events, ["input"]);
+    assert.deepEqual(input_events, ["blur"]);
+});
+
+run_test("query_helpers", ({override}) => {
+    const info = set_up({override});
+    const {$input, $pill_container, pill_items} = info;
+
+    assert.equal(left_sidebar_filter.has_left_sidebar_filter_value(), false);
+
+    pill_items.push({syntax: "is:resolved"});
+    assert.equal(left_sidebar_filter.has_left_sidebar_filter_value(), true);
+
+    const container_events = [];
+    $pill_container.on("input", () => {
+        container_events.push("input");
+    });
+    $input.html("devel");
+    left_sidebar_filter.clear_query();
+    assert.equal($input.html(), "");
+    assert.deepEqual(container_events, ["input"]);
+});
+
+run_test("typeahead_source_options", ({override}) => {
+    const info = set_up({override});
+    const {$input, state} = info;
+    const source = state.captured_config.source;
+
+    assert.deepEqual(source(), []);
+
+    state.narrowed_stream_id = 42;
+    state.is_subscribed = false;
+    assert.deepEqual(source(), []);
+
+    state.is_subscribed = true;
+    state.has_resolved_topics = false;
+    $input.text("is:");
+    assert.deepEqual(source(), [filter_options[2]]);
+
+    state.has_resolved_topics = true;
+    assert.deepEqual(source(), [filter_options[0], filter_options[1], filter_options[2]]);
+});
+
+run_test("typeahead_updater", ({override}) => {
+    const info = set_up({override});
+    const {$input, state} = info;
+    $input.text("is:res");
+
+    const focus_events = [];
+    $input.on("focus", () => {
+        focus_events.push("focus");
+    });
+
+    const result = state.captured_config.updater(filter_options[1]);
+    assert.equal(result, "");
+    assert.equal(state.clear_called_with, true);
+    assert.equal(state.append_called_with, "is:resolved");
+    assert.deepEqual(focus_events, ["focus"]);
+    assert.equal($input.text(), "");
+});
+
+run_test("typeahead_keydown", ({override}) => {
+    const info = set_up({override});
+    const {$input} = info;
+    const keydown_handler = $input.get_on_handler("keydown");
+
+    for (const key of ["Enter", ","]) {
+        let stop_called = false;
+        let prevent_called = false;
+        keydown_handler({
+            key,
+            stopPropagation() {
+                stop_called = true;
+            },
+            preventDefault() {
+                prevent_called = true;
+            },
+        });
+        assert.ok(stop_called);
+        assert.equal(prevent_called, key === "Enter");
+    }
+});
+
+run_test("placeholder_updates", ({override}) => {
+    const info = set_up({override});
+    const {$input, pill_items, handlers} = info;
+
+    assert.equal($input.attr("data-placeholder"), default_placeholder);
+
+    $input.text("search");
+    handlers.on_text_input();
+    assert.equal($input.attr("data-placeholder"), "");
+
+    $input.text("");
+    handlers.on_text_input();
+    assert.equal($input.attr("data-placeholder"), default_placeholder);
+
+    pill_items.push({syntax: "is:resolved"});
+    handlers.on_pill_create();
+    assert.equal($input.attr("data-placeholder"), filter_placeholder);
+
+    pill_items.pop();
+    handlers.on_pill_remove();
+    assert.equal($input.attr("data-placeholder"), default_placeholder);
+});

--- a/web/tests/lib/zjquery_element.cjs
+++ b/web/tests/lib/zjquery_element.cjs
@@ -162,6 +162,7 @@ class FakeElement extends RejectMissing {
     classList = new FakeClassList();
     dataset = new FakeDataSet(this);
     innerHTML = "never-been-set";
+    scrollTop = 0;
     selectionEnd = undefined;
     selectionStart = undefined;
     style = new FakeStyle();
@@ -768,6 +769,15 @@ exports.FakeJQuery = class extends RejectMissing {
         assert.equal(this.length, 1);
         assert.equal($result.length, 1);
         this[0].previousElementSibling = $result[0];
+    }
+    scrollTop(val) {
+        if (val === undefined) {
+            return this[0]?.scrollTop ?? 0;
+        }
+        for (const element of this) {
+            element.scrollTop = val;
+        }
+        return this;
     }
     show() {
         for (const element of this) {

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -38,6 +38,32 @@ mock_esm("../src/unread", {
     }),
     stream_has_any_unread_mentions: () => stream_has_any_unread_mentions,
     stream_has_any_unmuted_mentions: () => noop,
+    get_missing_topics: () => [],
+    get_topics_with_unread_mentions: () => new Set(),
+    num_unread_for_topic: () => 0,
+    get_channels_with_unread_mentions: () => new Set(),
+    get_channels_with_unmuted_mentions: () => new Set(),
+});
+
+let left_sidebar_topics_state = "";
+mock_esm("../src/left_sidebar_filter", {
+    clear_left_sidebar_filter: () => {
+        $("#left-sidebar-search .input-close-filter-button").trigger("click");
+    },
+    clear_query: () => {
+        $("#left-sidebar-filter-query").empty();
+        $("#left-sidebar-filter-query").text("");
+    },
+    get_effective_topics_state_for_search: () => left_sidebar_topics_state,
+    get_raw_topics_state: () =>
+        $("#left-sidebar-filter-input .pill").length > 0 ? "is:followed" : "",
+});
+
+let browser_history_navigated_to;
+mock_esm("../src/browser_history", {
+    go_to_location: (url) => {
+        browser_history_navigated_to = url;
+    },
 });
 
 const {Filter} = zrequire("../src/filter");
@@ -46,9 +72,11 @@ const stream_data = zrequire("stream_data");
 const stream_list = zrequire("stream_list");
 stream_list.set_update_inbox_channel_view_callback(noop);
 const stream_list_sort = zrequire("stream_list_sort");
+const stream_topic_history = zrequire("stream_topic_history");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 const settings_config = zrequire("settings_config");
+const user_topics = zrequire("user_topics");
 mock_esm("../src/settings_data", {
     user_can_create_private_streams: () => true,
     user_has_permission_for_group_setting: () => true,
@@ -157,6 +185,13 @@ function test_ui(label, f) {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
         stream_list.stream_sidebar.rows.clear();
+        stream_topic_history.reset();
+        user_topics.set_user_topics([]);
+        $("#left-sidebar-filter-query").text("");
+        $.reset_selector("#left-sidebar-filter-input .pill");
+        $.set_results("#left-sidebar-filter-input .pill", []);
+        left_sidebar_topics_state = "";
+        browser_history_navigated_to = undefined;
         f(helpers);
     });
 }
@@ -284,6 +319,150 @@ test_ui("pinned_streams_never_inactive", ({mock_template, override_rewire}) => {
 
     row.update_whether_active();
     assert.ok(!$devel_sidebar.hasClass("inactive_stream"));
+});
+
+test_ui("clear_search", () => {
+    const scenarios = [
+        {
+            search_term: "",
+            has_topic_state_pill: false,
+            expected_filter_events: ["blur"],
+            expected_close_button_events: [],
+        },
+        {
+            search_term: "",
+            has_topic_state_pill: true,
+            expected_filter_events: [],
+            expected_close_button_events: ["click"],
+        },
+    ];
+
+    for (const scenario of scenarios) {
+        $.reset_selector("#left-sidebar-filter-query");
+        $.reset_selector("#left-sidebar-search .input-close-filter-button");
+        $.reset_selector("#left-sidebar-filter-input .pill");
+        $.set_results("#left-sidebar-filter-input .pill", []);
+        const $filter = $("#left-sidebar-filter-query");
+        $filter.text(scenario.search_term);
+        if (scenario.has_topic_state_pill) {
+            const $pill = $.create("left-sidebar-topic-state-pill");
+            $.reset_selector("#left-sidebar-filter-input .pill");
+            $.set_results("#left-sidebar-filter-input .pill", [$pill[0]]);
+        }
+
+        const filter_events = [];
+        $filter.on("blur", () => {
+            filter_events.push("blur");
+        });
+
+        const close_button_events = [];
+        const $close_button = $("#left-sidebar-search .input-close-filter-button");
+        $close_button.on("click", () => {
+            close_button_events.push("click");
+        });
+
+        stream_list.clear_search();
+
+        assert.deepEqual(filter_events, scenario.expected_filter_events);
+        assert.deepEqual(close_button_events, scenario.expected_close_button_events);
+    }
+});
+
+test_ui("searching", () => {
+    const $filter = $("#left-sidebar-filter-query");
+    $.reset_selector("#left-sidebar-filter-input .pill");
+    $.set_results("#left-sidebar-filter-input .pill", []);
+
+    assert.equal(stream_list.searching(), false);
+
+    $filter.trigger("focus");
+    assert.equal(stream_list.searching(), true);
+
+    $filter.trigger("blur");
+    assert.equal(stream_list.searching(), false);
+
+    const $pill = $.create("left-sidebar-topic-state-pill-searching");
+    $.reset_selector("#left-sidebar-filter-input .pill");
+    $.set_results("#left-sidebar-filter-input .pill", [$pill[0]]);
+
+    $pill.trigger("focus");
+    assert.equal(stream_list.searching(), true);
+
+    $pill.trigger("blur");
+    assert.equal(stream_list.searching(), false);
+});
+
+test_ui("on_sidebar_channel_click_with_preserved_topic_state_filter", ({override}) => {
+    stream_data.add_sub_for_tests(develSub);
+
+    override(
+        user_settings,
+        "web_channel_default_view",
+        settings_config.web_channel_default_view_values.top_topic_in_channel.code,
+    );
+
+    const $filter = $("#left-sidebar-filter-query");
+    const scenarios = [
+        {
+            search_term: "de",
+            add_matching_followed_topic() {
+                user_topics.update_user_topics(
+                    develSub.stream_id,
+                    develSub.name,
+                    "topic 2",
+                    user_topics.all_visibility_policies.FOLLOWED,
+                    1,
+                );
+            },
+            expected_topic_name: "topic 2",
+            expected_show_channel_feed_called: false,
+        },
+        {
+            search_term: "",
+            add_matching_followed_topic: noop,
+            expected_topic_name: undefined,
+            expected_show_channel_feed_called: true,
+        },
+    ];
+
+    for (const scenario of scenarios) {
+        left_sidebar_topics_state = "is:followed";
+        $filter.text(scenario.search_term);
+        $filter.html(scenario.search_term);
+
+        stream_topic_history.add_message({
+            stream_id: develSub.stream_id,
+            topic_name: "topic 1",
+            message_id: 1,
+        });
+        stream_topic_history.add_message({
+            stream_id: develSub.stream_id,
+            topic_name: "topic 2",
+            message_id: 2,
+        });
+        scenario.add_matching_followed_topic();
+        const expected_url =
+            scenario.expected_topic_name === undefined
+                ? undefined
+                : stream_topic_history.channel_topic_permalink_hash(
+                      develSub.stream_id,
+                      scenario.expected_topic_name,
+                  );
+
+        let show_channel_feed_called = false;
+        stream_list.on_sidebar_channel_click(develSub.stream_id, null, () => {
+            show_channel_feed_called = true;
+        });
+
+        assert.equal($filter.html(), "");
+        assert.equal(browser_history_navigated_to, expected_url);
+        assert.equal(show_channel_feed_called, scenario.expected_show_channel_feed_called);
+
+        stream_topic_history.reset();
+        user_topics.set_user_topics([]);
+        browser_history_navigated_to = undefined;
+        left_sidebar_topics_state = "";
+    }
 });
 
 function add_row(sub) {

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -18,6 +18,7 @@ const stream_topic_history = zrequire("stream_topic_history");
 const message_lists = zrequire("message_lists");
 const channel_folders = zrequire("channel_folders");
 const ui_util = zrequire("ui_util");
+const user_topics = zrequire("user_topics");
 const {initialize_user_settings} = zrequire("user_settings");
 
 state_data.set_realm(
@@ -179,6 +180,7 @@ function sort_groups(query) {
 function test(label, f) {
     run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
+        user_topics.set_user_topics([]);
         f(helpers);
     });
 }
@@ -554,6 +556,39 @@ test("left_sidebar_search", ({override, override_rewire}) => {
     assert.deepEqual(sorted_sections.length, 2);
     assert.deepEqual(sorted_sections[0].default_visible_streams, []);
     assert.deepEqual(sorted_sections[1].default_visible_streams, []);
+});
+
+test("left_sidebar_topic_state_filter_does_not_filter_stream_rows", () => {
+    add_all_subs();
+
+    {
+        const history = stream_topic_history.find_or_create(scalene.stream_id);
+        history.add_or_update("followed topic", 2);
+    }
+    {
+        const history = stream_topic_history.find_or_create(fast_tortoise.stream_id);
+        history.add_or_update("unfollowed topic", 2);
+    }
+
+    user_topics.update_user_topics(
+        scalene.stream_id,
+        scalene.name,
+        "followed topic",
+        user_topics.all_visibility_policies.FOLLOWED,
+        1,
+    );
+
+    const unfiltered_sections = stream_list_sort.sort_groups(
+        stream_data.subscribed_stream_ids(),
+        "",
+    ).sections;
+    const topic_filtered_sections = stream_list_sort.sort_groups(
+        stream_data.subscribed_stream_ids(),
+        "",
+        "is:followed",
+    ).sections;
+
+    assert.deepEqual(topic_filtered_sections, unfiltered_sections);
 });
 
 test("filter inactives", ({override}) => {


### PR DESCRIPTION
Fixes: #36877

In the filter box at the top of the left sidebar, this PR offers resolved, unresolved, followed, and unfollowed topic filters, sharing the exact same UX and autocomplete behavior as in the "all topics" view.

## Changes

1. **Contenteditable pill input for top left sidebar filter**:
   - `web/templates/left_sidebar.hbs`: Replaced the plain `<input>` with `<div class="input-element pill-container" id="left-sidebar-filter-input"><div class="input" contenteditable="true" id="left-sidebar-filter-query" data-placeholder="{{t 'Filter left sidebar' }}"></div></div>`.
   - `web/styles/left_sidebar.css`: Added styles for `#left-sidebar-search .left-sidebar-search-section.has-input-pills` to support pill containers with leading search icons and trailing close buttons.

2. **Pill widget and typeahead management**:
   - `web/src/left_sidebar_filter.ts`: Created module to manage pill creation via `topic_filter_pill.ts`, typeahead suggestions (`is:resolved`, `-is:resolved`, `is:followed`, `-is:followed`) when narrowed to a subscribed channel, dynamic placeholder updating (`Filter` vs `Filter left sidebar`), and filter clearing.

3. **Filtering and search integration**:
   - `web/src/ui_util.ts`: Updated `get_left_sidebar_search_term` to read from `#left-sidebar-filter-query` and `disable_left_sidebar_search` to check for pills.
   - `web/src/stream_list.ts` & `web/src/stream_list_sort.ts`: Accepted `topics_state` and filtered topics in channel rows accordingly.
   - `web/src/topic_list.ts`: Updated `get_typeahead_search_pills_syntax` to retrieve effective topics state from `left_sidebar_filter` when in unzoomed left sidebar view.
   - `web/src/sidebar_ui.ts`: Initialized filter typeahead, handled typeahead key navigation, and added `refresh_left_sidebar_search_for_narrow_change`.
   - `web/src/message_view.ts` & `web/src/views_util.ts`: Refreshed left sidebar search on narrow and view transitions.

## How changes were tested

- Added unit tests in `web/tests/left_sidebar_filter.test.cjs`:
  - `get_raw_topics_state`
  - `effective_topics_state_for_search`
  - `clear_left_sidebar_filter`
  - `query_helpers`
  - `typeahead_source_options`
  - `typeahead_updater`
  - `typeahead_keydown`
  - `placeholder_updates`
- Added unit tests in `web/tests/stream_list.test.cjs`:
  - `clear_search` (with and without topic state pills)
  - `searching` (input and pill focus)
  - `on_sidebar_channel_click_with_preserved_topic_state_filter`
- Added unit test in `web/tests/stream_list_sort.test.cjs`:
  - `left_sidebar_topic_state_filter_does_not_filter_stream_rows`
- Updated selector in `web/e2e-tests/message-basics.test.ts`.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
