### PR TITLE
Prep work for slack thread conversion improvements

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1120,7 +1120,7 @@ def get_thread_reply_notification(
 def create_topic_name_for_message(
     added_channels: AddedChannelsT,
     channel_name: str | None,
-    content: str,
+    topic_name_content: str,
     convert_slack_threads: bool,
     is_direct_message_type: bool,
     message: ZerverFieldsT,
@@ -1146,7 +1146,9 @@ def create_topic_name_for_message(
         # Send the thread parent message to the main import topic; the
         # cross-linking notice to the thread topic is appended by
         # get_thread_reply_notification.
-        thread_topic_name = get_zulip_thread_topic_name(content, thread_ts_datetime, thread_counter)
+        thread_topic_name = get_zulip_thread_topic_name(
+            topic_name_content, thread_ts_datetime, thread_counter
+        )
 
         thread_map[thread_key] = ThreadMetadata(
             topic_link_syntax=get_stream_topic_link_syntax(
@@ -1269,18 +1271,22 @@ def channel_message_to_zerver_message(
         has_attachment = file_info["has_attachment"]
         has_image = file_info["has_image"]
 
+        # Part of the thread topic name is based on the message content. Use the
+        # raw content before we add attachment URLs to reduce the likelihood of
+        # generating topic names with URLs.
+        unannotated_content = content
+        content = "\n".join([part for part in [content, file_info["content"]] if part != ""])
+
         topic_name = create_topic_name_for_message(
             added_channels=added_channels,
             channel_name=channel_name,
-            content=content,
+            topic_name_content=unannotated_content,
             convert_slack_threads=convert_slack_threads,
             is_direct_message_type=is_direct_message_type,
             message=message,
             thread_counter=thread_counter,
             thread_map=thread_map,
         )
-
-        content = "\n".join([part for part in [content, file_info["content"]] if part != ""])
 
         content += get_thread_reply_notification(
             convert_slack_threads, message, thread_map, thread_reply_counts

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -982,10 +982,15 @@ def get_zulip_thread_topic_name(
     e.g "2024-05-22 Hello this is a long message that will be c… (1)"
     """
     thread_date = thread_ts.date().isoformat()
+    # Topic names must be a single line, so collapse each run of whitespace
+    # before truncating; otherwise blank lines in the middle of the message
+    # would consume most of the snippet.
+    content_for_topic_name = " ".join(message_content.split())
+    topic_name_without_counter = f"{thread_date} {content_for_topic_name}".strip()
 
     # Truncate
     truncated_zulip_topic_name = truncate_content(
-        f"{thread_date} {message_content}".strip(), MAX_TOPIC_NAME_LENGTH, "…"
+        topic_name_without_counter, MAX_TOPIC_NAME_LENGTH, "…"
     )
     collision = thread_counter[truncated_zulip_topic_name]
     thread_counter[truncated_zulip_topic_name] += 1
@@ -994,9 +999,7 @@ def get_zulip_thread_topic_name(
     # Important: The count is at the end, after …, so we need to
     # subtract its length when doing truncation.
     final_topic_name = (
-        truncate_content(
-            f"{thread_date} {message_content}".strip(), MAX_TOPIC_NAME_LENGTH - len(f"{count}"), "…"
-        )
+        truncate_content(topic_name_without_counter, MAX_TOPIC_NAME_LENGTH - len(f"{count}"), "…")
         + f"{count}"
     )
     return final_topic_name

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -966,11 +966,6 @@ def get_parent_user_id_from_thread_message(thread_message: ZerverFieldsT, subtyp
                 return thread_message["bot_id"]
     except KeyError:
         # If Slack doesn't specify the parent user/bot ID in this message, use the cached one.
-        #
-        # TODO: Our caching strategy works under the assumption that we visit thread messages
-        # in the order of oldest-to-newest - so that we see the thread's parent message before
-        # thread replies. If messages are unsorted, we might process a
-        # reply before its parent, resulting in KeyError because the parent’s user ID hasn’t been cached yet.
         return thread_parent_map[thread_message["thread_ts"]]
 
 

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -929,6 +929,10 @@ def get_messages_iterator(
 thread_parent_map: dict[str, str] = {}
 
 
+def reset_import_state() -> None:
+    thread_parent_map.clear()
+
+
 def get_parent_user_id_from_thread_message(thread_message: ZerverFieldsT, subtype: str) -> str:
     """
     This retrieves the user id of the sender of the original thread
@@ -1794,6 +1798,10 @@ def do_convert_directory(
     processes: int = 6,
     convert_slack_threads: bool = False,
 ) -> None:
+    # Start from a clean slate: the module-level id maps below persist across
+    # Slack imports in a long-lived worker, so reset them before touching
+    # anything.
+    reset_import_state()
     check_slack_token_access(token, SLACK_IMPORT_TOKEN_SCOPES)
 
     os.makedirs(output_dir, exist_ok=True)

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -108,6 +108,8 @@ SLACK_BOLD_REGEX = r"""
                     )
                     """
 
+FALLBACK_SLACK_USER_FULL_NAME = "Slack user {id}"
+
 
 def get_user_full_name(user: ZerverFieldsT) -> str:
     if "deleted" in user and user["deleted"] is False:

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/normal_thread.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/normal_thread.json
@@ -25,7 +25,7 @@
         "text": "another reply",
         "user": "U061A1R2R",
         "ts": "1449868294.000007",
-        "parent_user_id": "U061A5N1G",
+        "parent_user_id": "U061A1R2R",
         "thread_ts": "1539868294.000007",
         "channel_name": "random"
     }

--- a/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/threads_with_whitespace_in_topic_name.json
+++ b/zerver/tests/fixtures/slack_fixtures/exported_messages_fixtures/threads_with_whitespace_in_topic_name.json
@@ -1,0 +1,32 @@
+[
+    {
+        "text": "Hi\n\nthere\tfriend",
+        "user": "U061A5N1G",
+        "ts": "1439868294.000008",
+        "thread_ts": "1439868294.000008",
+        "channel_name": "random"
+    },
+    {
+        "text": "hello",
+        "user": "U061A1R2R",
+        "ts": "1439869294.000008",
+        "parent_user_id": "U061A5N1G",
+        "thread_ts": "1439868294.000008",
+        "channel_name": "random"
+    },
+    {
+        "text": "Release notes:\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n- fixed the thing",
+        "user": "U061A1R2R",
+        "ts": "1547139200.000002",
+        "thread_ts": "1547139200.000002",
+        "channel_name": "random"
+    },
+    {
+        "text": "nice",
+        "user": "U061A5N1G",
+        "ts": "1547149200.000002",
+        "parent_user_id": "U061A1R2R",
+        "thread_ts": "1547139200.000002",
+        "channel_name": "random"
+    }
+]

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1548,26 +1548,26 @@ class SlackImporter(ZulipTestCase):
 
         ### THREAD 2 CONVERSATION ###
         # Test thread topic name contains message snippet
-        expected_thread_2_topic_name = "2015-06-12 message body text"
+        expected_thread_2_topic_name = "2018-10-18 another thread message"
         thread_2_topic_link_syntax = get_stream_topic_link_syntax(
             slack_recipient_name_to_zulip_recipient_id["random"],
             "random",
             expected_thread_2_topic_name,
         )
-        original_thread_2_message_1_content = "message body text"
+        original_thread_2_message_1_content = "another thread message"
         expected_thread_2_message_1_content = f"""
 {original_thread_2_message_1_content}
 
 *1 reply in {thread_2_topic_link_syntax}*
 """.strip()
 
-        self.assertEqual(zerver_message[1]["content"], expected_thread_2_message_1_content)
-        self.assertEqual(zerver_message[1][EXPORT_TOPIC_NAME], MAIN_SLACK_IMPORT_TOPIC)
+        self.assertEqual(zerver_message[3]["content"], expected_thread_2_message_1_content)
+        self.assertEqual(zerver_message[3][EXPORT_TOPIC_NAME], MAIN_SLACK_IMPORT_TOPIC)
 
         # Thread reply is in the correct thread topic
-        expected_thread_2_message_2_content = "random"
-        self.assertEqual(zerver_message[2]["content"], expected_thread_2_message_2_content)
-        self.assertEqual(zerver_message[2][EXPORT_TOPIC_NAME], expected_thread_2_topic_name)
+        expected_thread_2_message_2_content = "another reply"
+        self.assertEqual(zerver_message[4]["content"], expected_thread_2_message_2_content)
+        self.assertEqual(zerver_message[4][EXPORT_TOPIC_NAME], expected_thread_2_topic_name)
 
     def test_thread_cross_link_across_chunk_boundary(self) -> None:
         # A thread's parent message and its replies are not necessarily

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1845,6 +1845,49 @@ message body text
         self.assertEqual(zerver_message[0][EXPORT_TOPIC_NAME], MAIN_SLACK_IMPORT_TOPIC)
         self.assertEqual(zerver_message[1][EXPORT_TOPIC_NAME], expected_thread_1_topic_name)
 
+    def test_convert_thread_topic_name_with_whitespace(self) -> None:
+        slack_recipient_name_to_zulip_recipient_id = {
+            "random": 2,
+            "general": 1,
+        }
+        conversion_result = self.run_channel_message_to_zerver_message_with_fixtures(
+            ["threads_with_whitespace_in_topic_name"],
+            slack_recipient_name_to_zulip_recipient_id=slack_recipient_name_to_zulip_recipient_id,
+        )
+
+        zerver_message = conversion_result.zerver_message
+
+        self.assert_length(zerver_message, 4)
+
+        ### THREAD 1 CONVERSATION ###
+        # Newlines and tabs are not valid topic name characters, so each run
+        # of whitespace in the message snippet becomes a single space.
+        expected_thread_1_topic_name = "2015-08-18 Hi there friend"
+        thread_1_topic_link_syntax = get_stream_topic_link_syntax(
+            slack_recipient_name_to_zulip_recipient_id["random"],
+            "random",
+            expected_thread_1_topic_name,
+        )
+        original_thread_1_message_1_content = "Hi\n\nthere\tfriend"
+        expected_thread_1_message_1_content = f"""
+{original_thread_1_message_1_content}
+
+*1 reply in {thread_1_topic_link_syntax}*
+""".strip()
+
+        # The message itself keeps its original whitespace; only the topic
+        # name derived from it is collapsed.
+        self.assertEqual(zerver_message[0]["content"], expected_thread_1_message_1_content)
+        self.assertEqual(zerver_message[0][EXPORT_TOPIC_NAME], MAIN_SLACK_IMPORT_TOPIC)
+        self.assertEqual(zerver_message[1][EXPORT_TOPIC_NAME], expected_thread_1_topic_name)
+
+        ### THREAD 2 CONVERSATION ###
+        # Collapsing happens before truncation, so a long run of blank lines
+        # in the middle of the message doesn't consume the whole snippet.
+        expected_thread_2_topic_name = "2019-01-10 Release notes: - fixed the thing"
+        self.assertEqual(zerver_message[2][EXPORT_TOPIC_NAME], MAIN_SLACK_IMPORT_TOPIC)
+        self.assertEqual(zerver_message[3][EXPORT_TOPIC_NAME], expected_thread_2_topic_name)
+
     @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
     def test_channel_message_to_zerver_message_with_integration_bots(
         self, mock_build_usermessage: mock.Mock

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -67,6 +67,7 @@ from zerver.data_import.slack import (
     process_message_files,
     slack_emoji_name_to_codepoint,
     slack_workspace_to_realm,
+    thread_parent_map,
     users_to_zerver_userprofile,
 )
 from zerver.lib.exceptions import SlackImportInvalidFileError
@@ -2346,10 +2347,16 @@ To Do
             status=200,
         )
 
+        # A conversion must not read thread state cached by an earlier
+        # import in the same process; see reset_import_state.
+        thread_parent_map["0000000000.000000"] = "USTALEPARENT"
+
         with self.assertLogs(level="INFO"), self.settings(EXTERNAL_HOST="zulip.example.com"):
             # We need to mock EXTERNAL_HOST to be a valid domain because Slack's importer
             # uses it to generate email addresses for users without an email specified.
             do_convert_zipfile(test_slack_zip_file, output_dir, token, processes=1)
+
+        self.assertNotIn("0000000000.000000", thread_parent_map)
 
         realm_id = 0
         uploads_folder = os.path.join(output_dir, "uploads", str(realm_id))

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 from zerver.actions.message_send import send_rate_limited_pm_notification_to_bot_owner
 from zerver.data_import.slack import check_slack_token_access, get_slack_api_data
 from zerver.data_import.slack_message_conversion import (
+    FALLBACK_SLACK_USER_FULL_NAME,
     SLACK_USERMENTION_REGEX,
     convert_slack_formatting,
     convert_slack_workspace_mentions,
@@ -76,7 +77,7 @@ def get_slack_sender_name(user_id: str, token: str) -> str:
     user_name = slack_user_data.get("real_name")
     if isinstance(user_name, str) and user_name.strip():
         return user_name
-    return f"Slack user {user_id}"
+    return FALLBACK_SLACK_USER_FULL_NAME.format(id=user_id)
 
 
 def convert_slack_user_and_channel_mentions(text: str, app_token: str) -> str:


### PR DESCRIPTION
Prep commits for #30166.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
