### PR TITLE
condense: Add icons to the show more/less buttons.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -330,6 +330,15 @@
         font-family: inherit;
         font-size: inherit;
 
+        .zulip-icon {
+            /* Nudge the glyph onto the small-caps baseline, and keep it
+               inline rather than making the button a flex container, so
+               the text-overflow: ellipsis above still applies to long
+               translated labels. */
+            vertical-align: -0.1em;
+            margin-right: 3px;
+        }
+
         &:hover {
             background-color: var(
                 --color-show-more-less-button-background-hover

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -5,6 +5,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{else if (eq toggle_type "condenser")}}
@@ -14,6 +15,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
+    <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
     {{ label_text }}
 </button>
 {{/if}}


### PR DESCRIPTION
Adds `zulip-icon-expand` to the "Show more" button and `zulip-icon-collapse` to
the "Show less" button, so it's clear at a glance what clicking will do.

Fixes: #38844

I followed the pattern in `show_inactive_or_muted_channels.hbs`, which already
pairs these two icons with a text label.

One thing worth flagging: the obvious way to place an icon beside text is to make
the button a flex container, but `.message_length_toggle` is `width: 100%` with
`text-overflow: ellipsis`, and `text-overflow` doesn't apply to anonymous flex
items — so flex would silently break truncation for longer translated labels. I
aligned the icon inline with `vertical-align` instead.

**How changes were tested:**

Ran the dev server, posted a long message in #devel to get both states, and checked
light and dark mode. The icon inherits `currentColor`, so dark mode needed no extra
CSS. `./tools/lint` and `./tools/test-js-with-node` both pass.

**Screenshots and screen captures:**

| | Light | Dark |
|---|---|---|
| Show more | ![](https://raw.githubusercontent.com/Aeshvarya/zulip/pr-38844-screenshots/shots/z_more.png) | ![](https://raw.githubusercontent.com/Aeshvarya/zulip/pr-38844-screenshots/shots/z_more_dark.png) |
| Show less | ![](https://raw.githubusercontent.com/Aeshvarya/zulip/pr-38844-screenshots/shots/z_less.png) | ![](https://raw.githubusercontent.com/Aeshvarya/zulip/pr-38844-screenshots/shots/z_less_dark.png) |

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.
- [x] Highlights technical choices and bugs encountered.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.

</details>
