### PR TITLE
right_sidebar: Extend focus styles to users/subscribers links.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -610,6 +610,18 @@
     margin-top: calc(25px - (var(--legacy-body-line-height-unitless) * 1em));
     margin-bottom: var(--sidebar-bottom-spacing);
 
+    .invite-user-link {
+        /* TODO: We should eventually change the grid to use the correct
+           --right-sidebar-presence-circle-width with left spacing, and
+           share that left spacing value here. */
+        padding-left: calc(var(--right-sidebar-toggle-width-offset) + 0.3em);
+        text-decoration: none;
+    }
+}
+
+.invite-user-shortcut,
+.view-all-users-link,
+.view-all-subscribers-link {
     &:has(:focus-visible) {
         /* Apply focus and active styles to the parent container so the
         entire invite-user row receives keyboard focus indication,
@@ -621,16 +633,9 @@
         background-color: var(--color-background-hover-narrow-filter);
     }
 
-    .invite-user-link {
-        /* TODO: We should eventually change the grid to use the correct
-           --right-sidebar-presence-circle-width with left spacing, and
-           share that left spacing value here. */
-        padding-left: calc(var(--right-sidebar-toggle-width-offset) + 0.3em);
+    & a:focus {
+        outline: none;
         text-decoration: none;
-
-        &:focus {
-            outline: none;
-        }
     }
 }
 


### PR DESCRIPTION
This brings the correct focus styles to the View All Users and View All Subscribers links in the left sidebar.

Fixes: [#design > focus styles for 'View all users'](https://chat.zulip.org/#narrow/channel/101-design/topic/focus.20styles.20for.20.27View.20all.20users.27/with/2477675)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="630" height="1012" alt="view-all-users-dark-before" src="https://github.com/user-attachments/assets/9f107fe8-636b-41c2-b54d-29dfd522599a" /> | <img width="630" height="1012" alt="view-all-users-dark-after" src="https://github.com/user-attachments/assets/982c0b2e-cf62-44ca-82f6-92c87187ae07" /> |

| All Users | Subscribers |
| --- | --- |
| <img width="700" height="1314" alt="all-users-after" src="https://github.com/user-attachments/assets/e9363a02-48d9-4ec0-9ece-1a1e9ddec76f" /> | <img width="700" height="1314" alt="subscribers-after" src="https://github.com/user-attachments/assets/d7c7b5f9-6e32-4004-a60f-5813a8fdd05b" /> |

