### PR TITLE
Make logo optional for integrations in self-hosted servers.

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -145,6 +145,7 @@ def get_screenshot_configs(
 class Integration:
     DEFAULT_LOGO_STATIC_PATH_PNG = "images/integrations/logos/{name}.png"
     DEFAULT_LOGO_STATIC_PATH_SVG = "images/integrations/logos/{name}.svg"
+    ZULIP_LOGO_STATIC_PATH_PNG = "images/logo/zulip-icon-128x128.png"
     DEFAULT_BOT_AVATAR_PATH = "images/integrations/bot_avatars/{name}.png"
     DEFAULT_DOC_PATH = "zerver/integrations/{name}.md"
 
@@ -157,7 +158,6 @@ class Integration:
         webhook_screenshot_configs: list[WebhookScreenshotConfig] | None = None,
         client_name: str | None = None,
         logo: str | None = None,
-        fallback_logo_path: str | None = None,
         secondary_line_text: str | None = None,
         display_name: str | None = None,
         doc: str | None = None,
@@ -199,7 +199,7 @@ class Integration:
                 )
         self.categories = [CATEGORIES[c] for c in categories]
 
-        self.logo_path = logo if logo is not None else self.get_logo_path(fallback_logo_path)
+        self.logo_path = logo if logo is not None else self.get_logo_path()
         self.logo_url = staticfiles_storage.url(self.logo_path)
 
         if display_name is None:
@@ -219,21 +219,15 @@ class Integration:
             "hubot",
         )
 
-    def get_logo_path(self, fallback_logo_path: str | None = None) -> str:
+    def get_logo_path(self) -> str:
         paths_to_check = [
             self.DEFAULT_LOGO_STATIC_PATH_SVG.format(name=self.name),
             self.DEFAULT_LOGO_STATIC_PATH_PNG.format(name=self.name),
         ]
-        if fallback_logo_path is not None:
-            paths_to_check.append(fallback_logo_path)
-
         for potential_path in paths_to_check:
             if os.path.isfile(static_path(potential_path)):
                 return potential_path
-
-        raise AssertionError(
-            f"Could not find a logo for integration {self.name}. Paths checked: {', '.join(paths_to_check)}"
-        )
+        return self.ZULIP_LOGO_STATIC_PATH_PNG
 
     def get_bot_avatar_path(self) -> str:
         name = os.path.splitext(os.path.basename(self.logo_path))[0]
@@ -243,7 +237,6 @@ class Integration:
 class BotIntegration(Integration):
     DEFAULT_LOGO_STATIC_PATH_PNG = "generated/bots/{name}/logo.png"
     DEFAULT_LOGO_STATIC_PATH_SVG = "generated/bots/{name}/logo.svg"
-    ZULIP_LOGO_STATIC_PATH_PNG = "images/logo/zulip-icon-128x128.png"
     DEFAULT_DOC_PATH = "{name}/doc.md"
 
     def __init__(
@@ -264,7 +257,6 @@ class BotIntegration(Integration):
             fixtureless_screenshot_config_options=fixtureless_screenshot_config_options,
             secondary_line_text=secondary_line_text,
             logo=logo,
-            fallback_logo_path=self.ZULIP_LOGO_STATIC_PATH_PNG,
         )
 
         if display_name is None:
@@ -460,12 +452,10 @@ class EmbeddedBotIntegration(Integration):
     """
 
     DEFAULT_CLIENT_NAME = "Zulip{name}EmbeddedBot"
-    ZULIP_LOGO_STATIC_PATH_PNG = "images/logo/zulip-icon-128x128.png"
 
     def __init__(self, name: str, *args: Any, **kwargs: Any) -> None:
         assert kwargs.get("client_name") is None
         kwargs["client_name"] = self.DEFAULT_CLIENT_NAME.format(name=name.title())
-        kwargs["fallback_logo_path"] = self.ZULIP_LOGO_STATIC_PATH_PNG
         super().__init__(name, *args, **kwargs)
 
     @override

--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -43,23 +43,17 @@ class IntegrationsTestCase(ZulipTestCase):
         self.assertEqual(image_path, "static/images/integrations/ci/002.png")
 
     def test_get_logo_path(self) -> None:
-        # Test with an integration that passed logo as an argument
+        # Test integration with logo argument, so no logo in default paths
         integration = INTEGRATIONS["slack_incoming"]
-        with self.assertRaises(AssertionError):
-            integration.get_logo_path()
+        self.assertEqual(integration.get_logo_path(), Integration.ZULIP_LOGO_STATIC_PATH_PNG)
 
         # Test with an integration that has only a PNG option
         integration = INTEGRATIONS["onyx"]
         self.assertEqual(integration.get_logo_path(), "images/integrations/logos/onyx.png")
 
         # Test the fallback logo with an embedded integration without a logo
-        ZULIP_LOGO_STATIC_PATH_PNG = "images/logo/zulip-icon-128x128.png"
         integration = EMBEDDED_BOTS[0]
-        with self.assertRaises(AssertionError):
-            integration.get_logo_path()
-        self.assertEqual(
-            integration.get_logo_path(ZULIP_LOGO_STATIC_PATH_PNG), ZULIP_LOGO_STATIC_PATH_PNG
-        )
+        self.assertEqual(integration.get_logo_path(), Integration.ZULIP_LOGO_STATIC_PATH_PNG)
 
         # Test with a bot integration that has a logo
         # They use different DEFAULT_* paths.
@@ -74,8 +68,12 @@ class IntegrationsTestCase(ZulipTestCase):
             integration.get_bot_avatar_path(), "images/integrations/bot_avatars/prometheus.png"
         )
 
-        with self.assertRaises(AssertionError):
-            integration = Integration("alertmanager", ["misc"])
+        # bot avatar path for an integration using the fallback Zulip logo
+        integration = Integration("alertmanager", ["misc"])
+        self.assertEqual(
+            integration.get_bot_avatar_path(),
+            "images/integrations/bot_avatars/zulip-icon-128x128.png",
+        )
 
     def test_no_missing_doc_screenshot_config(self) -> None:
         integration_names = {

--- a/zerver/tests/test_integrations.py
+++ b/zerver/tests/test_integrations.py
@@ -75,6 +75,26 @@ class IntegrationsTestCase(ZulipTestCase):
             "images/integrations/bot_avatars/zulip-icon-128x128.png",
         )
 
+    def test_no_missing_logo(self) -> None:
+        # Integrations without logos in self-hosted servers can use the
+        # fallback Zulip logo. Official integrations should have their own
+        # logos.
+        integrations_using_fallback_logo = {
+            integration.name
+            for integration in INTEGRATIONS.values()
+            if integration.is_enabled_in_catalog()
+            and integration.logo_path == Integration.ZULIP_LOGO_STATIC_PATH_PNG
+        }
+
+        self.assertEqual(
+            integrations_using_fallback_logo,
+            set(),
+            "\n\nThe following integrations have no logo of their own:\n"
+            + "\n".join(integrations_using_fallback_logo)
+            + '\nAdd an SVG for each to "static/images/integrations/logos", or run'
+            + '\n"./tools/provision" if these are bot integrations.',
+        )
+
     def test_no_missing_doc_screenshot_config(self) -> None:
         integration_names = {
             integration.name


### PR DESCRIPTION
Motivation: [CZO discussion](https://chat.zulip.org/#narrow/channel/31-production-help/topic/.E2.9C.94.20Web.20hook.20integrations/with/2456400)

Missing logos in self-hosted servers should not cause runtime errors.

Approach:
- Fall back to the Zulip logo when an integration has none.
- Test that catalog integrations are not using the fallback logo.

Previous PR for reference: #36916

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
