### PR TITLE
markdown: Expand tabs to 2 spaces for nested list support (10.x)

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1791,6 +1791,70 @@ class Fence:
     is_code: bool
 
 
+LIST_INDENT_TAB_WIDTH = 2
+CODE_BLOCK_TAB_WIDTH = 4
+
+PREFIXED_FENCE_RE = re.compile(
+    r"""
+    ^[ ]*(?:>[ ]*)*
+    (?P<fence>~{3,}|`{3,})
+    [ ]*
+    (?:
+        \{?\.?
+        (?P<lang>[a-zA-Z0-9_+-./#]+)
+        [ ]*
+        (?P<header>[^ ~`][^~`]*)?
+        \}?
+    )?
+    [ ]*$
+    """,
+    re.VERBOSE,
+)
+
+
+class ZulipNormalizeWhitespace(markdown.preprocessors.Preprocessor):
+    """Normalize whitespace for consistent parsing.
+
+    Expands tabs to 2 spaces outside fenced code blocks to support
+    nested bulleted and numbered lists, while expanding tabs to 4 spaces
+    inside fenced code blocks to preserve code block tab stops.
+    """
+
+    @override
+    def run(self, lines: list[str]) -> list[str]:
+        source = "\n".join(lines)
+        source = source.replace(markdown.util.STX, "").replace(markdown.util.ETX, "")
+        source = source.replace("\r\n", "\n").replace("\r", "\n") + "\n\n"
+
+        raw_lines = source.split("\n")
+        expanded_lines: list[str] = []
+        open_fences: list[Fence] = []
+
+        for line in raw_lines:
+            m = PREFIXED_FENCE_RE.match(line)
+            in_code = bool(open_fences and open_fences[-1].is_code)
+
+            if m:
+                fence_str = m.group("fence")
+                lang = m.group("lang")
+                if in_code:
+                    if not lang and fence_str == open_fences[-1].fence_str:
+                        open_fences.pop()
+                else:
+                    if not lang and open_fences and fence_str == open_fences[-1].fence_str:
+                        open_fences.pop()
+                    else:
+                        is_code = (lang or "").lower() not in ("quote", "quoted", "spoiler")
+                        open_fences.append(Fence(fence_str, is_code))
+
+            tab_width = CODE_BLOCK_TAB_WIDTH if in_code else LIST_INDENT_TAB_WIDTH
+            expanded_lines.append(line.expandtabs(tab_width))
+
+        source = "\n".join(expanded_lines)
+        source = re.sub(r"(?<=\n) +\n", "\n", source)
+        return source.split("\n")
+
+
 class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     """Allows list blocks that come directly after another block
     to be rendered as a list.
@@ -2330,7 +2394,7 @@ class ZulipMarkdown(markdown.Markdown):
         preprocessors = markdown.util.Registry[markdown.preprocessors.Preprocessor]()
         preprocessors.register(MarkdownListPreprocessor(self), "hanging_lists", 35)
         preprocessors.register(
-            markdown.preprocessors.NormalizeWhitespace(self), "normalize_whitespace", 30
+            ZulipNormalizeWhitespace(self), "normalize_whitespace", 30
         )
         preprocessors.register(fenced_code.FencedBlockPreprocessor(self), "fenced_code_block", 25)
         preprocessors.register(

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -55,6 +55,13 @@
       "text_content": "Hamlet once said\ndef func():\n    x = 1\n\n    y = 2\n\n    z = 3\n\nAnd all was good."
     },
     {
+      "name": "codeblock_tab_indent",
+      "input": "```\ndef func():\n\tx = 1\n```",
+      "expected_output": "<div class=\"codehilite\"><pre><span></span><code>def func():\n    x = 1\n</code></pre></div>",
+      "marked_expected_output": "<div class=\"codehilite\"><pre><span></span><code>def func():\n\tx = 1\n</code></pre></div>",
+      "text_content": "def func():\n    x = 1\n"
+    },
+    {
       "name": "inline_code_spaces",
       "input": "` outer ` ```    space    ```",
       "expected_output": "<p><code> outer </code> <code>    space    </code></p>",
@@ -274,6 +281,12 @@
     {
       "name": "ulist_nested_ulist_two_space_indent",
       "input": "Nested list\n* I am outer list\n  * I am inner nested list first item\n  * I am inner nested list second item",
+      "expected_output": "<p>Nested list</p>\n<ul>\n<li>I am outer list<ul>\n<li>I am inner nested list first item</li>\n<li>I am inner nested list second item</li>\n</ul>\n</li>\n</ul>",
+      "text_content": "Nested list\n\nI am outer list\nI am inner nested list first item\nI am inner nested list second item\n\n\n"
+    },
+    {
+      "name": "ulist_nested_ulist_tab_indent",
+      "input": "Nested list\n* I am outer list\n\t* I am inner nested list first item\n\t* I am inner nested list second item",
       "expected_output": "<p>Nested list</p>\n<ul>\n<li>I am outer list<ul>\n<li>I am inner nested list first item</li>\n<li>I am inner nested list second item</li>\n</ul>\n</li>\n</ul>",
       "text_content": "Nested list\n\nI am outer list\nI am inner nested list first item\nI am inner nested list second item\n\n\n"
     },

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -38,6 +38,7 @@ from zerver.lib.markdown import (
     InlineInterestingLinkProcessor,
     MarkdownListPreprocessor,
     MessageRenderingResult,
+    ZulipNormalizeWhitespace,
     clear_web_link_regex_for_testing,
     content_has_emoji_syntax,
     fetch_tweet_data,
@@ -527,6 +528,68 @@ Outside. Should convert:<>
         """
         original, expected = self.split_message(msg)
         self.assertEqual(preprocessor.run(original), expected)
+
+
+class ZulipNormalizeWhitespaceTest(ZulipTestCase):
+    def test_tab_outside_code_block_is_2_spaces(self) -> None:
+        preprocessor = ZulipNormalizeWhitespace(Markdown())
+        msg = ["- one", "\t- two", "\t\t- three"]
+        expected = ["- one", "  - two", "    - three", "", ""]
+        self.assertEqual(preprocessor.run(msg), expected)
+
+    def test_tab_in_plain_code_block_is_4_spaces(self) -> None:
+        preprocessor = ZulipNormalizeWhitespace(Markdown())
+        msg = ["```python", "def func():", "\tx = 1", "```"]
+        expected = ["```python", "def func():", "    x = 1", "```", "", ""]
+        self.assertEqual(preprocessor.run(msg), expected)
+
+    def test_indented_fence_detected_as_code_block(self) -> None:
+        preprocessor = ZulipNormalizeWhitespace(Markdown())
+        msg = ["  ```python", "  def func():", "  \tx = 1", "  ```"]
+        expected = ["  ```python", "  def func():", "    x = 1", "  ```", "", ""]
+        self.assertEqual(preprocessor.run(msg), expected)
+
+    def test_blockquoted_fence_detected_as_code_block(self) -> None:
+        preprocessor = ZulipNormalizeWhitespace(Markdown())
+        msg = ["> ```python", "> def func():", ">\tx = 1", "> ```"]
+        expected = ["> ```python", "> def func():", ">   x = 1", "> ```", "", ""]
+        self.assertEqual(preprocessor.run(msg), expected)
+
+    def test_quote_block_tabs_are_2_spaces(self) -> None:
+        preprocessor = ZulipNormalizeWhitespace(Markdown())
+        msg = ["```quote", "* one", "\t* two", "```"]
+        expected = ["```quote", "* one", "  * two", "```", "", ""]
+        self.assertEqual(preprocessor.run(msg), expected)
+
+    def test_code_block_inside_quote_block(self) -> None:
+        preprocessor = ZulipNormalizeWhitespace(Markdown())
+        msg = [
+            "```quote",
+            "* one",
+            "\t* two",
+            "```python",
+            "def func():",
+            "\tx = 1",
+            "```",
+            "* three",
+            "\t* four",
+            "```",
+        ]
+        expected = [
+            "```quote",
+            "* one",
+            "  * two",
+            "```python",
+            "def func():",
+            "    x = 1",
+            "```",
+            "* three",
+            "  * four",
+            "```",
+            "",
+            "",
+        ]
+        self.assertEqual(preprocessor.run(msg), expected)
 
 
 class MarkdownFixtureTest(ZulipTestCase):


### PR DESCRIPTION
## Summary

Backports the fix for nested tab-indented lists to **Zulip Server 10.x**.

Fixes rendering of tab-indented nested bulleted and numbered lists by normalizing tab indentation to 2 spaces outside code blocks, while preserving 4-space tab stops inside fenced code blocks.

Fixes: #38436

---

## Visual Changes (Before vs. After)

| Before Fix (Tabs expanded to 4 spaces) | After Fix (Tabs expanded to 2 spaces) |
| :--- | :--- |
| ![Before Fix](https://files.catbox.moe/nx6pz7.png) | ![After Fix](https://files.catbox.moe/c58b3d.png) |
| *Tab-indented nested items rendered flat as `<br>` continuation lines under parent.* | *Tab-indented nested items correctly render as proper hierarchical sub-lists (`<ul><li>`).* |

---

## Problem & Architectural Fix

- **Version Targeted**: **Zulip Server 10.x**
- **Problem**: Zulip uses 2-space indentation for nested bulleted and numbered lists (`UListProcessor`, `ListIndentProcessor`). Upstream Python-Markdown's `NormalizeWhitespace` preprocessor expanded tabs to 4 spaces unconditionally. When users copy/paste tab-indented lists from external editors (Notion, VS Code, Obsidian), list items were misparsed as flat items with `<br>` continuation lines rather than sub-lists.
- **Solution**: Replaced `NormalizeWhitespace` with `ZulipNormalizeWhitespace`.
  - **Outside Code Blocks**: Expands tabs to 2 spaces (`LIST_INDENT_TAB_WIDTH = 2`) for nested list parsing.
  - **Inside Code Blocks**: Expands tabs to 4 spaces (`CODE_BLOCK_TAB_WIDTH = 4`), preserving standard code block tab stops across standard, indented (`   ``` `), and blockquoted (`> ``` `) code fences.

---

## Tests & Verification

1. **Unit Tests Added (`zerver/tests/test_markdown.py`)**:
   - `ZulipNormalizeWhitespaceTest`: Verified 6 test cases for standard code blocks, lists, indented fences, blockquoted fences, quote blocks, and nested blocks.
2. **Fixture Tests Added (`zerver/tests/fixtures/markdown_test_cases.json`)**:
   - `ulist_nested_ulist_tab_indent`: Verifies tab-indented nested bullet lists match expected nested list HTML.
   - `codeblock_tab_indent`: Verifies 4-space tab expansion inside code blocks.

---

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Automated tests verify logic where appropriate.
- [x] Completed manual review and testing of visual appearance of the changes.

</details>
