### PR TITLE
Suppress redundant conversation tooltips

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -12,6 +12,7 @@ import * as compose_validate from "./compose_validate.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
+import * as narrow_state from "./narrow_state.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as reactions from "./reactions.ts";
 import * as rows from "./rows.ts";
@@ -169,6 +170,20 @@ function get_time_string(timestamp: number): string {
 export function initialize(): void {
     message_list_tooltip(".tippy-narrow-tooltip", {
         delay: LONG_HOVER_DELAY,
+        onShow(instance) {
+            const in_topic_view =
+                instance.reference.matches(".focused-message-list .narrows_by_topic") &&
+                narrow_state.narrowed_by_topic_reply();
+            const in_dm_view =
+                instance.reference.matches(
+                    ".focused-message-list .message_header_private_message .narrows_by_recipient",
+                ) && narrow_state.narrowed_by_pm_reply();
+
+            if (in_topic_view || in_dm_view) {
+                return false;
+            }
+            return undefined;
+        },
         onCreate(instance) {
             // We sniff the href, rather than looking up the user's settings
             // so that the tooltip always matches the link.


### PR DESCRIPTION
The topic and direct-message headers currently offer a navigation tooltip even when the message list is already narrowed to that exact conversation. In that state, following the link would keep the user in the same view, so the tooltip describes an action with no effect.

This suppresses the redundant topic or DM tooltip only in the matching narrow. Channel tooltips and conversation tooltips in interleaved views remain available because those links still change the current narrow.

This follows the behavior proposed in the issue, with no remaining design concerns.

Fixes: #40026

**How changes were tested:**

- Ran the relevant frontend Node tests.
- Ran Prettier and ESLint on the changed source.
- Confirmed in the browser that the tooltip is hidden in an exact topic view while the channel tooltip remains available.
- Confirmed that the tooltip is hidden in one-to-one and group DM views.
- Confirmed that topic and DM tooltips remain available in interleaved views.
- Confirmed there were no browser console errors during these checks.

**Screenshots and screen captures:**

Topic view:

| Before | After |
| --- | --- |
| ![Topic header showing the redundant tooltip before the change](https://raw.githubusercontent.com/wessim852/zulip/pr-40027-screenshots/topic-tooltip-before-precise.png) | ![Topic header without the redundant tooltip after the change](https://raw.githubusercontent.com/wessim852/zulip/pr-40027-screenshots/topic-tooltip-after-precise.png) |

Direct-message view:

| Before | After |
| --- | --- |
| ![DM header showing the redundant tooltip before the change](https://raw.githubusercontent.com/wessim852/zulip/pr-40027-screenshots/dm-tooltip-before-precise.png) | ![DM header without the redundant tooltip after the change](https://raw.githubusercontent.com/wessim852/zulip/pr-40027-screenshots/dm-tooltip-after-precise.png) |

<details>
<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
