### PR TITLE
[ai] provision: Install libpcre2-dev for building uwsgi.

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -26,6 +26,7 @@ VENV_DEPENDENCIES = [
     "libvips-tools",
     "libicu-dev",  # For building pyicu
     "libcrypt-dev",  # For building uwsgi
+    "libpcre2-dev",  # For building uwsgi
 ]
 
 COMMON_YUM_VENV_DEPENDENCIES = [


### PR DESCRIPTION
Fixes: provisioning failure on a clean Ubuntu 24.04 machine.

`./tools/provision` fails while building the venv:

```
./uwsgi.h:445:10: fatal error: pcre2.h: No such file or directory
  445 | #include <pcre2.h>
```

uwsgi is published only as an sdist (no wheels), so it's compiled from
source on every install, and its build includes `pcre2.h`
unconditionally. Nothing in our dependency lists provides that header —
`pcre2` appears nowhere in the repo.

This adds `libpcre2-dev` next to `libcrypt-dev`, which is already listed
for this same uwsgi build. Scoped to the Debian/Ubuntu list to match how
`libcrypt-dev` is handled; the yum lists carry neither package.

**How changes were tested:**

- [x] Reproduced the failure on a clean Ubuntu 24.04 WSL 2 environment.
- [x] Installing `libpcre2-dev` lets uwsgi compile and provisioning
      completes: `Zulip development environment setup succeeded!`
- [x] Verified the entry reaches the installed set:
      `get_venv_dependencies("ubuntu", "24.04")` now contains it.
- [x] `./tools/lint scripts/lib/setup_venv.py` clean.

**Screenshots and screen captures:**

n/a — provisioning change.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Followed the AI use policy.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

</details>
