### PR TITLE
left_sidebar: Add 2px vertical breathing room for emoji in topic names.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1987,8 +1987,13 @@ li.active-sub-filter {
            we set the top space with padding. But to make the
            line-clamp effect work, we set the bottom space
            with margin. */
-        padding-top: var(--spacing-top-bottom-sidebar-topic-inner);
-        margin: 0 0 var(--spacing-top-bottom-sidebar-topic-inner) 0;
+        /* Emoji glyphs protrude above and below the standard
+           text em-box, so this spacing also keeps them clear
+           of the overflow: hidden boundary; the extra 2px
+           compensates for glyph overflow that sub-pixel
+           rounding can otherwise clip. */
+        padding-top: calc(var(--spacing-top-bottom-sidebar-topic-inner) + 2px);
+        margin: 0 0 calc(var(--spacing-top-bottom-sidebar-topic-inner) + 2px);
     }
 }
 


### PR DESCRIPTION
Fixes: #38264

**How changes were tested:**

Set up the Zulip development environment locally (WSL2), created a `sandbox` channel with emoji topic names (🚀 🎉 ✅ ❤️ 🔍 plus a plain-text `laptop` topic for comparison), and captured the sidebar with and without the fix from the same browser tab (1400x900 viewport, DPR 1), same narrow (`#narrow/channel/2-sandbox`), same zoom, same content.

**Why this approach:** the issue suggests increasing `padding-top` and the matched `margin-bottom`. `--spacing-top-bottom-sidebar-topic-inner` already exists to convert the prominent row height into the inner topic line-height space, so scaling that token with `calc(... + 2px)` keeps the extra breathing room proportional to the information-density settings instead of hard-coding pixels. Emoji glyphs protrude above and below the standard text em-box, and `.sidebar-topic-name-inner`'s `overflow: hidden` (required for `-webkit-line-clamp`) hard-clips at the content box, so the extra space keeps glyphs clear of the clip boundary. Bottom space stays `margin` (not `padding`) so the line-clamp arithmetic is unaffected.

**Screenshots and screen captures:**

Both shots were captured back-to-back in the same tab via hot-reload style swapping (no page reload between shots), with identical scroll state (sandbox channel row at viewport y=598.6, sidebar scroll 74.4, window scroll 1878.4 in both). The pixel diff of the full-viewport pair is confined to the sandbox topic rows; everything above them is bit-identical. The tight crops are cut from the same 340x230 region of each full shot.

| Before | After |
| --- | --- |
| ![Before: emoji topic rows without extra breathing room](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/topics_before.png) | ![After: emoji topic rows with 2px extra breathing room top and bottom](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/topics_after.png) |

Full-window captures (1400x900 each): [before](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/viewport_before.png) · [after](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/viewport_after.png)

**Longer topic names (default 16px font):** added a long plain-text topic (wraps to two lines, exercising the line-clamp), a long mixed-emoji topic, and an emoji-heavy topic to the same `sandbox` channel. Same capture method — back-to-back in one tab via hot-reload, identical scroll state; pixel-diff of the full-viewport pair is confined to the topic rows (23,942 changed pixels, zero above or outside the sidebar column).

| Before | After |
| --- | --- |
| ![Before: long plain and emoji topic rows](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/long_topics_before.png) | ![After: long topic rows with breathing room, no clipping or layout breakage](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/long_topics_after.png) |

Full-window captures (1400x900 each): [before](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/long_viewport_before.png) · [after](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/long_viewport_after.png)

**Larger font size (20px app font setting):** same long-topic view with `web_font_size_px` set to 20. The fix scales with the setting as designed (computed spacing goes from 5.14px to 7.14px, i.e. token + 2px at both sizes); pair verified the same way.

| Before | After |
| --- | --- |
| ![Before: long topics at 20px font](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/font20_topics_before.png) | ![After: long topics at 20px font with breathing room](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/font20_topics_after.png) |

Full-window captures (1400x900 each): [before](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/font20_viewport_before.png) · [after](https://raw.githubusercontent.com/Adarsh-Me/zulip/pr-screenshots/screenshots/font20_viewport_after.png)

Note: the visible difference is subtle by design (+2px each side, per the issue's suggestion). The issue's clipping reproduces most clearly on high-DPI/external monitors where sub-pixel rounding consumes the em-box slack (my earlier attempt at DPR 1.5); at DPR 1 the pair demonstrates the added breathing room and, per the pixel-diff check, no unintended visual changes anywhere else. The full-size images let reviewers zoom in to compare glyph clearance at the row boundaries.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes. *(before/after pair captured back-to-back in one tab via hot-reload, identical scroll state; pixel-diff confined to the topic rows; full-viewport captures included)*
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>

