### PR TITLE
webhooks/redmine: Use the journal author for issue edit events.

### DIFF
--- a/zerver/webhooks/redmine/fixtures/issue_updated.json
+++ b/zerver/webhooks/redmine/fixtures/issue_updated.json
@@ -59,10 +59,10 @@
       "author": {
         "icon_url": "http://www.gravatar.com/avatar/example",
         "identity_url": null,
-        "lastname": "user",
-        "firstname": "test",
-        "mail": "test@example.com",
-        "login": "test",
+        "lastname": "user2",
+        "firstname": "test2",
+        "mail": "test2@example.com",
+        "login": "test2",
         "id": 3
       },
       "created_on": "2014-03-01T16:17:48Z",

--- a/zerver/webhooks/redmine/tests.py
+++ b/zerver/webhooks/redmine/tests.py
@@ -24,7 +24,7 @@ I'm having a problem with this.
         self.check_webhook("issue_opened_without_assignee", self.TOPIC_NAME, expected_message)
 
     def test_issue_updated(self) -> None:
-        expected_message = """**test user** updated [#191 Found a bug](https://example.com).
+        expected_message = """**test2 user2** updated [#191 Found a bug](https://example.com).
 
 ~~~ quote
 I've started working on this issue. The problem seems to be in the authentication module.

--- a/zerver/webhooks/redmine/view.py
+++ b/zerver/webhooks/redmine/view.py
@@ -67,8 +67,7 @@ def handle_issue_opened(payload: WildValue) -> str:
 
 
 def handle_issue_updated(payload: WildValue) -> str:
-    issue = payload["issue"]
-    author_name = _get_user_name(issue["author"])
+    author_name = _get_user_name(payload["journal"]["author"])
     issue_link = _get_issue_link(payload)
 
     journal_notes = ""


### PR DESCRIPTION
Fixes #39448.

The solution described in the issue makes sense.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
