### PR TITLE
modal: Darken the cancel button on press in dark theme.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -27,7 +27,7 @@
     );
     --color-background-modal-cancel-button-active: light-dark(
         hsl(229deg 9% 36% / 11%),
-        hsl(230deg 9% 60% / 18%)
+        hsl(0deg 0% 0% / 12%)
     );
 
     /* Since modals are also present in portico and billing pages, we define


### PR DESCRIPTION
Fixes Daniel's report here: [#design > redesign modal footer buttons #39205 @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/redesign.20modal.20footer.20buttons.20.2339205/near/2517762)

Needs design review before merging.

Before:


https://github.com/user-attachments/assets/e4cf2b6b-78bf-4605-933c-3e0ecea6fb31



After:


https://github.com/user-attachments/assets/7a9e64d9-dd05-45db-be95-01bc9324016a

