### PR TITLE
[ai] settings: Add unit dropdown for custom message time limits.

### DIFF
--- a/web/src/admin.ts
+++ b/web/src/admin.ts
@@ -180,21 +180,22 @@ export function build_page(): void {
         can_add_emojis: settings_data.user_can_add_custom_emoji(),
         can_create_new_bots: settings_bots.can_create_incoming_webhooks(),
         realm_message_content_edit_limit_minutes:
-            settings_components.get_realm_time_limits_in_minutes(
+            settings_components.get_realm_time_limit_value_and_unit(
                 "realm_message_content_edit_limit_seconds",
-            ),
+            ).value,
         realm_move_messages_between_streams_limit_minutes:
-            settings_components.get_realm_time_limits_in_minutes(
+            settings_components.get_realm_time_limit_value_and_unit(
                 "realm_move_messages_between_streams_limit_seconds",
-            ),
+            ).value,
         realm_move_messages_within_stream_limit_minutes:
-            settings_components.get_realm_time_limits_in_minutes(
+            settings_components.get_realm_time_limit_value_and_unit(
                 "realm_move_messages_within_stream_limit_seconds",
-            ),
+            ).value,
         realm_message_content_delete_limit_minutes:
-            settings_components.get_realm_time_limits_in_minutes(
+            settings_components.get_realm_time_limit_value_and_unit(
                 "realm_message_content_delete_limit_seconds",
-            ),
+            ).value,
+        custom_time_unit_values: settings_config.custom_time_unit_values,
         realm_message_retention_days: realm.realm_message_retention_days,
         realm_message_edit_history_visibility_policy:
             realm.realm_message_edit_history_visibility_policy,

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -97,17 +97,38 @@ export type MessageTimeLimitSetting =
     | "realm_message_content_edit_limit_seconds"
     | "realm_message_content_delete_limit_seconds";
 
-export function get_realm_time_limits_in_minutes(property: MessageTimeLimitSetting): string {
-    const setting_value = realm[property];
-    if (setting_value === null) {
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+const MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
+
+export function get_realm_time_limit_value_and_unit(property: MessageTimeLimitSetting): {
+    value: string;
+    unit: string;
+} {
+    const setting_value_seconds = realm[property];
+    if (setting_value_seconds === null) {
         // This represents "Anytime" case.
-        return "";
+        return {value: "", unit: "minutes"};
     }
-    let val = (setting_value / 60).toFixed(1);
+
+    // Display the value in the largest unit that represents it exactly,
+    // so a realm default of "1 week" doesn't show up as "10080 minutes".
+    const setting_value_minutes = setting_value_seconds / 60;
+    if (setting_value_minutes % MINUTES_PER_WEEK === 0) {
+        return {value: (setting_value_minutes / MINUTES_PER_WEEK).toString(), unit: "weeks"};
+    }
+    if (setting_value_minutes % MINUTES_PER_DAY === 0) {
+        return {value: (setting_value_minutes / MINUTES_PER_DAY).toString(), unit: "days"};
+    }
+    if (setting_value_minutes % MINUTES_PER_HOUR === 0) {
+        return {value: (setting_value_minutes / MINUTES_PER_HOUR).toString(), unit: "hours"};
+    }
+
+    let val = setting_value_minutes.toFixed(1);
     if (Number.parseFloat(val) === Number.parseInt(val, 10)) {
-        val = (setting_value / 60).toFixed(0);
+        val = setting_value_minutes.toFixed(0);
     }
-    return val;
+    return {value: val, unit: "minutes"};
 }
 
 type RealmSetting = typeof realm;
@@ -311,33 +332,19 @@ function get_jitsi_server_url_setting_value(
     return JSON.stringify($custom_input_elem.val());
 }
 
-export function update_custom_time_limit_minute_text($input: JQuery<HTMLInputElement>): void {
-    const $minutes_text = $input.parent().find(".time-unit-text");
-    const count = Number.parseInt($input.val()!, 10);
-    $minutes_text.text(
-        $t(
-            {
-                defaultMessage: "{count, plural, one {minute} other {minutes}}",
-            },
-            {count},
-        ),
-    );
-}
-
 export function update_custom_value_input(property_name: MessageTimeLimitSetting): void {
     const $dropdown_elem = $(`#id_${CSS.escape(property_name)}`);
-    const custom_input_elem_id = $dropdown_elem
-        .parent()
-        .find(".time-limit-custom-input")
-        .attr("id")!;
+    const $parent = $dropdown_elem.parent();
+    const $custom_input_elem = $parent.find(".time-limit-custom-input");
 
     const show_custom_limit_input = $dropdown_elem.val() === "custom_period";
-    change_element_block_display_property(custom_input_elem_id, show_custom_limit_input);
+    change_element_block_display_property($custom_input_elem.attr("id")!, show_custom_limit_input);
     if (!show_custom_limit_input) {
         return;
     }
-    $(`#${CSS.escape(custom_input_elem_id)}`).val(get_realm_time_limits_in_minutes(property_name));
-    update_custom_time_limit_minute_text($(`#${CSS.escape(custom_input_elem_id)}`));
+    const {value, unit} = get_realm_time_limit_value_and_unit(property_name);
+    $custom_input_elem.val(value);
+    $parent.find(".time-limit-custom-input-unit").val(unit);
 }
 
 export function get_time_limit_dropdown_setting_value(
@@ -358,12 +365,13 @@ export function get_time_limit_dropdown_setting_value(
 
 export function set_time_limit_setting(property_name: MessageTimeLimitSetting): void {
     const dropdown_elem_val = get_time_limit_dropdown_setting_value(property_name);
+    const $parent = $(`#id_${CSS.escape(property_name)}`).parent();
     $(`#id_${CSS.escape(property_name)}`).val(dropdown_elem_val);
 
-    const $custom_input = $(`#id_${CSS.escape(property_name)}`)
-        .parent()
-        .find(".time-limit-custom-input");
-    $custom_input.val(get_realm_time_limits_in_minutes(property_name));
+    const $custom_input = $parent.find(".time-limit-custom-input");
+    const {value, unit} = get_realm_time_limit_value_and_unit(property_name);
+    $custom_input.val(value);
+    $parent.find(".time-limit-custom-input-unit").val(unit);
 
     change_element_block_display_property(
         $custom_input.attr("id")!,
@@ -813,8 +821,13 @@ export function get_auth_method_list_data(): Record<string, boolean> {
     return new_auth_methods;
 }
 
-export function parse_time_limit($elem: JQuery<HTMLInputElement>): number {
-    const time_limit_in_minutes = util.check_time_input($elem.val()!, true);
+export function parse_time_limit(
+    $elem: JQuery<HTMLInputElement>,
+    $unit_elem?: JQuery<HTMLSelectOneElement>,
+): number {
+    const time_limit_value = util.check_time_input($elem.val()!, true);
+    const time_unit = $unit_elem?.val() ?? "minutes";
+    const time_limit_in_minutes = util.get_custom_time_in_minutes(time_unit, time_limit_value);
     return Math.floor(time_limit_in_minutes * 60);
 }
 
@@ -856,7 +869,13 @@ function get_time_limit_setting_value(
         return util.check_time_input($custom_input_elem.val()!);
     }
 
-    return parse_time_limit($custom_input_elem);
+    const $custom_unit_elem = $input_elem
+        .parent()
+        .find<HTMLSelectOneElement>(".time-limit-custom-input-unit");
+    return parse_time_limit(
+        $custom_input_elem,
+        $custom_unit_elem.length > 0 ? $custom_unit_elem : undefined,
+    );
 }
 
 export function check_realm_settings_property_changed(elem: HTMLElement): boolean {
@@ -1407,6 +1426,7 @@ export function save_discard_default_realm_settings_widget_status_handler(
 function check_maximum_valid_value(
     $custom_input_elem: JQuery<HTMLInputElement>,
     property_name: string,
+    $custom_unit_elem?: JQuery<HTMLSelectOneElement>,
 ): boolean {
     let setting_value = Number.parseInt($custom_input_elem.val()!, 10);
     if (
@@ -1416,7 +1436,7 @@ function check_maximum_valid_value(
         property_name === "realm_move_messages_within_stream_limit_seconds" ||
         property_name === "email_notifications_batching_period_seconds"
     ) {
-        setting_value = parse_time_limit($custom_input_elem);
+        setting_value = parse_time_limit($custom_input_elem, $custom_unit_elem);
     }
     return setting_value <= MAX_CUSTOM_TIME_LIMIT_SETTING_VALUE;
 }
@@ -1443,6 +1463,9 @@ function should_disable_save_button_for_time_limit_settings(
         const $custom_input_elem = $(setting_elem).find<HTMLInputElement>(
             "input.time-limit-custom-input",
         );
+        const $custom_unit_elem = $(setting_elem).find<HTMLSelectOneElement>(
+            ".time-limit-custom-input-unit",
+        );
         const custom_input_elem_val = util.check_time_input($custom_input_elem.val()!);
 
         const for_realm_default_settings =
@@ -1454,7 +1477,11 @@ function should_disable_save_button_for_time_limit_settings(
             $dropdown_elem.val() === "custom_period" &&
             (custom_input_elem_val <= 0 ||
                 Number.isNaN(custom_input_elem_val) ||
-                !check_maximum_valid_value($custom_input_elem, property_name));
+                !check_maximum_valid_value(
+                    $custom_input_elem,
+                    property_name,
+                    $custom_unit_elem.length > 0 ? $custom_unit_elem : undefined,
+                ));
 
         if (
             $custom_input_elem.val() === "0" &&

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1685,16 +1685,6 @@ export function build_page(): void {
     update_description_empty_state();
     $("#id_realm_description").on("input", update_description_empty_state);
 
-    $(".org-permissions-form").on(
-        "input change",
-        ".time-limit-custom-input",
-        function (this: HTMLInputElement, e) {
-            e.preventDefault();
-            e.stopPropagation();
-            settings_components.update_custom_time_limit_minute_text($(this));
-        },
-    );
-
     $(".settings-subsection-parent").on("keydown", "input", (e) => {
         e.stopPropagation();
         if (keydown_util.is_enter_event(e)) {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1661,6 +1661,7 @@ label.preferences-radio-choice-label {
 }
 
 .time-limit-custom-input,
+.time-limit-custom-input-unit,
 .realm_jitsi_server_url_custom_input {
     padding: var(--input-vertical-padding) var(--input-horizontal-padding);
     color: var(--color-text-default);
@@ -1677,6 +1678,12 @@ label.preferences-radio-choice-label {
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
+}
+
+.time-limit-custom-input-unit {
+    width: auto;
+    margin-left: 6px;
+    cursor: pointer;
 }
 
 #realm_jitsi_server_url_setting {

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -173,11 +173,14 @@
                       autocomplete="off"
                       value="{{ realm_message_content_edit_limit_minutes }}"
                       {{#unless realm_allow_message_editing}}disabled{{/unless}}/>&nbsp;
-                    <span class="time-unit-text">
-                        {{t "{realm_message_content_edit_limit_minutes, plural, one {minute} other {minutes}}"}}
-                    </span>
-
-
+                    <select id="id_realm_message_content_edit_limit_unit"
+                      name="realm_message_content_edit_limit_unit"
+                      class="time-limit-custom-input-unit"
+                      {{#unless realm_allow_message_editing}}disabled{{/unless}}>
+                        {{#each (object_values custom_time_unit_values)}}
+                            <option value="{{this.name}}">{{this.description}}</option>
+                        {{/each}}
+                    </select>
                 </div>
             </div>
         </div>
@@ -209,9 +212,13 @@
                       name="realm_move_messages_within_stream_limit_minutes"
                       class="time-limit-custom-input"
                       autocomplete="off"/>&nbsp;
-                    <span class="time-unit-text">
-                        {{t "{realm_move_messages_within_stream_limit_minutes, plural, one {minute} other {minutes}}"}}
-                    </span>
+                    <select id="id_realm_move_messages_within_stream_limit_unit"
+                      name="realm_move_messages_within_stream_limit_unit"
+                      class="time-limit-custom-input-unit">
+                        {{#each (object_values custom_time_unit_values)}}
+                            <option value="{{this.name}}">{{this.description}}</option>
+                        {{/each}}
+                    </select>
                 </div>
             </div>
 
@@ -234,9 +241,13 @@
                       name="realm_move_messages_between_streams_limit_minutes"
                       class="time-limit-custom-input"
                       autocomplete="off"/>&nbsp;
-                    <span class="time-unit-text">
-                        {{t "{realm_move_messages_between_streams_limit_minutes, plural, one {minute} other {minutes}}"}}
-                    </span>
+                    <select id="id_realm_move_messages_between_streams_limit_unit"
+                      name="realm_move_messages_between_streams_limit_unit"
+                      class="time-limit-custom-input-unit">
+                        {{#each (object_values custom_time_unit_values)}}
+                            <option value="{{this.name}}">{{this.description}}</option>
+                        {{/each}}
+                    </select>
                 </div>
             </div>
 
@@ -278,7 +289,13 @@
                       class="time-limit-custom-input"
                       autocomplete="off"
                       value="{{ realm_message_content_delete_limit_minutes }}"/>&nbsp;
-                    <span class="time-unit-text">{{t "{realm_message_content_delete_limit_minutes, plural, one {minute} other {minutes}}"}}</span>
+                    <select id="id_realm_message_content_delete_limit_unit"
+                      name="realm_message_content_delete_limit_unit"
+                      class="time-limit-custom-input-unit">
+                        {{#each (object_values custom_time_unit_values)}}
+                            <option value="{{this.name}}">{{this.description}}</option>
+                        {{/each}}
+                    </select>
                 </div>
             </div>
 

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -323,9 +323,9 @@ function test_parse_time_limit({override}) {
             settings_components.parse_time_limit($elem),
         );
         assert.equal(
-            settings_components.get_realm_time_limits_in_minutes(
+            settings_components.get_realm_time_limit_value_and_unit(
                 "realm_message_content_edit_limit_seconds",
-            ),
+            ).value,
             expected_value,
         );
     };
@@ -346,6 +346,61 @@ function test_parse_time_limit({override}) {
     test_function("201.1");
     test_function("501.15", "501.1");
     test_function("501.34", "501.3");
+}
+
+function test_parse_time_limit_with_unit({override}) {
+    const $value_elem = $("#id_realm_message_content_edit_limit_minutes");
+    const $unit_elem = $.create("<stub time limit unit select>");
+
+    const test_function = (value, unit, expected_seconds) => {
+        $value_elem.val(value);
+        $unit_elem.val(unit);
+        assert.equal(
+            settings_components.parse_time_limit($value_elem, $unit_elem),
+            expected_seconds,
+        );
+    };
+
+    test_function("10", "minutes", 10 * 60);
+    test_function("2", "hours", 2 * 60 * 60);
+    test_function("3", "days", 3 * 24 * 60 * 60);
+    test_function("1", "weeks", 7 * 24 * 60 * 60);
+
+    // parse_time_limit falls back to minutes when no unit is given.
+    $value_elem.val("5");
+    assert.equal(settings_components.parse_time_limit($value_elem), 5 * 60);
+
+    override(realm, "realm_message_content_edit_limit_seconds", 2 * 24 * 60 * 60);
+    assert.deepEqual(
+        settings_components.get_realm_time_limit_value_and_unit(
+            "realm_message_content_edit_limit_seconds",
+        ),
+        {value: "2", unit: "days"},
+    );
+
+    override(realm, "realm_message_content_edit_limit_seconds", 3 * 60 * 60);
+    assert.deepEqual(
+        settings_components.get_realm_time_limit_value_and_unit(
+            "realm_message_content_edit_limit_seconds",
+        ),
+        {value: "3", unit: "hours"},
+    );
+
+    override(realm, "realm_message_content_edit_limit_seconds", 2 * 7 * 24 * 60 * 60);
+    assert.deepEqual(
+        settings_components.get_realm_time_limit_value_and_unit(
+            "realm_message_content_edit_limit_seconds",
+        ),
+        {value: "2", unit: "weeks"},
+    );
+
+    override(realm, "realm_message_content_edit_limit_seconds", null);
+    assert.deepEqual(
+        settings_components.get_realm_time_limit_value_and_unit(
+            "realm_message_content_edit_limit_seconds",
+        ),
+        {value: "", unit: "minutes"},
+    );
 }
 
 function test_discard_changes_button({override}, discard_changes) {
@@ -410,9 +465,12 @@ function test_discard_changes_button({override}, discard_changes) {
         settings_config.message_edit_history_visibility_policy_values.always.code,
     );
     assert.equal($msg_edit_limit_setting.val(), "3600");
-    assert.equal($message_content_edit_limit_minutes.val(), "60");
+    // 3600 seconds is displayed in the largest exact unit: 1 hour.
+    assert.equal($message_content_edit_limit_minutes.val(), "1");
+    assert.equal($("#id_realm_message_content_edit_limit_unit").val(), "hours");
     assert.equal($msg_delete_limit_setting.val(), "120");
     assert.equal($message_content_delete_limit_minutes.val(), "2");
+    assert.equal($("#id_realm_message_content_delete_limit_unit").val(), "minutes");
     assert.ok(!$save_button_controls.visible());
 }
 
@@ -496,6 +554,12 @@ test("set_up", ({override, override_rewire}) => {
         $custom_edit_limit_input,
     );
     $custom_edit_limit_input.attr("id", "id_realm_message_content_edit_limit_minutes");
+    const $custom_edit_limit_unit = $("#id_realm_message_content_edit_limit_unit");
+    $stub_message_content_edit_limit_parent.set_find_results(
+        ".time-limit-custom-input-unit",
+        $custom_edit_limit_unit,
+    );
+    $custom_edit_limit_unit.attr("id", "id_realm_message_content_edit_limit_unit");
 
     const $custom_move_within_stream_limit_input = $(
         "#id_realm_move_messages_within_stream_limit_minutes",
@@ -507,6 +571,17 @@ test("set_up", ({override, override_rewire}) => {
     $custom_move_within_stream_limit_input.attr(
         "id",
         "id_realm_move_messages_within_stream_limit_minutes",
+    );
+    const $custom_move_within_stream_limit_unit = $(
+        "#id_realm_move_messages_within_stream_limit_unit",
+    );
+    $stub_move_within_stream_limit_parent.set_find_results(
+        ".time-limit-custom-input-unit",
+        $custom_move_within_stream_limit_unit,
+    );
+    $custom_move_within_stream_limit_unit.attr(
+        "id",
+        "id_realm_move_messages_within_stream_limit_unit",
     );
 
     const $custom_move_between_streams_limit_input = $(
@@ -520,6 +595,17 @@ test("set_up", ({override, override_rewire}) => {
         "id",
         "id_realm_move_messages_between_streams_limit_minutes",
     );
+    const $custom_move_between_streams_limit_unit = $(
+        "#id_realm_move_messages_between_streams_limit_unit",
+    );
+    $stub_move_between_streams_limit_parent.set_find_results(
+        ".time-limit-custom-input-unit",
+        $custom_move_between_streams_limit_unit,
+    );
+    $custom_move_between_streams_limit_unit.attr(
+        "id",
+        "id_realm_move_messages_between_streams_limit_unit",
+    );
 
     const $custom_delete_limit_input = $("#id_realm_message_content_delete_limit_minutes");
     $stub_message_content_delete_limit_parent.set_find_results(
@@ -527,6 +613,12 @@ test("set_up", ({override, override_rewire}) => {
         $custom_delete_limit_input,
     );
     $custom_delete_limit_input.attr("id", "id_realm_message_content_delete_limit_minutes");
+    const $custom_delete_limit_unit = $("#id_realm_message_content_delete_limit_unit");
+    $stub_message_content_delete_limit_parent.set_find_results(
+        ".time-limit-custom-input-unit",
+        $custom_delete_limit_unit,
+    );
+    $custom_delete_limit_unit.attr("id", "id_realm_message_content_delete_limit_unit");
 
     const $stub_realm_message_retention_parent = $.create(
         "<stub message retention setting parent>",
@@ -601,6 +693,7 @@ test("set_up", ({override, override_rewire}) => {
     test_change_save_button_state();
     test_sync_realm_settings({override});
     test_parse_time_limit({override});
+    test_parse_time_limit_with_unit({override});
     test_discard_changes_button(
         {override},
         $(".admin-realm-form").get_on_handler(


### PR DESCRIPTION
## Summary

Fixes: #39969

The four custom "Time limit" organization settings (editing messages,
editing topics, moving messages between channels, deleting messages)
only accepted a number of **minutes**, so an admin who wanted "10
days" had to convert it by hand.

This adds a minutes / hours / days / weeks dropdown next to each
custom time-limit input, following the same input+dropdown pattern
already used for invite expiration time (`web/templates/invite_user_modal.hbs`).
The value is converted to seconds client-side before being sent to
the server (unchanged API), so **no backend changes are required**,
matching the scope described in the issue.

When displaying a stored value, the UI now shows it in the largest
unit that represents it exactly — e.g. a realm with a 1-week move
limit now shows "1" / "weeks" instead of "10080" minutes.

### Changes

- `web/src/settings_components.ts`: replaced `get_realm_time_limits_in_minutes`
  with `get_realm_time_limit_value_and_unit`, which also returns the
  best-fit unit; `parse_time_limit`, `get_time_limit_setting_value`,
  and the save-button max-value check now read the paired unit
  dropdown (falling back to minutes, e.g. for the unrelated waiting-period
  and message-retention settings that don't have a unit dropdown).
- `web/src/settings_org.ts`: removed the now-dead listener that kept
  the old "N minute(s)" label text in sync (replaced by the dropdown
  itself).
- `web/src/admin.ts`: passes `custom_time_unit_values` into the
  organization-permissions template context.
- `web/templates/settings/organization_permissions_admin.hbs`: adds
  the unit `<select>` next to each of the 4 custom time inputs;
  removed the old singular/plural "minute(s)" text per the issue
  (no "Expires on…"-style text is shown, just the "Time limit" label
  as requested).
- `web/styles/settings.css`: minimal styling for the new dropdown,
  reusing the existing custom-input border/padding treatment.
- `web/tests/settings_org.test.cjs`: updated existing coverage for
  the renamed function/new return shape, and added new coverage for
  unit-aware parsing (`parse_time_limit` with an explicit unit) and
  for `get_realm_time_limit_value_and_unit` picking hours/days/weeks
  when the stored seconds value divides evenly.

## Test plan

- [x] `node web/tests/lib/index.cjs web/tests/settings_org.test.cjs` (all subtests pass, including new unit-conversion coverage)
- [x] `node web/tests/lib/index.cjs web/tests/util.test.cjs web/tests/templates.test.cjs` (unaffected/related suites pass)
- [x] `tsc --noEmit` on the full project — no new type errors from this change (one pre-existing, unrelated error in `settings_account.ts` remains, present on `main` too)
- [x] `stylelint`/`prettier` clean on all touched files
- [x] Manually rendered `organization_permissions_admin.hbs` with representative context data (via a throwaway node script) to confirm all 4 unit `<select>` elements render, the old `.time-unit-text` markup is fully gone, and each dropdown offers all 4 units
- [ ] Full browser-based visual verification (light/dark theme, narrow width, RTL/long-string translations, keyboard nav) — **not done**. My sandbox has no provisioned Zulip dev environment (no Postgres/venv, `./tools/run-dev` unavailable), so I could not load the real settings page in a browser or run the `visual-test` Puppeteer skill. This should be verified by a reviewer with a working dev environment before merge.

## Open questions

- The issue said the exact layout would be confirmed on CZO ("Will confirm this layout once on CZO"). I implemented it to mirror the existing invite-expiration-time input+dropdown pattern as instructed, with "Time limit" as the label and no "Expires on…"-style helper text. If CZO settled on something different, happy to adjust.
- I kept the existing DOM id/name suffix `_minutes` on the number inputs (e.g. `id_realm_message_content_edit_limit_minutes`) even though the value may now represent a different unit, to avoid a much larger renaming diff across templates/tests. Open to renaming if maintainers prefer `_value`/`_custom_input` instead.

## Self-review checklist

- [x] The PR addresses all points described in the issue (dropdown with minutes/hours/days/weeks; seconds conversion; input+dropdown layout with "Time limit" label; no backend changes)
- [x] Relevant tests pass locally (see test plan)
- [x] Code follows existing patterns in the codebase (mirrors the invite-expiration-time and realm-deactivation custom-time-input patterns)
- [x] Names are clear and greppable
- [x] Commit message, comments are minimal and explain why
- [x] Single coherent commit
- [x] No debugging code or unnecessary comments remain
- [x] Type annotations complete (`tsc --noEmit` clean for touched files)
- [x] User-facing strings use existing translated `custom_time_unit_values` descriptions; no new untranslated strings added, and no translated strings needed removal from `.po` files (removed strings are pruned automatically on next `tools/i18n/push-translations` cycle)
- [ ] No secrets or credentials hardcoded — n/a, no secrets involved
- [ ] Documentation update — no docs mention the old minutes-only behavior explicitly; none found needing updates
- [x] Refactoring complete — `git grep` confirms no remaining references to the removed `get_realm_time_limits_in_minutes` / `update_custom_time_limit_minute_text` / `.time-unit-text`
- [x] Security audit — purely client-side unit conversion before existing, already-validated seconds value is sent; no new attack surface