### PR TITLE
message_length_toggle: Fix text click target and optical alignment.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -115,7 +115,10 @@ export function initialize(): void {
         }
 
         // Widget for adjusting the height of a message.
-        if ($target.is("button.message_expander") || $target.is("button.message_condenser")) {
+        if (
+            $target.closest("button.message_expander").length > 0 ||
+            $target.closest("button.message_condenser").length > 0
+        ) {
             return true;
         }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -315,6 +315,10 @@
     }
 
     .message_length_toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
         width: 100%;
         height: 1.714em; /* 24px / 14px em */
         margin-bottom: var(--message-box-markdown-aligned-vertical-space);
@@ -341,6 +345,10 @@
                 --color-show-more-less-button-background-active
             );
             scale: 0.98;
+        }
+
+        > span {
+            line-height: 1;
         }
     }
 

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -5,7 +5,8 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
-    {{ label_text }}
+    <i class="zulip-icon zulip-icon-expand" aria-hidden="true"></i>
+    <span>{{ label_text }}</span>
 </button>
 {{else if (eq toggle_type "condenser")}}
 <button type="button" class="message_condenser message_length_toggle"
@@ -14,6 +15,7 @@
   {{else}}
   data-enable-tooltip="false"
   {{/if}}>
-    {{ label_text }}
+    <i class="zulip-icon zulip-icon-collapse" aria-hidden="true"></i>
+    <span>{{ label_text }}</span>
 </button>
 {{/if}}


### PR DESCRIPTION
Fixes: #38844
Added Collapse & Expand Icons to Show More/Less Buttons and fixes optical vertical misalignment between the `.message_length_toggle` chevron icon and its small-caps text label, and ensures click event reliability on the entire toggle label span.

### Summary of Changes

1. **click_handlers**: Fixed click target handling for `.message_length_toggle` so clicking directly on the inner text `span` reliably triggers message expansion and collapse.
2. **message_length_toggle**: Resolved optical misalignment between the `.zulip-icon` chevron and small-caps label text by setting `line-height: 1` on the toggle button's direct `span` child. This collapses excess font leading without introducing prohibited hardcoded pixel offsets.

**How changes were tested:**
- Tested locally in Chrome and Firefox DevTools by expanding and collapsing long messages.
- Verified click target responsiveness across both the SVG chevron icon and inner text `span`.
- Checked optical centering at multiple zoom levels.

<!-- If the PR makes UI changes, you must include screenshots.
Detailed guide: https://zulip.readthedocs.io/en/latest/contributing/presenting-visual-changes.html
-->

**Screenshots and screen captures:**

| Before | After |
| :--- | :--- |
| <img width="624" alt="Before collapse 1" src="https://github.com/user-attachments/assets/4dc5e4e8-e048-432b-ace3-9ee80c570ed4" /> | <img width="693" alt="After collapse 1" src="https://github.com/user-attachments/assets/1cbd8832-003f-40b0-8868-aff0b5ed6a58" /> |
| <img width="755" alt="Before collapse 2" src="https://github.com/user-attachments/assets/6f21fecb-e792-4015-a28c-b68cd06b2180" /> | <img width="708" alt="After collapse 2" src="https://github.com/user-attachments/assets/be4599a4-5045-4651-93c6-9d695c855245" /> |

<img width="800" height="500" alt="afterBugFixedZulip-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/b512acaa-581e-4592-9660-994d506c73db" />
*Demonstrates clicking directly on the text label span to expand and collapse messages.*
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
