### PR TITLE
[ai] tools: In new-feature-level bot posts, include `#api design` links.

### DIFF
--- a/docs/processes/api-design.md
+++ b/docs/processes/api-design.md
@@ -353,6 +353,8 @@ More details on the process are below.
 If you're the author of a PR, please go ahead and
 start the [#api design][] thread yourself.
 Then put a link to it in the PR description.
+The bot that announces the change in [#api documentation][]
+picks the link up from there.
 
 For any discussion that isn't specifically related to the API changes,
 please use a different channel such as [#backend][]. (You can
@@ -445,7 +447,9 @@ and an API reviewer for most API changes.
 See the corresponding subsections above.
 
 After each API change is merged into the server,
-a bot will post a new thread in [#api documentation][].
+a bot will post a new thread in [#api documentation][],
+linking any [#api design][] discussions
+that the pull request's description mentions.
 You should make sure you or someone else
 replies to explicitly decide if there should be a mobile issue
 to track making a corresponding change in the mobile app,

--- a/tools/lib/api_design_links.py
+++ b/tools/lib/api_design_links.py
@@ -1,0 +1,66 @@
+"""Recognize links to conversations in the #api design channel.
+
+Our API-design policy asks that every API change be discussed and
+approved there; see docs/processes/api-design.md.
+"""
+
+import re
+from urllib.parse import urlsplit
+
+# The Zulip development community, where the #api design channel lives.
+CZO_URL = "https://chat.zulip.org"
+API_DESIGN_CHANNEL_ID = "378"
+
+# A candidate to examine: CZO_URL and everything up to the next
+# whitespace. Deliberately loose, since prose leaves punctuation stuck
+# to a link; is_api_design_link makes the real decision.
+CANDIDATE_LINK = re.compile(rf"{re.escape(CZO_URL)}/\S+")
+
+# Punctuation to strip from the end of a candidate link. A narrow link
+# never ends in one of these, because encodeHashComponent turns each into
+# a dot-escape like ".29" or ".3F", which ends in a hex digit. See
+# web/src/internal_url.ts.
+TRAILING_PUNCTUATION = ")]}>,;:!?'\"*."
+
+
+def is_api_design_link(candidate_url: str) -> bool:
+    """Whether this string is a link to a conversation in the #api design channel.
+
+    Returns False for anything else, including a string that isn't a URL.
+    """
+    try:
+        parts = urlsplit(candidate_url)
+    except ValueError:
+        # Some malformed URLs, like "https://[", can't be parsed at all.
+        return False
+    if f"{parts.scheme}://{parts.netloc}" != CZO_URL:
+        return False
+    if parts.path not in ("", "/"):
+        return False
+
+    # A narrow link's fragment is "narrow" followed by operator/operand
+    # pairs, like "narrow/channel/378-api-design/topic/some.20topic".
+    # See search_terms_to_hash in web/src/hash_util.ts.
+    segments = parts.fragment.split("/")
+    if segments[0] != "narrow":
+        return False
+    operands = {segments[i]: segments[i + 1] for i in range(1, len(segments) - 1, 2)}
+
+    # The operand is the channel's ID, optionally followed by its name.
+    # Zulip called channels streams until 2024 (see commit d3987f611).
+    channel = operands.get("channel", operands.get("stream"))
+    if channel is None or channel.split("-")[0] != API_DESIGN_CHANNEL_ID:
+        return False
+
+    # Require a topic.
+    return "topic" in operands
+
+
+def find_api_design_links(text: str) -> list[str]:
+    """Return the #api design conversations linked in this text, in order."""
+    links: list[str] = []
+    for candidate in CANDIDATE_LINK.findall(text):
+        link = candidate.rstrip(TRAILING_PUNCTUATION)
+        if is_api_design_link(link) and link not in links:
+            links.append(link)
+    return links

--- a/tools/notify-if-api-docs-changed
+++ b/tools/notify-if-api-docs-changed
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.request import Request, urlopen
 
@@ -14,7 +15,14 @@ sys.path.insert(0, os.path.dirname(TOOLS_DIR))
 from zerver.openapi.merge_api_changelogs import get_feature_level
 
 
-def get_pull_request_number_or_commit_hash() -> str:
+@dataclass
+class PullRequestData:
+    commit_hash: str
+    number: int | None = None
+    body: str | None = None
+
+
+def get_pull_request_data() -> PullRequestData:
     github_token = os.environ["GITHUB_TOKEN"]
     repo = os.environ["GITHUB_REPOSITORY"]
     commit_hash = os.environ["GITHUB_SHA"]
@@ -29,11 +37,15 @@ def get_pull_request_number_or_commit_hash() -> str:
         req = Request(url, headers=headers)
         with urlopen(req) as response:
             pull_requests = json.load(response)
-        if len(pull_requests) > 0:
-            return f"#{pull_requests[0]['number']}"
-        return commit_hash
+        if not pull_requests:
+            return PullRequestData(commit_hash=commit_hash)
+        return PullRequestData(
+            commit_hash=commit_hash,
+            number=pull_requests[0]["number"],
+            body=pull_requests[0]["body"],
+        )
     except Exception:
-        return commit_hash
+        return PullRequestData(commit_hash=commit_hash)
 
 
 def get_changelog_entries() -> str:
@@ -86,10 +98,13 @@ if __name__ == "__main__":
 
     topic = f"new feature level: {feature_level}"
 
-    pull_request = get_pull_request_number_or_commit_hash()
+    pull_request = get_pull_request_data()
+    pull_request_label = (
+        f"#{pull_request.number}" if pull_request.number else pull_request.commit_hash
+    )
     changelog_entries = get_changelog_entries()
 
-    content = f"{pull_request} has updated the API documentation for the following endpoints: \n{changelog_entries}"
+    content = f"{pull_request_label} has updated the API documentation for the following endpoints: \n{changelog_entries}"
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a") as f:

--- a/tools/notify-if-api-docs-changed
+++ b/tools/notify-if-api-docs-changed
@@ -12,6 +12,7 @@ TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(os.path.dirname(TOOLS_DIR))
 sys.path.insert(0, os.path.dirname(TOOLS_DIR))
 
+from tools.lib.api_design_links import find_api_design_links
 from zerver.openapi.merge_api_changelogs import get_feature_level
 
 
@@ -104,7 +105,17 @@ if __name__ == "__main__":
     )
     changelog_entries = get_changelog_entries()
 
+    discussion_links: list[str] = []
+    if pull_request.body:
+        discussion_links = find_api_design_links(pull_request.body)
+
     content = f"{pull_request_label} has updated the API documentation for the following endpoints: \n{changelog_entries}"
+    if len(discussion_links) == 1:
+        content += f"\n\nAPI design discussion: {discussion_links[0]}"
+    elif discussion_links:
+        content += "\n\nAPI design discussions:\n" + "\n".join(
+            f"- {link}" for link in discussion_links
+        )
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a") as f:

--- a/tools/notify-if-api-docs-changed
+++ b/tools/notify-if-api-docs-changed
@@ -53,7 +53,7 @@ def get_changelog_entries() -> str:
             if current_feature_level_found:
                 changelog_entries += line
 
-    return changelog_entries.replace("\n  ", " ")
+    return changelog_entries.replace("\n  ", " ").rstrip()
 
 
 def get_feature_level_before_commit() -> int:
@@ -80,14 +80,14 @@ def get_feature_level_before_commit() -> int:
 
 
 if __name__ == "__main__":
-    pull_request = get_pull_request_number_or_commit_hash()
-
     feature_level = get_feature_level(update_feature_level=False) - 1
     if feature_level <= get_feature_level_before_commit():
         sys.exit(1)
 
-    changelog_entries = get_changelog_entries()
     topic = f"new feature level: {feature_level}"
+
+    pull_request = get_pull_request_number_or_commit_hash()
+    changelog_entries = get_changelog_entries()
 
     content = f"{pull_request} has updated the API documentation for the following endpoints: \n{changelog_entries}"
     github_output = os.environ.get("GITHUB_OUTPUT")

--- a/tools/tests/test_api_design_links.py
+++ b/tools/tests/test_api_design_links.py
@@ -1,0 +1,103 @@
+import unittest
+
+from tools.lib.api_design_links import find_api_design_links, is_api_design_link
+
+API_DESIGN = "https://chat.zulip.org/#narrow/channel/378-api-design"
+
+
+class TestIsApiDesignLink(unittest.TestCase):
+    def test_conversations_in_the_channel(self) -> None:
+        for url in [
+            f"{API_DESIGN}/topic/some.20topic",
+            f"{API_DESIGN}/topic/some.20topic/near/12345",
+            f"{API_DESIGN}/topic/some.20topic/with/12345",
+            f"{API_DESIGN}/topic/some.20topic/",
+            # A link to the channel's "general chat", whose topic is empty.
+            f"{API_DESIGN}/topic/",
+            # The channel's ID identifies it; the name that follows is decoration.
+            "https://chat.zulip.org/#narrow/channel/378/topic/x",
+            # Zulip called channels streams until 2024.
+            "https://chat.zulip.org/#narrow/stream/378-api-design/topic/x",
+        ]:
+            with self.subTest(url=url):
+                self.assertTrue(is_api_design_link(url))
+
+    def test_other_links(self) -> None:
+        for url in [
+            # The channel as a whole, naming no conversation in it.
+            API_DESIGN,
+            f"{API_DESIGN}/",
+            "https://chat.zulip.org/#narrow/channel/3-backend/topic/x",
+            # A channel whose ID merely starts with the same digits.
+            "https://chat.zulip.org/#narrow/channel/3780-other/topic/x",
+            # A channel operator with no operand.
+            "https://chat.zulip.org/#narrow/channel",
+            "https://chat.zulip.org/#narrow",
+            "https://chat.zulip.org/",
+            "https://chat.zulip.org/api/get-messages",
+            # Not the realm's root, so not a narrow link.
+            "https://chat.zulip.org/somepage#narrow/channel/378-api-design",
+            "https://example.com/#narrow/channel/378-api-design/topic/x",
+            "not a URL at all",
+            "",
+        ]:
+            with self.subTest(url=url):
+                self.assertFalse(is_api_design_link(url))
+
+    def test_unparseable_urls(self) -> None:
+        # urlsplit rejects these outright, rather than returning parts.
+        for url in [
+            # An IPv6 host with no closing bracket.
+            "https://[",
+            "http://[::1",
+            # A host whose characters change under NFKC normalization.
+            "https://chat.zulip.org℀/#narrow/channel/378-api-design/topic/x",
+        ]:
+            with self.subTest(url=url):
+                self.assertFalse(is_api_design_link(url))
+
+
+class TestFindApiDesignLinks(unittest.TestCase):
+    def test_markdown_link(self) -> None:
+        text = f"Bug fix as discussed in [#api design > topic]({API_DESIGN}/topic/x/near/1)."
+        self.assertEqual(find_api_design_links(text), [f"{API_DESIGN}/topic/x/near/1"])
+
+    def test_trailing_punctuation(self) -> None:
+        # None of these characters can appear in a narrow link itself, so
+        # each came from the text around one.
+        for suffix in [".", ",", ")", "]", ">", "?", "!", "**", "'", '"', ");"]:
+            with self.subTest(suffix=suffix):
+                text = f"See {API_DESIGN}/topic/x{suffix} Thanks!"
+                self.assertEqual(find_api_design_links(text), [f"{API_DESIGN}/topic/x"])
+
+    def test_returns_each_link_once_in_order(self) -> None:
+        text = f"""
+        First {API_DESIGN}/topic/a/near/1
+        then {API_DESIGN}/topic/b/near/2
+        and {API_DESIGN}/topic/a/near/1 again.
+        """
+        self.assertEqual(
+            find_api_design_links(text),
+            [f"{API_DESIGN}/topic/a/near/1", f"{API_DESIGN}/topic/b/near/2"],
+        )
+
+    def test_link_to_the_channel_itself(self) -> None:
+        # A link to the channel names no discussion, so it's dropped even
+        # alongside a link to a real thread.
+        text = f"""
+        Discussed in [#api design > some topic]({API_DESIGN}/topic/x/near/1).
+
+        [#api design]: {API_DESIGN}
+        """
+        self.assertEqual(find_api_design_links(text), [f"{API_DESIGN}/topic/x/near/1"])
+
+    def test_links_to_elsewhere(self) -> None:
+        text = """
+        Fixes #1234. Discussed with the team in
+        https://chat.zulip.org/#narrow/channel/3-backend/topic/x
+        and see https://zulip.com/api/send-message .
+        """
+        self.assertEqual(find_api_design_links(text), [])
+
+    def test_no_text(self) -> None:
+        self.assertEqual(find_api_design_links(""), [])


### PR DESCRIPTION
When reading the bot announcements in `#api documentation` (see #40002 and #40003 for some bugfixes in that system), I'd find it helpful if they included the PR's links to the relevant `#api design` discussions, which are required per docs/processes/api-design.md.

This PR implements that, by searching the PR text for `#api design` links, deduping them, and printing them in order in the announcement. They aren't written into the actual changelog; this would just be for convenience as I consume the bot's announcements, as I'm responsible for doing (see docs/processes/api-design.md).

-----

Example:

## Before

> #39930 has updated the API documentation for the following endpoints:
> 
> * [`PATCH /messages/{message_id}`](/api/update-message): Fixed a bug where passing the `stream_id` that the message is already in was processed as a channel move.

## After

> #39930 has updated the API documentation for the following endpoints:
> 
> * [`PATCH /messages/{message_id}`](/api/update-message): Fixed a bug where passing the `stream_id` that the message is already in was processed as a channel move.
> 
> Design discussion: https://chat.zulip.org/#narrow/channel/378-api-design/topic/PATCH.20.2Fmessages.2F.7Bmessage_id.7D/with/2507912

-----

When a pull request links more than one thread, the last line becomes a list:

> Design discussions:
> - https://chat.zulip.org/#narrow/channel/378-api-design/topic/first.20thread/near/1
> - https://chat.zulip.org/#narrow/channel/378-api-design/topic/second.20thread/near/2

When the description links none, the post is unchanged from today.