### PR TITLE
typeahead: Fix momentary invalid outline on subscriber input

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -676,11 +676,16 @@ export class Typeahead<ItemType extends string | object> {
         scroll_util.scroll_element_into_container($prev, this.$menu);
     }
 
+    input(): void {
+        this.lookup(false);
+    }
+
     listen(): void {
         $(this.input_element.$element)
             .on("blur", this.blur.bind(this))
             .on("keypress", this.keypress.bind(this))
             .on("keyup", this.keyup.bind(this))
+            .on("input", this.input.bind(this))
             .on("click", this.element_click.bind(this))
             .on("focus", this.element_focus.bind(this))
             .on("keydown", this.keydown.bind(this))
@@ -703,7 +708,7 @@ export class Typeahead<ItemType extends string | object> {
     unlisten(): void {
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus"];
+        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus", "input"];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }


### PR DESCRIPTION
Fixes: #40017

When adding subscribers quickly, pressing Enter immediately after typing a character could briefly show the red invalid outline.

This happened because the typeahead suggestions were updated on `keyup`, so the Enter key could reach the subscriber input before the typeahead had updated its state.

This change updates the typeahead on the `input` event so that suggestions are available immediately after the input changes.

**How changes were tested:**

- Tested adding subscribers quickly by typing a character and pressing Enter.
- Confirmed that the subscriber is added without the red invalid outline.

**Screenshots and screen capture:**

| Subscriber Input, before | Subscriber Input, after |
| --- | --- |
| ![demo1before](https://github.com/user-attachments/assets/67c6a087-c258-4287-bc5d-9a305aaa2cbb) | ![demo1after](https://github.com/user-attachments/assets/da8b0718-726a-4b8d-8ee7-66295a13ea88) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
