### PR TITLE
users: Fix pipe-digit validation bypass in check_full_name.

### DIFF
--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -67,7 +67,7 @@ def check_full_name(
     # sloppily-written parsers of our Markdown syntax for mentioning
     # users with ambiguous names, and likely have no real use, so we
     # ban them.
-    if re.search(r"\|\d+$", full_name_raw):
+    if re.search(r"\|\d+$", full_name):
         raise JsonableError(_("Invalid format!"))
 
     if require_unique_names(realm):

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -487,6 +487,11 @@ class PermissionTest(ZulipTestCase):
         result = self.client_patch("/json/users/{}".format(self.example_user("hamlet").id), req)
         self.assert_json_error(result, "Invalid format!")
 
+        # Trailing whitespace should not bypass the pipe-digit check
+        req = dict(full_name="iago|72 ")
+        result = self.client_patch("/json/users/{}".format(self.example_user("hamlet").id), req)
+        self.assert_json_error(result, "Invalid format!")
+
     def test_allowed_format_complex(self) -> None:
         # Adding characters after r'|d+' doesn't break Markdown
         new_name = "Hello- 12iago|72k"


### PR DESCRIPTION
# users: Fix pipe-digit validation bypass in check_full_name.

The regex check that rejects names ending with `|<digits>` (to prevent ambiguity with Zulip's mention syntax) was applied to `full_name_raw` instead of the stripped `full_name`. Since `$` anchors to the end of the string, trailing whitespace like `"User|15 "` caused the regex to not match, but the function returned the stripped `"User|15"` — the exact pattern the check was designed to prevent.

Fix by checking the already-stripped `full_name`, consistent with every other validation in the function.

Fixes #40062.

<!-- Describe your pull request here.-->

Fixes: #40062

**How changes were tested:**

- Added `test_not_allowed_format_with_trailing_whitespace` in `zerver/tests/test_users.py` that sends `full_name = "iago|72 "` (with trailing space) to the user update endpoint and verifies it is correctly rejected with `"Invalid format!"`.
- Verified that the existing tests (`test_not_allowed_format`, `test_not_allowed_format_complex`, `test_allowed_format_complex`) continue to pass, ensuring no regression.

**Screenshots and screen captures:**

Not applicable — backend-only change with no UI impact.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- N/A Visual appearance of the changes.
- N/A Responsiveness and internationalization.
- N/A Strings and tooltips.
- N/A End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
