### PR TITLE
emails: Use channel privacy emoji icons in notifications

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -403,9 +403,10 @@ def get_user_muted_topics_map(user_ids: list[int]) -> dict[int, set[tuple[int, s
 
 
 def get_slim_stream_id_map(stream_ids: set[int]) -> dict[int, Stream]:
-    # "slim" because it only fetches the names of the stream objects,
+    # "slim" because it only fetches the fields of the stream objects
     # suitable for passing into build_message_list.
-    streams = Stream.objects.filter(id__in=stream_ids).only("id", "name")
+    fields = ["id", "name", "is_web_public", "invite_only"]
+    streams = Stream.objects.filter(id__in=stream_ids).only(*fields)
     return {stream.id: stream for stream in streams}
 
 

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -253,19 +253,20 @@ def add_quote_prefix_in_text(content: str) -> str:
 def get_channel_privacy_icon(channel: Stream) -> str:
     """
     Return the relevant icon for given channel.
+    Keep this logic consistent with web/templates/stream_privacy.hbs to avoid drift.
     """
-    # TODO: Implement emoji icons (🔒, 🌍, etc.) here.
-    #       Emojis were approved in #design > digest email design; when working
-    #       on this, include comments to keep this logic consistent with the
-    #       web app and avoid future drift.
-
+    if channel.invite_only:
+        return "🔒"
+    if channel.is_web_public:
+        return "🌍"
     return "#"
 
 
 def build_message_list(
     user: UserProfile,
     messages: list[Message],
-    stream_id_map: dict[int, Stream] | None = None,  # only needs id, name
+    stream_id_map: dict[int, Stream]
+    | None = None,  # only needs id, name, is_web_public, invite_only
 ) -> MessageListPayload:
     """
     Builds the message list object for the message notification email and

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -11,10 +11,12 @@ from django_auth_ldap.config import LDAPSearch
 
 from zerver.lib.email_notifications import (
     enqueue_welcome_emails,
+    get_channel_privacy_icon,
     get_onboarding_email_schedule,
     send_account_registered_email,
 )
 from zerver.lib.send_email import send_custom_email, send_custom_server_email
+from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import mock_queue_publish
 from zerver.models import Realm, ScheduledEmail, UserProfile
@@ -664,3 +666,19 @@ class TestUtmParamsInEmailLinks(ZulipTestCase):
         html_query = '<a href="https://blog.zulip.com/?page=2">Blog</a>'
         expected_query = '<a href="https://blog.zulip.com/?page=2&amp;utm_source=newsletter&amp;utm_medium=email&amp;utm_campaign=test_campaign">Blog</a>'
         self.assertEqual(add_utm_params_to_links(html_query, campaign_name), expected_query)
+
+
+class TestChannelPrivacyIcon(ZulipTestCase):
+    def test_get_channel_privacy_icon(self) -> None:
+        realm = self.example_user("hamlet").realm
+
+        public_stream = create_stream_if_needed(realm, "Public Stream")[0]
+        self.assertEqual(get_channel_privacy_icon(public_stream), "#")
+
+        private_stream = create_stream_if_needed(realm, "Private Stream", invite_only=True)[0]
+        self.assertEqual(get_channel_privacy_icon(private_stream), "🔒")
+
+        web_public_stream = create_stream_if_needed(realm, "Web Public Stream", is_web_public=True)[
+            0
+        ]
+        self.assertEqual(get_channel_privacy_icon(web_public_stream), "🌍")


### PR DESCRIPTION
Previously, `get_channel_privacy_icon` hardcoded `'#'` for all channels, ignoring channel privacy settings in missed-message and digest emails.

This PR:
- Updates `get_channel_privacy_icon` in `zerver/lib/email_notifications.py` to return `'🔒'` for invite-only channels and `'🌍'` for web-public channels, matching the web app template logic in `web/templates/stream_privacy.hbs`.
- Updates `get_slim_stream_id_map` in `zerver/lib/digest.py` to prefetch `is_web_public` and `invite_only` fields, preventing N+1 database queries during digest generation.
- Removes the resolved `TODO` comment in `zerver/lib/email_notifications.py`.
- Adds unit tests covering all channel privacy states in `zerver/tests/test_email_notifications.py`.

Fixes: Resolves the in-code `TODO` in `zerver/lib/email_notifications.py:257` regarding emoji icons for channel privacy in digest and notification emails.

**How changes were tested:**

1. Ran `./tools/lint`, passed cleanly.
2. Ran `./tools/test-backend zerver/tests/test_email_notifications.py zerver/tests/test_digest.py` inside the Vagrant guest environment – all 40 tests passed cleanly.

| Before | After (this PR) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/df184fca-aca5-4992-af3e-281872c35c6c" width="400" /> | <img src="https://github.com/user-attachments/assets/20461050-93d4-4a58-9ea2-8b3c74fe8b1d" width="400" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
