### PR TITLE
GitHub compact_edit_format URL option

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -667,6 +667,11 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
                 label="Include emoji indicators in the notifications",
                 input_type="checkbox_enabled",
             ),
+            WebhookUrlOption(
+                name="compact_edit_format",
+                label="Use a compact message format for edited issue and pull request descriptions",
+                input_type="checkbox_enabled",
+            ),
         ],
     ),
     IncomingWebhookIntegration(

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -669,7 +669,7 @@ INCOMING_WEBHOOK_INTEGRATIONS: list[IncomingWebhookIntegration] = [
             ),
             WebhookUrlOption(
                 name="compact_edit_format",
-                label="Use a compact message format for edited issue and pull request descriptions",
+                label="Use a compact message format for edited issue, pull request, and discussion notifications",
                 input_type="checkbox_enabled",
             ),
         ],

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2629,6 +2629,7 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         expected_message: str | None = None,
         content_type: str | None = "application/json",
         expect_noop: bool = False,
+        custom_payload: str | dict[str, Any] | None = None,
         **extra: str,
     ) -> None:
         """
@@ -2650,10 +2651,19 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         see send_and_test_private_message.
 
         When no message is expected to be sent, set `expect_noop` to True.
+
+        Pass `custom_payload` to send something other than the fixture's
+        contents, typically a fixture edited to exercise a different value
+        of a field, so that we don't need a near-duplicate fixture for it.
+        A dict also bypasses any `get_payload` override defined by the test
+        class.
         """
         self.subscribe(self.test_user, self.channel_name)
 
-        payload = self.get_payload(fixture_name)
+        if custom_payload is not None:
+            payload = custom_payload
+        else:
+            payload = self.get_payload(fixture_name)
         if content_type is not None:
             extra["content_type"] = content_type
         headers = call_fixture_to_headers(self.webhook_dir_name, fixture_name)

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -21,6 +21,7 @@ Get GitHub notifications in Zulip!
     - Whether to exclude notifications from private repositories.
     - Whether to include the repository name in the notifications.
     - Whether to include emoji indicators in the notifications.
+    - Whether to use a compact message format for edited issue and pull request descriptions.
 
 
 1. On your repository's web page, go to **Settings**. Select **Webhooks**,

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -21,7 +21,7 @@ Get GitHub notifications in Zulip!
     - Whether to exclude notifications from private repositories.
     - Whether to include the repository name in the notifications.
     - Whether to include emoji indicators in the notifications.
-    - Whether to use a compact message format for edited issue and pull request descriptions.
+    - Whether to use a compact message format for edited issue, pull request, and discussion notifications.
 
 
 1. On your repository's web page, go to **Settings**. Select **Webhooks**,

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -191,6 +191,24 @@ class GitHubWebhookTest(WebhookTestCase):
         expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/issues/2#issuecomment-99262140) on [issue #2](https://github.com/baxterthehacker/public-repo/issues/2):\n\n``` quote\nYou are totally right! I'll get this fixed right away.\n```"
         self.check_webhook("issue_comment", TOPIC_ISSUE, expected_message)
 
+    def test_issue_comment_edited_msg(self) -> None:
+        # Both issue and PR comments come under the `issue_comment` event.
+        payload = orjson.loads(self.get_body("issue_comment__edited__unchanged"))
+        payload["comment"]["body"] = "The comment, after being edited."
+        comment_link = "[comment](https://github.com/Niloth-p/webhook-tester/pull/1#issuecomment-2555981590) on [PR #1](https://github.com/Niloth-p/webhook-tester/pull/1)"
+        expected_messages = {
+            "true": f"AnotherUser edited a {comment_link}.",
+            "false": f"AnotherUser edited a {comment_link}:\n\n``` quote\nThe comment, after being edited.\n```",
+        }
+        for compact_edit_format, expected_message in expected_messages.items():
+            self.url = self.build_webhook_url(compact_edit_format=compact_edit_format)
+            self.check_webhook(
+                "issue_comment__edited__unchanged",
+                "webhook-tester / PR #1 Generic issue title",
+                expected_message,
+                custom_payload=payload,
+            )
+
     def test_issue_comment_deleted_msg(self) -> None:
         expected_topic_name = "Scheduler / issue #5 This is a new issue"
         expected_message = "eeshangarg deleted a [comment](https://github.com/eeshangarg/Scheduler/issues/5#issuecomment-425164194) on [issue #5](https://github.com/eeshangarg/Scheduler/issues/5):\n\n``` quote\nThis is a comment on this new issue.\n```"

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -776,7 +776,12 @@ A temporary team so that I can get some webhook fixtures!
         self.check_webhook("discussion__edited_title", expected_topic, expected_message)
 
     def test_discussion_edited_body(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         expected_message = "Niloth-p edited [discussion #3](https://github.com/Niloth-p/webhook-tester/discussions/3):\n\n``` quote\nWriting good commit messages is an art, but it's also an important part of maintaining a clear and understandable project history. What are some tips and tricks you've learned for writing clear and concise commit messages? Do you have any favorite templates or formats?\r\nAny advice would be greatly appreciated!\n```"
+        self.check_webhook("discussion__edited_body", TOPIC_DISCUSSION, expected_message)
+
+    def test_discussion_edited_body_compact(self) -> None:
+        expected_message = "Niloth-p edited [discussion #3](https://github.com/Niloth-p/webhook-tester/discussions/3)."
         self.check_webhook("discussion__edited_body", TOPIC_DISCUSSION, expected_message)
 
     def test_discussion_labeled(self) -> None:
@@ -826,7 +831,12 @@ A temporary team so that I can get some webhook fixtures!
         self.check_webhook("discussion_comment", expected_topic_name, expected_message)
 
     def test_discussion_comment_edited_msg(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         expected_message = "sbansal1999 edited a [comment](https://github.com/sbansal1999/testing-gh/discussions/20#discussioncomment-6332416) on [discussion #20](https://github.com/sbansal1999/testing-gh/discussions/20):\n\n``` quote\nsome random comment edited\n```"
+        self.check_webhook("discussion_comment__edited", TOPIC_DISCUSSION_COMMENT, expected_message)
+
+    def test_discussion_comment_edited_msg_compact(self) -> None:
+        expected_message = "sbansal1999 edited a [comment](https://github.com/sbansal1999/testing-gh/discussions/20#discussioncomment-6332416) on [discussion #20](https://github.com/sbansal1999/testing-gh/discussions/20)."
         self.check_webhook("discussion_comment__edited", TOPIC_DISCUSSION_COMMENT, expected_message)
 
     def test_comment_edited_unchanged_skipped(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -168,15 +168,24 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("fork", TOPIC_REPO, expected_message)
 
     def test_issues_edited_body(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         expected_topic_name = "test-repo / issue #6 New Issue edited"
         expected_message = "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6):\n\n``` quote\nThe body of the issue is edited.\n```"
         self.check_webhook("issues__edited_body", expected_topic_name, expected_message)
 
     def test_issues_edited_title(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         long_title = "This is a very long issue title used to exceed Zulip's maximum topic length so that truncation logic is exercised when the issue title is edited via the GitHub webhook"
         expected_topic_name = truncate_topic(f"test-repo / issue #6 {long_title}")
         expected_message = "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6):\n\n``` quote\nThe body of the issue is edited.\n```"
         self.check_webhook("issues__edited_title", expected_topic_name, expected_message)
+
+    def test_issues_edited_body_compact(self) -> None:
+        expected_topic_name = "test-repo / issue #6 New Issue edited"
+        expected_message = (
+            "Pritesh-30 edited [issue #6](https://github.com/Pritesh-30/test-repo/issues/6)."
+        )
+        self.check_webhook("issues__edited_body", expected_topic_name, expected_message)
 
     def test_issue_comment_msg(self) -> None:
         expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/issues/2#issuecomment-99262140) on [issue #2](https://github.com/baxterthehacker/public-repo/issues/2):\n\n``` quote\nYou are totally right! I'll get this fixed right away.\n```"
@@ -475,7 +484,14 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__edited", TOPIC_PR, expected_message)
 
     def test_pull_request_edited_with_body_change(self) -> None:
+        self.url = self.build_webhook_url(compact_edit_format="false")
         expected_message = "cozyrohan edited [PR #1](https://github.com/cozyrohan/public-repo/pull/1):\n\n``` quote\nPR EDITED\n```"
+        self.check_webhook("pull_request__edited_with_body_change", TOPIC_PR, expected_message)
+
+    def test_pull_request_edited_with_body_change_compact(self) -> None:
+        expected_message = (
+            "cozyrohan edited [PR #1](https://github.com/cozyrohan/public-repo/pull/1)."
+        )
         self.check_webhook("pull_request__edited_with_body_change", TOPIC_PR, expected_message)
 
     def test_pull_request_synchronized_with_body(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -473,6 +473,24 @@ class GitHubWebhookTest(WebhookTestCase):
         expected_message = ":speech_balloon: baxterthehacker created [PR review comment on #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#discussion_r29724692):\n\n``` quote\nMaybe you should use more emojji on this line.\n```"
         self.check_webhook("pull_request_review_comment", expected_topic_name, expected_message)
 
+    def test_pull_request_review_comment_edited_msg(self) -> None:
+        payload = orjson.loads(self.get_body("pull_request_review_comment"))
+        payload["action"] = "edited"
+        payload["changes"] = {"body": {"from": "The comment, before being edited."}}
+        comment_link = "[PR review comment](https://github.com/baxterthehacker/public-repo/pull/1#discussion_r29724692)"
+        expected_messages = {
+            "true": f":speech_balloon: baxterthehacker edited {comment_link}.",
+            "false": f":speech_balloon: baxterthehacker edited {comment_link}:\n\n``` quote\nMaybe you should use more emojji on this line.\n```",
+        }
+        for compact_edit_format, expected_message in expected_messages.items():
+            self.url = self.build_webhook_url(compact_edit_format=compact_edit_format)
+            self.check_webhook(
+                "pull_request_review_comment",
+                TOPIC_PR,
+                expected_message,
+                custom_payload=payload,
+            )
+
     def test_pull_request_locked(self) -> None:
         expected_message = "tushar912 has locked [PR #1](https://github.com/tushar912/public-repo/pull/1) as off-topic and limited conversation to collaborators."
         self.check_webhook("pull_request__locked", TOPIC_PR, expected_message)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -240,13 +240,18 @@ def get_issue_comment_body(helper: Helper) -> str:
     include_title = helper.include_title
     comment = payload["comment"]
     issue = payload["issue"]
+    message = (
+        None
+        if payload["action"].tame(check_string) == "edited" and helper.compact_edit_format
+        else comment["body"].tame(check_string)
+    )
 
     return get_pull_request_event_message(
         user_name=get_sender_name(helper),
         action=get_comment_action(payload),
         url=issue["html_url"].tame(check_string),
         number=issue["number"].tame(check_int),
-        message=comment["body"].tame(check_string),
+        message=message,
         title=issue["title"].tame(check_string) if include_title else None,
         type="PR" if is_pull_request_comment_event(payload) else "issue",
     )

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -100,6 +100,7 @@ class Helper:
         include_repository_name: bool,
         include_emoji_indicators: bool,
         user_profile: UserProfile,
+        compact_edit_format: bool,
     ) -> None:
         self.request = request
         self.payload = payload
@@ -107,6 +108,7 @@ class Helper:
         self.include_repository_name = include_repository_name
         self.include_emoji_indicators = include_emoji_indicators
         self.realm = user_profile.realm
+        self.compact_edit_format = compact_edit_format
 
     def log_unsupported(self, event: str) -> None:
         summary = f"The '{event}' event isn't currently supported by the GitHub webhook; ignoring"
@@ -125,7 +127,9 @@ def get_opened_or_update_pull_request_body(helper: Helper) -> str:
         assignee = pull_request["assignee"]["login"].tame(check_string)
     description = None
     changes = payload.get("changes", {})
-    if "body" in changes or action == "opened":
+    if action == "opened" or (
+        action == "edited" and not helper.compact_edit_format and "body" in changes
+    ):
         description = pull_request["body"].tame(check_none_or(check_string))
     target_branch = None
     base_branch = None
@@ -210,16 +214,20 @@ def get_issue_body(helper: Helper) -> str:
     include_title = helper.include_title
     action = payload["action"].tame(check_string)
     issue = payload["issue"]
+    use_compact_format = action == "edited" and helper.compact_edit_format
+    is_assignment_action = action in ("assigned", "unassigned")
+    message = (
+        None
+        if (use_compact_format or is_assignment_action)
+        else issue["body"].tame(check_none_or(check_string))
+    )
+
     return get_issue_event_message(
         user_name=get_sender_name(helper),
         action=action,
         url=issue["html_url"].tame(check_string),
         number=issue["number"].tame(check_int),
-        message=(
-            None
-            if action in ("assigned", "unassigned")
-            else issue["body"].tame(check_none_or(check_string))
-        ),
+        message=message,
         title=issue["title"].tame(check_string) if include_title else None,
         assignee_updated=(
             payload["assignee"]["login"].tame(check_string) if "assignee" in payload else None
@@ -1208,6 +1216,7 @@ def api_github_webhook(
     ignore_private_repositories: Json[bool] = False,
     include_repository_name: Json[bool] = False,
     include_emoji_indicators: Json[bool] = True,
+    compact_edit_format: Json[bool] = True,
 ) -> HttpResponse:
     """
     GitHub sends the event as an HTTP header.  We have our
@@ -1254,6 +1263,7 @@ def api_github_webhook(
         include_repository_name=include_repository_name,
         include_emoji_indicators=include_emoji_indicators,
         user_profile=user_profile,
+        compact_edit_format=compact_edit_format,
     )
     body = body_function(helper)
 

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -446,30 +446,37 @@ class LazyContext(dict[str, str | int]):
 
 def get_discussion_body(helper: Helper) -> str:
     payload = helper.payload
-    action = get_discussion_action(payload)
+    action = get_discussion_action(payload, helper.compact_edit_format)
     DISCUSSION_TEMPLATE = DISCUSSION_TEMPLATES[action]
     context = LazyContext(helper)
     return DISCUSSION_TEMPLATE.format_map(context)
 
 
-def get_discussion_action(payload: WildValue) -> str:
+def get_discussion_action(payload: WildValue, compact_edit_format: bool) -> str:
     action = payload["action"].tame(check_string)
     if action in ("unlocked", "pinned", "unpinned", "reopened"):
         action = "generic_action"
     if action == "edited":
-        edited_field = "body" if "body" in payload["changes"] else "title"
-        action = f"edited_{edited_field}"
+        if "body" in payload["changes"]:
+            action = "generic_action" if compact_edit_format else "edited_body"
+        else:
+            action = "edited_title"
     return action
 
 
 def get_discussion_comment_body(helper: Helper) -> str:
     payload = helper.payload
+    message = (
+        None
+        if payload["action"].tame(check_string) == "edited" and helper.compact_edit_format
+        else payload["comment"]["body"].tame(check_string)
+    )
     return get_pull_request_event_message(
         user_name=get_sender_name(helper),
         action=get_comment_action(payload),
         url=payload["discussion"]["html_url"].tame(check_string),
         number=payload["discussion"]["number"].tame(check_int),
-        message=payload["comment"]["body"].tame(check_string),
+        message=message,
         title=payload["discussion"]["title"].tame(check_string) if helper.include_title else None,
         type="discussion",
     )

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -805,7 +805,7 @@ def get_pull_request_review_comment_body(helper: Helper) -> str:
     include_title = helper.include_title
     action = payload["action"].tame(check_string)
     message = None
-    if action == "created":
+    if action == "created" or (action == "edited" and not helper.compact_edit_format):
         message = payload["comment"]["body"].tame(check_string)
 
     title = "on #{} {}".format(


### PR DESCRIPTION
Fixes: #32323.

Commit 1 - same as #37246.
Commit 2 - same as the first commit in #39972. (Simplifies the tests in commit 4)
Commits 3, 4, 5 - Extend compact_edit_format for discussions, discussion comments, PR comments, issue comments, PR review comments.

Relevant CZO: [#integrations > GitHub integration - compact edited notifications @ 💬](https://chat.zulip.org/#narrow/channel/127-integrations/topic/GitHub.20integration.20-.20compact.20edited.20notifications/near/2511373)

<details>
<summary><h3>Screenshot and Question</h3></summary>

Any ideas for renaming the URL option so it fits in one line on large screens?

<img width="346" height="373" alt="screenshot" src="https://github.com/user-attachments/assets/fd668b77-10f0-46dc-80df-4e2ee484dbe3" />

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
