### PR TITLE
streams: Add mandatory channel email notifications.

### DIFF
--- a/api_docs/unmerged.d/ZF-e45356.md
+++ b/api_docs/unmerged.d/ZF-e45356.md
@@ -1,0 +1,14 @@
+* [`POST /users/me/subscriptions`](/api/subscribe),
+  [`POST /channels/create`](/api/create-channel),
+  [`PATCH /streams/{stream_id}`](/api/update-stream): Added
+  `mandatory_email_notifications` boolean parameter. When enabled,
+  subscribers cannot disable email notifications for the channel.
+  Only organization administrators can set or modify this parameter.
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
+  [`GET /streams`](/api/get-streams),
+  [`GET /streams/{stream_id}`](/api/get-stream-by-id): Added
+  `mandatory_email_notifications` boolean field to channel objects.
+* [`POST /users/me/subscriptions`](/api/subscribe): When
+  `mandatory_email_notifications` is `true` for a channel, the server
+  rejects attempts to set `email_notifications` to `false` for that
+  channel.

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -40,7 +40,15 @@
     {% elif followed_topic_email_notify %}
     {% trans %}You are receiving this because you have email notifications enabled for topics you follow.{% endtrans %}<br />
     {% elif stream_email_notify %}
+    {% if mandatory_email_notifications %}
+    {% if user_can_unsubscribe_from_channel %}
+    {% trans unsubscribe_url=unsubscribe_channel_url, deactivate_url=deactivate_account_help_url %}This channel is configured to send email notifications to all subscribers. You can <a href="{{ unsubscribe_url }}">unsubscribe from the channel</a> or <a href="{{ deactivate_url }}">deactivate your account</a> to stop receiving these notifications.{% endtrans %}<br />
+    {% else %}
+    {% trans deactivate_url=deactivate_account_help_url %}This channel is configured to send email notifications to all subscribers, and your subscription to this channel is required by administrators. You can <a href="{{ deactivate_url }}">deactivate your account</a> to stop receiving these notifications.{% endtrans %}<br />
+    {% endif %}
+    {% else %}
     {% trans %}You are receiving this because you have email notifications enabled for #{{ channel_name }}.{% endtrans %}<br />
+    {% endif %}
     {% endif %}
     {% if reply_to_zulip %}
     {% trans notif_url=realm_url + "/#settings/notifications" %}Reply to this email directly, <a href="{{ narrow_url }}">view it in {{ realm_name }} Zulip</a>, or <a href="{{ notif_url }}">manage email preferences</a>.{% endtrans %}

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -34,7 +34,15 @@ This email does not include message content because you have chosen to hide mess
 {% elif followed_topic_email_notify %}
 {% trans %}You are receiving this because you have email notifications enabled for topics you follow.{% endtrans %}
 {% elif stream_email_notify %}
+{% if mandatory_email_notifications %}
+{% if user_can_unsubscribe_from_channel %}
+{% trans unsubscribe_url=unsubscribe_channel_url, deactivate_url=deactivate_account_help_url %}This channel is configured to send email notifications to all subscribers. You can unsubscribe from the channel ({{ unsubscribe_url }}) or deactivate your account ({{ deactivate_url }}) to stop receiving these notifications.{% endtrans %}
+{% else %}
+{% trans deactivate_url=deactivate_account_help_url %}This channel is configured to send email notifications to all subscribers, and your subscription to this channel is required by administrators. You can deactivate your account ({{ deactivate_url }}) to stop receiving these notifications.{% endtrans %}
+{% endif %}
+{% else %}
 {% trans %}You are receiving this because you have email notifications enabled for #{{ channel_name }}.{% endtrans %}
+{% endif %}
 {% endif %}
 
 {% if reply_to_zulip  %}

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -234,6 +234,10 @@ function stream_notification_setting_changed(target: HTMLInputElement, stream_id
 
     const $status_element = $(target).closest(".subsection-parent").find(".alert-notification");
     const setting = z.keyof(stream_specific_notification_settings_schema).parse(target.name);
+    if (setting === "email_notifications" && sub.mandatory_email_notifications) {
+        target.checked = stream_data.receives_notifications(stream_id, "email_notifications");
+        return;
+    }
     sub[setting] ??= user_settings[settings_config.generalize_stream_notification_setting[setting]];
     stream_settings_api.set_stream_property(
         sub,
@@ -261,6 +265,13 @@ function change_state_of_customize_stream_notifications_widget(
     if (!realm.realm_push_notifications_enabled) {
         $customizable_stream_notifications_table
             .find("input.push_notifications")
+            .prop("disabled", true);
+    }
+
+    const sub = sub_store.get(stream_id);
+    if (sub?.mandatory_email_notifications) {
+        $customizable_stream_notifications_table
+            .find("input.email_notifications")
             .prop("disabled", true);
     }
 

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -396,6 +396,15 @@ function create_stream(): void {
         );
     }
 
+    const $mandatory_email_notifications = $<HTMLInputElement>(
+        "#id_new_mandatory_email_notifications",
+    );
+    if ($mandatory_email_notifications.length > 0) {
+        data["mandatory_email_notifications"] = JSON.stringify(
+            $mandatory_email_notifications.prop("checked"),
+        );
+    }
+
     assert(folder_widget !== undefined);
     const folder_id = folder_widget.value();
     if (folder_id !== settings_config.no_folder_selected) {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -513,6 +513,13 @@ export function update_default_push_notifications(
     sub.default_push_notifications = default_push_notifications;
 }
 
+export function update_mandatory_email_notifications(
+    sub: StreamSubscription,
+    mandatory_email_notifications: boolean,
+): void {
+    sub.mandatory_email_notifications = mandatory_email_notifications;
+}
+
 export function update_stream_permission_group_setting(
     setting_name: StreamPermissionGroupSetting,
     sub: StreamSubscription,
@@ -532,6 +539,9 @@ export function receives_notifications(
     const sub = sub_store.get(stream_id);
     if (sub === undefined) {
         return false;
+    }
+    if (notification_name === "email_notifications" && sub.mandatory_email_notifications) {
+        return true;
     }
     if (sub[notification_name] !== null) {
         return sub[notification_name];

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -318,6 +318,7 @@ export function stream_settings(sub: StreamSubscription): StreamSetting[] {
         const notification_setting = notification_labels_schema.safeParse(setting);
 
         let is_checked;
+        let is_disabled;
         if (notification_setting.success) {
             // This block ensures we correctly display to users the
             // current state of stream-level notification settings
@@ -326,16 +327,25 @@ export function stream_settings(sub: StreamSubscription): StreamSetting[] {
             is_checked =
                 stream_data.receives_notifications(sub.stream_id, notification_setting.data) &&
                 !realm_setting;
+            is_disabled =
+                realm_setting ||
+                (notification_setting.data === "email_notifications" &&
+                    sub.mandatory_email_notifications);
         } else {
             is_checked = (sub[setting] ?? false) && !realm_setting;
+            is_disabled = realm_setting;
         }
         return {
             name: setting,
             label,
             disabled_realm_setting: realm_setting,
-            is_disabled: realm_setting,
+            is_disabled,
             has_global_notification_setting: notification_setting.success,
             is_checked,
+            mandatory_email_notifications:
+                notification_setting.success &&
+                notification_setting.data === "email_notifications" &&
+                sub.mandatory_email_notifications,
         };
     });
 }
@@ -471,6 +481,13 @@ function get_push_notifications_tooltip(): string | undefined {
     return undefined;
 }
 
+function get_mandatory_email_notifications_tooltip(): string | undefined {
+    if (!current_user.is_admin) {
+        return $t({defaultMessage: "Only organization administrators can edit this setting."});
+    }
+    return undefined;
+}
+
 export function show_settings_for(node: HTMLElement): void {
     // Hide any tooltips or popovers before we rerender / change
     // currently displayed stream settings.
@@ -503,6 +520,8 @@ export function show_settings_for(node: HTMLElement): void {
             realm.realm_org_type === settings_config.all_org_type_values.business.code,
         is_admin: current_user.is_admin,
         push_notifications_tooltip: get_push_notifications_tooltip(),
+        disable_mandatory_email_notifications: !current_user.is_admin,
+        mandatory_email_notifications_tooltip: get_mandatory_email_notifications_tooltip(),
         org_level_message_retention_setting: get_display_text_for_realm_message_retention_setting(),
         group_setting_labels: settings_config.all_group_setting_labels.stream,
         has_billing_access: settings_data.user_has_billing_access(),

--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -203,6 +203,10 @@ export function update_property<P extends keyof UpdatableStreamProperties>(
             sub.default_push_notifications = value;
             stream_settings_ui.update_default_push_notifications_setting(sub, value);
         },
+        mandatory_email_notifications(value) {
+            sub.mandatory_email_notifications = value;
+            stream_settings_ui.update_mandatory_email_notifications_setting(sub, value);
+        },
         topics_policy(value) {
             stream_settings_ui.update_topics_policy_setting(sub, value);
             compose_recipient.update_topic_inputbox_on_topics_policy_change();

--- a/web/src/stream_settings_data.ts
+++ b/web/src/stream_settings_data.ts
@@ -137,6 +137,7 @@ export function get_unmatched_streams_for_notification_settings(): ({
                 color: row.color,
                 invite_only: row.invite_only,
                 is_web_public: row.is_web_public,
+                mandatory_email_notifications: row.mandatory_email_notifications ?? false,
             });
         }
     }

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -245,6 +245,15 @@ export function update_default_push_notifications_setting(
     stream_ui_updates.update_setting_element(sub, "default_push_notifications");
 }
 
+export function update_mandatory_email_notifications_setting(
+    sub: StreamSubscription,
+    new_value: boolean,
+): void {
+    stream_data.update_mandatory_email_notifications(sub, new_value);
+    stream_ui_updates.update_setting_element(sub, "mandatory_email_notifications");
+    stream_ui_updates.update_mandatory_email_notification_checkboxes(sub);
+}
+
 export function update_stream_permission_group_setting(
     setting_name: StreamPermissionGroupSetting,
     sub: StreamSubscription,
@@ -1049,6 +1058,10 @@ function setup_page(callback: () => void): void {
             push_notifications_tooltip: realm.realm_push_notifications_enabled
                 ? undefined
                 : $t({defaultMessage: "Mobile push notifications are not enabled on this server."}),
+            disable_mandatory_email_notifications: !current_user.is_admin,
+            mandatory_email_notifications_tooltip: current_user.is_admin
+                ? undefined
+                : $t({defaultMessage: "Only organization administrators can edit this setting."}),
             empty_string_topic_display_name: util.get_final_topic_display_name(""),
         };
 

--- a/web/src/stream_types.ts
+++ b/web/src/stream_types.ts
@@ -49,6 +49,7 @@ export const stream_schema = z.object({
     creator_id: z.nullable(z.number()),
     date_created: z.number(),
     default_push_notifications: z.boolean(),
+    mandatory_email_notifications: z.boolean(),
     description: z.string(),
     first_message_id: z.nullable(z.number()),
     folder_id: z.nullable(z.number()),

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -366,6 +366,18 @@ export function enable_or_disable_permission_settings_in_edit_panel(
     );
     $default_push_notifications_setting.find("input").prop("disabled", disable_push_notifications);
 
+    const $mandatory_email_notifications_setting = $stream_settings
+        .find("input[name='mandatory_email_notifications']")
+        .closest(".settings-checkbox-wrapper");
+    const disable_mandatory_email_notifications = !current_user.is_admin;
+    $mandatory_email_notifications_setting.toggleClass(
+        "control-label-disabled",
+        disable_mandatory_email_notifications,
+    );
+    $mandatory_email_notifications_setting
+        .find("input")
+        .prop("disabled", disable_mandatory_email_notifications);
+
     if (!sub.can_change_stream_permissions_requiring_metadata_access) {
         settings_components.disable_group_permission_setting($permission_pill_container_elements);
         return;
@@ -463,10 +475,36 @@ export function update_notification_setting_checkbox(
         return;
     }
     const stream_id = Number($stream_row.attr("data-stream-id"));
-    $(`#${CSS.escape(notification_name)}_${CSS.escape(stream_id.toString())}`).prop(
-        "checked",
-        stream_data.receives_notifications(stream_id, notification_name),
+    const $checkbox = $(`#${CSS.escape(notification_name)}_${CSS.escape(stream_id.toString())}`);
+    $checkbox.prop("checked", stream_data.receives_notifications(stream_id, notification_name));
+}
+
+export function update_mandatory_email_notification_checkboxes(sub: StreamSubscription): void {
+    const mandatory_email = sub.mandatory_email_notifications;
+    const $settings_checkbox = $(`#email_notifications_${CSS.escape(sub.stream_id.toString())}`);
+    $settings_checkbox.prop("disabled", mandatory_email);
+    $settings_checkbox
+        .closest("#sub_email_notifications_setting")
+        .toggleClass("control-label-disabled", mandatory_email);
+    if (mandatory_email) {
+        $settings_checkbox.prop("checked", true);
+    }
+
+    const $notifications_table_checkbox = $(
+        `#stream-specific-notify-table tr[data-stream-id="${CSS.escape(sub.stream_id.toString())}"] input.email_notifications`,
     );
+    $notifications_table_checkbox.prop("disabled", mandatory_email);
+    const $wrapper = $notifications_table_checkbox.closest("span");
+    $wrapper.toggleClass("tippy-zulip-tooltip", mandatory_email);
+    if (mandatory_email) {
+        $wrapper.attr(
+            "data-tippy-content",
+            $t({defaultMessage: "Email notifications are required for this channel."}),
+        );
+        $notifications_table_checkbox.prop("checked", true);
+    } else {
+        $wrapper.removeAttr("data-tippy-content");
+    }
 }
 
 export function update_stream_row_in_settings_tab(sub: StreamSubscription): void {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1528,7 +1528,8 @@
 
 #subscription_overlay .default-stream,
 #subscription_overlay .history-public-to-subscribers,
-#subscription_overlay .default-push-notifications {
+#subscription_overlay .default-push-notifications,
+#subscription_overlay .mandatory-email-notifications {
     width: fit-content;
 
     .inline {

--- a/web/templates/settings/notification_settings_checkboxes.hbs
+++ b/web/templates/settings/notification_settings_checkboxes.hbs
@@ -1,5 +1,5 @@
 <td>
-    <span {{#if (and is_mobile_checkbox push_notifications_disabled)}} class="tippy-zulip-tooltip" data-tooltip-template-id="mobile-push-notification-tooltip-template"{{/if}}>
+    <span {{#if (and is_mobile_checkbox push_notifications_disabled)}} class="tippy-zulip-tooltip" data-tooltip-template-id="mobile-push-notification-tooltip-template"{{else if mandatory_email_notifications_required}} class="tippy-zulip-tooltip" data-tippy-content="{{t 'Email notifications are required for this channel.'}}"{{/if}}>
         <label class="checkbox">
             <input type="checkbox" name="{{setting_name}}" id="{{prefix}}{{setting_name}}"
               {{#if is_disabled}} disabled {{/if}}

--- a/web/templates/settings/stream_specific_notification_row.hbs
+++ b/web/templates/settings/stream_specific_notification_row.hbs
@@ -14,9 +14,10 @@
           setting_name=this
           prefix=(lookup ../stream "stream_id")
           is_checked=(lookup ../stream this)
-          is_disabled=(lookup ../is_disabled this)
+          is_disabled=(or (lookup ../is_disabled this) (and ../stream.mandatory_email_notifications (eq this "email_notifications")))
           is_mobile_checkbox=(eq this "push_notifications")
           push_notifications_disabled=../push_notifications_disabled
+          mandatory_email_notifications_required=(and ../stream.mandatory_email_notifications (eq this "email_notifications"))
           }}
     {{/each}}
 </tr>

--- a/web/templates/stream_settings/channel_permissions.hbs
+++ b/web/templates/stream_settings/channel_permissions.hbs
@@ -49,6 +49,16 @@
               tooltip_message=push_notifications_tooltip
               }}
         </div>
+        <div class="mandatory-email-notifications">
+            {{> ../settings/settings_checkbox
+              prefix=prefix
+              setting_name="mandatory_email_notifications"
+              is_checked=false
+              is_disabled=disable_mandatory_email_notifications
+              label=(t "Require email notifications for all subscribers")
+              tooltip_message=mandatory_email_notifications_tooltip
+              }}
+        </div>
         {{/if}}
     {{/unless}}
 </div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -58,8 +58,20 @@
                       prefix="id_"
                       setting_name="default_push_notifications"
                       is_checked=(lookup sub "default_push_notifications")
+                      is_disabled=(not is_admin)
                       label=(t "Mobile push notifications enabled by default")
                       tooltip_message=push_notifications_tooltip
+                      }}
+                </div>
+
+                <div class="mandatory-email-notifications">
+                    {{> ../settings/settings_checkbox
+                      prefix="id_"
+                      setting_name="mandatory_email_notifications"
+                      is_checked=(lookup sub "mandatory_email_notifications")
+                      is_disabled=disable_mandatory_email_notifications
+                      label=(t "Require email notifications for all subscribers")
+                      tooltip_message=mandatory_email_notifications_tooltip
                       }}
                 </div>
 
@@ -130,6 +142,7 @@
                           notification_setting=true
                           disabled_realm_setting=disabled_realm_setting
                           is_disabled=is_disabled
+                          mandatory_email_notifications=mandatory_email_notifications
                           label=label}}
                     </div>
                 {{/each}}

--- a/web/templates/stream_settings/stream_settings_checkbox.hbs
+++ b/web/templates/stream_settings/stream_settings_checkbox.hbs
@@ -2,7 +2,7 @@
 <div class="sub_setting_checkbox">
     <div id="sub_{{setting_name}}_setting" class="{{#if disabled_realm_setting}}control-label-disabled
       {{else if notification_setting}}sub_notification_setting{{/if}}">
-        <span {{#if (and disabled_realm_setting (eq setting_name "push_notifications"))}}class="tippy-zulip-tooltip" data-tooltip-template-id="mobile-push-notification-tooltip-template"{{/if}}>
+        <span {{#if (and disabled_realm_setting (eq setting_name "push_notifications"))}}class="tippy-zulip-tooltip" data-tooltip-template-id="mobile-push-notification-tooltip-template"{{else if mandatory_email_notifications}}class="tippy-zulip-tooltip" data-tippy-content="{{t 'Email notifications are required for this channel.'}}"{{/if}}>
             <label class="checkbox">
                 <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}"
                   class="sub_setting_control" type="checkbox"

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -67,6 +67,7 @@ exports.test_streams = {
         can_remove_subscribers_group: 2,
         is_recently_active: true,
         default_push_notifications: false,
+        mandatory_email_notifications: false,
         subscriber_count: 10,
     },
     test: {
@@ -95,6 +96,7 @@ exports.test_streams = {
         can_remove_subscribers_group: 2,
         is_recently_active: true,
         default_push_notifications: false,
+        mandatory_email_notifications: false,
         subscriber_count: 2,
     },
 };

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -897,6 +897,8 @@ test("stream_settings", ({override}) => {
     assert.equal(sub.can_administer_channel_group, moderators_group.id);
     assert.equal(sub.folder_id, 3);
     assert.equal(sub.default_push_notifications, true);
+    stream_data.update_mandatory_email_notifications(sub, true);
+    assert.equal(sub.mandatory_email_notifications, true);
 
     // For guest user only retrieve subscribed streams
     sub_rows = stream_settings_data.get_updated_unsorted_subs();
@@ -1124,6 +1126,11 @@ test("notifications", ({override}) => {
     india.email_notifications = false;
     assert.ok(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
 
+    india.mandatory_email_notifications = true;
+    assert.ok(stream_data.receives_notifications(india.stream_id, "email_notifications"));
+    india.mandatory_email_notifications = false;
+    assert.ok(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
+
     const canada = {
         stream_id: 103,
         name: "Canada",
@@ -1189,6 +1196,7 @@ test("notifications", ({override}) => {
             stream_name: "Canada",
             stream_id: 103,
             color: "#d80621",
+            mandatory_email_notifications: false,
         },
         {
             desktop_notifications: true,
@@ -1201,6 +1209,7 @@ test("notifications", ({override}) => {
             stream_name: "India",
             stream_id: 102,
             color: "#000080",
+            mandatory_email_notifications: false,
         },
     ];
 

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -307,6 +307,17 @@ test("update_property", ({override, override_rewire}) => {
         assert.equal(args.val, false);
     }
 
+    // Test stream mandatory_email_notifications change event
+    {
+        const stub = make_stub();
+        override(stream_settings_ui, "update_mandatory_email_notifications_setting", stub.f);
+        stream_events.update_property(stream_id, "mandatory_email_notifications", true);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("sub", "val");
+        assert.equal(args.sub.stream_id, stream_id);
+        assert.equal(args.val, true);
+    }
+
     // Test stream can_remove_subscribers_group change event
     {
         const stub = make_stub();

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -281,6 +281,11 @@ def get_recipient_info(
         # of this function for different message types.
         assert stream_topic is not None
 
+        stream = Stream.objects.only("mandatory_email_notifications").get(
+            id=stream_topic.stream_id, realm_id=realm_id
+        )
+        mandatory_email_notifications = stream.mandatory_email_notifications
+
         if possible_topic_wildcard_mention:
             # A topic participant is anyone who either sent or reacted to messages in the topic.
             # It is expensive to call `participants_for_topic` if the topic has a large number
@@ -301,6 +306,7 @@ def get_recipient_info(
                 stream_id=stream_topic.stream_id,
                 topic_name=stream_topic.topic_name,
                 possible_stream_wildcard_mention=possible_stream_wildcard_mention,
+                mandatory_email_notifications=mandatory_email_notifications,
                 topic_participant_user_ids=topic_participant_user_ids,
                 possibly_mentioned_user_ids=possibly_mentioned_user_ids,
             )
@@ -358,6 +364,9 @@ def get_recipient_info(
             *,
             channel_specific_setting_overrides_mute: bool = False,
         ) -> set[int]:
+            use_mandatory_email_notifications = (
+                mandatory_email_notifications and setting == "email_notifications"
+            )
             return {
                 row["user_profile_id"]
                 for row in subscription_rows
@@ -369,6 +378,7 @@ def get_recipient_info(
                     row[setting],
                     row[user_setting],
                     channel_specific_setting_overrides_mute,
+                    mandatory_email_notifications=use_mandatory_email_notifications,
                 )
             }
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -482,6 +482,7 @@ def send_subscription_add_events(
                 message_retention_days=stream_dict["message_retention_days"],
                 name=stream_dict["name"],
                 default_push_notifications=stream_dict["default_push_notifications"],
+                mandatory_email_notifications=stream_dict["mandatory_email_notifications"],
                 rendered_description=stream_dict["rendered_description"],
                 stream_id=stream_dict["stream_id"],
                 stream_post_policy=stream_dict["stream_post_policy"],
@@ -1189,6 +1190,13 @@ def do_change_subscription_property(
     if property_name == "in_home_view":
         database_property_name = "is_muted"
         database_value = not value
+
+    if (
+        property_name == "email_notifications"
+        and value is False
+        and stream.mandatory_email_notifications
+    ):
+        raise JsonableError(_("Email notifications are required for this channel."))
 
     old_value = getattr(sub, database_property_name)
     setattr(sub, database_property_name, database_value)

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -33,12 +33,14 @@ from zerver.lib.notification_data import get_mentioned_user_group
 from zerver.lib.queue import queue_event_on_commit
 from zerver.lib.send_email import FromAddress, send_future_email
 from zerver.lib.soft_deactivation import soft_reactivate_if_personal_notification
+from zerver.lib.streams import user_can_unsubscribe_from_stream
 from zerver.lib.tex import change_katex_to_raw_latex
 from zerver.lib.timestamp import format_datetime_to_string
 from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.topic import get_topic_display_name, get_topic_resolution_and_bare_name
 from zerver.lib.url_encoding import (
     direct_message_group_narrow_url,
+    encode_hash_component,
     message_link_url,
     stream_narrow_url,
     topic_narrow_url,
@@ -595,7 +597,9 @@ def do_send_missedmessage_events_reply_in_zulip(
                 }
             )
         assert message.recipient.type == Recipient.STREAM
-        stream = Stream.objects.only("id", "name").get(id=message.recipient.type_id)
+        stream = Stream.objects.only("id", "name", "mandatory_email_notifications").get(
+            id=message.recipient.type_id
+        )
         narrow_url = message_link_url(
             user_profile.realm, MessageDict.wide_dict(message), conversation_link=not mention
         )
@@ -607,6 +611,23 @@ def do_send_missedmessage_events_reply_in_zulip(
             topic_name=display_topic_name,
             topic_resolved=topic_resolved,
         )
+        if (
+            stream.mandatory_email_notifications
+            and NotificationTriggers.STREAM_EMAIL in unique_triggers
+        ):
+            context.update(
+                mandatory_email_notifications=True,
+                user_can_unsubscribe_from_channel=user_can_unsubscribe_from_stream(
+                    user_profile, stream
+                ),
+                unsubscribe_channel_url=(
+                    f"{user_profile.realm.url}/#channels/{stream.id}/"
+                    f"{encode_hash_component(stream.name)}/personal"
+                ),
+                deactivate_account_help_url=(
+                    f"{user_profile.realm.url}/help/deactivate-or-reactivate-a-user"
+                ),
+            )
         synthetic_root_message_id = prepare_synthetic_root_message_id(
             Recipient.STREAM, message.recipient_id, topic_name=display_topic_name
         )

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -648,6 +648,9 @@ def check_stream_update(
     elif prop == "default_push_notifications":
         assert extra_keys == set()
         assert isinstance(value, bool)
+    elif prop == "mandatory_email_notifications":
+        assert extra_keys == set()
+        assert isinstance(value, bool)
     else:
         raise AssertionError(f"Unknown property: {prop}")
 

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -972,6 +972,7 @@ class SingleSubscription(BaseModel):
     creator_id: int | None
     date_created: int
     default_push_notifications: bool
+    mandatory_email_notifications: bool
     description: str
     first_message_id: int | None
     is_recently_active: bool

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -295,6 +295,8 @@ def user_allows_notifications_in_StreamTopic(
     stream_specific_setting: bool | None,
     global_setting: bool,
     channel_specific_setting_overrides_mute: bool,
+    *,
+    mandatory_email_notifications: bool = False,
 ) -> bool:
     """
     Captures the hierarchy of notification settings, where visibility policy is considered first,
@@ -303,10 +305,20 @@ def user_allows_notifications_in_StreamTopic(
     When `channel_specific_setting_overrides_mute` is True (currently used for
     `wildcard_mentions_notify` setting), `stream_specific_setting` overrides
     channel mute, but not topic mute.
+
+    When `mandatory_email_notifications` is True, subscribers receive email
+    notifications for channel messages regardless of per-subscription and global
+    email notification settings, but muted topics and muted channels still
+    suppress notifications.
     """
     # Muted topics always suppress notifications, regardless of other settings.
     if visibility_policy == UserTopic.VisibilityPolicy.MUTED:
         return False
+
+    if mandatory_email_notifications:
+        if stream_is_muted and visibility_policy != UserTopic.VisibilityPolicy.UNMUTED:
+            return False
+        return True
 
     if stream_is_muted and visibility_policy != UserTopic.VisibilityPolicy.UNMUTED:
         if channel_specific_setting_overrides_mute and stream_specific_setting is not None:

--- a/zerver/lib/stream_subscription.py
+++ b/zerver/lib/stream_subscription.py
@@ -261,6 +261,7 @@ def get_subscriptions_for_send_message(
     stream_id: int,
     topic_name: str,
     possible_stream_wildcard_mention: bool,
+    mandatory_email_notifications: bool = False,
     topic_participant_user_ids: AbstractSet[int],
     possibly_mentioned_user_ids: AbstractSet[int],
 ) -> QuerySet[Subscription]:
@@ -297,7 +298,7 @@ def get_subscriptions_for_send_message(
         include_deactivated_users=False,
     )
 
-    if possible_stream_wildcard_mention:
+    if possible_stream_wildcard_mention or mandatory_email_notifications:
         return query
 
     query = query.filter(

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -87,6 +87,7 @@ class StreamDict(TypedDict, total=False):
 
     name: str
     default_push_notifications: bool
+    mandatory_email_notifications: bool
     description: str
     invite_only: bool
     is_web_public: bool
@@ -372,6 +373,7 @@ def create_stream_if_needed(
     stream_name: str,
     *,
     default_push_notifications: bool = False,
+    mandatory_email_notifications: bool = False,
     invite_only: bool = False,
     is_web_public: bool = False,
     history_public_to_subscribers: bool | None = None,
@@ -444,6 +446,7 @@ def create_stream_if_needed(
             history_public_to_subscribers=history_public_to_subscribers,
             message_retention_days=message_retention_days,
             default_push_notifications=default_push_notifications,
+            mandatory_email_notifications=mandatory_email_notifications,
             folder=folder,
             topics_policy=topics_policy,
             **group_setting_values,
@@ -521,6 +524,7 @@ def create_streams_if_needed(
             stream_description=stream_dict.get("description", ""),
             message_retention_days=stream_dict.get("message_retention_days", None),
             default_push_notifications=stream_dict.get("default_push_notifications", False),
+            mandatory_email_notifications=stream_dict.get("mandatory_email_notifications", False),
             topics_policy=stream_dict.get("topics_policy", None),
             can_add_subscribers_group=stream_dict.get("can_add_subscribers_group", None),
             can_administer_channel_group=stream_dict.get("can_administer_channel_group", None),
@@ -557,6 +561,10 @@ def subscribed_to_stream(user_profile: UserProfile, stream_id: int) -> bool:
         recipient__type=Recipient.STREAM,
         recipient__type_id=stream_id,
     ).exists()
+
+
+def user_can_unsubscribe_from_stream(user_profile: UserProfile, stream: Stream) -> bool:
+    return subscribed_to_stream(user_profile, stream.id)
 
 
 def is_user_in_can_administer_channel_group(
@@ -1906,6 +1914,7 @@ def stream_to_dict(
         creator_id=stream.creator_id,
         date_created=datetime_to_timestamp(stream.date_created),
         default_push_notifications=stream.default_push_notifications,
+        mandatory_email_notifications=stream.mandatory_email_notifications,
         description=stream.description,
         first_message_id=stream.first_message_id,
         folder_id=stream.folder_id,

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -100,6 +100,7 @@ def get_web_public_subs(
         creator_id = stream.creator_id
         date_created = datetime_to_timestamp(stream.date_created)
         default_push_notifications = stream.default_push_notifications
+        mandatory_email_notifications = stream.mandatory_email_notifications
         description = stream.description
         first_message_id = stream.first_message_id
         folder_id = stream.folder_id
@@ -152,6 +153,7 @@ def get_web_public_subs(
             creator_id=creator_id,
             date_created=date_created,
             default_push_notifications=default_push_notifications,
+            mandatory_email_notifications=mandatory_email_notifications,
             description=description,
             desktop_notifications=desktop_notifications,
             email_notifications=email_notifications,
@@ -261,6 +263,7 @@ def build_stream_api_dict(
         creator_id=raw_stream_dict["creator_id"],
         date_created=datetime_to_timestamp(raw_stream_dict["date_created"]),
         default_push_notifications=raw_stream_dict["default_push_notifications"],
+        mandatory_email_notifications=raw_stream_dict["mandatory_email_notifications"],
         description=raw_stream_dict["description"],
         first_message_id=raw_stream_dict["first_message_id"],
         folder_id=raw_stream_dict["folder_id"],
@@ -301,6 +304,7 @@ def build_stream_dict_for_sub(
     creator_id = stream_dict["creator_id"]
     date_created = stream_dict["date_created"]
     default_push_notifications = stream_dict["default_push_notifications"]
+    mandatory_email_notifications = stream_dict["mandatory_email_notifications"]
     description = stream_dict["description"]
     first_message_id = stream_dict["first_message_id"]
     folder_id = stream_dict["folder_id"]
@@ -351,6 +355,7 @@ def build_stream_dict_for_sub(
         creator_id=creator_id,
         date_created=date_created,
         default_push_notifications=default_push_notifications,
+        mandatory_email_notifications=mandatory_email_notifications,
         description=description,
         desktop_notifications=desktop_notifications,
         email_notifications=email_notifications,
@@ -386,6 +391,7 @@ def build_stream_dict_for_never_sub(
     creator_id = raw_stream_dict["creator_id"]
     date_created = datetime_to_timestamp(raw_stream_dict["date_created"])
     default_push_notifications = raw_stream_dict["default_push_notifications"]
+    mandatory_email_notifications = raw_stream_dict["mandatory_email_notifications"]
     description = raw_stream_dict["description"]
     first_message_id = raw_stream_dict["first_message_id"]
     folder_id = raw_stream_dict["folder_id"]
@@ -462,6 +468,7 @@ def build_stream_dict_for_never_sub(
         creator_id=creator_id,
         date_created=date_created,
         default_push_notifications=default_push_notifications,
+        mandatory_email_notifications=mandatory_email_notifications,
         description=description,
         first_message_id=first_message_id,
         folder_id=folder_id,

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -183,6 +183,7 @@ class RawStreamDict(TypedDict):
     date_created: datetime
     deactivated: bool
     default_push_notifications: bool
+    mandatory_email_notifications: bool
     description: str
     first_message_id: int | None
     folder_id: int | None
@@ -239,6 +240,7 @@ class SubscriptionStreamDict(TypedDict):
     creator_id: int | None
     date_created: int
     default_push_notifications: bool
+    mandatory_email_notifications: bool
     description: str
     desktop_notifications: bool | None
     email_notifications: bool | None
@@ -282,6 +284,7 @@ class NeverSubscribedStreamDict(TypedDict):
     creator_id: int | None
     date_created: int
     default_push_notifications: bool
+    mandatory_email_notifications: bool
     description: str
     first_message_id: int | None
     folder_id: int | None
@@ -323,6 +326,7 @@ class DefaultStreamDict(TypedDict):
     creator_id: int | None
     date_created: int
     default_push_notifications: bool
+    mandatory_email_notifications: bool
     description: str
     first_message_id: int | None
     folder_id: int | None

--- a/zerver/migrations/0812_stream_mandatory_email_notifications.py
+++ b/zerver/migrations/0812_stream_mandatory_email_notifications.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0811_usermessage_add_hide_link_previews"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="stream",
+            name="mandatory_email_notifications",
+            field=models.BooleanField(default=False, db_default=False),
+        ),
+    ]

--- a/zerver/models/streams.py
+++ b/zerver/models/streams.py
@@ -122,6 +122,10 @@ class Stream(models.Model):
     # inheriting from the user's account-level default.
     default_push_notifications = models.BooleanField(default=False, db_default=False)
 
+    # When True, all subscribers receive email notifications for channel messages
+    # when offline, regardless of per-subscription email notification settings.
+    mandatory_email_notifications = models.BooleanField(default=False, db_default=False)
+
     # on_delete field for group value settings is set to RESTRICT
     # because we don't want to allow deleting a user group in case it
     # is referenced by the respective setting. We are not using PROTECT
@@ -272,6 +276,7 @@ class Stream(models.Model):
         "date_created",
         "deactivated",
         "default_push_notifications",
+        "mandatory_email_notifications",
         "description",
         "first_message_id",
         "folder_id",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1596,6 +1596,7 @@ paths:
                                         "is_recently_active": true,
                                         "message_retention_days": null,
                                         "default_push_notifications": false,
+                                        "mandatory_email_notifications": false,
                                         "is_announcement_only": false,
                                         "can_add_subscribers_group": 2,
                                         "can_remove_subscribers_group": 2,
@@ -13266,6 +13267,8 @@ paths:
                   $ref: "#/components/schemas/MessageRetentionDays"
                 default_push_notifications:
                   $ref: "#/components/schemas/DefaultPushNotifications"
+                mandatory_email_notifications:
+                  $ref: "#/components/schemas/MandatoryEmailNotifications"
                 topics_policy:
                   $ref: "#/components/schemas/TopicsPolicy"
                 can_add_subscribers_group:
@@ -13320,6 +13323,8 @@ paths:
               history_public_to_subscribers:
                 contentType: application/json
               default_push_notifications:
+                contentType: application/json
+              mandatory_email_notifications:
                 contentType: application/json
               topics_policy:
                 contentType: application/json
@@ -19532,6 +19537,7 @@ paths:
                                 message_retention_days:
                                   nullable: true
                                 default_push_notifications: {}
+                                mandatory_email_notifications: {}
                                 history_public_to_subscribers: {}
                                 topics_policy: {}
                                 first_message_id:
@@ -24588,6 +24594,7 @@ paths:
                                 message_retention_days:
                                   nullable: true
                                 default_push_notifications: {}
+                                mandatory_email_notifications: {}
                                 history_public_to_subscribers: {}
                                 topics_policy: {}
                                 first_message_id:
@@ -24646,6 +24653,7 @@ paths:
                                 - stream_post_policy
                                 - message_retention_days
                                 - default_push_notifications
+                                - mandatory_email_notifications
                                 - history_public_to_subscribers
                                 - first_message_id
                                 - folder_id
@@ -24679,6 +24687,7 @@ paths:
                               "is_web_public": false,
                               "message_retention_days": null,
                               "default_push_notifications": false,
+                              "mandatory_email_notifications": false,
                               "name": "management",
                               "rendered_description": "<p>A private channel</p>",
                               "stream_id": 2,
@@ -24704,6 +24713,7 @@ paths:
                               "is_web_public": false,
                               "message_retention_days": null,
                               "default_push_notifications": false,
+                              "mandatory_email_notifications": false,
                               "name": "welcome",
                               "rendered_description": "<p>A default public channel</p>",
                               "stream_id": 1,
@@ -24761,6 +24771,7 @@ paths:
                             "is_web_public": false,
                             "message_retention_days": null,
                             "default_push_notifications": false,
+                            "mandatory_email_notifications": false,
                             "name": "Denmark",
                             "rendered_description": "<p>A Scandinavian country</p>",
                             "stream_id": 7,
@@ -24926,6 +24937,8 @@ paths:
                   $ref: "#/components/schemas/MessageRetentionDays"
                 default_push_notifications:
                   $ref: "#/components/schemas/DefaultPushNotifications"
+                mandatory_email_notifications:
+                  $ref: "#/components/schemas/MandatoryEmailNotifications"
                 is_archived:
                   description: |
                     A boolean indicating whether the channel is
@@ -25854,6 +25867,8 @@ paths:
                   $ref: "#/components/schemas/CanResolveTopicsGroup"
                 default_push_notifications:
                   $ref: "#/components/schemas/DefaultPushNotifications"
+                mandatory_email_notifications:
+                  $ref: "#/components/schemas/MandatoryEmailNotifications"
               required:
                 - name
                 - subscribers
@@ -25861,6 +25876,8 @@ paths:
               announce:
                 contentType: application/json
               default_push_notifications:
+                contentType: application/json
+              mandatory_email_notifications:
                 contentType: application/json
               can_add_subscribers_group:
                 contentType: application/json
@@ -27797,6 +27814,7 @@ components:
             message_retention_days:
               nullable: true
             default_push_notifications: {}
+            mandatory_email_notifications: {}
             history_public_to_subscribers: {}
             topics_policy: {}
             first_message_id:
@@ -27846,6 +27864,7 @@ components:
             - subscriber_count
             - message_retention_days
             - default_push_notifications
+            - mandatory_email_notifications
             - history_public_to_subscribers
             - first_message_id
             - folder_id
@@ -27965,6 +27984,8 @@ components:
             **Changes**: New in Zulip 3.0 (feature level 17).
         default_push_notifications:
           $ref: "#/components/schemas/DefaultPushNotifications"
+        mandatory_email_notifications:
+          $ref: "#/components/schemas/MandatoryEmailNotifications"
         history_public_to_subscribers:
           type: boolean
           description: |
@@ -29194,6 +29215,8 @@ components:
             **Changes**: New in Zulip 3.0 (feature level 17).
         default_push_notifications:
           $ref: "#/components/schemas/DefaultPushNotifications"
+        mandatory_email_notifications:
+          $ref: "#/components/schemas/MandatoryEmailNotifications"
         history_public_to_subscribers:
           type: boolean
           description: |
@@ -31272,6 +31295,17 @@ components:
         Only organization administrators can set or modify this value.
 
         **Changes**: New in Zulip 13.0 (feature level 507).
+      example: true
+    MandatoryEmailNotifications:
+      type: boolean
+      description: |
+        Whether email notifications are required for all subscribers to this
+        channel. When enabled, subscribers cannot disable email notifications
+        for the channel.
+
+        Only organization administrators can set or modify this value.
+
+        **Changes**: New in Zulip 13.0 (feature level ZF-e45356).
       example: true
     TopicsPolicy:
       type: string

--- a/zerver/tests/test_channel_creation.py
+++ b/zerver/tests/test_channel_creation.py
@@ -1462,3 +1462,42 @@ class TestCreateStreams(ZulipTestCase):
         self.assert_json_success(result)
         stream = get_stream("push_create_via_channels_api", realm)
         self.assertTrue(stream.default_push_notifications)
+
+    def test_create_stream_with_mandatory_email_notifications(self) -> None:
+        """An admin can set mandatory_email_notifications=True when creating a stream.
+        A non-admin cannot."""
+        admin = self.example_user("iago")
+        non_admin = self.example_user("hamlet")
+        realm = admin.realm
+
+        result = self.subscribe_via_post(
+            non_admin,
+            ["mandatory_email_create_nonadmin"],
+            extra_post_data={"mandatory_email_notifications": orjson.dumps(True).decode()},
+            allow_fail=True,
+        )
+        self.assert_json_error(result, "Insufficient permission")
+
+        result = self.create_channel_via_post(
+            non_admin,
+            name="mandatory_email_create_nonadmin_v2",
+            extra_post_data={"mandatory_email_notifications": orjson.dumps(True).decode()},
+        )
+        self.assert_json_error(result, "Insufficient permission")
+
+        self.subscribe_via_post(
+            admin,
+            ["mandatory_email_create_admin"],
+            extra_post_data={"mandatory_email_notifications": orjson.dumps(True).decode()},
+        )
+        stream = get_stream("mandatory_email_create_admin", realm)
+        self.assertTrue(stream.mandatory_email_notifications)
+
+        result = self.create_channel_via_post(
+            admin,
+            name="mandatory_email_create_via_channels_api",
+            extra_post_data={"mandatory_email_notifications": orjson.dumps(True).decode()},
+        )
+        self.assert_json_success(result)
+        stream = get_stream("mandatory_email_create_via_channels_api", realm)
+        self.assertTrue(stream.mandatory_email_notifications)

--- a/zerver/tests/test_channel_permissions.py
+++ b/zerver/tests/test_channel_permissions.py
@@ -1554,3 +1554,56 @@ class ChannelAdministerPermissionTest(ZulipTestCase):
                 "property": "default_push_notifications",
             },
         )
+
+    def test_update_stream_mandatory_email_notifications(self) -> None:
+        """Only admins can change mandatory_email_notifications; the update
+        fires a stream event and persists the value."""
+        admin = self.example_user("iago")
+        non_admin = self.example_user("hamlet")
+        self.login_user(admin)
+        stream = self.subscribe(admin, "test_mandatory_email_stream")
+        self.subscribe(non_admin, "test_mandatory_email_stream")
+        realm = admin.realm
+
+        self.login_user(non_admin)
+        result = self.client_patch(
+            f"/json/streams/{stream.id}",
+            {"mandatory_email_notifications": orjson.dumps(True).decode()},
+        )
+        self.assert_json_error(result, "You do not have permission to administer this channel.")
+
+        do_change_stream_group_based_setting(
+            stream,
+            "can_administer_channel_group",
+            UserGroupMembersData(direct_members=[non_admin.id], direct_subgroups=[]),
+            acting_user=admin,
+        )
+        self.login_user(non_admin)
+        result = self.client_patch(
+            f"/json/streams/{stream.id}",
+            {"mandatory_email_notifications": orjson.dumps(True).decode()},
+        )
+        self.assert_json_error(result, "Insufficient permission")
+
+        self.login_user(admin)
+        with self.capture_send_event_calls(expected_num_events=1) as events:
+            result = self.client_patch(
+                f"/json/streams/{stream.id}",
+                {"mandatory_email_notifications": orjson.dumps(True).decode()},
+            )
+        self.assert_json_success(result)
+        stream = get_stream("test_mandatory_email_stream", realm)
+        self.assertTrue(stream.mandatory_email_notifications)
+
+        event = events[0]["event"]
+        self.assertEqual(
+            event,
+            dict(
+                op="update",
+                type="stream",
+                property="mandatory_email_notifications",
+                value=True,
+                stream_id=stream.id,
+                name="test_mandatory_email_stream",
+            ),
+        )

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1496,7 +1496,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = user_profile.delivery_email
 
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(20):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -5367,6 +5367,15 @@ class SubscribeActionTest(BaseAction):
             )
         check_stream_update("events[0]", events[0])
 
+        with self.verify_action(include_subscribers=include_subscribers, num_events=1) as events:
+            do_set_stream_property(
+                stream,
+                "mandatory_email_notifications",
+                True,
+                iago,
+            )
+        check_stream_update("events[0]", events[0])
+
         for setting_name in Stream.stream_permission_group_settings:
             self.do_test_subscribe_events_for_stream_permission_group_setting(
                 setting_name, stream, iago, include_subscribers

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1621,7 +1621,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(57), self.assert_memcached_count(19):
+        with self.assert_database_query_count(59), self.assert_memcached_count(19):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -31,7 +31,7 @@ from zerver.lib.email_notifications import (
 from zerver.lib.emoji import get_emoji_file_name
 from zerver.lib.send_email import FromAddress
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import Message, UserMessage, UserProfile, UserTopic
+from zerver.models import Message, Subscription, UserMessage, UserProfile, UserTopic
 from zerver.models.realm_emoji import get_name_keyed_dict_for_active_realm_emoji
 from zerver.models.realms import get_realm
 from zerver.models.recipients import Recipient, get_or_create_direct_message_group
@@ -2113,3 +2113,52 @@ class TestMessageNotificationEmails(ZulipTestCase):
         )
         self.assertEqual(synthetic_root_message_id.count("@"), 1)
         self.assertNotIn(" ", synthetic_root_message_id)
+
+    def test_mandatory_email_notifications_stream_email_footer(self) -> None:
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        stream = self.make_stream("mandatory_email_stream", hamlet.realm)
+        stream.mandatory_email_notifications = True
+        stream.save()
+        self.subscribe(hamlet, stream.name)
+        self.subscribe(othello, stream.name)
+
+        hamlet.enable_stream_email_notifications = False
+        hamlet.save()
+        sub = Subscription.objects.get(
+            user_profile=hamlet,
+            recipient__type=Recipient.STREAM,
+            recipient__type_id=stream.id,
+        )
+        sub.email_notifications = False
+        sub.save()
+
+        msg_id = self.send_stream_message(othello, stream.name, "hello")
+        self.handle_missedmessage_emails(
+            hamlet.id,
+            {msg_id: MissedMessageData(trigger=NotificationTriggers.STREAM_EMAIL)},
+        )
+        body = self.normalize_string(mail.outbox[0].body)
+        self.assertIn("configured to send email notifications to all subscribers", body)
+        self.assertIn("unsubscribe from the channel", body)
+
+    @patch("zerver.lib.email_notifications.user_can_unsubscribe_from_stream", return_value=False)
+    def test_mandatory_email_notifications_required_subscription_footer(
+        self, ignored: object
+    ) -> None:
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        stream = self.make_stream("mandatory_email_required_sub", hamlet.realm)
+        stream.mandatory_email_notifications = True
+        stream.save()
+        self.subscribe(hamlet, stream.name)
+        self.subscribe(othello, stream.name)
+
+        msg_id = self.send_stream_message(othello, stream.name, "hello")
+        self.handle_missedmessage_emails(
+            hamlet.id,
+            {msg_id: MissedMessageData(trigger=NotificationTriggers.STREAM_EMAIL)},
+        )
+        body = self.normalize_string(mail.outbox[0].body)
+        self.assertIn("required by administrators", body)
+        self.assertIn("deactivate your account", body)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -915,7 +915,7 @@ class MessagePOSTTest(ZulipTestCase):
         # it reaches the check without its group memberships loaded, and we
         # treat those as empty rather than looking them up.
         flush_per_request_caches()
-        with self.assert_database_query_count(20):
+        with self.assert_database_query_count(21):
             result = self.api_post(
                 bot,
                 "/api/v1/messages",
@@ -1937,7 +1937,7 @@ class StreamMessagesTest(ZulipTestCase):
             setting_value=UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_NEVER,
             acting_user=None,
         )
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(16):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1957,7 +1957,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 5 queries: 1 to check if it is the first message in the topic +
         # 1 to check if the topic is already followed + 3 to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(20):
+        with self.assert_database_query_count(21):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1977,7 +1977,7 @@ class StreamMessagesTest(ZulipTestCase):
         # a message to a topic with visibility policy other than FOLLOWED.
         # 1 to check if the topic is already followed + 3 queries to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(20):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1988,7 +1988,7 @@ class StreamMessagesTest(ZulipTestCase):
         # If the topic is already FOLLOWED, there will be an increase in the query
         # count of 1 to check if the topic is already followed.
         flush_per_request_caches()
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -2013,7 +2013,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 1 to get the user_id of the mentioned user + 1 to check if the topic
         # is already followed + 3 queries to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(25):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -2026,7 +2026,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 1 to get the user_id of the mentioned user + 1 to check if the topic is
         # already followed.
         flush_per_request_caches()
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(22):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -2036,7 +2036,7 @@ class StreamMessagesTest(ZulipTestCase):
             )
 
         flush_per_request_caches()
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(19):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -2059,7 +2059,7 @@ class StreamMessagesTest(ZulipTestCase):
         )
         flush_per_request_caches()
 
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(20):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -1,9 +1,14 @@
 from zerver.actions.user_groups import check_add_user_group
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.mention import MentionBackend, MentionData
-from zerver.lib.notification_data import UserMessageNotificationsData, get_user_group_mentions_data
+from zerver.lib.notification_data import (
+    UserMessageNotificationsData,
+    get_user_group_mentions_data,
+    user_allows_notifications_in_StreamTopic,
+)
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models.scheduled_jobs import NotificationTriggers
+from zerver.models.user_topics import UserTopic
 
 
 class TestNotificationData(ZulipTestCase):
@@ -511,3 +516,45 @@ class TestNotificationData(ZulipTestCase):
         self.assertFalse(user_data.followed_topic_push_notify)
         self.assertFalse(user_data.topic_wildcard_mention_in_followed_topic_push_notify)
         self.assertFalse(user_data.stream_wildcard_mention_in_followed_topic_push_notify)
+
+    def test_user_allows_notifications_with_mandatory_email_notifications(self) -> None:
+        self.assertTrue(
+            user_allows_notifications_in_StreamTopic(
+                stream_is_muted=False,
+                visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
+                stream_specific_setting=False,
+                global_setting=False,
+                channel_specific_setting_overrides_mute=False,
+                mandatory_email_notifications=True,
+            )
+        )
+        self.assertFalse(
+            user_allows_notifications_in_StreamTopic(
+                stream_is_muted=True,
+                visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
+                stream_specific_setting=False,
+                global_setting=False,
+                channel_specific_setting_overrides_mute=False,
+                mandatory_email_notifications=True,
+            )
+        )
+        self.assertTrue(
+            user_allows_notifications_in_StreamTopic(
+                stream_is_muted=True,
+                visibility_policy=UserTopic.VisibilityPolicy.UNMUTED,
+                stream_specific_setting=False,
+                global_setting=False,
+                channel_specific_setting_overrides_mute=False,
+                mandatory_email_notifications=True,
+            )
+        )
+        self.assertFalse(
+            user_allows_notifications_in_StreamTopic(
+                stream_is_muted=False,
+                visibility_policy=UserTopic.VisibilityPolicy.MUTED,
+                stream_specific_setting=True,
+                global_setting=True,
+                channel_specific_setting_overrides_mute=False,
+                mandatory_email_notifications=True,
+            )
+        )

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -685,6 +685,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
             expected_count: int,
             *,
             possible_stream_wildcard_mention: bool = False,
+            mandatory_email_notifications: bool = False,
             topic_participant_user_ids: AbstractSet[int] = set(),
             possibly_mentioned_user_ids: AbstractSet[int] = set(),
         ) -> None:
@@ -695,6 +696,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
                         stream_id=stream_id,
                         topic_name=topic_name,
                         possible_stream_wildcard_mention=possible_stream_wildcard_mention,
+                        mandatory_email_notifications=mandatory_email_notifications,
                         topic_participant_user_ids=topic_participant_user_ids,
                         possibly_mentioned_user_ids=possibly_mentioned_user_ids,
                     )
@@ -706,12 +708,14 @@ class SoftDeactivationMessageTest(ZulipTestCase):
             content: str,
             *,
             possible_stream_wildcard_mention: bool = False,
+            mandatory_email_notifications: bool = False,
             topic_participant_user_ids: AbstractSet[int] = set(),
             possibly_mentioned_user_ids: AbstractSet[int] = set(),
         ) -> None:
             assert_num_possible_users(
                 expected_count=3,
                 possible_stream_wildcard_mention=possible_stream_wildcard_mention,
+                mandatory_email_notifications=mandatory_email_notifications,
                 topic_participant_user_ids=topic_participant_user_ids,
                 possibly_mentioned_user_ids=possibly_mentioned_user_ids,
             )
@@ -854,3 +858,15 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         # Sanity check after removing the alert word for Hamlet.
         AlertWord.objects.filter(user_profile=long_term_idle_user).delete()
         assert_stream_message_not_sent_to_idle_user("no alert words")
+
+        stream = get_stream(stream_name, cordelia.realm)
+        stream.mandatory_email_notifications = True
+        stream.save()
+        sub.email_notifications = False
+        sub.save()
+        long_term_idle_user.enable_stream_email_notifications = False
+        long_term_idle_user.save()
+        assert_stream_message_sent_to_idle_user(
+            "Mandatory email channel message",
+            mandatory_email_notifications=True,
+        )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4347,7 +4347,7 @@ class SubscriptionAPITest(ZulipTestCase):
         streams_to_sub = ["multi_user_stream"]
         with (
             self.capture_send_event_calls(expected_num_events=5) as events,
-            self.assert_database_query_count(45),
+            self.assert_database_query_count(46),
         ):
             self.subscribe_via_post(
                 self.test_user,
@@ -5256,7 +5256,7 @@ class SubscriptionAPITest(ZulipTestCase):
         ]
 
         # Test creating a public stream when realm does not have a notification stream.
-        with self.assert_database_query_count(45):
+        with self.assert_database_query_count(46):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[0]],
@@ -5264,7 +5264,7 @@ class SubscriptionAPITest(ZulipTestCase):
             )
 
         # Test creating private stream.
-        with self.assert_database_query_count(52):
+        with self.assert_database_query_count(53):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[1]],
@@ -5276,7 +5276,7 @@ class SubscriptionAPITest(ZulipTestCase):
         new_stream_announcements_stream = get_stream(self.streams[0], self.test_realm)
         self.test_realm.new_stream_announcements_stream_id = new_stream_announcements_stream.id
         self.test_realm.save()
-        with self.assert_database_query_count(57):
+        with self.assert_database_query_count(59):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[2]],

--- a/zerver/tests/test_subscription_settings.py
+++ b/zerver/tests/test_subscription_settings.py
@@ -463,3 +463,45 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         )
 
         self.assert_json_success(result, ignored_parameters=["invalid_parameter"])
+
+    def test_mandatory_email_notifications_subscription_property(self) -> None:
+        hamlet = self.example_user("hamlet")
+        stream = self.make_stream("mandatory_email", hamlet.realm)
+        stream.mandatory_email_notifications = True
+        stream.save()
+        self.subscribe(hamlet, stream.name)
+        self.login_user(hamlet)
+
+        result = self.api_post(
+            hamlet,
+            "/api/v1/users/me/subscriptions/properties",
+            {
+                "subscription_data": orjson.dumps(
+                    [
+                        {
+                            "property": "email_notifications",
+                            "stream_id": stream.id,
+                            "value": False,
+                        }
+                    ]
+                ).decode()
+            },
+        )
+        self.assert_json_error(result, "Email notifications are required for this channel.")
+
+        result = self.api_post(
+            hamlet,
+            "/api/v1/users/me/subscriptions/properties",
+            {
+                "subscription_data": orjson.dumps(
+                    [
+                        {
+                            "property": "email_notifications",
+                            "stream_id": stream.id,
+                            "value": True,
+                        }
+                    ]
+                ).decode()
+            },
+        )
+        self.assert_json_success(result)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -303,6 +303,7 @@ def update_stream_backend(
     can_send_message_group: Json[GroupSettingChangeRequest] | None = None,
     can_subscribe_group: Json[GroupSettingChangeRequest] | None = None,
     default_push_notifications: Json[bool] | None = None,
+    mandatory_email_notifications: Json[bool] | None = None,
     description: ChannelDescription = None,
     folder_id: Json[int | None] | MissingType = Missing,
     history_public_to_subscribers: Json[bool] | None = None,
@@ -446,6 +447,16 @@ def update_stream_backend(
             raise JsonableError(_("Insufficient permission"))
         do_set_stream_property(
             stream, "default_push_notifications", default_push_notifications, user_profile
+        )
+
+    if mandatory_email_notifications is not None:
+        if not user_profile.is_realm_admin:
+            raise JsonableError(_("Insufficient permission"))
+        do_set_stream_property(
+            stream,
+            "mandatory_email_notifications",
+            mandatory_email_notifications,
+            user_profile,
         )
 
     if is_archived is not None and not is_archived:
@@ -700,6 +711,7 @@ def create_channel(
     can_send_message_group: Json[int | UserGroupMembersData] | None = None,
     can_subscribe_group: Json[int | UserGroupMembersData] | None = None,
     default_push_notifications: Json[bool] = False,
+    mandatory_email_notifications: Json[bool] = False,
     description: ChannelDescription = None,
     folder_id: Json[int] | None = None,
     history_public_to_subscribers: Json[bool] | None = None,
@@ -756,6 +768,9 @@ def create_channel(
     if default_push_notifications and not user_profile.is_realm_admin:
         raise JsonableError(_("Insufficient permission"))
 
+    if mandatory_email_notifications and not user_profile.is_realm_admin:
+        raise JsonableError(_("Insufficient permission"))
+
     group_settings_map = stream_group_settings_map[name]
     new_channel, created = create_stream_if_needed(
         realm,
@@ -766,6 +781,7 @@ def create_channel(
         is_web_public=is_web_public,
         message_retention_days=parsed_message_retention_days,
         default_push_notifications=default_push_notifications,
+        mandatory_email_notifications=mandatory_email_notifications,
         anonymous_group_membership=anonymous_group_membership,
         acting_user=user_profile,
         can_add_subscribers_group=group_settings_map["can_add_subscribers_group"],
@@ -851,6 +867,7 @@ def add_subscriptions_backend(
     can_send_message_group: Json[int | UserGroupMembersData] | None = None,
     can_subscribe_group: Json[int | UserGroupMembersData] | None = None,
     default_push_notifications: Json[bool] = False,
+    mandatory_email_notifications: Json[bool] = False,
     folder_id: Json[int] | None = None,
     history_public_to_subscribers: Json[bool] | None = None,
     invite_only: Json[bool] = False,
@@ -878,6 +895,9 @@ def add_subscriptions_backend(
     if default_push_notifications and not user_profile.is_realm_admin:
         raise JsonableError(_("Insufficient permission"))
 
+    if mandatory_email_notifications and not user_profile.is_realm_admin:
+        raise JsonableError(_("Insufficient permission"))
+
     for stream_obj in streams_raw:
         # 'color' field is optional
         # check for its presence in the streams_raw first
@@ -901,6 +921,7 @@ def add_subscriptions_backend(
             stream_dict_copy["topics_policy"] = validated_topics_policy.value
         stream_dict_copy["folder"] = folder
         stream_dict_copy["default_push_notifications"] = default_push_notifications
+        stream_dict_copy["mandatory_email_notifications"] = mandatory_email_notifications
 
         stream_dicts.append(stream_dict_copy)
 


### PR DESCRIPTION
<!-- Describe your pull request here. -->

Adds a channel-level `mandatory_email_notifications` setting for
organization administrators. When enabled, subscribers cannot disable
per-channel email notifications in channel notification settings; the
checkbox is disabled and displays an explanatory tooltip.

The backend enforces mandatory email notifications when determining
whether to send a missed-message email. It also rejects API requests
that attempt to set `email_notifications` to `false` for a channel where
mandatory email notifications are enabled.

Missed-message emails explain how recipients can stop receiving these
notifications: by unsubscribing from the channel, deactivating their
account, or contacting an administrator when channel subscription is
required.

Fixes: #19664

**How changes were tested:**

- `./tools/lint --modified`
- Backend tests covering subscription settings, channel permissions,
  channel creation, notification data, missed-message emails, and soft
  deactivation.
- Frontend tests:
  - `web/tests/stream_data.test.cjs`
  - `web/tests/stream_events.test.cjs`
- Manually verified the disabled email notification checkbox and tooltip.
- Manually verified the missed-message email and mandatory-channel footer
  at `/emails`.
- OpenAPI validation:
  `node tools/check-openapi.ts zerver/openapi/zulip.yaml`

**Screenshots and screen captures:**

Channel settings: mandatory email notifications option for administrators.

<img width="1204" height="821" alt="Mandatory email notifications option in channel settings" src="https://github.com/user-attachments/assets/cd745a77-6571-4c05-a7df-f1175986e20d">

Subscribers cannot disable email notifications for a mandatory-email
channel.

<img width="1192" height="826" alt="Disabled email notifications checkbox for a mandatory-email channel" src="https://github.com/user-attachments/assets/882adb2f-961e-4746-87b2-3fd749082486">

### API documentation

The `mandatory_email_notifications` field is documented for the relevant
channel API endpoints. Until the change is merged, its API feature level
is represented by the `ZF-e45356` placeholder.

<img width="647" height="186" alt="image" src="https://github.com/user-attachments/assets/f11eab55-fcc9-4c6a-a9ef-f664e55c2706">

### API changelog

The API change is recorded in the unmerged changelog fragment
`api_docs/unmerged.d/ZF-e45356.md`.

<img width="1083" height="238" alt="image" src="https://github.com/user-attachments/assets/1716652f-e6d0-448f-b606-4867772a4338">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)
  the changes for clarity and maintainability.
- [x] Followed the
  [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Automated tests cover the new behavior.
- [x] Manually tested the affected UI and email flow.

</details>