### PR TITLE
docs: Better guide users on including screenshots.

### DIFF
--- a/docs/contributing/reviewable-prs.md
+++ b/docs/contributing/reviewable-prs.md
@@ -87,9 +87,11 @@ description for your pull request, you will:
 - Call out any open questions, concerns, or decisions you are uncertain about.
   The review process will go a lot more smoothly if points of uncertainty are
   explicitly laid out.
-- Include screenshots for all visual changes, so that they can be reviewed
-  without running your code. Be sure to follow our
-  [guide on presenting visual changes](../contributing/presenting-visual-changes.md).
+- [Include screenshots of any parts of the UI impacted by your PR](../contributing/presenting-visual-changes.md),
+  so that your changes can be quickly assessed without a reviewer needing to run
+  your code. It's just as important to document interface changes as it is to
+  demonstrate that your changes do not introduce any regressions to the UI's look
+  or interactions.
 
 If you have a question about a specific part of your code that you expect to be
 resolved during the review process, put it in a PR comment attached to a


### PR DESCRIPTION
Let's make it harder for contributors to miss the link to the guide to screenshot preparation, and also make it clearer that screenshots are required much more broadly to document changes as well as prove that changes do not introduce visual/interactive regressions.

Fixes: [#documentation > adding visual changes section to reviewable PRs doc](https://chat.zulip.org/#narrow/channel/19-documentation/topic/adding.20visual.20changes.20section.20to.20reviewable.20PRs.20doc/with/2479130)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1380" height="1160" alt="explain-your-changes-before" src="https://github.com/user-attachments/assets/ebddb14c-d960-4a2c-b30e-c337a4809895" /> | <img width="1380" height="1160" alt="explain-your-changes-after" src="https://github.com/user-attachments/assets/0e4d0cad-0c2d-4c0f-9d97-0a1136e1bf2f" /> |
