### PR TITLE
[ai] custom-profile-fields: Replace assert with JsonableError for non-string subtype.

### DIFF
--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -266,6 +266,14 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         data["field_data"] = orjson.dumps(
             {
+                "subtype": 123,
+            }
+        ).decode()
+        result = self.client_post("/json/realm/profile_fields", info=data)
+        self.assert_json_error(result, 'field_data["subtype"]["dict[str,str]"] is not a dict')
+
+        data["field_data"] = orjson.dumps(
+            {
                 "subtype": "123",
             }
         ).decode()

--- a/zerver/views/custom_profile_fields.py
+++ b/zerver/views/custom_profile_fields.py
@@ -202,7 +202,8 @@ def create_realm_custom_profile_field(
     try:
         if is_default_external_field(field_type, field_data):
             field_subtype = field_data["subtype"]
-            assert isinstance(field_subtype, str)
+            if not isinstance(field_subtype, str):
+                raise JsonableError(_("field_data.subtype is not a string"))
             field = try_add_realm_default_custom_profile_field(
                 realm=user_profile.realm,
                 field_subtype=field_subtype,


### PR DESCRIPTION
Fixes: #39845

## Summary

The `assert isinstance(field_subtype, str)` in `create_realm_custom_profile_field` produces an unhandled 500 error if a non-string `field_data.subtype` value is passed when creating a custom profile field of type `EXTERNAL_ACCOUNT`.

This PR replaces the `assert` with a proper `JsonableError` that returns a 400 response with a clear error message.

**Note:** Pydantic's typed endpoint validation (`Json[ProfileFieldData]`) currently catches non-string values before they reach this code path, so the 500 is not easily triggerable via the API in the current codebase. However, using `assert` for input validation is still incorrect — asserts can be disabled with `python -O` and should not be used as runtime checks on user-provided data.

## Test plan

- [x] `./tools/test-backend zerver.tests.test_custom_profile_data.CreateCustomProfileFieldTest.test_create_external_account_field`
- [x] `./tools/lint zerver/views/custom_profile_fields.py zerver/tests/test_custom_profile_data.py`
- Added test case for creating an external account field with a non-string (integer) subtype value

## Self-review checklist

- [x] The PR addresses all points described in the issue
- [x] All relevant tests pass locally
- [x] Code follows existing patterns in the codebase
- [x] Each commit is a minimal coherent idea
- [x] No debugging code or unnecessary comments remain
- [x] User-facing strings are tagged for translation
- [x] User-facing error messages are clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)