### PR TITLE
reactions: Abbreviate long names in reaction pills with ellipsis.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -17,6 +17,7 @@
         padding: 2.5px 5px 2.5px 4px;
         box-sizing: border-box;
         min-width: 44px;
+        max-width: 150px;
         cursor: pointer;
         color: var(--color-message-reaction-text);
         background-color: var(--color-message-reaction-background);
@@ -89,6 +90,11 @@
            count/name.
            13px at 12.6/1em */
         line-height: 1.0317em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+        /* required for ellipsis to work inside a flex container */
     }
 
     .message_reaction:hover .message_reaction_count {
@@ -163,7 +169,8 @@
     user-select: none;
 
     .emoji-popover {
-        width: 16.6667em; /* 250px at 15px/em */
+        width: 16.6667em;
+        /* 250px at 15px/em */
 
         .emoji-popover-category-tabs {
             /* Flex needed here to work around #7511 (90% zoom issues in firefox) */
@@ -174,11 +181,15 @@
             overflow: hidden;
 
             .emoji-popover-tab-item {
-                font-size: 1.0667em; /* 16px at 15px/em */
+                font-size: 1.0667em;
+                /* 16px at 15px/em */
                 display: inline-block;
-                padding-top: 0.5em; /* 8px at 16px/em */
-                width: 1.5625em; /* 25px at 16px/em */
-                height: 1.5625em; /* 25px at 16px/em */
+                padding-top: 0.5em;
+                /* 8px at 16px/em */
+                width: 1.5625em;
+                /* 25px at 16px/em */
+                height: 1.5625em;
+                /* 25px at 16px/em */
                 text-align: center;
                 cursor: pointer;
                 /* Flex needed here to work around #7511 (90% zoom issues in firefox) */
@@ -198,27 +209,34 @@
             position: relative;
             overflow: hidden auto;
             display: block;
-            width: 16.4667em; /* 247px at 15px/em */
-            padding-left: 0.2em; /* 3px at 15px/em */
+            width: 16.4667em;
+            /* 247px at 15px/em */
+            padding-left: 0.2em;
+            /* 3px at 15px/em */
         }
 
         .emoji-popover-emoji-map {
-            height: 16.6667em; /* 250px at 15px/em */
+            height: 16.6667em;
+            /* 250px at 15px/em */
 
             .emoji-popover-subheading {
                 font-weight: 600;
-                padding: 0.3333em 0.2em; /* 5px 3px at 15px/em */
+                padding: 0.3333em 0.2em;
+                /* 5px 3px at 15px/em */
             }
         }
 
         .emoji-popover-emoji {
             display: inline-block;
             margin: 0;
-            padding: 0.4em; /* 6px at 15px/em */
+            padding: 0.4em;
+            /* 6px at 15px/em */
             cursor: pointer;
             border-radius: 0.5em;
-            height: 1.6667em; /* 25px at 15px/em */
-            width: 1.6667em; /* 25px at 15px/em */
+            height: 1.6667em;
+            /* 25px at 15px/em */
+            width: 1.6667em;
+            /* 25px at 15px/em */
 
             &:focus {
                 background-color: var(
@@ -249,8 +267,10 @@
             }
 
             .emoji {
-                height: 1.6667em; /* 25px at 15px/em */
-                width: 1.6667em; /* 25px at 15px/em */
+                height: 1.6667em;
+                /* 25px at 15px/em */
+                width: 1.6667em;
+                /* 25px at 15px/em */
             }
         }
 
@@ -260,12 +280,15 @@
                cause the popover to render at incorrect position when
                the search container is hidden `onMount`. */
             display: none;
-            height: 18.8667em; /* 283px at 15px/em */
+            height: 18.8667em;
+            /* 283px at 15px/em */
 
             .emoji-popover-results-heading {
-                font-size: 1.1333em; /* 17px at 15px/em */
+                font-size: 1.1333em;
+                /* 17px at 15px/em */
                 font-weight: 600;
-                padding: 0.2941em 0.1765em 0.1765em 0.2941em; /* 5px 3px 3px 5px at 17px/em */
+                padding: 0.2941em 0.1765em 0.1765em 0.2941em;
+                /* 5px 3px 3px 5px at 17px/em */
             }
         }
     }
@@ -273,24 +296,33 @@
     .emoji-showcase-container {
         position: relative;
         background-color: var(--color-background-emoji-picker-popover);
-        min-height: 2.9333em; /* 44px at 15px/em */
-        width: 16.6667em; /* 250px at 15px/em */
+        min-height: 2.9333em;
+        /* 44px at 15px/em */
+        width: 16.6667em;
+        /* 250px at 15px/em */
         border-radius: 0 0 6px 6px;
 
         .emoji-preview {
             position: absolute;
-            width: 2.1333em; /* 32px at 15px/em */
-            height: 2.1333em; /* 32px at 15px/em */
-            left: 0.3333em; /* 5px at 15px/em */
-            top: 0.4em; /* 6px at 15px/em */
+            width: 2.1333em;
+            /* 32px at 15px/em */
+            height: 2.1333em;
+            /* 32px at 15px/em */
+            left: 0.3333em;
+            /* 5px at 15px/em */
+            top: 0.4em;
+            /* 6px at 15px/em */
             margin-top: 0;
         }
 
         .emoji-canonical-name {
-            font-size: 1.0667em; /* 16px at 15px/em */
+            font-size: 1.0667em;
+            /* 16px at 15px/em */
             position: relative;
-            top: 0.75em; /* 12px at 16px/em */
-            margin-left: 3.125em; /* 50px at 16px/em */
+            top: 0.75em;
+            /* 12px at 16px/em */
+            margin-left: 3.125em;
+            /* 50px at 16px/em */
             font-weight: 600;
             white-space: nowrap;
             text-overflow: ellipsis;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -29,10 +29,7 @@
         border-radius: 21px;
         align-items: center;
         box-shadow: inset 0 0 5px 0 var(--color-message-reaction-shadow-inner);
-        transition:
-            transform 100ms linear,
-            font-weight 100ms linear;
-        /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+        transition: transform 100ms linear;
 
         &.reacted {
             color: var(--color-message-reaction-text-reacted);
@@ -134,10 +131,13 @@
 
         &:hover {
             color: var(--color-message-reaction-button-text-hover);
-            background-color: var(--color-message-reaction-button-background-hover);
+            background-color: var(
+                --color-message-reaction-button-background-hover
+            );
             border: 1px solid var(--color-message-reaction-button-border-hover);
             border-color: var(--color-message-reaction-button-border-hover);
-            box-shadow: inset 0 0 5px 0 var(--color-message-reaction-shadow-inner);
+            box-shadow: inset 0 0 5px 0
+                var(--color-message-reaction-shadow-inner);
             cursor: pointer;
             opacity: 1;
         }
@@ -194,7 +194,9 @@
                 flex-grow: 1;
 
                 &.active {
-                    background-color: var(--color-background-emoji-picker-popover-tab-item-active);
+                    background-color: var(
+                        --color-background-emoji-picker-popover-tab-item-active
+                    );
                 }
             }
         }
@@ -235,20 +237,27 @@
             /* 25px at 15px/em */
 
             &:focus {
-                background-color: var(--color-background-emoji-picker-emoji-focus);
+                background-color: var(
+                    --color-background-emoji-picker-emoji-focus
+                );
                 /* Only dark mode takes a box shadow on
                    the emoji-picker's focused emoji. */
-                box-shadow: 0 0 1px var(--color-box-shadow-emoji-picker-emoji-focus);
+                box-shadow: 0 0 1px
+                    var(--color-box-shadow-emoji-picker-emoji-focus);
                 outline: none;
             }
 
             &.reacted {
-                background-color: var(--color-background-emoji-picker-emoji-reacted);
+                background-color: var(
+                    --color-background-emoji-picker-emoji-reacted
+                );
                 border-color: var(--color-border-emoji-picker-emoji-reacted);
             }
 
             &.reacted:focus {
-                background-color: var(--color-background-emoji-picker-emoji-reacted-focus);
+                background-color: var(
+                    --color-background-emoji-picker-emoji-reacted-focus
+                );
             }
 
             &.hide {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -17,7 +17,7 @@
         padding: 2.5px 5px 2.5px 4px;
         box-sizing: border-box;
         min-width: 44px;
-        max-width: 150px;
+        max-width: 15em;
         cursor: pointer;
         color: var(--color-message-reaction-text);
         background-color: var(--color-message-reaction-background);
@@ -31,7 +31,8 @@
         box-shadow: inset 0 0 5px 0 var(--color-message-reaction-shadow-inner);
         transition:
             transform 100ms linear,
-            font-weight 100ms linear; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+            font-weight 100ms linear;
+        /* stylelint-disable-line plugin/no-low-performance-animation-properties */
 
         &.reacted {
             color: var(--color-message-reaction-text-reacted);
@@ -133,13 +134,10 @@
 
         &:hover {
             color: var(--color-message-reaction-button-text-hover);
-            background-color: var(
-                --color-message-reaction-button-background-hover
-            );
+            background-color: var(--color-message-reaction-button-background-hover);
             border: 1px solid var(--color-message-reaction-button-border-hover);
             border-color: var(--color-message-reaction-button-border-hover);
-            box-shadow: inset 0 0 5px 0
-                var(--color-message-reaction-shadow-inner);
+            box-shadow: inset 0 0 5px 0 var(--color-message-reaction-shadow-inner);
             cursor: pointer;
             opacity: 1;
         }
@@ -196,9 +194,7 @@
                 flex-grow: 1;
 
                 &.active {
-                    background-color: var(
-                        --color-background-emoji-picker-popover-tab-item-active
-                    );
+                    background-color: var(--color-background-emoji-picker-popover-tab-item-active);
                 }
             }
         }
@@ -239,27 +235,20 @@
             /* 25px at 15px/em */
 
             &:focus {
-                background-color: var(
-                    --color-background-emoji-picker-emoji-focus
-                );
+                background-color: var(--color-background-emoji-picker-emoji-focus);
                 /* Only dark mode takes a box shadow on
                    the emoji-picker's focused emoji. */
-                box-shadow: 0 0 1px
-                    var(--color-box-shadow-emoji-picker-emoji-focus);
+                box-shadow: 0 0 1px var(--color-box-shadow-emoji-picker-emoji-focus);
                 outline: none;
             }
 
             &.reacted {
-                background-color: var(
-                    --color-background-emoji-picker-emoji-reacted
-                );
+                background-color: var(--color-background-emoji-picker-emoji-reacted);
                 border-color: var(--color-border-emoji-picker-emoji-reacted);
             }
 
             &.reacted:focus {
-                background-color: var(
-                    --color-background-emoji-picker-emoji-reacted-focus
-                );
+                background-color: var(--color-background-emoji-picker-emoji-reacted-focus);
             }
 
             &.hide {


### PR DESCRIPTION
<p>Fixes #38594.</p>

<h3>Summary</h3>

<p>
  Added <code>max-width: 15em</code> on <code>.message_reaction</code> to cap pill width,
  and <code>overflow: hidden</code>, <code>text-overflow: ellipsis</code>,
  <code>white-space: nowrap</code>, and <code>min-width: 0</code> on
  <code>.message_reaction_count</code> so long names truncate cleanly with an ellipsis
  instead of overflowing the layout.
</p>

<h3>Before / After</h3>

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img width="1280" height="199" alt="beforefinal (1)" src="https://github.com/user-attachments/assets/74d5a504-be2c-43c0-8a26-ca80a09ea90e" />
      </td>
      <td>
        <img width="1280" height="199" alt="afterfinal" src="https://github.com/user-attachments/assets/97b6ef3e-df41-450b-aff9-501fe6f56d69" />
      </td>
    </tr>
  </tbody>
</table>

<p>
  I've addressed both concerns:
</p>

<p>
  <strong>1. Screenshots:</strong><br>
  The before/after screenshots now show the actual bug — a reaction pill with a
  genuinely long repeated name (<code>DemanosDemanosDemanos...</code>) expanding
  and breaking the layout — and the after shows it cleanly truncated with an ellipsis.
</p>

<p>
  <strong>2. <code>max-width</code> value:</strong><br>
  Changed from <code>150px</code> to <code>15em</code> so that only truly long names
  are truncated and normal-length names are unaffected.
</p>

<h3>Comparison with Existing PRs</h3>

<ul>
  <li>
    <strong>#39049</strong> — Uses <code>max-width: 250px</code>
    (a fixed pixel value) on <code>.message_reaction</code>.
  </li>
  <li>
    <strong>#39829</strong> — Also uses a fixed <code>200px</code>.
    Both are pixel-based and don't scale with font size.
  </li>
  <li>
    <strong>#39768</strong> — Takes a more complex DOM-restructuring approach
    (rendering each name as a separate element). My change is minimal,
    a pure CSS fix with no JavaScript or template changes.
  </li>

  <li>
    <strong>My approach</strong> uses <code>15em</code>, which is relative to the
    font size and therefore scales better across different zoom levels and
    accessibility settings.
  </li>
</ul>

See the Before / After section above.

<details>
<summary>Self-review checklist</summary>

* [x] [[Self-reviewed](https://github.com/zulip/zulip/blob/main/CONTRIBUTING.md#how-to-review-code)](https://github.com/zulip/zulip/blob/main/CONTRIBUTING.md#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
* [x] Followed the [[AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines)](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

* [x] Explains differences from previous plans (e.g., issue description).
* [x] Highlights technical choices and bugs encountered.
* [x] Calls out remaining decisions and concerns.
* [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review.

* [x] Each commit is a coherent idea.
* [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

* [x] Visual appearance of the changes.
* [x] Responsiveness and internationalization.
* [ ] Strings and tooltips.
* [x] End-to-end functionality of buttons, interactions and flows.
* [x] Corner cases, error conditions, and easily imagined bugs.

</details>