### PR TITLE
[ai] IPv6 email server fixes

### DIFF
--- a/docs/production/email-gateway.md
+++ b/docs/production/email-gateway.md
@@ -97,6 +97,13 @@ using an [HTTP reverse proxy][reverse-proxy]).
 
 Congratulations! The integration should be fully operational.
 
+:::{note}
+The incoming mail server listens on port 25, on all IPv4 and IPv6
+addresses, by default; you can adjust this with the
+[`email_gateway.listen`](system-configuration.md#listen) setting in
+`/etc/zulip/zulip.conf`.
+:::
+
 [reverse-proxy]: reverse-proxies.md
 
 ## Polling setup

--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -533,3 +533,14 @@ The Sentry organization used for the [Sentry deploy hook](deployment.md#sentry-d
 #### `project`
 
 The Sentry project used for the [Sentry deploy hook](deployment.md#sentry-deploy-hook).
+
+### `[email_gateway]`
+
+#### `listen`
+
+The address for the [incoming email gateway's](email-gateway.md) SMTP
+server to bind to, as a bare port number, or `address:port`; IPv6
+addresses must be enclosed in square brackets (e.g.,
+`[2001:db8::1]:25`). Defaults to listening on port 25 on all
+addresses, both IPv4 and IPv6. This only applies to the local
+delivery mode of the gateway, not the polling mode.

--- a/puppet/zulip/manifests/local_mailserver.pp
+++ b/puppet/zulip/manifests/local_mailserver.pp
@@ -12,6 +12,7 @@ class zulip::local_mailserver {
       before => Service[$zulip::common::supervisor_service],
     }
   }
+  $listen = zulipconf('email_gateway', 'listen', '')
   file { "${zulip::common::supervisor_conf_dir}/email-mirror.conf":
     ensure  => file,
     require => [

--- a/puppet/zulip/templates/supervisor/email-mirror.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/email-mirror.conf.template.erb
@@ -1,5 +1,5 @@
 [program:zulip-email-server]
-command=nice -n15 /home/zulip/deployments/current/manage.py email_server --user zulip --group zulip
+command=nice -n15 /home/zulip/deployments/current/manage.py email_server --user zulip --group zulip<% if @listen != '' %> --listen <%= @listen %><% end %>
 environment=HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=350                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)

--- a/puppet/zulip/templates/supervisor/email-mirror.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/email-mirror.conf.template.erb
@@ -1,5 +1,7 @@
 [program:zulip-email-server]
-command=nice -n15 /home/zulip/deployments/current/manage.py email_server --user zulip --group zulip<% if @listen != '' %> --listen <%= @listen %><% end %>
+<%# supervisor expands the command as a format string, so percent signs
+    in the address (e.g. an IPv6 zone id) must be doubled. -%>
+command=nice -n15 /home/zulip/deployments/current/manage.py email_server --user zulip --group zulip<% if @listen != '' %> --listen <%= @listen.gsub('%', '%%') %><% end %>
 environment=HTTP_proxy="<%= @proxy %>",HTTPS_proxy="<%= @proxy %>"
 priority=350                   ; the relative start priority (default 999)
 autostart=true                 ; start at supervisord start (default: true)

--- a/zerver/lib/email_mirror_server.py
+++ b/zerver/lib/email_mirror_server.py
@@ -12,6 +12,7 @@ from collections.abc import Awaitable
 from contextlib import suppress
 from ssl import SSLContext, SSLError
 from typing import Any
+from urllib.parse import SplitResult
 
 from aiosmtpd.controller import UnthreadedController
 from aiosmtpd.handlers import Message as MessageHandler
@@ -152,6 +153,22 @@ class ZulipMessageHandler(MessageHandler):
             return "500 Server error"
 
 
+def parse_listen_address(listen: str) -> tuple[str, int]:
+    if listen.isdigit():
+        host, port = None, int(listen)
+    else:
+        r = SplitResult("", listen, "", "", "")
+        if r.port is None:
+            raise RuntimeError(f"{listen!r} does not have a valid port number.")
+        host, port = r.hostname, r.port
+    if host is None:
+        # With no address specified, bind the IPv6 wildcard address if
+        # IPv6 is available, since (with IPV6_V6ONLY disabled, as
+        # _create_server does) that accepts IPv4 connections as well.
+        host = "::" if socket.has_dualstack_ipv6() else "0.0.0.0"  # noqa: S104
+    return host, port
+
+
 class PermissionDroppingUnthreadedController(UnthreadedController):  # nocoverage
     @override
     def __init__(
@@ -175,9 +192,20 @@ class PermissionDroppingUnthreadedController(UnthreadedController):  # nocoverag
     def _create_server(self) -> Awaitable[asyncio.AbstractServer]:
         # Make the listen socket, then drop privileges before starting
         # the server
-        server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        family, type_, proto, _, sockaddr = socket.getaddrinfo(
+            self.hostname,
+            self.port,
+            type=socket.SOCK_STREAM,
+            flags=socket.AI_PASSIVE,
+        )[0]
+        server_socket = socket.socket(family, type_, proto)
         server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        server_socket.bind((self.hostname, self.port))
+        if family == socket.AF_INET6:
+            # Also accept IPv4 connections when binding the IPv6
+            # wildcard address; this has no effect when binding a
+            # specific address.
+            server_socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        server_socket.bind(sockaddr)
         if os.geteuid() == 0:
             assert self.user_id is not None
             assert self.group_id is not None
@@ -205,7 +233,7 @@ class PermissionDroppingUnthreadedController(UnthreadedController):  # nocoverag
 def run_smtp_server(
     user: str | None, group: str | None, host: str, port: int, tls_context: SSLContext | None
 ) -> None:  # nocoverage
-    logger.info("Listening on %s:%d", host, port)
+    logger.info("Listening on %s:%d", f"[{host}]" if ":" in host else host, port)
     server = PermissionDroppingUnthreadedController(
         user=user,
         group=group,

--- a/zerver/lib/email_mirror_server.py
+++ b/zerver/lib/email_mirror_server.py
@@ -154,13 +154,25 @@ class ZulipMessageHandler(MessageHandler):
 
 
 def parse_listen_address(listen: str) -> tuple[str, int]:
+    host: str | None
+    port: int | None
     if listen.isdigit():
         host, port = None, int(listen)
     else:
         r = SplitResult("", listen, "", "", "")
-        if r.port is None:
+        try:
+            port = r.port
+        except ValueError as e:
+            # An unbracketed IPv6 address is ambiguous with
+            # address:port, and parses as a host and a non-numeric
+            # port.
+            raise RuntimeError(
+                f"{listen!r} is not a valid port, or address:port; IPv6 addresses "
+                "must be enclosed in square brackets."
+            ) from e
+        if port is None:
             raise RuntimeError(f"{listen!r} does not have a valid port number.")
-        host, port = r.hostname, r.port
+        host = r.hostname
     if host is None:
         # With no address specified, bind the IPv6 wildcard address if
         # IPv6 is available, since (with IPV6_V6ONLY disabled, as

--- a/zerver/lib/email_mirror_server.py
+++ b/zerver/lib/email_mirror_server.py
@@ -206,6 +206,13 @@ class PermissionDroppingUnthreadedController(UnthreadedController):  # nocoverag
             # specific address.
             server_socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
         server_socket.bind(sockaddr)
+        # Log the address which was actually bound; if the requested
+        # address was a hostname with more than one address, only the
+        # first one that the resolver returned is used.
+        bound_host, bound_port = server_socket.getsockname()[:2]
+        if family == socket.AF_INET6:
+            bound_host = f"[{bound_host}]"
+        logger.info("Listening on %s:%d", bound_host, bound_port)
         if os.geteuid() == 0:
             assert self.user_id is not None
             assert self.group_id is not None
@@ -233,7 +240,7 @@ class PermissionDroppingUnthreadedController(UnthreadedController):  # nocoverag
 def run_smtp_server(
     user: str | None, group: str | None, host: str, port: int, tls_context: SSLContext | None
 ) -> None:  # nocoverage
-    logger.info("Listening on %s:%d", f"[{host}]" if ":" in host else host, port)
+    logger.info("Starting SMTP server on %s:%d", f"[{host}]" if ":" in host else host, port)
     server = PermissionDroppingUnthreadedController(
         user=user,
         group=group,

--- a/zerver/management/commands/email_server.py
+++ b/zerver/management/commands/email_server.py
@@ -1,12 +1,11 @@
 import os
 import ssl
 from typing import Any
-from urllib.parse import SplitResult
 
 from django.core.management.base import BaseCommand, CommandParser
 from typing_extensions import override
 
-from zerver.lib.email_mirror_server import run_smtp_server
+from zerver.lib.email_mirror_server import parse_listen_address, run_smtp_server
 
 
 class Command(BaseCommand):
@@ -15,7 +14,7 @@ class Command(BaseCommand):
     @override
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
-            "--listen", help="[Port, or address:port, to bind HTTP server to]", default="0.0.0.0:25"
+            "--listen", help="[Port, or address:port, to bind the SMTP server to]", default="25"
         )
         parser.add_argument(
             "--user",
@@ -52,14 +51,7 @@ class Command(BaseCommand):
 
     @override
     def handle(self, *args: Any, **options: Any) -> None:
-        listen = options["listen"]
-        if listen.isdigit():
-            host, port = "0.0.0.0", int(listen)  # noqa: S104
-        else:
-            r = SplitResult("", listen, "", "", "")
-            if r.port is None:
-                raise RuntimeError(f"{listen!r} does not have a valid port number.")
-            host, port = r.hostname or "0.0.0.0", r.port  # noqa: S104
+        host, port = parse_listen_address(options["listen"])
         if options["tls_cert"] and options["tls_key"]:
             tls_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             tls_context.load_cert_chain(options["tls_cert"], options["tls_key"])

--- a/zerver/management/commands/email_server.py
+++ b/zerver/management/commands/email_server.py
@@ -14,7 +14,10 @@ class Command(BaseCommand):
     @override
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
-            "--listen", help="[Port, or address:port, to bind the SMTP server to]", default="25"
+            "--listen",
+            help="[Port, or address:port, to bind the SMTP server to; "
+            "enclose IPv6 addresses in square brackets]",
+            default="25",
         )
         parser.add_argument(
             "--user",

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -45,7 +45,11 @@ from zerver.lib.email_mirror_helpers import (
     get_channel_email_token,
     get_email_gateway_message_string_from_address,
 )
-from zerver.lib.email_mirror_server import ZulipMessageHandler, send_to_postmaster
+from zerver.lib.email_mirror_server import (
+    ZulipMessageHandler,
+    parse_listen_address,
+    send_to_postmaster,
+)
 from zerver.lib.markdown.from_html import convert_html_to_markdown
 from zerver.lib.message import truncate_topic
 from zerver.lib.send_email import FromAddress
@@ -2168,6 +2172,23 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
 
 
 class TestEmailMirrorServer(ZulipTestCase):
+    def test_parse_listen_address(self) -> None:
+        ipv4_wildcard = "0.0.0.0"  # noqa: S104
+        with mock.patch("socket.has_dualstack_ipv6", return_value=True):
+            self.assertEqual(parse_listen_address("25"), ("::", 25))
+            self.assertEqual(parse_listen_address(":25"), ("::", 25))
+        with mock.patch("socket.has_dualstack_ipv6", return_value=False):
+            self.assertEqual(parse_listen_address("25"), (ipv4_wildcard, 25))
+            self.assertEqual(parse_listen_address(":25"), (ipv4_wildcard, 25))
+        self.assertEqual(parse_listen_address(f"{ipv4_wildcard}:25"), (ipv4_wildcard, 25))
+        self.assertEqual(parse_listen_address("[::]:2525"), ("::", 2525))
+        self.assertEqual(parse_listen_address("[2001:db8::1]:25"), ("2001:db8::1", 25))
+        self.assertEqual(parse_listen_address("mail.example.com:25"), ("mail.example.com", 25))
+        with self.assertRaisesRegex(
+            RuntimeError, "'mail.example.com' does not have a valid port number."
+        ):
+            parse_listen_address("mail.example.com")
+
     def test_send_postmaster(self) -> None:
         email = EmailMessage()
         email.set_content("Hello postmaster!")

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -2188,6 +2188,15 @@ class TestEmailMirrorServer(ZulipTestCase):
             RuntimeError, "'mail.example.com' does not have a valid port number."
         ):
             parse_listen_address("mail.example.com")
+        with self.assertRaisesRegex(RuntimeError, r"'\[::\]' does not have a valid port number."):
+            parse_listen_address("[::]")
+        for unbracketed in ("::", "::1", "2001:db8::1"):
+            with self.assertRaisesRegex(
+                RuntimeError, "IPv6 addresses must be enclosed in square brackets"
+            ):
+                parse_listen_address(unbracketed)
+        with self.assertRaisesRegex(RuntimeError, "is not a valid port, or address:port"):
+            parse_listen_address(f"{ipv4_wildcard}:99999")
 
     def test_send_postmaster(self) -> None:
         email = EmailMessage()


### PR DESCRIPTION
Fixes: Report in [#production-help > IPv6 support (email-server local delivery)](https://chat.zulip.org/#narrow/channel/31-production-help/topic/IPv6.20support.20.28email-server.20local.20delivery.29/near/2511543)

The incoming email gateway's SMTP server created its listening socket with a hard-coded `AF_INET` family, so it could not bind IPv6 addresses at all (`--listen '[::]:25'` crashed with `socket.gaierror`), and the `0.0.0.0` default meant remote mail servers could not deliver email over IPv6 out of the box. There was also no way to change the bind address without editing puppet-managed files.

The first commit chooses the socket family from `getaddrinfo` and defaults to the IPv6 wildcard with `IPV6_V6ONLY` disabled, so a single socket accepts both IPv4 and IPv6 connections; hosts with IPv6 disabled in the kernel fall back to the IPv4 wildcard. The second adds a `email_gateway.listen` setting in `zulip.conf` so deployments can adjust the bind address declaratively.