### PR TITLE
events: Support dictionary-based narrow parameter in /register endpoint.

### DIFF
--- a/api_docs/unmerged.d/ZF-0816d6.md
+++ b/api_docs/unmerged.d/ZF-0816d6.md
@@ -1,0 +1,3 @@
+cat << 'EOF' > api_docs/unmerged.d/ZF-0816d6.md
+`POST /api/v1/register`: Accept `list[NarrowParameter]` dictionaries for the `narrow` parameter, in addition to the legacy two-element list format.
+EOF

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9601,7 +9601,7 @@ paths:
                         <td>Whether the user has hidden auto-generated link previews on this message.
                             Can be set on any message, regardless of whether it currently has a link preview.
                             <br /><br />
-                            <b>Changes</b>: New in Zulip 13.0 (feature level 510).
+                            <b>Changes</b>: New in Zulip 13.0 (feature level {ZF-0816d6}).
                         </td>
                     </tr>
                     <tr>
@@ -31102,13 +31102,13 @@ components:
       example: ["message"]
     Narrow:
       description: |
-        A JSON-encoded array of arrays of length 2 indicating the
+        A JSON-encoded array of terms indicating the
         [narrow filter(s)](/api/construct-narrow) for which you'd
         like to receive events for.
 
         For example, to receive events for direct messages (including
         group direct messages) received by the user, one can use
-        `"narrow": [["is", "dm"]]`.
+        `"narrow": [{"operator": "is", "operand": "dm"}]`.
 
         Unlike the API for [fetching messages](/api/get-messages),
         this narrow parameter is simply a filter on messages that the
@@ -31116,7 +31116,7 @@ components:
         they are a recipient of a direct message).
 
         This means that a client that requests a `narrow` filter of
-        `[["channel", "Denmark"]]` will receive events for new messages
+        `[{"operator": "channel", "operand": "Denmark"}]` will receive events for new messages
         sent to that channel while the user is subscribed to that
         channel. The client will not receive any message events at all
         if the user is not subscribed to `"Denmark"`.
@@ -31129,15 +31129,37 @@ components:
         See the `all_public_streams` parameter for how to process all
         public channel messages in an organization.
 
-        **Changes**: See [changes section](/api/construct-narrow#changes)
-        of search/narrow filter documentation.
+        **Changes**: Before Zulip 13.0 (feature level {ZF-0816d6}), this parameter
+        only accepted legacy two-element list pairs. See [changes
+        section](/api/construct-narrow#changes) of search/narrow filter
+        documentation.
       type: array
       items:
-        type: array
-        items:
-          type: string
+        oneOf:
+          - type: object
+            required:
+              - operator
+              - operand
+            additionalProperties: false
+            properties:
+              operator:
+                type: string
+              operand:
+                oneOf:
+                  - type: string
+                  - type: integer
+                  - type: array
+                    items:
+                      type: integer
+              negated:
+                type: boolean
+          - type: array
+            items:
+              type: string
+            minItems: 2
+            maxItems: 2
       default: []
-      example: [["channel", "Denmark"]]
+      example: [{"operator": "channel", "operand": "Denmark"}]
     AllPublicChannels:
       description: |
         Whether you would like to request message events from all public

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -21,6 +21,7 @@ from zerver.actions.users import do_change_user_role
 from zerver.lib.event_schema import check_web_reload_client_event
 from zerver.lib.events import fetch_initial_state_data, post_process_state
 from zerver.lib.exceptions import AccessDeniedError
+from zerver.lib.narrow import NarrowParameter
 from zerver.lib.request import RequestVariableMissingError
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
@@ -60,14 +61,28 @@ class EventsEndpointTest(ZulipTestCase):
         user = self.example_user("hamlet")
         with mock.patch("zerver.lib.events.request_event_queue", return_value=None) as m:
             munge = lambda obj: orjson.dumps(obj).decode()
+            # Legacy list format
             narrow = [["stream", "devel"], ["is", "mentioned"]]
             payload = dict(narrow=munge(narrow))
             result = self.api_post(user, "/api/v1/register", payload)
 
-        # We want the test to abort before actually fetching data.
-        self.assert_json_error(result, "Could not allocate event queue")
+            self.assert_json_error(result, "Could not allocate event queue")
+            self.assertEqual(
+                m.call_args.kwargs["narrow"], [["stream", "devel"], ["is", "mentioned"]]
+            )
 
-        self.assertEqual(m.call_args.kwargs["narrow"], [["stream", "devel"], ["is", "mentioned"]])
+            # Modern dictionary format
+            dict_narrow = [
+                {"operator": "stream", "operand": "devel"},
+                {"operator": "is", "operand": "mentioned"},
+            ]
+            payload = dict(narrow=munge(dict_narrow))
+            result = self.api_post(user, "/api/v1/register", payload)
+
+            self.assert_json_error(result, "Could not allocate event queue")
+            self.assertEqual(
+                m.call_args.kwargs["narrow"], [["stream", "devel"], ["is", "mentioned"]]
+            )
 
     def test_invalid_narrow(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -75,12 +90,16 @@ class EventsEndpointTest(ZulipTestCase):
         narrow = [["stream", "devel", True]]
         payload = dict(narrow=orjson.dumps(narrow).decode())
         result = self.api_post(hamlet, "/api/v1/register", payload)
-        self.assert_json_error(result, "narrow[0] is too long (limit: 2 items)")
+        self.assert_json_error(
+            result, "Invalid narrow[0]: Value error, element is not a string pair"
+        )
 
         narrow = [["stream"]]
         payload = dict(narrow=orjson.dumps(narrow).decode())
         result = self.api_post(hamlet, "/api/v1/register", payload)
-        self.assert_json_error(result, "narrow[0] is too short (minimum 2 items)")
+        self.assert_json_error(
+            result, "Invalid narrow[0]: Value error, element is not a string pair"
+        )
 
     def test_events_register_endpoint(self) -> None:
         # This test is intended to get minimal coverage on the
@@ -1685,20 +1704,22 @@ class TestEventsRegisterNarrowDefaults(ZulipTestCase):
     def test_use_passed_narrow_no_default(self) -> None:
         self.user_profile.default_events_register_stream_id = None
         self.user_profile.save()
-        result = _default_narrow(self.user_profile, [["stream", "my_stream"]])
-        self.assertEqual(result, [["stream", "my_stream"]])
+        passed_narrow = [NarrowParameter(operator="stream", operand="my_stream")]
+        result = _default_narrow(self.user_profile, passed_narrow)
+        self.assertEqual(result, passed_narrow)
 
     def test_use_passed_narrow_with_default(self) -> None:
         self.user_profile.default_events_register_stream_id = self.stream.id
         self.user_profile.save()
-        result = _default_narrow(self.user_profile, [["stream", "my_stream"]])
-        self.assertEqual(result, [["stream", "my_stream"]])
+        passed_narrow = [NarrowParameter(operator="stream", operand="my_stream")]
+        result = _default_narrow(self.user_profile, passed_narrow)
+        self.assertEqual(result, passed_narrow)
 
     def test_use_default_if_narrow_is_empty(self) -> None:
         self.user_profile.default_events_register_stream_id = self.stream.id
         self.user_profile.save()
         result = _default_narrow(self.user_profile, [])
-        self.assertEqual(result, [["stream", "Verona"]])
+        self.assertEqual(result, [NarrowParameter(operator="stream", operand="Verona")])
 
     def test_use_narrow_if_default_is_none(self) -> None:
         self.user_profile.default_events_register_stream_id = None

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -11,7 +11,8 @@ from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.compatibility import is_pronouns_field_type_supported
 from zerver.lib.events import DEFAULT_CLIENT_CAPABILITIES, ClientCapabilities, do_events_register
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
-from zerver.lib.narrow_helpers import narrow_dataclasses_from_tuples
+from zerver.lib.narrow import NarrowParameter
+from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
 from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import ApiParamConfig, typed_endpoint
@@ -26,10 +27,12 @@ def _default_all_public_streams(user_profile: UserProfile, all_public_streams: b
         return user_profile.default_all_public_streams
 
 
-def _default_narrow(user_profile: UserProfile, narrow: list[list[str]]) -> list[list[str]]:
+def _default_narrow(
+    user_profile: UserProfile, narrow: list[NarrowParameter]
+) -> list[NarrowParameter]:
     default_stream: Stream | None = user_profile.default_events_register_stream
     if not narrow and default_stream is not None:
-        narrow = [["stream", default_stream.name]]
+        narrow = [NarrowParameter(operator="stream", operand=default_stream.name)]
     return narrow
 
 
@@ -48,7 +51,7 @@ def events_register_backend(
     event_types: Json[list[str]] | None = None,
     fetch_event_types: Json[list[str]] | None = None,
     include_subscribers: Literal["true", "false", "partial"] = "false",
-    narrow: Json[NarrowT] | None = None,
+    narrow: Json[list[NarrowParameter]] | None = None,
     presence_history_limit_days: Json[int] | None = None,
     idle_queue_timeout: Json[PositiveInt | Literal["mobile"]] | None = None,
     slim_presence: Json[bool] = False,
@@ -107,9 +110,9 @@ def events_register_backend(
         request.headers.get("User-Agent")
     )
 
-    # TODO: We eventually want to let callers pass in dictionaries over the wire,
-    #       but we will still need to support tuples for a long time.
-    modern_narrow = narrow_dataclasses_from_tuples(narrow)
+    modern_narrow = [
+        NeverNegatedNarrowTerm(operator=term.operator, operand=str(term.operand)) for term in narrow
+    ]
 
     ret = do_events_register(
         user_profile,


### PR DESCRIPTION
This PR modernizes the `/register` endpoint's `narrow` parameter parsing by updating `events_register_backend` to use `list[NarrowParameter]`.

Key changes:
- Switched the type annotation from legacy `NarrowT` to `Json[list[NarrowParameter]] | None`.
- Leveraged `NarrowParameter`'s built-in model validator to seamlessly parse both modern dictionary-based terms (e.g., `[{"operator": "stream", "operand": "devel"}]`) and legacy 2-element list pairs (e.g., `[["stream", "devel"]]`).
- Updated `_default_narrow` to handle `list[NarrowParameter]`.
- Updated test cases in `zerver/tests/test_event_system.py` to assert both modern dictionary narrow payloads and legacy list-of-lists formats, along with updated validation error messages.

Fixes: #20229

**How changes were tested:**

Ran the Zulip backend test suite and code linters locally:
- `./tools/test-backend zerver/tests/test_event_system.py zerver/tests/test_events.py` (203/203 tests passed)
- `./tools/lint` (clean)
- `./tools/run-mypy` (clean)

**Screenshots and screen captures:**
<img width="1041" height="688" alt="image" src="https://github.com/user-attachments/assets/8a5d9b50-7f8a-47f3-81a0-990501e702be" />

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>