### PR TITLE
Hide hotkey hints on mobile.

### DIFF
--- a/web/src/templates.ts
+++ b/web/src/templates.ts
@@ -7,6 +7,7 @@ import * as common from "./common.ts";
 import {default_html_elements, intl} from "./i18n.ts";
 import {postprocess_content} from "./postprocess_content.ts";
 import {user_settings} from "./user_settings.ts";
+import {is_mobile} from "./util.ts";
 
 const orig_escape_expression = Handlebars.Utils.escapeExpression;
 const orig_is_empty = Handlebars.Utils.isEmpty;
@@ -249,6 +250,9 @@ Handlebars.registerHelper("numberFormat", (number: number) => number.toLocaleStr
 
 Handlebars.registerHelper("tooltip_hotkey_hints", (...args) => {
     args.pop(); // Handlebars options
+    if (is_mobile()) {
+        return "";
+    }
     const hotkeys: string[] = args;
     let hotkey_hints = "";
     common.adjust_mac_hotkey_hints(hotkeys);

--- a/web/tests/templates.test.cjs
+++ b/web/tests/templates.test.cjs
@@ -87,6 +87,17 @@ run_test("tooltip_hotkey_hints", () => {
     assert.equal(html, expected_html);
 });
 
+run_test("tooltip_hotkey_hints mobile", ({override}) => {
+    const args = {
+        hotkey_one: "Ctrl",
+        hotkey_two: "C",
+    };
+
+    override(navigator, "userAgent", "Mozilla/5.0 (Linux; Android 10; Mobile)");
+    const html = require("./templates/tooltip_hotkey_hints.hbs")(args);
+    assert.equal(html, "\n");
+});
+
 run_test("popover_hotkey_hints", () => {
     const args = {
         hotkey_one: "Ctrl",


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Hide keyboard shortcut hints in mobile web tooltips, since they are not relevant to user accessing zulip through 
a touch screen.

CZO: [#issues > tooltips in mobile show keyboard shortcuts](https://chat.zulip.org/#narrow/channel/9-issues/topic/tooltips.20in.20mobile.20show.20keyboard.20shortcuts)

Fixes: <!-- Issue link, or clear description.-->Mobile web tooltips display keyboard shortcut hints that are not applicable/relevant to touch-first interaction.

**How changes were tested:**
- Tested manually in the developer environment in PC and mobile.
- Verified that tooltips no longer show keyboard shortcuts in mobile but still do in PC.
- Tooltips can be shown in mobile by holding an element for a short while but dragging
your finger so that the element doesn't get highlighted/selected.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
**Screenshots and screen captures:**
Before:
<img width="317" height="716" alt="image" src="https://github.com/user-attachments/assets/1057c3ac-4308-4634-af4f-1c240591ec0f" />
After:
<img width="317" height="723" alt="image" src="https://github.com/user-attachments/assets/9e8ee2cb-ea4f-41dc-8f6f-00797cec2617" />
Video showing what tooltips look like with this change:
https://github.com/user-attachments/assets/bbb794bc-fb62-4cdd-a7e8-9e95deaca5c4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
