### PR TITLE
overlays: Enable keyboard navigation for message action buttons.

### DIFF
--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -41,12 +41,19 @@ function undo_draft_deletion(): void {
         return;
     }
 
+    let first_restored_draft_id: string | undefined;
+
     for (const draft of draft_undo_delete_list) {
-        drafts.draft_model.addDraft(draft);
+        const id = drafts.draft_model.addDraft(draft);
+        first_restored_draft_id ??= id;
     }
 
     clear_undo_list();
     rerender_drafts();
+
+    if (first_restored_draft_id !== undefined) {
+        messages_overlay_ui.set_initial_element(first_restored_draft_id, keyboard_handling_context);
+    }
 
     $(".select-drafts-button").show();
     $(".delete-selected-drafts-button").show();
@@ -144,6 +151,7 @@ function remove_drafts($draft_rows: JQuery): void {
 
     if ($(".drafts-tab-pane .overlay-message-row").length === 0) {
         $(".drafts-tab-pane .no-drafts").show();
+        $("#draft_overlay").trigger("focus");
     }
     update_rendered_drafts(
         $("#drafts-from-conversation .overlay-message-row").length > 0,
@@ -396,14 +404,15 @@ function setup_event_handlers(): void {
 
     $("#drafts_table .overlay_message_controls .delete-overlay-message").on("click", function () {
         const $draft_row = $(this).closest(".overlay-message-row");
-
+        messages_overlay_ui.focus_on_sibling_element(keyboard_handling_context);
         remove_drafts($draft_row);
         update_bulk_delete_ui();
     });
 
-    $("#drafts_table .overlay_message_controls .draft-selection-checkbox").on("click", (e) => {
-        const is_checked = is_checkbox_icon_checked($(e.target));
-        toggle_checkbox_icon_state($(e.target), !is_checked);
+    $("#drafts_table .overlay_message_controls .draft-selection-tooltip").on("click", (e) => {
+        const $checkbox = $(e.currentTarget).find(".draft-selection-checkbox");
+        const is_checked = is_checkbox_icon_checked($checkbox);
+        toggle_checkbox_icon_state($checkbox, !is_checked);
         update_bulk_delete_ui();
     });
 }
@@ -511,7 +520,7 @@ export function is_checkbox_icon_checked($checkbox: JQuery): boolean {
 }
 
 export function toggle_checkbox_icon_state($checkbox: JQuery, checked: boolean): void {
-    $checkbox.parent().attr("aria-checked", checked.toString());
+    $checkbox.closest(".draft-selection-tooltip").attr("aria-checked", checked.toString());
     if (checked) {
         $checkbox.removeClass("fa-square-o").addClass("fa-check-square");
     } else {
@@ -541,6 +550,15 @@ export function initialize(): void {
         }
         const draft_row = e.target.closest(".overlay-message-info-box");
         if (draft_row instanceof HTMLElement) {
+            if (e.target !== draft_row) {
+                // Focus landed on an action button inside the draft row (copy, delete, checkbox).
+                // Do not steal focus back to the row, but keep this row marked active.
+                if (!draft_row.classList.contains("active")) {
+                    $("#drafts_table .overlay-message-info-box.active").removeClass("active");
+                    draft_row.classList.add("active");
+                }
+                return;
+            }
             // A draft gained focus; mark it as the selected draft.
             messages_overlay_ui.activate_element(draft_row, keyboard_handling_context);
         } else if (e.target.matches(overlay_util.OVERLAY_FOCUSABLE_SELECTOR)) {
@@ -553,7 +571,7 @@ export function initialize(): void {
             // ring; a pointer click shows no ring on the control, so keep the
             // selection.
             if (e.target.matches(":focus-visible")) {
-                $("#drafts_table .overlay-message-info-box").removeClass("active");
+                $("#drafts_table .overlay-message-info-box.active").removeClass("active");
             }
         } else {
             // Focus landed on a non-interactive area. Return focus to the

--- a/web/src/hotkey.ts
+++ b/web/src/hotkey.ts
@@ -683,11 +683,19 @@ function process_enter_key(e: JQuery.KeyDownEvent): boolean {
     }
 
     if (overlays.scheduled_messages_open()) {
+        const $scheduled_messages_overlay = $("#scheduled_messages_overlay");
+        if ($scheduled_messages_overlay.find("a:focus, button:focus, input:focus").length > 0) {
+            return false;
+        }
         scheduled_messages_overlay_ui.handle_keyboard_events("enter");
         return true;
     }
 
     if (overlays.reminders_open()) {
+        const $reminders_overlay = $("#reminders-overlay");
+        if ($reminders_overlay.find("a:focus, button:focus, input:focus").length > 0) {
+            return false;
+        }
         reminders_overlay_ui.handle_keyboard_events("enter");
         return true;
     }

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -28,12 +28,20 @@ export type Context = {
 };
 
 export function row_with_focus(context: Context): JQuery {
-    const $focused_item = $(`.${CSS.escape(context.box_item_selector)}:focus`);
-    return $focused_item.parent(`.${CSS.escape(context.row_item_selector)}`);
+    if (document.activeElement instanceof HTMLElement) {
+        const $focused_box = $(document.activeElement).closest(
+            `.${CSS.escape(context.box_item_selector)}`,
+        );
+        if ($focused_box.length > 0) {
+            return $focused_box.parent(`.${CSS.escape(context.row_item_selector)}`);
+        }
+    }
+    const $active_box = $(`.${CSS.escape(context.box_item_selector)}.active`);
+    return $active_box.parent(`.${CSS.escape(context.row_item_selector)}`);
 }
 
 export function activate_element(elem: HTMLElement, context: Context): void {
-    $(`.${CSS.escape(context.box_item_selector)}`).removeClass("active");
+    $(`.${CSS.escape(context.box_item_selector)}.active`).removeClass("active");
     elem.classList.add("active");
     elem.focus({preventScroll: true});
 }
@@ -162,7 +170,10 @@ function initialize_focus(event_name: string, context: Context): void {
     // if up_arrow is clicked or the first item if down_arrow is clicked.
     if (
         (event_name !== "up_arrow" && event_name !== "down_arrow") ||
-        $(`.${CSS.escape(context.box_item_selector)}:focus`).length > 0
+        $(`.${CSS.escape(context.box_item_selector)}:focus`).length > 0 ||
+        (document.activeElement instanceof HTMLElement &&
+            $(document.activeElement).closest(`.${CSS.escape(context.box_item_selector)}`).length >
+                0)
     ) {
         return;
     }

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -327,13 +327,26 @@ export function trap_focus_for_settings_overlay(): void {
 
     const overlay_focus_trap_selector =
         "#draft_overlay, #reminders-overlay, #scheduled_messages_overlay, #message-history-overlay, #about-zulip";
-    $("body").on("keydown", overlay_focus_trap_selector, function (this: HTMLElement, e) {
+    $("body").on("keydown", (e) => {
         if (e.key !== "Tab") {
             return;
         }
 
+        if (!(e.target instanceof HTMLElement)) {
+            return;
+        }
+
+        let $overlay = $(e.target).closest(overlay_focus_trap_selector);
+        if ($overlay.length === 0 && active_overlay?.$element.is(overlay_focus_trap_selector)) {
+            $overlay = active_overlay.$element;
+        }
+
+        if ($overlay.length === 0) {
+            return;
+        }
+
         const visible_focusable_elements =
-            overlay_util.get_visible_focusable_elements_in_overlay_container($(this));
+            overlay_util.get_visible_focusable_elements_in_overlay_container($overlay);
 
         if (overlay_util.wrap_overlay_tab_focus(e.shiftKey, visible_focusable_elements)) {
             e.preventDefault();

--- a/web/src/reminders_overlay_ui.ts
+++ b/web/src/reminders_overlay_ui.ts
@@ -143,13 +143,23 @@ export function initialize(): void {
             .attr("data-reminder-id");
         assert(scheduled_msg_id !== undefined);
 
+        messages_overlay_ui.focus_on_sibling_element(keyboard_handling_context);
         message_reminder.delete_reminder(Number.parseInt(scheduled_msg_id, 10));
 
         e.stopPropagation();
         e.preventDefault();
     });
 
-    $("body").on("focus", ".reminder-info-box", function (this: HTMLElement) {
+    $("body").on("focus", ".reminder-info-box", function (this: HTMLElement, e: JQuery.FocusEvent) {
+        if (e.target !== this) {
+            // Focus landed on an action button inside the reminder row.
+            // Do not steal focus back to the row, but keep this row marked active.
+            if (!this.classList.contains("active")) {
+                $(".reminder-info-box.active").removeClass("active");
+                this.classList.add("active");
+            }
+            return;
+        }
         messages_overlay_ui.activate_element(this, keyboard_handling_context);
     });
 

--- a/web/src/scheduled_messages_overlay_ui.ts
+++ b/web/src/scheduled_messages_overlay_ui.ts
@@ -211,13 +211,27 @@ export function initialize(): void {
             .attr("data-scheduled-message-id");
         assert(scheduled_msg_id !== undefined);
 
+        messages_overlay_ui.focus_on_sibling_element(keyboard_handling_context);
         scheduled_messages.delete_scheduled_message(Number.parseInt(scheduled_msg_id, 10));
 
         e.stopPropagation();
         e.preventDefault();
     });
 
-    $("body").on("focus", ".scheduled-message-info-box", function (this: HTMLElement) {
-        messages_overlay_ui.activate_element(this, keyboard_handling_context);
-    });
+    $("body").on(
+        "focus",
+        ".scheduled-message-info-box",
+        function (this: HTMLElement, e: JQuery.FocusEvent) {
+            if (e.target !== this) {
+                // Focus landed on an action button inside the scheduled-message row.
+                // Do not steal focus back to the row, but keep this row marked active.
+                if (!this.classList.contains("active")) {
+                    $(".scheduled-message-info-box.active").removeClass("active");
+                    this.classList.add("active");
+                }
+                return;
+            }
+            messages_overlay_ui.activate_element(this, keyboard_handling_context);
+        },
+    );
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -959,8 +959,36 @@ input.settings_text_input {
                 overflow-wrap: unset;
             }
 
+            .copy-overlay-message,
+            .draft-selection-button {
+                background: none;
+                border: none;
+                padding: 0;
+                color: inherit;
+                cursor: pointer;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                border-radius: 4px;
+
+                &:focus {
+                    outline: none;
+                }
+
+                &:focus-visible {
+                    outline: var(--outline-width-button-focus) solid
+                        var(--color-outline-button-focus);
+                    outline-offset: var(--outline-offset-button-focus);
+                }
+            }
+
             .copy-overlay-message {
                 font-size: 1.2em;
+                opacity: 0.7;
+
+                &:hover {
+                    opacity: 1;
+                }
             }
 
             .restore-overlay-message {

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -47,13 +47,13 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="overlay_message_controls">
-                            <span class="copy-button copy-overlay-message tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}" role="button">
+                            <button type="button" class="copy-button copy-overlay-message tippy-zulip-delayed-tooltip" data-draft-id="{{draft_id}}" data-tippy-content="{{t 'Copy draft' }}" aria-label="{{t 'Copy draft' }}">
                                 <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
-                            </span>
+                            </button>
                             {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-draft-tooltip-template" aria-label=(t "Delete") }}
-                            <div class="draft-selection-tooltip">
+                            <button type="button" class="draft-selection-tooltip draft-selection-button" role="checkbox" aria-checked="false" aria-label="{{t 'Select draft' }}">
                                 <i class="fa fa-square-o fa-lg draft-selection-checkbox" aria-hidden="true"></i>
-                            </div>
+                            </button>
                         </div>
                     </div>
                     <div class="message_content rendered_markdown restore-overlay-message">{{rendered_markdown content}}</div>

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -87,6 +87,8 @@ const popovers = mock_esm("../src/user_card_popover", {
 });
 const reactions = mock_esm("../src/reactions");
 const read_receipts = mock_esm("../src/read_receipts");
+const reminders_overlay_ui = mock_esm("../src/reminders_overlay_ui");
+const scheduled_messages_overlay_ui = mock_esm("../src/scheduled_messages_overlay_ui");
 const search = mock_esm("../src/search");
 const settings_data = mock_esm("../src/settings_data");
 const sidebar_ui = mock_esm("../src/sidebar_ui");
@@ -489,6 +491,96 @@ test_while_not_editing_text("drafts closed w/other overlay", ({override}) => {
 test_while_not_editing_text("drafts closed launch", ({override}) => {
     override(overlays, "any_active", () => false);
     assert_mapping("d", browser_history, "go_to_location");
+});
+
+test_while_not_editing_text("scheduled messages overlay enter hotkey", ({override}) => {
+    override(overlays, "scheduled_messages_open", () => true);
+    const $target = $.create("target-stub");
+    const e = {
+        key: "Enter",
+        target: $target[0],
+    };
+
+    // 1. Focus inside an action button/control in scheduled messages overlay:
+    // Hotkey processing should return false so the button's native action runs.
+    const $scheduled_action_button = $.create("scheduled-action-button");
+    $("#scheduled_messages_overlay").set_find_results(
+        "a:focus, button:focus, input:focus",
+        $scheduled_action_button,
+    );
+    with_overrides(({disallow}) => {
+        disallow(scheduled_messages_overlay_ui, "handle_keyboard_events");
+        assert.equal(hotkey.process_keydown(e), false);
+    });
+
+    // 2. Focus is on a row or outside action controls in scheduled messages overlay:
+    // Hotkey processing should call handle_keyboard_events("enter") and return true.
+    $("#scheduled_messages_overlay").set_find_results("a:focus, button:focus, input:focus", []);
+    stubbing(scheduled_messages_overlay_ui, "handle_keyboard_events", (stub) => {
+        assert.equal(hotkey.process_keydown(e), true);
+        assert.equal(stub.num_calls, 1);
+        assert.deepEqual(stub.last_call_args, ["enter"]);
+    });
+});
+
+test_while_not_editing_text("reminders overlay enter hotkey", ({override}) => {
+    override(overlays, "reminders_open", () => true);
+    const $target = $.create("target-stub");
+    const e = {
+        key: "Enter",
+        target: $target[0],
+    };
+
+    // 1. Focus inside an action button/control in reminders overlay:
+    // Hotkey processing should return false so the button's native action runs.
+    const $reminder_action_button = $.create("reminder-action-button");
+    $("#reminders-overlay").set_find_results(
+        "a:focus, button:focus, input:focus",
+        $reminder_action_button,
+    );
+    with_overrides(({disallow}) => {
+        disallow(reminders_overlay_ui, "handle_keyboard_events");
+        assert.equal(hotkey.process_keydown(e), false);
+    });
+
+    // 2. Focus is on a row or outside action controls in reminders overlay:
+    // Hotkey processing should call handle_keyboard_events("enter") and return true.
+    $("#reminders-overlay").set_find_results("a:focus, button:focus, input:focus", []);
+    stubbing(reminders_overlay_ui, "handle_keyboard_events", (stub) => {
+        assert.equal(hotkey.process_keydown(e), true);
+        assert.equal(stub.num_calls, 1);
+        assert.deepEqual(stub.last_call_args, ["enter"]);
+    });
+});
+
+test_while_not_editing_text("drafts overlay enter hotkey", ({override}) => {
+    override(overlays, "drafts_open", () => true);
+    const $target = $.create("target-stub");
+    const e = {
+        key: "Enter",
+        target: $target[0],
+    };
+
+    // 1. Focus inside an action button/control in drafts overlay:
+    // Hotkey processing should return false so the button's native action runs.
+    const $draft_action_button = $.create("draft-action-button");
+    $("#draft_overlay").set_find_results(
+        "a:focus, button:focus, input:focus",
+        $draft_action_button,
+    );
+    with_overrides(({disallow}) => {
+        disallow(drafts_overlay_ui, "handle_keyboard_events");
+        assert.equal(hotkey.process_keydown(e), false);
+    });
+
+    // 2. Focus is on a row or outside action controls in drafts overlay:
+    // Hotkey processing should call handle_keyboard_events("enter") and return true.
+    $("#draft_overlay").set_find_results("a:focus, button:focus, input:focus", []);
+    stubbing(drafts_overlay_ui, "handle_keyboard_events", (stub) => {
+        assert.equal(hotkey.process_keydown(e), true);
+        assert.equal(stub.num_calls, 1);
+        assert.deepEqual(stub.last_call_args, ["enter"]);
+    });
 });
 
 run_test("print hotkey", ({override}) => {


### PR DESCRIPTION
Fixes: #39005

### Problem
In the **Drafts**, **Scheduled messages**, and **Message reminders** overlays, it was not possible to navigate to row-level action buttons (such as copy draft, delete message/draft/reminder, and draft selection checkboxes) using the keyboard (<kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd>).

This was caused by two issues:
1. **Interactive semantics**: In `draft.hbs`, the copy button was a `<span>` lacking `tabindex="0"`, and the draft selection control was an unfocusable `<div>`, making them unreachable in standard keyboard tab flow.
2. **Focus interception in overlays**: The container-level `focus` event listener on `#draft_overlay`, `.scheduled-message-info-box`, and `.reminder-info-box` caught bubbled `focusin` events when child buttons gained focus and immediately invoked `messages_overlay_ui.activate_element()`, stealing focus back to the parent container (`.overlay-message-info-box`).

---

### Solution
1. **Semantic HTML & ARIA attributes**:
   - Converted the copy button and draft selection checkbox in `draft.hbs` into `<button type="button">` elements with accessible `aria-label` and `role="checkbox"` attributes.
   - Styled `.copy-overlay-message` and `.draft-selection-button` in `app_components.css` with reset button styles and standard Zulip `:focus-visible` outlines.
2. **Focus delegation & flicker-free class toggling**:
   - Updated the focus listeners in `drafts_overlay_ui.ts`, `scheduled_messages_overlay_ui.ts`, and `reminders_overlay_ui.ts` to detect when a child action button inside the row receives focus. Instead of forcing focus back to the row container, focus stays on the active button.
   - Guarded `.active` class removal so only the currently active row is mutated, preventing unnecessary DOM traversal or visual outline flicker.
3. **Navigation & hotkey handling**:
   - Updated `row_with_focus` and `initialize_focus` in `messages_overlay_ui.ts` to recognize rows whose child action buttons have focus, so <kbd>Up</kbd>/<kbd>Down</kbd> arrow key navigation and row operations continue to work seamlessly.
   - Updated `hotkey.ts` Enter key handling for scheduled messages and reminders overlays so pressing <kbd>Enter</kbd> while focused on an action button triggers the button's native action rather than restoring the message.

---

### How changes were tested
- [ ] Verified TypeScript check (`npx tsc --noEmit`) passes with 0 errors.
- [ ] Verified ESLint passes with 0 warnings/errors.
- [ ] Verified Prettier code style (`npx prettier --check`).
- [ ] Verified CSS linting (`npx stylelint`).
- [ ] Ran Node unit test suite (`./tools/test-js-with-node`).
- [ ] Manually tested keyboard navigation using <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> across Drafts, Scheduled messages, and Reminders overlays in the local dev server:
  - Tabbing through rows reaches each action button (copy, delete, checkbox) in order.
  - Activating the copy button copies the draft text.
  - Activating the delete button removes the draft/scheduled message/reminder.
  - Activating the checkbox toggles selection state.
  - Arrow keys continue moving between rows even when focus is on a child button.

### Screenshots and screen captures
<!-- Attach your screen recording here -->

---

<details>
<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns:
- [ ] Explains differences from previous plans.
- [ ] Highlights technical choices and bugs encountered.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review:
- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

https://github.com/user-attachments/assets/7dc7374a-abf2-4fac-82c9-3cb7c8fc8f1a

