### PR TITLE
Modular refactors of bots - users.py and test_bots.py

### DIFF
--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -149,9 +149,7 @@ def check_valid_incoming_webhook_bot_config(
             _("Invalid integration '{integration_name}'.").format(integration_name=service_name)
         )
 
-    config_options = {option.name: option.validator for option in integration.config_options}
-
-    missing_keys = set(config_options.keys()) - set(config_data.keys())
+    missing_keys = {option.name for option in integration.config_options} - config_data.keys()
     if missing_keys:
         raise JsonableError(
             _("Missing configuration parameters: {keys}").format(
@@ -159,12 +157,14 @@ def check_valid_incoming_webhook_bot_config(
             )
         )
 
-    for key, validator in config_options.items():
-        value = config_data[key]
-        error = validator(key, value)
+    for option in integration.config_options:
+        value = config_data[option.name]
+        error = option.validator(option.name, value)
         if error is not None:
             raise JsonableError(
-                _("Invalid {key} value {value} ({error})").format(key=key, value=value, error=error)
+                _("Invalid {key} value {value} ({error})").format(
+                    key=option.name, value=value, error=error
+                )
             )
 
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -167,12 +167,14 @@ def check_valid_incoming_webhook_bot_config(
 
 
 def check_valid_embedded_bot_config(service_name: str, config_data: Mapping[str, str]) -> None:
-    try:
-        from zerver.lib.bot_lib import get_bot_handler
+    from zerver.lib.bot_lib import get_bot_handler
 
-        bot_handler = get_bot_handler(service_name)
-        if hasattr(bot_handler, "validate_config"):
-            bot_handler.validate_config(config_data)
+    bot_handler = get_bot_handler(service_name)
+    if not hasattr(bot_handler, "validate_config"):
+        return
+
+    try:
+        bot_handler.validate_config(config_data)
     except ConfigValidationError:
         # The exception provides a specific error message, but that
         # message is not tagged translatable, because it is

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -131,57 +131,55 @@ def validate_short_name_and_construct_bot_email(
     return short_name, email
 
 
-def check_valid_bot_config(
-    bot_type: int, service_name: str, config_data: Mapping[str, str]
+def check_valid_incoming_webhook_bot_config(
+    service_name: str, config_data: Mapping[str, str]
 ) -> None:
-    if bot_type == UserProfile.INCOMING_WEBHOOK_BOT:
-        from zerver.lib.integrations import INCOMING_WEBHOOK_INTEGRATIONS
+    from zerver.lib.integrations import INCOMING_WEBHOOK_INTEGRATIONS
 
-        config_options = None
-        for integration in INCOMING_WEBHOOK_INTEGRATIONS:
-            if integration.name == service_name:
-                # key: validator
-                config_options = {
-                    option.name: option.validator for option in integration.config_options
-                }
-                break
-        if config_options is None:
+    config_options = None
+    for integration in INCOMING_WEBHOOK_INTEGRATIONS:
+        if integration.name == service_name:
+            # key: validator
+            config_options = {
+                option.name: option.validator for option in integration.config_options
+            }
+            break
+    if config_options is None:
+        raise JsonableError(
+            _("Invalid integration '{integration_name}'.").format(integration_name=service_name)
+        )
+
+    missing_keys = set(config_options.keys()) - set(config_data.keys())
+    if missing_keys:
+        raise JsonableError(
+            _("Missing configuration parameters: {keys}").format(
+                keys=missing_keys,
+            )
+        )
+
+    for key, validator in config_options.items():
+        value = config_data[key]
+        error = validator(key, value)
+        if error is not None:
             raise JsonableError(
-                _("Invalid integration '{integration_name}'.").format(integration_name=service_name)
+                _("Invalid {key} value {value} ({error})").format(key=key, value=value, error=error)
             )
 
-        missing_keys = set(config_options.keys()) - set(config_data.keys())
-        if missing_keys:
-            raise JsonableError(
-                _("Missing configuration parameters: {keys}").format(
-                    keys=missing_keys,
-                )
-            )
 
-        for key, validator in config_options.items():
-            value = config_data[key]
-            error = validator(key, value)
-            if error is not None:
-                raise JsonableError(
-                    _("Invalid {key} value {value} ({error})").format(
-                        key=key, value=value, error=error
-                    )
-                )
+def check_valid_embedded_bot_config(service_name: str, config_data: Mapping[str, str]) -> None:
+    try:
+        from zerver.lib.bot_lib import get_bot_handler
 
-    elif bot_type == UserProfile.EMBEDDED_BOT:
-        try:
-            from zerver.lib.bot_lib import get_bot_handler
-
-            bot_handler = get_bot_handler(service_name)
-            if hasattr(bot_handler, "validate_config"):
-                bot_handler.validate_config(config_data)
-        except ConfigValidationError:
-            # The exception provides a specific error message, but that
-            # message is not tagged translatable, because it is
-            # triggered in the external zulip_bots package.
-            # TODO: Think of some clever way to provide a more specific
-            # error message.
-            raise JsonableError(_("Invalid configuration data!"))
+        bot_handler = get_bot_handler(service_name)
+        if hasattr(bot_handler, "validate_config"):
+            bot_handler.validate_config(config_data)
+    except ConfigValidationError:
+        # The exception provides a specific error message, but that
+        # message is not tagged translatable, because it is
+        # triggered in the external zulip_bots package.
+        # TODO: Think of some clever way to provide a more specific
+        # error message.
+        raise JsonableError(_("Invalid configuration data!"))
 
 
 # Adds an outgoing webhook or embedded bot service.

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -170,6 +170,8 @@ def check_valid_embedded_bot_config(service_name: str, config_data: Mapping[str,
     from zerver.lib.bot_lib import get_bot_handler
 
     bot_handler = get_bot_handler(service_name)
+    if bot_handler is None:
+        raise JsonableError(_("Invalid embedded bot name."))
     if not hasattr(bot_handler, "validate_config"):
         return
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -136,18 +136,20 @@ def check_valid_incoming_webhook_bot_config(
 ) -> None:
     from zerver.lib.integrations import INCOMING_WEBHOOK_INTEGRATIONS
 
-    config_options = None
-    for integration in INCOMING_WEBHOOK_INTEGRATIONS:
-        if integration.name == service_name:
-            # key: validator
-            config_options = {
-                option.name: option.validator for option in integration.config_options
-            }
-            break
-    if config_options is None:
+    integration = next(
+        (
+            integration
+            for integration in INCOMING_WEBHOOK_INTEGRATIONS
+            if integration.name == service_name
+        ),
+        None,
+    )
+    if integration is None:
         raise JsonableError(
             _("Invalid integration '{integration_name}'.").format(integration_name=service_name)
         )
+
+    config_options = {option.name: option.validator for option in integration.config_options}
 
     missing_keys = set(config_options.keys()) - set(config_data.keys())
     if missing_keys:

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -66,14 +66,17 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         response_dict = self.assert_json_success(result)
         self.assert_length(response_dict["bots"], count)
 
-    def create_bot(self, **extras: Any) -> dict[str, Any]:
+    def bot_creation_info(self, **extras: Any) -> dict[str, Any]:
         bot_info = {
             "full_name": "The Bot of Hamlet",
             "short_name": "hambot",
             "bot_type": "1",
         }
         bot_info.update(extras)
-        result = self.client_post("/json/bots", bot_info)
+        return bot_info
+
+    def create_bot(self, **extras: Any) -> dict[str, Any]:
+        result = self.client_post("/json/bots", self.bot_creation_info(**extras))
         response_dict = self.assert_json_success(result)
         return response_dict
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -2249,39 +2249,6 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(config_data, {"integration_id": "helloworld"})
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_service_name_incorrect_keys(self) -> None:
-        self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripe",
-            "config_data": orjson.dumps({"stripe_api_key": "_invalid_key"}).decode(),
-        }
-        response = self.client_post("/json/bots", bot_metadata)
-        self.assertEqual(response.status_code, 400)
-        expected_error_message = 'Invalid stripe_api_key value _invalid_key (stripe_api_key starts with a "_" and is hence invalid.)'
-        self.assertEqual(orjson.loads(response.content)["msg"], expected_error_message)
-        with self.assertRaises(UserProfile.DoesNotExist):
-            UserProfile.objects.get(full_name="My Stripe Bot")
-
-    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_service_name_without_keys(self) -> None:
-        self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripe",
-        }
-        response = self.client_post("/json/bots", bot_metadata)
-        self.assertEqual(response.status_code, 400)
-        expected_error_message = "Missing configuration parameters: {'stripe_api_key'}"
-        self.assertEqual(orjson.loads(response.content)["msg"], expected_error_message)
-        with self.assertRaises(UserProfile.DoesNotExist):
-            UserProfile.objects.get(full_name="My Stripe Bot")
-
-    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_without_service_name(self) -> None:
         self.login("hamlet")
         bot_metadata = {
@@ -2295,20 +2262,26 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             get_bot_config(new_bot)
 
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
-    def test_create_incoming_webhook_bot_with_incorrect_service_name(self) -> None:
+    def test_create_incoming_webhook_bot_with_invalid_service(self) -> None:
         self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripes",
-        }
-        response = self.client_post("/json/bots", bot_metadata)
-        self.assertEqual(response.status_code, 400)
-        expected_error_message = "Invalid integration 'stripes'."
-        self.assertEqual(orjson.loads(response.content)["msg"], expected_error_message)
-        with self.assertRaises(UserProfile.DoesNotExist):
-            UserProfile.objects.get(full_name="My Stripe Bot")
+        for service_config, expected_error_message in [
+            (
+                {
+                    "service_name": "stripe",
+                    "config_data": orjson.dumps({"stripe_api_key": "_invalid_key"}).decode(),
+                },
+                'Invalid stripe_api_key value _invalid_key (stripe_api_key starts with a "_" and is hence invalid.)',
+            ),
+            ({"service_name": "stripe"}, "Missing configuration parameters: {'stripe_api_key'}"),
+            ({"service_name": "stripes"}, "Invalid integration 'stripes'."),
+        ]:
+            with self.subTest(expected_error_message):
+                bot_info = self.bot_creation_info(
+                    bot_type=UserProfile.INCOMING_WEBHOOK_BOT, **service_config
+                )
+                result = self.client_post("/json/bots", bot_info)
+                self.assert_json_error(result, expected_error_message)
+                self.assert_num_bots_equal(0)
 
     def test_get_bot_api_key(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -2220,16 +2220,12 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_and_with_keys(self) -> None:
         self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "stripe",
-            "config_data": orjson.dumps({"stripe_api_key": "sample-api-key"}).decode(),
-        }
-        self.create_bot(**bot_metadata)
-        new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
-        config_data = get_bot_config(new_bot)
+        bot = self.create_bot(
+            bot_type=UserProfile.INCOMING_WEBHOOK_BOT,
+            service_name="stripe",
+            config_data=orjson.dumps({"stripe_api_key": "sample-api-key"}).decode(),
+        )
+        config_data = get_bot_config(UserProfile.objects.get(id=bot["user_id"]))
         self.assertEqual(
             config_data, {"integration_id": "stripe", "stripe_api_key": "sample-api-key"}
         )
@@ -2237,27 +2233,14 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_and_no_config_options(self) -> None:
         self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Hello World Bot",
-            "short_name": "my-helloworld",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-            "service_name": "helloworld",
-        }
-        self.create_bot(**bot_metadata)
-        new_bot = UserProfile.objects.get(full_name="My Hello World Bot")
-        config_data = get_bot_config(new_bot)
+        bot = self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT, service_name="helloworld")
+        config_data = get_bot_config(UserProfile.objects.get(id=bot["user_id"]))
         self.assertEqual(config_data, {"integration_id": "helloworld"})
 
-    @patch("zerver.lib.integrations.INCOMING_WEBHOOK_INTEGRATIONS", test_sample_config_options)
     def test_create_incoming_webhook_bot_without_service_name(self) -> None:
         self.login("hamlet")
-        bot_metadata = {
-            "full_name": "My Stripe Bot",
-            "short_name": "my-stripe",
-            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
-        }
-        self.create_bot(**bot_metadata)
-        new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
+        bot = self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT)
+        new_bot = UserProfile.objects.get(id=bot["user_id"])
         with self.assertRaises(ConfigError):
             get_bot_config(new_bot)
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -87,8 +87,9 @@ from zerver.lib.users import (
     check_can_access_user,
     check_can_create_bot,
     check_full_name,
-    check_valid_bot_config,
     check_valid_bot_type,
+    check_valid_embedded_bot_config,
+    check_valid_incoming_webhook_bot_config,
     check_valid_interface_type,
     get_users_for_api,
     max_message_id_for_user,
@@ -716,8 +717,10 @@ def add_bot_backend(
             user_profile, default_events_register_stream_name
         )
 
-    if bot_type in (UserProfile.INCOMING_WEBHOOK_BOT, UserProfile.EMBEDDED_BOT) and service_name:
-        check_valid_bot_config(bot_type, service_name, config_data)
+    if bot_type == UserProfile.INCOMING_WEBHOOK_BOT and service_name:
+        check_valid_incoming_webhook_bot_config(service_name, config_data)
+    elif bot_type == UserProfile.EMBEDDED_BOT and service_name:
+        check_valid_embedded_bot_config(service_name, config_data)
 
     bot_profile = do_create_user(
         email=email,

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -52,7 +52,6 @@ from zerver.lib.exceptions import (
     OrganizationAdministratorRequiredError,
     OrganizationOwnerRequiredError,
 )
-from zerver.lib.integrations import EMBEDDED_BOTS
 from zerver.lib.rate_limiter import (
     rate_limit_spectator_attachment_access_by_file,
     should_rate_limit,
@@ -672,11 +671,8 @@ def add_bot_backend(
     )
     form = CreateUserForm({"full_name": full_name, "email": email})
 
-    if bot_type == UserProfile.EMBEDDED_BOT:
-        if not settings.EMBEDDED_BOTS_ENABLED:
-            raise JsonableError(_("Embedded bots are not enabled."))
-        if service_name not in [bot.name for bot in EMBEDDED_BOTS]:
-            raise JsonableError(_("Invalid embedded bot name."))
+    if bot_type == UserProfile.EMBEDDED_BOT and not settings.EMBEDDED_BOTS_ENABLED:
+        raise JsonableError(_("Embedded bots are not enabled."))
 
     if not form.is_valid():  # nocoverage
         # coverage note: The similar block above covers the most


### PR DESCRIPTION
All are refactor commits except the 6th commit, which reorders validation of the embedded bot's name.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
