### PR TITLE
[ai] poll: Render Markdown (mentions, emoji, etc.) in poll content.

### DIFF
--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -864,3 +864,18 @@ export function parse_non_message(raw_content: string): string {
     // handle things like mentions, stream links, and linkifiers.
     return parse({raw_content, helper_config: web_app_helpers}).content;
 }
+
+export function maybe_unwrap_single_paragraph(html: string): string {
+    // Markdown wraps single-line content in a <p> tag, which isn't
+    // valid when the caller wants to inline the result inside
+    // another element (e.g. a heading or a <span>). We only unwrap
+    // when there's a single paragraph; multi-paragraph content is
+    // left untouched, since stripping only the outer tags would
+    // leave behind an unpaired inner </p>...<p>.
+    const trimmed = html.trim();
+    const inner = trimmed.slice("<p>".length, -"</p>".length);
+    if (trimmed.startsWith("<p>") && trimmed.endsWith("</p>") && !inner.includes("<p>")) {
+        return inner;
+    }
+    return html;
+}

--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -8,10 +8,12 @@ import render_widgets_poll_widget_results from "../templates/widgets/poll_widget
 import * as blueslip from "./blueslip.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as markdown from "./markdown.ts";
 import type {Message} from "./message_store.ts";
 import * as people from "./people.ts";
 import type {PollWidgetOutboundData} from "./poll_data.ts";
 import {PollData, new_option_schema, question_schema, vote_schema} from "./poll_data.ts";
+import * as rendered_markdown from "./rendered_markdown.ts";
 import {ZulipWidgetContext} from "./widget_context.ts";
 import type {Event} from "./widget_data.ts";
 import type {AnyWidgetData, WidgetData} from "./widget_schema.ts";
@@ -105,6 +107,21 @@ export function render({
         $elem.find("button.poll-question-check").toggle(has_question);
     }
 
+    // Poll questions and options are plain text typed by users, but we
+    // still want to render mentions, emoji, and other inline Markdown
+    // in them the same way we would in a normal message.
+    function render_poll_content($content: JQuery, raw_content: string): void {
+        if (raw_content.trim() === "") {
+            $content.text("");
+            return;
+        }
+        const html = markdown.maybe_unwrap_single_paragraph(
+            markdown.parse_non_message(raw_content),
+        );
+        $content.html(html);
+        rendered_markdown.update_elements($content);
+    }
+
     function render_question(): void {
         const question = poll_data.get_question();
         const input_mode = poll_data.get_input_mode();
@@ -113,7 +130,7 @@ export function render({
         const waiting = !is_my_poll && !has_question;
 
         $elem.find(".poll-question-header").toggle(!input_mode);
-        $elem.find(".poll-question-header").text(question);
+        render_poll_content($elem.find(".poll-question-header"), question);
         $elem.find(".poll-edit-question").toggle(can_edit);
         update_edit_controls();
 
@@ -266,9 +283,20 @@ export function render({
 
     function render_results(): void {
         const widget_data = poll_data.get_widget_data();
+        const rendered_widget_data = {
+            ...widget_data,
+            options: widget_data.options.map((option_data) => ({
+                ...option_data,
+                option_html: markdown.maybe_unwrap_single_paragraph(
+                    markdown.parse_non_message(option_data.option),
+                ),
+            })),
+        };
 
-        const html = render_widgets_poll_widget_results(widget_data);
-        $elem.find("ul.poll-widget").html(html);
+        const html = render_widgets_poll_widget_results(rendered_widget_data);
+        const $poll_options = $elem.find("ul.poll-widget");
+        $poll_options.html(html);
+        rendered_markdown.update_elements($poll_options);
 
         $elem
             .find("button.poll-vote")

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -29,14 +29,6 @@ const meta = {
     loaded: false,
 };
 
-function maybe_unwrap_single_paragraph(html: string): string {
-    const trimmed = html.trim();
-    if (trimmed.startsWith("<p>") && trimmed.endsWith("</p>")) {
-        return trimmed.slice("<p>".length, -"</p>".length);
-    }
-    return html;
-}
-
 export function reset(): void {
     meta.loaded = false;
 }
@@ -401,7 +393,9 @@ export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
         get_item: ListWidget.default_get_item,
         modifier_html(linkifier, filter_value) {
             const rendered_example_input_html = linkifier.example_input
-                ? maybe_unwrap_single_paragraph(markdown.parse_non_message(linkifier.example_input))
+                ? markdown.maybe_unwrap_single_paragraph(
+                      markdown.parse_non_message(linkifier.example_input),
+                  )
                 : "";
 
             return render_admin_linkifier_list({

--- a/web/templates/widgets/poll_widget_results.hbs
+++ b/web/templates/widgets/poll_widget_results.hbs
@@ -4,7 +4,7 @@
             <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
                 {{ count }}
             </button>
-            <span class="poll-option-text">{{ option }}</span>
+            <span class="poll-option-text">{{{ option_html }}}</span>
         </label>
         {{#if names}}
         <span class="poll-names">({{ names }})</span>

--- a/web/tests/markdown.test.cjs
+++ b/web/tests/markdown.test.cjs
@@ -1054,6 +1054,25 @@ test("parse_non_message", () => {
     assert.equal(markdown.parse_non_message("type `/day`"), "<p>type <code>/day</code></p>");
 });
 
+test("maybe_unwrap_single_paragraph", () => {
+    assert.equal(markdown.maybe_unwrap_single_paragraph("<p>hello</p>"), "hello");
+    assert.equal(
+        markdown.maybe_unwrap_single_paragraph("  <p>hello</p>  "),
+        "hello",
+        "surrounding whitespace should be trimmed before checking for a wrapping <p> tag",
+    );
+    assert.equal(
+        markdown.maybe_unwrap_single_paragraph("<p>hello</p>\n<p>world</p>"),
+        "<p>hello</p>\n<p>world</p>",
+        "multiple paragraphs should be left untouched",
+    );
+    assert.equal(
+        markdown.maybe_unwrap_single_paragraph("hello"),
+        "hello",
+        "content with no wrapping <p> tag should be left untouched",
+    );
+});
+
 test("missing unicode emojis", ({override}) => {
     let message = {raw_content: "\u{1F6B2}"};
 

--- a/web/tests/poll_widget.test.cjs
+++ b/web/tests/poll_widget.test.cjs
@@ -5,12 +5,27 @@ const assert = require("node:assert/strict");
 const {make_realm} = require("./lib/example_realm.cjs");
 const {make_user} = require("./lib/example_user.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {noop, run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 const {$} = require("./lib/zjquery.cjs");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
+});
+
+// poll_widget.ts runs question/option text through the Markdown
+// pipeline, but that pipeline (and DOM post-processing for rendered
+// mentions) is exercised by markdown.test.cjs and
+// rendered_markdown.test.cjs; here we only care that poll_widget
+// calls into it correctly, so we stub both with the identity
+// transform by default. Individual tests can override these to
+// verify poll_widget wires the Markdown-rendered HTML into the DOM.
+const markdown = mock_esm("../src/markdown", {
+    parse_non_message: (raw_content) => raw_content,
+    maybe_unwrap_single_paragraph: (html) => html,
+});
+const rendered_markdown = mock_esm("../src/rendered_markdown", {
+    update_elements: noop,
 });
 
 const {PollData} = zrequire("poll_data");
@@ -282,7 +297,7 @@ run_test("activate another person poll", ({mock_template}) => {
 
     assert.equal($widget_elem.html(), "widgets/poll_widget");
     assert.equal($widget_option_container.html(), "widgets/poll_widget_results");
-    assert.equal($poll_question_header.text(), "What do you want?");
+    assert.equal($poll_question_header.html(), "What do you want?");
 
     {
         /* Testing data sent to server on adding option */
@@ -407,7 +422,7 @@ run_test("activate own poll", ({mock_template}) => {
 
     assert.equal($widget_elem.html(), "widgets/poll_widget");
     assert.equal($widget_option_container.html(), "widgets/poll_widget_results");
-    assert.equal($poll_question_header.text(), "Where to go?");
+    assert.equal($poll_question_header.html(), "Where to go?");
 
     {
         /* Testing data sent to server on editing question */
@@ -424,4 +439,78 @@ run_test("activate own poll", ({mock_template}) => {
         $poll_question_submit.trigger("click");
         assert.deepEqual(out_data, undefined);
     }
+});
+
+run_test("poll question and option text run through markdown", ({override, mock_template}) => {
+    mock_template("widgets/poll_widget.hbs", false, () => "widgets/poll_widget");
+    // Render the real results template so we can verify poll_widget
+    // passes it Markdown-rendered (unescaped) option HTML.
+    mock_template("widgets/poll_widget_results.hbs", true, (_data, html) => html);
+
+    // Fake mention rendering, so we can verify without depending on
+    // the real Markdown pipeline (covered by markdown.test.cjs).
+    override(markdown, "parse_non_message", (raw_content) =>
+        raw_content.replace(
+            /@\*\*(.+?)\*\*/,
+            '<span class="user-mention" data-user-id="100">@$1</span>',
+        ),
+    );
+    let update_elements_calls = 0;
+    override(rendered_markdown, "update_elements", () => {
+        update_elements_calls += 1;
+    });
+
+    const $widget_elem = $("<div>").addClass("widget-content");
+    const activate_opts = {
+        message: {
+            sender_id: alice.user_id,
+        },
+        any_data: {
+            widget_type: "poll",
+            extra_data: {
+                question: "cc @**Alice Lee**",
+                options: ["ping @**Alice Lee**"],
+            },
+        },
+    };
+
+    const set_widget_find_result = (selector) => {
+        const $elem = $.create(selector);
+        $widget_elem.set_find_results(selector, $elem);
+        return $elem;
+    };
+
+    set_widget_find_result("button.poll-option");
+    set_widget_find_result("input.poll-option");
+    const $widget_option_container = set_widget_find_result("ul.poll-widget");
+
+    set_widget_find_result("button.poll-question-check");
+    set_widget_find_result(".poll-edit-question");
+    const $poll_question_header = set_widget_find_result(".poll-question-header");
+    set_widget_find_result(".poll-question-bar");
+    set_widget_find_result(".poll-option-bar");
+    set_widget_find_result("button.poll-vote");
+    set_widget_find_result(".poll-please-wait");
+    set_widget_find_result("button.poll-question-remove");
+    set_widget_find_result("input.poll-question");
+
+    const {widget_data} = poll_widget.activate(activate_opts);
+    poll_widget.render({
+        $elem: $widget_elem,
+        callback: noop,
+        message: {sender_id: alice.user_id},
+        widget_data,
+        rerender: false,
+    });
+
+    assert.equal(
+        $poll_question_header.html(),
+        'cc <span class="user-mention" data-user-id="100">@Alice Lee</span>',
+    );
+    assert.match(
+        $widget_option_container.html(),
+        /<span class="poll-option-text">ping <span class="user-mention" data-user-id="100">@Alice Lee<\/span><\/span>/,
+    );
+    // Called once for the question and once for the options list.
+    assert.equal(update_elements_calls, 2);
 });


### PR DESCRIPTION
## Summary

Fixes: #39968

When a poll question or option contains manually-typed mention syntax
(e.g. `@**Full Name**`), the message gets the normal "you were
mentioned" background-color treatment, but the mention itself renders
as raw literal text inside the poll widget instead of a mention pill.

### Root cause

The message-highlight behavior is driven by the server's normal
Markdown render of the full raw message content (which includes the
literal `/poll ...` command text) at send time — that's a completely
separate pipeline from what the poll widget displays.

Poll question/option text itself, however, is plain text end-to-end:
extracted from the `/poll` command via string splitting
(`zerver/lib/widget.py`), stored/broadcast as raw JSON over
`SubMessage` events (`zerver/actions/submessage.py`), and inserted
into the DOM via `.text()` / auto-escaped Handlebars interpolation
(`web/src/poll_widget.ts`, `web/templates/widgets/poll_widget_results.hbs`)
— it is never run through any Markdown renderer, client or server.

### Fix

Poll content is only ever displayed in the browser (no `/poll` widget
markup on other clients needs re-rendering server-side), so this uses
Zulip's existing **client-side** Markdown pipeline
(`markdown.parse_non_message`) to render poll question/option text
before inserting it, matching the pattern already used for other
"not really a message, but has Markdown" strings (zcommand replies,
linkifier examples, compose-preview snippets). After rendering, we
run `rendered_markdown.update_elements(...)` — the same post-processing
normal message content gets — so mentions receive the pill styling
and `user-mention-me` highlight class consistent with regular
messages. Since poll question/option text is single-line, the
`<p>` wrapper Markdown normally adds is stripped before insertion
(reusing the same helper already used for linkifier example
rendering, now extracted into `markdown.ts` so it isn't duplicated a
third time).

No backend changes: poll content storage/broadcast was already raw
text, so nothing there needed to change.

### Scope

I deliberately did not add mention-typeahead support to the poll
question/option `<input>` fields — the issue says this "would need to
be looked into" for possible issues, so I kept this PR focused on the
rendering bug itself. Happy to follow up with the typeahead in a
separate PR if desired.

## Test plan

- [x] `node web/tests/lib/index.cjs web/tests/poll_widget.test.cjs` — including a new test that types `@**Alice Lee**` into a poll question and option and asserts the resulting DOM contains a real `.user-mention` span (via `markdown.parse_non_message`) and that `rendered_markdown.update_elements` is invoked
- [x] `node web/tests/lib/index.cjs web/tests/templates.test.cjs` — Handlebars helper tests still pass after switching the results template to `{{{ option }}}`
- [x] `tsc --noEmit` on the full project — no new type errors (one pre-existing, unrelated error in `settings_account.ts` remains, present on `main` too)
- [x] `prettier`/`stylelint` clean on all touched files
- [ ] Full browser-based visual verification (creating a real poll, typing a mention, confirming the pill renders/links to the right user, checking light/dark themes) — **not done**. My sandbox has no provisioned Zulip dev environment (no Postgres/venv, `./tools/run-dev` unavailable), so I could not exercise this in an actual browser. Would appreciate a reviewer double-checking this manually.

## Self-review checklist

- [x] The PR addresses the issue (mentions now render correctly inside poll content)
- [x] Relevant tests pass locally; new test added that would have caught this bug
- [x] Code follows existing patterns (`markdown.parse_non_message` + paragraph-unwrap, same as `settings_linkifiers.ts`/`zcommand.ts`; `rendered_markdown.update_elements`, same as normal message rendering)
- [x] Names are clear and greppable
- [x] Commit message explains why, single coherent commit
- [x] No debugging code or unnecessary comments remain
- [x] Type annotations complete (`tsc --noEmit` clean for touched files)
- [x] No new user-facing strings requiring translation
- [ ] No secrets or credentials hardcoded — n/a
- [ ] Documentation update — no docs describe the old (broken) behavior explicitly; none found needing updates
- [x] Refactoring complete — `git grep maybe_unwrap_single_paragraph` confirms only one definition now, in `markdown.ts`
- [x] Security audit — output HTML comes from the same trusted client-side Markdown renderer already used for local-echoed message content and other non-message strings (e.g. linkifier examples); no new unescaped user input path is introduced beyond what already exists elsewhere in the app