### PR TITLE
puppet: Add pipefail to deploy hook scripts.

### DIFF
--- a/puppet/zulip/files/hooks/common/sentry.sh
+++ b/puppet/zulip/files/hooks/common/sentry.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -u
+set -o pipefail
 
 if ! grep -Eq 'SENTRY_DSN|SENTRY_FRONTEND_DSN' /etc/zulip/settings.py; then
     echo "sentry: No DSN configured!  Set SENTRY_DSN or SENTRY_FRONTEND_DSN in /etc/zulip/settings.py"

--- a/puppet/zulip/files/hooks/common/zulip_notify.sh
+++ b/puppet/zulip/files/hooks/common/zulip_notify.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -u
+set -o pipefail
 
 if ! zulip_api_key=$(crudini --get /etc/zulip/zulip-secrets.conf secrets zulip_release_api_key); then
     echo "zulip_notify: No zulip_release_api_key set!  Set zulip_release_api_key in /etc/zulip/zulip-secrets.conf"


### PR DESCRIPTION
Adds `set -o pipefail` to two deploy hook scripts that already use `set -e` and `set -u`. This is a small first step toward making shell scripts safer.

Fixes: Part of #20748.

**How changes were tested:**

- Ran `bash -n puppet/zulip/files/hooks/common/sentry.sh puppet/zulip/files/hooks/common/zulip_notify.sh`.
- Ran `git diff --check`.

N/A. This is not a UI change.

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
