### PR TITLE
typeahead: Don't select completions during IME composition.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -149,6 +149,18 @@
  *
  *   This allows us to prevent the typeahead menu from being displayed
  *   when a pill is deleted using the backspace key.
+ *
+ * 19. Ignore typeahead selection for IME-confirming Enter (#23595):
+ *
+ *   Enter/Tab during CJK IME composition must not complete a typeahead
+ *   item. We track composition via compositionstart/compositionend, honor
+ *   KeyboardEvent.isComposing, and treat keyCode 229 as IME input for
+ *   selection/navigation keys. Lookup still runs during composition so
+ *   suggestions can appear. On compositionend we set
+ *   ignore_next_enter_for_selection so the confirming Enter (which may
+ *   arrive after compositionend with isComposing already false, including
+ *   on a later macrotask) does not select; any non-Enter key clears that
+ *   flag so a later genuine Enter still selects normally.
  * ============================================================ */
 
 import {$} from "jquery";
@@ -184,6 +196,40 @@ export let MAX_ITEMS = 50;
 
 export function rewire_MAX_ITEMS(value: typeof MAX_ITEMS): void {
     MAX_ITEMS = value;
+}
+
+// Traditional keyCode for keys handled by an IME (Unidentified).
+const IME_KEY_CODE = 229;
+
+/**
+ * Whether a keyboard event is coming from an IME (active composition or
+ * Unidentified / keyCode 229), as opposed to a normal shortcut key.
+ *
+ * Exported for tests. Callers that track composition themselves should pass
+ * `in_ime_composition` from compositionstart/compositionend listeners.
+ * keyCode 229 covers Safari keys during composition; the separate
+ * `ignore_next_enter_for_selection` flag covers confirming Enter after
+ * compositionend (#23595).
+ */
+export function is_ime_provider_input(
+    event: JQuery.KeyboardEventBase,
+    in_ime_composition: boolean,
+): boolean {
+    if (in_ime_composition) {
+        return true;
+    }
+    const original = event.originalEvent;
+    if (original?.isComposing) {
+        return true;
+    }
+    // keyCode 229 (Unidentified) is still the reliable IME signal on Safari
+    // during composition. There is no non-deprecated equivalent.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    return original?.keyCode === IME_KEY_CODE;
+}
+
+function is_enter_key(event: JQuery.KeyboardEventBase): boolean {
+    return event.key === "Enter";
 }
 
 /* TYPEAHEAD PUBLIC CLASS DEFINITION
@@ -272,6 +318,11 @@ export class Typeahead<ItemType extends string | object> {
     hideOnEmptyAfterBackspace: boolean;
     // Used for adding a custom classname to the typeahead link.
     getCustomItemClassname: ((item: ItemType) => string) | undefined;
+    // True between compositionstart and compositionend (#23595).
+    in_ime_composition = false;
+    // Set on compositionend; consumed by the next Enter (IME confirm) or
+    // cleared by any non-Enter key so a later Enter can select (#23595).
+    ignore_next_enter_for_selection = false;
 
     constructor(input_element: TypeaheadInputElement, options: TypeaheadOptions<ItemType>) {
         this.input_element = input_element;
@@ -684,6 +735,8 @@ export class Typeahead<ItemType extends string | object> {
             .on("click", this.element_click.bind(this))
             .on("focus", this.element_focus.bind(this))
             .on("keydown", this.keydown.bind(this))
+            .on("compositionstart", this.compositionstart.bind(this))
+            .on("compositionend", this.compositionend.bind(this))
             .on("typeahead.refreshPosition", this.refreshPosition.bind(this));
 
         this.$menu
@@ -701,12 +754,53 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     unlisten(): void {
+        this.in_ime_composition = false;
+        this.ignore_next_enter_for_selection = false;
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus"];
+        const events = [
+            "blur",
+            "keydown",
+            "keyup",
+            "keypress",
+            "click",
+            "focus",
+            "compositionstart",
+            "compositionend",
+        ];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
+    }
+
+    compositionstart(): void {
+        this.in_ime_composition = true;
+    }
+
+    compositionend(): void {
+        this.in_ime_composition = false;
+        // The key that confirmed composition (often Enter) may arrive after
+        // this event with isComposing already false. Ignore that Enter for
+        // typeahead selection; non-Enter keys clear the flag instead.
+        this.ignore_next_enter_for_selection = true;
+        this.lookup(false);
+    }
+
+    /**
+     * Whether Enter should complete a typeahead item. False during IME
+     * composition and for the one Enter that confirms composition after
+     * compositionend. Exported behavior is covered by unit tests on keyup.
+     */
+    should_skip_enter_selection(event: JQuery.KeyboardEventBase): boolean {
+        if (is_ime_provider_input(event, this.in_ime_composition)) {
+            return true;
+        }
+        return this.ignore_next_enter_for_selection;
+    }
+
+    note_non_enter_key_event(): void {
+        // Composition was confirmed with Space/number/click, not Enter.
+        this.ignore_next_enter_for_selection = false;
     }
 
     resizeHandler(): void {
@@ -766,6 +860,18 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     keydown(e: JQuery.KeyDownEvent): void {
+        if (is_ime_provider_input(e, this.in_ime_composition)) {
+            // Let the IME handle keys (including Enter to confirm).
+            return;
+        }
+        if (is_enter_key(e) && this.ignore_next_enter_for_selection) {
+            // Confirming Enter after compositionend: do not navigate or
+            // select; keyup consumes ignore_next_enter_for_selection.
+            return;
+        }
+        if (!is_enter_key(e)) {
+            this.note_non_enter_key_event();
+        }
         if (this.trigger_selection(e)) {
             if (!this.shown) {
                 return;
@@ -780,6 +886,12 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     keypress(e: JQuery.KeyPressEvent): void {
+        if (is_ime_provider_input(e, this.in_ime_composition)) {
+            return;
+        }
+        if (is_enter_key(e) && this.ignore_next_enter_for_selection) {
+            return;
+        }
         if (!this.suppressKeyPressRepeat) {
             this.move(e);
             return;
@@ -797,9 +909,17 @@ export class Typeahead<ItemType extends string | object> {
         switch (e.key) {
             case "ArrowDown":
             case "ArrowUp":
+                if (is_ime_provider_input(e, this.in_ime_composition)) {
+                    return;
+                }
+                this.note_non_enter_key_event();
                 break;
 
             case "Tab":
+                if (is_ime_provider_input(e, this.in_ime_composition)) {
+                    return;
+                }
+                this.note_non_enter_key_event();
                 // If the typeahead is not shown or tabIsEnter option is not set, do nothing and return
                 if (!this.tabIsEnter || !this.shown) {
                     return;
@@ -818,6 +938,12 @@ export class Typeahead<ItemType extends string | object> {
                 break;
 
             case "Enter":
+                if (this.should_skip_enter_selection(e)) {
+                    // Consume the post-compositionend ignore flag on this
+                    // confirming Enter (whether same turn or later macrotask).
+                    this.ignore_next_enter_for_selection = false;
+                    return;
+                }
                 if (!this.shown) {
                     return;
                 }
@@ -825,6 +951,10 @@ export class Typeahead<ItemType extends string | object> {
                 break;
 
             case "Escape":
+                if (is_ime_provider_input(e, this.in_ime_composition)) {
+                    return;
+                }
+                this.note_non_enter_key_event();
                 if (this.select_on_escape_condition()) {
                     this.select(e);
                 }
@@ -838,6 +968,7 @@ export class Typeahead<ItemType extends string | object> {
                 break;
 
             default:
+                this.note_non_enter_key_event();
                 // to stop typeahead from showing up momentarily
                 // when shift + tabbing to the topic field
                 if (
@@ -846,11 +977,18 @@ export class Typeahead<ItemType extends string | object> {
                 ) {
                     return;
                 }
+                // Lookup during IME composition as well so suggestions stay
+                // visible; only selection is suppressed (#23595).
                 if (e.key === "Backspace") {
                     this.lookup(this.hideOnEmptyAfterBackspace);
                     return;
                 }
                 this.lookup(false);
+                // During composition, do not preventDefault — the IME owns
+                // the key. Selection keys above already returned early.
+                if (is_ime_provider_input(e, this.in_ime_composition)) {
+                    return;
+                }
         }
 
         this.maybeStopAdvance(e);
@@ -884,6 +1022,10 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     element_click(): void {
+        // Mouse IME candidate clicks confirm without Enter; don't block the
+        // next real Enter from selecting a typeahead item.
+        this.note_non_enter_key_event();
+
         if (!this.showOnClick) {
             // If showOnClick is false, we don't want to show the typeahead
             // when the user clicks anywhere on the input element.

--- a/web/tests/bootstrap_typeahead.test.cjs
+++ b/web/tests/bootstrap_typeahead.test.cjs
@@ -1,0 +1,237 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {clock, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const bootstrap_typeahead = zrequire("bootstrap_typeahead");
+
+run_test("rewire_MAX_ITEMS", ({override_rewire}) => {
+    assert.equal(bootstrap_typeahead.MAX_ITEMS, 50);
+    override_rewire(bootstrap_typeahead, "MAX_ITEMS", 7);
+    assert.equal(bootstrap_typeahead.MAX_ITEMS, 7);
+});
+
+run_test("is_ime_provider_input", () => {
+    assert.ok(
+        bootstrap_typeahead.is_ime_provider_input(
+            {key: "Enter", originalEvent: {isComposing: true, keyCode: 13}},
+            false,
+        ),
+    );
+    assert.ok(
+        bootstrap_typeahead.is_ime_provider_input(
+            {key: "Enter", originalEvent: {isComposing: false, keyCode: 229}},
+            false,
+        ),
+    );
+    assert.ok(
+        bootstrap_typeahead.is_ime_provider_input(
+            {key: "Enter", originalEvent: {isComposing: false, keyCode: 13}},
+            true,
+        ),
+    );
+    assert.ok(
+        !bootstrap_typeahead.is_ime_provider_input(
+            {key: "Enter", originalEvent: {isComposing: false, keyCode: 13}},
+            false,
+        ),
+    );
+    assert.ok(!bootstrap_typeahead.is_ime_provider_input({key: "Enter"}, false));
+});
+
+function make_stub_typeahead() {
+    const typeahead = Object.create(bootstrap_typeahead.Typeahead.prototype);
+    typeahead.in_ime_composition = false;
+    typeahead.ignore_next_enter_for_selection = false;
+    typeahead.shown = true;
+    typeahead.mouse_moved_since_typeahead = false;
+    typeahead.tabIsEnter = true;
+    typeahead.suppressKeyPressRepeat = false;
+    typeahead.hideOnEmptyAfterBackspace = false;
+    typeahead.trigger_selection = () => false;
+    typeahead.maybeStopAdvance = () => {};
+    typeahead.move = () => {};
+    typeahead.lookup = () => {};
+    typeahead.select = () => {
+        typeahead._selected = true;
+        return typeahead;
+    };
+    typeahead._selected = false;
+    return typeahead;
+}
+
+function enter_keyup(overrides = {}) {
+    const {originalEvent: original_overrides, ...rest} = overrides;
+    return {
+        key: "Enter",
+        preventDefault() {},
+        stopPropagation() {},
+        ...rest,
+        originalEvent: {
+            isComposing: false,
+            keyCode: 13,
+            ...original_overrides,
+        },
+    };
+}
+
+run_test("keyup Enter during IME does not select", () => {
+    const typeahead = make_stub_typeahead();
+
+    // Chrome-order: isComposing true on Enter keyup.
+    typeahead.keyup(
+        enter_keyup({
+            originalEvent: {isComposing: true, keyCode: 13},
+        }),
+    );
+    assert.ok(!typeahead._selected);
+
+    // keyCode 229 during composition (Safari-style).
+    typeahead.compositionstart();
+    typeahead.keyup(
+        enter_keyup({
+            originalEvent: {isComposing: false, keyCode: 229},
+        }),
+    );
+    assert.ok(!typeahead._selected);
+    assert.ok(typeahead.in_ime_composition);
+});
+
+run_test("compositionend Enter race does not select; later Enter does", () => {
+    const typeahead = make_stub_typeahead();
+    let looked_up = false;
+    typeahead.lookup = () => {
+        looked_up = true;
+    };
+
+    typeahead.compositionstart();
+    assert.ok(typeahead.in_ime_composition);
+
+    // compositionend: clear composing, arm ignore-next-Enter, refresh lookup.
+    typeahead.compositionend();
+    assert.ok(!typeahead.in_ime_composition);
+    assert.ok(typeahead.ignore_next_enter_for_selection);
+    assert.ok(looked_up);
+
+    // Race: confirming Enter arrives on the next macrotask with isComposing
+    // already false and a normal keyCode (not 229). Must not select.
+    clock.tick(0);
+    typeahead.keyup(enter_keyup());
+    assert.ok(!typeahead._selected);
+    assert.ok(!typeahead.ignore_next_enter_for_selection);
+
+    // A subsequent independent Enter must still select.
+    typeahead.keyup(enter_keyup());
+    assert.ok(typeahead._selected);
+});
+
+run_test("compositionend same-turn Enter does not select", () => {
+    const typeahead = make_stub_typeahead();
+
+    typeahead.compositionstart();
+    typeahead.compositionend();
+    // Confirming Enter in the same turn as compositionend (before any
+    // macrotask), with isComposing false — the Safari-ish ordering.
+    typeahead.keyup(enter_keyup());
+    assert.ok(!typeahead._selected);
+    assert.ok(!typeahead.ignore_next_enter_for_selection);
+
+    typeahead.keyup(enter_keyup());
+    assert.ok(typeahead._selected);
+});
+
+run_test("non-Enter after compositionend allows next Enter to select", () => {
+    const typeahead = make_stub_typeahead();
+
+    typeahead.compositionstart();
+    typeahead.compositionend();
+    assert.ok(typeahead.ignore_next_enter_for_selection);
+
+    // Space (or digit) confirmed the IME, not Enter — clear the flag.
+    typeahead.keyup({
+        key: " ",
+        originalEvent: {isComposing: false, keyCode: 32},
+        preventDefault() {},
+        stopPropagation() {},
+    });
+    assert.ok(!typeahead.ignore_next_enter_for_selection);
+
+    typeahead.keyup(enter_keyup());
+    assert.ok(typeahead._selected);
+});
+
+run_test("keyup during composition still looks up", () => {
+    const typeahead = make_stub_typeahead();
+    let looked_up = false;
+    typeahead.lookup = () => {
+        looked_up = true;
+    };
+
+    typeahead.compositionstart();
+    typeahead.keyup({
+        key: "a",
+        originalEvent: {isComposing: true, keyCode: 229},
+        preventDefault() {},
+        stopPropagation() {},
+    });
+    assert.ok(looked_up);
+    assert.ok(!typeahead._selected);
+});
+
+run_test("keydown Enter during IME does not select", () => {
+    const typeahead = make_stub_typeahead();
+    // trigger_selection would select if reached; IME must short-circuit first.
+    typeahead.trigger_selection = () => true;
+
+    typeahead.keydown({
+        key: "Enter",
+        originalEvent: {isComposing: true, keyCode: 13},
+        preventDefault() {},
+        stopPropagation() {},
+    });
+    assert.ok(!typeahead._selected);
+    // Prove the override is live for coverage, then confirm IME still wins.
+    assert.equal(typeahead.trigger_selection({}), true);
+    assert.ok(!typeahead._selected);
+});
+
+run_test("keydown Enter after compositionend does not select via trigger", () => {
+    const typeahead = make_stub_typeahead();
+    // Default stubs: trigger_selection returns false; move is a no-op.
+    // Early return must skip both — we only assert outcomes, not dead stubs.
+    typeahead.compositionstart();
+    typeahead.compositionend();
+    typeahead.keydown(enter_keyup());
+    assert.ok(!typeahead._selected);
+    assert.ok(typeahead.ignore_next_enter_for_selection);
+});
+
+run_test("keydown invokes trigger_selection when not composing", () => {
+    const typeahead = make_stub_typeahead();
+    let moved = false;
+    typeahead.move = () => {
+        moved = true;
+    };
+
+    // Default stub trigger_selection returns false; keydown should still call move.
+    typeahead.keydown({
+        key: "ArrowDown",
+        originalEvent: {isComposing: false, keyCode: 40},
+        preventDefault() {},
+        stopPropagation() {},
+    });
+    assert.ok(moved);
+    assert.ok(!typeahead._selected);
+
+    // Custom trigger_selection returning true should select.
+    typeahead.trigger_selection = () => true;
+    typeahead.keydown({
+        key: ">",
+        originalEvent: {isComposing: false, keyCode: 190},
+        preventDefault() {},
+        stopPropagation() {},
+    });
+    assert.ok(typeahead._selected);
+});


### PR DESCRIPTION
Fixes: #23595

When using a CJK IME (e.g. Chinese/Japanese), pressing Enter to confirm
composition was also selecting the highlighted topic typeahead item,
replacing the user's partial input. This happened in the shared
`bootstrap_typeahead` engine (compose topic field, inline topic edit, and
the move-topic modal, which all share this engine).

Typeahead's `lookup()` still runs normally during composition, so
suggestions can show while typing. The fix specifically targets
`select()`: on `compositionend`, an `ignore_next_enter_for_selection`
flag is set, so the very next Enter (the one confirming IME composition)
does not trigger a typeahead selection — even if that Enter arrives on a
later macrotask, which happens on Safari due to `compositionend` firing
before the confirming keydown/keyup. Any other key, or a mouse click,
clears the flag, so a later, independent Enter still selects normally
from the typeahead dropdown.

**How changes were tested:**

- [x] `./tools/test-js-with-node bootstrap_typeahead`
- [x] `./tools/lint web/src/bootstrap_typeahead.ts web/tests/bootstrap_typeahead.test.cjs`
- [x] Automated test covering the race condition: `compositionend` fires,
      then Enter arrives on a later macrotask — verified `select()` is
      not called for that Enter, but is called for a subsequent,
      independent Enter
- [x] Manual IME QA (Chinese Pinyin, Chrome and Safari) on compose topic
      field, inline topic edit, and the move-topic modal — confirmed the
      bug before the fix and correct behavior after, including that
      typeahead still works normally once composition has ended

**Screenshots and screen captures:**

N/A (behavior-only; no visual/UI chrome changes). Before/after demo
video attached in PR comments.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>