### PR TITLE
jira: Add support for jira:worklog_updated events.

### DIFF
--- a/zerver/webhooks/jira/fixtures/worklog_updated__deleted.json
+++ b/zerver/webhooks/jira/fixtures/worklog_updated__deleted.json
@@ -1,0 +1,72 @@
+{
+  "timestamp": 1666877185412,
+  "webhookEvent": "jira:worklog_updated",
+  "issue_event_type_name": "issue_worklog_deleted",
+  "user": {
+    "self": "https://zulipp.atlassian.net/rest/api/2/user?username=admin",
+    "name": "admin",
+    "key": "admin",
+    "emailAddress": "othello@zulip.com",
+    "displayName": "Leonardo Franchi [Administrator]",
+    "active": true,
+    "timeZone": "Europe/Berlin"
+  },
+  "issue": {
+    "id": "10022",
+    "self": "https://zulipp.atlassian.net/rest/api/2/issue/10022",
+    "key": "SCRUM-23",
+    "fields": {
+      "issuetype": {
+        "self": "https://zulipp.atlassian.net/rest/api/2/issuetype/10002",
+        "id": "10002",
+        "name": "Story",
+        "subtask": false
+      },
+      "summary": "Improve the payment gateway",
+      "description": "The payment gateway times out under load.",
+      "timespent": null,
+      "aggregatetimespent": null,
+      "timeoriginalestimate": 21600,
+      "timeestimate": 21600,
+      "assignee": null,
+      "priority": {
+        "self": "https://zulipp.atlassian.net/rest/api/2/priority/3",
+        "name": "Medium",
+        "id": "3"
+      },
+      "status": {
+        "self": "https://zulipp.atlassian.net/rest/api/2/status/3",
+        "name": "In Progress",
+        "id": "3"
+      },
+      "created": "2022-09-19T06:00:40.345-0300",
+      "updated": "2022-10-27T10:26:25.412-0300",
+      "labels": [],
+      "components": [],
+      "versions": [],
+      "issuelinks": [],
+      "subtasks": []
+    }
+  },
+  "changelog": {
+    "id": "10501",
+    "items": [
+      {
+        "field": "WorklogId",
+        "fieldtype": "jira",
+        "from": "10201",
+        "fromString": "10201",
+        "to": null,
+        "toString": null
+      },
+      {
+        "field": "timespent",
+        "fieldtype": "jira",
+        "from": "21060",
+        "fromString": "21060",
+        "to": null,
+        "toString": null
+      }
+    ]
+  }
+}

--- a/zerver/webhooks/jira/fixtures/worklog_updated__edited.json
+++ b/zerver/webhooks/jira/fixtures/worklog_updated__edited.json
@@ -1,0 +1,72 @@
+{
+  "timestamp": 1666877021969,
+  "webhookEvent": "jira:worklog_updated",
+  "issue_event_type_name": "issue_work_logged",
+  "user": {
+    "self": "https://zulipp.atlassian.net/rest/api/2/user?username=admin",
+    "name": "admin",
+    "key": "admin",
+    "emailAddress": "othello@zulip.com",
+    "displayName": "Leonardo Franchi [Administrator]",
+    "active": true,
+    "timeZone": "Europe/Berlin"
+  },
+  "issue": {
+    "id": "10022",
+    "self": "https://zulipp.atlassian.net/rest/api/2/issue/10022",
+    "key": "SCRUM-23",
+    "fields": {
+      "issuetype": {
+        "self": "https://zulipp.atlassian.net/rest/api/2/issuetype/10002",
+        "id": "10002",
+        "name": "Story",
+        "subtask": false
+      },
+      "summary": "Improve the payment gateway",
+      "description": "The payment gateway times out under load.",
+      "timespent": 21060,
+      "aggregatetimespent": 21060,
+      "timeoriginalestimate": 21600,
+      "timeestimate": 540,
+      "assignee": null,
+      "priority": {
+        "self": "https://zulipp.atlassian.net/rest/api/2/priority/3",
+        "name": "Medium",
+        "id": "3"
+      },
+      "status": {
+        "self": "https://zulipp.atlassian.net/rest/api/2/status/3",
+        "name": "In Progress",
+        "id": "3"
+      },
+      "created": "2022-09-19T06:00:40.345-0300",
+      "updated": "2022-10-27T10:23:41.885-0300",
+      "labels": [],
+      "components": [],
+      "versions": [],
+      "issuelinks": [],
+      "subtasks": []
+    }
+  },
+  "changelog": {
+    "id": "10500",
+    "items": [
+      {
+        "field": "WorklogId",
+        "fieldtype": "jira",
+        "from": "10200",
+        "fromString": "10200",
+        "to": "10200",
+        "toString": "10200"
+      },
+      {
+        "field": "timespent",
+        "fieldtype": "jira",
+        "from": "19500",
+        "fromString": "19500",
+        "to": "21060",
+        "toString": "21060"
+      }
+    ]
+  }
+}

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -35,7 +35,6 @@ class JiraHookTests(WebhookTestCase):
             "issuelink_created",
             "issuelink_deleted",
             "jira:version_released",
-            "jira:worklog_updated",
             "sprint_closed",
             "sprint_started",
             "worklog_created",
@@ -58,6 +57,16 @@ class JiraHookTests(WebhookTestCase):
         expected_topic_name = "TEST-4: Test Created Assignee"
         expected_message = "Bo Williams created [TEST-4: Test Created Assignee](https://zulipp.atlassian.net/browse/TEST-4) with major priority (assigned to Kevin Lin)."
         self.check_webhook("issue_created_with_assignee", expected_topic_name, expected_message)
+
+    def test_worklog_updated(self) -> None:
+        expected_topic_name = "SCRUM-23: Improve the payment gateway"
+        expected_message = "@_**Othello, the Moor of Venice|12** updated a work log entry on [SCRUM-23: Improve the payment gateway](https://zulipp.atlassian.net/browse/SCRUM-23); total time spent is now 5h 51m."
+        self.check_webhook("worklog_updated__edited", expected_topic_name, expected_message)
+
+    def test_worklog_deleted(self) -> None:
+        expected_topic_name = "SCRUM-23: Improve the payment gateway"
+        expected_message = "@_**Othello, the Moor of Venice|12** deleted a work log entry from [SCRUM-23: Improve the payment gateway](https://zulipp.atlassian.net/browse/SCRUM-23)."
+        self.check_webhook("worklog_updated__deleted", expected_topic_name, expected_message)
 
     def test_deleted(self) -> None:
         expected_topic_name = "BUG-15: New bug with hook"

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -13,7 +13,7 @@ from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
-from zerver.lib.validator import WildValue, check_none_or, check_string
+from zerver.lib.validator import WildValue, check_int, check_none_or, check_string
 from zerver.lib.webhooks.common import (
     check_send_webhook_message,
     guess_zulip_user_from_external_account,
@@ -26,7 +26,6 @@ IGNORED_EVENTS = [
     "issuelink_created",
     "issuelink_deleted",
     "jira:version_released",
-    "jira:worklog_updated",
     "sprint_closed",
     "sprint_started",
     "worklog_created",
@@ -331,10 +330,43 @@ def handle_comment_deleted_event(payload: WildValue, user_profile: UserProfile) 
     )
 
 
+def format_time_spent(seconds: int) -> str:
+    hours, remainder = divmod(seconds, 3600)
+    minutes, _ = divmod(remainder, 60)
+
+    time_parts = []
+    if hours > 0:
+        time_parts.append(f"{hours}h")
+    if minutes > 0:
+        time_parts.append(f"{minutes}m")
+
+    return " ".join(time_parts) if time_parts else "0m"
+
+
+def handle_worklog_updated_event(payload: WildValue, user_profile: UserProfile) -> str:
+    author = get_issue_author(payload, user_profile.realm)
+    issue_string = get_issue_string(payload, with_title=True)
+
+    action = "updated a work log entry on"
+    for item in payload.get("changelog", {}).get("items", []):
+        field = item.get("field").tame(check_none_or(check_string))
+        # An empty WorklogId means the entry was deleted rather than edited.
+        if field == "WorklogId" and not item.get("to"):
+            action = "deleted a work log entry from"
+
+    time_spent = get_in(payload, ["issue", "fields", "timespent"])
+    if not isinstance(time_spent.value, int):
+        return f"{author} {action} {issue_string}."
+
+    total = format_time_spent(time_spent.tame(check_int))
+    return f"{author} {action} {issue_string}; total time spent is now {total}."
+
+
 JIRA_CONTENT_FUNCTION_MAPPER: dict[str, Callable[[WildValue, UserProfile], str] | None] = {
     "jira:issue_created": handle_created_issue_event,
     "jira:issue_deleted": handle_deleted_issue_event,
     "jira:issue_updated": handle_updated_issue_event,
+    "jira:worklog_updated": handle_worklog_updated_event,
     "comment_created": handle_comment_created_event,
     "comment_updated": handle_comment_updated_event,
     "comment_deleted": handle_comment_deleted_event,


### PR DESCRIPTION
Jira reuses the `jira:worklog_updated` event for two different actions: editing an existing work log entry and deleting one. Since the payloads are otherwise identical, the handler distinguishes between them using the changelog's `WorklogId` item  an edit, `from` and `to` both hold the same ID because the entry still exists. On a delete, `to` is empty because the entry is gone.

The message reports the issue's **total time spent** rather than the delta from the changelog. This is because `issue.fields.timespent` is always available, while the changelog's `timespent` item is not. When no time is logged (`timespent` is `null`), which occurs after deleting the only work log entry, the message omits the total instead of displaying `0m`.

This change only covers the Server/Data Center event. Jira Cloud's `worklog_created` and `worklog_updated` events remain in `IGNORED_EVENTS` because their payloads do not contain the issue fields required by `get_issue_topic`, and processing them would result in degraded topics. I plan to handle the remaining events from #16189 in follow-up pull requests.

**Fixes:** Part of #16189

**Documentation used:**

Jira:
- [Jira Server/Data Center webhooks](https://developer.atlassian.com/server/jira/platform/webhooks/) — documents `jira:worklog_updated` and the issue-event payload shape (`user`, `issue`, `changelog`). The sample JSON on that page is for `jira:issue_updated`, not a full `jira:worklog_updated` payload. 
- [Jira Cloud webhooks](https://developer.atlassian.com/cloud/jira/platform/webhooks/) — Cloud replacements `worklog_created` / `worklog_updated` / `worklog_deleted`.
- [Deprecation notice: worklog data in issue-related webhook events](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-worklog-data-in-issue-related-events-for-webhooks/) — why Cloud no longer sends `jira:worklog_updated` with issue worklog fields.

**How changes were tested:**

- Ran `./tools/test-backend zerver.webhooks.jira`, including two new tests covering the edited and deleted work log cases.
- Confirmed that `zerver/webhooks/jira/view.py` maintains complete line coverage using `./tools/test-backend --coverage`.
- Sent both fixtures to a development server channel using `curl` and verified the rendered messages.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
**Remaining Concerns**

- Server/DC `jira:worklog_updated` fixtures were built from Atlassian’s documented issue-event shape (along with the existing Zulip fixture style), not captured from a Data Center instance.Cloud does not send the `jira:worklog_updated` event.[Discussion]( https://chat.zulip.org/#narrow/channel/127-integrations/topic/jira.3A.20Add.20support.20for.20jira.3Aworklog_updated.20events.2E-.20.2339998/with/2514841)

- Cloud `worklog_created` / `worklog_updated` events remain ignored because live payloads contain only `worklog` and `issueId`, with no `issue` key or summary. As a result, `get_issue_topic()` cannot run.The same limitation applies to live `attachment_created` and `issuelink_created` events.

- If a `jira:worklog_updated` event has no changelog `WorklogId` item, the handler treats it as an edit. This execution path is currently untested.

**Screenshots and screen captures:**

<img width="1918" height="935" alt="image" src="https://github.com/user-attachments/assets/6836c09e-0bb2-4a55-ae13-a9145fddcafe" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
