### PR TITLE
message feed: Keep recipient bar controls visible after header rerender

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -567,6 +567,14 @@ export function initialize(): void {
     }
 
     $("#message_feed_container").on(
+        "mouseleave",
+        `.message_header.${ui_util.SHOW_RECIPIENT_BAR_CONTROLS_CLASS}`,
+        function (this: HTMLElement) {
+            $(this).removeClass(ui_util.SHOW_RECIPIENT_BAR_CONTROLS_CLASS);
+        },
+    );
+
+    $("#message_feed_container").on(
         "click",
         ".narrows_by_topic, .narrows_by_recipient",
         function (this: HTMLElement, e) {
@@ -580,7 +588,9 @@ export function initialize(): void {
             if ($(this).hasClass("narrows_by_topic")) {
                 e.preventDefault();
                 const row_id = get_row_id_for_narrowing(this);
+                const {clientX, clientY} = e;
                 message_view.narrow_by_topic(row_id, {trigger: "message header"});
+                ui_util.restore_recipient_bar_controls_at_point(clientX, clientY);
             }
         },
     );

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -33,6 +33,7 @@ import * as muted_users from "./muted_users.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
+import * as popover_menus from "./popover_menus.ts";
 import * as popovers from "./popovers.ts";
 import * as reactions from "./reactions.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
@@ -289,6 +290,25 @@ function get_topic_edit_properties(message: Message): {
     };
 }
 
+function hide_popovers_anchored_to_header($header: JQuery): void {
+    // These popovers attach to nodes inside the header. Hide them
+    // before replaceWith so Tippy is not left pointing at a detached
+    // reference (which can rebuild the menu with missing items).
+    const instances = [
+        popover_menus.popover_instances.topics_menu,
+        popover_menus.popover_instances.change_visibility_policy,
+    ];
+    for (const instance of instances) {
+        if (!instance?.state.isVisible) {
+            continue;
+        }
+        const reference = instance.reference;
+        if (reference instanceof Element && $header.has(reference).length > 0) {
+            popover_menus.hide_current_popover_if_visible(instance);
+        }
+    }
+}
+
 type RecipientRowUser = {
     full_name: string;
     should_add_guest_user_indicator: boolean;
@@ -401,6 +421,7 @@ export function populate_group_from_message(
     message: Message,
     date_unchanged: boolean,
     year_changed: boolean,
+    always_display_date = narrow_state.is_search_view(),
 ): MessageGroup {
     const is_stream = message.is_stream;
     const is_private = message.is_private;
@@ -410,7 +431,8 @@ export function populate_group_from_message(
 
     // Each searched message is a self-contained result,
     // so we always display date in the recipient bar for those messages.
-    const always_display_date = narrow_state.is_search_view();
+    // Callers should pass the message list's own filter; defaulting to
+    // the current narrow is only correct for the active view.
     if (is_stream) {
         assert(message.type === "stream");
         // stream messages have string display_recipient
@@ -975,6 +997,7 @@ export class MessageListView {
                 message_for_next_group,
                 same_day(message_for_next_group, prev_message),
                 !same_year(message_for_next_group, prev_message),
+                !this.list.data.filter.contains_no_partial_conversations(),
             );
         };
 
@@ -1815,6 +1838,10 @@ export class MessageListView {
         // class.
         const $header = $(`#${CSS.escape(group.message_group_id)}`).find(".message_header");
 
+        // replaceWith drops :hover until the pointer moves (#24228).
+        const was_hovered = $header.is(":hover");
+        hide_popovers_anchored_to_header($header);
+
         // TODO: It's possible that we no longer need this populate
         // call; it was introduced in an earlier version of this code
         // where we constructed an artificial message group for this
@@ -1829,6 +1856,7 @@ export class MessageListView {
                 group.message_containers[0]!.msg,
                 group.date_unchanged,
                 group.message_containers[0]!.year_changed,
+                !this.list.data.filter.contains_no_partial_conversations(),
             ),
             // We don't want `populate_group_from_message` to generate a
             // new id. We also preserve the message containers, since this
@@ -1836,9 +1864,19 @@ export class MessageListView {
             preserved_properties,
         );
 
-        const $rendered_recipient_row = $(render_recipient_row(group));
+        // `_render_group` passes this via the parent template.
+        const $rendered_recipient_row = $(
+            render_recipient_row({
+                ...group,
+                use_match_properties: this.list.is_keyword_search(),
+            }),
+        );
 
         $header.replaceWith($rendered_recipient_row);
+
+        if (was_hovered) {
+            $rendered_recipient_row.addClass(ui_util.SHOW_RECIPIENT_BAR_CONTROLS_CLASS);
+        }
     }
 
     _rerender_message(

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -350,6 +350,22 @@ export function rewire_get_left_sidebar_search_term(
     get_left_sidebar_search_term = value;
 }
 
+export const SHOW_RECIPIENT_BAR_CONTROLS_CLASS = "show-recipient-bar-controls";
+
+// Browsers do not recompute :hover when the hovered node is replaced
+// until the pointer moves. Re-apply control visibility for the header
+// currently under the cursor.
+export function restore_recipient_bar_controls_at_point(client_x: number, client_y: number): void {
+    const el = document.elementFromPoint(client_x, client_y);
+    if (el === null) {
+        return;
+    }
+    const $header = $(el).closest(".message_header");
+    if ($header.length === 1) {
+        $header.addClass(SHOW_RECIPIENT_BAR_CONTROLS_CLASS);
+    }
+}
+
 export const TOPIC_SEARCH_PREFIX = "topic:";
 
 export function get_left_sidebar_topic_search_term(): string | undefined {

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -119,6 +119,14 @@
                 transition: opacity 0.15s ease-in;
             }
         }
+
+        /* Applied when the header was replaced under the pointer. */
+        &.show-recipient-bar-controls {
+            .recipient_bar_controls {
+                opacity: 1;
+                transition: opacity 0.15s ease-in;
+            }
+        }
     }
 
     #report-message-preview-container & {

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -30,6 +30,14 @@ mock_esm("../src/people", {
     maybe_get_user_by_id: noop,
 });
 
+mock_esm("../src/popover_menus", {
+    popover_instances: {
+        topics_menu: null,
+        change_visibility_policy: null,
+    },
+    hide_current_popover_if_visible: noop,
+});
+
 const {Filter} = zrequire("../src/filter");
 const {MessageListView} = zrequire("../src/message_list_view");
 const message_list = zrequire("message_list");

--- a/web/tests/ui_util.test.cjs
+++ b/web/tests/ui_util.test.cjs
@@ -119,3 +119,44 @@ run_test("replace_emoji_name_with_emoji_unicode", () => {
     const man_cook_emoji = "👨‍🍳";
     assert.equal(man_cook_emoji, ui_util.convert_emoji_element_to_unicode($emoji));
 });
+
+run_test("restore_recipient_bar_controls_at_point", () => {
+    assert.equal(ui_util.SHOW_RECIPIENT_BAR_CONTROLS_CLASS, "show-recipient-bar-controls");
+
+    const $header = $.create("message-header-stub");
+    const $target = $.create("pointer-target");
+    $target.set_closest_results(".message_header", $header);
+
+    const original = document.elementFromPoint;
+    document.elementFromPoint = () => ({
+        to_$() {
+            return $target;
+        },
+    });
+    try {
+        ui_util.restore_recipient_bar_controls_at_point(12, 34);
+        assert.ok($header.hasClass("show-recipient-bar-controls"));
+    } finally {
+        document.elementFromPoint = original;
+    }
+
+    const $other = $.create("unrelated-pointer-target");
+    $other.set_closest_results(".message_header", []);
+    document.elementFromPoint = () => ({
+        to_$() {
+            return $other;
+        },
+    });
+    try {
+        ui_util.restore_recipient_bar_controls_at_point(0, 0);
+    } finally {
+        document.elementFromPoint = original;
+    }
+
+    document.elementFromPoint = () => null;
+    try {
+        ui_util.restore_recipient_bar_controls_at_point(1, 1);
+    } finally {
+        document.elementFromPoint = original;
+    }
+});


### PR DESCRIPTION
Fixes: #24228

Clicking a topic name in a search view (like **sent by you**) rebuilds the recipient header under the cursor. Browsers do not recompute `:hover` until the mouse moves, so the recipient-bar controls (edit / resolve / mute / menu) flash in and then vanish. Opening the topic menu at the same moment can leave Tippy attached to a detached node, which is why the popup then redraws with most items gone.

This keeps those controls visible after that rebuild:

- After a topic-name click, re-apply control visibility for the header still under the pointer.
- Do the same when live-update replaces a hovered header.
- Hide topic / visibility-policy popovers anchored to a header before replacing it.
- When rerendering a header, pass `use_match_properties` and the message list's own search-view flag, matching the original render path.

**How changes were tested:**

- Added node tests for `restore_recipient_bar_controls_at_point` (header under pointer, no header, `elementFromPoint` returning null).
- Mocked `popover_menus` in `message_list_view` tests so the new import does not load the real module.

I could not run the full node suite or the web app in this environment (no `node_modules` / Unix `tools/test-js-with-node`). Would be good to manually confirm: search **sent by you**, click a topic name, and check that the recipient-bar controls stay visible and the topic menu does not collapse.

**Screenshots and screen captures:**

Not included — this is restoring existing hover-visible controls after a DOM replace, using the same opacity as the existing sticky-header rule. Happy to add a capture after it's checked in a running app.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>