### PR TITLE
[ai] install: Reject non-ASCII hostnames before installing anything.

### DIFF
--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -102,7 +102,8 @@ of the failure, you can just rerun the script. For more information, see
 
 - `--hostname=zulip.example.com`: The user-accessible domain name for this Zulip
   server, i.e., what users will type in their web browser. This becomes
-  `EXTERNAL_HOST` in the Zulip [settings][doc-settings].
+  `EXTERNAL_HOST` in the Zulip [settings][doc-settings]. Use Punycode for
+  non-ASCII domains.
 
 - `--certbot`: With this option, the Zulip installer automatically obtains an
   SSL certificate for the server [using Certbot][doc-certbot], and configures a

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -13,6 +13,7 @@ Options:
       The user-accessible domain name for this Zulip server, i.e.,
       what users will type in their web browser.  Required, unless
       --no-init-db or --puppet-classes is set, and --certbot is not.
+      Use Punycode for non-ASCII domains.
 
   --email=zulip-admin@example.com
       The email address of the person or team who should get support
@@ -224,6 +225,33 @@ if [ "$EXTERNAL_HOST" = zulip.example.com ] \
     usage >&2
     exit 1
 fi
+
+case "$EXTERNAL_HOST" in
+    *[![:ascii:]]*)
+        # Non-ASCII hostnames are specifically checked for and would
+        # fail later; see zerver/checks.py
+        echo "error: The hostname ($EXTERNAL_HOST) contains non-ASCII characters." >&2
+        echo 'Internationalized domain names must be specified in punycode ("xn--") form:' >&2
+        # python3 is not installed until later, so it may not be
+        # available to compute the suggested encoding.
+        if command -v python3 >/dev/null 2>&1; then
+            suggestion="$(python3 -c '
+import sys
+
+hostname, sep, port = sys.argv[1].partition(":")
+print(
+    ".".join(
+        "xn--" + label.encode("punycode").decode() if not label.isascii() else label
+        for label in hostname.split(".")
+    )
+    + sep
+    + port
+)' "$EXTERNAL_HOST")"
+            echo "    --hostname=$suggestion" >&2
+        fi
+        exit 1
+        ;;
+esac
 
 case "$POSTGRESQL_VERSION" in
     [0-9] | [0-9].* | 1[0-3] | 1[0-3].*)


### PR DESCRIPTION
A non-ASCII EXTERNAL_HOST fails the system checks from zerver/checks.py, but those only run near the end of the install; worse, with --certbot, the install first dies inside certbot, which rejects Unicode arguments with a confusing error.  Either way, the user learns their hostname is unusable only after waiting through the full package installation.

Check the hostname up front, during argument validation, and suggest its punycode encoding, computed in the same way which zerver/checks.py computes it.  The encoding is only suggested, never applied automatically: the bare label-by-label punycode transform skips IDNA's mapping and validation steps, so the user should confirm the encoded name against what they registered in DNS.

Based on, and reported in, #33502.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
