### PR TITLE
claude: Move context-specific guidance into rules and skills.

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -172,21 +172,10 @@ Zulip has over 185,000 words of developer documentation. Before working on any a
 - Prefer writing code that is readable without explanation over heavily
   commented code using clever tricks. Comments should explain "why" when
   the reason isn't obvious, not narrate "what" the code does.
-- Use `em` units instead of `px` for computed CSS values that need to
-  scale with font size. Pixel approximations break at different zoom
-  levels and font-size settings.
 - Comments should have a line to themself except for CSS px math.
-- **Review CSS for redundant rules.** After writing CSS, review the
-  full set of rules affecting the same elements. Look for rules that
-  are immediately overridden by a more specific selector, duplicated
-  selector lists, or cases where scoping (e.g., `:not()`) would
-  eliminate the need for an override.
-- **Check CSS change scope.** When modifying CSS, always check what
-  other pages or components use the same selectors, files, and
-  classes. Use `git grep` on class names and check webpack bundle
-  entries to understand which pages load the file. Prefer scoped
-  overrides (e.g., `.parent .target`) over modifying shared rules,
-  to avoid unintended changes to other parts of the app.
+
+CSS rules can be found in `.claude/rules/css.md` (loaded
+automatically when you work on CSS files).
 
 See: https://zulip.readthedocs.io/en/latest/contributing/code-style.html
 
@@ -390,13 +379,6 @@ Recommend pausing for discussion when:
 5. No behavior changes unless explicitly discussed
 6. Verify completeness: use `git grep` to find all occurrences and
    confirm nothing was missed
-
-When removing a CSS dependency (e.g., Bootstrap), audit the full
-property list of every rule, not just visually obvious properties like
-colors and backgrounds. Subtle properties like `line-height`, `margin`,
-`padding`, `text-decoration`, `font-weight`, and `border` are easy to
-miss but cause visible regressions. Check inherited properties too —
-e.g., a `body` rule's `line-height` or `margin` affects all descendants.
 
 ## Key Documentation Links
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -143,6 +143,9 @@ specific test collections, not the entire test suite:
 ./tools/test-backend zerver.tests.test_relevant_module
 ```
 
+Run through the `/self-review` skill's checklist before suggesting opening
+a PR (`.claude/skills/self-review/SKILL.md`).
+
 ## Before You Start
 
 ### Read the Relevant Documentation
@@ -261,30 +264,6 @@ tests.
 If a PR makes frontend changes, manually verify the affected UI
 using the checklist in `.claude/rules/ui-testing.md` (loaded
 automatically when you work on frontend files).
-
-## Self-Review Checklist
-
-Before finalizing, verify:
-
-- [ ] The PR addresses all points described in the issue
-- [ ] All relevant tests pass locally
-- [ ] Code follows existing patterns in the codebase
-- [ ] Names (functions, variables, tests) are clear and greppable
-- [ ] Commit messages, comments, and PR description are well done.
-- [ ] Each commit is a minimal coherent idea
-- [ ] No debugging code or unnecessary comments remain
-- [ ] Type annotations are complete and correct
-- [ ] User-facing strings are tagged for translation
-- [ ] User-facing error messages are clear and actionable
-- [ ] No secrets or credentials are hardcoded
-- [ ] Documentation is updated if behavior changes
-- [ ] Refactoring is complete (`git grep` for remaining occurrences)
-- [ ] Security audit of changes. Always check for XSS in UI changes
-      and for incorrect access control in server changes.
-
-Always output a recommend pull request summary+description that
-follow's Zulip's guidelines once you finish preparing a series of
-commits.
 
 ## Common Pitfalls
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -268,39 +268,6 @@ Fixes #123.
   and `Fixes #123.` in the final commit.
 - Never: `Partially fixes #123.` (GitHub ignores "partially")
 
-### Rebasing Commits (Non-Interactive)
-
-Since `git rebase -i` requires an interactive editor, use
-`GIT_SEQUENCE_EDITOR` to supply the todo list via a script:
-
-1. **Updating the HEAD commit:** If the commit you need to modify is
-   already at HEAD, just use `git commit --amend` directly. The
-   fixup+rebase workflow below is only needed for non-HEAD commits.
-
-2. **Squashing fixups into existing commits:** Create fixup commits with
-   `git commit --fixup=<target-hash>`, then write a shell script that
-   outputs the desired todo (with `pick` and `fixup` lines in order)
-   and run:
-
-   ```bash
-   GIT_SEQUENCE_EDITOR=/path/to/todo-script.sh git rebase -i <base>
-   ```
-
-   Note: `--autosquash` alone without `-i` does **not** reorder or
-   squash anything.
-
-3. **Rewording commit messages:** Use `git format-patch` to export
-   commits as patch files, edit the message headers in the patch
-   files, then reapply:
-
-   ```bash
-   git format-patch <base> -o /tmp/patches/
-   # Edit the commit message in each /tmp/patches/000N-*.patch file
-   # (the message is between the Subject: line and the --- line)
-   git reset --hard <base>
-   git am /tmp/patches/*.patch
-   ```
-
 ## Testing Requirements
 
 Zulip server takes pride in its ~98% test coverage. All server changes

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -461,32 +461,11 @@ faster and easier to just plan and write them well the first time.
 
 ## Pull Request Guidelines
 
-### PR Description Should:
-
 When opening a pull request, prefix the PR title with `[ai]` (e.g.,
 `[ai] compose: Fix cursor position after emoji insertion.`). Use
-`upstream/main` as the base branch.
-
-Output the PR description in a markdown code block so that formatting
-(bold, headers, checkboxes, etc.) copy-pastes correctly into GitHub.
-
-1. Start with a `Fixes: #...` line linking the issue being addressed.
-2. Explain **why** the change is needed, not just what changed.
-3. Describe how you tested the change, using checkbox format for the
-   test plan (e.g., `- [x] ./tools/test-backend ...`).
-4. Include screenshots for UI changes.
-5. Link to relevant issues or discussions.
-6. Call out any open questions, concerns, or decisions you are uncertain
-   about, so they can be resolved during review.
-7. Include the self-review checklist from
-   `.github/pull_request_template.md` using checkbox format (`- [x]` /
-   `- [ ]`), checking off all applicable items.
-
-### PR Description Should Not:
-
-- Regurgitate information visible from the diff
-- Make claims you haven't double-checked
-- Express more certainty than is justified given the evidence
+`upstream/main` as the base branch. Use the `/pr-description` skill
+to write the PR description
+(`.claude/skills/pr-description/SKILL.md`).
 
 ## When to Pause and Discuss
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,29 +119,10 @@ Before writing code, explain the plan:
 
 Structure changes as clean commits:
 
-- Backend and API changes (with tests and API doc changes documented
-  fully using our double-entry changelog system). When starting an API
-  change, reread `docs/documentation/api.md` to review the process for
-  documenting an API change. Run `tools/create-api-changelog`; it
-  generates an empty `api_docs/unmerged.d/ZF-XXXXXX.md` file (where
-  `XXXXXX` is a random hex string the tool picks for you) and stages
-  it for you. Document the changes in that file as an unordered list
-  (`*` bullets) of the additions or changes, formatted to match
-  `api_docs/changelog.md`. Don't add a `**Feature level**` heading;
-  the merge tooling emits that itself.
-  In the OpenAPI yaml (`zerver/openapi/zulip.yaml`), reference the same
-  filename stem in **Changes** notes, e.g.,
-  `**Changes**: New in Zulip 13.0 (feature level ZF-XXXXXX).` The merge
-  process matches the `Zulip <version> (feature level ZF-XXXXXX)` shape
-  and overwrites both the version and the placeholder with the real
-  release version and final feature level. Use the upcoming release's
-  version — the next major release after the latest one shipped (e.g.,
-  13.0 while 12.0 is the current release), which you can read from the
-  first `## Changes in Zulip X.Y` heading in `api_docs/changelog.md`.
-  You must keep the literal `New in Zulip X.Y` format, or the merge
-  tooling won't recognize the note and CI (`check-feature-level-updated`)
-  will fail with the `ZF-` placeholder still in the file. Never update
-  `API_FEATURE_LEVEL` manually.
+- Backend and API changes, with tests and API doc changes documented
+  fully using our double-entry changelog system. Instructions for
+  documentation can be found in `.claude/rules/api-changelog.md`
+  (loaded automatically when you edit `zerver/openapi/zulip.yaml`).
 - Frontend UI changes (with tests and user-facing documentation
   updates). Remember to plan to use your visual test skill to check
   your work whenever you change web app code (HTML, CSS, JS).

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -388,33 +388,6 @@ before the change is ready.
 - Think about edge cases in data: empty lists, very long names, single
   items vs. hundreds, special characters in strings.
 
-### Puppeteer Visual Tests: Verifying Alignment
-
-When using Puppeteer to verify visual alignment, do not rely on
-eyeballing screenshots — especially small full-page ones. Instead:
-
-- Use `page.evaluate()` with `getBoundingClientRect()` to measure
-  actual pixel positions of the elements you need aligned, and print
-  them to the console. Compare the numbers.
-- Always take **both** a full-page screenshot and a zoomed clip of
-  the area of interest.
-- For zoomed clips, calculate the clip region from non-fixed elements;
-  fixed/sticky elements may report bounding-box positions that don't
-  match their visual location on the page.
-- Be aware that CSS nesting can scope styles to a specific parent
-  (e.g., `.parent .my-class`) — reusing the same class name in a
-  different context may not pick up the expected styles.
-- To verify keyboard-focus styles, use real keyboard navigation
-  (`page.keyboard.press`); programmatic `.focus()` doesn't reliably
-  trigger `:focus-visible` and may be overridden by view-level focus
-  management.
-- Focus rings drawn as `::before` / `::after` pseudo-elements aren't
-  visible in `getComputedStyle` of the focused element — verify them
-  in a screenshot, not via computed styles.
-- For visual changes, produce before/after screenshot pairs by writing
-  one test and running it twice with a `SCREENSHOT_SUFFIX` env var
-  (`-old` on `main`, `-updated` on your branch).
-
 ## Self-Review Checklist
 
 Before finalizing, verify:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -166,13 +166,13 @@ Zulip has over 185,000 words of developer documentation. Before working on any a
 - Keep everything well factored for maintainability. Avoid duplicating
   code, especially where access control or subtle correctness is involved.
 - Run `./tools/lint` to catch style issues before committing, including mypy issues.
-- JavaScript/TypeScript code must use `const` or `let`, never `var`.
-- Avoid lodash in favor of modern ECMAScript primitives where available,
-  keeping in mind our browserlist.
 - Prefer writing code that is readable without explanation over heavily
   commented code using clever tricks. Comments should explain "why" when
   the reason isn't obvious, not narrate "what" the code does.
 - Comments should have a line to themself except for CSS px math.
+
+Frontend rules can be found in `.claude/rules/frontend.md` (loaded
+automatically when you work on frontend JS/TS and template files).
 
 CSS rules can be found in `.claude/rules/css.md` (loaded
 automatically when you work on CSS files).
@@ -294,11 +294,6 @@ faster and easier to just plan and write them well the first time.
 - Don't use `Any` type annotations without comments justifying it.
 - Don't use `cursor.execute()` with string formatting (SQL injection risk)
 - Don't use `.extra()` in Django without careful review and commenting
-- Don't use `onclick` attributes in HTML; use event delegation
-- Don't access DOM APIs (`document.documentElement.style`, `$()`
-  selectors for specific elements) without guarding for node test
-  environments, where the DOM is mocked minimally. Check that the
-  element exists before using it.
 - Don't create N+1 query patterns:
 
   ```python

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -216,38 +216,8 @@ coherent idea."** This is non-negotiable.
 
 ### Commit Message Format
 
-```
-subsystem: Summary in 72 characters or less.
-
-The body explains why and how. Include context that helps reviewers
-and future developers understand your reasoning, analysis, and
-verification of the work above and beyond CI, without repeating
-details already well presented in the commit metadata (filenames,
-etc.). Explain what the change accomplishes and why it won't break
-things one might worry about.
-
-Line-wrap at 68-70 characters, except URLs and verbatim content
-(error messages, etc.).
-
-Fixes #123.
-```
-
-**Commit summary format:**
-
-- Before the colon is a lower-case brief gesture at subsystem (ex: "nginx" config) or
-  feature (ex: "compose" for the compose box) being modified.
-- Use a period at the end of the summary
-- Example: `compose: Fix cursor position after emoji insertion.`
-- Example: `nginx: Refactor immutable cache headers.`
-- Bad examples: `Fix bug`, `Update code`, `gather_subscriptions was broken`
-
-**Linking issues:**
-
-- `Fixes #123.` - Automatically closes the issue
-- `Fixes part of #123.` - Does not close (for partial fixes)
-- In a multi-commit PR, use `Fixes part of #123.` in earlier commits
-  and `Fixes #123.` in the final commit.
-- Never: `Partially fixes #123.` (GitHub ignores "partially")
+Use the `/commit-message` skill whenever you write or reword a
+commit message (`.claude/skills/commit-message/SKILL.md`).
 
 ## Testing Requirements
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -227,36 +227,16 @@ commit message (`.claude/skills/commit-message/SKILL.md`).
 Zulip server takes pride in its ~98% test coverage. All server changes
 must include nice tests that follow our testing philosophy.
 
+When writing tests, follow our testing philosophy in
+`.claude/rules/testing.md` (loaded automatically when you work on
+test files).
+
 ### Before Submitting:
 
 ```bash
 ./tools/test-js-with-node       # JavaScript tests; full suite fast enough
 ./tools/lint                    # Run all linters
 ./tools/test-backend            # Python tests
-```
-
-A common failure mode is failing to have test coverage for error
-conditions that require coverage (note `tools/coveragerc` excludes
-asserts). Run `test-backend --coverage FooTest` and check the coverage
-data to confirm that the new lines you added are in fact run by the
-tests.
-
-### Testing Philosophy:
-
-- Write end-to-end tests when possible verifying what's important, not
-  internal APIs.
-- Tests must work offline. Use fixtures (in `zerver/tests/fixtures`) for
-  external service testing and `responses` for simpler things.
-- Use time_machine and similar libraries to mock time.
-- Read `zerver/tests/test_example.py` for patterns.
-- A good failing test before implementing is good practice so your
-  test and code can jointly verify each other.
-- Remember to always assert state is correctly updated, not just "success".
-
-### For Webhooks:
-
-```bash
-./tools/test-backend zerver/webhooks/<integration>
 ```
 
 ### Manual Testing for UI Changes
@@ -340,10 +320,6 @@ faster and easier to just plan and write them well the first time.
   # GOOD
   foos = {f.id: f for f in Foo.objects.filter(id__in=[b.foo_id for b in bars])}
   ```
-
-- In tests, don't assert on `assertLogs` output with
-  `any(phrase in line for line in mock_log.output)`; pin the full line
-  against `mock_log.output`, or a substring to a specific `mock_log.output[i]`.
 
 ### Process:
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -288,53 +288,9 @@ tests.
 
 ### Manual Testing for UI Changes
 
-If a PR makes frontend changes, manually verify the affected UI. This
-catches issues that automated tests miss. **Treat this checklist as
-blocking, not advisory** — every applicable item must be verified
-before the change is ready.
-
-**Visual appearance:**
-
-- Is the new UI consistent with similar elements (fonts, colors, sizes)?
-  Find the closest existing analogues and compare carefully.
-- Is alignment correct, both vertically and horizontally? Measure
-  programmatically with `getBoundingClientRect()` when in doubt —
-  don't eyeball it.
-- Do clickable elements have hover behavior consistent with similar UI?
-- If elements can be disabled, does the disabled state look right?
-- Did the change accidentally affect other parts of the UI? Use
-  `git grep` to check if modified CSS is used elsewhere. CSS changes
-  are notorious for unintended consequences — check every page and
-  component that shares the selectors you modified.
-- Check all of the above in both light and dark themes when the
-  change could plausibly affect colors, contrast, or theme-dependent
-  imagery. Pure geometry/typography changes (`font-size`,
-  `line-height`, `margin`, `padding`, `display`, `font-weight`,
-  etc.) don't need a separate dark-theme pass —
-  `web/styles/dark_theme.css` only overrides colors, so a single
-  theme suffices for theme-invariant changes.
-
-**Responsiveness and internationalization:**
-
-- Does the UI look good at different window sizes? Check wide desktop
-  (1920px), typical laptop (1280px), tablet, and narrow phone (480px).
-- Would the UI break if translated strings were 1.5x longer than
-  English? What if they were half as long? Both directions matter.
-
-**Functionality:**
-
-- Are live updates working as expected?
-- Is keyboard navigation, including tabbing to interactive elements, working?
-- If the feature affects the message view, try different narrows: topic,
-  channel, Combined feed, direct messages.
-- If the feature affects the compose box, test both channel messages and
-  direct messages, and both ways of resizing.
-- If the feature requires elevated permissions, test as both a user who
-  has permissions and one who does not.
-- Think about feature interactions: could banners overlap? What about
-  resolved/unresolved topics? Collapsed or muted messages?
-- Think about edge cases in data: empty lists, very long names, single
-  items vs. hundreds, special characters in strings.
+If a PR makes frontend changes, manually verify the affected UI
+using the checklist in `.claude/rules/ui-testing.md` (loaded
+automatically when you work on frontend files).
 
 ## Self-Review Checklist
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -177,6 +177,9 @@ automatically when you work on frontend JS/TS and template files).
 CSS rules can be found in `.claude/rules/css.md` (loaded
 automatically when you work on CSS files).
 
+Python rules can be found in `.claude/rules/python.md` (loaded
+automatically when you work on .py files).
+
 See: https://zulip.readthedocs.io/en/latest/contributing/code-style.html
 
 ## Commit Discipline
@@ -288,24 +291,6 @@ changes. You can split into good commits after the fact, but it's much
 faster and easier to just plan and write them well the first time.
 
 ## What Not To Do
-
-### Code Quality:
-
-- Don't use `Any` type annotations without comments justifying it.
-- Don't use `cursor.execute()` with string formatting (SQL injection risk)
-- Don't use `.extra()` in Django without careful review and commenting
-- Don't create N+1 query patterns:
-
-  ```python
-  # BAD
-  for bar in bars:
-      foo = Foo.objects.get(id=bar.foo_id)
-
-  # GOOD
-  foos = {f.id: f for f in Foo.objects.filter(id__in=[b.foo_id for b in bars])}
-  ```
-
-### Process:
 
 - Always check if you're working on top of the latest upstream/main, and
   fetch + rebase when starting a project so you're not using a stale branch.

--- a/.claude/rules/api-changelog.md
+++ b/.claude/rules/api-changelog.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "zerver/openapi/**"
+  - "api_docs/**"
+---
+
+# Documenting API Changes
+
+API changes must be documented fully using our double-entry changelog
+system. When starting an API change, reread `docs/documentation/api.md`
+to review the process for documenting an API change. Run
+`tools/create-api-changelog`; it generates an empty
+`api_docs/unmerged.d/ZF-XXXXXX.md` file (where `XXXXXX` is a random
+hex string the tool picks for you) and stages it for you. Document
+the changes in that file as an unordered list (`*` bullets) of the
+additions or changes, formatted to match `api_docs/changelog.md`.
+Don't add a `**Feature level**` heading; the merge tooling emits that
+itself.
+
+In the OpenAPI yaml (`zerver/openapi/zulip.yaml`), reference the same
+filename stem in **Changes** notes, e.g.,
+`**Changes**: New in Zulip 13.0 (feature level ZF-XXXXXX).` The merge
+process matches the `Zulip <version> (feature level ZF-XXXXXX)` shape
+and overwrites both the version and the placeholder with the real
+release version and final feature level. Use the upcoming release's
+version — the next major release after the latest one shipped (e.g.,
+13.0 while 12.0 is the current release), which you can read from the
+first `## Changes in Zulip X.Y` heading in `api_docs/changelog.md`.
+You must keep the literal `New in Zulip X.Y` format, or the merge
+tooling won't recognize the note and CI (`check-feature-level-updated`)
+will fail with the `ZF-` placeholder still in the file. Never update
+`API_FEATURE_LEVEL` manually.

--- a/.claude/rules/css.md
+++ b/.claude/rules/css.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "web/styles/**"
+---
+
+# Writing CSS
+
+- Use `em` units instead of `px` for computed CSS values that need to
+  scale with font size. Pixel approximations break at different zoom
+  levels and font-size settings.
+- **Review CSS for redundant rules.** After writing CSS, review the
+  full set of rules affecting the same elements. Look for rules that
+  are immediately overridden by a more specific selector, duplicated
+  selector lists, or cases where scoping (e.g., `:not()`) would
+  eliminate the need for an override.
+- **Check CSS change scope.** When modifying CSS, always check what
+  other pages or components use the same selectors, files, and
+  classes. Use `git grep` on class names and check webpack bundle
+  entries to understand which pages load the file. Prefer scoped
+  overrides (e.g., `.parent .target`) over modifying shared rules,
+  to avoid unintended changes to other parts of the app.
+
+When removing a CSS dependency (e.g., Bootstrap), audit the full
+property list of every rule, not just visually obvious properties like
+colors and backgrounds. Subtle properties like `line-height`, `margin`,
+`padding`, `text-decoration`, `font-weight`, and `border` are easy to
+miss but cause visible regressions. Check inherited properties too —
+e.g., a `body` rule's `line-height` or `margin` affects all descendants.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "web/**/*.{js,cjs,mjs,ts,cts,mts}"
+  - "web/**/*.hbs"
+---
+
+# Frontend Code
+
+- JavaScript/TypeScript code must use `const` or `let`, never `var`.
+- Avoid lodash in favor of modern ECMAScript primitives where available,
+  keeping in mind our browserlist.
+- Don't use `onclick` attributes in HTML; use event delegation
+- Don't access DOM APIs (`document.documentElement.style`, `$()`
+  selectors for specific elements) without guarding for node test
+  environments, where the DOM is mocked minimally. Check that the
+  element exists before using it.

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "**/*.py"
+---
+
+# Python Code
+
+- Don't use `Any` type annotations without comments justifying it.
+- Don't use `cursor.execute()` with string formatting (SQL injection risk)
+- Don't use `.extra()` in Django without careful review and commenting
+- Don't create N+1 query patterns:
+
+  ```python
+  # BAD
+  for bar in bars:
+      foo = Foo.objects.get(id=bar.foo_id)
+
+  # GOOD
+  foos = {f.id: f for f in Foo.objects.filter(id__in=[b.foo_id for b in bars])}
+  ```

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "zerver/tests/**"
+  - "zerver/webhooks/**"
+  - "web/tests/**"
+---
+
+# Testing Philosophy
+
+- Write end-to-end tests when possible verifying what's important, not
+  internal APIs.
+- Tests must work offline. Use fixtures (in `zerver/tests/fixtures`) for
+  external service testing and `responses` for simpler things.
+- Use time_machine and similar libraries to mock time.
+- Read `zerver/tests/test_example.py` for patterns.
+- A good failing test before implementing is good practice so your
+  test and code can jointly verify each other.
+- Remember to always assert state is correctly updated, not just "success".
+- In tests, don't assert on `assertLogs` output with
+  `any(phrase in line for line in mock_log.output)`; pin the full line
+  against `mock_log.output`, or a substring to a specific `mock_log.output[i]`.
+
+A common failure mode is failing to have test coverage for error
+conditions that require coverage (note `tools/coveragerc` excludes
+asserts). Run `test-backend --coverage FooTest` and check the coverage
+data to confirm that the new lines you added are in fact run by the
+tests.
+
+## For webhooks
+
+```bash
+./tools/test-backend zerver/webhooks/<integration>
+```

--- a/.claude/rules/ui-testing.md
+++ b/.claude/rules/ui-testing.md
@@ -1,0 +1,55 @@
+---
+paths:
+  - "web/**"
+  - "templates/**"
+---
+
+# Manual Testing for UI Changes
+
+If a PR makes frontend changes, manually verify the affected UI. This
+catches issues that automated tests miss. **Treat this checklist as
+blocking, not advisory** — every applicable item must be verified
+before the change is ready.
+
+## Visual appearance
+
+- Is the new UI consistent with similar elements (fonts, colors, sizes)?
+  Find the closest existing analogues and compare carefully.
+- Is alignment correct, both vertically and horizontally? Measure
+  programmatically with `getBoundingClientRect()` when in doubt —
+  don't eyeball it.
+- Do clickable elements have hover behavior consistent with similar UI?
+- If elements can be disabled, does the disabled state look right?
+- Did the change accidentally affect other parts of the UI? Use
+  `git grep` to check if modified CSS is used elsewhere. CSS changes
+  are notorious for unintended consequences — check every page and
+  component that shares the selectors you modified.
+- Check all of the above in both light and dark themes when the
+  change could plausibly affect colors, contrast, or theme-dependent
+  imagery. Pure geometry/typography changes (`font-size`,
+  `line-height`, `margin`, `padding`, `display`, `font-weight`,
+  etc.) don't need a separate dark-theme pass —
+  `web/styles/dark_theme.css` only overrides colors, so a single
+  theme suffices for theme-invariant changes.
+
+## Responsiveness and internationalization
+
+- Does the UI look good at different window sizes? Check wide desktop
+  (1920px), typical laptop (1280px), tablet, and narrow phone (480px).
+- Would the UI break if translated strings were 1.5x longer than
+  English? What if they were half as long? Both directions matter.
+
+## Functionality
+
+- Are live updates working as expected?
+- Is keyboard navigation, including tabbing to interactive elements, working?
+- If the feature affects the message view, try different narrows: topic,
+  channel, Combined feed, direct messages.
+- If the feature affects the compose box, test both channel messages and
+  direct messages, and both ways of resizing.
+- If the feature requires elevated permissions, test as both a user who
+  has permissions and one who does not.
+- Think about feature interactions: could banners overlap? What about
+  resolved/unresolved topics? Collapsed or muted messages?
+- Think about edge cases in data: empty lists, very long names, single
+  items vs. hundreds, special characters in strings.

--- a/.claude/skills/commit-message/SKILL.md
+++ b/.claude/skills/commit-message/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: commit-message
+description: "Write a commit message following Zulip's format. Use whenever writing or rewording any commit message."
+---
+
+# Commit Message Format
+
+```
+subsystem: Summary in 72 characters or less.
+
+The body explains why and how. Include context that helps reviewers
+and future developers understand your reasoning, analysis, and
+verification of the work above and beyond CI, without repeating
+details already well presented in the commit metadata (filenames,
+etc.). Explain what the change accomplishes and why it won't break
+things one might worry about.
+
+Line-wrap at 68-70 characters, except URLs and verbatim content
+(error messages, etc.).
+
+Fixes #123.
+```
+
+## Commit summary format
+
+- Before the colon is a lower-case brief gesture at subsystem (ex: "nginx" config) or
+  feature (ex: "compose" for the compose box) being modified.
+- Use a period at the end of the summary
+- Example: `compose: Fix cursor position after emoji insertion.`
+- Example: `nginx: Refactor immutable cache headers.`
+- Bad examples: `Fix bug`, `Update code`, `gather_subscriptions was broken`
+
+## Linking issues
+
+- `Fixes #123.` - Automatically closes the issue
+- `Fixes part of #123.` - Does not close (for partial fixes)
+- In a multi-commit PR, use `Fixes part of #123.` in earlier commits
+  and `Fixes #123.` in the final commit.
+- Never: `Partially fixes #123.` (GitHub ignores "partially")

--- a/.claude/skills/git-rebase/SKILL.md
+++ b/.claude/skills/git-rebase/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: git-rebase
+description: "Squash fixups into earlier commits, reorder commits, or reword commit messages, without needing an interactive editor."
+---
+
+# Git Rebase (Non-Interactive)
+
+Since `git rebase -i` requires an interactive editor, use
+`GIT_SEQUENCE_EDITOR` to supply the todo list via a script:
+
+1. **Updating the HEAD commit:** If the commit you need to modify is
+   already at HEAD, just use `git commit --amend` directly. The
+   fixup+rebase workflow below is only needed for non-HEAD commits.
+
+2. **Squashing fixups into existing commits:** Create fixup commits with
+   `git commit --fixup=<target-hash>`, then write a shell script that
+   outputs the desired todo (with `pick` and `fixup` lines in order)
+   and run:
+
+   ```bash
+   GIT_SEQUENCE_EDITOR=/path/to/todo-script.sh git rebase -i <base>
+   ```
+
+   Note: `--autosquash` alone without `-i` does **not** reorder or
+   squash anything.
+
+3. **Rewording commit messages:** Use `git format-patch` to export
+   commits as patch files, edit the message headers in the patch
+   files, then reapply:
+
+   ```bash
+   git format-patch <base> -o /tmp/patches/
+   # Edit the commit message in each /tmp/patches/000N-*.patch file
+   # (the message is between the Subject: line and the --- line)
+   git reset --hard <base>
+   git am /tmp/patches/*.patch
+   ```

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: pr-description
+description: "Write a pull request description following Zulip's guidelines. Use when opening a pull request or drafting/revising its title or description."
+---
+
+# PR Descriptions
+
+Output the PR description in a markdown code block so that formatting
+(bold, headers, checkboxes, etc.) copy-pastes correctly into GitHub.
+
+## A PR description should:
+
+1. Start with a `Fixes: #...` line linking the issue being addressed.
+2. Explain **why** the change is needed, not just what changed.
+3. Describe how you tested the change, using checkbox format for the
+   test plan (e.g., `- [x] ./tools/test-backend ...`).
+4. Include screenshots for UI changes.
+5. Link to relevant issues or discussions.
+6. Call out any open questions, concerns, or decisions you are uncertain
+   about, so they can be resolved during review.
+7. Include the self-review checklist from
+   `.github/pull_request_template.md` using checkbox format (`- [x]` /
+   `- [ ]`), checking off all applicable items.
+
+## A PR description should not:
+
+- Regurgitate information visible from the diff
+- Make claims you haven't double-checked
+- Express more certainty than is justified given the evidence

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: self-review
+description: "Zulip's self-review checklist. Use when you believe a branch is complete, before presenting the work or opening a PR."
+---
+
+# Self-Review Checklist
+
+Before finalizing, verify:
+
+- [ ] The PR addresses all points described in the issue
+- [ ] All relevant tests pass locally
+- [ ] Code follows existing patterns in the codebase
+- [ ] Names (functions, variables, tests) are clear and greppable
+- [ ] Commit messages, comments, and PR description are well done.
+- [ ] Each commit is a minimal coherent idea
+- [ ] No debugging code or unnecessary comments remain
+- [ ] Type annotations are complete and correct
+- [ ] User-facing strings are tagged for translation
+- [ ] User-facing error messages are clear and actionable
+- [ ] No secrets or credentials are hardcoded
+- [ ] Documentation is updated if behavior changes
+- [ ] Refactoring is complete (`git grep` for remaining occurrences)
+- [ ] Security audit of changes. Always check for XSS in UI changes
+      and for incorrect access control in server changes.
+
+Always output a recommend pull request summary+description that
+follow's Zulip's guidelines once you finish preparing a series of
+commits.

--- a/.claude/skills/visual-test/SKILL.md
+++ b/.claude/skills/visual-test/SKILL.md
@@ -242,6 +242,33 @@ console.log(`\n${results.length - failures.length}/${results.length} tests passe
 This keeps the test running through failures so you see all results,
 unlike `assert` which aborts on the first failure.
 
+#### Verifying alignment
+
+When using Puppeteer to verify visual alignment, do not rely on
+eyeballing screenshots — especially small full-page ones. Instead:
+
+- Use `page.evaluate()` with `getBoundingClientRect()` to measure
+  actual pixel positions of the elements you need aligned, and print
+  them to the console. Compare the numbers.
+- Always take **both** a full-page screenshot and a zoomed clip of
+  the area of interest.
+- For zoomed clips, calculate the clip region from non-fixed elements;
+  fixed/sticky elements may report bounding-box positions that don't
+  match their visual location on the page.
+- Be aware that CSS nesting can scope styles to a specific parent
+  (e.g., `.parent .my-class`) — reusing the same class name in a
+  different context may not pick up the expected styles.
+- To verify keyboard-focus styles, use real keyboard navigation
+  (`page.keyboard.press`); programmatic `.focus()` doesn't reliably
+  trigger `:focus-visible` and may be overridden by view-level focus
+  management.
+- Focus rings drawn as `::before` / `::after` pseudo-elements aren't
+  visible in `getComputedStyle` of the focused element — verify them
+  in a screenshot, not via computed styles.
+- For visual changes, produce before/after screenshot pairs by writing
+  one test and running it twice with a `SCREENSHOT_SUFFIX` env var
+  (`-old` on `main`, `-updated` on your branch).
+
 ### 2. Run the test
 
 ```bash


### PR DESCRIPTION
@benprew recommended [here](https://github.com/zulip/zulip/pull/40038#pullrequestreview-5068914287) that we reduce the size of CLAUDE.md by moving things to rules.

Rules seem useful for things that aren't always applicable, and are specifically applicable when working on certain parts of the codebase. Skills were used otherwise.

To allow other agents to use the same high level file, I made sure to explicitly mention the skill and rules in `CLAUDE.md`. Open question: is it better to put the full path to the skills too?