### PR TITLE
claude: Improve agent instructions.

### DIFF
--- a/.claude/rules/css.md
+++ b/.claude/rules/css.md
@@ -19,6 +19,8 @@ paths:
   entries to understand which pages load the file. Prefer scoped
   overrides (e.g., `.parent .target`) over modifying shared rules,
   to avoid unintended changes to other parts of the app.
+- Use class or ID selectors, not bare tag selectors or attribute
+  selectors. If no suitable class exists, add one.
 
 When removing a CSS dependency (e.g., Bootstrap), audit the full
 property list of every rule, not just visually obvious properties like

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -16,3 +16,5 @@ paths:
   element exists before using it.
 - Use `util.the($el)` instead of `$el[0]!` when a jQuery object should
   hold exactly one element.
+- Use class or ID selectors, not bare tag selectors or attribute
+  selectors. If no suitable class exists, add one.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -14,3 +14,5 @@ paths:
   selectors for specific elements) without guarding for node test
   environments, where the DOM is mocked minimally. Check that the
   element exists before using it.
+- Use `util.the($el)` instead of `$el[0]!` when a jQuery object should
+  hold exactly one element.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,15 @@ coherent idea."** This is non-negotiable.
   When a commit is flagged as potentially droppable, verify all
   earlier commits work correctly without it.
 
+### Open Independently Useful Fixes as Separate PRs
+
+If, while building a feature, you find and fix a pre-existing bug or
+make a refactor that would be worth merging even if the feature never
+lands, split this into its own PR. A small isolated PR gets more
+scrutiny than the same change as part of a large PR. Prep commits
+that mainly make sense in the context of the feature PR should stay
+in the feature's PR.
+
 ### Commit Message Format
 
 Use the `/commit-message` skill whenever you write or reword a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ automatically when you work on CSS files).
 Python rules can be found in `.claude/rules/python.md` (loaded
 automatically when you work on .py files).
 
-See: https://zulip.readthedocs.io/en/latest/contributing/code-style.html
+See: `docs/contributing/code-style.md`
 
 ## Commit Discipline
 
@@ -369,13 +369,13 @@ Recommend pausing for discussion when:
 
 ## Key Documentation Links
 
-- Contributing guide: https://zulip.readthedocs.io/en/latest/contributing/contributing.html
-- Code style: https://zulip.readthedocs.io/en/latest/contributing/code-style.html
-- Commit discipline: https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html
-- Testing overview: https://zulip.readthedocs.io/en/latest/testing/testing.html
-- Backend tests: https://zulip.readthedocs.io/en/latest/testing/testing-with-django.html
-- Code review: https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html
-- mypy guide: https://zulip.readthedocs.io/en/latest/testing/mypy.html
+- Contributing guide: `docs/contributing/contributing.md`
+- Code style: `docs/contributing/code-style.md`
+- Commit discipline: `docs/contributing/commit-discipline.md`
+- Testing overview: `docs/testing/testing.md`
+- Backend tests: `docs/testing/testing-with-django.md`
+- Code review: `docs/contributing/code-reviewing.md`
+- mypy guide: `docs/testing/mypy.md`
 
 ## Repository Structure Quick Reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,7 +330,8 @@ Recommend pausing for discussion when:
 
 - The approach involves security-sensitive code
 - Database migrations are needed (See `docs/subsystems/schema-migrations.md`).
-- The change affects many files (>10)
+- The change alters behavior in several subsystems at once (renames
+  and type annotation changes that touch many files do not count)
 - Performance implications are unclear
 - The feature design isn't fully specified
 - The API or data model design isn't fully specified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,12 +341,16 @@ Recommend pausing for discussion when:
 
 ### For Bug Fixes
 
-1. Show the relevant code and explain what's happening
-2. Brainstorm theories for how the bug might be possible
+1. Look at the relevant code and brainstorm theories for
+   how the bug might be possible
+2. Provide a clear explanation for the bug, and ideally
+   provide steps for reproducing the bug on `main` in the
+   dev environment. Verify the cause of the bug before
+   suggesting a fix, unless a bug is very difficult to verify,
+   in which case say so and explain a hypothesis instead.
 3. Analyze and propose a fix with a clear explanation
 4. Write tests that would have caught this bug if possible
-5. Format as a single commit following commit guidelines
-6. Audit for whether the bug may exist elsewhere or might be
+5. Audit for whether the bug may exist elsewhere or might be
    re-introduced and propose appropriate changes to address if so.
 
 ### For New Features
@@ -354,8 +358,7 @@ Recommend pausing for discussion when:
 1. Read the relevant documentation in docs/
 2. Show similar existing features in the codebase
 3. Propose an implementation approach before coding
-4. Implement in minimal, coherent commits
-5. Each commit must pass tests independently
+4. Implement, following "Commit Discipline" above
 
 ### For Refactoring
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,7 +456,20 @@ content.
 git grep "pattern"          # Search codebase (use extensively!)
 ```
 
+Most of these commands take minutes, so run them in the background.
+
 If a tool complains that provision is outdated, run `./tools/provision`
 to fix it. Do not use `--skip-provision-check` to work around the
 error; the check exists because tests and linters depend on provisioned
 dependencies being current.
+
+If the development environment runs in a container (Vagrant/Docker),
+run `./tools/` commands inside it. Files and new screenshots will be
+accessible on both sides.
+
+```bash
+vagrant ssh -c 'cd ~/zulip && ./tools/lint path/to/changed/files.py'
+```
+
+If `vagrant ssh` fails with a Docker daemon error, Docker Desktop isn't
+running; ask the user to start it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,9 +174,28 @@ Zulip has over 185,000 words of developer documentation. Before working on any a
   code, especially where access control or subtle correctness is involved.
 - Run `./tools/lint` to catch style issues before committing, including mypy issues.
 - Prefer writing code that is readable without explanation over heavily
-  commented code using clever tricks. Comments should explain "why" when
-  the reason isn't obvious, not narrate "what" the code does.
+  commented code using clever tricks.
+- Don't reference line numbers (e.g., `filter.ts:493`) in comments, commit
+  messages, or PR descriptions; they get stale when files are edited.
+  Reference symbol names instead.
+
+**Comments**
+
+- Comments should explain "why" when the reason isn't obvious, not
+  narrate "what" the code does.
 - Comments should have a line to themself except for CSS px math.
+- Comments should never describe the change being made or a bug
+  being fixed. They should read as if they were there all along.
+  Descriptions of the diff belong in the commit message instead.
+- Match comment density of nearby code and similar functions.
+  If similar code doesn't comment on something, don't comment
+  on it in new code.
+- Avoid metaphors in favor of clear descriptive language. Match
+  existing idioms verbatim for comments describing specific
+  situations (e.g., `/* Override bootstrap defaults */`) rather
+  than writing a new or longer explanation.
+
+**Further rules**
 
 Frontend rules can be found in `.claude/rules/frontend.md` (loaded
 automatically when you work on frontend JS/TS and template files).


### PR DESCRIPTION
Part of the CLAUDE.md rework (follow-up to #40066; alongside #40076, #40078,
and #40079): improvements and additions to the agent instructions, largely
distilled from repeated corrections given to AI assistants during real Zulip
work and review.

Best reviewed commit-by-commit; each message carries the motivation for its
rule. A few more additions from the same backlog will follow separately.

Note: expect trivial merge conflicts with #40076 (nearby sections) and #40079
(renames this file); we'll rebase whichever lands last.