### PR TITLE
markdown: Allow backticks in tilde-fenced spoiler headers.

### DIFF
--- a/web/src/fenced_code.ts
+++ b/web/src/fenced_code.ts
@@ -31,14 +31,19 @@ const fencestr =
     "([a-zA-Z0-9_+-./#]*)" + // Language
     "\\}?" +
     ")" +
-    "[ ]*" + // Spaces
-    "(" +
-    "\\{?\\.?" +
-    "([^~`]*)" + // Header (see fenced_code.py)
-    "\\}?" +
-    ")" +
-    "$";
-const fence_re = new RegExp(fencestr);
+    "[ ]*"; // Spaces
+const fence_and_lang_re = new RegExp(fencestr);
+
+// The header (used by features like spoilers) may contain the fence
+// delimiter character *other* than the one that opened this block, but
+// not its own — this mirrors FENCE_RE's `header` group in the backend's
+// fenced_code. JS regexes can't express this as a single conditional
+// pattern, so we match the fence + language first, then build the header
+// regex based on which delimiter was actually used.
+function make_header_re(fence: string): RegExp {
+    const excluded = fence.startsWith("~") ? "~" : "`";
+    return new RegExp("^(\\{?\\.?([^" + excluded + "]*)\\}?)$");
+}
 
 // Default stashing function does nothing
 let stash_func = function (text: string): string {
@@ -209,16 +214,20 @@ export function process_fenced_code(content: string): string {
     }
 
     consume_line = function consume_line(output_lines: string[], line: string) {
-        const match = fence_re.exec(line);
-        if (match) {
-            const fence = match[1]!;
-            const lang = match[3]!;
-            const header = match[5]!;
-            const handler = handler_for_fence(output_lines, fence, lang, header);
-            handler_stack.push(handler);
-        } else {
-            output_lines.push(line);
+        const fence_and_lang_match = fence_and_lang_re.exec(line);
+        if (fence_and_lang_match) {
+            const fence = fence_and_lang_match[1]!;
+            const lang = fence_and_lang_match[3]!;
+            const remainder = line.slice(fence_and_lang_match[0].length);
+            const header_match = make_header_re(fence).exec(remainder);
+            if (header_match) {
+                const header = header_match[2]!;
+                const handler = handler_for_fence(output_lines, fence, lang, header);
+                handler_stack.push(handler);
+                return;
+            }
         }
+        output_lines.push(line);
     };
 
     const current_handler = default_handler();

--- a/web/tests/fenced_code.test.cjs
+++ b/web/tests/fenced_code.test.cjs
@@ -7,6 +7,13 @@ const {run_test} = require("./lib/test.cjs");
 
 const fenced_code = zrequire("fenced_code");
 
+// Shared identity stash function used to restore fenced_code's default
+// (no-op) stashing behavior at the end of tests that override it. Reusing
+// one reference (rather than a fresh `(text) => text` literal per test)
+// keeps this as a single coverage location that the next stash-triggering
+// test naturally exercises.
+const identity_stash_func = (text) => text;
+
 // Check the default behavior of fenced code blocks
 // works properly before Markdown is initialized.
 run_test("fenced_block_defaults", () => {
@@ -140,7 +147,42 @@ run_test("process_fenced_code_spoiler", () => {
     assert.ok(stashed.some((s) => s.includes("spoiler-block")));
 
     // Restore the default no-op stash func.
-    fenced_code.set_stash_func((text) => text);
+    fenced_code.set_stash_func(identity_stash_func);
+});
+
+run_test("process_fenced_code_spoiler_header_backticks", () => {
+    // Regression test for #37003:
+    // a tilde-fenced spoiler header may contain backticks (which will
+    // later be rendered as inline code spans by the full Markdown),
+    // since there's no ambiguity with the tilde fence.
+    const stashed = [];
+    fenced_code.set_stash_func((text) => {
+        stashed.push(text);
+        return "STASHED";
+    });
+
+    const input = "~~~spoiler Title that includes an `inline code span`\nhidden content\n~~~";
+    const output = fenced_code.process_fenced_code(input);
+    assert.ok(output.includes("Title that includes an `inline code span`"));
+    assert.ok(output.includes("hidden content"));
+    assert.ok(stashed.some((s) => s.includes("spoiler-block")));
+
+    // Restore the default no-op stash func.
+    fenced_code.set_stash_func(identity_stash_func);
+});
+
+run_test("process_fenced_code_spoiler_header_own_delimiter_still_restricted", () => {
+    // A header still cannot contain its *own* fence's delimiter, since
+    // that would be ambiguous with the fence itself. This restriction is
+    // unchanged by the #37003 fix, which only relaxes it for the other
+    // delimiter character.
+    const backtick_input = "```spoiler Title with a `backtick` in it\nhidden content\n```";
+    const backtick_output = fenced_code.process_fenced_code(backtick_input);
+    assert.ok(!backtick_output.includes("spoiler-header"));
+
+    const tilde_input = "~~~spoiler Title with a ~tilde~ in it\nhidden content\n~~~";
+    const tilde_output = fenced_code.process_fenced_code(tilde_input);
+    assert.ok(!tilde_output.includes("spoiler-header"));
 });
 
 run_test("process_fenced_code_tilde_fence", () => {

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -101,7 +101,7 @@ FENCE_RE = re.compile(
     r"""
     # ~~~ or ```
     (?P<fence>
-        ^(?:~{3,}|`{3,})
+        ^(?:(?P<fence_tilde>~{3,})|(?P<fence_backtick>`{3,}))
     )
 
     [ ]* # spaces
@@ -117,9 +117,19 @@ FENCE_RE = re.compile(
 
         [ ]* # spaces
 
-        # header for features that use fenced block header syntax (like spoilers)
+        # Header for features that use fenced block header syntax (like
+        # spoilers). We only need to forbid the header from containing the
+        # fence's own delimiter character, since that's the only character
+        # that could be confused with a continuation/closing of the fence.
+        # This means a `~~~`-fenced header can contain backticks (so that
+        # inline code spans work in spoiler titles), and a
+        # ```-fenced header can contain tildes.
         (?P<header>
-            [^ ~`][^~`]*
+            (?(fence_tilde)
+                [^ ~][^~]*
+            |
+                [^ `][^`]*
+            )
         )?
         \}?
     )?

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -2433,6 +2433,97 @@ class MarkdownCodeBlockTest(ZulipTestCase):
         self.assertEqual(rendering_result.rendered_content, expected_output)
 
 
+class MarkdownSpoilerTest(ZulipTestCase):
+    """
+    Regression tests for #37003:
+    inline code spans (backticks) inside a spoiler header should be
+    parsed correctly when the spoiler block itself uses tilde (~~~)
+    fencing, since there's no ambiguity between the two delimiters.
+    """
+
+    def test_tilde_spoiler_header_with_inline_code(self) -> None:
+        msg = "~~~spoiler Title that includes an `inline code span`\ncontents\n~~~"
+        converted = markdown_convert_wrapper(msg)
+        self.assertEqual(
+            converted,
+            '<div class="spoiler-block"><div class="spoiler-header">\n'
+            "<p>Title that includes an <code>inline code span</code></p>\n"
+            '</div><div class="spoiler-content" aria-hidden="true">\n'
+            "<p>contents</p>\n"
+            "</div></div>",
+        )
+
+    def test_tilde_spoiler_header_with_multiple_code_spans(self) -> None:
+        msg = "~~~spoiler Use `foo()` then `bar()`\ncontents\n~~~"
+        converted = markdown_convert_wrapper(msg)
+        self.assertEqual(
+            converted,
+            '<div class="spoiler-block"><div class="spoiler-header">\n'
+            "<p>Use <code>foo()</code> then <code>bar()</code></p>\n"
+            '</div><div class="spoiler-content" aria-hidden="true">\n'
+            "<p>contents</p>\n"
+            "</div></div>",
+        )
+
+    def test_tilde_spoiler_header_plain_title_no_regression(self) -> None:
+        # A tilde-fenced spoiler with a plain title (no backticks) should
+        # continue to render exactly as before.
+        msg = "~~~spoiler Plain title, no code\ncontents\n~~~"
+        converted = markdown_convert_wrapper(msg)
+        self.assertEqual(
+            converted,
+            '<div class="spoiler-block"><div class="spoiler-header">\n'
+            "<p>Plain title, no code</p>\n"
+            '</div><div class="spoiler-content" aria-hidden="true">\n'
+            "<p>contents</p>\n"
+            "</div></div>",
+        )
+
+    def test_backtick_spoiler_header_plain_title_no_regression(self) -> None:
+        # Standard backtick-fenced spoilers without any special characters
+        # in the header should also be unaffected.
+        msg = "```spoiler Plain title, no code\ncontents\n```"
+        converted = markdown_convert_wrapper(msg)
+        self.assertEqual(
+            converted,
+            '<div class="spoiler-block"><div class="spoiler-header">\n'
+            "<p>Plain title, no code</p>\n"
+            '</div><div class="spoiler-content" aria-hidden="true">\n'
+            "<p>contents</p>\n"
+            "</div></div>",
+        )
+
+    def test_backtick_spoiler_header_with_tilde_is_allowed(self) -> None:
+        # A backtick-fenced spoiler header may contain tildes, since only
+        # the fence's own delimiter character is restricted.
+        msg = "```spoiler Title with a ~tilde~ in it\ncontents\n```"
+        converted = markdown_convert_wrapper(msg)
+        self.assertEqual(
+            converted,
+            '<div class="spoiler-block"><div class="spoiler-header">\n'
+            "<p>Title with a ~tilde~ in it</p>\n"
+            '</div><div class="spoiler-content" aria-hidden="true">\n'
+            "<p>contents</p>\n"
+            "</div></div>",
+        )
+
+    def test_backtick_spoiler_header_with_backtick_not_supported(self) -> None:
+        # Per CommonMark-style fenced code block conventions, a header on a
+        # backtick-fenced block still cannot itself contain a backtick,
+        # since that would be ambiguous with the fence delimiter. This is
+        # unchanged by the #37003 fix, which only relaxes the restriction
+        # for the *other* delimiter character.
+        msg = "```spoiler Title with a `backtick` in it\ncontents\n```"
+        converted = markdown_convert_wrapper(msg)
+        self.assertNotIn('class="spoiler-block"', converted)
+
+    def test_tilde_spoiler_header_with_tilde_not_supported(self) -> None:
+        # Symmetrically, a tilde-fenced header cannot contain a tilde.
+        msg = "~~~spoiler Title with a ~tilde~ in it\ncontents\n~~~"
+        converted = markdown_convert_wrapper(msg)
+        self.assertNotIn('class="spoiler-block"', converted)
+
+
 class MarkdownMentionTest(ZulipTestCase):
     def test_mention_topic_wildcard(self) -> None:
         user_profile = self.example_user("othello")


### PR DESCRIPTION
Previously FENCE_RE's header group excluded both `~` and backtick characters unconditionally, so a `~~~spoiler` header containing a backtick failed to match the fence regex at all — not just fail to render the code span, but break spoiler-block parsing entirely.

Fix by tracking which delimiter opened the fence and only excluding that fence's own character from the header, matching CommonMark's convention. Tilde-fenced headers can now contain backticks (so inline code spans render correctly) and backtick-fenced headers can contain tildes; the reverse restriction is intentionally preserved.

Fixes #37003

**How changes were tested:**

- [x] Added python test cases for changes.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**
| Before | After |
|--|--|
|<img width="772" height="281" alt="image" src="https://github.com/user-attachments/assets/01db213b-8a55-45a8-89a3-31fdb2e944fe" />|<img width="772" height="281" alt="image" src="https://github.com/user-attachments/assets/f9b9a3e2-3aaf-4ba3-9b8c-5aaf3b26cd6a" />|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
