### PR TITLE
search_pill: Show general chat for suggestions matching typed text.

### DIFF
--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -221,49 +221,29 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
             case "sender":
                 return search_user_pill_data_from_term(narrow_term);
             case "topic": {
-                if (search_pill.operand === "") {
-                    // There are three variants of this suggestion state:
-                    //
-                    // (1) This is an already formed pill, i.e. not in the text input
-                    // (`text_query`), or is not the last term in the text input, and
-                    //  therefore the empty operand represents "general chat".
-                    //
-                    // (2) The user has selected a topic operator, and thus has
-                    // exactly `topic:` or `-topic:` written out, and it's appropriate
-                    // to suggest the "general chat" operand.
-                    //
-                    // (3) We're suggesting `topic` as a potential operator to add, say
-                    // if the user has typed `-to` so far. For that case, we want to
-                    // suggest adding a topic operator, but the user hasn't done anything
-                    // that would suggest we should further complete "general chat" as an
-                    // operand for that topic operator.
-                    if (
-                        // case 1
-                        text_query === "" ||
-                        index < search_terms.length - 1 ||
-                        // case 2
-                        text_query.trimEnd().endsWith("topic:")
-                    ) {
-                        // We want to show a combined pill for the case
-                        // where the preceding operator is a `channel`.
-                        const combined_channel_topic_pill_render_data =
-                            maybe_generate_combined_channel_topic_pill(
-                                index,
-                                search_terms,
-                                search_pill,
-                            );
-                        if (combined_channel_topic_pill_render_data) {
-                            redundant_channel_pill_index = index - 1;
-                            return combined_channel_topic_pill_render_data;
-                        }
-
-                        return {
-                            ...search_pill,
-                            is_empty_string_topic: true,
-                            sign: search_pill.negated ? "-" : "",
-                            topic_display_name: util.get_final_topic_display_name(""),
-                        };
-                    }
+                // There are three variants of an empty operand:
+                //
+                // (1) This is an already formed pill, i.e. not in the text input
+                // (`text_query`), or is not the last term in the text input, and
+                // therefore the empty operand represents "general chat".
+                //
+                // (2) The user has selected a topic operator, and thus has
+                // exactly `topic:` or `-topic:` written out, and it's appropriate
+                // to suggest the "general chat" operand.
+                //
+                // (3) We're suggesting `topic` as a potential operator to add, say
+                // if the user has typed `-to` so far. For that case, we want to
+                // suggest adding a topic operator, but the user hasn't done anything
+                // that would suggest we should further complete "general chat" as an
+                // operand for that topic operator.
+                if (
+                    search_pill.operand === "" &&
+                    // not case 1
+                    text_query !== "" &&
+                    index === search_terms.length - 1 &&
+                    // not case 2
+                    !text_query.trimEnd().endsWith("topic:")
+                ) {
                     // case 3
                     return {
                         ...search_pill,
@@ -272,13 +252,22 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
                     };
                 }
 
-                // Try generating a combined channel topic pill for
-                // non-empty operands.
+                // We want to show a combined pill for the case
+                // where the preceding operator is a `channel`.
                 const combined_channel_topic_pill_render_data =
                     maybe_generate_combined_channel_topic_pill(index, search_terms, search_pill);
                 if (combined_channel_topic_pill_render_data) {
                     redundant_channel_pill_index = index - 1;
                     return combined_channel_topic_pill_render_data;
+                }
+
+                if (search_pill.operand === "") {
+                    return {
+                        ...search_pill,
+                        is_empty_string_topic: true,
+                        sign: search_pill.negated ? "-" : "",
+                        topic_display_name: util.get_final_topic_display_name(""),
+                    };
                 }
                 break;
             }

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -12,7 +12,11 @@ import * as input_pill from "./input_pill.ts";
 import type {InputPill, InputPillContainer} from "./input_pill.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
-import {type Suggestion, search_term_description_html} from "./search_suggestion.ts";
+import {
+    type Suggestion,
+    search_term_description_html,
+    search_text_matches_operator,
+} from "./search_suggestion.ts";
 import type {NarrowCanonicalTerm, NarrowTermSuggestion} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
@@ -186,8 +190,19 @@ function maybe_generate_combined_channel_topic_pill(
     };
 }
 
+// Whether the user is still typing out a `topic` operator, e.g. `to`
+// or `-topi`, as opposed to a topic operand like `topic:gen` or a bare
+// search term like `general`.
+function is_typing_topic_operator(text_query: string): boolean {
+    const last_term = Filter.parse(text_query).at(-1);
+    return (
+        last_term?.operator === "search" && search_text_matches_operator(last_term.operand, "topic")
+    );
+}
+
 export function generate_pills_html(suggestion: Suggestion, text_query: string): string {
     const search_terms = Filter.parse(suggestion);
+    const typing_topic_operator = is_typing_topic_operator(text_query);
 
     // This is used to track the index of the channel pill data
     // for a channel that is combined with the subsequent topic pill
@@ -221,30 +236,21 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
             case "sender":
                 return search_user_pill_data_from_term(narrow_term);
             case "topic": {
-                // There are three variants of an empty operand:
+                // An empty operand represents "general chat", whether
+                // in an already formed pill or in a suggestion matching
+                // the text the user is typing, like `topic:gen`.
                 //
-                // (1) This is an already formed pill, i.e. not in the text input
-                // (`text_query`), or is not the last term in the text input, and
-                // therefore the empty operand represents "general chat".
-                //
-                // (2) The user has selected a topic operator, and thus has
-                // exactly `topic:` or `-topic:` written out, and it's appropriate
-                // to suggest the "general chat" operand.
-                //
-                // (3) We're suggesting `topic` as a potential operator to add, say
-                // if the user has typed `-to` so far. For that case, we want to
-                // suggest adding a topic operator, but the user hasn't done anything
-                // that would suggest we should further complete "general chat" as an
-                // operand for that topic operator.
+                // The exception is when we're suggesting `topic` as a
+                // potential operator to add, say if the user has typed
+                // `-to` so far. For that case, we want to suggest adding
+                // a topic operator, but the user hasn't done anything
+                // that would suggest we should further complete "general
+                // chat" as an operand for that topic operator.
                 if (
                     search_pill.operand === "" &&
-                    // not case 1
-                    text_query !== "" &&
                     index === search_terms.length - 1 &&
-                    // not case 2
-                    !text_query.trimEnd().endsWith("topic:")
+                    typing_topic_operator
                 ) {
-                    // case 3
                     return {
                         ...search_pill,
                         is_empty_string_topic: true,

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -869,6 +869,13 @@ function get_sent_by_me_suggestions(
     return [];
 }
 
+// Whether the text the user is typing, e.g. `to` or `-topi`, is a
+// partial `operator`.
+export function search_text_matches_operator(search_operand: string, operator: string): boolean {
+    const operand = search_operand.startsWith("-") ? search_operand.slice(1) : search_operand;
+    return common.phrase_match(operand, operator);
+}
+
 function get_operator_suggestions(
     last: NarrowCanonicalTermSuggestion,
     terms: NarrowCanonicalTerm[],
@@ -876,13 +883,7 @@ function get_operator_suggestions(
     if (!(last.operator === "search" || last.operator === "")) {
         return [];
     }
-    let last_operand = last.operand;
-
-    let negated = false;
-    if (last_operand.startsWith("-")) {
-        negated = true;
-        last_operand = last_operand.slice(1);
-    }
+    const negated = last.operand.startsWith("-");
 
     let canonicalized_operator_choices: NarrowCanonicalOperator[];
     let legacy_operator_choices: NarrowTerm["operator"][];
@@ -928,7 +929,7 @@ function get_operator_suggestions(
     });
 
     const choices = [...canonicalized_operator_choices, ...legacy_operator_choices].filter(
-        (choice) => common.phrase_match(last_operand, choice),
+        (choice) => search_text_matches_operator(last.operand, choice),
     );
 
     return choices.map((choice) => {

--- a/web/tests/search.test.cjs
+++ b/web/tests/search.test.cjs
@@ -419,6 +419,49 @@ run_test("generate_pills_html with an empty topic operand", ({mock_template, ove
     assert.ok(!html.includes("empty-topic-display"));
 });
 
+run_test("generate_pills_html for general chat suggestions", ({mock_template, override}) => {
+    mock_template("search_list_item.hbs", true, (_data, html) => html);
+    override(realm, "realm_empty_topic_display_name", "general chat");
+
+    const channel_topic_suggestion = `channel:${verona.stream_id} topic:`;
+
+    function assert_suggests_general_chat(suggestion, text_query) {
+        const html = search_pill.generate_pills_html(suggestion, text_query);
+        assert.ok(html.includes("empty-topic-display"));
+        assert.ok(html.includes("translated: general chat"));
+    }
+
+    function assert_suggests_topic_operator(suggestion, text_query) {
+        const html = search_pill.generate_pills_html(suggestion, text_query);
+        assert.ok(!html.includes("empty-topic-display"));
+        assert.ok(!html.includes("translated: general chat"));
+        assert.ok(html.includes("topic:"));
+    }
+
+    // An empty topic operand is rendered as general chat when it's an
+    // already formed pill, a bare `topic:` operator, a topic of a
+    // channel the user has typed, or matches the text the user is
+    // typing for the topic.
+    assert_suggests_general_chat(channel_topic_suggestion, "");
+    assert_suggests_general_chat(channel_topic_suggestion, "topic:");
+    assert_suggests_general_chat(channel_topic_suggestion, "-topic:");
+    assert_suggests_general_chat(channel_topic_suggestion, `channel:${verona.stream_id}`);
+    assert_suggests_general_chat(channel_topic_suggestion, "topic:gen");
+    assert_suggests_general_chat(channel_topic_suggestion, "topic:general chat");
+    assert_suggests_general_chat(channel_topic_suggestion, "general");
+    assert_suggests_general_chat(channel_topic_suggestion, "chat");
+
+    // But when the user is still typing the `topic` operator itself,
+    // we're suggesting the operator, not the general chat topic.
+    assert_suggests_topic_operator(channel_topic_suggestion, "to");
+    assert_suggests_topic_operator(channel_topic_suggestion, "Topic");
+    assert_suggests_topic_operator(`channel:${verona.stream_id} -topic:`, "-to");
+
+    // The operator suggestion only applies to the last term; an
+    // earlier empty topic term is always general chat.
+    assert_suggests_general_chat(`channel:${verona.stream_id} topic: has:link`, "to");
+});
+
 run_test("set_search_bar_contents with duplicate pills", () => {
     const duplicate_attachment_terms = [
         {


### PR DESCRIPTION
Since 62093ee37d, an empty topic operand in a suggestion is only rendered with the "general chat" display name when the typed text is empty or ends in exactly `topic:`. But `get_topic_suggestions` also suggests the empty topic whenever the typed text matches its display name, e.g. `topic:gen` or `general chat`, and those rows rendered as a bare `topic:` pill, indistinguishable from the suggestion to add a topic operator.

Instead, only omit the display name when the last typed term is a prefix of the `topic` operator itself, mirroring the condition under which `get_operator_suggestions` offers that operator.

Discussed in
https://chat.zulip.org/#narrow/channel/9-issues/topic/general.20chat.20in.20search/with/2499566
