### PR TITLE
remote_server: Upload data to advertise in communities directory.

### DIFF
--- a/web/src/admin.ts
+++ b/web/src/admin.ts
@@ -283,7 +283,6 @@ export function build_page(): void {
         realm_org_type_values: settings_org.get_org_type_dropdown_options(),
         realm_want_advertise_in_communities_directory:
             realm.realm_want_advertise_in_communities_directory,
-        disable_want_advertise_in_communities_directory: !realm.realm_push_notifications_enabled,
         is_business_type_org:
             realm.realm_org_type === settings_config.all_org_type_values.business.code,
         realm_enable_read_receipts: realm.realm_enable_read_receipts,

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -28,7 +28,6 @@
               setting_name="realm_want_advertise_in_communities_directory"
               prefix="id_"
               is_checked=realm_want_advertise_in_communities_directory
-              is_disabled=disable_want_advertise_in_communities_directory
               label=admin_settings_label.realm_want_advertise_in_communities_directory
               help_link="/help/communities-directory"}}
             {{> realm_description . }}

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -29,6 +29,8 @@ from zerver.lib.exceptions import (
 )
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.queue import queue_event_on_commit
+from zerver.lib.realm_description import get_realm_text_description
+from zerver.lib.realm_icon import get_realm_icon_url
 from zerver.lib.redis_utils import get_redis_client
 from zerver.lib.types import AnalyticsDataUploadLevel
 from zerver.models import Realm, RealmAuditLog
@@ -80,6 +82,17 @@ class RealmAuditLogDataForAnalytics(BaseModel):
     event_type: int
 
 
+class AdvertiseRealmData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    description: str | None = None
+    icon_url: str
+    invite_required: bool
+    emails_restricted_to_domains: bool
+    has_web_public_streams: bool
+    is_demo_organization: bool
+
+
 class RealmDataForAnalytics(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -93,6 +106,10 @@ class RealmDataForAnalytics(BaseModel):
     is_system_bot_realm: bool = False
 
     authentication_methods: dict[str, bool] = Field(default_factory=dict)
+
+    # Sent only for realms that have opted in to get listed
+    # in the Zulip communities directory (zulip.com/communities).
+    advertise_realm_data: AdvertiseRealmData | None = None
 
     uuid: UUID4
     uuid_owner_secret: str
@@ -359,6 +376,31 @@ def build_analytics_data(
     return realm_count_data, installation_count_data, zerver_realmauditlog
 
 
+def get_advertise_realm_data(realm: Realm) -> AdvertiseRealmData | None:
+    """Metadata the bouncer needs to list a realm in the Zulip communities
+    directory.
+
+    Uploaded only for realms that have opted in, on servers that have
+    enabled ZULIP_SERVICE_ADVERTISE_REALM.
+    """
+    if not (
+        settings.ZULIP_SERVICE_ADVERTISE_REALM and realm.want_advertise_in_communities_directory
+    ):
+        return None
+
+    return AdvertiseRealmData(
+        # A realm with no description is not eligible to be listed, so
+        # avoid sending the placeholder that get_realm_text_description
+        # substitutes for an empty one.
+        description=get_realm_text_description(realm) if realm.description else None,
+        icon_url=urljoin(realm.url, get_realm_icon_url(realm)),
+        invite_required=realm.invite_required,
+        emails_restricted_to_domains=realm.emails_restricted_to_domains,
+        has_web_public_streams=realm.has_web_public_streams(),
+        is_demo_organization=realm.demo_organization_scheduled_deletion_date is not None,
+    )
+
+
 def get_realms_info_for_push_bouncer(realm_id: int | None = None) -> list[RealmDataForAnalytics]:
     realms = Realm.objects.order_by("id")
     if realm_id is not None:  # nocoverage
@@ -377,6 +419,7 @@ def get_realms_info_for_push_bouncer(realm_id: int | None = None) -> list[RealmD
             name=realm.name,
             authentication_methods=realm.authentication_methods_dict(),
             is_system_bot_realm=realm.string_id == settings.SYSTEM_BOT_REALM,
+            advertise_realm_data=get_advertise_realm_data(realm),
         )
         for realm in realms
     ]

--- a/zerver/tests/test_zilencer_analytics.py
+++ b/zerver/tests/test_zilencer_analytics.py
@@ -10,6 +10,7 @@ import responses
 import time_machine
 from django.conf import settings
 from django.db.models import F
+from django.test import override_settings
 from django.utils.timezone import now
 from requests.exceptions import ConnectionError
 from typing_extensions import override
@@ -24,6 +25,7 @@ from zerver.actions.realm_settings import (
     do_change_realm_org_type,
     do_deactivate_realm,
     do_set_realm_authentication_methods,
+    do_set_realm_property,
 )
 from zerver.lib import redis_utils
 from zerver.lib.remote_server import (
@@ -31,6 +33,7 @@ from zerver.lib.remote_server import (
     AnalyticsRequest,
     PushNotificationBouncerRetryLaterError,
     build_analytics_data,
+    get_advertise_realm_data,
     get_realms_info_for_push_bouncer,
     record_push_notifications_recently_working,
     redis_client,
@@ -1466,3 +1469,71 @@ class AnalyticsBouncerTest(BouncerTestCase):
             audit_log.event_type, AuditLogEventType.REMOTE_REALM_LOCALLY_DELETED_RESTORED
         )
         self.assertEqual(audit_log.remote_realm, remote_realm_for_deleted_realm)
+
+
+class AdvertiseRealmDataTest(BouncerTestCase):
+    def test_uploaded_only_when_server_and_realm_both_opt_in(self) -> None:
+        realm = get_realm("zulip")
+
+        # Neither the server nor the realm has opted in.
+        self.assertIsNone(get_advertise_realm_data(realm))
+
+        # The realm wants to be listed, but the server has not
+        # enabled the service.
+        do_set_realm_property(
+            realm, "want_advertise_in_communities_directory", True, acting_user=None
+        )
+        self.assertIsNone(get_advertise_realm_data(realm))
+
+        with self.settings(ZULIP_SERVICE_ADVERTISE_REALM=True):
+            self.assertIsNotNone(get_advertise_realm_data(realm))
+
+            do_set_realm_property(
+                realm, "want_advertise_in_communities_directory", False, acting_user=None
+            )
+            self.assertIsNone(get_advertise_realm_data(realm))
+
+    @override_settings(ZULIP_SERVICE_ADVERTISE_REALM=True)
+    def test_empty_description_is_not_replaced_by_placeholder(self) -> None:
+        realm = get_realm("zulip")
+        do_set_realm_property(
+            realm, "want_advertise_in_communities_directory", True, acting_user=None
+        )
+        do_set_realm_property(realm, "description", "", acting_user=None)
+
+        data = get_advertise_realm_data(realm)
+        assert data is not None
+        self.assertIsNone(data.description)
+
+    @override_settings(ZULIP_SERVICE_ADVERTISE_REALM=True)
+    def test_advertise_realm_data_success(self) -> None:
+        realm = get_realm("zulip")
+        do_set_realm_property(
+            realm, "want_advertise_in_communities_directory", True, acting_user=None
+        )
+
+        realms_data = get_realms_info_for_push_bouncer()
+        self.assertTrue(
+            any(realm_data.advertise_realm_data is not None for realm_data in realms_data)
+        )
+
+        request = AnalyticsRequest.model_construct(
+            realm_counts=[],
+            installation_counts=[],
+            realmauditlog_rows=[],
+            realms=realms_data,
+            version=None,
+            merge_base=None,
+            api_feature_level=None,
+        )
+        result = self.uuid_post(
+            self.server_uuid,
+            "/api/v1/remotes/server/analytics",
+            request.model_dump(
+                round_trip=True, exclude={"version", "merge_base", "api_feature_level"}
+            ),
+            subdomain="",
+        )
+        self.assert_json_success(result)
+
+        # TODO: Extend it when implementing bouncer side of this feature.

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -96,6 +96,7 @@ from zilencer.views import update_remote_realm_data_for_server
 settings.ZULIP_SERVICE_PUSH_NOTIFICATIONS = False
 settings.ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS = False
 settings.ZULIP_SERVICE_SECURITY_ALERTS = False
+settings.ZULIP_SERVICE_ADVERTISE_REALM = False
 settings.ANALYTICS_DATA_UPLOAD_LEVEL = AnalyticsDataUploadLevel.NONE
 settings.USING_TORNADO = False
 # Disable using memcached caches to avoid 'unsupported pickle

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -71,6 +71,7 @@ from .configured_settings import (
     USING_CAPTCHA,
     USING_PGROONGA,
     ZULIP_ADMINISTRATOR,
+    ZULIP_SERVICE_ADVERTISE_REALM,
     ZULIP_SERVICE_PUSH_NOTIFICATIONS,
     ZULIP_SERVICE_SECURITY_ALERTS,
     ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS,
@@ -108,6 +109,7 @@ if raw_keys is not None:
 
 
 service_name_to_required_upload_level = {
+    "advertise_realm": AnalyticsDataUploadLevel.BASIC,
     "security_alerts": AnalyticsDataUploadLevel.BASIC,
     "mobile_push": AnalyticsDataUploadLevel.BILLING,
     "submit_usage_statistics": AnalyticsDataUploadLevel.ALL,
@@ -135,6 +137,8 @@ if ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS:
     services_append("submit_usage_statistics")
 if ZULIP_SERVICE_SECURITY_ALERTS:
     services_append("security_alerts")
+if ZULIP_SERVICE_ADVERTISE_REALM:
+    services_append("advertise_realm")
 
 if services is None and PUSH_NOTIFICATION_BOUNCER_URL is not None:
     # ZULIP_SERVICE_* are the new settings that control the services
@@ -156,7 +160,7 @@ if services is None and PUSH_NOTIFICATION_BOUNCER_URL is not None:
         services_append("submit_usage_statistics")
 
 if services is not None and set(services).intersection(
-    {"submit_usage_statistics", "security_alerts", "mobile_push"}
+    {"submit_usage_statistics", "security_alerts", "mobile_push", "advertise_realm"}
 ):
     # None of these make sense enabled without ZULIP_SERVICES_URL.
     assert ZULIP_SERVICES_URL is not None, (

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -269,6 +269,7 @@ ZULIP_SERVICE_PUSH_NOTIFICATIONS = False
 # is enabled.
 ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS: bool | None = None
 ZULIP_SERVICE_SECURITY_ALERTS = False
+ZULIP_SERVICE_ADVERTISE_REALM = False
 
 # Old setting kept around for backwards compatibility. Some old servers
 # may have it in their settings.py.

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -228,6 +228,7 @@ ZULIP_SERVICES_URL = f"http://push.{EXTERNAL_HOST}"
 ZULIP_SERVICE_PUSH_NOTIFICATIONS = False
 ZULIP_SERVICE_SUBMIT_USAGE_STATISTICS = False
 ZULIP_SERVICE_SECURITY_ALERTS = False
+ZULIP_SERVICE_ADVERTISE_REALM = False
 
 # Hack: This should be computed in computed_settings, but the transmission
 # of test settings overrides is wonky. See test_settings for more details.


### PR DESCRIPTION
CZO Discussion: [#backend > Allow self-hosted orgs to be listed in communities directory](https://chat.zulip.org/#narrow/channel/3-backend/topic/Allow.20self-hosted.20orgs.20to.20be.20listed.20in.20communities.20directory/with/2514292)

Fixes part of #40110 - first checkbox.

* Commit 1: Adds a new server-level setting to let server admin configure whether they want to use this service or not.
* Commit 2: Server uploads the metadata required for the service.
* Commit 3: Read commit message. Also: [#design > disable want_advertise_in_communities_directory ?](https://chat.zulip.org/#narrow/channel/101-design/topic/disable.20want_advertise_in_communities_directory.20.3F/with/2519053)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
