### PR TITLE
checks: Add check for jitsi server URL configuration error.

### DIFF
--- a/zerver/apps.py
+++ b/zerver/apps.py
@@ -13,6 +13,7 @@ from typing_extensions import override
 from zerver.checks import (
     check_auth_settings,
     check_external_host_setting,
+    check_jitsi_server_url,
     check_required_settings,
     check_uploads_settings,
 )
@@ -60,6 +61,7 @@ class ZerverConfig(AppConfig):
         register(check_external_host_setting)
         register(check_auth_settings)
         register(check_uploads_settings)
+        register(check_jitsi_server_url)
 
         if settings.SENTRY_DSN:  # nocoverage
             from zproject.config import get_config

--- a/zerver/checks.py
+++ b/zerver/checks.py
@@ -8,6 +8,22 @@ from django.conf import settings
 from django.core import checks
 
 
+def get_settings_error_message_strings(setting_name: str) -> tuple[str, str]:
+    # Even in Docker, MANUAL_CONFIGURATION means the admin
+    # manages /etc/zulip/settings.py themselves, so the SETTING_*
+    # environment variables are not where to make changes.
+    if settings.RUNNING_IN_HELM:
+        settings_location = "your Helm values"
+        setting_display_name = "zulip.environment.SETTING_" + setting_name
+    elif settings.RUNNING_IN_DOCKER and os.environ.get("MANUAL_CONFIGURATION") != "True":
+        settings_location = "your Docker environment configuration"
+        setting_display_name = "SETTING_" + setting_name
+    else:
+        settings_location = "/etc/zulip/settings.py"
+        setting_display_name = setting_name
+    return settings_location, setting_display_name
+
+
 def check_required_settings(
     app_configs: Sequence[AppConfig] | None,
     databases: Sequence[str] | None,
@@ -31,18 +47,7 @@ def check_required_settings(
         if value and value != default:
             continue
 
-        # Even in Docker, MANUAL_CONFIGURATION means the admin
-        # manages /etc/zulip/settings.py themselves, so the SETTING_*
-        # environment variables are not where to make changes.
-        if settings.RUNNING_IN_HELM:
-            settings_location = "your Helm values"
-            setting_display_name = "zulip.environment.SETTING_" + setting_name
-        elif settings.RUNNING_IN_DOCKER and os.environ.get("MANUAL_CONFIGURATION") != "True":
-            settings_location = "your Docker environment configuration"
-            setting_display_name = "SETTING_" + setting_name
-        else:
-            settings_location = "/etc/zulip/settings.py"
-            setting_display_name = setting_name
+        settings_location, setting_display_name = get_settings_error_message_strings(setting_name)
         if value:
             # The setting is still the example value from the
             # documentation, which the admin must replace -- saying

--- a/zerver/checks.py
+++ b/zerver/checks.py
@@ -6,6 +6,8 @@ from typing import Any
 from django.apps.config import AppConfig
 from django.conf import settings
 from django.core import checks
+from django.core.exceptions import ValidationError
+from django.core.validators import URLValidator
 
 
 def get_settings_error_message_strings(setting_name: str) -> tuple[str, str]:
@@ -209,3 +211,36 @@ def check_uploads_settings(
             )
         ]
     return []
+
+
+def check_jitsi_server_url(
+    app_configs: Sequence[AppConfig] | None,
+    databases: Sequence[str] | None,
+    **kwargs: Any,
+) -> Iterable[checks.CheckMessage]:
+    # As of Zulip 12.0, the web app will not load if a server-level
+    # Jitsi Meet integration has been configured that is not a URL.
+    # A None value is the valid way to disable the integration. By
+    # default, the integration uses the SaaS https://meet.jit.si
+    # server.
+    jitsi_server_url = settings.JITSI_SERVER_URL
+    if jitsi_server_url is None or jitsi_server_url == "https://meet.jit.si":
+        return []
+
+    assert isinstance(jitsi_server_url, str)
+    validate = URLValidator()
+    try:
+        validate(jitsi_server_url)
+        return []
+    except ValidationError:
+        settings_location, setting_display_name = get_settings_error_message_strings(
+            "JITSI_SERVER_URL"
+        )
+        message = f"{setting_display_name} in {settings_location} is not a URL"
+        return [
+            checks.Error(
+                message,
+                obj="settings.JITSI_SERVER_URL",
+                id="zulip.E007",
+            )
+        ]

--- a/zerver/tests/test_checks.py
+++ b/zerver/tests/test_checks.py
@@ -245,3 +245,28 @@ class TestChecks(ZulipTestCase):
 
     def test_checks_uploads_local_dir_valid(self) -> None:
         self.assert_check_with_error(None)
+
+    @override_settings(RUNNING_IN_DOCKER=False)
+    def test_check_jitsi_server_url(self) -> None:
+        self.assert_check_with_error(
+            "(zulip.E007) JITSI_SERVER_URL in /etc/zulip/settings.py is not a URL",
+            JITSI_SERVER_URL="example.jitsi.com",
+        )
+
+    @override_settings(RUNNING_IN_DOCKER=True)
+    def test_check_jitsi_server_url_in_docker(self) -> None:
+        self.assert_check_with_error(
+            "(zulip.E007) SETTING_JITSI_SERVER_URL in your Docker environment configuration is not a URL",
+            JITSI_SERVER_URL="jitsi[etc]",
+        )
+
+    @override_settings(RUNNING_IN_DOCKER=True, RUNNING_IN_HELM=True)
+    def test_check_jitsi_server_url_in_helm(self) -> None:
+        self.assert_check_with_error(
+            "(zulip.E007) zulip.environment.SETTING_JITSI_SERVER_URL in your Helm values is not a URL",
+            JITSI_SERVER_URL="example.com/jitsi",
+        )
+
+    @override_settings(JITSI_SERVER_URL="https://example.com/jitsi")
+    def test_check_jitsi_server_url_valid(self) -> None:
+        self.assert_check_with_error(None)


### PR DESCRIPTION
As noted in this review https://github.com/zulip/zulip/pull/39412#discussion_r3834774743, instead of guessing at how to correctly fix the string that's set for `settings.JITSI_SERVER_URL` so that it's a URL that can be parsed by the web app, we should just treat it as a configuration error.

Adds `check_jitsi_server_url` in `zerver/checks.py` to check the URL set for `JITSI_SERVER_URL` on the server.
    
CZO discussion: [#production help > 12.0 frontend stuck loading](https://chat.zulip.org/#narrow/channel/31-production-help/topic/12.2E0.20frontend.20stuck.20loading/with/2515689).

Fixes #39230.

**Notes**:
- I have not updated the description of #39230 for the fact that we're not allowing barehost names any longer if we go this route, but I have marked this PR as closing that issue.
- ~Even though this is the only not "required to change" setting that's being checked, I set up the changes so that it would be possible to add other settings here in the future.~ It's now it's own separate check
- In the tests, I varied the non-URL string for the different providers based on some of the ones we've seen as folks have reported the issue ("example.jitsi.com", "jitsi[etc]", "example.com/jitsi"). Not sure if it would be better to use just one or loop over the options for all three tests.
- I imagine that this should be a backport change if merged, so tagging with that label.
- To manually test, I put an invalid URL for the setting in `default_settings.py` and forced provision of my dev environment. See console output below.

```console
SystemCheckError: System check identified some issues:

ERRORS:
settings.JITSI_SERVER_URL: (zulip.E001) SETTING_JITSI_SERVER_URL in your Docker environment configuration is not a URL


Subcommand of /xxx/xxx/zulip/tools/lib/provision_inner.py failed with exit status 1: tools/rebuild-dev-database
Actual error output for the subcommand is just above this.
```

---

@andersk would you be up for looking at this one? @alexmv also tagging you in case you have a moment to look over these changes. Thanks!

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
