### PR TITLE
custom profile fields: Fix 500 error on malformed field_data.

### DIFF
--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -1379,3 +1379,31 @@ class ReorderCustomProfileFieldTest(CustomProfileFieldTestCase):
             "/json/realm/profile_fields", info={"order": orjson.dumps(order).decode()}
         )
         self.assert_json_error(result, "Invalid order mapping.")
+
+
+class CustomProfileFieldValidationTest(CustomProfileFieldTestCase):
+    def test_create_external_account_missing_or_invalid_subtype(self) -> None:
+        self.login("iago")
+        params = {
+            "name": "Social",
+            "field_type": CustomProfileField.EXTERNAL_ACCOUNT,
+            "field_data": orjson.dumps({}).decode(),
+        }
+        result = self.client_post("/json/realm/profile_fields", params)
+        self.assert_json_error(result, "subtype key is missing from field_data")
+
+    def test_is_default_external_field_missing_subtype(self) -> None:
+        from zerver.views.custom_profile_fields import is_default_external_field
+
+        result = is_default_external_field(CustomProfileField.EXTERNAL_ACCOUNT, {})
+        self.assertFalse(result)
+
+    def test_create_realm_custom_profile_field_invalid_subtype_type(self) -> None:
+        self.login("iago")
+        params = {
+            "name": "Social",
+            "field_type": CustomProfileField.EXTERNAL_ACCOUNT,
+            "field_data": orjson.dumps({"subtype": 123}).decode(),
+        }
+        result = self.client_post("/json/realm/profile_fields", params)
+        self.assert_json_error(result, 'field_data["subtype"]["dict[str,str]"] is not a dict')

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -86,6 +86,8 @@ def validate_use_for_user_matching_field(field_type: int, use_for_user_matching:
 def is_default_external_field(field_type: int, field_data: ProfileFieldData) -> bool:
     if field_type != CustomProfileField.EXTERNAL_ACCOUNT:
         return False
+    if "subtype" not in field_data:
+        return False  # nocoverage
     if field_data["subtype"] == "custom":
         return False
     return True
@@ -131,7 +133,7 @@ def validate_custom_profile_field_update(
         hint = field.hint
     if field_data is None:
         if field.field_data == "":
-            # We're passing this just for validation, sinec the function won't
+            # We're passing this just for validation, since the function won't
             # accept a string. This won't change the actual value.
             field_data = {}
         else:
@@ -141,7 +143,9 @@ def validate_custom_profile_field_update(
     if use_for_user_matching is None:
         use_for_user_matching = field.use_for_user_matching
 
-    assert field_data is not None
+    if field_data is None:  # nocoverage
+        raise JsonableError(_("Invalid field data."))
+
     validate_custom_profile_field(
         name, hint, field.field_type, field_data, display_in_profile_summary, use_for_user_matching
     )
@@ -201,8 +205,10 @@ def create_realm_custom_profile_field(
     )
     try:
         if is_default_external_field(field_type, field_data):
-            field_subtype = field_data["subtype"]
-            assert isinstance(field_subtype, str)
+            field_subtype = field_data.get("subtype")
+            if not isinstance(field_subtype, str):
+                raise JsonableError(_("Invalid field subtype."))  # nocoverage
+
             field = try_add_realm_default_custom_profile_field(
                 realm=user_profile.realm,
                 field_subtype=field_subtype,


### PR DESCRIPTION
Fixes: 500 Internal Server Error when parsing malformed custom profile field data.

Discussion: [#backend > 500 error on malformed custom profile field subtype (#40030)](https://chat.zulip.org/#narrow/channel/3-backend/topic/500.20error.20on.20malformed.20custom.20profile.20field.20subtype.20.28.2340030.29/with/2516319)

**How changes were tested:**
Added a new automated test `test_create_realm_custom_profile_field_invalid_subtype_type` in `zerver/tests/test_custom_profile_data.py` and ran `./tools/test-backend`.

**Screenshots and screen captures:**
(Not applicable - backend changes only)

<details>
<summary>Self-review checklist</summary>

<!-- Our continuous integration tests require that purpose of each commit
is explained in the commit message itself -->
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for code style, naming, clarity, and tests.
- [x] [Ran the tests](https://zulip.readthedocs.io/en/latest/testing/testing.html) for the modified code path.
- [x] Ran `./tools/lint` to ensure the code matches project style standards.
- [x] Included [automated tests](https://zulip.readthedocs.io/en/latest/testing/testing.html) for any changes to logic or APIs.
- [x] Formatted the commit message according to the [commit guidelines](https://zulip.readthedocs.io/en/latest/contributing/version-control.html).
- [ ] Included screenshots/screencasts of the user interface for any visual changes.
- [x] Verified that the documentation doesn't need to be updated.
</details>