### PR TITLE
message_overlay: Prevent grid blowouts on messagebox content.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -923,10 +923,13 @@ input.settings_text_input {
         }
 
         .messagebox-content {
-            grid-template: auto / auto max-content;
-            grid-template-areas:
-                "message controls"
-                "message .       ";
+            /* The min-content effectively cinches to the
+               height of the per-draft controls, while the
+               second row accommodates the full message. */
+            grid-template:
+                "message controls" min-content
+                "message .       " minmax(0, 1fr)
+                / minmax(0, 1fr) max-content;
             /* to space from restore draft button */
             column-gap: 5px;
             padding: 10px;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -876,7 +876,7 @@ input.settings_text_input {
    for other modals that currently employ flexbox. */
 .overlay-messages-container.drafts-container {
     display: grid;
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template: auto minmax(0, 1fr) / minmax(0, 1fr);
 
     /* min-height: 0 lets the tab pane shrink inside the 1fr grid row
        (grid items default to min-height: auto). */


### PR DESCRIPTION
This corrects an edge case on Safari and other browsers where a long line of non-breaking inline text (such as a link) cause a weird preview in the drafts and other message overlays.

A prep commit fixes the drafts overlay so it resizes as the viewport window gets smaller (and larger).

Fixes: [#issues > weird draft rendering of emoji + URL?](https://chat.zulip.org/#narrow/channel/9-issues/topic/weird.20draft.20rendering.20of.20emoji.20.2B.20URL.3F/with/2459654)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="2762" height="1794" alt="draft-preview-before" src="https://github.com/user-attachments/assets/cb7c26e3-b58a-4398-8c2c-0b6d8e461136" /> | <img width="2762" height="1794" alt="draft-preview-after" src="https://github.com/user-attachments/assets/2ee2a625-eba1-4e07-b76c-379bedd63a2f" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>