### PR TITLE
reload: Preserve draft id when restoring compose after reload.

### DIFF
--- a/web/src/reload_setup.ts
+++ b/web/src/reload_setup.ts
@@ -80,7 +80,11 @@ export function initialize(): void {
             if (draft === false) {
                 blueslip.warn("Tried to restore a draft that didn't exist.");
             } else {
-                compose_actions.start({...draft, message_type: draft.type});
+                compose_actions.start({
+                    ...draft,
+                    message_type: draft.type,
+                    draft_id: data.compose_active_draft_id,
+                });
                 if (data.compose_active_draft_send_immediately) {
                     compose.finish();
                 }

--- a/web/tests/reload_setup.test.cjs
+++ b/web/tests/reload_setup.test.cjs
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+
+const compose_actions = mock_esm("../src/compose_actions");
+const drafts = mock_esm("../src/drafts", {draft_model: {}});
+mock_esm("../src/activity", {set_new_user_input: noop});
+mock_esm("../src/message_fetch", {set_initial_pointer_and_offset: noop});
+mock_esm("../src/message_view", {changehash: noop});
+
+// override file-level function call in reload.ts
+window.addEventListener = noop;
+const {localstorage} = zrequire("localstorage");
+const reload_setup = zrequire("reload_setup");
+
+run_test("restored compose keeps its draft_id", ({override}) => {
+    const draft_id = "1234abcd-5678";
+    const draft = {
+        type: "stream",
+        stream_id: 1,
+        topic: "reload",
+        content: "unsent message",
+        updatedAt: 1,
+        is_sending_saving: false,
+        drafts_version: 1,
+    };
+    override(drafts.draft_model, "getDraft", (id) => {
+        assert.equal(id, draft_id);
+        return draft;
+    });
+
+    const ls = localstorage();
+    ls.set("reload:42", {
+        hash: "#feed",
+        timestamp: 1,
+        compose_active_draft_id: draft_id,
+    });
+    window.location.hash = "#reload:42";
+
+    let start_opts;
+    override(compose_actions, "start", (opts) => {
+        start_opts = opts;
+    });
+
+    reload_setup.initialize();
+
+    // The restored compose box must be associated with the draft that
+    // was saved before the reload, so that subsequent saves update it
+    // instead of adding a duplicate.
+    assert.deepEqual(start_opts, {...draft, message_type: "stream", draft_id});
+    assert.equal(ls.get("reload:42"), undefined);
+});


### PR DESCRIPTION
When the app reloads itself (after a server deploy, or when the event queue has been garbage-collected), preserve_state saves the compose box as a draft and records its id in the reload token. On the other side, reload_setup restored the compose box from that draft but did not tell compose_actions.start which draft it was, so compose_draft_id stayed unset.

The next draft save (autosave, window blur, beforeunload, or the next reload) then had no draft to update and added a new copy. Each reload cycle of an idle tab with an open compose box thus produced one more identical draft; users reported dozens accumulating overnight.

Sending had the same problem: compose.finish saves and then deletes the draft it thinks is active, so a send-after-reload created and removed a fresh copy while leaving the reload-saved draft behind.

The legacy reload-token path already passed draft_id through; this was lost when the token format was rewritten in
f5af06479ef51ce2b0c56d7a37eaf4b4c7807cc5.

---

repro steps for bug (verified fixed after the change)

1. Open the (dev) web app, start a draft, leave compose open.
2. Touch any Python file Tornado imports — e.g. add a blank line to zerver/tornado/views.py and save. Tornado restarts, the tab reloads itself.
3. Compose comes back with your text.
4. Repeat step 2, each time the draft count increases

CZO discussion: [#issues > numerous duplicate drafts in Safari](https://chat.zulip.org/#narrow/channel/9-issues/topic/numerous.20duplicate.20drafts.20in.20Safari/with/2514226)