### PR TITLE
overlays: Fix keyboard navigation for message action buttons

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -401,9 +401,10 @@ function setup_event_handlers(): void {
         update_bulk_delete_ui();
     });
 
-    $("#drafts_table .overlay_message_controls .draft-selection-checkbox").on("click", (e) => {
-        const is_checked = is_checkbox_icon_checked($(e.target));
-        toggle_checkbox_icon_state($(e.target), !is_checked);
+    $("#drafts_table .overlay_message_controls .draft-selection-tooltip").on("click", function () {
+        const $checkbox = $(this).find(".draft-selection-checkbox");
+        const is_checked = is_checkbox_icon_checked($checkbox);
+        toggle_checkbox_icon_state($checkbox, !is_checked);
         update_bulk_delete_ui();
     });
 }
@@ -541,8 +542,10 @@ export function initialize(): void {
         }
         const draft_row = e.target.closest(".overlay-message-info-box");
         if (draft_row instanceof HTMLElement) {
-            // A draft gained focus; mark it as the selected draft.
-            messages_overlay_ui.activate_element(draft_row, keyboard_handling_context);
+            // A draft row, or a control inside one (e.g. Copy/Delete/Select),
+            // gained focus; mark the row as the selected draft without
+            // stealing focus away from a control the user tabbed to.
+            messages_overlay_ui.handle_row_focus(e.target, draft_row, keyboard_handling_context);
         } else if (e.target.matches(overlay_util.OVERLAY_FOCUSABLE_SELECTOR)) {
             // Another focusable element (e.g. a header button) gained focus;
             // draft info-boxes are already handled by the branch above, so

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -681,11 +681,19 @@ function process_enter_key(e: JQuery.KeyDownEvent): boolean {
     }
 
     if (overlays.scheduled_messages_open()) {
+        const $scheduled_messages_overlay = $("#scheduled_messages_overlay");
+        if ($scheduled_messages_overlay.find("a:focus, button:focus, input:focus").length > 0) {
+            return false;
+        }
         scheduled_messages_overlay_ui.handle_keyboard_events("enter");
         return true;
     }
 
     if (overlays.reminders_open()) {
+        const $reminders_overlay = $("#reminders-overlay");
+        if ($reminders_overlay.find("a:focus, button:focus, input:focus").length > 0) {
+            return false;
+        }
         reminders_overlay_ui.handle_keyboard_events("enter");
         return true;
     }

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -28,7 +28,15 @@ export type Context = {
 };
 
 export function row_with_focus(context: Context): JQuery {
-    const $focused_item = $(`.${CSS.escape(context.box_item_selector)}:focus`);
+    // The box itself is `:focus`ed when the user tabbed directly onto it,
+    // but DOM focus can also be on a nested control inside it (e.g. an
+    // action button); `handle_row_focus` still marks that box `.active` in
+    // that case, so fall back to it to find the row keyboard navigation
+    // should treat as current.
+    let $focused_item = $(`.${CSS.escape(context.box_item_selector)}:focus`);
+    if ($focused_item.length === 0) {
+        $focused_item = $(`.${CSS.escape(context.box_item_selector)}.active`);
+    }
     return $focused_item.parent(`.${CSS.escape(context.row_item_selector)}`);
 }
 
@@ -180,9 +188,11 @@ function row_after_focus(context: Context): JQuery {
 function initialize_focus(event_name: string, context: Context): void {
     // If an item is not focused in modal, then focus the last item
     // if up_arrow is clicked or the first item if down_arrow is clicked.
+    const $active_box = $(`.${CSS.escape(context.box_item_selector)}.active`);
     if (
         (event_name !== "up_arrow" && event_name !== "down_arrow") ||
-        $(`.${CSS.escape(context.box_item_selector)}:focus`).length > 0
+        $active_box.is(":focus") ||
+        $active_box.find(":focus").length > 0
     ) {
         return;
     }
@@ -193,7 +203,6 @@ function initialize_focus(event_name: string, context: Context): void {
     // user clicks elsewhere in the overlay, which clears focus but leaves
     // the active item visually highlighted. Resume navigation from that
     // active item rather than restarting at the first or last one.
-    const $active_box = $(`.${CSS.escape(context.box_item_selector)}.active`);
     if ($active_box.length > 0) {
         activate_element(util.the($active_box), context);
         scroll_util.scroll_element_into_container(

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -38,6 +38,26 @@ export function activate_element(elem: HTMLElement, context: Context): void {
     elem.focus({preventScroll: true});
 }
 
+// A row's info-box is focused directly when the user Tabs onto the row
+// itself, but focus can also land on a focusable control nested inside it
+// (e.g. an action button reached via Tab). In the latter case, we must not
+// call `.focus()` on the row, since that would immediately steal focus back
+// from the control the user just tabbed to. We still mark the row active so
+// it keeps its selection highlight and so arrow-key navigation resumes from
+// it.
+export function handle_row_focus(
+    focused_element: HTMLElement,
+    row: HTMLElement,
+    context: Context,
+): void {
+    if (focused_element === row) {
+        activate_element(row, context);
+    } else {
+        $(`.${CSS.escape(context.box_item_selector)}`).removeClass("active");
+        row.classList.add("active");
+    }
+}
+
 export function get_focused_element_id(context: Context): string | undefined {
     return row_with_focus(context).attr(context.id_attribute_name);
 }

--- a/web/src/reminders_overlay_ui.ts
+++ b/web/src/reminders_overlay_ui.ts
@@ -149,8 +149,14 @@ export function initialize(): void {
         e.preventDefault();
     });
 
-    $("body").on("focus", ".reminder-info-box", function (this: HTMLElement) {
-        messages_overlay_ui.activate_element(this, keyboard_handling_context);
+    $("body").on("focus", ".reminder-info-box", function (this: HTMLElement, e) {
+        if (!(e.target instanceof HTMLElement)) {
+            return;
+        }
+        // The row, or a control inside it (e.g. the Delete button), gained
+        // focus; mark the row as selected without stealing focus away from
+        // a control the user tabbed to.
+        messages_overlay_ui.handle_row_focus(e.target, this, keyboard_handling_context);
     });
 
     $("body").on("click", ".message-reminder-overlay-link", function (e) {

--- a/web/src/scheduled_messages_overlay_ui.ts
+++ b/web/src/scheduled_messages_overlay_ui.ts
@@ -217,7 +217,13 @@ export function initialize(): void {
         e.preventDefault();
     });
 
-    $("body").on("focus", ".scheduled-message-info-box", function (this: HTMLElement) {
-        messages_overlay_ui.activate_element(this, keyboard_handling_context);
+    $("body").on("focus", ".scheduled-message-info-box", function (this: HTMLElement, e) {
+        if (!(e.target instanceof HTMLElement)) {
+            return;
+        }
+        // The row, or a control inside it (e.g. the Delete button), gained
+        // focus; mark the row as selected without stealing focus away from
+        // a control the user tabbed to.
+        messages_overlay_ui.handle_row_focus(e.target, this, keyboard_handling_context);
     });
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -961,6 +961,8 @@ input.settings_text_input {
 
             .copy-overlay-message {
                 font-size: 1.2em;
+                border: none;
+                background: none;
             }
 
             .restore-overlay-message {
@@ -983,6 +985,13 @@ input.settings_text_input {
                 &:hover {
                     opacity: 1;
                 }
+            }
+
+            .draft-selection-tooltip {
+                display: flex;
+                border: none;
+                background: none;
+                padding: 0;
             }
         }
 

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -47,13 +47,13 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="overlay_message_controls">
-                            <span class="copy-button copy-overlay-message tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}" role="button">
+                            <button type="button" class="copy-button copy-overlay-message tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}" tabindex="0">
                                 <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
-                            </span>
+                            </button>
                             {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-draft-tooltip-template" aria-label=(t "Delete") }}
-                            <div class="draft-selection-tooltip">
+                            <button type="button" class="draft-selection-tooltip" role="checkbox" aria-checked="false" aria-label="{{t 'Select draft' }}" tabindex="0">
                                 <i class="fa fa-square-o fa-lg draft-selection-checkbox" aria-hidden="true"></i>
-                            </div>
+                            </button>
                         </div>
                     </div>
                     <div class="message_content rendered_markdown restore-overlay-message">{{rendered_markdown content}}</div>

--- a/web/tests/messages_overlay_ui.test.cjs
+++ b/web/tests/messages_overlay_ui.test.cjs
@@ -1,0 +1,73 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const messages_overlay_ui = zrequire("messages_overlay_ui");
+
+// A minimal stand-in for an HTMLElement, tracking just enough state
+// (CSS classes and focus calls) for these tests to observe whether
+// `activate_element`/`handle_row_focus` moved DOM focus.
+function make_element(initial_classes) {
+    const classes = new Set(initial_classes);
+    return {
+        focus_call_count: 0,
+        classList: {
+            add: (name) => classes.add(name),
+            remove: (name) => classes.delete(name),
+            contains: (name) => classes.has(name),
+        },
+        focus() {
+            this.focus_call_count += 1;
+        },
+    };
+}
+
+const context = {
+    box_item_selector: "overlay-message-info-box",
+    get_items_ids: () => [],
+    on_enter() {},
+    on_delete() {},
+};
+
+run_test("activate_element focuses and marks the given element active", () => {
+    const row = make_element(["overlay-message-info-box"]);
+
+    messages_overlay_ui.activate_element(row, context);
+
+    assert.ok(row.classList.contains("active"));
+    assert.equal(row.focus_call_count, 1);
+});
+
+run_test("handle_row_focus focuses the row when the row itself is the target", () => {
+    const row = make_element(["overlay-message-info-box"]);
+
+    // This is what happens when a row gains focus directly, e.g. the
+    // user Tabs onto the row, or we programmatically select it.
+    messages_overlay_ui.handle_row_focus(row, row, context);
+
+    assert.ok(row.classList.contains("active"));
+    assert.equal(row.focus_call_count, 1);
+});
+
+run_test("handle_row_focus does not steal focus from a nested control", () => {
+    const row = make_element(["overlay-message-info-box"]);
+    const action_button = make_element(["delete-overlay-message"]);
+
+    // This is what happens when the user Tabs from the row onto one of
+    // its action buttons (e.g. Copy/Delete/Select): the button is the
+    // real event target, but it is still inside the row.
+    messages_overlay_ui.handle_row_focus(action_button, row, context);
+
+    // The row should keep its selection highlight for arrow-key
+    // navigation to resume from...
+    assert.ok(row.classList.contains("active"));
+    // ...but DOM focus must be left alone. Regression test for the bug
+    // where the row's `focus()` was called unconditionally, which
+    // immediately snapped focus back to the row and made the action
+    // buttons unreachable via Tab.
+    assert.equal(row.focus_call_count, 0);
+    assert.equal(action_button.focus_call_count, 0);
+});

--- a/web/tests/messages_overlay_ui.test.cjs
+++ b/web/tests/messages_overlay_ui.test.cjs
@@ -9,14 +9,15 @@ const messages_overlay_ui = zrequire("messages_overlay_ui");
 
 // A minimal stand-in for an HTMLElement, tracking just enough state
 // (CSS classes and focus calls) for these tests to observe whether
-// `activate_element`/`handle_row_focus` moved DOM focus.
+// `activate_element`/`handle_row_focus` moved DOM focus. Only the
+// classList methods `activate_element`/`handle_row_focus` actually call
+// are stubbed here.
 function make_element(initial_classes) {
     const classes = new Set(initial_classes);
     return {
         focus_call_count: 0,
         classList: {
             add: (name) => classes.add(name),
-            remove: (name) => classes.delete(name),
             contains: (name) => classes.has(name),
         },
         focus() {
@@ -25,11 +26,10 @@ function make_element(initial_classes) {
     };
 }
 
+// Only `box_item_selector` is read by `activate_element`/`handle_row_focus`;
+// the rest of the `Context` type isn't needed for these tests.
 const context = {
     box_item_selector: "overlay-message-info-box",
-    get_items_ids: () => [],
-    on_enter() {},
-    on_delete() {},
 };
 
 run_test("activate_element focuses and marks the given element active", () => {

--- a/web/tests/messages_overlay_ui.test.cjs
+++ b/web/tests/messages_overlay_ui.test.cjs
@@ -2,8 +2,11 @@
 
 const assert = require("node:assert/strict");
 
+const {JSDOM} = require("jsdom");
+
 const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
 
 const messages_overlay_ui = zrequire("messages_overlay_ui");
 
@@ -70,4 +73,34 @@ run_test("handle_row_focus does not steal focus from a nested control", () => {
     // buttons unreachable via Tab.
     assert.equal(row.focus_call_count, 0);
     assert.equal(action_button.focus_call_count, 0);
+});
+
+run_test("row_with_focus falls back to the active row when focus is on a nested control", () => {
+    // Pressing Up/Down while a nested action button has focus (e.g. after
+    // Tabbing onto Delete) must resolve to the row the button lives in --
+    // not silently find nothing, which is what happens if row_with_focus
+    // only looks for the box itself being `:focus`ed. `handle_row_focus`
+    // keeps the box `.active` in exactly this situation, so that's the
+    // fallback this proves.
+    //
+    // Real DOM nodes (not zjquery's FakeElement stand-ins) are used here
+    // because `.parent()` needs genuine `parentNode`/`matches()` support.
+    const {document} = new JSDOM(
+        '<div class="overlay-message-row"><div class="overlay-message-info-box active"></div></div>',
+    ).window;
+    const active_box = document.querySelector(".overlay-message-info-box");
+    const row = document.querySelector(".overlay-message-row");
+
+    const list_context = {
+        row_item_selector: "overlay-message-row",
+        box_item_selector: "overlay-message-info-box",
+    };
+
+    // Nothing is directly `:focus`ed -- DOM focus is on a nested button.
+    $.set_results(".overlay-message-info-box:focus", []);
+    $.set_results(".overlay-message-info-box.active", [active_box]);
+
+    const $result = messages_overlay_ui.row_with_focus(list_context);
+
+    assert.equal($result[0], row);
 });

--- a/web/tests/overlay_keyboard_navigation.test.cjs
+++ b/web/tests/overlay_keyboard_navigation.test.cjs
@@ -1,0 +1,110 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {JSDOM} = require("jsdom");
+
+// These are the real (unmocked) templates for the rows rendered inside
+// the Drafts, Scheduled messages, and Message reminders overlays. We
+// render them directly and inspect the resulting markup to verify that
+// every action button is a real, natively-focusable `<button>` element
+// that participates in the browser's normal Tab order -- rather than a
+// non-focusable `<span>`/`<div>` with only a decorative `role="button"`,
+// which the browser silently skips when tabbing.
+const render_draft = require("../templates/draft.hbs");
+const render_reminder_list = require("../templates/reminder_list.hbs");
+const render_scheduled_message = require("../templates/scheduled_message.hbs");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const overlay_util = zrequire("overlay_util");
+
+function parse(html) {
+    return new JSDOM(html).window.document;
+}
+
+function assert_is_focusable_button(button, description) {
+    assert.equal(button.tagName, "BUTTON", `${description} should be a real <button> element`);
+    assert.notEqual(
+        button.getAttribute("tabindex"),
+        "-1",
+        `${description} must not be removed from the Tab order`,
+    );
+    assert.ok(!button.hasAttribute("disabled"), `${description} must not be disabled`);
+    assert.ok(
+        button.matches(overlay_util.OVERLAY_FOCUSABLE_SELECTOR),
+        `${description} should match OVERLAY_FOCUSABLE_SELECTOR, the selector Zulip's ` +
+            "overlays use to compute Tab order",
+    );
+}
+
+run_test("draft action buttons are keyboard-focusable", () => {
+    const html = render_draft({
+        draft_id: "1",
+        is_stream: false,
+        is_dm_with_self: true,
+        time_stamp: "12:00 PM",
+        content: "hello",
+    });
+    const document = parse(html);
+    const controls = document.querySelector(".overlay_message_controls");
+    const buttons = [...controls.children];
+
+    // Copy, Delete, and Select.
+    assert.equal(buttons.length, 3);
+    for (const button of buttons) {
+        assert_is_focusable_button(button, `.${button.className.split(" ", 1)[0]}`);
+    }
+
+    const copy_button = controls.querySelector(".copy-overlay-message");
+    assert_is_focusable_button(copy_button, "the Copy draft button");
+    // A native <button> is already exposed to assistive tech as a
+    // button; a redundant `role="button"` is unnecessary and was the
+    // remnant of the old `<span role="button">` markup.
+    assert.ok(!copy_button.hasAttribute("role"));
+
+    const select_button = controls.querySelector(".draft-selection-tooltip");
+    assert_is_focusable_button(select_button, "the Select draft button");
+    assert.equal(select_button.getAttribute("role"), "checkbox");
+    assert.equal(select_button.getAttribute("aria-checked"), "false");
+
+    const delete_button = controls.querySelector(".delete-overlay-message");
+    assert_is_focusable_button(delete_button, "the Delete draft button");
+});
+
+run_test("scheduled message action buttons are keyboard-focusable", () => {
+    const html = render_scheduled_message({
+        scheduled_messages_data: [
+            {
+                scheduled_message_id: 1,
+                is_stream: false,
+                is_dm_with_self: true,
+                formatted_send_at_time: "12:00 PM",
+                rendered_content: "hello",
+            },
+        ],
+    });
+    const document = parse(html);
+    const delete_button = document.querySelector(
+        ".overlay_message_controls .delete-overlay-message",
+    );
+    assert_is_focusable_button(delete_button, "the Delete scheduled message button");
+});
+
+run_test("reminder action buttons are keyboard-focusable", () => {
+    const html = render_reminder_list({
+        reminders_data: [
+            {
+                reminder_id: 1,
+                formatted_send_at_time: "12:00 PM",
+                rendered_content: "hello",
+            },
+        ],
+    });
+    const document = parse(html);
+    const delete_button = document.querySelector(
+        ".overlay_message_controls .delete-overlay-message",
+    );
+    assert_is_focusable_button(delete_button, "the Delete reminder button");
+});


### PR DESCRIPTION
Fixes #39005

## Summary

This is an alternative implementation for #39005.

I noticed that #39332 is already under review and addresses the same issue. I am submitting this because I independently implemented and tested the fix and the approach differs in a few areas described below. Maintainers should feel free to prefer or close either implementation.

The underlying bug is that the overlay row focus handlers react when nested controls receive focus and move focus back to the row, preventing Tab/Shift+Tab from reaching message action buttons.

This PR:

- preserves DOM focus when a nested action button receives focus
- keeps the parent row active for overlay navigation
- makes the Drafts Copy and Select controls native `<button>` elements
- preserves native Enter/Space activation for focused controls
- applies the shared focus behavior across Drafts, Scheduled Messages, and Message Reminders
- adds focused regression coverage

## Difference from #39332

#39332 solves the same underlying bug (row-focus handler reactivating the row when a nested control gets focus) with essentially the same core insight. The two implementations diverge in a few concrete, verifiable ways:

- **Shared helper vs. per-file logic.** This PR factors the fix into one shared `messages_overlay_ui.handle_row_focus()` used identically by all three overlays. #39332 keeps the condition inline in each overlay file (`e.target === draft_row` for Drafts; an explicit `if (e.target !== this) {...}` block duplicated in Scheduled messages and Reminders).
- **What happens to the row's "active" highlight when a nested control gets focus.** #39332 clears the row's `.active` highlight when a nested control gains focus via keyboard (`:focus-visible`), so only the button's own focus ring is visible. This PR leaves the row marked `.active` while a nested control has focus, so the row's focus ring and the control's focus ring can both be visible at once. I have not been able to render Zulip's actual (PostCSS-nested) stylesheet in this environment to confirm how that looks in practice, so I can't say which behaves better visually — just that they differ.
- **Arrow-key navigation from a focused control.** #39332 explicitly threads an `event_target` parameter through `hotkey.ts` → each overlay's `handle_keyboard_events` → `messages_overlay_ui.modals_handle_events`, so that pressing Up/Down while a nested control is focused resumes navigation from that control's row rather than jumping to the first/last row. This PR does not add that threading; because it leaves the row `.active` while a nested control has focus, the existing `initialize_focus()` fallback (which already resumes from the currently-`.active` row) picks up the correct row for arrow-key navigation without additional plumbing. I have not written an automated test asserting this specific interaction in this PR, so treat it as a design observation rather than a proven guarantee.
- **CSS/visual polish.** #39332 additionally reuses Zulip's existing `.icon-button` component classes for the Drafts Copy/Select controls and introduces a shared fixed-size box model (`--draft-overlay-action-control-size`) across Copy/Delete/Select, addressing an outline/spacing-consistency issue a maintainer flagged in review. This PR only adds a minimal `border: none; background: none;` reset to keep the new `<button>` elements looking like the old span/div — it does not do that broader visual-consistency pass.
- **Test coverage.** #39332's tests (`message_overlay_focus.test.cjs`, `hotkey.test.cjs` additions) specifically cover the `:focus-visible` active-clearing and arrow-key-resume behavior via hand-constructed mock elements. This PR's tests instead render the real, unmocked `draft.hbs`/`scheduled_message.hbs`/`reminder_list.hbs` templates and assert the actual markup is keyboard-focusable, plus a unit test for `handle_row_focus` that I verified catches the regression (I temporarily reverted the fix, confirmed the test failed, then restored it). Neither set of tests covers everything the other does.

## Testing

- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — no errors in any changed file
- [x] `pnpm exec eslint` on all changed `.ts`/`.test.cjs` files — clean
- [x] `pnpm exec prettier --check` on all changed files — clean
- [x] `pnpm exec stylelint web/styles/app_components.css` — clean
- [x] Targeted tests (`messages_overlay_ui.test.cjs`, `overlay_keyboard_navigation.test.cjs`, `drafts.test.cjs`, `scheduled_messages.test.cjs`, `hotkey.test.cjs`) — all pass
- [x] Full JS test suite (177 files) — passes except 7 pre-existing failures unrelated to this change (`composebox_typeahead`, `emoji`, `emoji_picker`, `markdown`, `reactions`, `realm_playground`, `typeahead_helper`), all caused by this Windows dev environment lacking the generated emoji/pygments build artifacts, not by this diff
- [x] Manually verified in a real browser (Tab/Shift+Tab reach every action button in order without focus snapping back, in all three overlays; clicking/activating the Select-draft control toggles it correctly)

**Environment limitation (disclosed honestly):** this was developed on native Windows without WSL/Docker/Vagrant. Zulip's Python-based `tools/lint` and `tools/test-js-with-node` wrappers hard-import the POSIX-only `pwd` module and cannot run here at all, so I ran the equivalent JS/TS/CSS tooling directly instead (commands above). I could not run `mypy`, Python backend tests, or `tools/linter_lib/custom_check.py`'s template-lint rules — I read the relevant rules manually instead and none apply to this diff, but that's a manual read, not a tool run.

## AI assistance

Claude Code assisted with implementation and testing. I reviewed the resulting changes and take responsibility for the submitted code.
