### PR TITLE
restart-server: Report progress during rolling restart

### DIFF
--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -9,6 +9,7 @@ import socket
 import subprocess
 import sys
 import time
+from typing import Any
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from scripts.lib.setup_path import setup_path
@@ -260,7 +261,7 @@ if has_application_server():
             logging.info("%s Tornado process", verbing)
             restart_or_start("zulip-tornado:*")
 
-    def get_uwsgi_stats() -> dict[str, object]:
+    def get_uwsgi_stats() -> dict[str, Any]:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.connect("/home/zulip/deployments/uwsgi-stats")
             data = b""

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -303,7 +303,8 @@ if has_application_server():
                 if n % 5 == 0:
                     stats = get_uwsgi_stats()
                     reloaded = sum(
-                        1 for w in stats["workers"]
+                        1
+                        for w in stats["workers"]
                         if w["respawn_count"] > initial_respawn_counts[w["id"]]
                     )
                     logging.info("Reloaded %s out of %s workers", reloaded, total_workers)

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -5,6 +5,7 @@ import logging
 import os
 import pwd
 import shlex
+import socket
 import subprocess
 import sys
 import time
@@ -259,6 +260,17 @@ if has_application_server():
             logging.info("%s Tornado process", verbing)
             restart_or_start("zulip-tornado:*")
 
+    def get_uwsgi_stats() -> dict[str, object]:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect("/home/zulip/deployments/uwsgi-stats")
+            data = b""
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+        return json.loads(data)
+
     # Finally, restart the Django uWSGI processes.
     if (
         action == "restart"
@@ -280,12 +292,21 @@ if has_application_server():
                 # "c" is chain-reloading:
                 # https://uwsgi-docs.readthedocs.io/en/latest/MasterFIFO.html#available-commands
                 control_socket.write("c")
+            stats = get_uwsgi_stats()
+            initial_respawn_counts = {w["id"]: w["respawn_count"] for w in stats["workers"]}
+            total_workers = len(stats["workers"])
+
             n = 0
             while not os.path.exists("/var/lib/zulip/django-workers.ready"):
                 time.sleep(1)
                 n += 1
                 if n % 5 == 0:
-                    logging.info("...")
+                    stats = get_uwsgi_stats()
+                    reloaded = sum(
+                        1 for w in stats["workers"]
+                        if w["respawn_count"] > initial_respawn_counts[w["id"]]
+                    )
+                    logging.info("Reloaded %s out of %s workers", reloaded, total_workers)
             logging.info("Chain reloading complete")
         else:
             logging.info("Starting django server")


### PR DESCRIPTION
When doing a rolling restart, instead of printing '...' every 5 seconds, query the uWSGI stats socket to report how many workers have been reloaded so far out of the total.

Fixes #40056

When doing a rolling restart, instead of printing '...' every 5
seconds, query the uWSGI stats socket to report how many workers
have been reloaded so far out of the total.

The approach:
- Before triggering chain reload, take a snapshot of each worker's
  respawn_count from the uWSGI stats socket
- During the wait loop, compare current respawn_count values against
  the snapshot to count how many workers have been reloaded
- Print "Reloaded X out of Y workers" every 5 seconds instead of "..."

Fixes: https://github.com/zulip/zulip/issues/40056.

**How changes were tested:**
Tested by simulating the progress output locally. The change queries
the uWSGI stats socket which is already present in production at
/home/zulip/deployments/uwsgi-stats.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
