### PR TITLE
docs: Fix broken relative links missing .md extension

### DIFF
--- a/docs/contributing/reviewable-prs.md
+++ b/docs/contributing/reviewable-prs.md
@@ -88,7 +88,8 @@ description for your pull request, you will:
   The review process will go a lot more smoothly if points of uncertainty are
   explicitly laid out.
 - Include screenshots for all visual changes, so that they can be reviewed
-  without running your code. Be sure to follow our [guide on presenting visual changes](../contributing/presenting-visual-changes).
+  without running your code. Be sure to follow our
+  [guide on presenting visual changes](../contributing/presenting-visual-changes.md).
 
 If you have a question about a specific part of your code that you expect to be
 resolved during the review process, put it in a PR comment attached to a

--- a/docs/subsystems/html-css.md
+++ b/docs/subsystems/html-css.md
@@ -281,7 +281,7 @@ commit should just move the code, not translate it to TypeScript).
 TypeScript provides more accurate information to development tools,
 allowing for better refactoring, auto-completion and static analysis.
 TypeScript also uses the ES6 module system. See our documentation on
-[TypeScript static types](../testing/typescript).
+[TypeScript static types](../testing/typescript.md).
 
 Webpack does not ordinarily allow modules to be accessed directly from
 the browser console, but for debugging convenience, we have a custom

--- a/docs/webhooks/incoming-webhooks-overview.md
+++ b/docs/webhooks/incoming-webhooks-overview.md
@@ -57,7 +57,7 @@ write, including tests and documentation, if you use the right process.
 
 ## Hello world walkthrough
 
-Check out [this detailed guide](incoming-webhooks-walkthrough) for
+Check out [this detailed guide](incoming-webhooks-walkthrough.md) for
 step-by-step instructions on developing an incoming webhook integration.
 
 ## Checklist

--- a/docs/webhooks/incoming-webhooks-reference.md
+++ b/docs/webhooks/incoming-webhooks-reference.md
@@ -2,7 +2,7 @@
 
 This guide provides a detailed reference for developing and configuring
 Zulip incoming webhook integrations. For step-by-step guidance, read the
-[incoming webhooks walkthrough](incoming-webhooks-walkthrough), before using
+[incoming webhooks walkthrough](incoming-webhooks-walkthrough.md), before using
 this reference guide.
 
 ## Custom HTTP headers


### PR DESCRIPTION
Four relative documentation links pointed at file names without the `.md` extension. Under MyST/Sphinx these do not resolve as pages, so they render as dead links:

- `docs/contributing/reviewable-prs.md`: link to the guide on presenting visual changes (the same file links it correctly with `.md` a few lines earlier)
- `docs/subsystems/html-css.md`: link to the TypeScript static types doc
- `docs/webhooks/incoming-webhooks-overview.md` and `docs/webhooks/incoming-webhooks-reference.md`: links to the incoming webhooks walkthrough

Each target file exists in the tree; only the extension was missing.

Found via a relative-link check over `docs/`, `web/docs`, and `api_docs` while filtering out build-time-rewritten paths (`/api/...`, `/help/...`, `/images/...`).