### PR TITLE
migrations: Fix NULLS ordering in Message indexes.

### DIFF
--- a/zerver/migrations/0808_message_topic_indexes_nulls_first.py
+++ b/zerver/migrations/0808_message_topic_indexes_nulls_first.py
@@ -1,0 +1,83 @@
+import django.db.models.functions.text
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0807_usertopic_zerver_usertopic_user_visibility_recipient_idx"),
+    ]
+
+    operations = [
+        migrations.RenameIndex(
+            model_name="message",
+            new_name="zerver_message_realm_upper_subject_nulls_last",
+            old_name="zerver_message_realm_upper_subject",
+        ),
+        migrations.RenameIndex(
+            model_name="message",
+            new_name="zerver_message_realm_recipient_upper_subject_nulls_last",
+            old_name="zerver_message_realm_recipient_upper_subject",
+        ),
+        migrations.RenameIndex(
+            model_name="message",
+            new_name="zerver_message_realm_recipient_subject_nulls_last",
+            old_name="zerver_message_realm_recipient_subject",
+        ),
+        migrations.RenameIndex(
+            model_name="message",
+            new_name="zerver_message_realm_id_nulls_last",
+            old_name="zerver_message_realm_id",
+        ),
+        AddIndexConcurrently(
+            model_name="message",
+            index=models.Index(
+                models.F("realm_id"),
+                django.db.models.functions.text.Upper("subject"),
+                models.OrderBy(models.F("id"), descending=True),
+                condition=models.Q(("is_channel_message", True)),
+                name="zerver_message_realm_upper_subject",
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="message",
+            index=models.Index(
+                models.F("realm_id"),
+                models.F("recipient_id"),
+                django.db.models.functions.text.Upper("subject"),
+                models.OrderBy(models.F("id"), descending=True),
+                condition=models.Q(("is_channel_message", True)),
+                name="zerver_message_realm_recipient_upper_subject",
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="message",
+            index=models.Index(
+                models.F("realm_id"),
+                models.F("recipient_id"),
+                models.F("subject"),
+                models.OrderBy(models.F("id"), descending=True),
+                condition=models.Q(("is_channel_message", True)),
+                name="zerver_message_realm_recipient_subject",
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="message",
+            index=models.Index(
+                models.F("realm_id"),
+                models.OrderBy(models.F("id"), descending=True),
+                name="zerver_message_realm_id",
+            ),
+        ),
+        # The two indexes above on Upper("subject") are expression
+        # indexes, whose per-expression statistics are only collected
+        # by ANALYZE; without them the planner cannot estimate the
+        # selectivity of a topic lookup.
+        migrations.RunSQL(
+            sql="ANALYZE zerver_message",
+            reverse_sql=migrations.RunSQL.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/migrations/0809_remove_message_nulls_last_topic_indexes.py
+++ b/zerver/migrations/0809_remove_message_nulls_last_topic_indexes.py
@@ -1,0 +1,29 @@
+from django.contrib.postgres.operations import RemoveIndexConcurrently
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0808_message_topic_indexes_nulls_first"),
+    ]
+
+    operations = [
+        RemoveIndexConcurrently(
+            model_name="message",
+            name="zerver_message_realm_upper_subject_nulls_last",
+        ),
+        RemoveIndexConcurrently(
+            model_name="message",
+            name="zerver_message_realm_recipient_upper_subject_nulls_last",
+        ),
+        RemoveIndexConcurrently(
+            model_name="message",
+            name="zerver_message_realm_recipient_subject_nulls_last",
+        ),
+        RemoveIndexConcurrently(
+            model_name="message",
+            name="zerver_message_realm_id_nulls_last",
+        ),
+    ]

--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -228,7 +228,7 @@ class Message(AbstractMessage):
                 # is done case-insensitively
                 "realm_id",
                 Upper("subject"),
-                F("id").desc(nulls_last=True),
+                F("id").desc(),
                 name="zerver_message_realm_upper_subject",
                 condition=Q(is_channel_message=True),
             ),
@@ -240,7 +240,7 @@ class Message(AbstractMessage):
                 "realm_id",
                 "recipient_id",
                 Upper("subject"),
-                F("id").desc(nulls_last=True),
+                F("id").desc(),
                 name="zerver_message_realm_recipient_upper_subject",
                 condition=Q(is_channel_message=True),
             ),
@@ -250,14 +250,14 @@ class Message(AbstractMessage):
                 "realm_id",
                 "recipient_id",
                 "subject",
-                F("id").desc(nulls_last=True),
+                F("id").desc(),
                 name="zerver_message_realm_recipient_subject",
                 condition=Q(is_channel_message=True),
             ),
             models.Index(
                 # Only used by update_first_visible_message_id
                 "realm_id",
-                F("id").desc(nulls_last=True),
+                F("id").desc(),
                 name="zerver_message_realm_id",
             ),
             models.Index(


### PR DESCRIPTION
`DESC NULLS LAST` is the wrong ordering of NULLs in these indexes, as it makes them not usable for ordering in the `ORDER BY` clause, both in `ASC` and `DESC` mode. That's because:
- `ORDER BY id DESC` is equivalent to `ORDER BY id DESC NULLS FIRST`
- `ORDER BY id ASC` is equivalent to `ORDER BY id ASC NULLS LAST`

Neither of these is consistent with the indexes. The `ORDER BY DESC` case is obvious (`NULLS FIRST` vs `NULLS LAST`). The `ORDER BY ASC` case cannot use the index, because `ASC NULLS LAST` would need an index that's `DESC NULLS FIRST`.
(ref https://www.postgresql.org/docs/18/indexes-ordering.html)

One might reasonably expect the NULLS ordering technicality not to matter on the `id` column, which doesn't have any NULLs. Postgres does not take that into account however.

The consequence of this mismatch is that queries fetching "the last N messages", even when they use these indexes for their WHERE clause, end up fetching **all** the WHERE-matching results in order to then sort them and get the last N - instead of stopping early at N rows.

The incorrect ordering was originally introduced in b246723d837cddde898316b67ab5af1feba67817 and later copied when adding new indexes.

In Zulip Cloud, where we detected this bug, adding the correct index takes the simple `get_latest_message_for_user_in_topic` query:
```
messages_for_topic(realm_id, recipient_id, topic_name).values_list("id", flat=True).last()
```
for a certain large topic, from 10 second execution time to 3ms.


