### PR TITLE
cache: Include realm_id in bot_profile_cache_key.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -497,7 +497,7 @@ def user_profile_delivery_email_cache_key(delivery_email: str, realm_id: int) ->
 
 
 def bot_profile_cache_key(email: str, realm_id: int) -> str:
-    return f"bot_profile:{hashlib.sha1(email.strip().encode()).hexdigest()}"
+    return f"bot_profile:{hashlib.sha1(email.strip().encode()).hexdigest()}:{realm_id}"
 
 
 def user_profile_by_id_cache_key(user_profile_id: int) -> str:

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -7,6 +7,7 @@ from zerver.apps import flush_cache
 from zerver.lib.cache import (
     MEMCACHED_MAX_KEY_LENGTH,
     InvalidCacheKeyError,
+    bot_profile_cache_key,
     bulk_cached_fetch,
     cache_delete,
     cache_delete_many,
@@ -15,6 +16,7 @@ from zerver.lib.cache import (
     cache_set,
     cache_set_many,
     cache_with_key,
+    open_graph_description_cache_key,
     safe_cache_get_many,
     safe_cache_set_many,
     user_profile_by_id_cache_key,
@@ -331,3 +333,39 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
             id_fetcher=get_user_email,
         )
         self.assertEqual(result, {})
+
+
+class CacheKeyFunctionTest(ZulipTestCase):
+    def test_bot_profile_cache_key_includes_realm_id(self) -> None:
+        """bot_profile_cache_key must produce distinct keys for
+        different realm_id values, even when the email is the same."""
+        email = "notification-bot@zulip.com"
+        key_realm_1 = bot_profile_cache_key(email, 1)
+        key_realm_2 = bot_profile_cache_key(email, 2)
+        self.assertNotEqual(key_realm_1, key_realm_2)
+        self.assertIn(":1", key_realm_1)
+        self.assertIn(":2", key_realm_2)
+
+    def test_bot_profile_cache_key_strips_email(self) -> None:
+        """Leading/trailing whitespace in the email should not affect
+        the generated cache key."""
+        key_clean = bot_profile_cache_key("bot@zulip.com", 1)
+        key_padded = bot_profile_cache_key("  bot@zulip.com  ", 1)
+        self.assertEqual(key_clean, key_padded)
+
+    def test_open_graph_description_cache_key_includes_content(self) -> None:
+        """open_graph_description_cache_key must produce distinct keys
+        when the same URL serves different content."""
+        url = "/help/getting-started"
+        key_v1 = open_graph_description_cache_key(b"<p>Version 1</p>", url)
+        key_v2 = open_graph_description_cache_key(b"<p>Version 2</p>", url)
+        self.assertNotEqual(key_v1, key_v2)
+
+    def test_open_graph_description_cache_key_same_content_same_url(self) -> None:
+        """Identical content and URL should produce the same cache key."""
+        url = "/help/getting-started"
+        content = b"<p>Hello world</p>"
+        key_a = open_graph_description_cache_key(content, url)
+        key_b = open_graph_description_cache_key(content, url)
+        self.assertEqual(key_a, key_b)
+


### PR DESCRIPTION
`bot_profile_cache_key` accepts a `realm_id` parameter but previously
omitted it from the generated cache key. This is inconsistent with
every other realm-scoped cache key function in the module (e.g.
`user_profile_by_email_realm_id_cache_key`,
`user_profile_delivery_email_cache_key`) and means all realms shared
a single cache entry for each system bot email address.

The `realm_id` parameter was added to `get_system_bot` and
`bot_profile_cache_key` as preparation for the planned per-realm
system bot migration (see the docstring on `get_system_bot`). However,
the cache key was never updated to include it, meaning when that
migration lands, the cache would silently serve cross-realm stale
data without an obvious failure mode.

Including `realm_id` in the key now is a zero-risk forward-compatibility
fix: current usage passes the same set of system bot emails regardless
of realm, so the cache simply becomes keyed more narrowly.

Fixes: Cache isolation gap in `bot_profile_cache_key` — `realm_id` parameter accepted but silently dropped from key.

**How changes were tested:**
- Added unit tests in `test_cache.py` verifying that `bot_profile_cache_key`
  produces distinct keys for different `realm_id` values and that email
  whitespace stripping is preserved.
- Existing test suite (`./tools/test-backend zerver/tests/test_cache.py`)
  continues to pass.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>