### PR TITLE
actions: Add update_fields to more bare .save() calls.

### DIFF
--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -142,18 +142,25 @@ def try_update_realm_custom_profile_field(
     editable_by_user: bool | None = None,
     use_for_user_matching: bool | None = None,
 ) -> None:
+    update_fields = []
     if name is not None:
         field.name = name
+        update_fields.append("name")
     if hint is not None:
         field.hint = hint
+        update_fields.append("hint")
     if required is not None:
         field.required = required
+        update_fields.append("required")
     if editable_by_user is not None:
         field.editable_by_user = editable_by_user
+        update_fields.append("editable_by_user")
     if display_in_profile_summary is not None:
         field.display_in_profile_summary = display_in_profile_summary
+        update_fields.append("display_in_profile_summary")
     if use_for_user_matching is not None:
         field.use_for_user_matching = use_for_user_matching
+        update_fields.append("use_for_user_matching")
 
     if field.field_type in (
         CustomProfileField.DROPDOWN,
@@ -168,7 +175,10 @@ def try_update_realm_custom_profile_field(
         # to an empty dict.
         if field_data is not None or field.field_data == "":
             field.field_data = orjson.dumps(field_data or {}).decode()
-    field.save()
+            update_fields.append("field_data")
+
+    if update_fields:
+        field.save(update_fields=update_fields)
     notify_realm_custom_profile_fields(realm)
 
 

--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -169,7 +169,7 @@ def do_change_default_stream_group_name(
         )
 
     group.name = new_group_name
-    group.save()
+    group.save(update_fields=["name"])
     notify_default_stream_groups(realm)
 
 
@@ -177,7 +177,7 @@ def do_change_default_stream_group_description(
     realm: Realm, group: DefaultStreamGroup, new_description: str
 ) -> None:
     group.description = new_description
-    group.save()
+    group.save(update_fields=["description"])
     notify_default_stream_groups(realm)
 
 

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -718,7 +718,7 @@ def do_change_user_group_permission_setting(
 ) -> None:
     old_value = getattr(user_group, setting_name)
     setattr(user_group, setting_name, setting_value_group)
-    user_group.save()
+    user_group.save(update_fields=[setting_name])
 
     if old_setting_api_value is None:
         # Most production callers will have computed this as part of


### PR DESCRIPTION
<!-- Describe your pull request here.-->
CZO discussion: [optimizing .save() update_fields in actions](https://chat.zulip.org/#narrow/channel/3-backend/topic/optimizing.20.2Esave.28.29.20update_fields.20in.20actions/with/2517379)

Bare `.save()` calls on existing model objects overwrite all columns, which can cause subtle data loss if another process updates the same row concurrently (e.g., an admin changing a group's name while another admin changes its description). This explicitly passes `update_fields` to prevent race conditions when updating user groups, default streams, and custom profile fields.

Fixes: <!-- Issue link, or clear description.-->
Prevents race conditions in user groups and stream configurations.

**How changes were tested:**
Verified no test failures.

**Screenshots and screen captures:**
N/A

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
