### PR TITLE
api-docs: Revise feature level 212 update.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -2826,14 +2826,16 @@ No changes; feature level used for Zulip 8.0 release.
 
 **Feature level 212**
 
-* [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue),
-  `PATCH /realm`: Added the `jitsi_server_url` field to the `realm` object,
-  allowing organizations to set a custom Jitsi Meet server. Previously, this
-  was only available as a server-level configuration.
+* [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue)
+  `PATCH /realm`: Added the `jitsi_server_url` realm setting, allowing
+  organizations to set a custom Jitsi Meet server. Previously, this was
+  only available as a server-level configuration.
 
 * [`POST /register`](/api/register-queue): Added `server_jitsi_server_url`
-  fields to the `realm` object. The existing `jitsi_server_url` will now be
-  calculated as `realm_jitsi_server_url || server_jitsi_server_url`.
+  field to the response for the Jitsi Meet server-level configuration. The
+  existing `jitsi_server_url` field, which previously was the same value of
+  the new field, is now deprecated and will be calculated as
+  `realm_jitsi_server_url ?? server_jitsi_server_url`.
 
 **Feature level 211**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5652,8 +5652,8 @@ paths:
                                         The URL of the custom Jitsi Meet server configured in this organization's
                                         settings.
 
-                                        `null`, the default, means that the organization is using the should use the
-                                        server-level configuration, `server_jitsi_server_url`.
+                                        `null`, the default, means that the organization is using the server-level
+                                        configuration, `server_jitsi_server_url`.
 
                                         **Changes**: New in Zulip 8.0 (feature level 212). Previously, this was only
                                         available as a server-level configuration, and required a server restart to
@@ -21214,10 +21214,10 @@ paths:
                           The URL of the custom Jitsi Meet server configured in this organization's
                           settings.
 
-                          `null`, the default, means that the organization is using the should use the
-                          server-level configuration, `server_jitsi_server_url`. A correct client
-                          supporting only the modern API should use `realm_jitsi_server_url ??
-                          server_jitsi_server_url` to create calls.
+                          `null`, the default, means that the organization is using the server-level
+                          configuration, `server_jitsi_server_url`. A correct client supporting only
+                          the modern API should use `realm_jitsi_server_url ?? server_jitsi_server_url`
+                          to create calls.
 
                           **Changes**: New in Zulip 8.0 (feature level 212). Previously, this was only
                           available as a server-level configuration, which was available via the

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -21216,7 +21216,7 @@ paths:
 
                           `null`, the default, means that the organization is using the should use the
                           server-level configuration, `server_jitsi_server_url`. A correct client
-                          supporting only the modern API should use `realm_jitsi_server_url ||
+                          supporting only the modern API should use `realm_jitsi_server_url ??
                           server_jitsi_server_url` to create calls.
 
                           **Changes**: New in Zulip 8.0 (feature level 212). Previously, this was only
@@ -21813,14 +21813,14 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           The base URL to be used to create Jitsi video calls. Equals
-                          `realm_jitsi_server_url || server_jitsi_server_url`.
+                          `realm_jitsi_server_url ?? server_jitsi_server_url`.
 
                           **Changes**: Deprecated in Zulip 8.0 (feature level 212) and will
                           eventually be removed. Previously, the Jitsi server to use was not
                           configurable on a per-realm basis, and this field contained the server's
                           configured Jitsi server. (Which is now provided as
                           `server_jitsi_server_url`). Clients supporting older versions should fall
-                          back to this field when creating calls: using `realm_jitsi_server_url ||
+                          back to this field when creating calls: using `realm_jitsi_server_url ??
                           server_jitsi_server_url` with newer servers and using `jitsi_server_url`
                           with servers below feature level 212.
                       development_environment:


### PR DESCRIPTION
Implements the feedback from this review: https://github.com/zulip/zulip/pull/26399#pullrequestreview-1640559330 on the implementation of a realm setting for the Jitsi Meet server URL.

**Notes**:
- Uses `??` instead of `||` for the pseudo code in the documentation.
- Fixes the two "is using the should use the" typos.
- Revises the feature level 212 changelog entries to better follow our general practices.

@sahil839 tagging you for integration review. @chrisbobbe flagging you just so that you're looped in to API docs update.

---

**Screenshots and screen captures:**

*Examples of the changes, but not all the parts of the documentation that were updated for the above revisions*

**`realm_jitsi_server_url` in the register response documentation - [current doc link](https://zulip.com/api/register-queue), search for the field on the page.**

<img width="1504" height="476" alt="Screenshot From 2026-08-27 20-01-20" src="https://github.com/user-attachments/assets/ca717eda-476a-4f8c-8450-f583826c15d0" />

**Feature level 212 changelog note - [current doc link](https://zulip.com/api/changelog), search for the feature level number**

<img width="1504" height="464" alt="Screenshot From 2026-08-27 19-59-56" src="https://github.com/user-attachments/assets/822491cc-e2b7-4ae4-9bef-d6203f9b09ef" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
