### PR TITLE
[ai] test: Add JUnit reports for Puppeteer tests

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -21,6 +21,7 @@ defaults:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   tests:
@@ -175,7 +176,15 @@ jobs:
         if: ${{ matrix.include_frontend_tests }}
         run: |
           source tools/ci/activate-venv
-          ./tools/test-js-with-puppeteer
+          ./tools/test-js-with-puppeteer --xml-report
+
+      - name: Publish Puppeteer test report
+        if: ${{ always() && matrix.include_frontend_tests }}
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
+        with:
+          name: Puppeteer tests
+          path: var/puppeteer/junit.xml
+          reporter: java-junit
 
       - name: Check pnpm dedupe
         if: ${{ matrix.include_frontend_tests }}

--- a/tools/lib/test_script.py
+++ b/tools/lib/test_script.py
@@ -2,6 +2,7 @@ import glob
 import os
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from argparse import ArgumentParser
 from collections.abc import Iterable
 
@@ -116,6 +117,33 @@ def find_js_test_files(test_dir: str, files: Iterable[str]) -> list[str]:
         )
 
     return test_files
+
+
+def write_junit_report(test_results: Iterable[tuple[str, int, float]], path: str) -> None:
+    """Write one JUnit testcase for each Puppeteer test file that ran."""
+    results = list(test_results)
+    failures = [result for result in results if result[1] != 0]
+    suite = ET.Element(
+        "testsuite",
+        name="Puppeteer frontend tests",
+        tests=str(len(results)),
+        failures=str(len(failures)),
+        time=f"{sum(result[2] for result in results):.3f}",
+    )
+    for test_file, return_code, duration in results:
+        testcase = ET.SubElement(
+            suite,
+            "testcase",
+            classname="Puppeteer",
+            name=os.path.basename(test_file),
+            time=f"{duration:.3f}",
+        )
+        if return_code != 0:
+            failure = ET.SubElement(testcase, "failure", message=f"exit code {return_code}")
+            failure.text = f"Puppeteer test exited with code {return_code}."
+
+    ET.indent(suite, space="  ")
+    ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
 
 
 def prepare_puppeteer_run(is_firefox: bool = False) -> None:

--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -4,6 +4,7 @@ import os
 import shlex
 import subprocess
 import sys
+import time
 
 import requests
 
@@ -46,6 +47,7 @@ from tools.lib.test_script import (
     assert_provisioning_status_ok,
     find_js_test_files,
     prepare_puppeteer_run,
+    write_junit_report,
 )
 from tools.lib.test_server import test_server_running
 
@@ -55,6 +57,7 @@ parser.add_argument("--interactive", action="store_true", help="Run tests intera
 add_provision_check_override_param(parser)
 parser.add_argument("--firefox", action="store_true", help="Run tests with firefox.")
 parser.add_argument("--loop", nargs="?", type=int, default=1)
+parser.add_argument("--xml-report", action="store_true", help="Write a JUnit XML report")
 parser.add_argument(
     "tests", nargs=argparse.REMAINDER, help="Specific tests to run; by default, runs all tests"
 )
@@ -88,11 +91,14 @@ def run_tests(files: Iterable[str], external_host: str, loop: int = 1) -> None:
     test_dir = os.path.join(ZULIP_PATH, "web/e2e-tests")
     test_files = find_js_test_files(test_dir, files)
     total_tests = len(test_files)
+    test_results: list[tuple[str, int, float]] = []
 
     def run_tests(test_number: int = 0) -> tuple[int, int]:
         current_test_num = test_number
         for test_file in test_files[test_number:]:
+            start_time = time.monotonic()
             return_code = run_single_test(test_file, current_test_num + 1, total_tests)
+            test_results.append((test_file, return_code, time.monotonic() - start_time))
             if return_code != 0:
                 return return_code, current_test_num
             current_test_num += 1
@@ -122,6 +128,9 @@ def run_tests(files: Iterable[str], external_host: str, loop: int = 1) -> None:
                     print(f"{OKGREEN}All tests passed!{ENDC}")
                 else:
                     break
+
+    if options.xml_report:
+        write_junit_report(test_results, "var/puppeteer/junit.xml")
 
     if ret != 0:
         failed_test_file_name = os.path.basename(test_files[current_test_num])

--- a/tools/tests/test_test_script.py
+++ b/tools/tests/test_test_script.py
@@ -1,0 +1,32 @@
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from tools.lib.test_script import write_junit_report
+
+
+class WriteJUnitReportTest(unittest.TestCase):
+    def test_writes_testcases_and_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "junit.xml"
+            write_junit_report(
+                [("/tests/passing.test.ts", 0, 0.125), ("/tests/failing.test.ts", 1, 0.25)],
+                str(report_path),
+            )
+
+            suite = ET.parse(report_path).getroot()
+            self.assertEqual(suite.attrib["tests"], "2")
+            self.assertEqual(suite.attrib["failures"], "1")
+            testcases = suite.findall("testcase")
+            self.assertEqual(
+                [testcase.attrib["name"] for testcase in testcases],
+                ["passing.test.ts", "failing.test.ts"],
+            )
+            failure = testcases[1].find("failure")
+            self.assertIsNotNone(failure)
+            self.assertEqual(failure.attrib["message"], "exit code 1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds JUnit XML reporting for Puppeteer frontend test runs so CI can publish structured test results through GitHub Checks.

The report records one testcase per executed Puppeteer test file, including duration and non-zero exit-code failures.

## Test plan

- [x] Targeted `WriteJUnitReportTest` passes on Windows with a minimal `pwd` compatibility stub.
- [x] Python compilation passes for changed Python/script files.
- [x] `git diff --check` passes.
- [ ] Full Puppeteer suite: not run on this Windows environment.
- [ ] Zulip lint: blocked because this environment does not provide `python3`.

Closes #16239
