### PR TITLE
settings: Fix crash when removing custom profile field options.

### DIFF
--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -466,7 +466,7 @@ function show_modal_for_deleting_options(
         count: users_count_with_deleted_option_selected,
         field_name: field.name,
         deleted_options_count,
-        deleted_values,
+        deleted_option_texts: deleted_values.values().toArray(),
     });
 
     confirm_dialog.launch({

--- a/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
@@ -20,7 +20,7 @@
     {{/if}}
 </div>
 <ul class="modal-options-list">
-    {{#each (object_values deleted_values)}}
+    {{#each deleted_option_texts}}
         <li>{{this}}</li>
     {{/each}}
 </ul>


### PR DESCRIPTION
Removing an option from a "List of options" field and saving showed no confirmation dialog; instead it raised "object_values requires a plain object". The template's object_values helper expects a plain object, but deleted_values became a Map in 11646015a6 (eslint: Fix unicorn/no-computed-property-existence-check.).

Pass the option texts to the template as an array instead.



<!-- Describe your pull request here.-->


**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
