### PR TITLE
streams: Report an invalid subscription color instead of erroring.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3583,6 +3583,24 @@ class SubscriptionRestApiTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Unknown subscription property: invalid")
 
+    def test_api_invalid_color_value(self) -> None:
+        """
+        An invalid color is reported to the client, rather than raising
+        an uncaught pydantic ValidationError.
+        """
+        user = self.example_user("hamlet")
+
+        self.login_user(user)
+        subs = gather_subscriptions(user)[0]
+
+        for invalid_color in ["true", "3ffrff"]:
+            result = self.api_patch(
+                user,
+                "/api/v1/users/me/subscriptions/{}".format(subs[0]["stream_id"]),
+                {"property": "color", "value": invalid_color},
+            )
+            self.assert_json_error(result, "color is not a valid hex color code")
+
     def test_api_invalid_stream_id(self) -> None:
         """
         Trying to set an invalid stream id returns a JSON error.

--- a/zerver/tests/test_subscription_settings.py
+++ b/zerver/tests/test_subscription_settings.py
@@ -59,9 +59,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
                 ).decode()
             },
         )
-        self.assert_json_error(
-            result, "Invalid subscription_data[0]: Value error, color is not a valid hex color code"
-        )
+        self.assert_json_error(result, "color is not a valid hex color code")
 
     def test_set_color_missing_stream_id(self) -> None:
         """
@@ -395,9 +393,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
                 ).decode()
             },
         )
-        self.assert_json_error(
-            result, "Invalid subscription_data[0]: Value error, color is not a valid hex color code"
-        )
+        self.assert_json_error(result, "color is not a valid hex color code")
 
     def test_json_subscription_property_invalid_stream(self) -> None:
         test_user = self.example_user("hamlet")

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -1363,7 +1363,11 @@ class SubscriptionPropertyChangeRequest(BaseModel):
         }
 
         if self.property == "color":
-            self.value = check_color("color", self.value)
+            try:
+                self.value = check_color("color", self.value)
+            except ValueError as e:
+                # Raise JsonableError on validation failure to avoid 500.
+                raise JsonableError(str(e))
         elif self.property in boolean_properties:
             if not isinstance(self.value, bool):
                 raise JsonableError(_("{property} is not a boolean").format(property=self.property))


### PR DESCRIPTION
Two of the three failure branches in SubscriptionPropertyChangeRequest raise JsonableError; the color one instead let check_color's ValueError become a pydantic ValidationError. That is fine for the bulk endpoint, whose subscription_data parameter typed_endpoint validates and reports, but update_subscriptions_property builds the model in the view body, where nothing catches it. Every invalid color sent to the single-property endpoint was therefore a 500 rather than an error the client could act on.

Raise JsonableError for this branch too, which fixes the 500 and makes both endpoints report an invalid color the same way they already report a non-boolean value. The bulk endpoint's message loses its pydantic "Invalid subscription_data[0]: Value error, " prefix as a result.


---


Asked Claude to fix this [error](https://zulip.sentry.io/issues/7715043128/events/83a4e39295dd486d99247e770c72c883/?project=5303926)