### PR TITLE
markdown: Fix MarkdownListPreprocessor list-item detection bugs.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1541,7 +1541,7 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     directly after a line of text, and inserts a newline between
     to satisfy Markdown"""
 
-    LI_RE = re.compile(r"^[ ]*([*+-]|\d\.)[ ]+(.*)", re.MULTILINE)
+    LI_RE = re.compile(r"^[ ]*([*+-]|\d+\.)[ ]+(.*)", re.MULTILINE)
 
     @override
     def run(self, lines: list[str]) -> list[str]:
@@ -1580,12 +1580,25 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
                 and lines[i]
                 and (
                     (li2 and not li1)
-                    or (li1 and li2 and (len(li1.group(1)) == 1) != (len(li2.group(1)) == 1))
+                    or (
+                        li1
+                        and li2
+                        and (len(li1.group(1)) == 1) != (len(li2.group(1)) == 1)
+                        # A differently-typed item indented deeper than the
+                        # current one starts a nested sub-list, which Markdown
+                        # handles on its own; inserting a blank line there
+                        # would wrap the parent item in a <p> tag.
+                        and self.indentation(lines[i + 1]) <= self.indentation(lines[i])
+                    )
                 )
             ):
                 copy.insert(i + inserts + 1, "")
                 inserts += 1
         return copy
+
+    @staticmethod
+    def indentation(line: str) -> int:
+        return len(line) - len(line.lstrip(" "))
 
 
 # Name for the outer capture group we use to separate whitespace and

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -503,6 +503,26 @@ class MarkdownListPreprocessorTest(ZulipTestCase):
         original, expected = self.split_message("```\nList without a gap\n* One\n* Two\n```")
         self.assertEqual(preprocessor.run(original), expected)
 
+    def test_multi_digit_ordered_item_after_nested_unordered_list(self) -> None:
+        preprocessor = MarkdownListPreprocessor()
+        # "10. ten" must be recognized as an ordered list item resuming after
+        # the nested unordered list, not as part of it.
+        original, expected = self.split_message("8. eight\n9. nine\n  - sub item\n<>10. ten")
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_nested_list_of_different_type(self) -> None:
+        preprocessor = MarkdownListPreprocessor()
+        # A differently-typed sub-list nested under a list item is handled by
+        # Markdown itself; a blank line here would wrap the parent item in <p>.
+        original, expected = self.split_message("1. Parent item\n  * nested bullet")
+        self.assertEqual(preprocessor.run(original), expected)
+
+    def test_sibling_list_of_different_type(self) -> None:
+        preprocessor = MarkdownListPreprocessor()
+        # A differently-typed list at the same level still needs the separator.
+        original, expected = self.split_message("* bullet\n<>1. ordered")
+        self.assertEqual(preprocessor.run(original), expected)
+
     def test_complex_nesting_with_different_fences(self) -> None:
         preprocessor = MarkdownListPreprocessor()
         msg = """```quote


### PR DESCRIPTION
Fixes: #39797

`MarkdownListPreprocessor` decides where a blank line must be inserted so that Markdown starts a new list block. It had two flaws in that decision, fixed here:

1. `LI_RE` matched only single-digit ordered items (`\d\.`). A multi-digit item such as `10. ten` following a nested unordered item was not recognized as a list item at all, so no separator was inserted and it rendered as part of the nested unordered list instead of the next item of the ordered list (first checkbox of the issue). The pattern now uses `\d+\.`, matching what the list block processors use. The existing bullet-vs-ordered check (`len(group(1)) == 1`) already works for multi-digit markers, since ordered markers are always longer than the single-character bullet markers.

2. The different-type clause inserted a blank line between a list item and *any* differently-typed item, including one indented deeper under it (second checkbox of the issue). Markdown nests such sub-lists on its own; the extra blank line is what wrapped the parent item in a `<p>` tag. The separator is now only inserted when the second item is not indented deeper than the first, so same-level type switches still get one and nested sub-lists do not.

**How changes were tested:**

- Added direct unit tests to `MarkdownListPreprocessorTest` covering the multi-digit case from the issue, the nested-different-type case, and the same-level type switch (which must keep its separator).
- Verified the preprocessor output directly for these and the pre-existing behaviors (paragraph-to-list insertion, same-type nesting, no-op inside code fences, blank-line separation) - all pass.
- Rendered the post-preprocessor output for the issue's reproducer with python-markdown 3.10.3 (the pinned version) plus the nl2br/tables extensions: the ordered list now resumes at `10.` instead of absorbing `10. ten` into the nested `<ul>`.

Zulip CI will exercise the fixture suite for full-render confirmation.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
