### PR TITLE
Remove the usage of nonexistent ZULIP_SERVICES setting.

### DIFF
--- a/zerver/tests/test_handle_push_notification.py
+++ b/zerver/tests/test_handle_push_notification.py
@@ -357,7 +357,7 @@ class HandlePushNotificationTest(PushNotificationTestCase):
             handle_push_notification(self.user_profile.id, missed_message)
 
     @mock.patch("zerver.lib.push_notifications.push_notifications_configured", return_value=True)
-    @override_settings(ZULIP_SERVICE_PUSH_NOTIFICATIONS=False, ZULIP_SERVICES=set())
+    @override_settings(ZULIP_SERVICE_PUSH_NOTIFICATIONS=False)
     def test_read_message(self, mock_push_notifications: mock.MagicMock) -> None:
         self.setup_apns_tokens()
         self.setup_fcm_tokens()

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -275,7 +275,7 @@ ZULIP_SERVICE_SECURITY_ALERTS = False
 PUSH_NOTIFICATION_BOUNCER_URL: str | None = None
 # Keep this default True, so that legacy deployments that configured PUSH_NOTIFICATION_BOUNCER_URL
 # without overriding SUBMIT_USAGE_STATISTICS get the original behavior. If a server configures
-# the modern ZULIP_SERVICES setting, all this will be ignored.
+# the modern ZULIP_SERVICE_* settings, all this will be ignored.
 SUBMIT_USAGE_STATISTICS = True
 
 PROMOTE_SPONSORING_ZULIP = True


### PR DESCRIPTION
We use `ZULIP_SERVICES` setting name in a couple of places. No such setting exists.

These were mistakenly added in 4a9314943525ad001c46a8ab44a0ca42e26bbb80

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
