### PR TITLE
[ai] deferred_work: Allow a dedicated queue for high-latency jobs.

### DIFF
--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -183,8 +183,9 @@ useful on large servers; smaller servers should leave it disabled.
 
 #### `dedicated_deferred_work_high_latency_queue`
 
-Some deferred work has no latency expectations at all: realm data exports
-and Slack imports can each take many minutes. By default they run in the
+Some deferred work has no latency expectations at all: realm data
+exports, Slack imports, and scrubbing the data of a deactivated
+organization can each take many minutes. By default they run in the
 shared `deferred_work` queue, where they can hold up other,
 latency-sensitive jobs in that queue. Set this to true to process them in
 a dedicated queue, isolating them from the rest of `deferred_work`.
@@ -195,8 +196,8 @@ multithreaded mode it costs only a thread. Set it identically on all
 application frontends, and on the host running the RabbitMQ Nagios
 checks, so that monitoring agrees with which queue is in use.
 
-Turning this back off requires care, because exports and Slack imports
-already in the `deferred_work_high_latency` queue are not moved back to
+Turning this back off requires care, because jobs already in the
+`deferred_work_high_latency` queue are not moved back to
 `deferred_work`. A stranded export is displayed to administrators as
 permanently in progress and cannot be deleted; a stranded Slack import
 leaves that organization's signup permanently stuck. Disable it in this

--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -181,6 +181,55 @@ multiprocess mode, a dedicated worker process), so they aren't delayed
 behind such jobs. This costs an additional worker process, so it is most
 useful on large servers; smaller servers should leave it disabled.
 
+#### `dedicated_deferred_work_high_latency_queue`
+
+Some deferred work has no latency expectations at all: realm data exports
+and Slack imports can each take many minutes. By default they run in the
+shared `deferred_work` queue, where they can hold up other,
+latency-sensitive jobs in that queue. Set this to true to process them in
+a dedicated queue, isolating them from the rest of `deferred_work`.
+
+In multiprocess mode (see `queue_workers_multiprocess` above) this costs
+an additional worker process that is idle almost all the time; in
+multithreaded mode it costs only a thread. Set it identically on all
+application frontends, and on the host running the RabbitMQ Nagios
+checks, so that monitoring agrees with which queue is in use.
+
+Turning this back off requires care, because exports and Slack imports
+already in the `deferred_work_high_latency` queue are not moved back to
+`deferred_work`. A stranded export is displayed to administrators as
+permanently in progress and cannot be deleted; a stranded Slack import
+leaves that organization's signup permanently stuck. Disable it in this
+order, so that nothing new is enqueued while the worker still exists:
+
+1. Set it to false in `/etc/zulip/zulip.conf`.
+
+2. Restart the server, so that it stops publishing to the dedicated
+   queue. Running `zulip-puppet-apply` alone does not do this:
+
+   ```console
+   # /home/zulip/deployments/current/scripts/restart-server
+   ```
+
+3. Wait for the queue to drain. As root, this should report `0`:
+
+   ```console
+   # rabbitmqctl list_queues name messages | grep deferred_work_high_latency
+   ```
+
+4. Run `zulip-puppet-apply` to remove the now-idle worker.
+
+If the worker was removed before the queue drained, you can drain it
+directly; interrupt the command with ^C once the queue is empty:
+
+```console
+$ /home/zulip/deployments/current/manage.py process_queue \
+    --queue_name=deferred_work_high_latency
+```
+
+Note that `manage.py process_queue --all` and `manage.py purge_queue`
+both skip this queue while the setting is disabled.
+
 #### `rolling_restart`
 
 If set to true, when using `./scripts/restart-server` to restart

--- a/puppet/kandra/files/nagios4/conf.d/services.cfg
+++ b/puppet/kandra/files/nagios4/conf.d/services.cfg
@@ -329,6 +329,12 @@ define service {
 
 define service {
         use                             rabbitmq-consumer-service
+        service_description             Check RabbitMQ deferred_work_high_latency consumers
+        check_command                   check_rabbitmq_consumers!deferred_work_high_latency
+}
+
+define service {
+        use                             rabbitmq-consumer-service
         service_description             Check RabbitMQ digest digest_emails consumers
         check_command                   check_rabbitmq_consumers!digest_emails
 }

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -165,12 +165,17 @@ class zulip::app_frontend_base {
     'user_activity',
     'user_activity_interval',
   ]
-  # Soft reactivations normally share the deferred_work queue; larger
-  # servers can opt into a dedicated queue (and worker process) for them.
-  $queues = zulipconf('application_server', 'dedicated_soft_reactivation_queue', false) ? {
-    true    => $base_queues + ['soft_reactivation'],
-    default => $base_queues,
+  # Larger servers can opt each of these out of the shared deferred_work
+  # queue, into a dedicated queue and worker process.
+  $soft_reactivation_queue = zulipconf('application_server', 'dedicated_soft_reactivation_queue', false) ? {
+    true    => ['soft_reactivation'],
+    default => [],
   }
+  $high_latency_queue = zulipconf('application_server', 'dedicated_deferred_work_high_latency_queue', false) ? {
+    true    => ['deferred_work_high_latency'],
+    default => [],
+  }
+  $queues = $base_queues + $soft_reactivation_queue + $high_latency_queue
 
   if $zulip::common::total_memory_mb > 24000 {
     $uwsgi_default_processes = 16

--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -28,10 +28,15 @@ normal_queues = [
     "user_activity_interval",
 ]
 
-# Soft reactivations share the deferred_work queue unless a server opts
-# into a dedicated queue; only then is there a consumer to monitor.
+# These queues exist only when a server opts into them; until then their
+# events stay in deferred_work, and there is no consumer to monitor.
 if get_config(get_config_file(), "application_server", "dedicated_soft_reactivation_queue", False):
     normal_queues.append("soft_reactivation")
+
+if get_config(
+    get_config_file(), "application_server", "dedicated_deferred_work_high_latency_queue", False
+):
+    normal_queues.append("deferred_work_high_latency")
 
 mobile_notification_shards = int(
     get_config(get_config_file(), "application_server", "mobile_notification_shards", "1")
@@ -59,6 +64,11 @@ MAX_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     # own queue; keep deferred_work's generous clear-time budget so the slow
     # backfills that motivated the split don't trip false alerts.
     soft_reactivation=600,
+    # Unlike deferred_work, this queue has no fast events to dilute its
+    # average consume time, which the check multiplies by queue depth. A
+    # 600s budget would alert for the whole of any export averaging over
+    # ten minutes, with nothing queued behind it.
+    deferred_work_high_latency=6 * 60 * 60,
     digest_emails=1200,
     missedmessage_mobile_notifications=120,
     embed_links=60,
@@ -69,6 +79,7 @@ CRITICAL_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     lambda: 60,
     deferred_work=900,
     soft_reactivation=900,
+    deferred_work_high_latency=12 * 60 * 60,
     missedmessage_mobile_notifications=180,
     digest_emails=1800,
     embed_links=90,

--- a/tools/tests/test_check_rabbitmq_queue.py
+++ b/tools/tests/test_check_rabbitmq_queue.py
@@ -31,6 +31,22 @@ class AnalyzeQueueStatsTests(TestCase):
         )
         self.assertEqual(result["status"], OK)
 
+    def test_high_latency_queue_tolerates_a_single_long_job(self) -> None:
+        """A realm export averaging 30 minutes is normal for this queue, not a
+        backlog: it must not alert while that one job is in flight."""
+        stats = {
+            "update_time": time.time(),
+            "queue_last_emptied_timestamp": time.time() - 1800,
+            "recent_average_consume_time": 1800,
+        }
+        # The in-flight job is unacknowledged, so rabbitmqctl counts it.
+        result = analyze_queue_stats("deferred_work_high_latency", stats, 1)
+        self.assertEqual(result["status"], OK)
+
+        result = analyze_queue_stats("deferred_work_high_latency", stats, 25)
+        self.assertEqual(result["status"], CRITICAL)
+        self.assertIn("clearing the backlog", result["message"])
+
     def test_queue_normal(self) -> None:
         """10000 events and each takes a second => it'll take a long time to empty."""
         result = analyze_queue_stats(

--- a/zerver/actions/realm_export.py
+++ b/zerver/actions/realm_export.py
@@ -1,10 +1,24 @@
+import logging
+import tempfile
+import time
+from typing import Any
+
+from django.conf import settings
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
+from django.utils.translation import gettext as _
+from django.utils.translation import override as override_language
 
-from zerver.lib.export import get_realm_exports_serialized
+from zerver.actions.message_send import internal_send_private_message
+from zerver.lib.export import (
+    export_realm_wrapper,
+    export_tarball_prefix,
+    get_realm_exports_serialized,
+)
 from zerver.lib.upload import delete_export_tarball
 from zerver.models import Realm, RealmAuditLog, RealmExport, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
+from zerver.models.users import get_system_bot, get_user_profile_by_id
 from zerver.tornado.django_api import send_event_on_commit
 
 
@@ -31,4 +45,95 @@ def do_delete_realm_export(export_row: RealmExport, acting_user: UserProfile) ->
         event_type=AuditLogEventType.REALM_EXPORT_DELETED,
         event_time=export_row.date_deleted,
         extra_data={"realm_export_id": export_row.id},
+    )
+
+
+def export_realm_from_event(
+    event: dict[str, Any], *, threaded: bool, logger: logging.Logger
+) -> None:
+    start = time.time()
+    user_profile = get_user_profile_by_id(event["user_profile_id"])
+    realm = user_profile.realm
+    output_dir = tempfile.mkdtemp(prefix=export_tarball_prefix(realm))
+    export_event = None
+
+    if "realm_export_id" in event:
+        export_row = RealmExport.objects.get(id=event["realm_export_id"])
+    else:  # nocoverage
+        # Handle existing events in the queue before we switched to RealmExport model.
+        export_event = RealmAuditLog.objects.get(id=event["id"])
+        extra_data = export_event.extra_data
+
+        if extra_data.get("export_row_id") is not None:
+            export_row = RealmExport.objects.get(id=extra_data["export_row_id"])
+        else:
+            export_row = RealmExport.objects.create(
+                realm=realm,
+                type=RealmExport.EXPORT_PUBLIC,
+                acting_user=user_profile,
+                status=RealmExport.REQUESTED,
+                date_requested=event["time"],
+            )
+            export_event.extra_data = {"export_row_id": export_row.id}
+            export_event.save(update_fields=["extra_data"])
+
+    if export_row.status != RealmExport.REQUESTED:
+        logger.error(
+            "Marking export for realm %s as failed due to retry -- possible OOM during export?",
+            realm.string_id,
+        )
+        export_row.status = RealmExport.FAILED
+        export_row.date_failed = timezone_now()
+        export_row.save(update_fields=["status", "date_failed"])
+        notify_realm_export(realm)
+        return
+
+    logger.info(
+        "Starting realm export for realm %s into %s, initiated by user_profile_id %s",
+        realm.string_id,
+        output_dir,
+        user_profile.id,
+    )
+
+    try:
+        export_realm_wrapper(
+            export_row=export_row,
+            output_dir=output_dir,
+            processes=1 if threaded else 6,
+            upload=True,
+        )
+    except Exception:
+        logging.exception(
+            "Data export for %s failed after %s",
+            realm.string_id,
+            time.time() - start,
+            stack_info=True,
+        )
+        notify_realm_export(realm)
+        return
+
+    # We create RealmAuditLog entry in 'export_realm_wrapper'.
+    # Delete the old entry created before we switched to RealmExport model.
+    if export_event:  # nocoverage
+        export_event.delete()
+
+    # Send a direct message notification letting the user who
+    # triggered the export know the export finished.
+    with override_language(user_profile.default_language):
+        content = _(
+            "Your data export is complete. [View and download exports]({export_settings_link})."
+        ).format(export_settings_link="/#organization/data-exports-admin")
+    internal_send_private_message(
+        sender=get_system_bot(settings.NOTIFICATION_BOT, realm.id),
+        recipient_user=user_profile,
+        content=content,
+    )
+
+    # For future frontend use, also notify administrator
+    # clients that the export happened.
+    notify_realm_export(realm)
+    logging.info(
+        "Completed data export for %s in %s",
+        realm.string_id,
+        time.time() - start,
     )

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -19,7 +19,7 @@ from zerver.actions.user_settings import do_scrub_avatar_images
 from zerver.lib.demo_organizations import demo_organization_owner_email_exists
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import parse_message_time_limit_setting, update_first_visible_message_id
-from zerver.lib.queue import queue_json_publish_rollback_unsafe
+from zerver.lib.queue import high_latency_queue_name, queue_json_publish_rollback_unsafe
 from zerver.lib.retention import move_messages_to_archive
 from zerver.lib.send_email import FromAddress, send_email, send_email_to_admins
 from zerver.lib.sessions import delete_realm_user_sessions
@@ -660,7 +660,7 @@ def do_deactivate_realm(
                 "type": "scrub_deactivated_realm",
                 "realm_id": realm.id,
             }
-            queue_json_publish_rollback_unsafe("deferred_work", event)
+            queue_json_publish_rollback_unsafe(high_latency_queue_name(), event)
 
     # Don't deactivate the users, as that would lose a lot of state if
     # the realm needs to be reactivated, but do delete their sessions

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -473,6 +473,12 @@ def mobile_notifications_queue_name(user_id: int) -> str:
     return "missedmessage_mobile_notifications"
 
 
+def high_latency_queue_name() -> str:
+    if settings.DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE:
+        return "deferred_work_high_latency"
+    return "deferred_work"
+
+
 def retry_event(
     queue_name: str, event: dict[str, Any], failure_processor: Callable[[dict[str, Any]], None]
 ) -> None:

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -17,7 +17,7 @@ from django.test import override_settings
 from typing_extensions import override
 
 from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
-from zerver.lib.queue import MAX_REQUEST_RETRIES
+from zerver.lib.queue import MAX_REQUEST_RETRIES, high_latency_queue_name
 from zerver.lib.remote_server import PushNotificationBouncerRetryLaterError
 from zerver.lib.send_email import EmailNotDeliveredError, FromAddress
 from zerver.lib.test_classes import ZulipTestCase
@@ -29,12 +29,13 @@ from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.streams import get_stream
 from zerver.tornado.event_queue import build_offline_notification
 from zerver.worker import base as base_worker
+from zerver.worker import deferred_work_high_latency
 from zerver.worker.email_mirror import MirrorWorker
 from zerver.worker.email_senders import ImmediateEmailSenderWorker
 from zerver.worker.embed_links import FetchLinksEmbedData
 from zerver.worker.missedmessage_emails import MissedMessageWorker
 from zerver.worker.missedmessage_mobile_notifications import PushNotificationsWorker
-from zerver.worker.queue_processors import get_active_worker_queues
+from zerver.worker.queue_processors import get_active_worker_queues, get_worker
 from zerver.worker.user_activity import UserActivityWorker
 
 Event: TypeAlias = dict[str, Any]
@@ -838,3 +839,57 @@ class WorkerTest(ZulipTestCase):
         self.assertNotIn("soft_reactivation", get_active_worker_queues())
         with override_settings(DEDICATED_SOFT_REACTIVATION_QUEUE=True):
             self.assertIn("soft_reactivation", get_active_worker_queues())
+
+    def test_high_latency_queue_name(self) -> None:
+        self.assertEqual(high_latency_queue_name(), "deferred_work")
+        with override_settings(DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE=True):
+            self.assertEqual(high_latency_queue_name(), "deferred_work_high_latency")
+
+    def test_high_latency_queue_is_opt_in(self) -> None:
+        # Keeps the production install's queue-processor check consistent.
+        self.assertNotIn("deferred_work_high_latency", get_active_worker_queues())
+        with override_settings(DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE=True):
+            queues = get_active_worker_queues()
+            self.assertIn("deferred_work_high_latency", queues)
+            # deferred_work keeps running, to drain what is already queued there.
+            self.assertIn("deferred_work", queues)
+
+    def test_high_latency_worker_dispatches_both_event_types(self) -> None:
+        worker = get_worker("deferred_work_high_latency")
+        # These jobs have no SLO; a per-event timeout would kill them partway.
+        self.assertIsNone(worker.MAX_CONSUME_SECONDS)
+
+        export_event = {"type": "realm_export", "user_profile_id": 1, "realm_export_id": 1}
+        with (
+            patch(
+                "zerver.worker.deferred_work_high_latency.export_realm_from_event"
+            ) as mock_export,
+            self.assertLogs(deferred_work_high_latency.logger, level="INFO") as export_logs,
+        ):
+            worker.consume(export_event)
+        mock_export.assert_called_once_with(
+            export_event, threaded=False, logger=deferred_work_high_latency.logger
+        )
+        self.assertIn(
+            "deferred_work_high_latency processed realm_export event", export_logs.output[0]
+        )
+
+        import_event = {
+            "type": "import_slack_data",
+            "preregistration_realm_id": 1,
+            "filename": "import/1/slack.zip",
+            "slack_access_token": "xoxb-token",
+        }
+        with (
+            patch("zerver.worker.deferred_work_high_latency.import_slack_data") as mock_import,
+            self.assertLogs(deferred_work_high_latency.logger, level="INFO"),
+        ):
+            worker.consume(import_event)
+        mock_import.assert_called_once_with(import_event)
+
+    def test_high_latency_worker_rejects_unknown_event_type(self) -> None:
+        """Acknowledging an unrecognized type would silently discard a job that
+        can take an hour to redo."""
+        worker = get_worker("deferred_work_high_latency")
+        with self.assertRaises(AssertionError):
+            worker.consume({"type": "soft_reactivate", "user_profile_id": 1})

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -887,6 +887,16 @@ class WorkerTest(ZulipTestCase):
             worker.consume(import_event)
         mock_import.assert_called_once_with(import_event)
 
+        scrub_event = {"type": "scrub_deactivated_realm", "realm_id": 1}
+        with (
+            patch(
+                "zerver.worker.deferred_work_high_latency.clean_deactivated_realm_data"
+            ) as mock_scrub,
+            self.assertLogs(deferred_work_high_latency.logger, level="INFO"),
+        ):
+            worker.consume(scrub_event)
+        mock_scrub.assert_called_once_with()
+
     def test_high_latency_worker_rejects_unknown_event_type(self) -> None:
         """Acknowledging an unrecognized type would silently discard a job that
         can take an hour to redo."""

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1481,6 +1481,27 @@ class RealmTest(ZulipTestCase):
             clean_deactivated_realm_data()
             mock_scrub_realm.assert_called_once_with(zephyr, acting_user=None)
 
+    @override_settings(DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE=True)
+    def test_scrub_uses_dedicated_queue_when_enabled(self) -> None:
+        """Scrubbing a realm walks every message and attachment it owns, so it
+        belongs in the high-latency queue rather than ahead of deferred_work's
+        latency-sensitive jobs."""
+        lear = get_realm("lear")
+        with mock.patch(
+            "zerver.actions.realm_settings.queue_json_publish_rollback_unsafe"
+        ) as mock_queue:
+            do_deactivate_realm(
+                lear,
+                acting_user=None,
+                deletion_delay_days=0,
+                deactivation_reason="owner_request",
+                email_owners=False,
+            )
+        mock_queue.assert_called_once_with(
+            "deferred_work_high_latency",
+            {"type": "scrub_deactivated_realm", "realm_id": lear.id},
+        )
+
     def test_delete_expired_demo_organizations(self) -> None:
         demo_organization_owner = self.create_demo_organization_owner()
         demo_organization = demo_organization_owner.realm

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -7,6 +7,7 @@ import botocore.exceptions
 import orjson
 import time_machine
 from django.conf import settings
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
 from analytics.models import RealmCount
@@ -218,6 +219,69 @@ class RealmExportTest(ZulipTestCase):
         # Now try to delete a non-existent export.
         result = self.client_delete("/json/export/realm/0")
         self.assert_json_error(result, "Invalid data export ID")
+
+    @override_settings(DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE=True)
+    def test_export_uses_dedicated_queue_when_enabled(self) -> None:
+        admin = self.example_user("iago")
+        self.login_user(admin)
+
+        with patch("zerver.views.realm_export.queue_event_on_commit") as mock_queue:
+            result = self.client_post("/json/export/realm")
+        self.assert_json_success(result)
+        mock_queue.assert_called_once_with(
+            "deferred_work_high_latency",
+            {
+                "type": "realm_export",
+                "user_profile_id": admin.id,
+                "realm_export_id": orjson.loads(result.content)["id"],
+            },
+        )
+
+        tarball_path = create_dummy_file("test-export.tar.gz")
+        with (
+            patch("zerver.lib.export.do_export_realm", return_value=(tarball_path, dict())),
+            stdout_suppressed(),
+            self.assertLogs(level="INFO") as info_logs,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self.client_post("/json/export/realm")
+        self.assert_json_success(result)
+        self.assertTrue(
+            info_logs.output[0].startswith("INFO:root:Completed data export for zulip in ")
+        )
+        self.assertEqual(RealmExport.objects.latest("id").status, RealmExport.SUCCEEDED)
+
+    @override_settings(DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE=True)
+    def test_deferred_work_drains_exports_when_dedicated_queue_enabled(self) -> None:
+        """Opting in must not strand realm_export events already sitting in
+        deferred_work, so its handler stays the drain path."""
+        admin = self.example_user("iago")
+        export_row = RealmExport.objects.create(
+            realm=admin.realm,
+            type=RealmExport.EXPORT_PUBLIC,
+            acting_user=admin,
+            status=RealmExport.REQUESTED,
+            date_requested=timezone_now(),
+        )
+        tarball_path = create_dummy_file("test-export.tar.gz")
+        with (
+            patch("zerver.lib.export.do_export_realm", return_value=(tarball_path, dict())),
+            stdout_suppressed(),
+            self.assertLogs(level="INFO") as info_logs,
+        ):
+            queue_json_publish_rollback_unsafe(
+                "deferred_work",
+                {
+                    "type": "realm_export",
+                    "user_profile_id": admin.id,
+                    "realm_export_id": export_row.id,
+                },
+            )
+        self.assertTrue(
+            info_logs.output[0].startswith("INFO:root:Completed data export for zulip in ")
+        )
+        export_row.refresh_from_db()
+        self.assertEqual(export_row.status, RealmExport.SUCCEEDED)
 
     def test_export_tarball_prefix(self) -> None:
         realm = self.example_user("iago").realm

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -18,6 +18,7 @@ from attr import dataclass
 from django.conf import settings
 from django.db import IntegrityError
 from django.http import HttpResponse
+from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from requests.models import PreparedRequest
 
@@ -72,6 +73,7 @@ from zerver.data_import.slack import (
 from zerver.lib.exceptions import SlackImportInvalidFileError
 from zerver.lib.import_realm import do_import_realm
 from zerver.lib.mime_types import INLINE_MIME_TYPES
+from zerver.lib.queue import high_latency_queue_name
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import find_key_by_email, read_test_image_file
 from zerver.lib.thumbnail import THUMBNAIL_ACCEPT_IMAGE_TYPES, BadImageError
@@ -2689,8 +2691,9 @@ To Do
                 importer_set_email_address_visibility,
             )
 
+        # The queue name comes from the setting; see the dedicated-queue test below.
         m.assert_called_once_with(
-            "deferred_work",
+            high_latency_queue_name(),
             {
                 "type": "import_slack_data",
                 "preregistration_realm_id": prereg_realm.id,
@@ -2856,6 +2859,13 @@ To Do
         self.assertEqual(result["Location"], f"/realm/import/post_process/{confirmation_key}")
         result = self.client_get(f"/realm/import/post_process/{confirmation_key}")
         self.assert_in_success_response(["Select your account"], result)
+
+    @override_settings(DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE=True)
+    def test_end_to_end_slack_import_with_dedicated_queue(self) -> None:
+        """Half the point of the dedicated queue is routing Slack imports to
+        it, so run the same flow with the setting enabled."""
+        self.assertEqual(high_latency_queue_name(), "deferred_work_high_latency")
+        self.test_end_to_end_slack_import()
 
     @mock.patch("zerver.actions.data_import.do_import_realm")
     @mock.patch("zerver.actions.data_import.do_convert_zipfile")

--- a/zerver/views/realm_export.py
+++ b/zerver/views/realm_export.py
@@ -11,7 +11,7 @@ from zerver.actions.realm_export import do_delete_realm_export, notify_realm_exp
 from zerver.decorator import require_realm_admin
 from zerver.lib.exceptions import JsonableError, OrganizationOwnerRequiredError
 from zerver.lib.export import get_realm_exports_serialized
-from zerver.lib.queue import queue_event_on_commit
+from zerver.lib.queue import high_latency_queue_name, queue_event_on_commit
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress
 from zerver.lib.typed_endpoint import typed_endpoint
@@ -107,14 +107,13 @@ def export_realm(
     # Allow for UI updates on a pending export
     notify_realm_export(realm)
 
-    # Using the deferred_work queue processor to avoid
-    # killing the process after 60s
+    # Run in a queue processor to avoid killing the process after 60s.
     event = {
         "type": "realm_export",
         "user_profile_id": user.id,
         "realm_export_id": row.id,
     }
-    queue_event_on_commit("deferred_work", event)
+    queue_event_on_commit(high_latency_queue_name(), event)
     return json_success(request, data={"id": row.id})
 
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -82,7 +82,7 @@ from zerver.lib.i18n import (
     get_language_name,
 )
 from zerver.lib.pysa import mark_sanitized
-from zerver.lib.queue import queue_json_publish_rollback_unsafe
+from zerver.lib.queue import high_latency_queue_name, queue_json_publish_rollback_unsafe
 from zerver.lib.rate_limiter import rate_limit_request_by_ip, readable_expiry_string_for_html
 from zerver.lib.response import json_success
 from zerver.lib.send_email import EmailNotDeliveredError, FromAddress, send_email
@@ -447,7 +447,7 @@ def registration_helper(
 
             logger.info("(%s) Enqueueing Slack import", prereg_realm.string_id)
             queue_json_publish_rollback_unsafe(
-                "deferred_work",
+                high_latency_queue_name(),
                 {
                     "type": "import_slack_data",
                     "preregistration_realm_id": prereg_realm.id,

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -1,21 +1,15 @@
 # Documented in https://zulip.readthedocs.io/en/latest/subsystems/queuing.html
 import logging
-import tempfile
 import time
 from typing import Any
 
-from django.conf import settings
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import gettext as _
-from django.utils.translation import override as override_language
 from typing_extensions import override
 
 from zerver.actions.data_import import import_slack_data
 from zerver.actions.message_flags import do_mark_stream_messages_as_read
-from zerver.actions.message_send import internal_send_private_message
-from zerver.actions.realm_export import notify_realm_export
+from zerver.actions.realm_export import export_realm_from_event
 from zerver.actions.realm_settings import scrub_deactivated_realm
-from zerver.lib.export import export_realm_wrapper, export_tarball_prefix
 from zerver.lib.push_notifications import clear_push_device_tokens
 from zerver.lib.queue import retry_event
 from zerver.lib.remote_server import (
@@ -24,8 +18,8 @@ from zerver.lib.remote_server import (
 )
 from zerver.lib.soft_deactivation import reactivate_user_if_soft_deactivated
 from zerver.lib.upload import handle_reupload_emojis_event
-from zerver.models import Realm, RealmAuditLog, RealmExport
-from zerver.models.users import get_system_bot, get_user_profile_by_id
+from zerver.models import Realm
+from zerver.models.users import get_user_profile_by_id
 from zerver.worker.base import QueueProcessingWorker, assign_queue
 
 logger = logging.getLogger(__name__)
@@ -80,91 +74,7 @@ class DeferredWorker(QueueProcessingWorker):
 
                 retry_event(self.queue_name, event, failure_processor)
         elif event["type"] == "realm_export":
-            user_profile = get_user_profile_by_id(event["user_profile_id"])
-            realm = user_profile.realm
-            output_dir = tempfile.mkdtemp(prefix=export_tarball_prefix(realm))
-            export_event = None
-
-            if "realm_export_id" in event:
-                export_row = RealmExport.objects.get(id=event["realm_export_id"])
-            else:
-                # Handle existing events in the queue before we switched to RealmExport model.
-                export_event = RealmAuditLog.objects.get(id=event["id"])
-                extra_data = export_event.extra_data
-
-                if extra_data.get("export_row_id") is not None:
-                    export_row = RealmExport.objects.get(id=extra_data["export_row_id"])
-                else:
-                    export_row = RealmExport.objects.create(
-                        realm=realm,
-                        type=RealmExport.EXPORT_PUBLIC,
-                        acting_user=user_profile,
-                        status=RealmExport.REQUESTED,
-                        date_requested=event["time"],
-                    )
-                    export_event.extra_data = {"export_row_id": export_row.id}
-                    export_event.save(update_fields=["extra_data"])
-
-            if export_row.status != RealmExport.REQUESTED:
-                logger.error(
-                    "Marking export for realm %s as failed due to retry -- possible OOM during export?",
-                    realm.string_id,
-                )
-                export_row.status = RealmExport.FAILED
-                export_row.date_failed = timezone_now()
-                export_row.save(update_fields=["status", "date_failed"])
-                notify_realm_export(realm)
-                return
-
-            logger.info(
-                "Starting realm export for realm %s into %s, initiated by user_profile_id %s",
-                realm.string_id,
-                output_dir,
-                user_profile.id,
-            )
-
-            try:
-                export_realm_wrapper(
-                    export_row=export_row,
-                    output_dir=output_dir,
-                    processes=1 if self.threaded else 6,
-                    upload=True,
-                )
-            except Exception:
-                logging.exception(
-                    "Data export for %s failed after %s",
-                    realm.string_id,
-                    time.time() - start,
-                    stack_info=True,
-                )
-                notify_realm_export(realm)
-                return
-
-            # We create RealmAuditLog entry in 'export_realm_wrapper'.
-            # Delete the old entry created before we switched to RealmExport model.
-            if export_event:
-                export_event.delete()
-
-            # Send a direct message notification letting the user who
-            # triggered the export know the export finished.
-            with override_language(user_profile.default_language):
-                content = _(
-                    "Your data export is complete. [View and download exports]({export_settings_link})."
-                ).format(export_settings_link="/#organization/data-exports-admin")
-            internal_send_private_message(
-                sender=get_system_bot(settings.NOTIFICATION_BOT, realm.id),
-                recipient_user=user_profile,
-                content=content,
-            )
-
-            # For future frontend use, also notify administrator
-            # clients that the export happened.
-            notify_realm_export(realm)
-            logging.info(
-                "Completed data export for %s in %s",
-                realm.string_id,
-                time.time() - start,
-            )
+            export_realm_from_event(event, threaded=self.threaded, logger=logger)
         elif event["type"] == "reupload_realm_emoji":
             # This is a special event queued by the migration for reuploading emojis.
             # We don't want to run the necessary code in the actual migration, so it simply

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -32,6 +32,12 @@ class DeferredWorker(QueueProcessingWorker):
     thread from the Django worker that initiated it (E.g. so we that
     can provide a low-latency HTTP response or avoid risk of request
     timeouts for an operation that could in rare cases take minutes).
+
+    Several of these event types can be routed to a dedicated queue
+    instead, via a dedicated_*_queue setting in zulip.conf. Their handlers
+    below must not be removed even then: they remain the default path, and
+    they drain any events already queued here when a server opts in --
+    stale deferred_work events can linger across upgrades for a long time.
     """
 
     # Because these operations have no SLO, and can take minutes,
@@ -83,13 +89,6 @@ class DeferredWorker(QueueProcessingWorker):
             logger.info("Processing reupload_realm_emoji event for realm %s", realm.id)
             handle_reupload_emojis_event(realm, logger)
         elif event["type"] == "soft_reactivate":
-            # Soft reactivations are normally enqueued here. A server can
-            # opt into a dedicated soft_reactivation queue via the
-            # dedicated_soft_reactivation_queue setting; even then, do not
-            # remove this handler. It remains the default path, and it
-            # drains any soft_reactivate events already in this queue when
-            # that option is enabled -- stale deferred_work events can
-            # linger across upgrades for a long time.
             logger.info(
                 "Starting soft reactivation for user_profile_id %s",
                 event["user_profile_id"],

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -3,13 +3,12 @@ import logging
 import time
 from typing import Any
 
-from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from zerver.actions.data_import import import_slack_data
 from zerver.actions.message_flags import do_mark_stream_messages_as_read
 from zerver.actions.realm_export import export_realm_from_event
-from zerver.actions.realm_settings import scrub_deactivated_realm
+from zerver.actions.realm_settings import clean_deactivated_realm_data
 from zerver.lib.push_notifications import clear_push_device_tokens
 from zerver.lib.queue import retry_event
 from zerver.lib.remote_server import (
@@ -101,12 +100,7 @@ class DeferredWorker(QueueProcessingWorker):
             logger.info("Updating push bouncer with metadata on behalf of realm %s", realm_id)
             send_server_data_to_push_bouncer(consider_usage_statistics=False)
         elif event["type"] == "scrub_deactivated_realm":
-            realms_to_scrub = Realm.objects.filter(
-                deactivated=True,
-                scheduled_deletion_date__lte=timezone_now(),
-            )
-            for realm in realms_to_scrub:
-                scrub_deactivated_realm(realm)
+            clean_deactivated_realm_data()
         elif event["type"] == "import_slack_data":
             import_slack_data(event)
 

--- a/zerver/worker/deferred_work_high_latency.py
+++ b/zerver/worker/deferred_work_high_latency.py
@@ -1,0 +1,44 @@
+# Documented in https://zulip.readthedocs.io/en/latest/subsystems/queuing.html
+import logging
+import time
+from typing import Any
+
+from typing_extensions import override
+
+from zerver.actions.data_import import import_slack_data
+from zerver.actions.realm_export import export_realm_from_event
+from zerver.worker.base import QueueProcessingWorker, assign_queue
+
+logger = logging.getLogger(__name__)
+
+
+@assign_queue("deferred_work_high_latency")
+class DeferredWorkHighLatencyWorker(QueueProcessingWorker):
+    """Runs deferred work with no latency expectations at all, currently
+    realm data exports and Slack imports, each of which can take many
+    minutes.
+
+    Such jobs normally share the deferred_work queue, where they hold up
+    its latency-sensitive jobs. A server can opt into this dedicated queue
+    via the DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE setting to isolate
+    them.
+    """
+
+    MAX_CONSUME_SECONDS = None
+
+    @override
+    def consume(self, event: dict[str, Any]) -> None:
+        start = time.time()
+        if event["type"] == "realm_export":
+            export_realm_from_event(event, threaded=self.threaded, logger=logger)
+        elif event["type"] == "import_slack_data":
+            import_slack_data(event)
+        else:
+            raise AssertionError(f"Unexpected event type {event['type']}")
+
+        end = time.time()
+        logger.info(
+            "deferred_work_high_latency processed %s event (%dms)",
+            event["type"],
+            (end - start) * 1000,
+        )

--- a/zerver/worker/deferred_work_high_latency.py
+++ b/zerver/worker/deferred_work_high_latency.py
@@ -7,6 +7,7 @@ from typing_extensions import override
 
 from zerver.actions.data_import import import_slack_data
 from zerver.actions.realm_export import export_realm_from_event
+from zerver.actions.realm_settings import clean_deactivated_realm_data
 from zerver.worker.base import QueueProcessingWorker, assign_queue
 
 logger = logging.getLogger(__name__)
@@ -15,8 +16,8 @@ logger = logging.getLogger(__name__)
 @assign_queue("deferred_work_high_latency")
 class DeferredWorkHighLatencyWorker(QueueProcessingWorker):
     """Runs deferred work with no latency expectations at all, currently
-    realm data exports and Slack imports, each of which can take many
-    minutes.
+    realm data exports, Slack imports and scrubbing deactivated realms,
+    each of which can take many minutes.
 
     Such jobs normally share the deferred_work queue, where they hold up
     its latency-sensitive jobs. A server can opt into this dedicated queue
@@ -33,6 +34,8 @@ class DeferredWorkHighLatencyWorker(QueueProcessingWorker):
             export_realm_from_event(event, threaded=self.threaded, logger=logger)
         elif event["type"] == "import_slack_data":
             import_slack_data(event)
+        elif event["type"] == "scrub_deactivated_realm":
+            clean_deactivated_realm_data()
         else:
             raise AssertionError(f"Unexpected event type {event['type']}")
 

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -37,8 +37,10 @@ def get_active_worker_queues(only_test_queues: bool = False) -> list[str]:
         for queue_name in worker_classes
         if bool(queue_name in test_queues) == only_test_queues
     ]
-    if not settings.DEDICATED_SOFT_REACTIVATION_QUEUE:
-        # Soft reactivations share the deferred_work queue unless a server
-        # opts into a dedicated queue, so its worker is not run otherwise.
-        queues = [queue_name for queue_name in queues if queue_name != "soft_reactivation"]
-    return queues
+    # A queue whose setting is off keeps its events in deferred_work, so its
+    # worker must neither run nor be expected by the production install check.
+    opt_in_queues = {
+        "soft_reactivation": settings.DEDICATED_SOFT_REACTIVATION_QUEUE,
+        "deferred_work_high_latency": settings.DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE,
+    }
+    return [queue_name for queue_name in queues if opt_in_queues.get(queue_name, True)]

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1294,6 +1294,14 @@ DEDICATED_SOFT_REACTIVATION_QUEUE = get_config(
     "application_server", "dedicated_soft_reactivation_queue", False
 )
 
+# Process realm data exports and Slack imports in their own queue
+# instead of sharing deferred_work, so they can't hold up its
+# latency-sensitive jobs. Like DEDICATED_SOFT_REACTIVATION_QUEUE above,
+# this can only be set in zulip.conf, and is off by default.
+DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE = get_config(
+    "application_server", "dedicated_deferred_work_high_latency_queue", False
+)
+
 TWO_FACTOR_PATCH_ADMIN = False
 
 # Allow the environment to override the default DSN

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1294,9 +1294,9 @@ DEDICATED_SOFT_REACTIVATION_QUEUE = get_config(
     "application_server", "dedicated_soft_reactivation_queue", False
 )
 
-# Process realm data exports and Slack imports in their own queue
-# instead of sharing deferred_work, so they can't hold up its
-# latency-sensitive jobs. Like DEDICATED_SOFT_REACTIVATION_QUEUE above,
+# Process realm data exports, Slack imports and realm scrubbing in
+# their own queue instead of sharing deferred_work, so they can't hold
+# up its latency-sensitive jobs. Like DEDICATED_SOFT_REACTIVATION_QUEUE above,
 # this can only be set in zulip.conf, and is off by default.
 DEDICATED_DEFERRED_WORK_HIGH_LATENCY_QUEUE = get_config(
     "application_server", "dedicated_deferred_work_high_latency_queue", False


### PR DESCRIPTION
Realm data exports and Slack imports both run in the shared deferred_work
queue and can each take many minutes. While one is running, the other,
latency-sensitive jobs in that queue — marking messages as read on
unsubscribe, clearing push tokens, reuploading emoji — wait behind it.

Adding a dedicated queue for high latency jobs helps avoids this.