### PR TITLE
Fix mobile email button

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -138,6 +138,7 @@ a.help_link_widget {
         pointer-events: none;
     }
 }
+
 #email_field_container,
 #change_email_button,
 #change_password {
@@ -2389,6 +2390,10 @@ label.preferences-radio-choice-label {
     /* Subtract (2 * horizontal padding) + (2 * border width) */
     width: calc(
         var(--modal-input-width) - 2 * var(--input-horizontal-padding) - 2 *
+            var(--input-border-width)
+    );
+    max-width: calc(
+        100% - 2 * var(--input-horizontal-padding) - 2 *
             var(--input-border-width)
     );
     font-family: inherit;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -138,7 +138,7 @@ a.help_link_widget {
         pointer-events: none;
     }
 }
-
+#email_field_container,
 #change_email_button,
 #change_password {
     min-width: 0;


### PR DESCRIPTION
Fixes #40051

The email field in Account settings overflowed the viewport on narrow
mobile screen widths, causing the Edit email button to be pushed outside
the visible layout.

This PR:
- constrains the email input to the available width;
- keeps the Edit email button visible within the viewport.

**How changes were tested:**

Manually tested the Account settings page using the local Zulip development
server at a narrow mobile viewport.

Verified that:
- the email input no longer overflows the viewport;
- the Edit email button remains visible and horizontally aligned;
- the existing email field appearance is preserved.

**Screenshots and screen captures:**

**Before:**

<img width="475" height="837" alt="Before: Edit email button not visible on a narrow mobile viewport" src="https://github.com/user-attachments/assets/c083b7a6-b93f-4be4-bd4f-537cd4e00a3b" />

**After:**

<img width="492" height="850" alt="After: Edit email button visible on a narrow mobile viewport" src="https://github.com/user-attachments/assets/f0fc8b35-19f1-4b5a-9401-1fc1a04d9ba7" />

**Self-review checklist:**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.