### PR TITLE
[ai] dark_theme: Clean up four dark-theme overrides.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -818,6 +818,14 @@
 
     /* Colors used across the app */
     --color-date: light-dark(hsl(0deg 0% 15% / 75%), hsl(0deg 0% 100% / 75%));
+    --color-background-simplebar-scrollbar: light-dark(
+        hsl(0deg 0% 0%),
+        hsl(0deg 0% 100%)
+    );
+    --color-box-shadow-simplebar-scrollbar: light-dark(
+        hsl(0deg 0% 100% / 33%),
+        hsl(0deg 0% 0% / 33%)
+    );
     --color-background-private-message-header: light-dark(
         hsl(46deg 35% 93%),
         hsl(46deg 15% 20%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1811,6 +1811,14 @@
         hsl(0deg 0% 80%),
         hsl(0deg 0% 33%)
     );
+    --color-background-rendered-markdown-time: light-dark(
+        hsl(0deg 0% 93%),
+        hsl(0deg 0% 0% / 20%)
+    );
+    --color-box-shadow-rendered-markdown-time: light-dark(
+        hsl(0deg 0% 80%),
+        hsl(0deg 0% 0% / 40%)
+    );
 
     /* Tab-switcher colors */
     /* The non-selected colors here are shared with numerous other

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -75,8 +75,8 @@ a.no-underline:focus {
 
 .simplebar-track {
     .simplebar-scrollbar::before {
-        background-color: hsl(0deg 0% 0%);
-        box-shadow: 0 0 0 1px hsl(0deg 0% 100% / 33%);
+        background-color: var(--color-background-simplebar-scrollbar);
+        box-shadow: 0 0 0 1px var(--color-box-shadow-simplebar-scrollbar);
     }
 
     &.simplebar-vertical {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -222,10 +222,6 @@
         box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 33%);
     }
 
-    .collapse-settings-button:hover {
-        color: hsl(200deg 79% 66%);
-    }
-
     #loading_older_messages_indicator,
     #recent_view_loading_messages_indicator {
         & path {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -123,11 +123,6 @@
         color: inherit;
     }
 
-    & time {
-        background: hsl(0deg 0% 0% / 20%);
-        box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 40%);
-    }
-
     .tip {
         color: inherit;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -217,11 +217,6 @@
         filter: invert(100%);
     }
 
-    .simplebar-track .simplebar-scrollbar::before {
-        background-color: hsl(0deg 0% 100%);
-        box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 33%);
-    }
-
     #loading_older_messages_indicator,
     #recent_view_loading_messages_indicator {
         & path {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -257,10 +257,6 @@
         }
     }
 
-    .help_link_widget:hover {
-        color: inherit;
-    }
-
     #uppy-editor .uppy-ImageCropper {
         /* Uppy cropper canvas has some CSS properties set for the background that
         do not look good for dark theme. When using Uppy Dashboard, this can be

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -354,9 +354,9 @@
 
     /* Timestamps */
     & time {
-        background: hsl(0deg 0% 93%);
+        background: var(--color-background-rendered-markdown-time);
         border-radius: 3px;
-        box-shadow: 0 0 0 1px hsl(0deg 0% 80%);
+        box-shadow: 0 0 0 1px var(--color-box-shadow-rendered-markdown-time);
         white-space: nowrap;
         margin: 0 2px;
         /* Reduce the font-size to reduce the


### PR DESCRIPTION
Manually took screenshots for the commits and pasted them inline!

---

Fixes part of #39354.

Four small `dark_theme.css` cleanups, one per commit, all intended to be no-ops visually:

- Two overrides were already redundant: `.collapse-settings-button:hover` forced the exact color that `--color-text-url-hover` already resolves to in dark theme, and `.help_link_widget:hover { color: inherit }` duplicated the all-themes rule on `a.help_link_widget:hover` (every `.help_link_widget` is an `<a>`). Both are simply removed.
- The simplebar scrollbar thumb and the rendered Markdown `<time>` element each had a light rule with hardcoded colors and a dark override with different hardcoded colors. Those become `light-dark()` variables in `app_variables.css`, used from the single light-theme rule; only the colors moved into variables, the `box-shadow` geometry stays in the rules. Values match the previous light and dark values exactly.
