### PR TITLE
Developer docs update

### DIFF
--- a/docs/documentation/overview.md
+++ b/docs/documentation/overview.md
@@ -49,10 +49,11 @@ to help make reviews efficient.
 If you want to build the developer documentation locally (e.g., to test
 your changes), the dependencies are automatically installed as part of
 Zulip development environment provisioning, and you can build the
-documentation using:
+documentation and run the server using:
 
 ```bash
 ./tools/build-docs
+./tools/run-dev
 ```
 
 and then opening `http://127.0.0.1:9991/docs/index.html` in your

--- a/docs/git/cloning.md
+++ b/docs/git/cloning.md
@@ -124,8 +124,9 @@ you create a pull request. While you wait for GitHub Actions jobs
 to run, you can start working on your next task. When the tests finish,
 you can create a pull request that you already know passes the tests.
 
-GitHub Actions will run all the jobs by default on your forked repository.
-You can check the `Actions` tab of your repository to see the builds.
+You can [manually run GitHub Actions jobs][github-manual-workflow] when you
+first push your new branch. Once you make a PR, GitHub Actions will run all
+the jobs automatically.
 
 [gitbook-rebase]: https://git-scm.com/book/en/v2/Git-Branching-Rebasing
 [github-help-add-ssh-key]: https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account
@@ -135,6 +136,7 @@ You can check the `Actions` tab of your repository to see the builds.
 [github-zulip]: https://github.com/zulip/
 [github-zulip-zulip]: https://github.com/zulip/zulip/
 [github-actions]: https://docs.github.com/en/actions
+[github-manual-workflow]: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#running-a-workflow
 [zulip-rtd-dev-first-time]: ../development/setup-recommended.md
 [zulip-rtd-dev-overview]: ../development/overview.md
 [zulip-rtd-tools-setup]: zulip-tools.md#set-up-git-repo-script

--- a/docs/testing/testing-with-puppeteer.md
+++ b/docs/testing/testing-with-puppeteer.md
@@ -74,7 +74,7 @@ integration](continuous-integration.md):
   affects any of the selectors used in the tests? If so, the test may
   just need to be updated for your changes.
 - Does the test fail deterministically when you run it locally using
-  e.g., `./tools/test-js-with-puppeteer compose.ts`? If so, you can
+  e.g., `./tools/test-js-with-puppeteer compose.test.ts`? If so, you can
   iteratively debug to see the failure.
 - Does the test fail nondeterministically? If so, the problem is
   likely that a `waitForSelector` statement is either missing or not


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This adds and updates out-of-date information in the developer docs. Related discussion: [#documentation > Updating information in the docs](https://chat.zulip.org/#narrow/channel/19-documentation/topic/Updating.20information.20in.20the.20docs/with/2509075)

**Rename puppeteer test file:**
In the `web/e2e-tests` directory, `compose.ts` is now named `compose.test.ts`
|Before|After|
|---|---|
|<img width="595" height="641" alt="puppeteer-before" src="https://github.com/user-attachments/assets/e84a827d-b5b2-44b1-ab95-3d689355e21e" />|<img width="595" height="641" alt="puppeteer-after" src="https://github.com/user-attachments/assets/53cd4e9f-64ad-499f-be47-6237a9eb1f6c" />

**Running tests manually:**
Github Actions jobs are not triggered automatically on push since [this commit](https://github.com/zulip/zulip/commit/acff0879e7a3078a88cc8b1a39853102ac3e6bf2). The update refers the reader to [this article](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#running-a-workflow) to learn how to trigger the jobs manually.
|Before|After|
|---|---|
|<img width="595" height="641" alt="ci-before" src="https://github.com/user-attachments/assets/e8ffdf7c-e2a2-4500-b59f-add1891fe2ab" />|<img width="595" height="641" alt="ci-after" src="https://github.com/user-attachments/assets/07f8410d-016f-4520-8e7a-4679283e53d3" />

**Running the server for the docs:**
It took me a while to figure out that the docs and app run on the same server. I think it's better to add the command explicitly.
|Before|After|
|---|---|
|<img width="595" height="641" alt="docs-before" src="https://github.com/user-attachments/assets/10bc1f25-c400-483f-9ee0-206a8c9e21ec" />|<img width="595" height="641" alt="docs-after" src="https://github.com/user-attachments/assets/2e85f84a-72a2-420c-8e99-279bb3fb0c41" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
