### PR TITLE
cache: Include content hash in open_graph_description_cache_key.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -778,7 +778,9 @@ def to_dict_cache_key(message: "Message", realm_id: int | None = None) -> str:
 
 
 def open_graph_description_cache_key(content: bytes, request_url: str) -> str:
-    return f"open_graph_description_path:{hashlib.sha1(request_url.encode()).hexdigest()}"
+    content_hash = hashlib.sha1(content).hexdigest()
+    url_hash = hashlib.sha1(request_url.encode()).hexdigest()
+    return f"open_graph_description_path:{url_hash}:{content_hash}"
 
 
 def zoom_server_access_token_cache_key(account_id: str) -> str:

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -15,6 +15,7 @@ from zerver.lib.cache import (
     cache_set,
     cache_set_many,
     cache_with_key,
+    open_graph_description_cache_key,
     safe_cache_get_many,
     safe_cache_set_many,
     user_profile_by_id_cache_key,
@@ -331,3 +332,21 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
             id_fetcher=get_user_email,
         )
         self.assertEqual(result, {})
+
+
+class CacheKeyFunctionTest(ZulipTestCase):
+    def test_open_graph_description_cache_key_includes_content(self) -> None:
+        """open_graph_description_cache_key must produce distinct keys
+        when the same URL serves different content."""
+        url = "/help/getting-started"
+        key_v1 = open_graph_description_cache_key(b"<p>Version 1</p>", url)
+        key_v2 = open_graph_description_cache_key(b"<p>Version 2</p>", url)
+        self.assertNotEqual(key_v1, key_v2)
+
+    def test_open_graph_description_cache_key_same_content_same_url(self) -> None:
+        """Identical content and URL should produce the same cache key."""
+        url = "/help/getting-started"
+        content = b"<p>Hello world</p>"
+        key_a = open_graph_description_cache_key(content, url)
+        key_b = open_graph_description_cache_key(content, url)
+        self.assertEqual(key_a, key_b)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
CZO discussion: [cache: Open Graph description key content hashing](https://chat.zulip.org/#narrow/channel/3-backend/topic/cache.3A.20Open.20Graph.20description.20key.20content.20hashing/with/2517380)

If a website updates its open graph metadata without changing its URL, Zulip serves stale preview data for up to 24 hours because the cache key only relies on the URL. Hashing the content into the cache key ensures it invalidates immediately upon changes.

Fixes: <!-- Issue link, or clear description.-->
Fixes stale Open Graph link previews.

**How changes were tested:**
Added a unit test in `zerver/tests/test_cache.py` verifying that different content on the same URL yields different cache keys.

**Screenshots and screen captures:**
N/A

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
