### PR TITLE
actions: Add update_fields to bare .save() calls.

### DIFF
--- a/zerver/actions/saved_snippets.py
+++ b/zerver/actions/saved_snippets.py
@@ -53,13 +53,16 @@ def do_edit_saved_snippet(
     except SavedSnippet.DoesNotExist:
         raise ResourceNotFoundError(_("Saved snippet does not exist."))
 
+    update_fields = []
     if title is not None:
         saved_snippet.title = title
+        update_fields.append("title")
     if content is not None:
         saved_snippet.content = content
+        update_fields.append("content")
 
     with transaction.atomic(durable=True):
-        saved_snippet.save()
+        saved_snippet.save(update_fields=update_fields)
 
         event = {
             "type": "saved_snippets",

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -237,6 +237,8 @@ def edit_scheduled_message(
             realm=realm,
         )
 
+    update_fields = []
+
     if recipient_type_name is not None or message_to is not None:
         assert send_request is not None
         # User has updated the scheduled message's recipient.
@@ -245,6 +247,7 @@ def edit_scheduled_message(
         # Update the topic based on the new recipient information.
         new_topic_name = send_request.message.topic_name()
         scheduled_message_object.set_topic_name(topic_name=new_topic_name)
+        update_fields.extend(["recipient", "stream", "subject"])
     elif topic_name is not None and existing_recipient_type_name == "stream":
         # User has updated the scheduled message's topic, but not
         # the existing recipient information. We ignore topics sent
@@ -252,6 +255,7 @@ def edit_scheduled_message(
         check_stream_topic(topic_name)
         new_topic_name = truncate_topic(topic_name)
         scheduled_message_object.set_topic_name(topic_name=new_topic_name)
+        update_fields.append("subject")
 
     if message_content is not None:
         assert send_request is not None
@@ -262,13 +266,16 @@ def edit_scheduled_message(
             scheduled_message_object, send_request.rendering_result
         )
         scheduled_message_object.has_attachment = attachment_reference_change.did_attachment_change
+        update_fields.extend(["content", "rendered_content", "has_attachment"])
 
     if deliver_at is not None:
         # User has updated the scheduled message's send timestamp.
         scheduled_message_object.scheduled_timestamp = deliver_at
+        update_fields.append("scheduled_timestamp")
 
     # Update for most recent Client information.
     scheduled_message_object.sending_client = client
+    update_fields.append("sending_client")
 
     # If the user is editing a scheduled message that the server tried
     # and failed to send, we need to update the `failed` boolean field
@@ -276,8 +283,9 @@ def edit_scheduled_message(
     if scheduled_message_object.failed:
         scheduled_message_object.failed = False
         scheduled_message_object.failure_message = None
+        update_fields.extend(["failed", "failure_message"])
 
-    scheduled_message_object.save()
+    scheduled_message_object.save(update_fields=update_fields)
 
     notify_update_scheduled_message(sender, scheduled_message_object)
 

--- a/zerver/lib/drafts.py
+++ b/zerver/lib/drafts.py
@@ -162,7 +162,7 @@ def do_edit_draft(draft_id: int, draft: DraftData, user_profile: UserProfile) ->
     draft_object.last_edit_time = valid_draft_dict.last_edit_time
 
     with transaction.atomic(durable=True):
-        draft_object.save()
+        draft_object.save(update_fields=["content", "topic", "recipient_id", "last_edit_time"])
 
         event = {"type": "drafts", "op": "update", "draft": draft_object.to_dict()}
         send_event_on_commit(user_profile.realm, event, [user_profile.id])


### PR DESCRIPTION
<!-- Describe your pull request here.-->
CZO discussion: [optimizing .save() update_fields in actions](https://chat.zulip.org/#narrow/channel/3-backend/topic/optimizing.20.2Esave.28.29.20update_fields.20in.20actions/with/2517379)

Bare `.save()` calls on existing model objects overwrite all columns, which can cause subtle data loss if another process (like a background worker) updates the same row concurrently. This explicitly passes `update_fields` to prevent race conditions during updates to drafts, saved snippets, and scheduled messages.

Fixes: <!-- Issue link, or clear description.-->
Prevents race conditions in drafts and scheduled messages.

**How changes were tested:**
Verified no test failures.

**Screenshots and screen captures:**
N/A

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
