### PR TITLE
search-operators: Revise descriptions of DM operators in web app search filters overlay.

### DIFF
--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -46,8 +46,16 @@
                         <td class="operator">dm:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
-                                Narrow to direct messages with <z-value></z-value>.
+                                Narrow to 1-on-1 direct messages with <z-value></z-value>.
                                 {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
+                            {{/tr}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">dm:<span class="operator_value">user A, user B</span></td>
+                        <td class="definition">
+                            {{#tr}}
+                                Narrow to direct messages with specified users.
                             {{/tr}}
                         </td>
                     </tr>
@@ -55,7 +63,7 @@
                         <td class="operator">dm-including:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
-                                Narrow to direct messages that include <z-value></z-value>.
+                                Narrow to all direct messages that include <z-value></z-value>.
                                 {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
                             {{/tr}}
                         </td>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -52,20 +52,20 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">date:<span class="operator_value">date</span></td>
-                        <td class="definition">
-                            {{#tr}}
-                                Narrow to messages around <z-value></z-value>.
-                                {{#*inline "z-value"}}<span class="operator_value">date</span>{{/inline}}
-                            {{/tr}}
-                        </td>
-                    </tr>
-                    <tr>
                         <td class="operator">dm-including:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
                                 Narrow to direct messages that include <z-value></z-value>.
                                 {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
+                            {{/tr}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">date:<span class="operator_value">date</span></td>
+                        <td class="definition">
+                            {{#tr}}
+                                Narrow to messages around <z-value></z-value>.
+                                {{#*inline "z-value"}}<span class="operator_value">date</span>{{/inline}}
                             {{/tr}}
                         </td>
                     </tr>


### PR DESCRIPTION
[#design > rename dm-including to dm-with ( issue #34932 ) @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/rename.20dm-including.20to.20dm-with.20.28.20issue.20.2334932.20.29/near/2521064)

**Notes**:
- Moves the `date` operator row to be below all of the direct message operators.
- Adds a row with an example of the `dm` operator with multiple users.
- Revises the descriptions for the `dm` operator with one user and the `dm-including` operator so that they better match the help center documentation here: https://zulip.com/help/search-for-messages#search-by-location
- These strings are marked for translation, so there's some translation overhead in making these changes. Therefore, we should be confident that these revisions are improvements on the current state before merging.

**Screenshots and screen captures:**

<img width="1436" height="832" alt="Screenshot From 2026-09-08 16-31-21" src="https://github.com/user-attachments/assets/a6c18ff3-63be-44c3-b6e6-0ac1a269c3c0" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
