### PR TITLE
Poll_widget: Add markdown rendering and typeahead support 

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1742,11 +1742,18 @@ function set_recipient_from_typeahead(item: UserGroupPillData | UserPillData): v
     }
 }
 
-export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElement>): void {
-    const bootstrap_typeahead_input: TypeaheadInputElement = {
-        $element,
-        type: "textarea",
-    };
+export function initialize_compose_typeahead(
+    $element: JQuery<HTMLInputElement | HTMLTextAreaElement>,
+): void {
+    const bootstrap_typeahead_input: TypeaheadInputElement = $element.is("input")
+        ? {
+              $element: $element.find<HTMLInputElement>("*").addBack("input"),
+              type: "input",
+          }
+        : {
+              $element: $element.find<HTMLTextAreaElement>("*").addBack("textarea"),
+              type: "textarea",
+          };
 
     compose_ui.maybe_set_compose_textarea_typeahead(
         new Typeahead(bootstrap_typeahead_input, {

--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -6,12 +6,15 @@ import render_widgets_poll_widget from "../templates/widgets/poll_widget.hbs";
 import render_widgets_poll_widget_results from "../templates/widgets/poll_widget_results.hbs";
 
 import * as blueslip from "./blueslip.ts";
+import * as composebox_typeahead from "./composebox_typeahead.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as markdown from "./markdown.ts";
 import type {Message} from "./message_store.ts";
 import * as people from "./people.ts";
 import type {PollWidgetOutboundData} from "./poll_data.ts";
 import {PollData, new_option_schema, question_schema, vote_schema} from "./poll_data.ts";
+import * as rendered_markdown from "./rendered_markdown.ts";
 import {ZulipWidgetContext} from "./widget_context.ts";
 import type {Event} from "./widget_data.ts";
 import type {AnyWidgetData, WidgetData} from "./widget_schema.ts";
@@ -113,7 +116,9 @@ export function render({
         const waiting = !is_my_poll && !has_question;
 
         $elem.find(".poll-question-header").toggle(!input_mode);
-        $elem.find(".poll-question-header").text(question);
+        const rendered_question = markdown.parse_non_message(question);
+        $elem.find(".poll-question-header").html(rendered_question);
+        rendered_markdown.update_elements($elem.find(".poll-question-header"));
         $elem.find(".poll-edit-question").toggle(can_edit);
         update_edit_controls();
 
@@ -192,12 +197,21 @@ export function render({
         const html = render_widgets_poll_widget({});
         $elem.html(html);
 
-        $elem.find("input.poll-question").on("keyup", (e) => {
+        const $poll_question_input = $elem.find<HTMLInputElement>("input.poll-question");
+        const $poll_option_input = $elem.find<HTMLInputElement>("input.poll-option");
+
+        composebox_typeahead.initialize_compose_typeahead($poll_question_input);
+        composebox_typeahead.initialize_compose_typeahead($poll_option_input);
+
+        $poll_question_input.on("keyup", (e) => {
             e.stopPropagation();
             update_edit_controls();
         });
 
-        $elem.find("input.poll-question").on("keydown", (e) => {
+        $poll_question_input.on("keydown", (e) => {
+            if (e.isDefaultPrevented()) {
+                return;
+            }
             e.stopPropagation();
 
             if (keydown_util.is_enter_event(e)) {
@@ -232,7 +246,10 @@ export function render({
             submit_option();
         });
 
-        $elem.find("input.poll-option").on("keyup", (e) => {
+        $poll_option_input.on("keyup", (e) => {
+            if (e.isDefaultPrevented()) {
+                return;
+            }
             e.stopPropagation();
             check_option_button();
 
@@ -242,7 +259,7 @@ export function render({
             }
 
             if (e.key === "Escape") {
-                $("input.poll-option").val("");
+                $poll_option_input.val("");
                 return;
             }
         });
@@ -266,9 +283,17 @@ export function render({
 
     function render_results(): void {
         const widget_data = poll_data.get_widget_data();
+        const options = widget_data.options.map((option) => ({
+            ...option,
+            option_html: markdown.parse_non_message(option.option),
+        }));
 
-        const html = render_widgets_poll_widget_results(widget_data);
+        const html = render_widgets_poll_widget_results({
+            ...widget_data,
+            options,
+        });
         $elem.find("ul.poll-widget").html(html);
+        rendered_markdown.update_elements($elem.find("ul.poll-widget"));
 
         $elem
             .find("button.poll-vote")

--- a/web/templates/widgets/poll_widget_results.hbs
+++ b/web/templates/widgets/poll_widget_results.hbs
@@ -4,7 +4,7 @@
             <button class="poll-vote {{#if current_user_vote}}current-user-vote{{/if}}" data-key="{{ key }}">
                 {{ count }}
             </button>
-            <span class="poll-option-text">{{ option }}</span>
+            <span class="poll-option-text">{{{ option_html }}}</span>
         </label>
         {{#if names}}
         <span class="poll-names">({{ names }})</span>

--- a/web/tests/poll_widget.test.cjs
+++ b/web/tests/poll_widget.test.cjs
@@ -10,7 +10,18 @@ const blueslip = require("./lib/zblueslip.cjs");
 const {$} = require("./lib/zjquery.cjs");
 
 mock_esm("../src/settings_data", {
-    user_can_access_all_other_users: () => true,
+    user_can_access_all_other_users() {
+        return true;
+    },
+});
+const composebox_typeahead = mock_esm("../src/composebox_typeahead", {
+    initialize_compose_typeahead() {},
+});
+const markdown = mock_esm("../src/markdown", {
+    parse_non_message: (raw) => `<p>${raw}</p>`,
+});
+const rendered_markdown = mock_esm("../src/rendered_markdown", {
+    update_elements() {},
 });
 
 const {PollData} = zrequire("poll_data");
@@ -282,7 +293,7 @@ run_test("activate another person poll", ({mock_template}) => {
 
     assert.equal($widget_elem.html(), "widgets/poll_widget");
     assert.equal($widget_option_container.html(), "widgets/poll_widget_results");
-    assert.equal($poll_question_header.text(), "What do you want?");
+    assert.equal($poll_question_header.html(), "<p>What do you want?</p>");
 
     {
         /* Testing data sent to server on adding option */
@@ -407,7 +418,7 @@ run_test("activate own poll", ({mock_template}) => {
 
     assert.equal($widget_elem.html(), "widgets/poll_widget");
     assert.equal($widget_option_container.html(), "widgets/poll_widget_results");
-    assert.equal($poll_question_header.text(), "Where to go?");
+    assert.equal($poll_question_header.html(), "<p>Where to go?</p>");
 
     {
         /* Testing data sent to server on editing question */
@@ -424,4 +435,106 @@ run_test("activate own poll", ({mock_template}) => {
         $poll_question_submit.trigger("click");
         assert.deepEqual(out_data, undefined);
     }
+});
+
+run_test("poll markdown rendering and typeahead", ({mock_template, override}) => {
+    let results_template_data;
+    mock_template("widgets/poll_widget.hbs", false, () => "widgets/poll_widget");
+    mock_template("widgets/poll_widget_results.hbs", false, (data) => {
+        results_template_data = data;
+        return "widgets/poll_widget_results";
+    });
+
+    let typeahead_initialized_count = 0;
+    override(composebox_typeahead, "initialize_compose_typeahead", () => {
+        typeahead_initialized_count += 1;
+    });
+
+    const parse_non_message_calls = [];
+    override(markdown, "parse_non_message", (raw) => {
+        parse_non_message_calls.push(raw);
+        return `<span class="rendered">${raw}</span>`;
+    });
+
+    const updated_elements = [];
+    override(rendered_markdown, "update_elements", ($elem) => {
+        updated_elements.push($elem);
+    });
+
+    const $widget_elem = $("<div>").addClass("widget-content");
+
+    const set_widget_find_result = (selector) => {
+        const $elem = $.create(selector);
+        $widget_elem.set_find_results(selector, $elem);
+        return $elem;
+    };
+
+    set_widget_find_result("button.poll-option");
+    set_widget_find_result("input.poll-option");
+    set_widget_find_result("ul.poll-widget");
+    set_widget_find_result("button.poll-question-check");
+    set_widget_find_result(".poll-edit-question");
+    const $poll_question_header = set_widget_find_result(".poll-question-header");
+    set_widget_find_result(".poll-question-bar");
+    set_widget_find_result(".poll-option-bar");
+    set_widget_find_result("button.poll-vote");
+    set_widget_find_result(".poll-please-wait");
+    set_widget_find_result("button.poll-question-remove");
+    set_widget_find_result("input.poll-question");
+
+    const activate_opts = {
+        message: {
+            sender_id: me.user_id,
+        },
+        any_data: {
+            widget_type: "poll",
+            extra_data: {
+                question: "What is your **favorite** option?",
+                options: ["Option **A**", "Option *B*"],
+            },
+        },
+    };
+
+    const {widget_data} = poll_widget.activate(activate_opts);
+    const render_opts = {
+        $elem: $widget_elem,
+        callback() {},
+        message: {
+            sender_id: me.user_id,
+        },
+        widget_data,
+        rerender: false,
+    };
+
+    poll_widget.render(render_opts);
+
+    // Verify typeahead was initialized for poll question and option inputs
+    assert.equal(typeahead_initialized_count, 2);
+
+    // Verify markdown.parse_non_message was called for question and options
+    assert.deepEqual(parse_non_message_calls, [
+        "What is your **favorite** option?",
+        "Option **A**",
+        "Option *B*",
+    ]);
+
+    // Verify question header HTML contains parsed markdown
+    assert.equal(
+        $poll_question_header.html(),
+        '<span class="rendered">What is your **favorite** option?</span>',
+    );
+
+    // Verify option_html was passed to template data
+    assert.equal(results_template_data.options.length, 2);
+    assert.equal(
+        results_template_data.options[0].option_html,
+        '<span class="rendered">Option **A**</span>',
+    );
+    assert.equal(
+        results_template_data.options[1].option_html,
+        '<span class="rendered">Option *B*</span>',
+    );
+
+    // Verify rendered_markdown.update_elements was called for question header and results list
+    assert.equal(updated_elements.length, 2);
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
https://github.com/zulip/zulip/issues/39968

<summary>

## Problem
Previously, poll question headers and poll option choices rendered as raw unformatted strings. User/stream mentions, linkifiers, and custom emojis were displayed as raw Markdown syntax rather than rendered HTML elements. Additionally, mention and emoji typeahead autocomplete suggestions were unavailable while typing poll questions or option choices.

## Technical Fix
1. **Typeahead Utilities (`web/src/composebox_typeahead.ts`)**:
   - Expanded `initialize_compose_typeahead` parameter signature to accept `JQuery<HTMLInputElement | HTMLTextAreaElement>` so input fields can utilize composebox typeahead autocomplete.

2. **Poll Widget Logic & Rendering (`web/src/poll_widget.ts` & `web/templates/widgets/poll_widget_results.hbs`)**:
   - Parsed poll questions and option strings using `markdown.parse_non_message`.
   - Post-processed rendered DOM elements with `rendered_markdown.update_elements` to render user/stream mentions, linkifiers, and emojis.
   - Updated `poll_widget_results.hbs` to output `{{{ option_html }}}` using triple-brace Handlebars syntax so parsed HTML renders cleanly.
   - Initialized `composebox_typeahead.initialize_compose_typeahead` on poll question (`input.poll-question`) and option (`input.poll-option`) inputs.
   - Added `e.isDefaultPrevented()` guards on `keyup`/`keydown` event handlers to prevent premature form submission when selecting autocomplete items with `Enter`.

## Testing Verification
- Added node unit test `"poll markdown rendering and typeahead"` in `web/tests/poll_widget.test.cjs` covering Markdown parsing, template rendering, post-processing, and typeahead setup.
- Executed `./tools/test-js-with-node web/tests/poll_widget.test.cjs` and confirmed all unit tests pass.
- Verified code formatting and type safety with `./tools/lint`.

Fixes #39968.

</summary>