### PR TITLE
api-docs: Split "Specialty endpoints" section endpoints.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -176,12 +176,15 @@
 * [Update a bot's stored data](/api/update-bot-storage)
 * [Remove a bot's stored data](/api/remove-bot-storage)
 
-## Specialty endpoints
+## Video call integrations
 
-* [Fetch an API key (production)](/api/fetch-api-key)
-* [Fetch an API key (development only)](/api/dev-fetch-api-key)
-* [Fetch an API key (JWT)](/api/jwt-fetch-api-key)
-* [List users (development only)](/api/dev-list-users)
+* [Create BigBlueButton video call](/api/create-big-blue-button-video-call)
+* [Create Constructor Groups video call](/api/create-constructor-groups-video-call)
+* [Create Nextcloud Talk video call](/api/create-nextcloud-talk-video-call)
+* [Create Webex video call](/api/create-webex-video-call)
+
+## Mobile push notifications
+
 * [Register a logged-in device](/api/register-client-device)
 * [Remove a registered device](/api/remove-client-device)
 * [Send an E2EE test notification to mobile device(s)](/api/e2ee-test-notify)
@@ -193,8 +196,11 @@
 * [Remove an APNs device token](/api/remove-apns-token)
 * [Add an FCM registration token](/api/add-fcm-token)
 * [Remove an FCM registration token](/api/remove-fcm-token)
-* [Create BigBlueButton video call](/api/create-big-blue-button-video-call)
-* [Create Constructor Groups video call](/api/create-constructor-groups-video-call)
-* [Create Nextcloud Talk video call](/api/create-nextcloud-talk-video-call)
-* [Create Webex video call](/api/create-webex-video-call)
+
+## Specialty endpoints
+
+* [Fetch an API key (production)](/api/fetch-api-key)
+* [Fetch an API key (development only)](/api/dev-fetch-api-key)
+* [Fetch an API key (JWT)](/api/jwt-fetch-api-key)
+* [List users (development only)](/api/dev-list-users)
 * [Outgoing webhook payloads](/api/outgoing-webhook-payload)


### PR DESCRIPTION
See [#api documentation > splitting the specialty endpoints section in sidebar](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/splitting.20the.20specialty.20endpoints.20section.20in.20sidebar/with/2506987) for context.

**Notes**:
- Moves the video call integrations and mobile push notification endpoints to new sections in the left sidebar. Used "Video call" vs "Call" as they are in the "Video calling" category in the integration documentation pages.
- Leaves the API key and development endpoints in the specialty endpoints section, as well as the outgoing webhook payload documentation.


---

Heads up to @0xthedance and @hanyucrocks that when/if this is merged you might need to update some of your pull requests with API documentation changes.

---

**Screenshots and screen captures:**

<details>
<summary>Updated API docs sidebar</summary>

<img width="618" height="1548" alt="Screenshot From 2026-08-20 20-29-17" src="https://github.com/user-attachments/assets/c7e67700-47d6-41ae-bca0-8a3f24c71aac" />
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
