### PR TITLE
message_report: Fix **Changes** note wording in API docs.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10982,8 +10982,8 @@ paths:
         parameter is required. Clients should also enforce and communicate this
         behavior in the UI.
 
-        **Changes**: In Zulip 13.0 (feature level 511), this endpoint
-        now returns an error if the message report fails to be sent to the
+        **Changes**: Before Zulip 13.0 (feature level 511), this endpoint
+        did not return an error if the message report failed to be sent to the
         moderation request channel.
 
         **Changes**: New in Zulip 11.0 (feature level 382). This API builds on


### PR DESCRIPTION
This is a follow-up to #39943, per @chrisbobbe's post-merge review.

The `**Changes**` note added in that PR used forward framing
("In Zulip 13.0, this endpoint now returns an error if..."),
which doesn't follow project conventions. Per
`docs/documentation/api.md`, **Changes** notes should describe
what old servers did differently — not repeat the new behavior
that already belongs in the main description.

**How changes were tested:**
- Verified the diff touches only the two wording lines, nothing else.

<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability.
- [x] Each commit is a coherent idea.
- [x] Commit message explains reasoning and motivation for changes.

</details>
