### PR TITLE
webhooks/gogs: fix topic title for pull requests

### DIFF
--- a/zerver/webhooks/gitea/fixtures/pull_request__merged.json
+++ b/zerver/webhooks/gitea/fixtures/pull_request__merged.json
@@ -5,7 +5,7 @@
   "pull_request": {
     "id": 1905,
     "url": "https://try.gitea.io/kostekIV/test/pulls/4",
-    "number": 1905,
+    "number": 4,
     "user": {
       "id": 21818,
       "login": "kostekIV",
@@ -18,7 +18,7 @@
       "created": "2019-11-15T19:17:02Z",
       "username": "kostekIV"
     },
-    "title": "Fix remove-op on reaction event",
+    "title": "New pr",
     "body": "Body",
     "labels": [],
     "milestone": null,
@@ -47,7 +47,7 @@
     },
     "base": {
       "label": "master",
-      "ref": "main",
+      "ref": "master",
       "sha": "1d40c3be7919f066f9158eaaaecaf696b3e22886",
       "repo_id": 14576,
       "repo": {
@@ -110,7 +110,7 @@
     },
     "head": {
       "label": "test-branch",
-      "ref": "reaction-metadata",
+      "ref": "test-branch",
       "sha": "01efc1fe09d4fba25397a386a6c623fd12eadd79",
       "repo_id": 14576,
       "repo": {
@@ -191,7 +191,7 @@
       "created": "2019-11-15T19:17:02Z",
       "username": "kostekIV"
     },
-    "name": "zulip-terminal",
+    "name": "test",
     "full_name": "kostekIV/test",
     "description": "",
     "empty": false,

--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -21,39 +21,39 @@ class GiteaHookTests(WebhookTestCase):
         self.check_webhook("create__branch", expected_topic_name, expected_message)
 
     def test_pull_request_opened(self) -> None:
-        expected_topic_name = "test / PR #1905 New pr"
+        expected_topic_name = "test / PR #4 New pr"
         expected_message = """kostekIV opened [PR #4](https://try.gitea.io/kostekIV/test/pulls/4) from `test-branch` to `master`."""
         self.check_webhook("pull_request__opened", expected_topic_name, expected_message)
 
     def test_pull_request_merged(self) -> None:
-        expected_topic_name = "test / PR #1905 New pr"
+        expected_topic_name = "test / PR #4 New pr"
         expected_message = """kostekIV merged [PR #4](https://try.gitea.io/kostekIV/test/pulls/4) from `test-branch` to `master`."""
         self.check_webhook("pull_request__merged", expected_topic_name, expected_message)
 
     def test_pull_request_edited(self) -> None:
-        expected_topic_name = "test / PR #1906 test 2"
+        expected_topic_name = "test / PR #5 test 2"
         expected_message = (
             """kostekIV edited [PR #5](https://try.gitea.io/kostekIV/test/pulls/5)."""
         )
         self.check_webhook("pull_request__edited", expected_topic_name, expected_message)
 
     def test_pull_request_reopened(self) -> None:
-        expected_topic_name = "test / PR #1906 test 2"
+        expected_topic_name = "test / PR #5 test 2"
         expected_message = """kostekIV reopened [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) from `d` to `master`."""
         self.check_webhook("pull_request__reopened", expected_topic_name, expected_message)
 
     def test_pull_request_closed(self) -> None:
-        expected_topic_name = "test / PR #1906 test 2"
+        expected_topic_name = "test / PR #5 test 2"
         expected_message = """kostekIV closed [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) from `d` to `master`."""
         self.check_webhook("pull_request__closed", expected_topic_name, expected_message)
 
     def test_pull_request_closed_different_user(self) -> None:
-        expected_topic_name = "test / PR #126085 PR closed"
+        expected_topic_name = "test / PR #1 PR closed"
         expected_message = """Aneesh-Hegde closed [PR #1](https://gitea.com/Aneesh-Hegde/test-repo/pulls/1) from `main` to `main`."""
         self.check_webhook("pull_request__closed_diff_user", expected_topic_name, expected_message)
 
     def test_pull_request_assigned(self) -> None:
-        expected_topic_name = "test / PR #1906 test 2"
+        expected_topic_name = "test / PR #5 test 2"
         expected_message = """kostekIV assigned kostekIV to [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) from `d` to `master` (assigned to kostekIV)."""
         self.check_webhook("pull_request__assigned", expected_topic_name, expected_message)
 

--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -26,8 +26,8 @@ class GiteaHookTests(WebhookTestCase):
         self.check_webhook("pull_request__opened", expected_topic_name, expected_message)
 
     def test_pull_request_merged(self) -> None:
-        expected_topic_name = "zulip-terminal / PR #1905 Fix remove-op on reaction event"
-        expected_message = """kostekIV merged [PR #1905](https://try.gitea.io/kostekIV/test/pulls/4) from `reaction-metadata` to `main`."""
+        expected_topic_name = "test / PR #1905 New pr"
+        expected_message = """kostekIV merged [PR #4](https://try.gitea.io/kostekIV/test/pulls/4) from `test-branch` to `master`."""
         self.check_webhook("pull_request__merged", expected_topic_name, expected_message)
 
     def test_pull_request_edited(self) -> None:

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -79,22 +79,22 @@ class GogsHookTests(WebhookTestCase):
         self.check_webhook("pull_request__merged", expected_topic_name, expected_message)
 
     def test_pull_request_reopened(self) -> None:
-        expected_topic_name = "test / PR #1349 reopened"
+        expected_topic_name = "test / PR #2 reopened"
         expected_message = """kostekIV reopened [PR #2](https://try.gogs.io/kostekIV/test/pulls/2) from `c` to `master`."""
         self.check_webhook("pull_request__reopened", expected_topic_name, expected_message)
 
     def test_pull_request_edited(self) -> None:
-        expected_topic_name = "test / PR #1349 Test"
+        expected_topic_name = "test / PR #2 Test"
         expected_message = """kostekIV edited [PR #2](https://try.gogs.io/kostekIV/test/pulls/2)."""
         self.check_webhook("pull_request__edited", expected_topic_name, expected_message)
 
     def test_pull_request_assigned(self) -> None:
-        expected_topic_name = "test / PR #1349 Test"
+        expected_topic_name = "test / PR #2 Test"
         expected_message = """kostekIV assigned kostekIV to [PR #2](https://try.gogs.io/kostekIV/test/pulls/2) from `c` to `master`."""
         self.check_webhook("pull_request__assigned", expected_topic_name, expected_message)
 
     def test_pull_request_synchronized(self) -> None:
-        expected_topic_name = "test / PR #1349 Test"
+        expected_topic_name = "test / PR #2 Test"
         expected_message = """kostekIV synchronized [PR #2](https://try.gogs.io/kostekIV/test/pulls/2) from `c` to `master`."""
         self.check_webhook("pull_request__synchronized", expected_topic_name, expected_message)
 

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -221,7 +221,7 @@ def gogs_webhook_main(
         topic_name = TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE.format(
             repo=repo,
             type="PR",
-            id=payload["pull_request"]["id"].tame(check_int),
+            id=payload["pull_request"]["number"].tame(check_int),
             title=payload["pull_request"]["title"].tame(check_string),
         )
     elif event == "issues":


### PR DESCRIPTION
Fixes: Invalid topic name for pull requests events in Gogs/Gitea/Forgejo integration.

The PR number in the JSON payload is in the field `number`, the field `id` contains an internal ID of the gogs/gitea/forgejo instance. The field `number` is correctly used everywhere except in this one instance which I am fixing here.

(Reading fixture JSON files that are in the repo as well as the JSON from my Forgejo instance, I confirmed that the `number` field is the correct field to use to extract the PR number.)

<!-- Describe your pull request here.-->

**How changes were tested:**

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->
I deployed this change on my Zulip instance, it does indeed fix the topic title for PR events.


**Screenshots and screen captures:**

Before:

<img width="923" height="116" alt="before" src="https://github.com/user-attachments/assets/d2914381-96fb-4809-951e-e2329e66b415" />

After:

<img width="918" height="111" alt="after1" src="https://github.com/user-attachments/assets/9cea5e7d-a863-4732-b8b5-9ee7efe3bee4" />

Correct PR number is indeed 1531

**Remaining concerns:**

By inspecting the JSON produced by my Foregjo instance and also the JSON fixture that are already in the repo for Gogs/Gitea, I'm confident that **for all three software** `number` is the correct JSON field to use instead of `id`. However I haven't tested the change with Gogs/Gitea.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
