### PR TITLE
[ai] web: Show overlay names in browser history

### DIFF
--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -17,6 +17,7 @@ import * as message_fetch from "./message_fetch.ts";
 import * as message_view from "./message_view.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as modals from "./modals.ts";
+import * as narrow_title from "./narrow_title.ts";
 import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -566,6 +567,7 @@ function hashchanged(
 
     const was_internal_change = browser_history.save_old_hash();
     if (was_internal_change) {
+        narrow_title.redraw_title();
         return undefined;
     }
 
@@ -584,6 +586,7 @@ function hashchanged(
     popovers.hide_all();
 
     if (hash_parser.is_overlay_hash(current_hash)) {
+        narrow_title.redraw_title();
         browser_history.state.changing_hash = true;
         modals.close_active_if_any();
         do_hashchange_overlay(old_hash);

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -3,11 +3,12 @@ import assert from "minimalistic-assert";
 import {electron_bridge} from "./electron_bridge.ts";
 import * as favicon from "./favicon.ts";
 import type {Filter} from "./filter.ts";
+import * as hash_parser from "./hash_parser.ts";
 import {$t} from "./i18n.ts";
 import * as inbox_util from "./inbox_util.ts";
 import * as people from "./people.ts";
 import * as recent_view_util from "./recent_view_util.ts";
-import {realm} from "./state_data.ts";
+import {current_user, realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as unread from "./unread.ts";
 import type {FullUnreadCountsData} from "./unread.ts";
@@ -15,6 +16,45 @@ import type {FullUnreadCountsData} from "./unread.ts";
 export let unread_count = 0;
 let pm_count = 0;
 export let narrow_title = "home";
+
+export function compute_overlay_title(hash: string): string | undefined {
+    switch (hash_parser.get_hash_category(hash)) {
+        case "drafts":
+            return $t({defaultMessage: "Drafts"});
+        case "groups":
+            return current_user.is_guest ? undefined : $t({defaultMessage: "User groups"});
+        case "settings":
+            return $t({defaultMessage: "Personal settings"});
+        case "organization":
+            return $t({defaultMessage: "Organization settings"});
+        case "channels":
+        case "streams":
+            return $t({defaultMessage: "Channels"});
+        case "invite":
+            // The invite modal opens without changing the hash.
+            return undefined;
+        case "keyboard-shortcuts":
+            return $t({defaultMessage: "Keyboard shortcuts"});
+        case "message-formatting":
+            return $t({defaultMessage: "Message formatting"});
+        case "search-operators":
+            return $t({defaultMessage: "Search filters"});
+        case "about-zulip":
+            return $t({defaultMessage: "About Zulip"});
+        case "scheduled":
+            return $t({defaultMessage: "Scheduled messages"});
+        case "reminders":
+            return $t({defaultMessage: "Scheduled reminders"});
+        case "user": {
+            const user_id = Number.parseInt(hash_parser.get_hash_section(hash), 10);
+            return people.is_known_user_id(user_id)
+                ? people.get_full_name(user_id)
+                : $t({defaultMessage: "No user found"});
+        }
+        default:
+            return undefined;
+    }
+}
 
 export function compute_narrow_title(filter?: Filter): string {
     if (filter === undefined) {
@@ -69,9 +109,10 @@ export function compute_narrow_title(filter?: Filter): string {
 
 export function redraw_title(): void {
     // Update window title to reflect unread messages in current view
+    const overlay_title = compute_overlay_title(window.location.hash);
     const new_title =
-        (unread_count ? "(" + unread_count + ") " : "") +
-        narrow_title +
+        (overlay_title === undefined && unread_count ? "(" + unread_count + ") " : "") +
+        (overlay_title ?? narrow_title) +
         " - " +
         realm.realm_name +
         " - " +

--- a/web/tests/hashchange.test.cjs
+++ b/web/tests/hashchange.test.cjs
@@ -12,13 +12,16 @@ const {page_params} = require("./lib/zpage_params.cjs");
 let $window_stub;
 set_global("to_$", () => $window_stub);
 
-set_global("document", "document-stub");
+set_global("document", {title: ""});
 const history = set_global("history", {state: null});
 
 const admin = mock_esm("../src/admin");
 const drafts_overlay_ui = mock_esm("../src/drafts_overlay_ui");
 const info_overlay = mock_esm("../src/info_overlay");
 const message_viewport = mock_esm("../src/message_viewport");
+const narrow_title = mock_esm("../src/narrow_title", {
+    redraw_title() {},
+});
 const overlays = mock_esm("../src/overlays");
 const popovers = mock_esm("../src/popovers");
 const recent_view_ui = mock_esm("../src/recent_view_ui");
@@ -205,6 +208,10 @@ run_test("hash_interactions", ({override, override_rewire}) => {
     override(sidebar_ui, "hide_all", () => {
         sidebar_hide_all_called = true;
     });
+    let redraw_title_calls = 0;
+    override(narrow_title, "redraw_title", () => {
+        redraw_title_calls += 1;
+    });
     window.location.hash = "#unknown_hash";
 
     browser_history.clear_for_testing();
@@ -217,6 +224,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         [overlays, "close_for_hash_change"],
         [message_viewport, "stop_auto_scrolling"],
     ]);
+    assert.equal(redraw_title_calls, 0);
 
     window.location.hash = "#feed";
     hide_all_called = false;
@@ -301,9 +309,11 @@ run_test("hash_interactions", ({override, override_rewire}) => {
     // Test a narrow that spectators are not permitted to access.
     window.location.hash = "#narrow/is/resolved/is/unread";
 
+    redraw_title_calls = 0;
     helper.clear_events();
     $window_stub.trigger("hashchange");
     helper.assert_events([[spectators, "login_to_access"]]);
+    assert.equal(redraw_title_calls, 0);
 
     page_params.is_spectator = false;
 
@@ -330,9 +340,11 @@ run_test("hash_interactions", ({override, override_rewire}) => {
     recent_view_ui_shown = false;
     window.location.hash = "#reload:send_after_reload=0...";
 
+    redraw_title_calls = 0;
     helper.clear_events();
     $window_stub.trigger("hashchange");
     helper.assert_events([]);
+    assert.equal(redraw_title_calls, 0);
     // If it's reload hash it shouldn't show the home view.
     assert.equal(recent_view_ui_shown, false);
 
@@ -356,12 +368,14 @@ run_test("hash_interactions", ({override, override_rewire}) => {
 
     window.location.hash = "#drafts";
 
+    redraw_title_calls = 0;
     helper.clear_events();
     $window_stub.trigger("hashchange");
     helper.assert_events([
         [overlays, "close_for_hash_change"],
         [drafts_overlay_ui, "launch"],
     ]);
+    assert.equal(redraw_title_calls, 1);
 
     window.location.hash = "#settings/alert-words";
 
@@ -411,6 +425,14 @@ run_test("hash_interactions", ({override, override_rewire}) => {
     browser_history.exit_overlay();
 
     helper.assert_events([[ui_util, "blur_active_element"]]);
+
+    // Internal hash changes return before normal hashchange processing, but
+    // still need to redraw the title for the new browser history entry.
+    redraw_title_calls = 0;
+    helper.clear_events();
+    $window_stub.trigger("hashchange");
+    assert.equal(redraw_title_calls, 1);
+    helper.assert_events([]);
 });
 
 run_test("update_hash_to_match_filter", ({override, override_rewire}) => {

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -12,6 +12,13 @@ const blueslip = require("./lib/zblueslip.cjs");
 const {$} = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
+mock_esm("../src/favicon", {
+    update_favicon() {},
+});
+mock_esm("../src/electron_bridge", {
+    electron_bridge: undefined,
+});
+
 const hash_util = zrequire("hash_util");
 const compose_state = zrequire("compose_state");
 const narrow_banner = zrequire("narrow_banner");
@@ -32,12 +39,13 @@ const {initialize_user_settings} = zrequire("user_settings");
 const {MessageList} = zrequire("message_list");
 const {MessageListData} = zrequire("message_list_data");
 
-set_current_user({});
+const current_user = {};
+set_current_user(current_user);
 const realm = make_realm();
 set_realm(realm);
 initialize_user_settings({user_settings: {}});
 
-set_global("document", "document-stub");
+const document_stub = set_global("document", {title: ""});
 const message_lists = mock_esm("../src/message_lists", {
     update_current_message_list() {},
 });
@@ -1305,4 +1313,99 @@ run_test("narrow_compute_title", () => {
 
     filter = new Filter([{operator: "dm", operand: [9999]}]);
     assert.equal(narrow_title.compute_narrow_title(filter), "translated: Invalid user");
+});
+
+run_test("overlay_compute_title", ({override}) => {
+    const profile_user = make_user({
+        email: "profile-user@example.com",
+        user_id: 32,
+        full_name: "Profile User",
+    });
+    people.add_active_user(profile_user, "server_events");
+    const inaccessible_user = make_user({
+        email: "inaccessible-user@example.com",
+        user_id: 33,
+        full_name: "Inaccessible User",
+        is_inaccessible_user: true,
+    });
+    people.add_active_user(inaccessible_user, "server_events");
+
+    const expected_titles = new Map([
+        ["#drafts", "translated: Drafts"],
+        ["#groups", "translated: User groups"],
+        ["#settings/alert-words", "translated: Personal settings"],
+        ["#organization/users/active", "translated: Organization settings"],
+        ["#channels/subscribed", "translated: Channels"],
+        ["#streams/subscribed", "translated: Channels"],
+        ["#keyboard-shortcuts", "translated: Keyboard shortcuts"],
+        ["#message-formatting", "translated: Message formatting"],
+        ["#search-operators", "translated: Search filters"],
+        ["#about-zulip", "translated: About Zulip"],
+        ["#scheduled", "translated: Scheduled messages"],
+        ["#reminders", "translated: Scheduled reminders"],
+        ["#user/32", "Profile User"],
+        ["#user/33", "translated: No user found"],
+        ["#user/9999", "translated: No user found"],
+    ]);
+
+    for (const [hash, title] of expected_titles) {
+        assert.equal(narrow_title.compute_overlay_title(hash), title);
+    }
+
+    assert.equal(narrow_title.compute_overlay_title("#invite"), undefined);
+    assert.equal(narrow_title.compute_overlay_title("#narrow/is/starred"), undefined);
+
+    override(current_user, "is_guest", true);
+    assert.equal(narrow_title.compute_overlay_title("#groups"), undefined);
+});
+
+run_test("redraw_title omits unread count for overlay title", ({override}) => {
+    override(realm, "realm_name", "Test realm");
+
+    const filter = new Filter([{operator: "in", operand: "home"}]);
+    window.location.hash = "#narrow/in/home";
+    narrow_title.update_narrow_title(filter);
+    assert.equal(document_stub.title, "translated: Combined feed - Test realm - Zulip");
+
+    const unread_counts = {
+        direct_message_count: 0,
+        mentioned_message_count: 0,
+        direct_message_with_mention_count: 0,
+        stream_unread_messages: 4,
+        followed_topic_unread_messages_count: 0,
+        followed_topic_unread_messages_with_mention_count: 0,
+        unfollowed_topic_unread_messages_count: 4,
+        muted_topic_unread_messages_count: 0,
+        stream_count: new Map(),
+        streams_with_mentions: [],
+        streams_with_unmuted_mentions: [],
+        pm_count: new Map(),
+        home_unread_messages: 4,
+    };
+    narrow_title.update_unread_counts(unread_counts);
+    assert.equal(document_stub.title, "(4) translated: Combined feed - Test realm - Zulip");
+
+    window.location.hash = "#drafts";
+    narrow_title.redraw_title();
+    assert.equal(document_stub.title, "translated: Drafts - Test realm - Zulip");
+
+    narrow_title.update_unread_counts({
+        ...unread_counts,
+        stream_unread_messages: 5,
+        unfollowed_topic_unread_messages_count: 5,
+        home_unread_messages: 5,
+    });
+    assert.equal(document_stub.title, "translated: Drafts - Test realm - Zulip");
+
+    window.location.hash = "#narrow/in/home";
+    narrow_title.redraw_title();
+    assert.equal(document_stub.title, "(5) translated: Combined feed - Test realm - Zulip");
+
+    window.location.hash = "";
+    narrow_title.update_unread_counts({
+        ...unread_counts,
+        stream_unread_messages: 0,
+        unfollowed_topic_unread_messages_count: 0,
+        home_unread_messages: 0,
+    });
 });


### PR DESCRIPTION
Opening an overlay adds an entry to browser history, but the entry currently keeps the title of the previous message view. This makes entries for Drafts, Settings, Channels, and Keyboard shortcuts difficult to tell apart.

PR #37432 previously tried to fix this by keeping a stack of saved titles. That PR was closed because it was not on track to solve the issue. I started this implementation from scratch. It chooses the title from the current URL hash and redraws it when an overlay opens or closes. No code from #37432 was reused.

Title construction remains in `narrow_title`, so unread counts, realm names, and the product name keep the existing format. The change covers every hash-backed overlay that opens UI. Known user profiles use the user's full name. Invalid and inaccessible profiles use the existing `No user found` label. The invite modal is not included because it opens without changing the URL hash.

Fixes: https://github.com/zulip/zulip/issues/24469

**How changes were tested:**

- `tools/test-js-with-node hashchange message_view`
- `tools/run-tsc`
- `tools/lint web/src/hashchange.ts web/src/narrow_title.ts web/tests/hashchange.test.cjs web/tests/message_view.test.cjs`
- Manually opened Drafts, Personal settings, Organization settings, Channels, the legacy Streams route, User groups, the informational overlays, About Zulip, Scheduled messages, Scheduled reminders, and known and invalid user profiles.
- Checked browser back, forward, and Escape navigation, including restoring the Inbox title.
- Checked that the invite modal keeps the underlying Inbox title.

**Screenshots and screen captures:**

Not included. This changes the browser tab title and history label rather than anything inside the page.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).
- [x] Explained the relationship with the earlier PR.
- [x] Added automated tests for the title logic and hash-change paths.
- [x] Tested the affected overlays and browser navigation manually.
- [x] Kept the change in one coherent commit.

</details>
