### PR TITLE
webhooks/grafana: catch validation errors on missing fields

### DIFF
--- a/zerver/webhooks/grafana/fixtures/alert_alerts_style_missing_fields.json
+++ b/zerver/webhooks/grafana/fixtures/alert_alerts_style_missing_fields.json
@@ -1,0 +1,20 @@
+{
+    "receiver": "",
+    "status": "firing",
+    "alerts": [
+      {
+        "status": "firing"
+      }
+    ],
+    "groupLabels": {},
+    "commonLabels": {},
+    "commonAnnotations": {},
+    "externalURL": "https://zuliptestingwh2.grafana.net/",
+    "version": "1",
+    "groupKey": "{}",
+    "truncatedAlerts": 1,
+    "orgId": 1,
+    "title": "[FIRING:1]",
+    "state": "alerting",
+    "message": "Webhook test message."
+}

--- a/zerver/webhooks/grafana/tests.py
+++ b/zerver/webhooks/grafana/tests.py
@@ -310,3 +310,17 @@ Annotations:
             "Unable to parse request: Did Grafana generate this event?",
             e.exception.args[0],
         )
+
+    def test_anomalous_webhook_payload_alerts_style_missing_fields(self) -> None:
+        with self.assertRaises(AssertionError) as e:
+            self.check_webhook(
+                fixture_name="alert_alerts_style_missing_fields",
+                expected_topic_name="",
+                expected_message="",
+                expect_noop=True,
+            )
+
+        self.assertIn(
+            "Unable to parse request: Did Grafana generate this event?",
+            e.exception.args[0],
+        )

--- a/zerver/webhooks/grafana/view.py
+++ b/zerver/webhooks/grafana/view.py
@@ -96,80 +96,89 @@ def api_grafana_webhook(
         # - https://grafana.com/docs/grafana/v9.0/alerting/contact-points/notifiers/webhook-notifier/
         # - https://grafana.com/docs/grafana/v10.0/alerting/alerting-rules/manage-contact-points/webhook-notifier/
         # - https://grafana.com/docs/grafana/v11.0/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/
-        for alert in payload["alerts"]:
-            status = alert["status"].tame(check_string_in(["firing", "resolved"]))
-            if status == "firing":
-                body = ALERT_STATUS_TEMPLATE.format(
-                    alert_icon=":alert:", alert_state=status.upper()
-                )
-            else:
-                body = ALERT_STATUS_TEMPLATE.format(
-                    alert_icon=":checkbox:", alert_state=status.upper()
-                )
-
-            if "alertname" in alert["labels"] and alert["labels"]["alertname"]:
-                alertname = alert["labels"]["alertname"].tame(check_string)
-                topic_name = NEW_TOPIC_TEMPLATE.format(alertname=alertname)
-                body += "**" + alertname + "**\n\n"
-            else:
-                # if no alertname, fallback to the alert fingerprint
-                topic_name = NEW_TOPIC_TEMPLATE.format(
-                    alertname=alert["fingerprint"].tame(check_string)
-                )
-
-            body += START_TIME_TEMPLATE.format(
-                start_time=get_global_time(alert["startsAt"].tame(check_string))
-            )
-
-            end_time = alert["endsAt"].tame(check_string)
-            if end_time != "0001-01-01T00:00:00Z":
-                body += END_TIME_TEMPLATE.format(end_time=get_global_time(end_time))
-
-            if alert["labels"]:
-                label_information = ""
-                for key, value in alert["labels"].items():
-                    label_information += "- " + key + ": " + value.tame(check_string) + "\n"
-                body += MESSAGE_LABELS_TEMPLATE.format(label_information=label_information)
-
-            if alert.get("values"):
-                value_information = ""
-                for key, value in alert["values"].items():
-                    value_information += "- " + key + ": " + str(value.tame(check_anything)) + "\n"
-                body += MESSAGE_VALUES_TEMPLATE.format(value_information=value_information)
-            elif alert.get("valueString"):
-                body += (
-                    MESSAGE_VALUES_TEMPLATE.format(
-                        value_information=alert["valueString"].tame(check_string)
+        try:
+            for alert in payload["alerts"]:
+                status = alert["status"].tame(check_string_in(["firing", "resolved"]))
+                if status == "firing":
+                    body = ALERT_STATUS_TEMPLATE.format(
+                        alert_icon=":alert:", alert_state=status.upper()
                     )
-                    + "\n"
+                else:
+                    body = ALERT_STATUS_TEMPLATE.format(
+                        alert_icon=":checkbox:", alert_state=status.upper()
+                    )
+
+                if "alertname" in alert["labels"] and alert["labels"]["alertname"]:
+                    alertname = alert["labels"]["alertname"].tame(check_string)
+                    topic_name = NEW_TOPIC_TEMPLATE.format(alertname=alertname)
+                    body += "**" + alertname + "**\n\n"
+                else:
+                    # if no alertname, fallback to the alert fingerprint
+                    topic_name = NEW_TOPIC_TEMPLATE.format(
+                        alertname=alert["fingerprint"].tame(check_string)
+                    )
+
+                body += START_TIME_TEMPLATE.format(
+                    start_time=get_global_time(alert["startsAt"].tame(check_string))
                 )
 
-            if alert.get("annotations"):
-                annotation_information = ""
-                for key, value in alert["annotations"].items():
-                    annotation_information += "- " + key + ": " + value.tame(check_string) + "\n"
-                body += MESSAGE_ANNOTATIONS_TEMPLATE.format(
-                    annotation_information=annotation_information
-                )
+                end_time = alert["endsAt"].tame(check_string)
+                if end_time != "0001-01-01T00:00:00Z":
+                    body += END_TIME_TEMPLATE.format(end_time=get_global_time(end_time))
 
-            if alert.get("generatorURL"):
-                body += MESSAGE_GENERATOR_TEMPLATE.format(
-                    generator_url=alert["generatorURL"].tame(check_string)
-                )
+                if alert["labels"]:
+                    label_information = ""
+                    for key, value in alert["labels"].items():
+                        label_information += "- " + key + ": " + value.tame(check_string) + "\n"
+                    body += MESSAGE_LABELS_TEMPLATE.format(label_information=label_information)
 
-            if alert.get("silenceURL"):
-                body += MESSAGE_SILENCE_TEMPLATE.format(
-                    silence_url=alert["silenceURL"].tame(check_string)
-                )
+                if alert.get("values"):
+                    value_information = ""
+                    for key, value in alert["values"].items():
+                        value_information += (
+                            "- " + key + ": " + str(value.tame(check_anything)) + "\n"
+                        )
+                    body += MESSAGE_VALUES_TEMPLATE.format(value_information=value_information)
+                elif alert.get("valueString"):
+                    body += (
+                        MESSAGE_VALUES_TEMPLATE.format(
+                            value_information=alert["valueString"].tame(check_string)
+                        )
+                        + "\n"
+                    )
 
-            if alert.get("imageURL"):
-                body += MESSAGE_IMAGE_TEMPLATE.format(
-                    image_url=alert["imageURL"].tame(check_string)
-                )
+                if alert.get("annotations"):
+                    annotation_information = ""
+                    for key, value in alert["annotations"].items():
+                        annotation_information += (
+                            "- " + key + ": " + value.tame(check_string) + "\n"
+                        )
+                    body += MESSAGE_ANNOTATIONS_TEMPLATE.format(
+                        annotation_information=annotation_information
+                    )
 
-            body += "\n"
+                if alert.get("generatorURL"):
+                    body += MESSAGE_GENERATOR_TEMPLATE.format(
+                        generator_url=alert["generatorURL"].tame(check_string)
+                    )
 
-            check_send_webhook_message(request, user_profile, topic_name, body, status)
+                if alert.get("silenceURL"):
+                    body += MESSAGE_SILENCE_TEMPLATE.format(
+                        silence_url=alert["silenceURL"].tame(check_string)
+                    )
+
+                if alert.get("imageURL"):
+                    body += MESSAGE_IMAGE_TEMPLATE.format(
+                        image_url=alert["imageURL"].tame(check_string)
+                    )
+
+                body += "\n"
+
+                check_send_webhook_message(request, user_profile, topic_name, body, status)
+        except ValidationError:
+            # The payload did not include the expected fields for an
+            # "alerts"-style (Grafana 8.0+) webhook.
+            raise AnomalousWebhookPayloadError
 
         return json_success(request)
 


### PR DESCRIPTION
added try/except to the grafana 8 alerts branch just like the legacy grafana 7 fix. this stops the app from crashing with a 500 error when fields like alert["status"] are missing. now it throws a clean AnomalousWebhookPayloadError instead.

Fixes: crashes and 500 errors on malformed grafana 8 webhook payloads

**How changes were tested:**

added a test json fixture missing required fields and wrote a test to make sure it throws AnomalousWebhookPayloadError. i had to skip the local vagrant backend tests because of a python version mismatch on my mac, but the logic matches the working grafana 7 branch directly above it and i tested the python files compile cleanly.

**Screenshots and screen captures:**
n/a (backend only)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>