### PR TITLE
users: Skip redundant workplace users count entry on role change.

### DIFF
--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -109,7 +109,11 @@ def create_user_group_in_database(
 
 @transaction.atomic(savepoint=False)
 def update_users_in_full_members_system_group(
-    realm: Realm, affected_user_ids: Sequence[int] = [], *, acting_user: UserProfile | None
+    realm: Realm,
+    affected_user_ids: Sequence[int] = [],
+    *,
+    acting_user: UserProfile | None,
+    skip_workplace_users_count_audit_log: bool = False,
 ) -> None:
     full_members_system_group = NamedUserGroup.objects.get(
         realm_for_sharding=realm, name=SystemGroups.FULL_MEMBERS, is_system_group=True
@@ -166,12 +170,18 @@ def update_users_in_full_members_system_group(
 
     if len(old_full_members) > 0:
         bulk_remove_members_from_user_groups(
-            [full_members_system_group], old_full_member_ids, acting_user=acting_user
+            [full_members_system_group],
+            old_full_member_ids,
+            acting_user=acting_user,
+            skip_workplace_users_count_audit_log=skip_workplace_users_count_audit_log,
         )
 
     if len(new_full_members) > 0:
         bulk_add_members_to_user_groups(
-            [full_members_system_group], new_full_member_ids, acting_user=acting_user
+            [full_members_system_group],
+            new_full_member_ids,
+            acting_user=acting_user,
+            skip_workplace_users_count_audit_log=skip_workplace_users_count_audit_log,
         )
 
 
@@ -326,6 +336,7 @@ def bulk_add_members_to_user_groups(
     user_profile_ids: list[int],
     *,
     acting_user: UserProfile | None,
+    skip_workplace_users_count_audit_log: bool = False,
 ) -> None:
     # All intended callers of this function involve a single user
     # being added to one or more groups, or many users being added to
@@ -363,7 +374,9 @@ def bulk_add_members_to_user_groups(
         for user_group in user_groups
     )
 
-    if check_any_group_used_for_workplace_users_group(realm, user_groups):
+    if not skip_workplace_users_count_audit_log and check_any_group_used_for_workplace_users_group(
+        realm, user_groups
+    ):
         RealmAuditLog.objects.create(
             realm=realm,
             acting_user=acting_user,
@@ -417,6 +430,7 @@ def bulk_remove_members_from_user_groups(
     user_profile_ids: list[int],
     *,
     acting_user: UserProfile | None,
+    skip_workplace_users_count_audit_log: bool = False,
 ) -> None:
     # All intended callers of this function involve a single user
     # being added to one or more groups, or many users being added to
@@ -452,7 +466,9 @@ def bulk_remove_members_from_user_groups(
         for user_group in user_groups
     )
 
-    if check_any_group_used_for_workplace_users_group(realm, user_groups):
+    if not skip_workplace_users_count_audit_log and check_any_group_used_for_workplace_users_group(
+        realm, user_groups
+    ):
         RealmAuditLog.objects.create(
             realm=realm,
             acting_user=acting_user,

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -691,8 +691,15 @@ def do_change_user_role(
     do_send_user_group_members_update_event("add_members", system_group, [user_profile.id])
 
     if UserProfile.ROLE_MEMBER in [old_value, value]:
+        # The USER_ROLE_CHANGED entry above records the workplace users
+        # count once all the membership updates for this role change are
+        # done, so a WORKPLACE_USERS_COUNT_CHANGED entry recording the
+        # same count would be redundant.
         update_users_in_full_members_system_group(
-            user_profile.realm, [user_profile.id], acting_user=acting_user
+            user_profile.realm,
+            [user_profile.id],
+            acting_user=acting_user,
+            skip_workplace_users_count_audit_log=True,
         )
 
     # realm_user_count_by_role counts the workplace users from

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -1944,6 +1944,7 @@ class TestRealmAuditLog(ZulipTestCase):
             realm, "workplace_users_group", moderators_group, acting_user=None
         )
         realm.refresh_from_db()
+        now = timezone_now()
         do_change_user_role(
             user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None, notify=False
         )
@@ -1960,6 +1961,15 @@ class TestRealmAuditLog(ZulipTestCase):
             .filter(is_bot=False, is_active=True)
             .count(),
         )
+        # We skip creating WORKPLACE_USERS_COUNT_CHAGNED entry since
+        # USER_ROLE_CHANGED entry already has the correct user count.
+        self.assertFalse(
+            RealmAuditLog.objects.filter(
+                realm=realm,
+                event_type=AuditLogEventType.WORKPLACE_USERS_COUNT_CHANGED,
+                event_time__gte=now,
+            ).exists()
+        )
 
         # Check when workplace_users_group is set to a system group
         # where just role counts are not enough and group membership
@@ -1968,6 +1978,7 @@ class TestRealmAuditLog(ZulipTestCase):
             realm, "workplace_users_group", full_members_group, acting_user=None
         )
         realm.refresh_from_db()
+        now = timezone_now()
         do_change_user_role(user_profile, UserProfile.ROLE_GUEST, acting_user=None, notify=False)
         role_changed_entry = RealmAuditLog.objects.filter(
             realm=realm,
@@ -1982,6 +1993,13 @@ class TestRealmAuditLog(ZulipTestCase):
             .filter(is_bot=False, is_active=True)
             .count(),
         )
+        self.assertFalse(
+            RealmAuditLog.objects.filter(
+                realm=realm,
+                event_type=AuditLogEventType.WORKPLACE_USERS_COUNT_CHANGED,
+                event_time__gte=now,
+            ).exists()
+        )
 
         # Check with workplace_users_group set to an anonymous group.
         do_change_realm_permission_group_setting(
@@ -1991,6 +2009,7 @@ class TestRealmAuditLog(ZulipTestCase):
             acting_user=None,
         )
         realm.refresh_from_db()
+        now = timezone_now()
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None, notify=False)
         role_changed_entry = RealmAuditLog.objects.filter(
             realm=realm,
@@ -2004,6 +2023,13 @@ class TestRealmAuditLog(ZulipTestCase):
             get_recursive_group_members(realm.workplace_users_group_id)
             .filter(is_bot=False, is_active=True)
             .count(),
+        )
+        self.assertFalse(
+            RealmAuditLog.objects.filter(
+                realm=realm,
+                event_type=AuditLogEventType.WORKPLACE_USERS_COUNT_CHANGED,
+                event_time__gte=now,
+            ).exists()
         )
 
     def test_workplace_users_count_when_creating_user(self) -> None:


### PR DESCRIPTION
When `workplace_users_group` is set to the full members group, or to a group containing it,
a role change involving the member role also updated the full members group memberships,
and hence created a `WORKPLACE_USERS_COUNT_CHANGED` entry.

That entry is redundant, since the `USER_ROLE_CHANGED` entry for the same change already
records the workplace users count computed after all these membership updates have run.
Skipping it also makes role changes uniform: with `workplace_users_group` set to any other
system group, only the `USER_ROLE_CHANGED` entry was created already.

https://chat.zulip.org/#narrow/channel/3-backend/topic/inconsistency.20in.20WORKPLACE_USERS_COUNT_CHANGED.20audit.20logs/with/2519245

<!-- Describe your pull request here.-->
<!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
