### PR TITLE
[ai] webhooks/jira: Add URL options for configuring notification fields.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -783,6 +783,18 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
         "jira",
         ["project-management"],
         [WebhookScreenshotConfig("issue_created_with_assignee.json")],
+        url_options=[
+            WebhookUrlOption(
+                "include_priority",
+                label="Include the issue priority in the notifications",
+                input_type="checkbox_enabled",
+            ),
+            WebhookUrlOption(
+                "include_assignee",
+                label="Include the issue assignee in the notifications",
+                input_type="checkbox_enabled",
+            ),
+        ],
     ),
     IncomingWebhookIntegration(
         "jotform", ["productivity"], [WebhookScreenshotConfig("screenshot_response.multipart")]

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -794,6 +794,31 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
                 label="Include the issue assignee in the notifications",
                 input_type="checkbox_enabled",
             ),
+            WebhookUrlOption(
+                "include_issue_type",
+                label="Include the issue type in the notifications",
+                input_type="checkbox",
+            ),
+            WebhookUrlOption(
+                "include_status",
+                label="Include the issue status in the notifications",
+                input_type="checkbox",
+            ),
+            WebhookUrlOption(
+                "include_components",
+                label="Include the issue components in the notifications",
+                input_type="checkbox",
+            ),
+            WebhookUrlOption(
+                "include_versions",
+                label="Include the issue versions in the notifications",
+                input_type="checkbox",
+            ),
+            WebhookUrlOption(
+                "include_labels",
+                label="Include the issue labels in the notifications",
+                input_type="checkbox",
+            ),
         ],
     ),
     IncomingWebhookIntegration(

--- a/zerver/webhooks/jira/fixtures/issue_created_with_additional_fields.json
+++ b/zerver/webhooks/jira/fixtures/issue_created_with_additional_fields.json
@@ -1,0 +1,148 @@
+{
+    "webhookEvent": "jira:issue_created",
+    "issue_event_type_name": "issue_created",
+    "timestamp": 1364403238369,
+    "user": {
+        "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+        "name": "lfranchi",
+        "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
+        "emailAddress": "othello@zulip.com",
+        "avatarUrls": {
+            "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+            "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+        },
+        "displayName": "Leo Franchi",
+        "active": true
+    },
+    "issue": {
+        "id": "10400",
+        "self": "http://lfranchi.com:8080/rest/api/2/issue/10400",
+        "key": "BUG-15",
+        "fields": {
+            "summary": "New bug with hook",
+            "progress": {
+                "progress": 0,
+                "total": 0
+            },
+            "timetracking": {},
+            "issuetype": {
+                "self": "http://lfranchi.com:8080/rest/api/2/issuetype/1",
+                "id": "1",
+                "description": "A problem which impairs or prevents the functions of the product.",
+                "iconUrl": "http://lfranchi.com:8080/images/icons/bug.gif",
+                "name": "Bug",
+                "subtask": false
+            },
+            "votes": {
+                "self": "http://lfranchi.com:8080/rest/api/2/issue/BUG-15/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "resolution": null,
+            "fixVersions": [],
+            "resolutiondate": null,
+            "timespent": null,
+            "reporter": {
+                "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+                "name": "lfranchi",
+                "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
+                "emailAddress": "othello@zulip.com",
+                "avatarUrls": {
+                    "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+                    "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+                },
+                "displayName": "Leo Franchi",
+                "active": true
+            },
+            "aggregatetimeoriginalestimate": null,
+            "created": "2013-03-27T16:53:58.301+0000",
+            "updated": "2013-03-27T16:53:58.301+0000",
+            "description": "Fix me please",
+            "priority": {
+                "self": "http://lfranchi.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://lfranchi.com:8080/images/icons/priority_major.gif",
+                "name": "Major",
+                "id": "3"
+            },
+            "duedate": null,
+            "issuelinks": [],
+            "watches": {
+                "self": "http://lfranchi.com:8080/rest/api/2/issue/BUG-15/watchers",
+                "watchCount": 0,
+                "isWatching": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 0,
+                "total": 0,
+                "worklogs": []
+            },
+            "customfield_10000": null,
+            "subtasks": [],
+            "status": {
+                "self": "http://lfranchi.com:8080/rest/api/2/status/1",
+                "description": "The issue is open and ready for the assignee to start work on it.",
+                "iconUrl": "http://lfranchi.com:8080/images/icons/status_open.gif",
+                "name": "Open",
+                "id": "1"
+            },
+            "labels": [
+                "regression",
+                "customer-reported"
+            ],
+            "workratio": -1,
+            "assignee": null,
+            "attachment": [],
+            "aggregatetimeestimate": null,
+            "project": {
+                "self": "http://lfranchi.com:8080/rest/api/2/project/BUG",
+                "id": "10000",
+                "key": "BUG",
+                "name": "buggery-test",
+                "avatarUrls": {
+                    "16x16": "http://lfranchi.com:8080/secure/projectavatar?size=small&pid=10000&avatarId=10011",
+                    "48x48": "http://lfranchi.com:8080/secure/projectavatar?pid=10000&avatarId=10011"
+                }
+            },
+            "versions": [
+                {
+                    "self": "http://lfranchi.com:8080/rest/api/2/version/10100",
+                    "id": "10100",
+                    "name": "R4",
+                    "released": false
+                }
+            ],
+            "environment": null,
+            "timeestimate": null,
+            "aggregateprogress": {
+                "progress": 0,
+                "total": 0
+            },
+            "lastViewed": null,
+            "components": [
+                {
+                    "self": "http://lfranchi.com:8080/rest/api/2/component/10000",
+                    "id": "10000",
+                    "name": "Backend"
+                },
+                {
+                    "self": "http://lfranchi.com:8080/rest/api/2/component/10002",
+                    "id": "10002"
+                },
+                {
+                    "self": "http://lfranchi.com:8080/rest/api/2/component/10001",
+                    "id": "10001",
+                    "name": "API"
+                }
+            ],
+            "comment": {
+                "startAt": 0,
+                "maxResults": 0,
+                "total": 0,
+                "comments": []
+            },
+            "timeoriginalestimate": null,
+            "aggregatetimespent": null
+        }
+    }
+}

--- a/zerver/webhooks/jira/fixtures/issue_created_without_list_fields.json
+++ b/zerver/webhooks/jira/fixtures/issue_created_without_list_fields.json
@@ -1,0 +1,120 @@
+{
+    "webhookEvent": "jira:issue_created",
+    "issue_event_type_name": "issue_created",
+    "timestamp": 1364403238369,
+    "user": {
+        "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+        "name": "lfranchi",
+        "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
+        "emailAddress": "othello@zulip.com",
+        "avatarUrls": {
+            "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+            "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+        },
+        "displayName": "Leo Franchi",
+        "active": true
+    },
+    "issue": {
+        "id": "10400",
+        "self": "http://lfranchi.com:8080/rest/api/2/issue/10400",
+        "key": "BUG-15",
+        "fields": {
+            "summary": "New bug with hook",
+            "progress": {
+                "progress": 0,
+                "total": 0
+            },
+            "timetracking": {},
+            "issuetype": {
+                "self": "http://lfranchi.com:8080/rest/api/2/issuetype/1",
+                "id": "1",
+                "description": "A problem which impairs or prevents the functions of the product.",
+                "iconUrl": "http://lfranchi.com:8080/images/icons/bug.gif",
+                "name": "Bug",
+                "subtask": false
+            },
+            "votes": {
+                "self": "http://lfranchi.com:8080/rest/api/2/issue/BUG-15/votes",
+                "votes": 0,
+                "hasVoted": false
+            },
+            "resolution": null,
+            "fixVersions": [],
+            "resolutiondate": null,
+            "timespent": null,
+            "reporter": {
+                "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+                "name": "lfranchi",
+                "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
+                "emailAddress": "othello@zulip.com",
+                "avatarUrls": {
+                    "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+                    "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+                },
+                "displayName": "Leo Franchi",
+                "active": true
+            },
+            "aggregatetimeoriginalestimate": null,
+            "created": "2013-03-27T16:53:58.301+0000",
+            "updated": "2013-03-27T16:53:58.301+0000",
+            "description": "Fix me please",
+            "priority": {
+                "self": "http://lfranchi.com:8080/rest/api/2/priority/3",
+                "iconUrl": "http://lfranchi.com:8080/images/icons/priority_major.gif",
+                "name": "Major",
+                "id": "3"
+            },
+            "duedate": null,
+            "issuelinks": [],
+            "watches": {
+                "self": "http://lfranchi.com:8080/rest/api/2/issue/BUG-15/watchers",
+                "watchCount": 0,
+                "isWatching": false
+            },
+            "worklog": {
+                "startAt": 0,
+                "maxResults": 0,
+                "total": 0,
+                "worklogs": []
+            },
+            "customfield_10000": null,
+            "subtasks": [],
+            "status": {
+                "self": "http://lfranchi.com:8080/rest/api/2/status/1",
+                "description": "The issue is open and ready for the assignee to start work on it.",
+                "iconUrl": "http://lfranchi.com:8080/images/icons/status_open.gif",
+                "name": "Open",
+                "id": "1"
+            },
+            "workratio": -1,
+            "assignee": null,
+            "attachment": [],
+            "aggregatetimeestimate": null,
+            "project": {
+                "self": "http://lfranchi.com:8080/rest/api/2/project/BUG",
+                "id": "10000",
+                "key": "BUG",
+                "name": "buggery-test",
+                "avatarUrls": {
+                    "16x16": "http://lfranchi.com:8080/secure/projectavatar?size=small&pid=10000&avatarId=10011",
+                    "48x48": "http://lfranchi.com:8080/secure/projectavatar?pid=10000&avatarId=10011"
+                }
+            },
+            "environment": null,
+            "timeestimate": null,
+            "aggregateprogress": {
+                "progress": 0,
+                "total": 0
+            },
+            "lastViewed": null,
+            "comment": {
+                "startAt": 0,
+                "maxResults": 0,
+                "total": 0,
+                "comments": []
+            },
+            "timeoriginalestimate": null,
+            "aggregatetimespent": null
+        }
+    }
+}

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -59,6 +59,34 @@ class JiraHookTests(WebhookTestCase):
         expected_message = "Bo Williams created [TEST-4: Test Created Assignee](https://zulipp.atlassian.net/browse/TEST-4) with major priority (assigned to Kevin Lin)."
         self.check_webhook("issue_created_with_assignee", expected_topic_name, expected_message)
 
+    def test_created_with_priority_disabled(self) -> None:
+        self.url = self.build_webhook_url(include_priority="false")
+        expected_topic_name = "BUG-15: New bug with hook"
+        expected_message = "@_**Othello, the Moor of Venice|12** created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15)."
+        self.check_webhook("issue_created", expected_topic_name, expected_message)
+
+    def test_created_with_assignee_disabled(self) -> None:
+        self.url = self.build_webhook_url(include_assignee="false")
+        expected_topic_name = "TEST-4: Test Created Assignee"
+        expected_message = "Bo Williams created [TEST-4: Test Created Assignee](https://zulipp.atlassian.net/browse/TEST-4) with major priority."
+        self.check_webhook("issue_created_with_assignee", expected_topic_name, expected_message)
+
+    def test_created_with_priority_and_assignee_disabled(self) -> None:
+        self.url = self.build_webhook_url(include_priority="false", include_assignee="false")
+        expected_topic_name = "TEST-4: Test Created Assignee"
+        expected_message = "Bo Williams created [TEST-4: Test Created Assignee](https://zulipp.atlassian.net/browse/TEST-4)."
+        self.check_webhook("issue_created_with_assignee", expected_topic_name, expected_message)
+
+    def test_reassigned_with_assignee_disabled(self) -> None:
+        # The assignee blurb is dropped from the header, but the changelog
+        # still reports the assignee change itself.
+        self.url = self.build_webhook_url(include_assignee="false")
+        expected_topic_name = "BUG-15: New bug with hook"
+        expected_message = """@_**Othello, the Moor of Venice|12** updated [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15):
+
+* Changed assignee to @_**Othello, the Moor of Venice|12**"""
+        self.check_webhook("issue_updated__reassigned", expected_topic_name, expected_message)
+
     def test_deleted(self) -> None:
         expected_topic_name = "BUG-15: New bug with hook"
         expected_message = "@_**Othello, the Moor of Venice|12** deleted [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15)."

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -87,6 +87,72 @@ class JiraHookTests(WebhookTestCase):
 * Changed assignee to @_**Othello, the Moor of Venice|12**"""
         self.check_webhook("issue_updated__reassigned", expected_topic_name, expected_message)
 
+    def test_created_with_additional_fields(self) -> None:
+        # The components in this fixture include one carrying no name,
+        # which is skipped rather than raising a validation error.
+        self.url = self.build_webhook_url(
+            include_issue_type="true",
+            include_status="true",
+            include_components="true",
+            include_versions="true",
+            include_labels="true",
+        )
+        expected_topic_name = "BUG-15: New bug with hook"
+        expected_message = """@_**Othello, the Moor of Venice|12** created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15) with major priority.
+* Type: Bug
+* Status: Open
+* Components: Backend, API
+* Versions: R4
+* Labels: regression, customer-reported"""
+        self.check_webhook(
+            "issue_created_with_additional_fields", expected_topic_name, expected_message
+        )
+
+    def test_created_with_additional_fields_absent_from_payload(self) -> None:
+        # The stock issue_created payload has empty components, versions
+        # and labels, so those bullets should be omitted entirely rather
+        # than rendered as empty.
+        self.url = self.build_webhook_url(
+            include_issue_type="true",
+            include_status="true",
+            include_components="true",
+            include_versions="true",
+            include_labels="true",
+        )
+        expected_topic_name = "BUG-15: New bug with hook"
+        expected_message = """@_**Othello, the Moor of Venice|12** created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15) with major priority.
+* Type: Bug
+* Status: Open"""
+        self.check_webhook("issue_created", expected_topic_name, expected_message)
+
+    def test_created_with_list_fields_missing_from_payload(self) -> None:
+        # Not every Jira deployment sends these keys at all, as opposed to
+        # sending them empty; the bullets should be omitted either way.
+        self.url = self.build_webhook_url(
+            include_components="true",
+            include_versions="true",
+            include_labels="true",
+        )
+        expected_topic_name = "BUG-15: New bug with hook"
+        expected_message = "@_**Othello, the Moor of Venice|12** created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15) with major priority."
+        self.check_webhook(
+            "issue_created_without_list_fields", expected_topic_name, expected_message
+        )
+
+    def test_created_with_only_requested_additional_fields(self) -> None:
+        self.url = self.build_webhook_url(
+            include_priority="false",
+            include_components="true",
+            include_versions="true",
+        )
+        expected_topic_name = "BUG-15: New bug with hook"
+        expected_message = """@_**Othello, the Moor of Venice|12** created [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15).
+* Components: Backend, API
+* Versions: R4"""
+        self.check_webhook(
+            "issue_created_with_additional_fields", expected_topic_name, expected_message
+        )
+
     def test_deleted(self) -> None:
         expected_topic_name = "BUG-15: New bug with hook"
         expected_message = "@_**Othello, the Moor of Venice|12** deleted [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15)."

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
+from pydantic import Json
 
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import AnomalousWebhookPayloadError, UnsupportedWebhookEventTypeError
@@ -35,9 +36,17 @@ IGNORED_EVENTS = [
 
 
 class Helper:
-    def __init__(self, payload: WildValue, user_profile: UserProfile) -> None:
+    def __init__(
+        self,
+        payload: WildValue,
+        user_profile: UserProfile,
+        include_priority: bool,
+        include_assignee: bool,
+    ) -> None:
         self.payload = payload
         self.user_profile = user_profile
+        self.include_priority = include_priority
+        self.include_assignee = include_assignee
 
 
 def guess_zulip_user_from_jira(jira_username: str, realm: Realm) -> UserProfile | None:
@@ -232,7 +241,9 @@ def handle_updated_issue_event(helper: Helper) -> str:
     else:
         assignee_mention = ""
 
-    if assignee_mention != "":
+    # The changelog below still reports assignee changes when this option
+    # is off; it describes a change rather than decorating the header.
+    if helper.include_assignee and assignee_mention != "":
         assignee_blurb = f" (assigned to {assignee_mention})"
     else:
         assignee_blurb = ""
@@ -267,21 +278,25 @@ def handle_created_issue_event(helper: Helper) -> str:
     payload = helper.payload
     user_profile = helper.user_profile
 
-    priority = get_in(payload, ["issue", "fields", "priority", "name"]).tame(check_string).lower()
+    author = get_issue_author(payload, user_profile.realm)
+    issue_string = get_issue_string(payload, with_title=True)
+    content = f"{author} created {issue_string}"
+
+    if helper.include_priority:
+        priority = (
+            get_in(payload, ["issue", "fields", "priority", "name"]).tame(check_string).lower()
+        )
+        content += f" with {priority} priority"
 
     assignee_payload = get_in(payload, ["issue", "fields", "assignee"])
-    if assignee_payload.value and isinstance(assignee_payload.value, dict):
-        assignee_blurb = f" (assigned to {get_user_mention(user_profile.realm, assignee_payload)})"
-    else:
-        assignee_blurb = ""
+    if (
+        helper.include_assignee
+        and assignee_payload.value
+        and isinstance(assignee_payload.value, dict)
+    ):
+        content += f" (assigned to {get_user_mention(user_profile.realm, assignee_payload)})"
 
-    template = "{author} created {issue_string} with {priority} priority{assignee_blurb}."
-    return template.format(
-        author=get_issue_author(payload, user_profile.realm),
-        issue_string=get_issue_string(payload, with_title=True),
-        priority=priority,
-        assignee_blurb=assignee_blurb,
-    )
+    return content + "."
 
 
 def handle_deleted_issue_event(helper: Helper) -> str:
@@ -374,6 +389,8 @@ def api_jira_webhook(
     user_profile: UserProfile,
     *,
     payload: JsonBodyPayload[WildValue],
+    include_priority: Json[bool] = True,
+    include_assignee: Json[bool] = True,
 ) -> HttpResponse:
     event = payload.get("webhookEvent").tame(check_none_or(check_string))
     if event in IGNORED_EVENTS:
@@ -388,7 +405,7 @@ def api_jira_webhook(
     if content_func is None:
         raise UnsupportedWebhookEventTypeError(event)
 
-    helper = Helper(payload, user_profile)
+    helper = Helper(payload, user_profile, include_priority, include_assignee)
     topic_name = get_issue_topic(payload)
     content: str = content_func(helper)
 

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -42,11 +42,21 @@ class Helper:
         user_profile: UserProfile,
         include_priority: bool,
         include_assignee: bool,
+        include_issue_type: bool,
+        include_status: bool,
+        include_components: bool,
+        include_versions: bool,
+        include_labels: bool,
     ) -> None:
         self.payload = payload
         self.user_profile = user_profile
         self.include_priority = include_priority
         self.include_assignee = include_assignee
+        self.include_issue_type = include_issue_type
+        self.include_status = include_status
+        self.include_components = include_components
+        self.include_versions = include_versions
+        self.include_labels = include_labels
 
 
 def guess_zulip_user_from_jira(jira_username: str, realm: Realm) -> UserProfile | None:
@@ -123,6 +133,53 @@ def get_in(payload: WildValue, keys: list[str], default: str = "") -> WildValue:
     except (AttributeError, KeyError, TypeError, ValidationError):
         return WildValue("default", default)
     return payload
+
+
+def get_list_field(payload: WildValue, field: str, key: str | None = None) -> str:
+    """Comma-separate a Jira list field.
+
+    Such fields hold either plain strings (labels) or objects carrying
+    their name under `key` (components, versions). Entries missing that
+    name are skipped, since indexing for it would raise.
+    """
+    field_payload = get_in(payload, ["issue", "fields", field])
+    if not isinstance(field_payload.value, list):
+        return ""
+
+    names = [
+        entry.tame(check_string)
+        if key is None
+        else entry.get(key).tame(check_none_or(check_string))
+        for entry in field_payload
+    ]
+    return ", ".join(name for name in names if name)
+
+
+def get_additional_issue_fields(helper: Helper) -> str:
+    """Render the enabled issue fields as a Markdown bullet list.
+
+    Empty and absent fields are skipped, so enabling an option for a
+    field a project does not populate leaves no empty bullet behind.
+    """
+    payload = helper.payload
+    fields: list[tuple[str, str]] = []
+
+    if helper.include_issue_type:
+        fields.append(
+            ("Type", get_in(payload, ["issue", "fields", "issuetype", "name"]).tame(check_string))
+        )
+    if helper.include_status:
+        fields.append(
+            ("Status", get_in(payload, ["issue", "fields", "status", "name"]).tame(check_string))
+        )
+    if helper.include_components:
+        fields.append(("Components", get_list_field(payload, "components", "name")))
+    if helper.include_versions:
+        fields.append(("Versions", get_list_field(payload, "versions", "name")))
+    if helper.include_labels:
+        fields.append(("Labels", get_list_field(payload, "labels")))
+
+    return "".join(f"\n* {label}: {value}" for label, value in fields if value)
 
 
 def get_issue_string(
@@ -296,7 +353,7 @@ def handle_created_issue_event(helper: Helper) -> str:
     ):
         content += f" (assigned to {get_user_mention(user_profile.realm, assignee_payload)})"
 
-    return content + "."
+    return content + "." + get_additional_issue_fields(helper)
 
 
 def handle_deleted_issue_event(helper: Helper) -> str:
@@ -391,6 +448,11 @@ def api_jira_webhook(
     payload: JsonBodyPayload[WildValue],
     include_priority: Json[bool] = True,
     include_assignee: Json[bool] = True,
+    include_issue_type: Json[bool] = False,
+    include_status: Json[bool] = False,
+    include_components: Json[bool] = False,
+    include_versions: Json[bool] = False,
+    include_labels: Json[bool] = False,
 ) -> HttpResponse:
     event = payload.get("webhookEvent").tame(check_none_or(check_string))
     if event in IGNORED_EVENTS:
@@ -405,7 +467,17 @@ def api_jira_webhook(
     if content_func is None:
         raise UnsupportedWebhookEventTypeError(event)
 
-    helper = Helper(payload, user_profile, include_priority, include_assignee)
+    helper = Helper(
+        payload,
+        user_profile,
+        include_priority=include_priority,
+        include_assignee=include_assignee,
+        include_issue_type=include_issue_type,
+        include_status=include_status,
+        include_components=include_components,
+        include_versions=include_versions,
+        include_labels=include_labels,
+    )
     topic_name = get_issue_topic(payload)
     content: str = content_func(helper)
 

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -34,6 +34,12 @@ IGNORED_EVENTS = [
 ]
 
 
+class Helper:
+    def __init__(self, payload: WildValue, user_profile: UserProfile) -> None:
+        self.payload = payload
+        self.user_profile = user_profile
+
+
 def guess_zulip_user_from_jira(jira_username: str, realm: Realm) -> UserProfile | None:
     try:
         # Try to find a matching user in Zulip
@@ -209,7 +215,10 @@ def add_change_info(
     return content
 
 
-def handle_updated_issue_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_updated_issue_event(helper: Helper) -> str:
+    payload = helper.payload
+    user_profile = helper.user_profile
+
     # Reassigned, commented, reopened, and resolved events are all bundled
     # into this one 'updated' event type, so we try to extract the meaningful
     # event that happened
@@ -254,7 +263,10 @@ def handle_updated_issue_event(payload: WildValue, user_profile: UserProfile) ->
     return content
 
 
-def handle_created_issue_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_created_issue_event(helper: Helper) -> str:
+    payload = helper.payload
+    user_profile = helper.user_profile
+
     priority = get_in(payload, ["issue", "fields", "priority", "name"]).tame(check_string).lower()
 
     assignee_payload = get_in(payload, ["issue", "fields", "assignee"])
@@ -272,7 +284,10 @@ def handle_created_issue_event(payload: WildValue, user_profile: UserProfile) ->
     )
 
 
-def handle_deleted_issue_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_deleted_issue_event(helper: Helper) -> str:
+    payload = helper.payload
+    user_profile = helper.user_profile
+
     template = "{author} deleted {issue_string}{punctuation}"
     title = get_issue_title(payload)
     punctuation = "." if title[-1] not in string.punctuation else ""
@@ -298,7 +313,10 @@ def get_comment_author(comment_payload: WildValue, realm: Realm) -> str:
     return get_user_mention(realm, author_payload)
 
 
-def handle_comment_created_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_created_event(helper: Helper) -> str:
+    payload = helper.payload
+    user_profile = helper.user_profile
+
     return "{author} commented on {issue_string}\
 \n``` quote\n{comment}\n```\n".format(
         author=get_comment_author(payload["comment"], user_profile.realm),
@@ -309,7 +327,10 @@ def handle_comment_created_event(payload: WildValue, user_profile: UserProfile) 
     )
 
 
-def handle_comment_updated_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_updated_event(helper: Helper) -> str:
+    payload = helper.payload
+    user_profile = helper.user_profile
+
     return "{author} updated their comment on {issue_string}\
 \n``` quote\n{comment}\n```\n".format(
         author=get_comment_author(payload["comment"], user_profile.realm),
@@ -320,7 +341,10 @@ def handle_comment_updated_event(payload: WildValue, user_profile: UserProfile) 
     )
 
 
-def handle_comment_deleted_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_deleted_event(helper: Helper) -> str:
+    payload = helper.payload
+    user_profile = helper.user_profile
+
     return "{author} deleted their comment on {issue_string}\
 \n``` quote\n~~{comment}~~\n```\n".format(
         author=get_comment_author(payload["comment"], user_profile.realm),
@@ -331,7 +355,7 @@ def handle_comment_deleted_event(payload: WildValue, user_profile: UserProfile) 
     )
 
 
-JIRA_CONTENT_FUNCTION_MAPPER: dict[str, Callable[[WildValue, UserProfile], str] | None] = {
+JIRA_CONTENT_FUNCTION_MAPPER: dict[str, Callable[[Helper], str] | None] = {
     "jira:issue_created": handle_created_issue_event,
     "jira:issue_deleted": handle_deleted_issue_event,
     "jira:issue_updated": handle_updated_issue_event,
@@ -364,8 +388,9 @@ def api_jira_webhook(
     if content_func is None:
         raise UnsupportedWebhookEventTypeError(event)
 
+    helper = Helper(payload, user_profile)
     topic_name = get_issue_topic(payload)
-    content: str = content_func(payload, user_profile)
+    content: str = content_func(helper)
 
     check_send_webhook_message(
         request, user_profile, topic_name, content, event, unquote_url_parameters=True


### PR DESCRIPTION
Fixes: #17141

The Jira issue-created notification hardcoded which fields it showed:
always the priority and assignee, never anything else. As the reporter
described, workflows that don't set priority or assignee until later
get notifications where half the content is noise, while the fields
they do populate on creation — component, version — aren't available
at all.

As @timabbott suggested on the issue, this uses the `url_options`
framework so fields are chosen in the "generate integration URL" UI
rather than by editing the integration, following the pattern the Gong
and GitHub integrations already use.

Seven options are added:

- `include_priority`, `include_assignee` — **default on**, so existing
  integration URLs produce byte-identical messages
- `include_issue_type`, `include_status`, `include_components`,
  `include_versions`, `include_labels` — **default off**, rendered as a
  Markdown bullet list under the summary line

**Open question on scope.** #17141 explicitly asks for components and
versions; the other three are my extrapolation from the discussion, so
I'd welcome direction on whether that set is right. I deliberately left
out the issue description: it's multi-line free text rather than a short
field, and how to present it (truncation? quoting?) seemed like a
separate design question rather than something to decide here.
Per-instance custom fields (`customfield_10000`) are likewise left for
later, since they need instance-specific naming.

`include_assignee` also governs the assignee blurb on issue-updated
notifications, on the reasoning that an option named for the assignee
shouldn't apply to only one event type. The changelog portion of those
messages still reports assignee *changes* when it's off, since that
describes a change rather than decorating the header. Happy to narrow
this if you'd rather it were creation-only.

No documentation change: `generate-webhook-url-basic.md` is generic and
the options render automatically in the integration-URL UI, matching how
Gong's five options are handled.

**How changes were tested:**

- [x] `./tools/test-backend zerver.webhooks.jira` — 24 tests pass. The
      16 pre-existing tests pass **unmodified**, which is the
      backward-compatibility check: default options reproduce current
      output exactly.
- [x] `./tools/test-backend zerver.webhooks zerver.tests.test_docs
      zerver.tests.test_integrations` — 1200 tests, no regressions.
- [x] `./tools/test-backend --coverage zerver.webhooks.jira` — no
      missing lines in `view.py`.
- [x] `./tools/lint` clean on all touched files.
- [x] Each of the three commits verified to pass the suite
      independently (16 → 20 → 24 tests).
- [x] Exercised the real "Generate integration URL" modal with
      Puppeteer against the dev server: all seven checkboxes render,
      `include_priority`/`include_assignee` are checked by default and
      the other five unchecked, no label overflows its container, and
      toggling options updates the generated URL
      (`include_components=true`, `include_priority=false`).

Two fixtures are added: one with components/versions/labels populated
(the stock payloads have them all empty), and one omitting those keys
entirely, since Jira deployments vary in whether they send them.

Not tested against a live Jira instance — I don't have one, so the
verification is fixture-based.

**Screenshots and screen captures:**

No new UI code: the checkboxes are rendered generically by the existing
integration-URL modal from the `url_options` declaration. They are
visible to users though, so here is the modal with Jira selected —
defaults on the left, and after toggling priority off and components on.

<img width="1400" height="937" alt="1-jira-options-defaults" src="https://github.com/user-attachments/assets/36e41a9c-8116-4d27-9997-8787135195e4" />
<img width="1400" height="937" alt="2-jira-options-toggled" src="https://github.com/user-attachments/assets/b68317c2-274f-4f07-8c69-1ba0f132a3ba" />

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips. (Option labels are untranslated, matching
      every other integration's `url_options`.)
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
