### PR TITLE
help: Add mobile instructions for reporting a message.

### DIFF
--- a/starlight_help/src/content/docs/report-a-message.mdx
+++ b/starlight_help/src/content/docs/report-a-message.mdx
@@ -6,6 +6,7 @@ import {TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
 import MessageActionsMenu from "../include/_MessageActionsMenu.mdx";
+import MessageLongPressMenu from "../include/_MessageLongPressMenu.mdx";
 
 When moderation requests are enabled, you can report problematic messages. This
 sends a message to a private channel, where moderators can review the report.
@@ -27,6 +28,19 @@ that you report, not other DMs in the same thread.
       1. Fill out the requested information. Moderators will see the message
          you're reporting when they review your report.
       1. Click **Submit** to report the message.
+    </FlattenedSteps>
+  </TabItem>
+
+  <TabItem label="Mobile">
+    <FlattenedSteps>
+      <MessageLongPressMenu />
+
+      1. Tap **Report message**. If you do not see this option, moderation
+         requests are [disabled](/help/enable-moderation-requests) in this
+         organization.
+      1. Fill out the requested information. Moderators will see the message
+         you're reporting when they review your report.
+      1. Tap **Submit** to report the message.
     </FlattenedSteps>
   </TabItem>
 </Tabs>

--- a/starlight_help/src/content/docs/report-a-message.mdx
+++ b/starlight_help/src/content/docs/report-a-message.mdx
@@ -5,9 +5,7 @@ title: Report a message
 import {TabItem, Tabs} from "@astrojs/starlight/components";
 
 import FlattenedSteps from "../../components/FlattenedSteps.astro";
-import MessageActions from "../include/_MessageActions.mdx";
-
-import FlagIcon from "~icons/zulip-icon/flag";
+import MessageActionsMenu from "../include/_MessageActionsMenu.mdx";
 
 When moderation requests are enabled, you can report problematic messages. This
 sends a message to a private channel, where moderators can review the report.
@@ -21,10 +19,11 @@ that you report, not other DMs in the same thread.
 <Tabs>
   <TabItem label="Desktop/Web">
     <FlattenedSteps>
-      <MessageActions />
+      <MessageActionsMenu />
 
-      1. Select **report message**. If you do not see this option, moderation requests
-         are [disabled](/help/enable-moderation-requests) in this organization.
+      1. Select **Report message**. If you do not see this option, moderation
+         requests are [disabled](/help/enable-moderation-requests) in this
+         organization.
       1. Fill out the requested information. Moderators will see the message
          you're reporting when they review your report.
       1. Click **Submit** to report the message.


### PR DESCRIPTION
Reporting a message shipped in the mobile app in release 30.0.273, so these instructions no longer need to be web-only.

The desktop instructions now start from the message actions menu, since "Report message" is an item in the ellipsis menu rather than one of the icons revealed on hover, and the option's label is capitalized as it is in the apps. Drops an unused icon import.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

Manually (Local dev-server).

**Screenshots and screen captures:**


| Before | After (Web) | After (Mobile) |
| - | - | - | 
| <img width="762" height="288" alt="Screenshot 2026-08-20 at 21 42 58" src="https://github.com/user-attachments/assets/63c0ed64-c39d-4e0d-9095-188c40ec47e9" /> | <img width="762" height="318" alt="Screenshot 2026-08-20 at 21 42 13" src="https://github.com/user-attachments/assets/a39d31d9-df4b-4980-8d7d-1be272c3477e" /> | <img width="762" height="288" alt="Screenshot 2026-08-20 at 21 42 22" src="https://github.com/user-attachments/assets/2514df82-e9b2-4ff4-8135-6abd0d9ae48f" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
