### PR TITLE
send_email: Encode non-ASCII From display names.

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -209,7 +209,7 @@ def build_email(
         from_address = FromAddress.SUPPORT
 
     # Set the "From" that is displayed separately from the envelope-from.
-    extra_headers["From"] = str(Address(display_name=from_name, addr_spec=from_address))
+    extra_headers["From"] = formataddr((from_name, from_address), charset="utf-8")
     # As above, with the "To" line, we drop the name part if it would
     # result in an address which is longer than 320 bytes.
     if len(sanitize_address(extra_headers["From"], "utf-8")) > 320:

--- a/zerver/tests/test_send_email.py
+++ b/zerver/tests/test_send_email.py
@@ -80,6 +80,20 @@ class TestBuildEmail(ZulipTestCase):
         )
         self.assertEqual(mail.to[0], hamlet.delivery_email)
 
+    def test_from_header_non_ascii_display_name(self) -> None:
+        hamlet = self.example_user("hamlet")
+        mail = build_email(
+            "zerver/emails/password_reset",
+            to_emails=[hamlet.email],
+            from_name="Zulip Älëbërä",
+            from_address=FromAddress.NOREPLY,
+            language="en",
+        )
+        # Regression test: non-ASCII From display names must be encoded into
+        # an ASCII-safe header, not emitted as raw Unicode.
+        self.assertTrue(mail.extra_headers["From"].isascii())
+        self.assertIn(FromAddress.NOREPLY, mail.extra_headers["From"])
+
     def test_email_subject_strips_crlf(self) -> None:
         # Email header injection would require a CR or LF making it
         # through email-subject rendering.  Templates are trusted, but


### PR DESCRIPTION
Fixes #39649

When a non-ASCII display name is used in the `From` header, `Address` can produce a header containing raw Unicode characters. Some SMTP providers reject these messages.

This change uses `formataddr()` with UTF-8 to RFC 2047-encode non-ASCII display names, ensuring the resulting `From` header is ASCII-safe.

I also added a regression test covering a non-ASCII display name.

This issue was previously investigated in PR #39740 and PR #39958; this PR keeps the fix focused to the email header handling and regression test.

**How changes were tested:**
- `./tools/test-backend zerver/tests/test_send_email.py`
- `./tools/lint`
- `git diff origin/main...HEAD --check`

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>