### PR TITLE
message_summary: Support mention for users included in LLM summary.

### DIFF
--- a/zerver/actions/message_summary.py
+++ b/zerver/actions/message_summary.py
@@ -9,6 +9,7 @@ from openai.types.chat import ChatCompletionMessageParam
 
 from analytics.lib.counts import COUNT_STATS, do_increment_logging_stat
 from zerver.lib.markdown import markdown_convert
+from zerver.lib.mention import MentionBackend, MentionData, silence_mentions
 from zerver.lib.message import messages_for_ids
 from zerver.lib.narrow import (
     LARGER_THAN_MAX_MESSAGE_ID,
@@ -47,15 +48,20 @@ def ai_stats_finish() -> None:
     ai_total_time += time.time() - ai_time_start
 
 
+def rewrite_mentions_to_silent_mentions(message_content: str) -> str:
+    # Rewrite every mention to its silent mention syntax.
+    # TODO: We need to either exclude wild card mention or
+    # tell the model, below, how to handle or refer to them.
+    return silence_mentions(message_content)
+
+
 def format_zulip_messages_for_model(zulip_messages: list[dict[str, Any]]) -> str:
     # Format the Zulip messages for processing by the model.
     #
     # - We don't need to encode the recipient, since that's the same for
     #   every message in the conversation.
-    # - We use full names to reference senders, since we want the
-    #   model to refer to users by name. We may want to experiment
-    #   with using silent-mention syntax for users if we move to
-    #   Markdown-rendering what the model returns.
+    # - Every user or group the summary may name is written
+    #   as a silent mention for the model to copy.
     # - We don't include timestamps, since experiments with current models
     #   suggest they do not make relevant use of them.
     # - We haven't figured out a useful way to include reaction metadata (either
@@ -63,7 +69,10 @@ def format_zulip_messages_for_model(zulip_messages: list[dict[str, Any]]) -> str
     # - Polls/TODO widgets are currently sent to the model as empty messages,
     #   since this logic doesn't inspect SubMessage objects.
     zulip_messages_list = [
-        {"sender": message["sender_full_name"], "content": message["content"]}
+        {
+            "sender": f"@_**{message['sender_full_name']}|{message['sender_id']}**",
+            "content": rewrite_mentions_to_silent_mentions(message["content"]),
+        }
         for message in zulip_messages
     ]
     return orjson.dumps(zulip_messages_list).decode()
@@ -157,9 +166,29 @@ def do_summarize_narrow(
     prompt = (
         f"Succinctly summarize this conversation based only on the information provided, "
         f"in up to {max_summary_length} sentences, for someone who is familiar with the context. "
-        f"Mention key conclusions and actions, if any. Refer to specific people as appropriate. "
+        f"Mention key conclusions and actions, if any. "
         f"Don't use an intro phrase. You can use Zulip's CommonMark based formatting."
     )
+
+    # TODO: A model may confuse a wild card mention with a person,
+    # since they have the same mention syntax. We should instruct the model
+    # how to handle a wild card mention in case we decide to leave it.
+    mention_instructions = (
+        " Refer to specific people and groups as appropriate. "
+        "Every person and group in the conversation above is written as a mention: \n"
+        " -person mention: the prefix @_** followed by text identifying that person followed "
+        "by the suffix **. A message's author appears as its sender; anyone else appears within "
+        "the message content.\n"
+        " -group mention: the prefix @_* followed by text identifying that group followed "
+        "by the suffix *.\n"
+        "When you refer to a person or a group, reproduce their whole mention character for "
+        "character, prefix and suffix included. "
+        "Never write a mention that does not appear above; where a person or group is given as "
+        "plain text rather than as a mention, refer to them by that plain text alone."
+    )
+
+    prompt += mention_instructions
+
     messages = [
         make_message(intro, "system"),
         make_message(formatted_conversation),
@@ -208,8 +237,21 @@ def do_summarize_narrow(
 
     summary = response.choices[0].message.content
     assert summary is not None
-    # TODO: This may want to fetch `MentionData`, in order to be able
-    # to process channel or user mentions that might be in the
-    # content. Requires a prompt that supports it.
-    rendered_summary = markdown_convert(summary, message_realm=user_profile.realm).rendered_content
+
+    # We render the LLM summary against MentionData scoped to the acting
+    # user, to handle mention permission for users (senders or mentioned)
+    # that are all now mentioned in the summary, and also in
+    # case the model invents inaccessible/non-existing users.
+    mention_backend = MentionBackend(user_profile.realm_id)
+    mention_data = MentionData(
+        mention_backend=mention_backend,
+        content=summary,
+        message_sender=user_profile,
+    )
+    rendered_summary = markdown_convert(
+        summary,
+        message_realm=user_profile.realm,
+        acting_user=user_profile,
+        mention_data=mention_data,
+    ).rendered_content
     return rendered_summary

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1518,12 +1518,9 @@ class BlockQuoteProcessor(markdown.blockprocessors.BlockQuoteProcessor):
 
     @override
     def clean(self, line: str) -> str:
-        # Silence all the mentions inside blockquotes
-        line = mention.MENTIONS_RE.sub(lambda m: "@_**{}**".format(m.group("match")), line)
-        # Silence all the user group mentions inside blockquotes
-        line = mention.USER_GROUP_MENTIONS_RE.sub(lambda m: "@_*{}*".format(m.group("match")), line)
+        line = mention.silence_mentions(line)
 
-        # And then run the upstream processor's code for removing the '>'
+        # Run the upstream processor's code for removing the '>'
         return super().clean(line)
 
 

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -468,6 +468,15 @@ class MentionData:
         return self.mention_backend.get_topic_info_map(channel_topics, acting_user=acting_user)
 
 
+def silence_mentions(content: str) -> str:
+    """
+    Silence all mentions inside content.
+    """
+    content = MENTIONS_RE.sub(lambda m: "@_**{}**".format(m.group("match")), content)
+    content = USER_GROUP_MENTIONS_RE.sub(lambda m: "@_*{}*".format(m.group("match")), content)
+    return content
+
+
 def silent_mention_syntax_for_user(user_profile: UserProfile | UserDisplayRecipient) -> str:
     if isinstance(user_profile, UserProfile):
         return f"@_**{user_profile.full_name}|{user_profile.id}**"

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -232,12 +232,12 @@ DEMO_ORG_DEADLINE_DAYS = 30
 if external_host_env is None and not IS_DEV_DROPLET:
     USING_CAPTCHA = True
 
-TOPIC_SUMMARIZATION_MODEL = "llama-3.3-70b-versatile"
+TOPIC_SUMMARIZATION_MODEL = "openai/gpt-oss-120b"
 TOPIC_SUMMARIZATION_API_BASE = "https://api.groq.com/openai/v1"
-# Defaults based on groq's pricing for Llama 3.3 70B Versatile 128k.
-# https://groq.com/pricing/
-OUTPUT_COST_PER_GIGATOKEN = 590
-INPUT_COST_PER_GIGATOKEN = 790
+# Defaults based on groq's pricing for GPT-OSS 120B (128k context).
+# https://console.groq.com/docs/model/openai/gpt-oss-120b
+OUTPUT_COST_PER_GIGATOKEN = 600
+INPUT_COST_PER_GIGATOKEN = 150
 MAX_PER_USER_MONTHLY_AI_COST = 1
 MAX_WEB_DATA_IMPORT_SIZE_MB = 1024
 


### PR DESCRIPTION
Any conversation user, participant or mentioned, the LLM decides to include in its LLM summary is silently mentioned to support Zulip frontend style for mentioned users.

We now extend the prompt with a custom `mention_instructions`.

## Model used
`TOPIC_SUMMARIZATION_MODEL= "openai/gpt-oss-120b"`

## Conversation screenshot
<details>
  <summary>See original conversation</summary>
  
<img width="942" height="735" alt="Dark_chocolate_conversation_1" src="https://github.com/user-attachments/assets/6b27472e-e71b-4b15-b6b7-c8c67a10e709" />

<img width="943" height="690" alt="Dark_chocolate_conversation_2" src="https://github.com/user-attachments/assets/e73020b1-7ac2-4907-b819-9248eb2e171d" />
</details>



## LLM summary output

Note that both the senders and the mentioned users who are not participants (`Imported User` and `Othello, the Moor of Venice`) are mentioned correctly.

<img width="786" height="344" alt="LLM_summary" src="https://github.com/user-attachments/assets/a27308a0-4f65-4f0b-af07-2528b9e6b4d6" />

## TODO

- [X] Address group mentions
- [ ] Address channel references/links
- [ ] Frontend changes to support: opening user card on click and highlight the current user differently.
- [ ] Relevant tests
