### PR TITLE
typeahead: Use grid layout for typeahead content.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -68,13 +68,26 @@
             }
 
             .typeahead-content {
-                display: flex;
+                display: grid;
+                grid-template-areas: "icon content";
+                grid-template-columns: max-content minmax(0, 1fr);
                 align-items: center;
                 overflow: hidden;
                 gap: 0.3571em;
+
+                &:not(:has(> .typeahead-image, > .emoji)) {
+                    grid-template-areas: "content";
+                    grid-template-columns: minmax(0, 1fr);
+                }
+
+                > .typeahead-image,
+                > .emoji {
+                    grid-area: icon;
+                }
             }
 
             .typeahead-text-container {
+                grid-area: content;
                 display: flex;
                 align-self: center;
                 overflow: hidden;


### PR DESCRIPTION
The typeahead rows have two logical parts: an optional leading avatar/icon and the text content. CSS Grid lets us represent those as explicit columns instead of relying on flex alignment. For rows without a leading icon, the layout collapses to a single content column, avoiding unnecessary reserved space while preserving the existing visual layout.

This follows the plan posted on #37030; there are no intentional visual changes.

Fixes: #37030

**How changes were tested:**

- Ran `tools/lint web/styles/typeahead.css`.
- Ran `tools/test-js-with-node typeahead_helper`.
- Ran `tools/test-js-with-node composebox_typeahead`.
- Confirmed `.typeahead-content` is the shared typeahead-row layout in `web/templates/typeahead_list_item.hbs`, so the visual review focuses on the two layout shapes introduced by this CSS: rows with a leading image/emoji and rows without one.
- Manually spot-checked mention typeaheads at 12px, the default font size, and 20px. The screenshots below focus on the distinct layout states rather than duplicating the same state at multiple font sizes.
- Compared precise Before/After screenshots for both layout shapes. Every pair uses the same UI state and identical 1462×664 capture dimensions.
- Screenshot files are hosted from a separate `pr-assets-40085` branch in my fork so they are publicly accessible without adding image files to this feature PR.

**Screenshots and screen captures:**

### Mention typeahead — rows with leading avatars/icons

This pair covers the icon/avatar-backed layout and a mixed result set in one state: the highlighted row, ordinary users, `all` / `topic` special mentions, a long display name, a guest, and an imported user.

| Before | After |
| --- | --- |
| ![Mention typeahead before](https://raw.githubusercontent.com/pinankshah8-Aa/zulip/pr-assets-40085/pr-assets/40085/mention-before.png) | ![Mention typeahead after](https://raw.githubusercontent.com/pinankshah8-Aa/zulip/pr-assets-40085/pr-assets/40085/mention-after.png) |

### Slash-command typeahead — rows without a leading image/emoji

This pair covers the single-column text-only layout created by the `:not(:has(...))` branch.

| Before | After |
| --- | --- |
| ![Slash-command typeahead before](https://raw.githubusercontent.com/pinankshah8-Aa/zulip/pr-assets-40085/pr-assets/40085/slash-command-before.png) | ![Slash-command typeahead after](https://raw.githubusercontent.com/pinankshah8-Aa/zulip/pr-assets-40085/pr-assets/40085/slash-command-after.png) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
