### PR TITLE
[ai] settings: Fix password change crash with password manager extensions.

### DIFF
--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -1,8 +1,8 @@
 import {$} from "jquery";
 import * as tippy from "tippy.js";
 
+import * as blueslip from "./blueslip.ts";
 import {$t} from "./i18n.ts";
-import * as util from "./util.ts";
 
 export const status_classes = "alert-error alert-success alert-info alert-warning";
 
@@ -119,7 +119,13 @@ function set_password_toggle_label(
 ): void {
     $(password_selector).attr("aria-label", label);
     if (tippy_tooltips) {
-        const element: tippy.ReferenceElement = util.the($(password_selector));
+        const element: tippy.ReferenceElement | undefined = $(password_selector)[0];
+        if (element === undefined) {
+            // Report the missing toggle without throwing, so that
+            // callers still run cleanup like clearing password inputs.
+            blueslip.error("Password visibility toggle not found", {password_selector});
+            return;
+        }
         const tippy_instance = element._tippy ?? tippy.default(element);
         tippy_instance.setContent(label);
     } else {

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -389,7 +389,7 @@ export function set_up(): void {
         $("#api_key_buttons").hide();
         common.setup_password_visibility_toggle(
             "#get_api_key_password",
-            "#get_api_key_password + .password_visibility_toggle",
+            "#get_api_key_password ~ .password_visibility_toggle",
             {tippy_tooltips: true},
         );
 
@@ -457,7 +457,7 @@ export function set_up(): void {
         $("#api_key_modal [data-micromodal-close]").on("click", () => {
             common.reset_password_toggle_icons(
                 "#get_api_key_password",
-                "#get_api_key_password + .password_visibility_toggle",
+                "#get_api_key_password ~ .password_visibility_toggle",
             );
         });
         new ClipboardJS("#show_api_key .copy-button", {
@@ -491,11 +491,11 @@ export function set_up(): void {
         // for an XSS attacker to find.
         common.reset_password_toggle_icons(
             "#old_password",
-            "#old_password + .password_visibility_toggle",
+            "#old_password ~ .password_visibility_toggle",
         );
         common.reset_password_toggle_icons(
             "#new_password",
-            "#new_password + .password_visibility_toggle",
+            "#new_password ~ .password_visibility_toggle",
         );
         $("#old_password, #new_password").val("");
         password_quality?.("", $("#pw_strength .bar"), $("#new_password"));
@@ -509,12 +509,12 @@ export function set_up(): void {
             });
         common.setup_password_visibility_toggle(
             "#old_password",
-            "#old_password + .password_visibility_toggle",
+            "#old_password ~ .password_visibility_toggle",
             {tippy_tooltips: true},
         );
         common.setup_password_visibility_toggle(
             "#new_password",
-            "#new_password + .password_visibility_toggle",
+            "#new_password ~ .password_visibility_toggle",
             {tippy_tooltips: true},
         );
         clear_password_change();

--- a/web/tests/common.test.cjs
+++ b/web/tests/common.test.cjs
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
+const blueslip = require("./lib/zblueslip.cjs");
 const {$} = require("./lib/zjquery.cjs");
 
 mock_esm("tippy.js", {
@@ -157,6 +158,17 @@ run_test("adjust_mac_hotkey_hints mac random", ({override}) => {
     for (const test_item of test_items) {
         assert.deepStrictEqual(test_item.mac_key, test_item.adjusted_key);
     }
+});
+
+run_test("reset password toggle icons with missing toggle", () => {
+    // Password manager extensions can rearrange the DOM around
+    // password inputs such that the toggle selector matches nothing.
+    const password_selector = "#mangled_password ~ .password_visibility_toggle";
+    $.create(password_selector, {elements: []});
+
+    blueslip.expect("error", "Password visibility toggle not found");
+    common.reset_password_toggle_icons("#mangled_password", password_selector);
+    assert.equal($("#mangled_password").attr("type"), "password");
 });
 
 run_test("show password", () => {


### PR DESCRIPTION
Sentry issue: ZULIP-FRONTEND-3M1 | [#kandra js errors > TypeError: can't access property "_tippy", n is undefined](https://chat.zulip.org/#narrow/channel/464-kandra-js-errors/topic/TypeError.3A.20can.27t.20access.20property.20.22_tippy.22.2C.20n.20is.20undefined/with/2510632)

`set_password_toggle_label` crashed with a TypeError when the password
visibility toggle selector matched nothing. Sentry data (user/IP/url/browser
tags and breadcrumbs) shows this affecting users whose browser extensions —
most plausibly password managers — inject elements next to password inputs,
breaking the adjacent sibling (`+`) selectors the app modals used to find
the toggle icon. The crash also aborted `clear_password_change` before it
cleared password values out of the DOM.

The first commit reports a specific blueslip error and returns instead of
throwing when the toggle can't be found, so cleanup still runs. The second
switches the app modal selectors to general sibling (`~`) selectors,
matching the existing portico login/signup convention, so an injected
sibling no longer breaks the lookup at all.

---

Reproduced error with these steps:

1. Ran `./manage.py print_initial_password desdemona@zulip.com` to get the password for the user I was logged in as
2. Went to http://localhost:9991/#settings/account-and-privacy and clicked change password
3. Pasted `document.querySelector("#old_password").insertAdjacentElement("afterend", document.createElement("span"))` in the console to get an interfering element
4. Changed the password

Error confirmed before the changes, not visible after the changes.