### PR TITLE
lightbox: Add expanded view and line wrapping for code blocks

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -333,12 +333,37 @@ function display_video(payload: Media): void {
     $("#lightbox_overlay .player-container").append($iframe);
 }
 
+export function display_code_block($code_block: JQuery): void {
+    $(
+        "#lightbox_overlay .image-preview, #lightbox_overlay .player-container, #lightbox_overlay .video-player, #lightbox_overlay .media-description, #lightbox_overlay .media-actions, #lightbox_overlay .center",
+    ).hide();
+
+    const $code_block_clone = $code_block.clone();
+    $code_block_clone.find(".code-buttons-container").remove();
+    $("#lightbox_overlay .code-preview").empty().append($code_block_clone).show();
+}
+
 function invoke_overlay_restore_callback(): void {
     const callback = overlay_restore_callback;
     overlay_restore_callback = undefined;
     if (callback) {
         callback();
     }
+}
+
+function open_lightbox(on_close: () => void): void {
+    if (is_open) {
+        return;
+    }
+
+    overlays.open_overlay({
+        name: "lightbox",
+        $overlay: $("#lightbox_overlay"),
+        on_close,
+    });
+
+    popovers.hide_all();
+    is_open = true;
 }
 
 export function build_open_media_function(
@@ -359,8 +384,10 @@ export function build_open_media_function(
         render_lightbox_media_list();
 
         $(
-            "#lightbox_overlay .image-preview, .lightbox-zoom-reset, .player-container, .video-player",
+            "#lightbox_overlay .image-preview, #lightbox_overlay .code-preview, .lightbox-zoom-reset, .player-container, .video-player",
         ).hide();
+        $("#lightbox_overlay .code-preview").empty();
+        $("#lightbox_overlay .center").show();
 
         if (payload.type === "image") {
             display_image(payload);
@@ -400,19 +427,7 @@ export function build_open_media_function(
             // It's an external embed (YouTube/Vimeo) - hide the metadata and download button
             $(".media-description, .media-actions .download").hide();
         }
-        if (is_open) {
-            return;
-        }
-
-        assert(on_close !== undefined);
-        overlays.open_overlay({
-            name: "lightbox",
-            $overlay: $("#lightbox_overlay"),
-            on_close,
-        });
-
-        popovers.hide_all();
-        is_open = true;
+        open_lightbox(on_close);
     };
 }
 
@@ -686,6 +701,7 @@ export function initialize(): void {
 
     const reset_lightbox_state = function (): void {
         remove_video_players();
+        $("#lightbox_overlay .code-preview").empty().hide();
         is_open = false;
         assert(document.activeElement instanceof HTMLElement);
         document.activeElement.blur();
@@ -717,6 +733,16 @@ export function initialize(): void {
 
         const $video = $(e.currentTarget).find<HTMLMediaElement>("video");
         handle_inline_media_element_click($video);
+    });
+
+    $("#main_div, #compose .preview_content").on("click", ".expand_codeblock", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const $code_block = $(this).closest(".codehilite");
+        assert($code_block.length > 0);
+        display_code_block($code_block);
+        open_lightbox(reset_lightbox_state);
     });
 
     $("#lightbox_overlay .download").on("click", function () {

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -336,10 +336,17 @@ function display_video(payload: Media): void {
     $("#lightbox_overlay .player-container").append($iframe);
 }
 
+export function set_code_wrapping(should_wrap: boolean): void {
+    $("#lightbox_overlay .code-preview").toggleClass("wrap-code", should_wrap);
+    $("#lightbox_overlay .lightbox-code-wrap").attr("aria-pressed", should_wrap.toString());
+}
+
 export function display_code_block($code_block: JQuery): void {
     $(
         "#lightbox_overlay .image-preview, #lightbox_overlay .player-container, #lightbox_overlay .video-player, #lightbox_overlay .media-description, #lightbox_overlay .media-actions, #lightbox_overlay .center",
     ).hide();
+
+    set_code_wrapping(false);
 
     const $code_block_clone = $code_block.clone();
     $code_block_clone.find(".code-buttons-container").remove();
@@ -714,6 +721,7 @@ export function initialize(): void {
 
     const reset_lightbox_state = function (): void {
         remove_video_players();
+        set_code_wrapping(false);
         $("#lightbox_overlay .code-preview").empty().hide();
         $("#lightbox_overlay .code-actions").removeClass("show");
         playground_links_popover.hide();
@@ -773,6 +781,12 @@ export function initialize(): void {
         const $code_block = $("#lightbox_overlay .code-preview .codehilite");
         assert($code_block.length > 0);
         playground_links_popover.open_code_in_playground($code_block, this);
+    });
+
+    $("#lightbox_overlay .lightbox-code-wrap").on("click", (e) => {
+        e.stopPropagation();
+        const should_wrap = !$("#lightbox_overlay .code-preview").hasClass("wrap-code");
+        set_code_wrapping(should_wrap);
     });
 
     $("#lightbox_overlay .download").on("click", function () {

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -1,3 +1,4 @@
+import ClipboardJS from "clipboard";
 import {$} from "jquery";
 import assert from "minimalistic-assert";
 import panzoom from "panzoom";
@@ -6,9 +7,11 @@ import type {PanZoom} from "panzoom";
 import render_lightbox_overlay from "../templates/lightbox_overlay.hbs";
 
 import * as blueslip from "./blueslip.ts";
+import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as message_store from "./message_store.ts";
 import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
+import * as playground_links_popover from "./playground_links_popover.ts";
 import * as popovers from "./popovers.ts";
 import * as rows from "./rows.ts";
 import * as util from "./util.ts";
@@ -341,6 +344,14 @@ export function display_code_block($code_block: JQuery): void {
     const $code_block_clone = $code_block.clone();
     $code_block_clone.find(".code-buttons-container").remove();
     $("#lightbox_overlay .code-preview").empty().append($code_block_clone).show();
+    $("#lightbox_overlay .code-actions").addClass("show");
+    $("#lightbox_overlay .lightbox-code-playground").toggle(
+        $code_block.find(".code_external_link").length > 0,
+    );
+}
+
+export function get_code_preview_text(): string {
+    return $("#lightbox_overlay .code-preview code").text();
 }
 
 function invoke_overlay_restore_callback(): void {
@@ -387,6 +398,8 @@ export function build_open_media_function(
             "#lightbox_overlay .image-preview, #lightbox_overlay .code-preview, .lightbox-zoom-reset, .player-container, .video-player",
         ).hide();
         $("#lightbox_overlay .code-preview").empty();
+        $("#lightbox_overlay .code-actions").removeClass("show");
+        $("#lightbox_overlay .media-actions").show();
         $("#lightbox_overlay .center").show();
 
         if (payload.type === "image") {
@@ -702,6 +715,8 @@ export function initialize(): void {
     const reset_lightbox_state = function (): void {
         remove_video_players();
         $("#lightbox_overlay .code-preview").empty().hide();
+        $("#lightbox_overlay .code-actions").removeClass("show");
+        playground_links_popover.hide();
         is_open = false;
         assert(document.activeElement instanceof HTMLElement);
         document.activeElement.blur();
@@ -713,6 +728,14 @@ export function initialize(): void {
 
     open_image = build_open_media_function(reset_lightbox_state);
     open_video = build_open_media_function(undefined);
+
+    const $copy_code_button = $("#lightbox_overlay .lightbox-copy-code");
+    const clipboard = new ClipboardJS(util.the($copy_code_button), {
+        text: get_code_preview_text,
+    });
+    clipboard.on("success", () => {
+        show_copied_confirmation(util.the($copy_code_button));
+    });
 
     $("#main_div, #compose .preview_content").on(
         "click",
@@ -743,6 +766,13 @@ export function initialize(): void {
         assert($code_block.length > 0);
         display_code_block($code_block);
         open_lightbox(reset_lightbox_state);
+    });
+
+    $("#lightbox_overlay .lightbox-code-playground").on("click", function (e) {
+        e.stopPropagation();
+        const $code_block = $("#lightbox_overlay .code-preview .codehilite");
+        assert($code_block.length > 0);
+        playground_links_popover.open_code_in_playground($code_block, this);
     });
 
     $("#lightbox_overlay .download").on("click", function () {

--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -348,7 +348,7 @@ export function initialize(): void {
     });
 
     message_list_tooltip(
-        ".rendered_markdown .copy_codeblock, .rendered_markdown .code_external_link",
+        ".rendered_markdown .copy_codeblock, .rendered_markdown .code_external_link, .rendered_markdown .expand_codeblock",
         {
             onHidden(instance) {
                 instance.destroy();

--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -95,43 +95,47 @@ export function handle_keyboard(key: string): void {
     popover_menus.popover_items_handle_keyboard(key, $items);
 }
 
+export function open_code_in_playground(
+    $codehilite_div: JQuery,
+    popover_target: tippy.ReferenceElement,
+): void {
+    const language = $codehilite_div.attr("data-code-language");
+    if (language === undefined) {
+        return;
+    }
+    const playground_info = realm_playground.get_playground_info_for_languages(language);
+    if (playground_info === undefined) {
+        return;
+    }
+    // We do the code extraction here and send user to the target destination,
+    // obtained by expanding the url_template with the extracted code.
+    // Depending on whether the language has multiple playground links configured,
+    // a popover is shown.
+    const extracted_code = $codehilite_div.find("code").text();
+    if (playground_info.length === 1 && playground_info[0] !== undefined) {
+        const url_template = new Template(playground_info[0].url_template);
+        const playground_url = url_template.expand({code: extracted_code});
+        window.open(playground_url, "_blank", "noopener,noreferrer");
+    } else {
+        const playground_store = new Map<number, RealmPlaygroundWithURL>();
+        for (const playground of playground_info) {
+            const url_template = new Template(playground.url_template);
+            const playground_url = url_template.expand({code: extracted_code});
+            playground_store.set(playground.id, {...playground, playground_url});
+        }
+        toggle_playground_links_popover(popover_target, playground_store);
+    }
+}
+
 function register_click_handlers(): void {
     $("#main_div, #preview_content, #message-history").on(
         "click",
         ".code_external_link",
         function (e) {
-            const $view_in_playground_button = $(this);
             const $codehilite_div = $(this).closest(".codehilite");
             e.stopPropagation();
-            const language = $codehilite_div.attr("data-code-language");
-            if (language === undefined) {
-                return;
-            }
-            const playground_info = realm_playground.get_playground_info_for_languages(language);
-            if (playground_info === undefined) {
-                return;
-            }
-            // We do the code extraction here and send user to the target destination,
-            // obtained by expanding the url_template with the extracted code.
-            // Depending on whether the language has multiple playground links configured,
-            // a popover is shown.
-            const extracted_code = $codehilite_div.find("code").text();
-            if (playground_info.length === 1 && playground_info[0] !== undefined) {
-                const url_template = new Template(playground_info[0].url_template);
-                const playground_url = url_template.expand({code: extracted_code});
-                window.open(playground_url, "_blank", "noopener,noreferrer");
-            } else {
-                const playground_store = new Map<number, RealmPlaygroundWithURL>();
-                for (const playground of playground_info) {
-                    const url_template = new Template(playground.url_template);
-                    const playground_url = url_template.expand({code: extracted_code});
-                    playground_store.set(playground.id, {...playground, playground_url});
-                }
-                const popover_target = util.the(
-                    $view_in_playground_button.find(".playground-links-popover-container"),
-                );
-                toggle_playground_links_popover(popover_target, playground_store);
-            }
+            const popover_target = util.the($(this).find(".playground-links-popover-container"));
+            open_code_in_playground($codehilite_div, popover_target);
         },
     );
 

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -85,7 +85,8 @@
         background-color: transparent;
     }
 
-    .media-actions {
+    .media-actions,
+    .code-actions {
         display: flex;
         flex-shrink: 0;
         gap: 10px;
@@ -100,6 +101,7 @@
             border-radius: 4px;
             text-decoration: none;
             display: inline-block;
+            cursor: pointer;
 
             &:hover {
                 background-color: hsl(0deg 0% 100%);
@@ -117,6 +119,18 @@
                 color: hsl(0deg 0% 100%);
                 border: 1px solid hsl(0deg 0% 100% / 60%);
             }
+        }
+    }
+
+    .code-actions {
+        display: none;
+        flex: 1;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        min-width: 0;
+
+        &.show {
+            display: flex;
         }
     }
 

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -34,6 +34,14 @@
         }
     }
 
+    .code-preview {
+        flex: 1;
+        display: none;
+        min-height: 0;
+        padding: 0 20px 20px;
+        overflow: auto;
+    }
+
     .video-player {
         flex: 1;
         display: flex;

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -40,6 +40,12 @@
         min-height: 0;
         padding: 0 20px 20px;
         overflow: auto;
+
+        &.wrap-code pre {
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+            word-break: normal;
+        }
     }
 
     .video-player {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -968,9 +968,10 @@
         z-index: 0;
     }
 
-    /* The properties of the code_external_link button are copied from the
-       copy-button class in app_components.css. */
-    .code_external_link {
+    /* The properties of the code_external_link and expand_codeblock
+       buttons are copied from the copy-button class in app_components.css. */
+    .code_external_link,
+    .expand_codeblock {
         display: flex;
         border-radius: 4px;
         color: var(--color-copy-button);
@@ -979,7 +980,7 @@
         cursor: pointer;
 
         &:hover,
-        :focus-visible {
+        &:focus-visible {
             background-color: var(--color-copy-button-square-bg-hover);
         }
 
@@ -989,8 +990,14 @@
         }
     }
 
+    .expand_codeblock {
+        font: inherit;
+        background-color: transparent;
+    }
+
     .copy_codeblock,
-    .code_external_link {
+    .code_external_link,
+    .expand_codeblock {
         font-size: 1.1363em;
         border: 1px solid var(--color-copy-button-square-bg-active);
         backdrop-filter: blur(20px);

--- a/web/templates/code_buttons_container.hbs
+++ b/web/templates/code_buttons_container.hbs
@@ -8,4 +8,7 @@
         <i class="zulip-icon zulip-icon-external-link playground-links-popover-container"></i>
     </span>
     {{~/if~}}
+    <button type="button" class="expand_codeblock" data-tippy-content="{{t 'Expand code block' }}" aria-label="{{t 'Expand code block' }}">
+        <i class="zulip-icon zulip-icon-expand-both-diagonals" aria-hidden="true"></i>
+    </button>
 </div>

--- a/web/templates/lightbox_overlay.hbs
+++ b/web/templates/lightbox_overlay.hbs
@@ -17,6 +17,7 @@
     <div class="image-preview no-select">
         <div class="zoom-element no-select"></div>
     </div>
+    <div class="code-preview rendered_markdown"></div>
     <div class="video-player"></div>
     <div class="player-container"></div>
     <div class="center">

--- a/web/templates/lightbox_overlay.hbs
+++ b/web/templates/lightbox_overlay.hbs
@@ -9,6 +9,10 @@
             <a class="lightbox-media-action open" rel="noopener noreferrer" target="_blank">{{t "Open" }}</a>
             <a class="lightbox-media-action download" download>{{t "Download" }}</a>
         </div>
+        <div class="code-actions">
+            <button type="button" class="lightbox-media-action lightbox-copy-code">{{t "Copy" }}</button>
+            <button type="button" class="lightbox-media-action lightbox-code-playground">{{t "View in playground" }}</button>
+        </div>
         <div class="exit" aria-label="{{t 'Close' }}">
             <span aria-hidden="true" class="zulip-icon zulip-icon-close"></span>
         </div>

--- a/web/templates/lightbox_overlay.hbs
+++ b/web/templates/lightbox_overlay.hbs
@@ -11,6 +11,7 @@
         </div>
         <div class="code-actions">
             <button type="button" class="lightbox-media-action lightbox-copy-code">{{t "Copy" }}</button>
+            <button type="button" class="lightbox-media-action lightbox-code-wrap" aria-pressed="false">{{t "Wrap lines" }}</button>
             <button type="button" class="lightbox-media-action lightbox-code-playground">{{t "View in playground" }}</button>
         </div>
         <div class="exit" aria-label="{{t 'Close' }}">

--- a/web/tests/lightbox.test.cjs
+++ b/web/tests/lightbox.test.cjs
@@ -274,6 +274,21 @@ run_test("parse_media_data asset map cache", () => {
     assert.equal(result2, result1);
 });
 
+run_test("set_code_wrapping", () => {
+    const $code_preview = $("#lightbox_overlay .code-preview");
+    const $wrap_button = $("#lightbox_overlay .lightbox-code-wrap");
+
+    lightbox.set_code_wrapping(true);
+
+    assert.equal($code_preview.hasClass("wrap-code"), true);
+    assert.equal($wrap_button.attr("aria-pressed"), "true");
+
+    lightbox.set_code_wrapping(false);
+
+    assert.equal($code_preview.hasClass("wrap-code"), false);
+    assert.equal($wrap_button.attr("aria-pressed"), "false");
+});
+
 run_test("display_code_block", () => {
     const hidden_elements_selector =
         "#lightbox_overlay .image-preview, #lightbox_overlay .player-container, #lightbox_overlay .video-player, #lightbox_overlay .media-description, #lightbox_overlay .media-actions, #lightbox_overlay .center";
@@ -281,7 +296,9 @@ run_test("display_code_block", () => {
     const $code_preview = $("#lightbox_overlay .code-preview").hide();
     const $code_actions = $("#lightbox_overlay .code-actions").removeClass("show");
     const $playground_action = $("#lightbox_overlay .lightbox-code-playground").hide();
+    const $wrap_button = $("#lightbox_overlay .lightbox-code-wrap");
     $code_preview.html("old code");
+    lightbox.set_code_wrapping(true);
 
     const $code_block = $.create("<code-block>");
     const $code_block_clone = $.create("<code-block-clone>");
@@ -307,6 +324,8 @@ run_test("display_code_block", () => {
     assert.equal($code_preview.visible(), true);
     assert.equal($code_actions.hasClass("show"), true);
     assert.equal($playground_action.visible(), true);
+    assert.equal($code_preview.hasClass("wrap-code"), false);
+    assert.equal($wrap_button.attr("aria-pressed"), "false");
     assert.equal($code_preview.html(), "");
     assert.equal(appended_element, $code_block_clone[0]);
     assert.equal(removed_buttons, true);
@@ -339,5 +358,6 @@ run_test("lightbox overlay includes code actions", () => {
     const html = render_lightbox_overlay();
 
     assert.match(html, /class="lightbox-media-action lightbox-copy-code"/);
+    assert.match(html, /class="lightbox-media-action lightbox-code-wrap" aria-pressed="false"/);
     assert.match(html, /class="lightbox-media-action lightbox-code-playground"/);
 });

--- a/web/tests/lightbox.test.cjs
+++ b/web/tests/lightbox.test.cjs
@@ -273,3 +273,35 @@ run_test("parse_media_data asset map cache", () => {
     const result2 = lightbox.parse_media_data(media2);
     assert.equal(result2, result1);
 });
+
+run_test("display_code_block", () => {
+    const hidden_elements_selector =
+        "#lightbox_overlay .image-preview, #lightbox_overlay .player-container, #lightbox_overlay .video-player, #lightbox_overlay .media-description, #lightbox_overlay .media-actions, #lightbox_overlay .center";
+    const $hidden_elements = $(hidden_elements_selector).show();
+    const $code_preview = $("#lightbox_overlay .code-preview").hide();
+    $code_preview.html("old code");
+
+    const $code_block = $.create("<code-block>");
+    const $code_block_clone = $.create("<code-block-clone>");
+    const $code_buttons = $.create("<code-buttons>");
+    $code_block_clone.set_find_results(".code-buttons-container", $code_buttons);
+    $code_block.clone = () => $code_block_clone;
+
+    let removed_buttons = false;
+    $code_buttons[0].remove = () => {
+        removed_buttons = true;
+    };
+
+    let appended_element;
+    $code_preview[0].append = (element) => {
+        appended_element = element;
+    };
+
+    lightbox.display_code_block($code_block);
+
+    assert.equal($hidden_elements.visible(), false);
+    assert.equal($code_preview.visible(), true);
+    assert.equal($code_preview.html(), "");
+    assert.equal(appended_element, $code_block_clone[0]);
+    assert.equal(removed_buttons, true);
+});

--- a/web/tests/lightbox.test.cjs
+++ b/web/tests/lightbox.test.cjs
@@ -279,11 +279,15 @@ run_test("display_code_block", () => {
         "#lightbox_overlay .image-preview, #lightbox_overlay .player-container, #lightbox_overlay .video-player, #lightbox_overlay .media-description, #lightbox_overlay .media-actions, #lightbox_overlay .center";
     const $hidden_elements = $(hidden_elements_selector).show();
     const $code_preview = $("#lightbox_overlay .code-preview").hide();
+    const $code_actions = $("#lightbox_overlay .code-actions").removeClass("show");
+    const $playground_action = $("#lightbox_overlay .lightbox-code-playground").hide();
     $code_preview.html("old code");
 
     const $code_block = $.create("<code-block>");
     const $code_block_clone = $.create("<code-block-clone>");
     const $code_buttons = $.create("<code-buttons>");
+    const $playground_link = $.create("<playground-link>");
+    $code_block.set_find_results(".code_external_link", $playground_link);
     $code_block_clone.set_find_results(".code-buttons-container", $code_buttons);
     $code_block.clone = () => $code_block_clone;
 
@@ -301,7 +305,39 @@ run_test("display_code_block", () => {
 
     assert.equal($hidden_elements.visible(), false);
     assert.equal($code_preview.visible(), true);
+    assert.equal($code_actions.hasClass("show"), true);
+    assert.equal($playground_action.visible(), true);
     assert.equal($code_preview.html(), "");
     assert.equal(appended_element, $code_block_clone[0]);
     assert.equal(removed_buttons, true);
+});
+
+run_test("display_code_block without a configured playground", () => {
+    const $code_block = $.create("<code-block-without-playground>");
+    const $code_block_clone = $.create("<code-block-clone-without-playground>");
+    const $code_buttons = $.create("<code-buttons-without-playground>");
+    $code_block.set_find_results(".code_external_link", []);
+    $code_block_clone.set_find_results(".code-buttons-container", $code_buttons);
+    $code_block.clone = () => $code_block_clone;
+    $code_buttons[0].remove = () => {};
+
+    lightbox.display_code_block($code_block);
+
+    assert.equal($("#lightbox_overlay .code-actions").hasClass("show"), true);
+    assert.equal($("#lightbox_overlay .lightbox-code-playground").visible(), false);
+});
+
+run_test("get_code_preview_text", () => {
+    const $code = $("#lightbox_overlay .code-preview code");
+    $code.text("const greeting = 'hello';\n");
+
+    assert.equal(lightbox.get_code_preview_text(), "const greeting = 'hello';\n");
+});
+
+run_test("lightbox overlay includes code actions", () => {
+    const render_lightbox_overlay = require("../templates/lightbox_overlay.hbs");
+    const html = render_lightbox_overlay();
+
+    assert.match(html, /class="lightbox-media-action lightbox-copy-code"/);
+    assert.match(html, /class="lightbox-media-action lightbox-code-playground"/);
 });

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -836,6 +836,15 @@ function assert_clipboard_setup() {
     assert.equal(text, "text");
 }
 
+run_test("code block buttons include expand action", () => {
+    const render_code_buttons_container = require("../templates/code_buttons_container.hbs");
+    const html = render_code_buttons_container({show_playground_button: false});
+
+    assert.match(html, /<button type="button" class="expand_codeblock"/);
+    assert.match(html, /aria-label="translated: Expand code block"/);
+    assert.match(html, /zulip-icon-expand-both-diagonals/);
+});
+
 function test_code_playground(mock_template, viewing_code) {
     const $content = get_content_element();
     const $hilite = $.create("div.codehilite");


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Extends the existing lightbox to display code blocks in a larger view. Rendered
code blocks now have an Expand button that opens the code in the lightbox while
preserving syntax highlighting.

The expanded view provides actions to copy the code, open it in a configured
playground, and toggle line wrapping.

A later comment on the issue also suggests adding line numbers. This PR leaves
that for a follow-up because it is unclear whether line numbers should always be
shown or controlled by another toggle.

Implemented in collaboration with @johnnelsan 

Fixes: #5595 

**How changes were tested:**
- `tools/test-js-with-node web/tests/lightbox.test.cjs web/tests/rendered_markdown.test.cjs`
- Targeted lint for all changed files
- Manual testing of expanding code blocks, copying code, opening configured playgrounds, and toggling line wrapping
- Tested string internationalization. "Wrap lines" and "Expand code block" are newly introduced strings to be translated

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
<img width="1920" height="1080" alt="wide 2" src="https://github.com/user-attachments/assets/bb5874ec-f7ae-4935-84dd-0fdcf1fce3c5" />
<img width="1901" height="943" alt="wide 1" src="https://github.com/user-attachments/assets/018b9db6-d435-4105-8dc3-7ab375dc84bf" />
<img width="490" height="618" alt="narrow 2" src="https://github.com/user-attachments/assets/a8b26378-1b93-43c7-ac92-e614ec937d56" />
<img width="389" height="511" alt="narrow 1" src="https://github.com/user-attachments/assets/06efc908-4b06-4f08-a383-0ef2bb9e3f9b" />
<img width="735" height="532" alt="narrow viewport" src="https://github.com/user-attachments/assets/8d0c48d8-a150-44f4-842c-d362d1d71b75" />
<img width="913" height="201" alt="Screenshot_20260820_205935" src="https://github.com/user-attachments/assets/798e505a-3fe1-4434-af66-82c1cf632ce1" />
[Screencast_20260820_205111.webm](https://github.com/user-attachments/assets/15884596-a77f-4c3d-9652-f141f7af1e39)
<img width="1875" height="1053" alt="persian" src="https://github.com/user-attachments/assets/23ccd4ce-98e1-4348-8b32-595058061313" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
