### PR TITLE
GitHub integration - Ignore unlabeled events on label deletion.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -634,6 +634,19 @@ A temporary team so that I can get some webhook fixtures!
         payload = self.get_body("pull_request_review__edited_empty_changes")
         self.verify_post_is_ignored(payload, "pull_request_review")
 
+    def test_unlabeled_by_label_deletion_ignored(self) -> None:
+        # GitHub omits the "label" field when a deleted label is
+        # automatically removed from the items it was applied to.
+        event_types_and_fixtures = [
+            ("pull_request", "pull_request__unlabeled"),
+            ("issues", "issues__unlabeled"),
+            ("discussion", "discussion__unlabeled"),
+        ]
+        for http_x_github_event, fixture_name in event_types_and_fixtures:
+            payload = orjson.loads(self.get_body(fixture_name))
+            del payload["label"]
+            self.verify_post_is_ignored(orjson.dumps(payload).decode(), http_x_github_event)
+
     def test_ignored_team_actions(self) -> None:
         ignored_actions = [
             "added_to_repository",

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -1228,13 +1228,20 @@ def api_github_webhook(
 
     # Ignore 'comment edited' events (except discussion comments)
     # if the comment body remains unchanged.
+    action = payload.get("action", "").tame(check_string)
     if (
         "comment" in header_event
         and "discussion" not in header_event
-        and payload.get("action", "").tame(check_string) == "edited"
+        and action == "edited"
         and payload["changes"]["body"]["from"].tame(check_string)
         == payload["comment"]["body"].tame(check_string)
     ):
+        return json_success(request)
+
+    # Deleting a label removes it from all issues, PRs, and discussions.
+    # Suppress noisy per-item "unlabeled" notifications when the "label"
+    # does not exist.
+    if action == "unlabeled" and "label" not in payload:
         return json_success(request)
 
     event = get_zulip_event_name(header_event, payload, branches)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -1217,31 +1217,7 @@ def api_github_webhook(
     """
     header_event = get_event_header(request, "X-GitHub-Event", "GitHub")
 
-    # Ignore events from private repositories if the URL option is set
-    if (
-        "repository" in payload
-        and payload["repository"]["private"].tame(check_bool)
-        and ignore_private_repositories
-    ):
-        # Ignore private repository events
-        return json_success(request)
-
-    # Ignore 'comment edited' events (except discussion comments)
-    # if the comment body remains unchanged.
-    action = payload.get("action", "").tame(check_string)
-    if (
-        "comment" in header_event
-        and "discussion" not in header_event
-        and action == "edited"
-        and payload["changes"]["body"]["from"].tame(check_string)
-        == payload["comment"]["body"].tame(check_string)
-    ):
-        return json_success(request)
-
-    # Deleting a label removes it from all issues, PRs, and discussions.
-    # Suppress noisy per-item "unlabeled" notifications when the "label"
-    # does not exist.
-    if action == "unlabeled" and "label" not in payload:
+    if is_ignored_event(header_event, payload, ignore_private_repositories):
         return json_success(request)
 
     event = get_zulip_event_name(header_event, payload, branches)
@@ -1266,6 +1242,38 @@ def api_github_webhook(
 
     check_send_webhook_message(request, user_profile, topic_name, body, event)
     return json_success(request)
+
+
+def is_ignored_event(
+    header_event: str,
+    payload: WildValue,
+    ignore_private_repositories: bool,
+) -> bool:
+    action = payload.get("action", "").tame(check_string)
+
+    # Ignore events from private repositories if the URL option is set.
+    if (
+        "repository" in payload
+        and payload["repository"]["private"].tame(check_bool)
+        and ignore_private_repositories
+    ):
+        return True
+
+    # Ignore 'comment edited' events (except discussion comments)
+    # if the comment body remains unchanged.
+    if (
+        "comment" in header_event
+        and "discussion" not in header_event
+        and action == "edited"
+        and payload["changes"]["body"]["from"].tame(check_string)
+        == payload["comment"]["body"].tame(check_string)
+    ):
+        return True
+
+    # Deleting a label removes it from all issues, PRs, and discussions.
+    # Suppress noisy per-item "unlabeled" notifications when the "label"
+    # does not exist.
+    return action == "unlabeled" and "label" not in payload
 
 
 def is_empty_pull_request_review_event(payload: WildValue) -> bool:


### PR DESCRIPTION
[Sentry error](https://zulip.sentry.io/issues/7238883065/?project=5303926&query=is%3Aunresolved&referrer=issue-stream)

Deleting a label removes it from all issues, PRs, and discussions. Suppress noisy per-item "unlabeled" notifications when the "label" does not exist.

The 2nd commit proposes a refactor, grouping the ignore-event checks.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [ ] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

</details>
