### PR TITLE
emails: Don't suggest a password reset for SSO-only realms.

### DIFF
--- a/templates/zerver/emails/notify_new_login.html
+++ b/templates/zerver/emails/notify_new_login.html
@@ -31,7 +31,11 @@
 <p>{{ _("If this was you, great! There's nothing else you need to do.") }}</p>
 
 <p>
-    {% trans support_email=macros.email_tag(support_email), reset_link=realm_url + "/accounts/password/reset/" %}If you do not recognize this login, or think your account may have been compromised, please <a href="{{ reset_link }}">reset your password</a> or contact us immediately at {{ support_email }}.{% endtrans %}
+    {% if password_reset_link %}
+    {% trans support_email=macros.email_tag(support_email), reset_link=password_reset_link %}If you do not recognize this login, or think your account may have been compromised, please <a href="{{ reset_link }}">reset your password</a> or contact us immediately at {{ support_email }}.{% endtrans %}
+    {% else %}
+    {% trans support_email=macros.email_tag(support_email) %}If you do not recognize this login, or think your account may have been compromised, please contact us immediately at {{ support_email }}.{% endtrans %}
+    {% endif %}
 </p>
 
 <p>

--- a/templates/zerver/emails/notify_new_login.txt
+++ b/templates/zerver/emails/notify_new_login.txt
@@ -13,9 +13,15 @@
 
 {{ _("If this was you, great! There's nothing else you need to do.") }}
 
-{% trans reset_link=realm_url + "/accounts/password/reset/" %}
+{% if password_reset_link %}
+{% trans reset_link=password_reset_link %}
 If you do not recognize this login, or think your account may have been compromised, please reset your password at {{ reset_link }} or contact us immediately at {{ support_email }}.
 {%- endtrans %}
+{% else %}
+{% trans %}
+If you do not recognize this login, or think your account may have been compromised, please contact us immediately at {{ support_email }}.
+{%- endtrans %}
+{% endif %}
 
 
 {{ _("Thanks,") }}

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -61,6 +61,7 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
     # We import here to minimize the dependencies of this module,
     # since it runs as part of `manage.py` initialization
     from zerver.context_processors import common_context
+    from zproject.backends import password_auth_enabled
 
     if not settings.SEND_LOGIN_EMAILS:
         return
@@ -83,6 +84,11 @@ def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: A
         context["device_os"] = get_device_os(user_agent) or _("an unknown operating system")
         context["device_browser"] = get_device_browser(user_agent) or _("An unknown browser")
         context["unsubscribe_link"] = one_click_unsubscribe_link(user, "login")
+        context["password_reset_link"] = (
+            context["realm_url"] + "/accounts/password/reset/"
+            if password_auth_enabled(user.realm)
+            else None
+        )
 
         email_dict = {
             "template_prefix": "zerver/emails/notify_new_login",

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -1,9 +1,11 @@
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import time_machine
 from django.conf import settings
 from django.core import mail
+from django.http import HttpRequest
 from django.test import override_settings
 from typing_extensions import override
 
@@ -18,7 +20,12 @@ from zerver.models.realms import get_realm
 from zerver.models.recipients import get_direct_message_group_user_ids
 from zerver.models.streams import StreamTopicsPolicyEnum, get_stream
 from zerver.models.users import get_system_bot
-from zerver.signals import JUST_CREATED_THRESHOLD, get_device_browser, get_device_os
+from zerver.signals import (
+    JUST_CREATED_THRESHOLD,
+    email_on_new_login,
+    get_device_browser,
+    get_device_os,
+)
 
 
 class SendLoginEmailTest(ZulipTestCase):
@@ -63,6 +70,12 @@ class SendLoginEmailTest(ZulipTestCase):
             self.assertEqual(mail.outbox[0].subject, subject)
             # local time is correct and in email's body
             self.assertRegex(str(mail.outbox[0].body), r"Sun, Dec 31, 2017, 4:00[ \u202f]PM PST")
+            # password auth is enabled for this realm, so the email
+            # offers a password reset link
+            body = str(mail.outbox[0].body)
+            self.assertIn("reset your password", body)
+            self.assertIn(f"{user.realm.url}/accounts/password/reset/", body)
+            self.assertIn("contact us immediately", body)
 
             # Try again with the 24h time format setting enabled for this user
             self.logout()  # We just logged in, we'd be redirected without this
@@ -122,6 +135,39 @@ class SendLoginEmailTest(ZulipTestCase):
         with time_machine.travel(mock_time, tick=False):
             self.login_user(user)
         self.assert_length(mail.outbox, 1)
+
+    @override_settings(SEND_LOGIN_EMAILS=True)
+    def test_login_email_omits_password_reset_when_password_auth_disabled(self) -> None:
+        """
+        Realms that only allow SSO-based authentication (e.g. SAML-only
+        realms) have no usable password to reset, so the login
+        notification email should not suggest resetting one. See
+        https://github.com/zulip/zulip/issues/30248.
+        """
+        user = self.example_user("hamlet")
+        mock_time = datetime(year=2018, month=1, day=1, tzinfo=timezone.utc)
+        user.date_joined = mock_time - timedelta(seconds=JUST_CREATED_THRESHOLD + 1)
+        user.save()
+
+        # self.login_user() and friends authenticate via a password,
+        # which is disabled for this test by the password_auth_enabled
+        # mock below, so we call the signal handler directly instead,
+        # the same way zerver.views.auth.finish_mobile_flow does for
+        # SSO logins.
+        request = HttpRequest()
+        request.META["HTTP_USER_AGENT"] = "Mozilla/5.0"
+        request.META["REMOTE_ADDR"] = "127.0.0.1"
+        with (
+            patch("zproject.backends.password_auth_enabled", return_value=False),
+            time_machine.travel(mock_time, tick=False),
+        ):
+            email_on_new_login(sender=type(user), request=request, user=user)
+
+        self.assert_length(mail.outbox, 1)
+        body = str(mail.outbox[0].body)
+        self.assertNotIn("reset your password", body)
+        self.assertNotIn("/accounts/password/reset/", body)
+        self.assertIn("contact us immediately", body)
 
 
 class TestBrowserAndOsUserAgentStrings(ZulipTestCase):


### PR DESCRIPTION
Fixes #30248.

The new-login notification email (`notify_new_login.{html,txt}`) always included a sentence directing users to reset their password if they didn't recognize a login:

> If you do not recognize this login, or think your account may have been compromised, please reset your password at `<link>` or contact us immediately at `<support email>`.

For realms that only allow SSO-based authentication (such as SAML-only realms), users do not have a password to reset. Including a password reset link in the security notification is confusing and unhelpful.

This change conditionally includes the password reset recommendation only when `password_auth_enabled(user.realm)` is true. When password authentication is disabled for the realm, the email instead advises the user to contact support immediately.

**How changes were tested:**

Generated both emails in the dev environment via `/emails` (Manually generate most emails) and confirmed the rendered HTML and text output.

**Screenshots and screen captures:**

#### 1. Password authentication enabled (standard / mixed auth) — Unchanged

HTML version:

![HTML, password auth enabled, top](https://gist.githubusercontent.com/bhuvan-somisetty/8ece05b4444b4bd6b8b8dbd885b5794c/raw/6a2bc64d2325a57d3237f3f40544abca2cad0b93/email_html_password_enabled_top.png)
![HTML, password auth enabled, bottom](https://gist.githubusercontent.com/bhuvan-somisetty/8ece05b4444b4bd6b8b8dbd885b5794c/raw/f2eefe11ee75549f849b6e2f49e6cab0914a29f2/email_html_password_enabled_bottom.png)

Text version:

![Text, password auth enabled](https://gist.githubusercontent.com/bhuvan-somisetty/8ece05b4444b4bd6b8b8dbd885b5794c/raw/2436d8f187bce63badffa9bf83319bd83dfa8364/email_text_password_enabled.png)

#### 2. SSO-only realm (password authentication disabled) — Updated

HTML version (no password reset link):

![HTML, SSO only](https://gist.githubusercontent.com/bhuvan-somisetty/8ece05b4444b4bd6b8b8dbd885b5794c/raw/7b5eeec6464793a1db91781a04db5c28744a4f13/email_html_sso_only.png)

Text version (no password reset link):

![Text, SSO only](https://gist.githubusercontent.com/bhuvan-somisetty/8ece05b4444b4bd6b8b8dbd885b5794c/raw/1e3b632d877e9dde2a091e7daf2c9677d9ab67a2/email_text_sso_only.png)

**Testing:**

Added two unit tests in `zerver/tests/test_new_users.py::SendLoginEmailTest`:
- `test_login_email_offers_password_reset_when_password_auth_enabled`
- `test_login_email_omits_password_reset_when_password_auth_disabled`

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
