### PR TITLE
[ai] copy_messages: Let the browser copy selections with no message content.

### DIFF
--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -261,6 +261,135 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
+type CopyRangeEndpoint = {
+    role: "message_time" | "sender" | "content" | "topic_header" | "reminder";
+    content: string;
+};
+
+async function copy_custom_range(
+    page: Page,
+    start: CopyRangeEndpoint,
+    end: CopyRangeEndpoint,
+    split_into_disjoint_ranges = false,
+    end_text_node_offset?: number,
+): Promise<{
+    default_prevented: boolean;
+    copied_lines: string[];
+    selection_text: string;
+    range_count: number;
+}> {
+    return await page.evaluate(
+        (
+            start: CopyRangeEndpoint,
+            end: CopyRangeEndpoint,
+            split_into_disjoint_ranges: boolean,
+            end_text_node_offset: number | undefined,
+        ) => {
+            function find_content(text: string): Element {
+                const node = [...document.querySelectorAll(".message-list .message_content")].find(
+                    (candidate) => candidate.textContent?.trim() === text,
+                );
+                if (!node) {
+                    throw new Error(`Expected message content: ${text}`);
+                }
+                return node;
+            }
+
+            function endpoint_node(endpoint: CopyRangeEndpoint): Node {
+                if (endpoint.role === "topic_header") {
+                    const header = document.querySelector(
+                        `.message-list .message_header[data-topic-name="${CSS.escape(endpoint.content)}"]`,
+                    );
+                    const header_contents = header?.querySelector(".message-header-contents");
+                    if (!header_contents) {
+                        throw new Error(`Expected topic header: ${endpoint.content}`);
+                    }
+                    return header_contents;
+                }
+                const content = find_content(endpoint.content);
+                const row = content.closest(".message_row");
+                if (!row) {
+                    throw new Error("Expected a message row");
+                }
+                if (endpoint.role === "content") {
+                    return content;
+                }
+                if (endpoint.role === "sender") {
+                    const sender = row.querySelector(".sender_name");
+                    if (!sender) {
+                        throw new Error("Expected a sender name");
+                    }
+                    return sender;
+                }
+                if (endpoint.role === "reminder") {
+                    const reminder = row.querySelector(".message-reminder");
+                    if (!reminder) {
+                        throw new Error("Expected a reminder");
+                    }
+                    return reminder;
+                }
+                const time = row.querySelector(".message-time");
+                if (!time) {
+                    throw new Error("Expected a message timestamp");
+                }
+                return time;
+            }
+
+            const start_node = endpoint_node(start);
+            const end_node = endpoint_node(end);
+            const selection = window.getSelection()!;
+            selection.removeAllRanges();
+            if (split_into_disjoint_ranges) {
+                // Firefox <147 does this around `user-select: none`
+                // nodes. Chrome usually keeps only the first range.
+                const start_range = document.createRange();
+                start_range.selectNode(start_node);
+                selection.addRange(start_range);
+                const end_range = document.createRange();
+                end_range.selectNode(end_node);
+                selection.addRange(end_range);
+            } else {
+                const range = document.createRange();
+                range.setStartBefore(start_node);
+                if (end_text_node_offset !== undefined) {
+                    const end_text = find_content(end.content).querySelector("p")?.firstChild;
+                    if (!(end_text instanceof Text)) {
+                        throw new TypeError("Expected a Text node");
+                    }
+                    range.setEnd(end_text, end_text.length - end_text_node_offset);
+                } else {
+                    range.setEndAfter(end_node);
+                }
+                selection.addRange(range);
+            }
+
+            const clipboard_data = new DataTransfer();
+            const copy_event = new ClipboardEvent("copy", {
+                bubbles: true,
+                cancelable: true,
+                clipboardData: clipboard_data,
+            });
+            document.dispatchEvent(copy_event);
+
+            const copied_html = clipboard_data.getData("text/html");
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(copied_html, "text/html");
+            return {
+                default_prevented: copy_event.defaultPrevented,
+                copied_lines: [...doc.body.children]
+                    .map((el) => el.textContent.trim())
+                    .filter((line) => line !== ""),
+                selection_text: window.getSelection()!.toString(),
+                range_count: window.getSelection()!.rangeCount,
+            };
+        },
+        start,
+        end,
+        split_into_disjoint_ranges,
+        end_text_node_offset,
+    );
+}
+
 async function test_copying_selection_with_no_message_content(page: Page): Promise<void> {
     // A recipient header plus the first message's sender name has no
     // `.message_content`.
@@ -306,6 +435,190 @@ async function test_copying_selection_with_no_message_content(page: Page): Promi
     assert.ok(result.selection_text.includes("Desdemona"));
 }
 
+async function test_copying_me_timestamp_through_next_sender(page: Page): Promise<void> {
+    // /me timestamp through the next sender: no message body.
+    const result = await copy_custom_range(
+        page,
+        {role: "message_time", content: "is posing for copy tests"},
+        {role: "sender", content: "regular after me for copy tests"},
+    );
+    assert.equal(result.default_prevented, false);
+    assert.deepStrictEqual(result.copied_lines, []);
+    assert.ok(result.selection_text.includes("Desdemona"));
+}
+
+async function test_copying_me_timestamp_through_next_body(page: Page): Promise<void> {
+    // /me timestamp through the next message body.
+    const result = await copy_custom_range(
+        page,
+        {role: "message_time", content: "is posing for copy tests"},
+        {role: "content", content: "regular after me for copy tests"},
+    );
+    assert.equal(result.default_prevented, true);
+    assert.deepStrictEqual(result.copied_lines, ["Desdemona:", "regular after me for copy tests"]);
+}
+
+async function test_copying_me_timestamp_through_partial_next_body(page: Page): Promise<void> {
+    const result = await copy_custom_range(
+        page,
+        {role: "message_time", content: "is posing for copy tests"},
+        {role: "content", content: "regular after me for copy tests"},
+        false,
+        6,
+    );
+    assert.equal(result.default_prevented, true);
+    assert.deepStrictEqual(result.copied_lines, ["Desdemona:", "regular after me for copy..."]);
+}
+
+async function test_copying_me_timestamp_through_later_sender(page: Page): Promise<void> {
+    // /me timestamp through a later /me sender.
+    const result = await copy_custom_range(
+        page,
+        {role: "message_time", content: "is posing for copy tests"},
+        {role: "sender", content: "is posing again for copy tests"},
+    );
+    assert.equal(result.default_prevented, true);
+    assert.deepStrictEqual(result.copied_lines, [
+        "Desdemona:",
+        "regular after me for copy tests",
+        "Desdemona:",
+        "regular last after two mes",
+    ]);
+}
+
+async function test_copying_me_timestamp_through_later_body(page: Page): Promise<void> {
+    const result = await copy_custom_range(
+        page,
+        {role: "message_time", content: "is posing for copy tests"},
+        {role: "content", content: "regular last after two mes"},
+    );
+    assert.equal(result.default_prevented, true);
+    assert.deepStrictEqual(result.copied_lines, [
+        "Desdemona:",
+        "regular after me for copy tests",
+        "Desdemona:",
+        "regular last after two mes",
+    ]);
+}
+
+async function test_copying_disjoint_ranges_with_no_message_content(page: Page): Promise<void> {
+    // Firefox <147 splits a selection around `user-select: none`.
+    const header_and_sender = await copy_custom_range(
+        page,
+        {role: "topic_header", content: "copy-paste-topic #2"},
+        {role: "sender", content: "copy paste test C"},
+        true,
+    );
+    assert.ok(header_and_sender.range_count >= 1);
+    assert.equal(header_and_sender.default_prevented, false);
+    assert.deepStrictEqual(header_and_sender.copied_lines, []);
+
+    const me_time_and_next_sender = await copy_custom_range(
+        page,
+        {role: "message_time", content: "is posing for copy tests"},
+        {role: "sender", content: "regular after me for copy tests"},
+        true,
+    );
+    assert.ok(me_time_and_next_sender.range_count >= 1);
+    assert.equal(me_time_and_next_sender.default_prevented, false);
+    assert.deepStrictEqual(me_time_and_next_sender.copied_lines, []);
+}
+
+async function test_copying_disjoint_ranges_with_later_body(page: Page): Promise<void> {
+    // Firefox <147: disjoint /me timestamp range and next-body range.
+    const result = await copy_custom_range(
+        page,
+        {role: "message_time", content: "is posing for copy tests"},
+        {role: "content", content: "regular after me for copy tests"},
+        true,
+    );
+    if (result.range_count > 1) {
+        assert.equal(result.default_prevented, true);
+        assert.deepStrictEqual(result.copied_lines, [
+            "Desdemona:",
+            "regular after me for copy tests",
+        ]);
+    } else {
+        // Chrome ignored the second range; a lone /me timestamp is a
+        // same-message selection and is copied natively.
+        assert.equal(result.default_prevented, false);
+        assert.deepStrictEqual(result.copied_lines, []);
+    }
+}
+
+async function schedule_reminder_on_message(page: Page, content: string): Promise<void> {
+    await page.evaluate(async (content: string) => {
+        const node = [...document.querySelectorAll(".message-list .message_content")].find(
+            (candidate) => candidate.textContent?.trim() === content,
+        );
+        const message_id = node?.closest(".message_row")?.getAttribute("data-message-id");
+        const csrf = document.querySelector<HTMLInputElement>(
+            "input[name=csrfmiddlewaretoken]",
+        )?.value;
+        if (!message_id || !csrf) {
+            throw new Error("Expected message id and csrf token");
+        }
+        const res = await fetch("/json/reminders", {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": csrf,
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: new URLSearchParams({
+                message_id,
+                scheduled_delivery_timestamp: String(Math.floor(Date.now() / 1000) + 86400),
+            }),
+        });
+        if (!res.ok) {
+            throw new Error(`Failed to schedule reminder: ${res.status}`);
+        }
+    }, content);
+    await page.waitForSelector(".message-list .message-reminder", {visible: true});
+}
+
+async function test_copying_from_reminder_through_next_body(page: Page): Promise<void> {
+    // Reminder text through the next message.
+    await schedule_reminder_on_message(page, "copy paste test F");
+    const regular_through_body = await copy_custom_range(
+        page,
+        {role: "reminder", content: "copy paste test F"},
+        {role: "content", content: "copy paste test G"},
+    );
+    assert.equal(regular_through_body.default_prevented, true);
+    assert.deepStrictEqual(regular_through_body.copied_lines, ["Desdemona:", "copy paste test G"]);
+
+    await schedule_reminder_on_message(page, "is posing for copy tests");
+    const through_sender = await copy_custom_range(
+        page,
+        {role: "reminder", content: "is posing for copy tests"},
+        {role: "sender", content: "regular after me for copy tests"},
+    );
+    assert.equal(through_sender.default_prevented, false);
+    assert.deepStrictEqual(through_sender.copied_lines, []);
+
+    const through_body = await copy_custom_range(
+        page,
+        {role: "reminder", content: "is posing for copy tests"},
+        {role: "content", content: "regular after me for copy tests"},
+    );
+    assert.equal(through_body.default_prevented, true);
+    assert.deepStrictEqual(through_body.copied_lines, [
+        "Desdemona:",
+        "regular after me for copy tests",
+    ]);
+}
+
+async function test_copying_through_trailing_sender_name(page: Page): Promise<void> {
+    // Selection ends on a sender name.
+    const result = await copy_custom_range(
+        page,
+        {role: "content", content: "is posing for copy tests"},
+        {role: "sender", content: "regular after me for copy tests"},
+    );
+    assert.equal(result.default_prevented, true);
+    assert.deepStrictEqual(result.copied_lines, ["Desdemona:", "is posing for copy tests"]);
+}
+
 async function copy_paste_test(page: Page): Promise<void> {
     await common.log_in(page);
     await common.send_multiple_messages(page, [
@@ -328,6 +641,30 @@ async function copy_paste_test(page: Page): Promise<void> {
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test F"},
 
         {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test G"},
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "/me is posing for copy tests",
+        },
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "regular after me for copy tests",
+        },
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "regular last after two mes",
+        },
+
+        {
+            stream_name: "Verona",
+            topic: "copy-paste-topic #4",
+            content: "/me is posing again for copy tests",
+        },
     ]);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
@@ -340,6 +677,15 @@ async function copy_paste_test(page: Page): Promise<void> {
             ["copy paste test C", "copy paste test D", "copy paste test E"],
         ],
         ["Verona > copy-paste-topic #3", ["copy paste test F", "copy paste test G"]],
+        [
+            "Verona > copy-paste-topic #4",
+            [
+                "is posing for copy tests",
+                "regular after me for copy tests",
+                "regular last after two mes",
+                "is posing again for copy tests",
+            ],
+        ],
     ]);
     console.log("Messages were sent successfully");
 
@@ -353,6 +699,15 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_messages_from_several_topics(page);
     await test_timestamp_clipboard_has_datetime(page);
     await test_copying_selection_with_no_message_content(page);
+    await test_copying_me_timestamp_through_next_sender(page);
+    await test_copying_me_timestamp_through_next_body(page);
+    await test_copying_me_timestamp_through_partial_next_body(page);
+    await test_copying_me_timestamp_through_later_sender(page);
+    await test_copying_me_timestamp_through_later_body(page);
+    await test_copying_disjoint_ranges_with_no_message_content(page);
+    await test_copying_disjoint_ranges_with_later_body(page);
+    await test_copying_from_reminder_through_next_body(page);
+    await test_copying_through_trailing_sender_name(page);
     await test_multiple_message_selection_with_partially_selected_bookend_messages(page);
 }
 

--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -261,6 +261,51 @@ async function test_multiple_message_selection_with_partially_selected_bookend_m
     assert.deepStrictEqual(actual_copied_lines, expected_copied_lines);
 }
 
+async function test_copying_selection_with_no_message_content(page: Page): Promise<void> {
+    // A recipient header plus the first message's sender name has no
+    // `.message_content`.
+    const result = await page.evaluate(() => {
+        const header = document.querySelector(
+            '.message-list .message_header[data-topic-name="copy-paste-topic #2"]',
+        );
+        const sender_name = header
+            ?.closest(".recipient_row")
+            ?.querySelector(":scope .message_row .sender_name");
+        const header_contents = header?.querySelector(".message-header-contents");
+        if (!header_contents || !sender_name) {
+            throw new Error("Expected topic header and sender name");
+        }
+
+        const range = document.createRange();
+        range.setStart(header_contents, 0);
+        range.setEndAfter(sender_name);
+        window.getSelection()!.removeAllRanges();
+        window.getSelection()!.addRange(range);
+
+        const clipboard_data = new DataTransfer();
+        const copy_event = new ClipboardEvent("copy", {
+            bubbles: true,
+            cancelable: true,
+            clipboardData: clipboard_data,
+        });
+        document.dispatchEvent(copy_event);
+
+        return {
+            default_prevented: copy_event.defaultPrevented,
+            copied_html: clipboard_data.getData("text/html"),
+            copied_text: clipboard_data.getData("text/plain"),
+            selection_text: window.getSelection()!.toString(),
+        };
+    });
+
+    // Synthetic ClipboardEvent: native copy does not fill clipboard_data.
+    // defaultPrevented === false is what shows the handler stepped aside.
+    assert.equal(result.default_prevented, false);
+    assert.equal(result.copied_html, "");
+    assert.equal(result.copied_text, "");
+    assert.ok(result.selection_text.includes("Desdemona"));
+}
+
 async function copy_paste_test(page: Page): Promise<void> {
     await common.log_in(page);
     await common.send_multiple_messages(page, [
@@ -307,6 +352,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     await test_copying_all_from_prev_first_from_next(page);
     await test_copying_messages_from_several_topics(page);
     await test_timestamp_clipboard_has_datetime(page);
+    await test_copying_selection_with_no_message_content(page);
     await test_multiple_message_selection_with_partially_selected_bookend_messages(page);
 }
 

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -181,15 +181,17 @@ https://github.com/zulip/zulip/commit/fc0b7c00f16316a554349f0ad58c6517ebdd7ac4
 
 The idea is that we build a temp div, let jQuery process the
 selection, then restore the selection on a zero-second timer back
-to the original selection.
+to the original selection. Returning `false` indicates that we prefer
+the browser's native copy and have not manipulated the temp copy
+div.
 
 Do not be afraid to change this code if you understand
 how modern browsers deal with copy/paste.  Just test
 your changes carefully.
 */
-function construct_copy_div($div: JQuery, start_id: number, end_id: number): void {
+function construct_copy_div($div: JQuery, start_id: number, end_id: number): boolean {
     if (message_lists.current === undefined) {
-        return;
+        return false;
     }
     let $first_message_element;
     let $last_message_element;
@@ -223,7 +225,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
             copy_rows.splice(-1, 1);
             if (copy_rows.length === 0) {
                 // In case this just involved selecting the username of a message.
-                return;
+                return false;
             }
         }
         assert(copy_rows[0] && copy_rows.at(-1));
@@ -319,6 +321,7 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): voi
     if (should_include_start_recipient_header) {
         construct_recipient_header($start_row).prependTo($div);
     }
+    return true;
 }
 
 // We want to grab the closest katex span up the tree
@@ -603,7 +606,11 @@ export function copy_handler(ev: ClipboardEvent): boolean {
     // more difficult since we can get a range (start_id and end_id) for
     // each selection `Range`.
     const $div = $("<div>");
-    construct_copy_div($div, start_id, end_id);
+    if (!construct_copy_div($div, start_id, end_id)) {
+        // No message content in the selection so we let the browser copy
+        // the highlighted text natively.
+        return false;
+    }
 
     const html_content = $div.html().trim();
     const plain_text = $div.text().trim();

--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -71,6 +71,60 @@ function get_selected_message_content_elements(): NodeListOf<HTMLElement> | unde
         .querySelectorAll(".message_content");
 }
 
+// First selected range start through last selected range end.
+// Firefox <147 splits a contiguous selection into several ranges
+// around `user-select: none` nodes.
+function selection_extent_range(): Range | undefined {
+    const selection = window.getSelection();
+    if (selection === null || selection.rangeCount === 0) {
+        return undefined;
+    }
+    const first = selection.getRangeAt(0);
+    if (selection.rangeCount === 1) {
+        return first;
+    }
+    const last = selection.getRangeAt(selection.rangeCount - 1);
+    const extent = document.createRange();
+    extent.setStart(first.startContainer, first.startOffset);
+    extent.setEnd(last.endContainer, last.endOffset);
+    return extent;
+}
+
+function selection_covers_message_content($row: JQuery, range: Range): boolean {
+    const content = $row[0]?.querySelector(".message_content");
+    return content instanceof Element && range.intersectsNode(content);
+}
+
+// "end" when the selection starts after the previous message's
+// body, for example on a /me timestamp or reminder, and ends
+// in the middle of this message.
+// "start" when the range begins inside the first body.
+function bookend_ellipsis_side(original: Element, selected: HTMLElement): RangeContainer {
+    const original_text = original.textContent?.trim() ?? "";
+    const selected_text = selected.textContent?.trim() ?? "";
+    if (original_text.startsWith(selected_text)) {
+        return "end";
+    }
+    return "start";
+}
+
+// Drop a bookend row whose .message_content is outside the selection.
+function drop_unselected_bookend_rows(copy_rows: JQuery[]): void {
+    const range = selection_extent_range();
+    if (range === undefined) {
+        copy_rows.length = 0;
+        return;
+    }
+    const $first = copy_rows[0];
+    if ($first !== undefined && !selection_covers_message_content($first, range)) {
+        copy_rows.shift();
+    }
+    const $last = copy_rows.at(-1);
+    if ($last !== undefined && !selection_covers_message_content($last, range)) {
+        copy_rows.pop();
+    }
+}
+
 // Returns the inner HTML of the `.message_content` element
 // for the first or last message of a single range selection.
 // The caller is expected to only pass the first or last message
@@ -144,9 +198,11 @@ function maybe_expand_selection_for_first_and_last_messages(
     copy_rows: JQuery[],
     range_count: number,
 ): void {
-    // This is only meant for a multi-message selection involving
-    // multiple ranges.
-    assert(range_count > 1 && copy_rows.length > 1);
+    // Firefox <147 can emit multiple ranges for a single-row
+    // selection; expanding is only for a multi-row copy.
+    if (range_count <= 1 || copy_rows.length <= 1) {
+        return;
+    }
 
     if (navigator.userAgent.includes("Chrome")) {
         blueslip.error("Multiple ranges detected in Chrome for a multi-message selection.");
@@ -196,8 +252,14 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
     let $first_message_element;
     let $last_message_element;
     const copy_rows = rows.visible_range(start_id, end_id);
-    const range_count = window.getSelection()?.rangeCount;
-    if (range_count && range_count > 1) {
+    const range_count = window.getSelection()?.rangeCount ?? 0;
+    // Trim before expanding a Firefox <147 multi-range selection,
+    // which can have rangeCount > 1 with fewer contentful rows.
+    drop_unselected_bookend_rows(copy_rows);
+    if (copy_rows.length === 0) {
+        return false;
+    }
+    if (range_count > 1) {
         // Expand selection to select content from all the messages
         // belonging to the multi-message selection.
         // We do this only for Firefox where multi-message selections are
@@ -215,19 +277,6 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
         // a single range for a multi-message selection.
         const selected_message_content_elements = get_selected_message_content_elements();
         assert(selected_message_content_elements !== undefined);
-        // Case where the last message doesn't have any highlighted `.message_content`.
-        // Here, end_id is set to id of the message whose username at the top
-        // was highlighted, but has no highlighted `.message_content`.
-        // (See analyze_selection for details.)
-        // So the actually useful/contentful last message of this selection is
-        // at copy_rows[copy_rows.length - 2]
-        if (selected_message_content_elements.length === copy_rows.length - 1) {
-            copy_rows.splice(-1, 1);
-            if (copy_rows.length === 0) {
-                // In case this just involved selecting the username of a message.
-                return false;
-            }
-        }
         assert(copy_rows[0] && copy_rows.at(-1));
         const first_selected_message_content_element = the(copy_rows[0]).querySelector(
             ".message_content",
@@ -236,9 +285,20 @@ function construct_copy_div($div: JQuery, start_id: number, end_id: number): boo
             ".message_content",
         );
         assert(first_selected_message_content_element && last_selected_message_content_element);
+        assert(
+            selected_message_content_elements[0] !== undefined &&
+                selected_message_content_elements[0] instanceof HTMLElement,
+        );
+        const first_bookend_side =
+            selected_message_content_elements.length === 1
+                ? bookend_ellipsis_side(
+                      first_selected_message_content_element,
+                      selected_message_content_elements[0],
+                  )
+                : "start";
         $first_message_element = $(
             get_html_for_bookend_message_content(
-                "start",
+                first_bookend_side,
                 first_selected_message_content_element,
                 selected_message_content_elements[0],
             ),


### PR DESCRIPTION
When `construct_copy_div` found no message body in the selection, it returned without filling the copy div, but `copy_handler` still called `preventDefault` and wrote that empty div to the clipboard. Copying a recipient header plus a sender name therefore replaced the clipboard with an empty string. Selecting only a sender name already let the browser handle the copy.

Have `construct_copy_div` report failure and `copy_handler` return false so the browser copies the highlighted text natively.

The e2e test starts the range inside `.message-header-contents`. `setStartBefore(header)` puts the start on `.recipient_row`, which `analyze_selection` skips, so the handler never reaches this path.

Fixes https://github.com/zulip/zulip/pull/39678#issuecomment-5234566011.