### PR TITLE
desktop_notifications: Improve checks for Notification API support.

### DIFF
--- a/web/src/desktop_notifications.ts
+++ b/web/src/desktop_notifications.ts
@@ -84,12 +84,12 @@ export function initialize(): void {
 }
 
 export function permission_state(): string {
-    if (NotificationAPI === undefined) {
-        // act like notifications are blocked if they do not have access to
-        // the notification API.
-        return "denied";
+    if (NotificationAPI) {
+        return NotificationAPI.permission;
     }
-    return NotificationAPI.permission;
+    // Act like notifications are blocked if a UA
+    // has no access to the notification API.
+    return "denied";
 }
 
 export function close_notification(message: Message): void {
@@ -109,7 +109,7 @@ export async function request_desktop_notifications_permission(): Promise<Notifi
     if (NotificationAPI) {
         return await NotificationAPI.requestPermission();
     }
-    // Act like notifications are blocked if they do not have access to
-    // the notification API.
+    // Act like notifications are blocked if a UA
+    // has no access to the notification API.
     return "denied";
 }

--- a/web/src/desktop_notifications.ts
+++ b/web/src/desktop_notifications.ts
@@ -83,6 +83,11 @@ export function initialize(): void {
     });
 }
 
+// Utility function for testing support for the Notifications API
+export function has_notification_support(): boolean {
+    return NotificationAPI !== undefined;
+}
+
 export function permission_state(): string {
     if (NotificationAPI) {
         return NotificationAPI.permission;

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -28,7 +28,6 @@ import * as unread from "./unread.ts";
 import * as unread_ops from "./unread_ops.ts";
 import {user_settings} from "./user_settings.ts";
 import * as user_topics from "./user_topics.ts";
-import * as util from "./util.ts";
 
 function open_navbar_banner_and_resize(banner: AlertBanner): void {
     banners.open(banner, $("#navbar_alerts_wrapper"));
@@ -55,10 +54,8 @@ export function should_show_desktop_notifications_banner(ls: LocalStorage): bool
         // Spectators cannot receive desktop notifications, so never
         // request permissions to send them.
         !page_params.is_spectator &&
-        // notifications *basically* don't work on any mobile platforms, so don't
-        // event show the banners. This prevents trying to access things that
-        // don't exist like `Notification.permission`.
-        !util.is_mobile() &&
+        // Only show banners on UAs that do not include the Notification API.
+        desktop_notifications.has_notification_support() &&
         // if permission has not been granted yet.
         !desktop_notifications.granted_desktop_notifications_permission() &&
         // if permission is allowed to be requested (e.g. not in "denied" state).

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -11,6 +11,7 @@ import * as banners from "./banners.ts";
 import * as blueslip from "./blueslip.ts";
 import * as channel from "./channel.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
+import * as desktop_notifications from "./desktop_notifications.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as message_notifications from "./message_notifications.ts";
@@ -122,13 +123,9 @@ function rerender_ui(): void {
 }
 
 function update_desktop_notification_banner(): void {
-    // As is also noted in `navbar_alerts.ts`, notifications *basically*
-    // don't work on any mobile platforms, so don't event show the banners.
-    // This prevents trying to access things that don't exist, like
-    // `Notification.permission` in a mobile context, in which we'll also
-    // hide the ability to send a test notification before exiting with an
-    // early return.
-    if (util.is_mobile()) {
+    // Don't attempt to show the notification banner on UAs
+    // that don't support the Notification API.
+    if (!desktop_notifications.has_notification_support()) {
         $(".send_test_notification").hide();
         return;
     }

--- a/web/tests/navbar_alerts.test.cjs
+++ b/web/tests/navbar_alerts.test.cjs
@@ -11,7 +11,6 @@ const {page_params} = require("./lib/zpage_params.cjs");
 
 const desktop_notifications = mock_esm("../src/desktop_notifications");
 const unread = mock_esm("../src/unread");
-const util = mock_esm("../src/util");
 
 const {localstorage} = zrequire("localstorage");
 const navbar_alerts = zrequire("navbar_alerts");
@@ -40,7 +39,7 @@ test("should_show_desktop_notifications_banner", ({override}) => {
     // - The user has not said to never show banner on this device again.
     ls.set("dontAskForNotifications", undefined);
     page_params.is_spectator = false;
-    override(util, "is_mobile", () => false);
+    override(desktop_notifications, "has_notification_support", () => true);
     override(desktop_notifications, "granted_desktop_notifications_permission", () => false);
     override(desktop_notifications, "permission_state", () => "default");
     assert.equal(navbar_alerts.should_show_desktop_notifications_banner(ls), true);
@@ -50,10 +49,10 @@ test("should_show_desktop_notifications_banner", ({override}) => {
     assert.equal(navbar_alerts.should_show_desktop_notifications_banner(ls), false);
     ls.set("dontAskForNotifications", undefined);
 
-    // Don't ask for permission if device is mobile.
-    override(util, "is_mobile", () => true);
+    // Don't ask for permission if UA has no Notification API support.
+    override(desktop_notifications, "has_notification_support", () => false);
     assert.equal(navbar_alerts.should_show_desktop_notifications_banner(ls), false);
-    override(util, "is_mobile", () => false);
+    override(desktop_notifications, "has_notification_support", () => true);
 
     // Don't ask for permission if notification is denied by user.
     override(desktop_notifications, "permission_state", () => "denied");


### PR DESCRIPTION
This PR fixes a bug reported on Safari/iPadOS that prevented the display of the Notifications pane under user settings.

To ensure that this bug doesn't creep up on any other device (mobile or otherwise), the PR removes all instances of `util.is_mobile()` that were intended to prevent execution of Notification logic where it wasn't actually supported.

In place of those checks, the PR introduces a new utility function inside of `desktop_notifications.ts` for desktop-notification support as a feature check, rather than a mobile check. `desktop_notifications.ts` is a better location than `util.ts` for such a thing, because of the logic we've written to support notifications within the Electron app.

I've used the new `has_notification_support()` check in the navbar-alert logic and the notifications-settings logic, which are the two places in the codebase where we're handling desktop notifications.

- [ ] TODO: Once this PR has been merged, I want to file an issue to audit and likely remove all other `util.is_mobile()` checks in the codebase, and replace them with similarly robust feature-detection logic.

Fixes: [#frontend > settings/notifications won't load on iOS web app @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/settings.2Fnotifications.20won.27t.20load.20on.20iOS.20web.20app/near/2511032)

**Screenshots and screen captures:**

_iPad running the dev server:_

| Before | After |
| --- | --- |
| <img width="1194" height="834" alt="ipad-settings-notifications-before" src="https://github.com/user-attachments/assets/2effe5f2-7367-4309-98fc-0c96bd1e8371" /> | <img width="1194" height="834" alt="ipad-settings-notifications-after" src="https://github.com/user-attachments/assets/08f26a9a-c16a-4ed3-bb93-8a8c6c7922e9" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>