### PR TITLE
portico: Add landing page at /case-studies/.

### DIFF
--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -165,6 +165,11 @@ landing_page_urls = [
     path("role/engineers/", landing_view, {"template_name": "corporate/role/engineers.html"}),
     # case-studies
     path(
+        "case-studies/",
+        landing_view,
+        {"template_name": "corporate/case-studies/case-studies.html"},
+    ),
+    path(
         "case-studies/idrift/",
         landing_view,
         {"template_name": "corporate/case-studies/idrift-case-study.html"},

--- a/templates/corporate/case-studies/case-studies.html
+++ b/templates/corporate/case-studies/case-studies.html
@@ -1,0 +1,28 @@
+{% extends "zerver/marketing_page.html" %}
+
+{% set PAGE_TITLE = "Case studies | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Real-world examples of Zulip in use for business, education, research, open-source projects, and communities." %}
+
+{% block marketing_content %}
+
+<div class="portico-landing why-page solutions-page case-study-page">
+    <div class="hero bg-education">
+        <div class="bg-dimmer"></div>
+        <div class="content">
+            <h1 class="center">Case studies</h1>
+        </div>
+        <div class="hero-text">
+            Does choosing Zulip really make a difference? Read about how Zulip has transformed communication across industries and use cases.
+        </div>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content markdown">
+                {{ render_markdown_path('corporate/case-studies/case-studies.md') }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/corporate/case-studies/case-studies.md
+++ b/templates/corporate/case-studies/case-studies.md
@@ -1,0 +1,75 @@
+Zulip’s organized team chat app makes communication dramatically more efficient
+than other popular apps like Slack and Microsoft Teams, which push teams towards
+chaotic and disruptive communication patterns.
+
+But don't just take our word for it. Across diverse, demanding organizations
+in [business](#business), [education and research](#education-and-research),
+and [open-source projects and communities](#open-source-projects-and-communities),
+the case studies below feature Zulip users describing in detail how Zulip supports
+and transforms communication for the better.
+
+## Business
+
+- ### [Efficient distributed team management at iDrift AS](/case-studies/idrift/)
+  While Slack worked reasonably well for real-time chat, busy Slack channels
+  hindered async discussions. iDrift AS evaluated and adopted Zulip in 2020.
+- ### [Easy communication for 1000 agents at GUT contact](/case-studies/gut-contact/)
+  GUT contact offers flexibility to work from one of 10 offices across 3 countries,
+  or from home. Zulip keeps teams in sync across all job functions.
+- ### [Managing hundreds of projects at End Point Dev](/case-studies/end-point/)
+  For nearly a decade, Zulip has been a virtual office for End Point’s distributed
+  team. Discussing projects in Zulip channels keeps everyone informed.
+- ### [Worldwide operations and AI at WindBorne](/case-studies/windborne/)
+  Zulip is WindBorne's irreplaceable hub for coordinating work ranging from
+  balloon launches around the globe to developing state-of-the-art AI models.
+- ### [More efficient communication than Slack at Semsee](/case-studies/semsee/)
+  New Semsee employees adapt easily to Zulip’s organized conversations. They quickly
+  develop an intuition for when to start a new topic, and what topic names work well.
+- ### [Open distributed communication at Atolio](/case-studies/atolio/)
+  Since February 2020, Zulip’s organized team chat has enabled the open
+  communication culture Atolio’s founders wanted.
+
+## Education and research
+
+- ### [Organized chat for 1000s of students at TUM](/case-studies/tum/)
+  Prior to adopting Zulip, instructors had cycled through product after product
+  in search of a way to effectively manage communication among their 30-50
+  person course staff and 1400-2000 students at a time.
+- ### [Communication hub across 6 continents at UCSD](/case-studies/ucsd/)
+  With students logging in at all hours of the day, Zulip’s topic model is key for
+  finding materials and participating in discussions. Zulip’s rich functionality
+  smoothed out many aspects of remote communication.
+- ### [Connecting across generations at the National University of Córdoba](/case-studies/university-of-cordoba/)
+  The Mathematics, Astronomy, Physics and Computing (FAMAF) department tried moving
+  to Slack. However, without a software budget, the 90-day message history limit on
+  Slack’s free plan was a major frustration.
+- ### [Research collaboration at scale in the Lean mathematical community](/case-studies/lean/)
+  Zulip’s unique combination of topic-based organization with a casual chat app feel
+  helps the Lean community create a welcoming environment for newcomers.
+
+## Open-source projects and communities
+
+- ### [Inclusive discussion in the open-source Asciidoctor community](/case-studies/asciidoctor/)
+  If a topic starts in the wrong place or veers off course, Zulip’s moderation
+  tools make it easy to fix. Community moderators can keep the dialogue
+  organized by reclassifying topics and posts without disrupting the ongoing
+  conversation.
+- ### [Faster decision-making in the Rust language community](/case-studies/rust/)
+  In contrast to other chat tools, Zulip makes it pleasant to have multiple
+  conversations at once. Zulip’s thread-based organization creates a clear record
+  of past discussions, documenting the decision-making process.
+- ### [Platform for a worldwide community since 2013 at Recurse Center](/case-studies/recurse-center/)
+  The Recurse Center was an early adopter of Zulip. They began to use the product
+  in January 2013, when it was still in private beta. Even then, Zulip’s
+  thoughtful design made it stand out.
+- ### [Professional community support at Rush Stack](/case-studies/rush-stack/)
+  To make the transition, Rush Stack imported the project’s full chat history from
+  Gitter into Zulip, making it an easily searchable resource. Enabling Zulip’s
+  feature for logging in with GitHub meant that users didn’t have to make new
+  accounts.
+- ### [Collaboration drives innovation at Mixxx](/case-studies/mixxx/)
+  Zulip has proven perfectly suited to support Mixxx’s worldwide community: It has
+  made collaboration easier, and community engagement has grown as a result. Zulip’s
+  threading model works well for occasional participants in the community, and
+  world-public channels make it possible to view discussions without even creating
+  an account.

--- a/templates/corporate/hello.html
+++ b/templates/corporate/hello.html
@@ -151,7 +151,7 @@
             <div class="screen-3__container">
                 <div class="screen-3__content">
                     <h2 class="screen-3__header">Zulip empowers remote and flexible work.</h2>
-                    <div class="screen-3__subtitle">Check out these case studies to see the impact.</div>
+                    <div class="screen-3__subtitle">Check out these <a href="/case-studies/">case studies</a> to see the impact.</div>
                     <div class='screen-3__quotes'>
                         <a class="quote" href="/case-studies/atolio/">
                             <div class="quote__text">

--- a/web/styles/portico/hello.css
+++ b/web/styles/portico/hello.css
@@ -622,6 +622,7 @@ ul {
     }
 
     .screen-2__desc a,
+    .screen-3__subtitle a,
     .screen-4__desc a {
         font-weight: 550;
         text-decoration: underline;
@@ -632,6 +633,7 @@ ul {
     }
 
     .screen-2__desc a:hover,
+    .screen-3__subtitle a:hover,
     .screen-4__desc a:hover {
         text-decoration-color: hsl(0deg 0% 100%);
         transition: none;

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -323,6 +323,7 @@ class DocPageTest(ZulipTestCase):
         self._test("/zulip-cloud/", ["Zulip Cloud"])
         self._test("/security/", ["TLS encryption"])
         self._test("/use-cases/", ["Use cases and customer stories"])
+        self._test("/case-studies/", ["Case studies"])
         self._test("/why-zulip/", ["Why Zulip?"])
         # /for/... pages
         self._test("/for/open-source/", ["for open source projects"])


### PR DESCRIPTION
This PR adds a landing page for quicker reference to our many case studies.

It Frankensteins together some of Zulip's marketing copy, and pulls in interesting pieces of the case studies themselves to entice users to read on.

This also links from the home page to the new `/case-studies/` page, to aid with search-engine indexing.

<img width="2000" height="5600" alt="case-studies-landing-page-02" src="https://github.com/user-attachments/assets/870b72d0-079e-4a56-8f3b-8de45dbc9cf1" />

