### PR TITLE
Make group mention permission consistent

### DIFF
--- a/api_docs/unmerged.d/ZF-31a8cd.md
+++ b/api_docs/unmerged.d/ZF-31a8cd.md
@@ -1,0 +1,9 @@
+**Feature level ZF-31a8cd**
+
+* [`POST /users/me/subscriptions`](/api/subscribe), [`PATCH
+  /streams/{stream_id}`](/api/update-stream), [`POST
+  /channel_folders/create`](/api/create-channel-folder), [`PATCH
+  /channel_folders/{channel_folder_id}`](/api/update-channel-folder):
+  A channel or channel folder description that mentions a user group
+  which the acting user is not allowed to mention is now rejected,
+  matching the behavior when sending a message.

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1739,7 +1739,7 @@ def check_update_message(
         mention_data = MentionData(
             mention_backend=mention_backend,
             content=message_edit_request.content,
-            message_sender=message.sender,
+            acting_user=message.sender,
         )
         prior_mention_user_ids = get_mentions_for_message_updates(message)
 

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1770,8 +1770,7 @@ def check_update_message(
                 raise TopicWildcardMentionNotAllowedError
 
         if rendering_result.mentions_user_group_ids:
-            mentioned_group_ids = list(rendering_result.mentions_user_group_ids)
-            check_user_group_mention_allowed(user_profile, mentioned_group_ids)
+            check_user_group_mention_allowed(rendering_result.mentions_user_group_ids, mention_data)
 
     if isinstance(message_edit_request, StreamMessageEditRequest):
         user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -687,7 +687,7 @@ def build_message_send_dict(
     mention_data = MentionData(
         mention_backend=mention_backend,
         content=message.content,
-        message_sender=message.sender,
+        acting_user=message.sender,
     )
 
     if message.is_channel_message:

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -2033,8 +2033,8 @@ def check_message(
         raise TopicWildcardMentionNotAllowedError
 
     if message_send_dict.rendering_result.mentions_user_group_ids:
-        mentioned_group_ids = list(message_send_dict.rendering_result.mentions_user_group_ids)
-        check_user_group_mention_allowed(sender, mentioned_group_ids)
+        mentioned_group_ids = message_send_dict.rendering_result.mentions_user_group_ids
+        check_user_group_mention_allowed(mentioned_group_ids, message_send_dict.mention_data)
 
     return message_send_dict
 

--- a/zerver/lib/channel_folders.py
+++ b/zerver/lib/channel_folders.py
@@ -4,6 +4,8 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.markdown import markdown_convert
+from zerver.lib.mention import MentionBackend, MentionData
+from zerver.lib.message import check_user_group_mention_allowed
 from zerver.lib.streams import get_web_public_streams_queryset
 from zerver.lib.string_validation import check_string_is_printable
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -39,9 +41,17 @@ def check_channel_folder_name(name: str, realm: Realm) -> None:
 
 
 def render_channel_folder_description(text: str, realm: Realm, *, acting_user: UserProfile) -> str:
-    return markdown_convert(
-        text, message_realm=realm, no_previews=True, acting_user=acting_user
-    ).rendered_content
+    mention_backend = MentionBackend(realm.id)
+    mention_data = MentionData(mention_backend, text, acting_user)
+    rendering_result = markdown_convert(
+        text,
+        message_realm=realm,
+        no_previews=True,
+        acting_user=acting_user,
+        mention_data=mention_data,
+    )
+    check_user_group_mention_allowed(rendering_result.mentions_user_group_ids, mention_data)
+    return rendering_result.rendered_content
 
 
 def get_channel_folder_data(channel_folder: ChannelFolder) -> ChannelFolderData:

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -98,10 +98,10 @@ class ChannelInfo:
 
 class MentionBackend:
     # Be careful about reuse: MentionBackend contains caches which are
-    # designed to only have the lifespan of a sender user (typically a
+    # designed to only have the lifespan of an acting user (typically a
     # single request).
     #
-    # In particular, user_cache is not robust to message_sender
+    # In particular, user_cache is not robust to acting_user
     # within the lifetime of a single MentionBackend lifetime.
 
     def __init__(self, realm_id: int) -> None:
@@ -111,7 +111,7 @@ class MentionBackend:
         self.topic_cache: dict[ChannelTopicInfo, int | None] = {}
 
     def get_full_name_info_list(
-        self, user_filters: list[UserFilter], message_sender: UserProfile | None
+        self, user_filters: list[UserFilter], acting_user: UserProfile | None
     ) -> list[FullNameInfo]:
         result: list[FullNameInfo] = []
         unseen_user_filters: list[UserFilter] = []
@@ -153,7 +153,7 @@ class MentionBackend:
 
             possible_mention_user_ids = [row.id for row in rows]
             inaccessible_user_ids = get_inaccessible_user_ids(
-                possible_mention_user_ids, message_sender
+                possible_mention_user_ids, acting_user
             )
 
             user_list = [
@@ -345,7 +345,7 @@ def possible_user_group_mentions(content: str) -> dict[str, Literal["silent", "n
 
 
 def get_possible_mentions_info(
-    mention_backend: MentionBackend, mention_texts: set[str], message_sender: UserProfile | None
+    mention_backend: MentionBackend, mention_texts: set[str], acting_user: UserProfile | None
 ) -> list[FullNameInfo]:
     if not mention_texts:
         return []
@@ -369,19 +369,19 @@ def get_possible_mentions_info(
             # For **name** syntax.
             user_filters.append(UserFilter(full_name=mention_text, id=None))
 
-    return mention_backend.get_full_name_info_list(user_filters, message_sender)
+    return mention_backend.get_full_name_info_list(user_filters, acting_user)
 
 
 class MentionData:
     def __init__(
-        self, mention_backend: MentionBackend, content: str, message_sender: UserProfile | None
+        self, mention_backend: MentionBackend, content: str, acting_user: UserProfile | None
     ) -> None:
         self.mention_backend = mention_backend
         realm_id = mention_backend.realm_id
-        self.message_sender = message_sender
+        self.acting_user = acting_user
         mentions = possible_mentions(content)
         possible_mentions_info = get_possible_mentions_info(
-            mention_backend, mentions.mention_texts, message_sender
+            mention_backend, mentions.mention_texts, acting_user
         )
         self.full_name_info = {row.full_name.lower(): row for row in possible_mentions_info}
         self.user_id_info = {row.id: row for row in possible_mentions_info}
@@ -412,16 +412,16 @@ class MentionData:
                 self.user_group_name_info[group.name.lower()] = group
                 self.user_group_names[group.id] = group.name
 
-            # message_sender can be None when mentioning
+            # acting_user can be None when mentioning
             # a group inside a channel/channel folder description,
             # in such case we allow the mention.
             # TODO: This is not consistent, the permission
             # to mention a group must be the same everywhere.
-            if self.message_sender is None:
+            if self.acting_user is None:
                 self.allowed_mention_group_ids = set(self.user_group_names.keys())
             else:
-                self.allowed_mention_group_ids = bulk_get_groups_sender_can_mention(
-                    self.message_sender, named_user_groups
+                self.allowed_mention_group_ids = bulk_get_groups_user_can_mention(
+                    self.acting_user, named_user_groups
                 )
 
             # We only fetch group memberships that can
@@ -506,14 +506,14 @@ def get_user_group_mention_display_name(user_group: NamedUserGroup) -> StrPromis
     return user_group.name
 
 
-def bulk_get_groups_sender_can_mention(
-    sender: UserProfile, named_user_groups: QuerySet[NamedUserGroup]
+def bulk_get_groups_user_can_mention(
+    acting_user: UserProfile, named_user_groups: QuerySet[NamedUserGroup]
 ) -> set[int]:
     # Ids of NamedUserGroup that don't need to be checked against
-    # the sender's permission.
+    # the acting user's permission.
     group_ids_everyone_can_mention = set()
 
-    # NamedUserGroups that must be checked against the sender's permission.
+    # NamedUserGroups that must be checked against the acting user's permission.
     named_groups_requiring_permission_check = set()
 
     for named_group in named_user_groups:
@@ -532,25 +532,25 @@ def bulk_get_groups_sender_can_mention(
 
     setting_config = NamedUserGroup.GROUP_PERMISSION_SETTINGS["can_mention_group"]
 
-    if is_cross_realm_bot_email(sender.delivery_email) or (
-        not setting_config.allow_everyone_group and sender.is_guest
+    if is_cross_realm_bot_email(acting_user.delivery_email) or (
+        not setting_config.allow_everyone_group and acting_user.is_guest
     ):
         return group_ids_everyone_can_mention
 
-    # Ids of all direct and indirect groups the sender is a member of.
+    # Ids of all direct and indirect groups the acting user is a member of.
     user_recursive_group_ids = set(
-        get_recursive_membership_groups(sender).values_list("id", flat=True)
+        get_recursive_membership_groups(acting_user).values_list("id", flat=True)
     )
 
-    # The sender can mention a named_group if they are direct/indirect member
-    # of that named_group.can_mention_group.
-    group_ids_sender_can_mention = {
+    # The acting user can mention a named_group if they are direct/indirect
+    # member of that named_group.can_mention_group.
+    group_ids_user_can_mention = {
         named_group.id
         for named_group in named_groups_requiring_permission_check
         if named_group.can_mention_group_id in user_recursive_group_ids
     }
 
-    # The sender is allowed to mention a NamedUserGroup if that group:
+    # The acting user is allowed to mention a NamedUserGroup if that group:
     # 1- already allows mention by everyone.
-    # 2- required permission check and have passed it for that sender.
-    return group_ids_everyone_can_mention | group_ids_sender_can_mention
+    # 2- required permission check and have passed it for that user.
+    return group_ids_everyone_can_mention | group_ids_user_can_mention

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -6,7 +6,7 @@ from re import Match
 from typing import Literal
 
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django_stubs_ext import StrPromise
 
 from zerver.lib.streams import get_content_access_streams
@@ -14,8 +14,8 @@ from zerver.lib.topic import get_latest_message_for_user_in_topic
 from zerver.lib.types import UserDisplayRecipient
 from zerver.lib.user_groups import (
     UserGroupMembershipDetails,
+    get_recursive_membership_groups,
     get_root_id_annotated_recursive_subgroups_for_groups,
-    user_has_permission_for_group_setting,
 )
 from zerver.lib.users import get_inaccessible_user_ids
 from zerver.models import NamedUserGroup, UserProfile
@@ -397,37 +397,54 @@ class MentionData:
 
     def init_user_group_data(self, realm_id: int, content: str) -> None:
         self.user_group_name_info: dict[str, NamedUserGroup] = {}
+        self.user_group_names: dict[int, str] = {}
         self.user_group_members: dict[int, set[int]] = defaultdict(set)
+        self.allowed_mention_group_ids: set[int] = set()
         user_group_names_mentions = possible_user_group_mentions(content)
         if user_group_names_mentions:
             named_user_groups = NamedUserGroup.objects.filter(
                 realm_for_sharding_id=realm_id, name__in=user_group_names_mentions
-            )
+            ).select_related("can_mention_group", "can_mention_group__named_user_group")
 
-            # No filter here as we need user_group_name_info for all groups mentions.
-            self.user_group_name_info = {group.name.lower(): group for group in named_user_groups}
+            # No filter here as we need user_group_name_info
+            # and user_group_names for all groups mentions.
+            for group in named_user_groups:
+                self.user_group_name_info[group.name.lower()] = group
+                self.user_group_names[group.id] = group.name
 
-            # We only fetch group membership mentions that can
+            # message_sender can be None when mentioning
+            # a group inside a channel/channel folder description,
+            # in such case we allow the mention.
+            # TODO: This is not consistent, the permission
+            # to mention a group must be the same everywhere.
+            if self.message_sender is None:
+                self.allowed_mention_group_ids = set(self.user_group_names.keys())
+            else:
+                self.allowed_mention_group_ids = bulk_get_groups_sender_can_mention(
+                    self.message_sender, named_user_groups
+                )
+
+            # We only fetch group memberships that can
             # possibly trigger notifications.
-            filtered_group_ids = [
+            group_ids_to_fetch_membership_for = [
                 group.id
                 for group in named_user_groups
                 if not group.deactivated
                 and user_group_names_mentions.get(group.name) == "non-silent"
+                and group.id in self.allowed_mention_group_ids
             ]
 
             # Avoid doing a database query if there's nothing to fetch.
-            #
-            # This isn't quite optimal -- we've not checked our user
-            # has permission to mention the group yet.
-            if len(filtered_group_ids) == 0:
+            if len(group_ids_to_fetch_membership_for) == 0:
                 return
 
             # Fetch membership for the groups filtered above in a
             # single, efficient bulk query, mapping each group to its
             # direct and indirect members.
             for group_root_id, member_id in (
-                get_root_id_annotated_recursive_subgroups_for_groups(filtered_group_ids, realm_id)
+                get_root_id_annotated_recursive_subgroups_for_groups(
+                    group_ids_to_fetch_membership_for, realm_id
+                )
                 .filter(direct_members__is_active=True)
                 .values_list("root_id", "direct_members")  # type: ignore[misc]  # root_id is an annotated field.
             ):
@@ -453,6 +470,9 @@ class MentionData:
 
     def get_user_group(self, name: str) -> NamedUserGroup | None:
         return self.user_group_name_info.get(name.lower(), None)
+
+    def get_user_group_name(self, group_id: int) -> str:
+        return self.user_group_names.get(group_id, "")
 
     def get_group_members(self, user_group_id: int) -> set[int]:
         return self.user_group_members.get(user_group_id, set())
@@ -486,23 +506,51 @@ def get_user_group_mention_display_name(user_group: NamedUserGroup) -> StrPromis
     return user_group.name
 
 
-def sender_can_mention_group(sender: UserProfile | None, named_group: NamedUserGroup) -> bool:
-    can_mention_group = named_group.can_mention_group
+def bulk_get_groups_sender_can_mention(
+    sender: UserProfile, named_user_groups: QuerySet[NamedUserGroup]
+) -> set[int]:
+    # Ids of NamedUserGroup that don't need to be checked against
+    # the sender's permission.
+    group_ids_everyone_can_mention = set()
 
-    if (
-        hasattr(can_mention_group, "named_user_group")
-        and can_mention_group.named_user_group.name == SystemGroups.EVERYONE
+    # NamedUserGroups that must be checked against the sender's permission.
+    named_groups_requiring_permission_check = set()
+
+    for named_group in named_user_groups:
+        can_mention_group = named_group.can_mention_group
+
+        if (
+            hasattr(can_mention_group, "named_user_group")
+            and can_mention_group.named_user_group.name == SystemGroups.EVERYONE
+        ):
+            group_ids_everyone_can_mention.add(named_group.id)
+        else:
+            named_groups_requiring_permission_check.add(named_group)
+
+    if not named_groups_requiring_permission_check:
+        return group_ids_everyone_can_mention
+
+    setting_config = NamedUserGroup.GROUP_PERMISSION_SETTINGS["can_mention_group"]
+
+    if is_cross_realm_bot_email(sender.delivery_email) or (
+        not setting_config.allow_everyone_group and sender.is_guest
     ):
-        return True
+        return group_ids_everyone_can_mention
 
-    assert sender is not None
-
-    if is_cross_realm_bot_email(sender.delivery_email):
-        return False
-
-    return user_has_permission_for_group_setting(
-        can_mention_group.id,
-        sender,
-        NamedUserGroup.GROUP_PERMISSION_SETTINGS["can_mention_group"],
-        direct_member_only=False,
+    # Ids of all direct and indirect groups the sender is a member of.
+    user_recursive_group_ids = set(
+        get_recursive_membership_groups(sender).values_list("id", flat=True)
     )
+
+    # The sender can mention a named_group if they are direct/indirect member
+    # of that named_group.can_mention_group.
+    group_ids_sender_can_mention = {
+        named_group.id
+        for named_group in named_groups_requiring_permission_check
+        if named_group.can_mention_group_id in user_recursive_group_ids
+    }
+
+    # The sender is allowed to mention a NamedUserGroup if that group:
+    # 1- already allows mention by everyone.
+    # 2- required permission check and have passed it for that sender.
+    return group_ids_everyone_can_mention | group_ids_sender_can_mention

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -412,11 +412,10 @@ class MentionData:
                 self.user_group_name_info[group.name.lower()] = group
                 self.user_group_names[group.id] = group.name
 
-            # acting_user can be None when mentioning
-            # a group inside a channel/channel folder description,
-            # in such case we allow the mention.
-            # TODO: This is not consistent, the permission
-            # to mention a group must be the same everywhere.
+            # acting_user is None when rendering content that no
+            # user is responsible for such as a realm description or
+            # data imported from another chat product; we allow
+            # mentions in those cases.
             if self.acting_user is None:
                 self.allowed_mention_group_ids = set(self.user_group_names.keys())
             else:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -18,7 +18,7 @@ from zerver.lib.cache import generic_bulk_cached_fetch, to_dict_cache_key_id
 from zerver.lib.display_recipient import get_display_recipient_by_id
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
 from zerver.lib.markdown import MessageRenderingResult
-from zerver.lib.mention import MentionData, sender_can_mention_group, silent_mention_syntax_for_user
+from zerver.lib.mention import MentionData, silent_mention_syntax_for_user
 from zerver.lib.message_cache import MessageDict, extract_message_dict, stringify_message_dict
 from zerver.lib.partial import partial
 from zerver.lib.request import RequestVariableConversionError
@@ -46,7 +46,6 @@ from zerver.lib.user_topics import build_get_topic_visibility_policy, get_topic_
 from zerver.lib.users import get_inaccessible_user_ids
 from zerver.models import (
     Message,
-    NamedUserGroup,
     Realm,
     Recipient,
     Stream,
@@ -1521,16 +1520,14 @@ def stream_wildcard_mention_allowed(sender: UserProfile, stream: Stream, realm: 
     return can_mention_many_users(sender)
 
 
-def check_user_group_mention_allowed(sender: UserProfile, user_group_ids: list[int]) -> None:
-    user_groups = NamedUserGroup.objects.filter(id__in=user_group_ids).select_related(
-        "can_mention_group", "can_mention_group__named_user_group"
-    )
-
-    for group in user_groups:
-        if not sender_can_mention_group(sender, group):
+def check_user_group_mention_allowed(
+    mentioned_group_ids: set[int], mention_data: MentionData
+) -> None:
+    for group_id in mentioned_group_ids:
+        if group_id not in mention_data.allowed_mention_group_ids:
             raise JsonableError(
                 _("You are not allowed to mention user group '{user_group_name}'.").format(
-                    user_group_name=group.name
+                    user_group_name=mention_data.get_user_group_name(group_id)
                 )
             )
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -209,10 +209,20 @@ def render_stream_description(
     text: str, realm: Realm, *, acting_user: UserProfile | None = None
 ) -> str:
     from zerver.lib.markdown import markdown_convert
+    from zerver.lib.mention import MentionBackend, MentionData
+    from zerver.lib.message import check_user_group_mention_allowed
 
-    return markdown_convert(
-        text, message_realm=realm, no_previews=True, acting_user=acting_user
-    ).rendered_content
+    mention_backend = MentionBackend(realm.id)
+    mention_data = MentionData(mention_backend, text, acting_user)
+    rendering_result = markdown_convert(
+        text,
+        message_realm=realm,
+        no_previews=True,
+        acting_user=acting_user,
+        mention_data=mention_data,
+    )
+    check_user_group_mention_allowed(rendering_result.mentions_user_group_ids, mention_data)
+    return rendering_result.rendered_content
 
 
 def send_stream_creation_event(

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13173,6 +13173,10 @@ paths:
                           The [description](/help/change-the-channel-description)
                           to use for a new channel being created, in text/markdown format.
 
+                          **Changes**: Before Zulip 13.0 (feature level ZF-31a8cd), a
+                          description could mention any user group, ignoring the group's
+                          `can_mention_group` setting.
+
                           See the help center article on [message formatting](/help/format-your-message-using-markdown) for details on Zulip-flavored Markdown.
 
                           Clients should use the `max_stream_description_length` returned
@@ -24669,7 +24673,11 @@ paths:
                     by the [`POST /register`](/api/register-queue) endpoint to
                     determine the maximum channel description length.
 
-                    **Changes**: Removed unnecessary JSON-encoding of this parameter in
+                    **Changes**: Before Zulip 13.0 (feature level ZF-31a8cd), a
+                    description could mention any user group, ignoring the group's
+                    `can_mention_group` setting.
+
+                    Removed unnecessary JSON-encoding of this parameter in
                     Zulip 4.0 (feature level 64).
                   type: string
                   example: "Discuss Italian history and travel destinations."
@@ -26792,6 +26800,10 @@ paths:
                     Note that this parameter must be passed as part of the request,
                     but can be an empty string if no description for the new channel
                     folder is desired.
+
+                    **Changes**: Before Zulip 13.0 (feature level ZF-31a8cd), a
+                    description could mention any user group, ignoring the group's
+                    `can_mention_group` setting.
                   type: string
                   example: Channels for marketing.
               required:
@@ -27009,6 +27021,10 @@ paths:
                     Clients should use the `max_channel_folder_description_length`
                     returned by the [`POST /register`](/api/register-queue) endpoint
                     to determine the maximum channel folder description length.
+
+                    **Changes**: Before Zulip 13.0 (feature level ZF-31a8cd), a
+                    description could mention any user group, ignoring the group's
+                    `can_mention_group` setting.
                   type: string
                   example: Backend channels.
                 is_archived:

--- a/zerver/tests/test_channel_folders.py
+++ b/zerver/tests/test_channel_folders.py
@@ -9,6 +9,11 @@ from zerver.actions.channel_folders import (
     try_reorder_realm_channel_folders,
 )
 from zerver.actions.streams import do_change_stream_folder, do_deactivate_stream
+from zerver.actions.user_groups import (
+    bulk_add_members_to_user_groups,
+    check_add_user_group,
+    do_change_user_group_permission_setting,
+)
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import ChannelFolder
 from zerver.models.realms import get_realm
@@ -375,6 +380,56 @@ class UpdateChannelFoldersTest(ChannelFoldersTestCase):
         self.assert_json_success(result)
         channel_folder = ChannelFolder.objects.get(id=channel_folder_id)
         self.assertTrue(channel_folder.is_archived)
+
+    def test_user_group_mention_in_channel_folder_description(self) -> None:
+        realm = get_realm("zulip")
+        aaron = self.example_user("aaron")
+        iago = self.example_user("iago")
+        othello = self.example_user("othello")
+        self.login_user(iago)
+
+        test_group = check_add_user_group(realm, "test_group", [aaron], acting_user=othello)
+        channel_folder = ChannelFolder.objects.get(name="Frontend", realm=realm)
+
+        description = "Ask @*test_group* for help"
+        # iago can mention test_group by default.
+        result = self.client_patch(
+            f"/json/channel_folders/{channel_folder.id}",
+            {"description": description},
+        )
+        self.assert_json_success(result)
+        channel_folder.refresh_from_db()
+        self.assertEqual(
+            channel_folder.rendered_description,
+            f'<p>Ask <span class="user-group-mention" data-user-group-id="{test_group.id}">@test_group</span> for help</p>',
+        )
+
+        # Restrict mentioning test_group to its own members, which iago is not.
+        do_change_user_group_permission_setting(
+            test_group, "can_mention_group", test_group, acting_user=None
+        )
+        # Change description, since an unchanged description is not
+        # re-rendered.
+        description = "Can I ask @*test_group* for help?"
+        # iago is now NOT allowed to mention the group inside a channel folder description.
+        result = self.client_patch(
+            f"/json/channel_folders/{channel_folder.id}",
+            {"description": description},
+        )
+        self.assert_json_error(result, "You are not allowed to mention user group 'test_group'.")
+
+        # Add iago to test_group, to regain mention permission.
+        bulk_add_members_to_user_groups([test_group], [iago.id], acting_user=othello)
+        result = self.client_patch(
+            f"/json/channel_folders/{channel_folder.id}",
+            {"description": description},
+        )
+        self.assert_json_success(result)
+        channel_folder.refresh_from_db()
+        self.assertEqual(
+            channel_folder.rendered_description,
+            f'<p>Can I ask <span class="user-group-mention" data-user-group-id="{test_group.id}">@test_group</span> for help?</p>',
+        )
 
 
 class ReorderChannelFolderTest(ChannelFoldersTestCase):

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -690,7 +690,7 @@ class NormalActionsTest(BaseAction):
         mention_data = MentionData(
             mention_backend=mention_backend,
             content=content,
-            message_sender=self.example_user("cordelia"),
+            acting_user=self.example_user("cordelia"),
         )
 
         message_edit_request = build_message_edit_request(
@@ -1002,7 +1002,7 @@ class NormalActionsTest(BaseAction):
         mention_data = MentionData(
             mention_backend=mention_backend,
             content=content,
-            message_sender=iago,
+            acting_user=iago,
         )
 
         message_edit_request = build_message_edit_request(
@@ -1073,7 +1073,7 @@ class NormalActionsTest(BaseAction):
         mention_data = MentionData(
             mention_backend=MentionBackend(message.realm_id),
             content=content,
-            message_sender=message.sender,
+            acting_user=message.sender,
         )
         rendering_result = render_message_markdown(message, content, mention_data=mention_data)
         with self.verify_action(state_change_expected=False) as events:

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -25,6 +25,7 @@ from zerver.actions.streams import do_change_stream_group_based_setting
 from zerver.actions.user_groups import (
     add_subgroups_to_user_group,
     check_add_user_group,
+    do_change_user_group_permission_setting,
     do_deactivate_user_group,
 )
 from zerver.actions.user_settings import do_change_user_setting
@@ -313,23 +314,6 @@ class MarkdownMiscTest(ZulipTestCase):
         mention_data = MentionData(mention_backend, content, message_sender=None)
         self.assertEqual(mention_data.get_group_members(group.id), {hamlet.id})
 
-    def test_bulk_user_group_mentions(self) -> None:
-        realm = get_realm("zulip")
-        hamlet = self.example_user("hamlet")
-        cordelia = self.example_user("cordelia")
-        othello = self.example_user("othello")
-        mention_backend = MentionBackend(realm.id)
-
-        content = ""
-        for i in range(5):
-            group_name = f"group{i}"
-            check_add_user_group(realm, group_name, [hamlet, cordelia], acting_user=othello)
-            content += f" @*{group_name}*"
-
-        CONSTANT_QUERY_COUNT = 2  # even if it increases in future, make sure it's constant.
-        with self.assert_database_query_count(CONSTANT_QUERY_COUNT):
-            MentionData(mention_backend, content, message_sender=None)
-
     def test_mention_user_groups_with_common_subgroup(self) -> None:
         # Mention multiple groups (class-A and class-B) with a common sub-group (good-students)
         # and make sure each mentioned group has the expected members
@@ -397,6 +381,155 @@ class MarkdownMiscTest(ZulipTestCase):
         content = "@_*hamletcharacters*, @*hamletcharacters*"
         mention_data = MentionData(mention_backend, content, message_sender=None)
         self.assertEqual(mention_data.get_group_members(hamlet_group.id), {hamlet.id, cordelia.id})
+
+    def test_fetch_group_membership_when_mention_group_permission_changes(self) -> None:
+        # Test we ONLY fetch group membership when sender
+        # is allowed, via direct/indirect membership, to mention that group.
+        # This also tests an edge case where a sender's permission changes
+        # (i.e. they can't mention that group) while sending the message
+        # and after writing @group_name in compose box,
+        # in which case we should NOT fetch membership.
+        realm = get_realm("zulip")
+
+        # hamlet_group members
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        iago = self.example_user("iago")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        prospero = self.example_user("prospero")
+        othello = self.example_user("othello")
+
+        mention_backend = MentionBackend(realm.id)
+        test_group = check_add_user_group(realm, "test_group", [aaron], acting_user=iago)
+
+        sub_group_lvl_1 = check_add_user_group(realm, "sub_group_lvl_1", [zoe], acting_user=iago)
+        sub_group_lvl_2 = check_add_user_group(
+            realm, "sub_group_lvl_2", [prospero], acting_user=iago
+        )
+        hamlet_group = NamedUserGroup.objects.get(realm=realm, name="hamletcharacters")
+        content = "@*hamletcharacters*"
+        hamlet_members_ids = {hamlet.id, cordelia.id}
+
+        # Change permission, so that only test_group (with aaron being the only member)
+        # can mention hamlet_group.
+        do_change_user_group_permission_setting(
+            hamlet_group,
+            "can_mention_group",
+            test_group,
+            acting_user=None,
+        )
+
+        # We should fetch group membership when sender (aaron) is allowed to mention the group.
+        mention_data = MentionData(mention_backend, content, message_sender=aaron)
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+
+        # We should NOT fetch group membership when sender is NOT allowed
+        # (only aaron is allowed at this point) to mention the group.
+        mention_data = MentionData(mention_backend, content, message_sender=othello)
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), set())
+
+        # Add 2 levels of sub-groups to test_group.
+        add_subgroups_to_user_group(test_group, [sub_group_lvl_1], acting_user=iago)
+        add_subgroups_to_user_group(sub_group_lvl_1, [sub_group_lvl_2], acting_user=iago)
+
+        # 3 senders (which are direct/indirect members of test_group)
+        # mention hamlet_group.
+        aaron_mention_data = MentionData(mention_backend, content, message_sender=aaron)
+        zoe_mention_data = MentionData(mention_backend, content, message_sender=zoe)
+        prospero_mention_data = MentionData(mention_backend, content, message_sender=prospero)
+
+        # We should fetch group membership, as all senders are allowed to mention that group.
+        self.assertEqual(aaron_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(zoe_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(
+            prospero_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids
+        )
+
+    def test_fetch_group_membership_for_bulk_mention_groups(self) -> None:
+        # Same as test_fetch_group_membership_when_mention_group_permission_changes
+        # but for bulk mentioning groups in a single message.
+        # This test ensures we do the permission check for bulk groups mentions correctly
+        # and in a constant time.
+        realm = get_realm("zulip")
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        hamlet_members_ids = {hamlet.id, cordelia.id}
+        iago = self.example_user("iago")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        othello = self.example_user("othello")
+
+        mention_backend = MentionBackend(realm.id)
+
+        test_group = check_add_user_group(realm, "can_mention_group", [aaron], acting_user=iago)
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm=realm, is_system_group=True
+        )
+        sub_group = check_add_user_group(realm, "sub_group", [zoe], acting_user=iago)
+        add_subgroups_to_user_group(test_group, [sub_group], acting_user=iago)
+        hamlet_group = NamedUserGroup.objects.get(realm=realm, name="hamletcharacters")
+
+        content = "@*hamletcharacters*, "
+        mentioned_groups = []
+
+        for i in range(6):
+            group_name = f"group_{i}"
+            group = check_add_user_group(realm, group_name, [othello], acting_user=iago)
+            mentioned_groups.append(group)
+            content += f"@*{group_name}*, "
+
+        # Bulk mention groups with the default mention permission i.e. SystemGroups.EVERYONE.
+        # We make sure it's constant.
+        with self.assert_database_query_count(2):
+            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+
+        # We should fetch group memberships for all mentioned groups,
+        # since the default is to allow mention by all.
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        for group in mentioned_groups:
+            self.assertEqual(mention_data.get_group_members(group.id), {othello.id})
+
+        # Now, change the default permission for each group to allow some groups
+        # to be mentioned by the sender "zoe" through test_group,
+        # but prevent other groups through moderators_group. This way we can test that
+        # our algorithm correctly and efficiently does the permission
+        # check against different mention permissions for different groups.
+        for i, group in enumerate(mentioned_groups):
+            if i % 2 == 0:
+                do_change_user_group_permission_setting(
+                    group,
+                    "can_mention_group",
+                    test_group,
+                    acting_user=None,
+                )
+            else:
+                do_change_user_group_permission_setting(
+                    group,
+                    "can_mention_group",
+                    moderators_group,
+                    acting_user=None,
+                )
+
+        # Bulk mention groups that have different (non default) mention permissions.
+        # This is one extra query than the previous case which is
+        # triggered when any or all mentioned group/s needs
+        # a permission check (e.g. not SystemGroups.EVERYONE).
+        # Again, we make sure it's constant.
+        with self.assert_database_query_count(3):
+            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+
+        # We should fetch group membership, ONLY for groups the sender "zoe" is allowed
+        # to mention.
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[0].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[1].id), set())
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[2].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[3].id), set())
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[4].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[5].id), set())
 
     def test_invalid_katex_path(self) -> None:
         with self.settings(DEPLOY_ROOT="/nonexistent"):

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -251,7 +251,7 @@ class MarkdownMiscTest(ZulipTestCase):
         lst = get_possible_mentions_info(
             mention_backend,
             {"Fred Flintstone", "Cordelia, LEAR's daughter", "Not A User"},
-            message_sender=None,
+            acting_user=None,
         )
         set_of_names = {x.full_name.lower() for x in lst}
         self.assertEqual(set_of_names, {"fred flintstone", "cordelia, lear's daughter"})
@@ -280,7 +280,7 @@ class MarkdownMiscTest(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         content = "@**King Hamlet** @**Cordelia, lear's daughter**"
         mention_backend = MentionBackend(realm.id)
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         self.assertEqual(mention_data.get_user_ids(), {hamlet.id, cordelia.id})
         self.assertEqual(
             mention_data.get_user_by_id(hamlet.id),
@@ -297,21 +297,21 @@ class MarkdownMiscTest(ZulipTestCase):
 
         self.assertFalse(mention_data.message_has_stream_wildcards())
         content = "@**King Hamlet** @**Cordelia, lear's daughter** @**all**"
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         self.assertTrue(mention_data.message_has_stream_wildcards())
 
         self.assertFalse(mention_data.message_has_topic_wildcards())
         content = "@**King Hamlet** @**Cordelia, lear's daughter** @**topic**"
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         self.assertTrue(mention_data.message_has_topic_wildcards())
 
         content = "@*hamletcharacters*"
         group = NamedUserGroup.objects.get(realm_for_sharding=realm, name="hamletcharacters")
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         self.assertEqual(mention_data.get_group_members(group.id), {hamlet.id, cordelia.id})
 
         change_user_is_active(cordelia, False)
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         self.assertEqual(mention_data.get_group_members(group.id), {hamlet.id})
 
     def test_mention_user_groups_with_common_subgroup(self) -> None:
@@ -337,7 +337,7 @@ class MarkdownMiscTest(ZulipTestCase):
 
         content = "@*class-A*  @*class-B*"
         mention_backend = MentionBackend(realm.id)
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
 
         # both groups should have their direct members and the sub-group's members.
         self.assertEqual(mention_data.get_group_members(class_A.id), {iago.id, aaron.id, hamlet.id})
@@ -361,7 +361,7 @@ class MarkdownMiscTest(ZulipTestCase):
 
         # mention zulip_group, but silent mention hamlet_group.
         content = "@*zulip_group*, @_*hamletcharacters*"
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
 
         # non-silent mention should fetch group membership.
         self.assertEqual(mention_data.get_group_members(zulip_group.id), {iago.id, aaron.id})
@@ -374,12 +374,12 @@ class MarkdownMiscTest(ZulipTestCase):
 
         # non-silent before silent.
         content = "@*hamletcharacters*, @_*hamletcharacters*"
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         self.assertEqual(mention_data.get_group_members(hamlet_group.id), {hamlet.id, cordelia.id})
 
         # non-silent after silent.
         content = "@_*hamletcharacters*, @*hamletcharacters*"
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         self.assertEqual(mention_data.get_group_members(hamlet_group.id), {hamlet.id, cordelia.id})
 
     def test_fetch_group_membership_when_mention_group_permission_changes(self) -> None:
@@ -422,12 +422,12 @@ class MarkdownMiscTest(ZulipTestCase):
         )
 
         # We should fetch group membership when sender (aaron) is allowed to mention the group.
-        mention_data = MentionData(mention_backend, content, message_sender=aaron)
+        mention_data = MentionData(mention_backend, content, acting_user=aaron)
         self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
 
         # We should NOT fetch group membership when sender is NOT allowed
         # (only aaron is allowed at this point) to mention the group.
-        mention_data = MentionData(mention_backend, content, message_sender=othello)
+        mention_data = MentionData(mention_backend, content, acting_user=othello)
         self.assertEqual(mention_data.get_group_members(hamlet_group.id), set())
 
         # Add 2 levels of sub-groups to test_group.
@@ -436,9 +436,9 @@ class MarkdownMiscTest(ZulipTestCase):
 
         # 3 senders (which are direct/indirect members of test_group)
         # mention hamlet_group.
-        aaron_mention_data = MentionData(mention_backend, content, message_sender=aaron)
-        zoe_mention_data = MentionData(mention_backend, content, message_sender=zoe)
-        prospero_mention_data = MentionData(mention_backend, content, message_sender=prospero)
+        aaron_mention_data = MentionData(mention_backend, content, acting_user=aaron)
+        zoe_mention_data = MentionData(mention_backend, content, acting_user=zoe)
+        prospero_mention_data = MentionData(mention_backend, content, acting_user=prospero)
 
         # We should fetch group membership, as all senders are allowed to mention that group.
         self.assertEqual(aaron_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
@@ -484,7 +484,7 @@ class MarkdownMiscTest(ZulipTestCase):
         # Bulk mention groups with the default mention permission i.e. SystemGroups.EVERYONE.
         # We make sure it's constant.
         with self.assert_database_query_count(2):
-            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+            mention_data = MentionData(mention_backend, content, acting_user=zoe)
 
         # We should fetch group memberships for all mentioned groups,
         # since the default is to allow mention by all.
@@ -519,7 +519,7 @@ class MarkdownMiscTest(ZulipTestCase):
         # a permission check (e.g. not SystemGroups.EVERYONE).
         # Again, we make sure it's constant.
         with self.assert_database_query_count(3):
-            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+            mention_data = MentionData(mention_backend, content, acting_user=zoe)
 
         # We should fetch group membership, ONLY for groups the sender "zoe" is allowed
         # to mention.
@@ -2708,7 +2708,7 @@ class MarkdownMentionTest(ZulipTestCase):
         content = f"@**{aaron.full_name}**, @_**{hamlet.full_name}**, @**|{cordelia.id}**, @_**|{othello.id}**"
 
         mention_backend = MentionBackend(realm.id)
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
 
         # user_ids of all the mentioned users, by different mention types,
         # should be captured in mention_data.get_user_ids().
@@ -3631,7 +3631,7 @@ class MarkdownStreamTopicMentionTests(ZulipTestCase):
         # test caching of topic data for user.
         content = "#**Denmark>some topic**"
         mention_backend = MentionBackend(realm.id)
-        mention_data = MentionData(mention_backend, content, message_sender=None)
+        mention_data = MentionData(mention_backend, content, acting_user=None)
         render_message_markdown(msg, content, mention_data=mention_data)
 
         with (
@@ -3652,7 +3652,7 @@ class MarkdownStreamTopicMentionTests(ZulipTestCase):
         )
 
         # Test when trying to render a topic link of a channel with shared
-        # history, if message_sender is None, topic link is permalink.
+        # history, if acting_user is None, topic link is permalink.
         content = "#**Denmark>some topic**"
         self.assertEqual(
             markdown_convert_wrapper(content),
@@ -3726,7 +3726,7 @@ class MarkdownStreamTopicMentionTests(ZulipTestCase):
         )
 
         # Test when trying to render a topic link of a channel with protected
-        # history, if message_sender is None, topic link is not permalink.
+        # history, if acting_user is None, topic link is not permalink.
         content = "#**core>testing**"
         self.assertEqual(
             markdown_convert_wrapper(content),

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -386,7 +386,7 @@ class TestNotificationData(ZulipTestCase):
         result = get_user_group_mentions_data(
             mentioned_user_ids=set(),
             mentioned_user_group_ids=[],
-            mention_data=MentionData(mention_backend, "no group mentioned", message_sender=None),
+            mention_data=MentionData(mention_backend, "no group mentioned", acting_user=None),
         )
         self.assertDictEqual(result, {})
 
@@ -395,7 +395,7 @@ class TestNotificationData(ZulipTestCase):
             mentioned_user_ids=set(),
             mentioned_user_group_ids=[hamlet_and_cordelia.id],
             mention_data=MentionData(
-                mention_backend, "hey @*hamlet_and_cordelia*!", message_sender=None
+                mention_backend, "hey @*hamlet_and_cordelia*!", acting_user=None
             ),
         )
         self.assertDictEqual(
@@ -414,7 +414,7 @@ class TestNotificationData(ZulipTestCase):
             mention_data=MentionData(
                 mention_backend,
                 "hey @*hamlet_and_cordelia* and @*hamlet_only*",
-                message_sender=None,
+                acting_user=None,
             ),
         )
         self.assertDictEqual(
@@ -433,7 +433,7 @@ class TestNotificationData(ZulipTestCase):
             mention_data=MentionData(
                 mention_backend,
                 "hey @*hamlet_only* and @*hamlet_and_cordelia*",
-                message_sender=None,
+                acting_user=None,
             ),
         )
         self.assertDictEqual(
@@ -450,7 +450,7 @@ class TestNotificationData(ZulipTestCase):
             mentioned_user_ids={hamlet.id},
             mentioned_user_group_ids=[hamlet_and_cordelia.id],
             mention_data=MentionData(
-                mention_backend, "hey @*hamlet_and_cordelia*!", message_sender=None
+                mention_backend, "hey @*hamlet_and_cordelia*!", acting_user=None
             ),
         )
         self.assertDictEqual(
@@ -466,7 +466,7 @@ class TestNotificationData(ZulipTestCase):
             mentioned_user_ids=set(),
             mentioned_user_group_ids=[hamlet_and_cordelia.id],
             mention_data=MentionData(
-                mention_backend, "hey @*hamlet_and_cordelia*!", message_sender=None
+                mention_backend, "hey @*hamlet_and_cordelia*!", acting_user=None
             ),
         )
         self.assertDictEqual(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -35,7 +35,11 @@ from zerver.actions.streams import (
     do_set_stream_property,
     do_unarchive_stream,
 )
-from zerver.actions.user_groups import bulk_add_members_to_user_groups, check_add_user_group
+from zerver.actions.user_groups import (
+    bulk_add_members_to_user_groups,
+    check_add_user_group,
+    do_change_user_group_permission_setting,
+)
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.attachments import (
     validate_attachment_request,
@@ -2282,6 +2286,58 @@ class StreamAdminTest(ZulipTestCase):
         self.assertEqual(
             stream.rendered_description,
             f'<p><a class="stream-topic" data-stream-id="{core_stream.id}" href="/#narrow/channel/{core_stream.id}-core/topic/testing/with/{msg_id}">#{core_stream.name} &gt; testing</a></p>',
+        )
+
+    def test_user_group_mention_in_stream_description(self) -> None:
+        realm = get_realm("zulip")
+        iago = self.example_user("iago")
+        othello = self.example_user("othello")
+        aaron = self.example_user("aaron")
+        stream = self.subscribe(iago, "stream_name1")
+        self.login_user(iago)
+
+        test_group = check_add_user_group(realm, "test_group", [aaron], acting_user=othello)
+
+        # iago can mention test_group by default.
+        description = "Ask @*test_group* for help"
+        result = self.client_patch(f"/json/streams/{stream.id}", {"description": description})
+        self.assert_json_success(result)
+        stream.refresh_from_db()
+        self.assertEqual(
+            stream.rendered_description,
+            f'<p>Ask <span class="user-group-mention" data-user-group-id="{test_group.id}">@test_group</span> for help</p>',
+        )
+
+        # Restrict mentioning test_group to its own members, which iago is not.
+        do_change_user_group_permission_setting(
+            test_group, "can_mention_group", test_group, acting_user=None
+        )
+        result = self.client_patch(f"/json/streams/{stream.id}", {"description": description})
+        self.assert_json_error(result, "You are not allowed to mention user group 'test_group'.")
+
+        # As when sending a message, the restriction does not apply to
+        # silent mentions.
+        result = self.client_patch(
+            f"/json/streams/{stream.id}", {"description": "Ask @_*test_group* for help"}
+        )
+        self.assert_json_success(result)
+
+        # Creating a channel with such a description is rejected too.
+        result = self.subscribe_via_post(
+            iago,
+            [{"name": "new_stream", "description": description}],
+            allow_fail=True,
+        )
+        self.assert_json_error(result, "You are not allowed to mention user group 'test_group'.")
+
+        # Add iago to test_group, to regain mention permission.
+        bulk_add_members_to_user_groups([test_group], [iago.id], acting_user=othello)
+        result = self.client_patch(f"/json/streams/{stream.id}", {"description": description})
+        self.assert_json_success(result)
+        stream.refresh_from_db()
+        self.assertEqual(
+            stream.rendered_description,
+            f'<p>Ask <span class="user-group-mention" data-user-group-id="{test_group.id}">@test_group</span> for help</p>',
         )
 
     def test_change_stream_message_retention_days_notifications(self) -> None:

--- a/zerver/worker/embed_links.py
+++ b/zerver/worker/embed_links.py
@@ -61,7 +61,7 @@ class FetchLinksEmbedData(QueueProcessingWorker):
             mention_data = MentionData(
                 mention_backend=MentionBackend(message.realm_id),
                 content=message.content,
-                message_sender=message.sender,
+                acting_user=message.sender,
             )
             rendering_result = render_incoming_message(
                 message,


### PR DESCRIPTION
Follow up to  and rebased on top of #34484

CZO dicussion: [#backend > Handle Group mention permission](https://chat.zulip.org/#narrow/channel/3-backend/topic/Handle.20Group.20mention.20permission/with/2508997)